### PR TITLE
chore(gitignore): add .keys/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ run
 
 # Temporary directory
 temp
+
+# Keys
+.keys/


### PR DESCRIPTION
## Summary
- Add `.keys/` to `.gitignore` to prevent key files from being committed

## Test plan
- [x] Verify `.keys/` directory is ignored by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)