### PR TITLE
ci(release): add cross-repo release propagation workflow

### DIFF
--- a/.github/workflows/release-propagate.yml
+++ b/.github/workflows/release-propagate.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          repositories: bitrouter-docs,bitrouter-plugins
+          repositories: bitrouter-docs,bitrouter-openclaw
 
       - name: Dispatch to bitrouter-docs
         uses: peter-evans/repository-dispatch@v3
@@ -26,10 +26,10 @@ jobs:
           event-type: bitrouter-release
           client-payload: '{"tag": "${{ github.event.release.tag_name }}"}'
 
-      - name: Dispatch to bitrouter-plugins
+      - name: Dispatch to bitrouter-openclaw
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ steps.generate-token.outputs.token }}
-          repository: bitrouter/bitrouter-plugins
+          repository: bitrouter/bitrouter-openclaw
           event-type: bitrouter-release
           client-payload: '{"tag": "${{ github.event.release.tag_name }}"}'


### PR DESCRIPTION
## Summary
- Adds `release-propagate.yml` that fires `repository_dispatch` events to `bitrouter-docs` and `bitrouter-plugins` when a GitHub Release is published
- Uses existing GitHub App credentials (`APP_ID` / `APP_PRIVATE_KEY`) to generate cross-repo tokens
- Only the version tag is passed in the payload; sibling repos fetch full release data themselves

## Trigger chain
```
release-plz → GitHub Release published → release-propagate.yml → repository_dispatch → sibling repos
```

## Test plan
- [ ] Merge sibling repo PRs first (workflows must exist on `main` to receive dispatches)
- [ ] Merge this PR
- [ ] Test by dispatching manually: `gh api repos/bitrouter/bitrouter-docs/dispatches -f event_type=bitrouter-release -f 'client_payload[tag]=v0.11.0'`
- [ ] Verify issues are created in both sibling repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)