### PR TITLE
fix(solana-mpp): pass through open action to process request

### DIFF
--- a/bitrouter-api/src/mpp/solana_session_method.rs
+++ b/bitrouter-api/src/mpp/solana_session_method.rs
@@ -479,14 +479,16 @@ impl SessionMethodTrait for SolanaSessionMethod {
         credential: &PaymentCredential,
         _receipt: &Receipt,
     ) -> Option<serde_json::Value> {
-        // Management actions (open, topup, close) should short-circuit the
-        // normal request flow and return an empty response.
+        // Management actions (topup, close) short-circuit the normal request
+        // flow and return an empty response. "Open" falls through so the
+        // server processes the actual request after accepting the channel,
+        // matching the mppx client's single-retry 402 flow.
         let payload: SolanaSessionCredentialPayload = credential.payload_as().ok()?;
         match payload {
-            SolanaSessionCredentialPayload::Open { .. }
-            | SolanaSessionCredentialPayload::TopUp { .. }
+            SolanaSessionCredentialPayload::TopUp { .. }
             | SolanaSessionCredentialPayload::Close { .. } => Some(serde_json::json!(null)),
-            SolanaSessionCredentialPayload::Update { .. } => None,
+            SolanaSessionCredentialPayload::Open { .. }
+            | SolanaSessionCredentialPayload::Update { .. } => None,
         }
     }
 }


### PR DESCRIPTION
The `respond()` method in `SolanaSessionMethod` was returning a management response (`Some(json!(null))`) for channel "open" actions, causing the chat completion handler to short-circuit and return a `null` body instead of processing the actual request.

The mppx client performs a single 402 retry: it receives the challenge, creates a credential (which for new sessions is an "open" action), and expects the response to contain the actual resource. By making "open" fall through (returning `None` from `respond()`), the server now opens the channel AND processes the chat completion in a single round trip.

TopUp and Close remain management-only since they are standalone lifecycle actions that don't carry a user request.
