### PR TITLE
fix(mcp,a2a): surface config parse errors and support flat MCP server format

### DIFF
--- a/bitrouter-config/src/config.rs
+++ b/bitrouter-config/src/config.rs
@@ -670,6 +670,59 @@ a2a_agents:
     }
 
     #[test]
+    fn load_with_flat_mcp_servers_config() {
+        let yaml = r#"
+mcp_servers:
+  - name: "filesystem"
+    command: "npx"
+    args:
+      - "-y"
+      - "@modelcontextprotocol/server-filesystem"
+      - "/tmp/workspace"
+  - name: "remote"
+    url: "http://localhost:3000/mcp"
+"#;
+        let config = BitrouterConfig::load_from_str(yaml, None).unwrap();
+        assert_eq!(config.mcp_servers.len(), 2);
+
+        let fs = &config.mcp_servers[0];
+        assert_eq!(fs.name, "filesystem");
+        match &fs.transport {
+            bitrouter_core::routers::upstream::ToolServerTransport::Stdio {
+                command, args, ..
+            } => {
+                assert_eq!(command, "npx");
+                assert_eq!(args.len(), 3);
+            }
+            _ => panic!("expected Stdio transport"),
+        }
+
+        let remote = &config.mcp_servers[1];
+        assert_eq!(remote.name, "remote");
+        match &remote.transport {
+            bitrouter_core::routers::upstream::ToolServerTransport::Http { url, .. } => {
+                assert_eq!(url, "http://localhost:3000/mcp");
+            }
+            _ => panic!("expected Http transport"),
+        }
+    }
+
+    #[test]
+    fn load_with_nested_mcp_servers_config() {
+        let yaml = r#"
+mcp_servers:
+  - name: "filesystem"
+    transport:
+      type: stdio
+      command: "npx"
+      args: ["-y", "server"]
+"#;
+        let config = BitrouterConfig::load_from_str(yaml, None).unwrap();
+        assert_eq!(config.mcp_servers.len(), 1);
+        assert_eq!(config.mcp_servers[0].name, "filesystem");
+    }
+
+    #[test]
     fn derives_inherits_model_catalog() {
         let yaml = r#"
 providers:

--- a/bitrouter-core/src/routers/upstream.rs
+++ b/bitrouter-core/src/routers/upstream.rs
@@ -6,6 +6,7 @@
 
 use std::collections::HashMap;
 
+use serde::de::Deserializer;
 use serde::{Deserialize, Serialize};
 
 use super::admin::{ParamRestrictions, ToolFilter};
@@ -13,14 +14,97 @@ use super::admin::{ParamRestrictions, ToolFilter};
 // ── Tool server config ──────────────────────────────────────────────
 
 /// Configuration for a single upstream tool server.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+///
+/// Supports two YAML formats:
+///
+/// **Nested** (explicit transport):
+/// ```yaml
+/// - name: my-server
+///   transport:
+///     type: stdio
+///     command: npx
+///     args: ["-y", "server"]
+/// ```
+///
+/// **Flat** (inferred transport — `command` implies stdio, `url` implies http):
+/// ```yaml
+/// - name: my-server
+///   command: npx
+///   args: ["-y", "server"]
+/// ```
+#[derive(Debug, Clone, Serialize)]
 pub struct ToolServerConfig {
     pub name: String,
     pub transport: ToolServerTransport,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tool_filter: Option<ToolFilter>,
     #[serde(default)]
     pub param_restrictions: ParamRestrictions,
+}
+
+impl<'de> Deserialize<'de> for ToolServerConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        /// Helper that accepts both nested and flat transport layouts.
+        #[derive(Deserialize)]
+        struct Raw {
+            name: String,
+
+            // ── Nested format ──
+            #[serde(default)]
+            transport: Option<ToolServerTransport>,
+
+            // ── Flat stdio fields ──
+            #[serde(default)]
+            command: Option<String>,
+            #[serde(default)]
+            args: Vec<String>,
+            #[serde(default)]
+            env: HashMap<String, String>,
+
+            // ── Flat http fields ──
+            #[serde(default)]
+            url: Option<String>,
+            #[serde(default)]
+            headers: HashMap<String, String>,
+
+            // ── Common fields ──
+            #[serde(default)]
+            tool_filter: Option<ToolFilter>,
+            #[serde(default)]
+            param_restrictions: ParamRestrictions,
+        }
+
+        let raw = Raw::deserialize(deserializer)?;
+
+        let transport = if let Some(t) = raw.transport {
+            t
+        } else if let Some(command) = raw.command {
+            ToolServerTransport::Stdio {
+                command,
+                args: raw.args,
+                env: raw.env,
+            }
+        } else if let Some(url) = raw.url {
+            ToolServerTransport::Http {
+                url,
+                headers: raw.headers,
+            }
+        } else {
+            return Err(serde::de::Error::custom(
+                "mcp_servers entry must have `transport`, `command` (stdio), or `url` (http)",
+            ));
+        };
+
+        Ok(ToolServerConfig {
+            name: raw.name,
+            transport,
+            tool_filter: raw.tool_filter,
+            param_restrictions: raw.param_restrictions,
+        })
+    }
 }
 
 impl ToolServerConfig {
@@ -275,6 +359,76 @@ mod tests {
         let json = serde_json::to_string(&config).expect("serialize");
         let parsed: ToolServerConfig = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(parsed.name, "remote");
+    }
+
+    // ── Flat format deserialization tests ─────────────────────────────
+
+    #[test]
+    fn deserialize_flat_stdio() {
+        let json = r#"{
+            "name": "fs",
+            "command": "npx",
+            "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+        }"#;
+        let config: ToolServerConfig = serde_json::from_str(json).expect("deserialize flat stdio");
+        assert_eq!(config.name, "fs");
+        match &config.transport {
+            ToolServerTransport::Stdio { command, args, .. } => {
+                assert_eq!(command, "npx");
+                assert_eq!(args.len(), 3);
+            }
+            _ => panic!("expected Stdio transport"),
+        }
+    }
+
+    #[test]
+    fn deserialize_flat_http() {
+        let json = r#"{
+            "name": "remote",
+            "url": "http://localhost:3000/mcp",
+            "headers": {"Authorization": "Bearer tok"}
+        }"#;
+        let config: ToolServerConfig = serde_json::from_str(json).expect("deserialize flat http");
+        assert_eq!(config.name, "remote");
+        match &config.transport {
+            ToolServerTransport::Http { url, headers } => {
+                assert_eq!(url, "http://localhost:3000/mcp");
+                assert_eq!(
+                    headers.get("Authorization").map(String::as_str),
+                    Some("Bearer tok")
+                );
+            }
+            _ => panic!("expected Http transport"),
+        }
+    }
+
+    #[test]
+    fn deserialize_nested_still_works() {
+        let json = r#"{
+            "name": "test",
+            "transport": {
+                "type": "stdio",
+                "command": "echo",
+                "args": ["hello"]
+            }
+        }"#;
+        let config: ToolServerConfig =
+            serde_json::from_str(json).expect("deserialize nested transport");
+        assert_eq!(config.name, "test");
+        match &config.transport {
+            ToolServerTransport::Stdio { command, args, .. } => {
+                assert_eq!(command, "echo");
+                assert_eq!(args, &["hello"]);
+            }
+            _ => panic!("expected Stdio transport"),
+        }
+    }
+
+    #[test]
+    fn deserialize_rejects_missing_transport() {
+        let json = r#"{"name": "bad"}"#;
+        let result = serde_json::from_str::<ToolServerConfig>(json);
+        assert!(result.is_err());
     }
 
     // ── ToolServerAccessGroups tests ────────────────────────────────

--- a/bitrouter/src/main.rs
+++ b/bitrouter/src/main.rs
@@ -6,7 +6,7 @@ mod tui;
 
 use std::path::PathBuf;
 
-use crate::runtime::{AppRuntime, PathOverrides, resolve_home};
+use crate::runtime::{AppRuntime, PathOverrides, RuntimePaths, resolve_home};
 use bitrouter_core::auth::claims::{BudgetScope, TokenScope};
 use clap::{Parser, Subcommand};
 
@@ -306,8 +306,7 @@ async fn run_cli(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             return Ok(());
         }
         Some(Command::Agents { action }) => {
-            let runtime: DefaultRuntime = DefaultRuntime::load(paths.clone())
-                .unwrap_or_else(|_| DefaultRuntime::scaffold(paths.clone()));
+            let runtime: DefaultRuntime = load_or_warn_scaffold(&paths);
             let addr = runtime.config.server.listen;
             match action {
                 AgentsAction::List => cli::agents::run_list(&keys_dir, addr)?,
@@ -316,8 +315,7 @@ async fn run_cli(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             return Ok(());
         }
         Some(Command::Tools { action }) => {
-            let runtime: DefaultRuntime = DefaultRuntime::load(paths.clone())
-                .unwrap_or_else(|_| DefaultRuntime::scaffold(paths.clone()));
+            let runtime: DefaultRuntime = load_or_warn_scaffold(&paths);
             let addr = runtime.config.server.listen;
             match action {
                 ToolsAction::List => cli::tools::run_list(&keys_dir, addr)?,
@@ -341,8 +339,7 @@ async fn run_cli(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
         Some(Command::Route { action }) => {
             // Route commands talk to a running daemon, so we only need the
             // config to know the listen address.
-            let runtime: DefaultRuntime = DefaultRuntime::load(paths.clone())
-                .unwrap_or_else(|_| DefaultRuntime::scaffold(paths.clone()));
+            let runtime: DefaultRuntime = load_or_warn_scaffold(&paths);
             let addr = runtime.config.server.listen;
             match action {
                 RouteAction::List => cli::route::run_list(&keys_dir, addr)?,
@@ -373,8 +370,7 @@ async fn run_cli(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
         init_tracing();
     }
 
-    let mut runtime: DefaultRuntime = DefaultRuntime::load(paths.clone())
-        .unwrap_or_else(|_| DefaultRuntime::scaffold(paths.clone()));
+    let mut runtime: DefaultRuntime = load_or_warn_scaffold(&paths);
 
     // ── First-run guidance ────────────────────────────────────────
     // On serve/start, if onboarding hasn't been completed, print a message
@@ -402,8 +398,7 @@ async fn run_cli(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             match init::run_init(&paths) {
                 Ok(init::InitOutcome::Configured) => {
                     // Reload runtime with the newly written config
-                    runtime = DefaultRuntime::load(paths.clone())
-                        .unwrap_or_else(|_| DefaultRuntime::scaffold(paths.clone()));
+                    runtime = load_or_warn_scaffold(&paths);
                 }
                 Ok(init::InitOutcome::Cancelled) => {
                     // User cancelled — fall through to TUI with empty state
@@ -495,6 +490,25 @@ async fn run_cli(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
     }
 
     Ok(())
+}
+
+/// Load config from disk, warning on stderr if the file exists but fails to
+/// parse (and falling back to scaffold defaults).
+fn load_or_warn_scaffold(paths: &RuntimePaths) -> DefaultRuntime {
+    match DefaultRuntime::load(paths.clone()) {
+        Ok(rt) => rt,
+        Err(e) => {
+            if paths.config_file.exists() {
+                eprintln!(
+                    "warning: failed to parse {}: {e}",
+                    paths.config_file.display()
+                );
+                eprintln!("         falling back to default configuration");
+                eprintln!();
+            }
+            DefaultRuntime::scaffold(paths.clone())
+        }
+    }
 }
 
 fn print_first_run_guidance(runtime: &DefaultRuntime) {


### PR DESCRIPTION
## Summary

- **Fix silent config fallback**: When `bitrouter.yaml` had any deserialization error, `DefaultRuntime::load().unwrap_or_else(|_| scaffold())` silently discarded the error and started with empty defaults — zero `mcp_servers`, zero `a2a_agents`. Now `load_or_warn_scaffold()` prints the parse error to stderr before falling back.
- **Support flat MCP config format**: `ToolServerConfig` now accepts both the nested `transport: { type: stdio, ... }` format and the common flat format where `command`/`args` (stdio) or `url` (http) are top-level keys — matching the format users see in Claude Desktop and MCP docs.
- **Add tests**: 4 unit tests for flat/nested deserialization in `upstream.rs` + 2 config-level YAML parsing tests in `config.rs`.

Closes #156
Closes #157

## Test plan

- [x] `cargo test --workspace` — all 576 tests pass (including 6 new ones)
- [x] `cargo clippy` — clean
- [x] `cargo fmt -- --check` — clean
- [ ] Manual: configure `mcp_servers` with flat format (`command: npx`), verify server starts with N > 0 upstreams
- [ ] Manual: configure `a2a_agents`, verify "A2A gateway started" appears
- [ ] Manual: introduce a YAML typo, verify warning is printed to stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)