### PR TITLE
fix(pricing): make pricing fields Optional instead of defaulting to zero

### DIFF
--- a/bitrouter-api/src/mpp/pricing.rs
+++ b/bitrouter-api/src/mpp/pricing.rs
@@ -45,12 +45,12 @@ pub fn calculate_usage_cost(usage: &LanguageModelUsage, pricing: &ModelPricing) 
             let no_cache = usage.input_tokens.no_cache.unwrap_or(0) as f64;
             let cache_read = usage.input_tokens.cache_read.unwrap_or(0) as f64;
             let cache_write = usage.input_tokens.cache_write.unwrap_or(0) as f64;
-            (no_cache * pricing.input_tokens.no_cache
-                + cache_read * pricing.input_tokens.cache_read
-                + cache_write * pricing.input_tokens.cache_write)
+            (no_cache * pricing.input_tokens.no_cache.unwrap_or(0.0)
+                + cache_read * pricing.input_tokens.cache_read.unwrap_or(0.0)
+                + cache_write * pricing.input_tokens.cache_write.unwrap_or(0.0))
                 / PER_MILLION
         } else if let Some(total) = usage.input_tokens.total {
-            total as f64 * pricing.input_tokens.no_cache / PER_MILLION
+            total as f64 * pricing.input_tokens.no_cache.unwrap_or(0.0) / PER_MILLION
         } else {
             0.0
         }
@@ -63,10 +63,11 @@ pub fn calculate_usage_cost(usage: &LanguageModelUsage, pricing: &ModelPricing) 
         if has_granular {
             let text = usage.output_tokens.text.unwrap_or(0) as f64;
             let reasoning = usage.output_tokens.reasoning.unwrap_or(0) as f64;
-            (text * pricing.output_tokens.text + reasoning * pricing.output_tokens.reasoning)
+            (text * pricing.output_tokens.text.unwrap_or(0.0)
+                + reasoning * pricing.output_tokens.reasoning.unwrap_or(0.0))
                 / PER_MILLION
         } else if let Some(total) = usage.output_tokens.total {
-            total as f64 * pricing.output_tokens.text / PER_MILLION
+            total as f64 * pricing.output_tokens.text.unwrap_or(0.0) / PER_MILLION
         } else {
             0.0
         }

--- a/bitrouter-api/src/router/anthropic/messages/filters.rs
+++ b/bitrouter-api/src/router/anthropic/messages/filters.rs
@@ -232,7 +232,9 @@ where
             tokio::sync::mpsc::channel::<Result<warp::sse::Event, std::convert::Infallible>>(32);
 
         let pricing = table.model_pricing(&provider_name, &target_model_id);
-        let tick_cost = crate::mpp::cost_to_micro_units(pricing.output_tokens.text / 1_000_000.0);
+        let tick_cost = crate::mpp::cost_to_micro_units(
+            pricing.output_tokens.text.unwrap_or(0.0) / 1_000_000.0,
+        );
 
         let metered = crate::mpp::metered_sse::MeteredSseContext {
             mpp_state: mpp_state.clone(),

--- a/bitrouter-api/src/router/google/generate_content/filters.rs
+++ b/bitrouter-api/src/router/google/generate_content/filters.rs
@@ -264,7 +264,9 @@ where
             tokio::sync::mpsc::channel::<Result<warp::sse::Event, std::convert::Infallible>>(32);
 
         let pricing = table.model_pricing(&provider_name, &target_model_id);
-        let tick_cost = crate::mpp::cost_to_micro_units(pricing.output_tokens.text / 1_000_000.0);
+        let tick_cost = crate::mpp::cost_to_micro_units(
+            pricing.output_tokens.text.unwrap_or(0.0) / 1_000_000.0,
+        );
 
         let metered = crate::mpp::metered_sse::MeteredSseContext {
             mpp_state: mpp_state.clone(),

--- a/bitrouter-api/src/router/openai/chat/filters.rs
+++ b/bitrouter-api/src/router/openai/chat/filters.rs
@@ -214,7 +214,9 @@ where
             tokio::sync::mpsc::channel::<Result<warp::sse::Event, std::convert::Infallible>>(32);
 
         let pricing = table.model_pricing(&provider_name, &target_model_id);
-        let tick_cost = crate::mpp::cost_to_micro_units(pricing.output_tokens.text / 1_000_000.0);
+        let tick_cost = crate::mpp::cost_to_micro_units(
+            pricing.output_tokens.text.unwrap_or(0.0) / 1_000_000.0,
+        );
 
         let metered = crate::mpp::metered_sse::MeteredSseContext {
             mpp_state: mpp_state.clone(),

--- a/bitrouter-api/src/router/openai/responses/filters.rs
+++ b/bitrouter-api/src/router/openai/responses/filters.rs
@@ -232,7 +232,9 @@ where
             tokio::sync::mpsc::channel::<Result<warp::sse::Event, std::convert::Infallible>>(32);
 
         let pricing = table.model_pricing(&provider_name, &target_model_id);
-        let tick_cost = crate::mpp::cost_to_micro_units(pricing.output_tokens.text / 1_000_000.0);
+        let tick_cost = crate::mpp::cost_to_micro_units(
+            pricing.output_tokens.text.unwrap_or(0.0) / 1_000_000.0,
+        );
 
         let metered = crate::mpp::metered_sse::MeteredSseContext {
             mpp_state: mpp_state.clone(),

--- a/bitrouter-config/src/config.rs
+++ b/bitrouter-config/src/config.rs
@@ -322,7 +322,7 @@ pub struct ModelInfo {
 ///
 /// Field names mirror the sub-category fields of `LanguageModelInputTokens`
 /// and `LanguageModelOutputTokens` from `bitrouter-core` for cross-provider
-/// compatibility. Defaults to `0.0` for all fields.
+/// compatibility. Fields are `None` when not configured.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ModelPricing {
     #[serde(default)]
@@ -336,13 +336,13 @@ pub struct ModelPricing {
 pub struct InputTokenPricing {
     /// Cost per million non-cached input tokens.
     #[serde(default)]
-    pub no_cache: f64,
+    pub no_cache: Option<f64>,
     /// Cost per million cache-read input tokens.
     #[serde(default)]
-    pub cache_read: f64,
+    pub cache_read: Option<f64>,
     /// Cost per million cache-write input tokens.
     #[serde(default)]
-    pub cache_write: f64,
+    pub cache_write: Option<f64>,
 }
 
 /// Output token pricing per million tokens.
@@ -350,10 +350,10 @@ pub struct InputTokenPricing {
 pub struct OutputTokenPricing {
     /// Cost per million text output tokens.
     #[serde(default)]
-    pub text: f64,
+    pub text: Option<f64>,
     /// Cost per million reasoning output tokens.
     #[serde(default)]
-    pub reasoning: f64,
+    pub reasoning: Option<f64>,
 }
 
 // ── MPP (Machine Payment Protocol) configuration ─────────────────────
@@ -708,12 +708,12 @@ providers:
             gpt4o.input_modalities,
             vec![Modality::Text, Modality::Image]
         );
-        assert_eq!(gpt4o.pricing.input_tokens.no_cache, 2.50);
-        assert_eq!(gpt4o.pricing.output_tokens.text, 10.00);
+        assert_eq!(gpt4o.pricing.input_tokens.no_cache, Some(2.50));
+        assert_eq!(gpt4o.pricing.output_tokens.text, Some(10.00));
 
         let mini = &models["gpt-4o-mini"];
         assert_eq!(mini.name.as_deref(), Some("GPT-4o Mini"));
-        assert_eq!(mini.pricing.input_tokens.no_cache, 0.0); // default
+        assert_eq!(mini.pricing.input_tokens.no_cache, None); // default
     }
 
     #[test]

--- a/bitrouter-config/src/routing.rs
+++ b/bitrouter-config/src/routing.rs
@@ -204,6 +204,11 @@ impl ModelRegistry for ConfigRoutingTable {
                     .map(|ep| ep.provider.clone())
                     .collect();
                 let pricing = convert_pricing(&model_config.pricing);
+                let pricing = if pricing.is_empty() {
+                    None
+                } else {
+                    Some(pricing)
+                };
                 ModelEntry {
                     id: model_name.clone(),
                     providers,
@@ -221,7 +226,7 @@ impl ModelRegistry for ConfigRoutingTable {
                         .iter()
                         .map(|m| m.to_string())
                         .collect(),
-                    pricing: Some(pricing),
+                    pricing,
                 }
             })
             .collect();
@@ -433,13 +438,13 @@ mod tests {
             ModelInfo {
                 pricing: ModelPricing {
                     input_tokens: InputTokenPricing {
-                        no_cache: 2.50,
-                        cache_read: 1.25,
-                        cache_write: 2.50,
+                        no_cache: Some(2.50),
+                        cache_read: Some(1.25),
+                        cache_write: Some(2.50),
                     },
                     output_tokens: OutputTokenPricing {
-                        text: 10.00,
-                        reasoning: 10.00,
+                        text: Some(10.00),
+                        reasoning: Some(10.00),
                     },
                 },
                 ..Default::default()
@@ -448,24 +453,24 @@ mod tests {
         let table = ConfigRoutingTable::new(providers, HashMap::new());
 
         let pricing = table.model_pricing("openai", "gpt-4o");
-        assert_eq!(pricing.input_tokens.no_cache, 2.50);
-        assert_eq!(pricing.input_tokens.cache_read, 1.25);
-        assert_eq!(pricing.output_tokens.text, 10.00);
+        assert_eq!(pricing.input_tokens.no_cache, Some(2.50));
+        assert_eq!(pricing.input_tokens.cache_read, Some(1.25));
+        assert_eq!(pricing.output_tokens.text, Some(10.00));
     }
 
     #[test]
-    fn model_pricing_unknown_model_returns_zeros() {
+    fn model_pricing_unknown_model_returns_defaults() {
         let table = ConfigRoutingTable::new(test_providers(), HashMap::new());
         let pricing = table.model_pricing("openai", "nonexistent");
-        assert_eq!(pricing.input_tokens.no_cache, 0.0);
-        assert_eq!(pricing.output_tokens.text, 0.0);
+        assert_eq!(pricing.input_tokens.no_cache, None);
+        assert_eq!(pricing.output_tokens.text, None);
     }
 
     #[test]
-    fn model_pricing_unknown_provider_returns_zeros() {
+    fn model_pricing_unknown_provider_returns_defaults() {
         let table = ConfigRoutingTable::new(test_providers(), HashMap::new());
         let pricing = table.model_pricing("unknown-provider", "gpt-4o");
-        assert_eq!(pricing.input_tokens.no_cache, 0.0);
+        assert_eq!(pricing.input_tokens.no_cache, None);
     }
 
     #[test]

--- a/bitrouter-core/src/routers/routing_table.rs
+++ b/bitrouter-core/src/routers/routing_table.rs
@@ -25,27 +25,53 @@ pub struct RouteEntry {
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct InputTokenPricing {
     /// Cost per million non-cached input tokens.
-    pub no_cache: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub no_cache: Option<f64>,
     /// Cost per million cache-read input tokens.
-    pub cache_read: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_read: Option<f64>,
     /// Cost per million cache-write input tokens.
-    pub cache_write: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_write: Option<f64>,
+}
+
+impl InputTokenPricing {
+    fn is_empty(&self) -> bool {
+        self.no_cache.is_none() && self.cache_read.is_none() && self.cache_write.is_none()
+    }
 }
 
 /// Output token pricing per million tokens.
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct OutputTokenPricing {
     /// Cost per million text output tokens.
-    pub text: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text: Option<f64>,
     /// Cost per million reasoning output tokens.
-    pub reasoning: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning: Option<f64>,
+}
+
+impl OutputTokenPricing {
+    fn is_empty(&self) -> bool {
+        self.text.is_none() && self.reasoning.is_none()
+    }
 }
 
 /// Token pricing per million tokens for a model.
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct ModelPricing {
+    #[serde(skip_serializing_if = "InputTokenPricing::is_empty")]
     pub input_tokens: InputTokenPricing,
+    #[serde(skip_serializing_if = "OutputTokenPricing::is_empty")]
     pub output_tokens: OutputTokenPricing,
+}
+
+impl ModelPricing {
+    /// Returns `true` when no pricing data is set.
+    pub fn is_empty(&self) -> bool {
+        self.input_tokens.is_empty() && self.output_tokens.is_empty()
+    }
 }
 
 /// A routing table that maps incoming model names to routing targets (provider + model ID).

--- a/bitrouter/src/runtime/server.rs
+++ b/bitrouter/src/runtime/server.rs
@@ -114,11 +114,11 @@ where
                 .cloned()
                 .unwrap_or_default();
             Pricing {
-                input_no_cache: mp.input_tokens.no_cache,
-                input_cache_read: mp.input_tokens.cache_read,
-                input_cache_write: mp.input_tokens.cache_write,
-                output_text: mp.output_tokens.text,
-                output_reasoning: mp.output_tokens.reasoning,
+                input_no_cache: mp.input_tokens.no_cache.unwrap_or(0.0),
+                input_cache_read: mp.input_tokens.cache_read.unwrap_or(0.0),
+                input_cache_write: mp.input_tokens.cache_write.unwrap_or(0.0),
+                output_text: mp.output_tokens.text.unwrap_or(0.0),
+                output_reasoning: mp.output_tokens.reasoning.unwrap_or(0.0),
             }
         };
 


### PR DESCRIPTION
Make all pricing `f64` fields `Option<f64>` across the codebase to correctly distinguish between "price is zero" (`Some(0.0)`) and "price is not configured" (`None`). This is a breaking change.

Changes:
- **bitrouter-core**: `InputTokenPricing` (`no_cache`, `cache_read`, `cache_write`) and `OutputTokenPricing` (`text`, `reasoning`) changed from `f64` to `Option<f64>` with `skip_serializing_if = "Option::is_none"`. Added `skip_serializing_if` on empty sub-structs in `ModelPricing`.
- **bitrouter-config**: Config-layer pricing structs updated to `Option<f64>` with `#[serde(default)]`. Set pricing to `None` when all fields are empty in `list_models()`.
- **bitrouter-api**: Updated `calculate_usage_cost()` and 4 provider filter files (`openai/chat`, `openai/responses`, `anthropic/messages`, `google/generate_content`) to use `.unwrap_or(0.0)` on pricing fields.
- **bitrouter/runtime/server.rs**: Updated `Pricing` struct construction with `.unwrap_or(0.0)` fallbacks.
- **Tests**: Updated all pricing assertions to use `Some(value)` / `None`.

Before: `{"no_cache": 0.2, "cache_read": 0, "cache_write": 0}`
After: `{"no_cache": 0.2}`

All 579+ tests pass.

<!-- START COPILOT CODING AGENT TIPS -->
---

🔒 GitHub Advanced Security automatically protects Copilot coding agent pull requests. You can protect all pull requests by enabling Advanced Security for your repositories. [Learn more about Advanced Security.](https://gh.io/cca-advanced-security)