### PR TITLE
feat(api): add GET /v1/models endpoint with query filters

### DIFF
--- a/bitrouter-api/src/router/mod.rs
+++ b/bitrouter-api/src/router/mod.rs
@@ -4,6 +4,7 @@ pub mod anthropic;
 #[cfg(feature = "google")]
 pub mod google;
 pub mod metrics;
+pub mod models;
 #[cfg(feature = "openai")]
 pub mod openai;
 pub mod routes;

--- a/bitrouter-api/src/router/models.rs
+++ b/bitrouter-api/src/router/models.rs
@@ -1,0 +1,139 @@
+//! Warp filter for the `GET /v1/models` endpoint.
+//!
+//! Returns all models available across all configured providers, including
+//! metadata such as display name, description, context window, modalities,
+//! and the owning provider.
+//!
+//! Supports optional query parameter filters:
+//!
+//! - `provider` — exact match on provider name
+//! - `id` — substring match on model ID
+//! - `input_modality` — model must support this input modality
+//! - `output_modality` — model must support this output modality
+
+use std::sync::Arc;
+
+use bitrouter_core::routers::routing_table::RoutingTable;
+use serde::Serialize;
+use warp::Filter;
+
+/// Query parameters for filtering the model list.
+#[derive(Debug, Default)]
+pub struct ModelQuery {
+    /// Filter by provider name (exact match).
+    pub provider: Option<String>,
+    /// Filter by model ID (substring match, case-insensitive).
+    pub id: Option<String>,
+    /// Filter by supported input modality (e.g. "text", "image").
+    pub input_modality: Option<String>,
+    /// Filter by supported output modality.
+    pub output_modality: Option<String>,
+}
+
+/// Creates a warp filter for `GET /v1/models`.
+pub fn models_filter<T>(
+    table: Arc<T>,
+) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone
+where
+    T: RoutingTable + Send + Sync + 'static,
+{
+    warp::path!("v1" / "models")
+        .and(warp::get())
+        .and(optional_raw_query())
+        .and(warp::any().map(move || table.clone()))
+        .map(handle_list_models)
+}
+
+/// Extracts the raw query string as `Option<String>`. Returns `None` when
+/// the request has no query component instead of rejecting.
+fn optional_raw_query()
+-> impl Filter<Extract = (Option<String>,), Error = std::convert::Infallible> + Clone {
+    warp::query::raw()
+        .map(Some)
+        .or(warp::any().map(|| None))
+        .unify()
+}
+
+#[derive(Serialize)]
+struct ModelResponse {
+    id: String,
+    provider: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_input_tokens: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_output_tokens: Option<u64>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    input_modalities: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    output_modalities: Vec<String>,
+}
+
+fn parse_query(raw: &str) -> ModelQuery {
+    let mut query = ModelQuery::default();
+    for pair in raw.split('&') {
+        if let Some((key, value)) = pair.split_once('=') {
+            match key {
+                "provider" => query.provider = Some(value.to_owned()),
+                "id" => query.id = Some(value.to_owned()),
+                "input_modality" => query.input_modality = Some(value.to_owned()),
+                "output_modality" => query.output_modality = Some(value.to_owned()),
+                _ => {}
+            }
+        }
+    }
+    query
+}
+
+fn handle_list_models<T: RoutingTable>(
+    raw_query: Option<String>,
+    table: Arc<T>,
+) -> impl warp::Reply {
+    let query = raw_query.as_deref().map(parse_query).unwrap_or_default();
+    let entries = table.list_models();
+    let id_lower = query.id.as_deref().map(str::to_lowercase);
+
+    let models: Vec<ModelResponse> = entries
+        .into_iter()
+        .filter(|e| {
+            if query.provider.as_deref().is_some_and(|p| e.provider != p) {
+                return false;
+            }
+            if id_lower
+                .as_deref()
+                .is_some_and(|s| !e.id.to_lowercase().contains(s))
+            {
+                return false;
+            }
+            if query
+                .input_modality
+                .as_deref()
+                .is_some_and(|m| !e.input_modalities.iter().any(|x| x == m))
+            {
+                return false;
+            }
+            if query
+                .output_modality
+                .as_deref()
+                .is_some_and(|m| !e.output_modalities.iter().any(|x| x == m))
+            {
+                return false;
+            }
+            true
+        })
+        .map(|e| ModelResponse {
+            id: e.id,
+            provider: e.provider,
+            name: e.name,
+            description: e.description,
+            max_input_tokens: e.max_input_tokens,
+            max_output_tokens: e.max_output_tokens,
+            input_modalities: e.input_modalities,
+            output_modalities: e.output_modalities,
+        })
+        .collect();
+    warp::reply::json(&serde_json::json!({ "models": models }))
+}

--- a/bitrouter-config/src/routing.rs
+++ b/bitrouter-config/src/routing.rs
@@ -3,11 +3,11 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use bitrouter_core::{
     errors::{BitrouterError, Result},
-    routers::routing_table::{RouteEntry, RoutingTable, RoutingTarget},
+    routers::routing_table::{ModelEntry, RouteEntry, RoutingTable, RoutingTarget},
 };
 
 use crate::config::{
-    ApiProtocol, ModelConfig, ModelInfo, ModelPricing, ProviderConfig, RoutingStrategy,
+    ApiProtocol, Modality, ModelConfig, ModelInfo, ModelPricing, ProviderConfig, RoutingStrategy,
 };
 
 /// A routing target with full resolution context including any per-endpoint overrides.
@@ -135,6 +135,16 @@ impl ConfigRoutingTable {
     }
 }
 
+fn modality_to_string(m: &Modality) -> String {
+    match m {
+        Modality::Text => "text",
+        Modality::Image => "image",
+        Modality::Audio => "audio",
+        Modality::Video => "video",
+    }
+    .to_owned()
+}
+
 impl RoutingTable for ConfigRoutingTable {
     async fn route(&self, incoming_model_name: &str) -> Result<RoutingTarget> {
         let resolved = self.resolve(incoming_model_name)?;
@@ -167,6 +177,40 @@ impl RoutingTable for ConfigRoutingTable {
             }
         }
         entries.sort_by(|a, b| a.model.cmp(&b.model));
+        entries
+    }
+
+    fn list_models(&self) -> Vec<ModelEntry> {
+        let mut entries = Vec::new();
+        for (provider_name, provider_config) in &self.providers {
+            // Only include providers that have an API key configured.
+            if provider_config.api_key.is_none() {
+                continue;
+            }
+            if let Some(models) = &provider_config.models {
+                for (model_id, info) in models {
+                    entries.push(ModelEntry {
+                        id: model_id.clone(),
+                        provider: provider_name.clone(),
+                        name: info.name.clone(),
+                        description: info.description.clone(),
+                        max_input_tokens: info.max_input_tokens,
+                        max_output_tokens: info.max_output_tokens,
+                        input_modalities: info
+                            .input_modalities
+                            .iter()
+                            .map(modality_to_string)
+                            .collect(),
+                        output_modalities: info
+                            .output_modalities
+                            .iter()
+                            .map(modality_to_string)
+                            .collect(),
+                    });
+                }
+            }
+        }
+        entries.sort_by(|a, b| a.provider.cmp(&b.provider).then(a.id.cmp(&b.id)));
         entries
     }
 }

--- a/bitrouter-core/src/routers/dynamic.rs
+++ b/bitrouter-core/src/routers/dynamic.rs
@@ -13,7 +13,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use crate::errors::{BitrouterError, Result};
 
 use super::admin::{AdminRoutingTable, DynamicRoute, RouteEndpoint, RouteStrategy};
-use super::routing_table::{RouteEntry, RoutingTable, RoutingTarget};
+use super::routing_table::{ModelEntry, RouteEntry, RoutingTable, RoutingTarget};
 
 /// Internal representation of a dynamic route with its round-robin counter.
 struct DynamicRouteData {
@@ -98,6 +98,10 @@ impl<T: RoutingTable + Sync> RoutingTable for DynamicRoutingTable<T> {
 
         entries.sort_by(|a, b| a.model.cmp(&b.model));
         entries
+    }
+
+    fn list_models(&self) -> Vec<ModelEntry> {
+        self.inner.list_models()
     }
 }
 

--- a/bitrouter-core/src/routers/routing_table.rs
+++ b/bitrouter-core/src/routers/routing_table.rs
@@ -19,6 +19,27 @@ pub struct RouteEntry {
     pub protocol: String,
 }
 
+/// A single model available through a provider, with its metadata.
+#[derive(Debug, Clone)]
+pub struct ModelEntry {
+    /// The upstream model ID (e.g. "gpt-4o", "claude-sonnet-4-20250514").
+    pub id: String,
+    /// The provider that offers this model.
+    pub provider: String,
+    /// Human-readable display name.
+    pub name: Option<String>,
+    /// Brief description of the model's capabilities.
+    pub description: Option<String>,
+    /// Maximum input context window in tokens.
+    pub max_input_tokens: Option<u64>,
+    /// Maximum number of output tokens the model can produce.
+    pub max_output_tokens: Option<u64>,
+    /// Input modalities the model accepts (e.g. "text", "image").
+    pub input_modalities: Vec<String>,
+    /// Output modalities the model can produce.
+    pub output_modalities: Vec<String>,
+}
+
 /// A routing table that maps incoming model names to routing targets (provider + model ID).
 pub trait RoutingTable {
     /// Routes an incoming model name to a routing target.
@@ -29,6 +50,11 @@ pub trait RoutingTable {
 
     /// Lists all configured model routes.
     fn list_routes(&self) -> Vec<RouteEntry> {
+        Vec::new()
+    }
+
+    /// Lists all models available across all configured providers.
+    fn list_models(&self) -> Vec<ModelEntry> {
         Vec::new()
     }
 }

--- a/bitrouter/src/runtime/server.rs
+++ b/bitrouter/src/runtime/server.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use bitrouter_api::metrics::MetricsStore;
-use bitrouter_api::router::{admin, anthropic, google, openai, routes};
+use bitrouter_api::router::{admin, anthropic, google, models, openai, routes};
 use bitrouter_config::BitrouterConfig;
 use bitrouter_core::hooks::HookedRouter;
 use bitrouter_core::routers::admin::AdminRoutingTable;
@@ -73,6 +73,9 @@ where
         // Route listing — no auth required.
         let route_list = routes::routes_filter(self.table.clone());
 
+        // Model listing — no auth required.
+        let model_list = models::models_filter(self.table.clone());
+
         // Metrics endpoint — no auth required.
         let metrics_endpoint = bitrouter_api::router::metrics::metrics_filter(metrics.clone());
 
@@ -122,6 +125,7 @@ where
 
             let all = health
                 .or(route_list)
+                .or(model_list)
                 .or(metrics_endpoint)
                 .or(admin_routes)
                 .or(chat)
@@ -142,6 +146,7 @@ where
         } else {
             let all = health
                 .or(route_list)
+                .or(model_list)
                 .or(metrics_endpoint)
                 .or(admin_routes)
                 .or(chat)


### PR DESCRIPTION
## Summary
- Add `GET /v1/models` endpoint that returns all models from providers with configured API keys, including metadata (name, description, context window, modalities)
- Support optional query parameter filters: `provider` (exact), `id` (substring), `input_modality`, `output_modality`
- Add `ModelEntry` struct and `list_models()` to the `RoutingTable` trait in `bitrouter-core`, with `ConfigRoutingTable` implementation in `bitrouter-config`

## Test plan
- [ ] `cargo test --workspace` passes
- [ ] `cargo clippy` clean
- [ ] `GET /v1/models` returns all models with no filters
- [ ] `GET /v1/models?provider=anthropic` filters by provider
- [ ] `GET /v1/models?id=claude` filters by ID substring
- [ ] `GET /v1/models?input_modality=image` filters by modality
- [ ] Combined filters work (e.g. `?id=flash&provider=google`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)