### PR TITLE
ci(pr): rename workflow and job

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,4 +1,4 @@
-name: Validate PR Title
+name: PR
 
 on:
   pull_request:
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   pr-title:
+    name: validate title
     runs-on: ubuntu-latest
     steps:
       - uses: ytanikin/pr-conventional-commits@1.4.2


### PR DESCRIPTION
Renamed workflow from 'Validate PR Title' to 'PR' and updated job name to 'validate title'.