### PR TITLE
feat(solana-mpp): make session challenge asset configurable

### DIFF
--- a/bitrouter-api/src/mpp/state.rs
+++ b/bitrouter-api/src/mpp/state.rs
@@ -40,7 +40,7 @@ enum MppBackend {
 struct SolanaState {
     realm: String,
     secret_key: String,
-    currency: String,
+    asset: bitrouter_config::config::SolanaAssetConfig,
     recipient: String,
     session_method: super::solana_session_method::SolanaSessionMethod,
 }
@@ -178,14 +178,12 @@ impl MppState {
         };
         let session_method = SolanaSessionMethod::new(store, config);
 
-        let currency = "SOL".to_string();
-
         self.backends.insert(
             "solana".to_string(),
             MppBackend::Solana(SolanaState {
                 realm: self.realm.clone(),
                 secret_key,
-                currency,
+                asset: solana.asset.clone(),
                 recipient: solana.recipient.clone(),
                 session_method,
             }),
@@ -426,10 +424,10 @@ fn solana_session_challenge(
 
     let request = SolanaSessionChallengeRequest {
         asset: SolanaAsset {
-            kind: "sol".to_string(),
-            decimals: 9,
-            mint: None,
-            symbol: Some(state.currency.clone()),
+            kind: state.asset.kind.clone(),
+            decimals: state.asset.decimals,
+            mint: state.asset.mint.clone(),
+            symbol: state.asset.symbol.clone(),
         },
         channel_program: config.channel_program.clone(),
         network: Some(config.network.clone()),

--- a/bitrouter-config/src/config.rs
+++ b/bitrouter-config/src/config.rs
@@ -433,6 +433,53 @@ pub struct SolanaMppConfig {
     /// Solana network name (e.g., "mainnet-beta", "devnet").
     #[serde(default = "default_solana_network")]
     pub network: String,
+
+    /// Payment asset configuration. Defaults to native SOL.
+    #[serde(default)]
+    pub asset: SolanaAssetConfig,
+}
+
+/// Payment asset descriptor for Solana MPP.
+#[cfg(feature = "mpp-solana")]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SolanaAssetConfig {
+    /// Asset kind: `"sol"` for native SOL, `"spl"` for an SPL token.
+    #[serde(default = "default_solana_asset_kind")]
+    pub kind: String,
+
+    /// Decimal precision (9 for SOL, 6 for USDC).
+    #[serde(default = "default_solana_asset_decimals")]
+    pub decimals: u8,
+
+    /// SPL token mint address. Required when `kind` is `"spl"`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mint: Option<String>,
+
+    /// Display symbol (e.g. `"SOL"`, `"USDC"`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub symbol: Option<String>,
+}
+
+#[cfg(feature = "mpp-solana")]
+impl Default for SolanaAssetConfig {
+    fn default() -> Self {
+        Self {
+            kind: default_solana_asset_kind(),
+            decimals: default_solana_asset_decimals(),
+            mint: None,
+            symbol: None,
+        }
+    }
+}
+
+#[cfg(feature = "mpp-solana")]
+fn default_solana_asset_kind() -> String {
+    "sol".into()
+}
+
+#[cfg(feature = "mpp-solana")]
+fn default_solana_asset_decimals() -> u8 {
+    9
 }
 
 #[cfg(feature = "mpp-solana")]


### PR DESCRIPTION
Replace hardcoded SOL asset in Solana session challenges with a configurable `SolanaAssetConfig` on `SolanaMppConfig`. Defaults to native SOL (kind=sol, decimals=9) for backward compatibility.

**Changes:**
- `bitrouter-config`: Add `SolanaAssetConfig` struct with `kind`, `decimals`, `mint`, `symbol` fields (defaults to SOL)
- `bitrouter-config`: Add `asset: SolanaAssetConfig` field to `SolanaMppConfig`
- `bitrouter-api`: Replace hardcoded `currency: "SOL"` in `SolanaState` with `asset: SolanaAssetConfig`
- `bitrouter-api`: Use configured asset in `solana_session_challenge()` instead of hardcoded values

**Motivation:**
The Solana session challenge was hardcoded to emit `asset: { kind: "sol", decimals: 9 }`. This broke the `@solana/mpp` SDK's `SwigSessionAuthorizer` which uses `resolveOnChainSpendLimit()` to compare on-chain Swig role limits against the challenged asset type. For USDC payments, the server must now send `kind: "spl"` with the USDC mint address.

**Config example:**
```yaml
mpp:
  networks:
    solana:
      recipient: ${RECIPIENT_ADDRESS_SOLANA}
      channel_program: ${MPP_SOLANA_CHANNEL_PROGRAM}
      asset:
        kind: spl
        decimals: 6
        mint: EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
        symbol: USDC
```
