### PR TITLE
feat(config): add per-model metadata and token pricing

### DIFF
--- a/bitrouter-config/providers/anthropic.yaml
+++ b/bitrouter-config/providers/anthropic.yaml
@@ -2,6 +2,6 @@ api_protocol: anthropic
 api_base: https://api.anthropic.com
 env_prefix: ANTHROPIC
 models:
-  - claude-sonnet-4-20250514
-  - claude-3.5-haiku-20241022
-  - claude-3-opus-20240229
+  claude-sonnet-4-20250514: {}
+  claude-3.5-haiku-20241022: {}
+  claude-3-opus-20240229: {}

--- a/bitrouter-config/providers/google.yaml
+++ b/bitrouter-config/providers/google.yaml
@@ -2,7 +2,7 @@ api_protocol: google
 api_base: https://generativelanguage.googleapis.com
 env_prefix: GOOGLE
 models:
-  - gemini-2.5-flash
-  - gemini-2.5-flash-lite
-  - gemini-1.5-pro
-  - gemini-1.5-flash
+  gemini-2.5-flash: {}
+  gemini-2.5-flash-lite: {}
+  gemini-1.5-pro: {}
+  gemini-1.5-flash: {}

--- a/bitrouter-config/providers/openai.yaml
+++ b/bitrouter-config/providers/openai.yaml
@@ -2,10 +2,10 @@ api_protocol: openai
 api_base: https://api.openai.com/v1
 env_prefix: OPENAI
 models:
-  - gpt-4o
-  - gpt-4o-mini
-  - gpt-4-turbo
-  - gpt-3.5-turbo
-  - o1
-  - o1-mini
-  - o3-mini
+  gpt-4o: {}
+  gpt-4o-mini: {}
+  gpt-4-turbo: {}
+  gpt-3.5-turbo: {}
+  o1: {}
+  o1-mini: {}
+  o3-mini: {}

--- a/bitrouter-config/src/config.rs
+++ b/bitrouter-config/src/config.rs
@@ -204,6 +204,92 @@ pub struct ProviderConfig {
     /// Extra default HTTP headers sent with every request.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub default_headers: Option<HashMap<String, String>>,
+
+    /// Per-model metadata and pricing catalog.
+    ///
+    /// Keys are upstream model IDs (e.g. `"gpt-4o"`). Values carry optional
+    /// display name, description, context length, supported modalities, and
+    /// token pricing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub models: Option<HashMap<String, ModelInfo>>,
+}
+
+// ── Model metadata & pricing ─────────────────────────────────────────
+
+/// Media modality supported by a model.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Modality {
+    Text,
+    Image,
+    Audio,
+    Video,
+}
+
+/// Metadata and pricing for a single model offered by a provider.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ModelInfo {
+    /// Human-readable display name (e.g. "GPT-4o").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+
+    /// Brief description of the model's capabilities.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    /// Maximum context window in tokens.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_length: Option<u64>,
+
+    /// Input modalities the model accepts.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub input_modalities: Vec<Modality>,
+
+    /// Output modalities the model can produce.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub output_modalities: Vec<Modality>,
+
+    /// Token pricing per million tokens.
+    #[serde(default)]
+    pub pricing: ModelPricing,
+}
+
+/// Token pricing per million tokens for a model.
+///
+/// Field names mirror the sub-category fields of `LanguageModelInputTokens`
+/// and `LanguageModelOutputTokens` from `bitrouter-core` for cross-provider
+/// compatibility. Defaults to `0.0` for all fields.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ModelPricing {
+    #[serde(default)]
+    pub input_tokens: InputTokenPricing,
+    #[serde(default)]
+    pub output_tokens: OutputTokenPricing,
+}
+
+/// Input token pricing per million tokens.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct InputTokenPricing {
+    /// Cost per million non-cached input tokens.
+    #[serde(default)]
+    pub no_cache: f64,
+    /// Cost per million cache-read input tokens.
+    #[serde(default)]
+    pub cache_read: f64,
+    /// Cost per million cache-write input tokens.
+    #[serde(default)]
+    pub cache_write: f64,
+}
+
+/// Output token pricing per million tokens.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct OutputTokenPricing {
+    /// Cost per million text output tokens.
+    #[serde(default)]
+    pub text: f64,
+    /// Cost per million reasoning output tokens.
+    #[serde(default)]
+    pub reasoning: f64,
 }
 
 /// Authentication configuration.
@@ -365,5 +451,113 @@ providers:
         assert!(config.providers.contains_key("openai"));
         assert!(config.providers.contains_key("anthropic"));
         assert!(config.providers.contains_key("google"));
+    }
+
+    #[test]
+    fn model_info_round_trips_through_yaml() {
+        let yaml = r#"
+name: "GPT-4o"
+description: "Multimodal flagship model"
+context_length: 128000
+input_modalities:
+  - text
+  - image
+output_modalities:
+  - text
+pricing:
+  input_tokens:
+    no_cache: 2.50
+    cache_read: 1.25
+    cache_write: 2.50
+  output_tokens:
+    text: 10.00
+    reasoning: 10.00
+"#;
+        let info: ModelInfo = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(info.name.as_deref(), Some("GPT-4o"));
+        assert_eq!(
+            info.description.as_deref(),
+            Some("Multimodal flagship model")
+        );
+        assert_eq!(info.context_length, Some(128000));
+        assert_eq!(info.input_modalities, vec![Modality::Text, Modality::Image]);
+        assert_eq!(info.output_modalities, vec![Modality::Text]);
+        assert_eq!(info.pricing.input_tokens.no_cache, 2.50);
+        assert_eq!(info.pricing.input_tokens.cache_read, 1.25);
+        assert_eq!(info.pricing.input_tokens.cache_write, 2.50);
+        assert_eq!(info.pricing.output_tokens.text, 10.00);
+        assert_eq!(info.pricing.output_tokens.reasoning, 10.00);
+
+        // Round-trip
+        let serialized = serde_yaml::to_string(&info).unwrap();
+        let deserialized: ModelInfo = serde_yaml::from_str(&serialized).unwrap();
+        assert_eq!(deserialized.name, info.name);
+        assert_eq!(deserialized.pricing.input_tokens.no_cache, 2.50);
+    }
+
+    #[test]
+    fn empty_model_info_deserializes_to_defaults() {
+        let info: ModelInfo = serde_yaml::from_str("{}").unwrap();
+        assert!(info.name.is_none());
+        assert!(info.description.is_none());
+        assert!(info.context_length.is_none());
+        assert!(info.input_modalities.is_empty());
+        assert!(info.output_modalities.is_empty());
+        assert_eq!(info.pricing.input_tokens.no_cache, 0.0);
+        assert_eq!(info.pricing.output_tokens.text, 0.0);
+    }
+
+    #[test]
+    fn load_with_provider_model_metadata() {
+        let yaml = r#"
+providers:
+  openai:
+    api_key: "sk-test"
+    models:
+      gpt-4o:
+        name: "GPT-4o"
+        context_length: 128000
+        input_modalities: [text, image]
+        output_modalities: [text]
+        pricing:
+          input_tokens:
+            no_cache: 2.50
+          output_tokens:
+            text: 10.00
+      gpt-4o-mini:
+        name: "GPT-4o Mini"
+"#;
+        let config = BitrouterConfig::load_from_str(yaml, None).unwrap();
+        let openai = &config.providers["openai"];
+        let models = openai.models.as_ref().unwrap();
+
+        let gpt4o = &models["gpt-4o"];
+        assert_eq!(gpt4o.name.as_deref(), Some("GPT-4o"));
+        assert_eq!(gpt4o.context_length, Some(128000));
+        assert_eq!(
+            gpt4o.input_modalities,
+            vec![Modality::Text, Modality::Image]
+        );
+        assert_eq!(gpt4o.pricing.input_tokens.no_cache, 2.50);
+        assert_eq!(gpt4o.pricing.output_tokens.text, 10.00);
+
+        let mini = &models["gpt-4o-mini"];
+        assert_eq!(mini.name.as_deref(), Some("GPT-4o Mini"));
+        assert_eq!(mini.pricing.input_tokens.no_cache, 0.0); // default
+    }
+
+    #[test]
+    fn derives_inherits_model_catalog() {
+        let yaml = r#"
+providers:
+  my-openai:
+    derives: openai
+    api_key: "sk-custom"
+"#;
+        let config = BitrouterConfig::load_from_str(yaml, None).unwrap();
+        let my_openai = &config.providers["my-openai"];
+        // Should inherit the built-in openai models catalog
+        let models = my_openai.models.as_ref().unwrap();
+        assert!(models.contains_key("gpt-4o"));
     }
 }

--- a/bitrouter-config/src/lib.rs
+++ b/bitrouter-config/src/lib.rs
@@ -7,8 +7,9 @@ pub mod routing;
 pub mod writer;
 
 pub use config::{
-    ApiProtocol, AuthConfig, BitrouterConfig, ControlEndpoint, DatabaseConfig, ModelConfig,
-    ModelEndpoint, ProviderConfig, RoutingStrategy, ServerConfig,
+    ApiProtocol, AuthConfig, BitrouterConfig, ControlEndpoint, DatabaseConfig, InputTokenPricing,
+    Modality, ModelConfig, ModelEndpoint, ModelInfo, ModelPricing, OutputTokenPricing,
+    ProviderConfig, RoutingStrategy, ServerConfig,
 };
 pub use detect::{DetectedProvider, detect_providers, detect_providers_from_env};
 pub use error::{ConfigError, Result};

--- a/bitrouter-config/src/registry.rs
+++ b/bitrouter-config/src/registry.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use serde::Deserialize;
 
-use crate::config::{ApiProtocol, ProviderConfig};
+use crate::config::{ApiProtocol, ModelInfo, ProviderConfig};
 
 // ── Compile-time embedded provider definitions ──────────────────────
 
@@ -19,7 +19,7 @@ struct ProviderDef {
     api_base: String,
     env_prefix: String,
     #[serde(default)]
-    models: Vec<String>,
+    models: HashMap<String, ModelInfo>,
 }
 
 /// A built-in provider with its configuration and known model IDs.
@@ -36,6 +36,7 @@ pub fn builtin_provider_defs() -> HashMap<String, BuiltinProvider> {
         .map(|(name, yaml)| {
             let def: ProviderDef = serde_yaml::from_str(yaml)
                 .unwrap_or_else(|e| panic!("invalid built-in provider YAML '{name}': {e}"));
+            let models: Vec<String> = def.models.keys().cloned().collect();
             (
                 (*name).to_owned(),
                 BuiltinProvider {
@@ -43,9 +44,14 @@ pub fn builtin_provider_defs() -> HashMap<String, BuiltinProvider> {
                         api_protocol: Some(def.api_protocol),
                         api_base: Some(def.api_base),
                         env_prefix: Some(def.env_prefix),
+                        models: if def.models.is_empty() {
+                            None
+                        } else {
+                            Some(def.models)
+                        },
                         ..Default::default()
                     },
-                    models: def.models,
+                    models,
                 },
             )
         })
@@ -86,6 +92,9 @@ pub fn merge_provider(base: &mut ProviderConfig, overlay: ProviderConfig) {
     }
     if overlay.default_headers.is_some() {
         base.default_headers = overlay.default_headers;
+    }
+    if overlay.models.is_some() {
+        base.models = overlay.models;
     }
 }
 
@@ -166,6 +175,9 @@ fn resolve_derives(
         }
         if child.default_headers.is_none() {
             child.default_headers = parent.default_headers;
+        }
+        if child.models.is_none() {
+            child.models = parent.models;
         }
         child.derives = None;
     }
@@ -327,5 +339,129 @@ mod tests {
 
         assert_eq!(base.api_base.as_deref(), Some("https://base.com/v1")); // kept
         assert_eq!(base.api_key.as_deref(), Some("overlay-key")); // overridden
+    }
+
+    #[test]
+    fn builtin_providers_carry_model_catalogs() {
+        let defs = builtin_provider_defs();
+        let openai = &defs["openai"];
+        assert!(!openai.models.is_empty());
+        assert!(openai.models.contains(&"gpt-4o".to_owned()));
+        // Also on config
+        let models = openai.config.models.as_ref().unwrap();
+        assert!(models.contains_key("gpt-4o"));
+    }
+
+    #[test]
+    fn merge_provider_overlay_replaces_models() {
+        use crate::config::ModelInfo;
+
+        let mut base = ProviderConfig {
+            models: Some(HashMap::from([
+                ("model-a".into(), ModelInfo::default()),
+                ("model-b".into(), ModelInfo::default()),
+            ])),
+            ..Default::default()
+        };
+        let overlay = ProviderConfig {
+            models: Some(HashMap::from([(
+                "model-c".into(),
+                ModelInfo {
+                    name: Some("Model C".into()),
+                    ..Default::default()
+                },
+            )])),
+            ..Default::default()
+        };
+        merge_provider(&mut base, overlay);
+
+        let models = base.models.as_ref().unwrap();
+        assert_eq!(models.len(), 1);
+        assert!(models.contains_key("model-c"));
+    }
+
+    #[test]
+    fn merge_provider_no_overlay_keeps_base_models() {
+        use crate::config::ModelInfo;
+
+        let mut base = ProviderConfig {
+            models: Some(HashMap::from([("model-a".into(), ModelInfo::default())])),
+            ..Default::default()
+        };
+        let overlay = ProviderConfig::default();
+        merge_provider(&mut base, overlay);
+
+        assert!(base.models.as_ref().unwrap().contains_key("model-a"));
+    }
+
+    #[test]
+    fn derives_inherits_models() {
+        use crate::config::ModelInfo;
+
+        let mut providers = HashMap::new();
+        providers.insert(
+            "parent".into(),
+            ProviderConfig {
+                api_protocol: Some(ApiProtocol::Openai),
+                models: Some(HashMap::from([(
+                    "parent-model".into(),
+                    ModelInfo {
+                        name: Some("Parent Model".into()),
+                        ..Default::default()
+                    },
+                )])),
+                ..Default::default()
+            },
+        );
+        providers.insert(
+            "child".into(),
+            ProviderConfig {
+                derives: Some("parent".into()),
+                ..Default::default()
+            },
+        );
+
+        let env = HashMap::new();
+        let resolved = resolve_providers(providers, &env);
+
+        let child = &resolved["child"];
+        let models = child.models.as_ref().unwrap();
+        assert!(models.contains_key("parent-model"));
+        assert_eq!(models["parent-model"].name.as_deref(), Some("Parent Model"));
+    }
+
+    #[test]
+    fn derives_child_models_override_parent() {
+        use crate::config::ModelInfo;
+
+        let mut providers = HashMap::new();
+        providers.insert(
+            "parent".into(),
+            ProviderConfig {
+                api_protocol: Some(ApiProtocol::Openai),
+                models: Some(HashMap::from([("model-a".into(), ModelInfo::default())])),
+                ..Default::default()
+            },
+        );
+        providers.insert(
+            "child".into(),
+            ProviderConfig {
+                derives: Some("parent".into()),
+                models: Some(HashMap::from([(
+                    "child-model".into(),
+                    ModelInfo::default(),
+                )])),
+                ..Default::default()
+            },
+        );
+
+        let env = HashMap::new();
+        let resolved = resolve_providers(providers, &env);
+
+        let child = &resolved["child"];
+        let models = child.models.as_ref().unwrap();
+        // Child's own models take precedence, parent models not inherited
+        assert!(models.contains_key("child-model"));
+        assert!(!models.contains_key("model-a"));
     }
 }

--- a/bitrouter-config/src/routing.rs
+++ b/bitrouter-config/src/routing.rs
@@ -6,7 +6,9 @@ use bitrouter_core::{
     routers::routing_table::{RouteEntry, RoutingTable, RoutingTarget},
 };
 
-use crate::config::{ApiProtocol, ModelConfig, ProviderConfig, RoutingStrategy};
+use crate::config::{
+    ApiProtocol, ModelConfig, ModelInfo, ModelPricing, ProviderConfig, RoutingStrategy,
+};
 
 /// A routing target with full resolution context including any per-endpoint overrides.
 #[derive(Debug, Clone)]
@@ -52,6 +54,29 @@ impl ConfigRoutingTable {
     /// Returns a reference to the resolved provider configurations.
     pub fn providers(&self) -> &HashMap<String, ProviderConfig> {
         &self.providers
+    }
+
+    /// Returns the model metadata for a given provider and model ID.
+    ///
+    /// Falls back to [`ModelInfo::default()`] for unknown providers or
+    /// unconfigured models.
+    pub fn model_info(&self, provider_name: &str, model_id: &str) -> ModelInfo {
+        self.providers
+            .get(provider_name)
+            .and_then(|p| p.models.as_ref())
+            .and_then(|models| models.get(model_id))
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    /// Returns the token pricing for a given provider and model ID.
+    ///
+    /// Convenience wrapper around [`model_info`](Self::model_info) that
+    /// returns only the pricing component. Falls back to
+    /// [`ModelPricing::default()`] (all zeros) for unknown providers or
+    /// unconfigured models.
+    pub fn model_pricing(&self, provider_name: &str, model_id: &str) -> ModelPricing {
+        self.model_info(provider_name, model_id).pricing
     }
 
     /// Resolves an incoming model name to a full target with any per-endpoint overrides.
@@ -149,7 +174,9 @@ impl RoutingTable for ConfigRoutingTable {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{ApiProtocol, ModelEndpoint};
+    use crate::config::{
+        ApiProtocol, InputTokenPricing, Modality, ModelEndpoint, OutputTokenPricing,
+    };
 
     fn test_providers() -> HashMap<String, ProviderConfig> {
         let mut p = HashMap::new();
@@ -332,5 +359,79 @@ mod tests {
         let table = ConfigRoutingTable::new(test_providers(), models);
         let result = table.resolve("empty");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn model_pricing_returns_configured_values() {
+        let mut providers = test_providers();
+        providers.get_mut("openai").unwrap().models = Some(HashMap::from([(
+            "gpt-4o".into(),
+            ModelInfo {
+                pricing: ModelPricing {
+                    input_tokens: InputTokenPricing {
+                        no_cache: 2.50,
+                        cache_read: 1.25,
+                        cache_write: 2.50,
+                    },
+                    output_tokens: OutputTokenPricing {
+                        text: 10.00,
+                        reasoning: 10.00,
+                    },
+                },
+                ..Default::default()
+            },
+        )]));
+        let table = ConfigRoutingTable::new(providers, HashMap::new());
+
+        let pricing = table.model_pricing("openai", "gpt-4o");
+        assert_eq!(pricing.input_tokens.no_cache, 2.50);
+        assert_eq!(pricing.input_tokens.cache_read, 1.25);
+        assert_eq!(pricing.output_tokens.text, 10.00);
+    }
+
+    #[test]
+    fn model_pricing_unknown_model_returns_zeros() {
+        let table = ConfigRoutingTable::new(test_providers(), HashMap::new());
+        let pricing = table.model_pricing("openai", "nonexistent");
+        assert_eq!(pricing.input_tokens.no_cache, 0.0);
+        assert_eq!(pricing.output_tokens.text, 0.0);
+    }
+
+    #[test]
+    fn model_pricing_unknown_provider_returns_zeros() {
+        let table = ConfigRoutingTable::new(test_providers(), HashMap::new());
+        let pricing = table.model_pricing("unknown-provider", "gpt-4o");
+        assert_eq!(pricing.input_tokens.no_cache, 0.0);
+    }
+
+    #[test]
+    fn model_info_returns_full_metadata() {
+        let mut providers = test_providers();
+        providers.get_mut("openai").unwrap().models = Some(HashMap::from([(
+            "gpt-4o".into(),
+            ModelInfo {
+                name: Some("GPT-4o".into()),
+                description: Some("Multimodal model".into()),
+                context_length: Some(128000),
+                input_modalities: vec![Modality::Text, Modality::Image],
+                output_modalities: vec![Modality::Text],
+                ..Default::default()
+            },
+        )]));
+        let table = ConfigRoutingTable::new(providers, HashMap::new());
+
+        let info = table.model_info("openai", "gpt-4o");
+        assert_eq!(info.name.as_deref(), Some("GPT-4o"));
+        assert_eq!(info.context_length, Some(128000));
+        assert_eq!(info.input_modalities, vec![Modality::Text, Modality::Image]);
+    }
+
+    #[test]
+    fn model_info_unknown_returns_defaults() {
+        let table = ConfigRoutingTable::new(test_providers(), HashMap::new());
+        let info = table.model_info("openai", "nonexistent");
+        assert!(info.name.is_none());
+        assert!(info.context_length.is_none());
+        assert!(info.input_modalities.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Adds per-model metadata and token pricing to the provider configuration in `bitrouter-config`.

### New Types

- **`Modality`** — text, image, audio, video
- **`ModelInfo`** — name, description, context_length, input/output modalities, pricing
- **`ModelPricing`** / **`InputTokenPricing`** / **`OutputTokenPricing`** — cost per million tokens

### Changes

- `ProviderConfig` gains `models: Option<HashMap<String, ModelInfo>>`
- Built-in provider YAMLs updated from list to map format (`gpt-4o: {}`)
- Pricing field names mirror `LanguageModelInputTokens` / `LanguageModelOutputTokens` sub-categories from `bitrouter-core` (no_cache, cache_read, cache_write, text, reasoning) for cross-provider compatibility
- `ConfigRoutingTable::model_info()` and `model_pricing()` lookups with fallback to defaults for unknown entries
- Full `derives` / `merge_provider` inheritance support
- No real pricing data shipped — structure only for now

### YAML Example

```yaml
providers:
  openai:
    api_key: "${OPENAI_API_KEY}"
    models:
      gpt-4o:
        name: "GPT-4o"
        description: "Multimodal flagship model"
        context_length: 128000
        input_modalities: [text, image]
        output_modalities: [text]
        pricing:
          input_tokens:
            no_cache: 2.50
            cache_read: 1.25
          output_tokens:
            text: 10.00
```
