### PR TITLE
fix(mpp): add suggested_deposit to Solana session challenges

### DIFF
--- a/bitrouter-api/src/mpp/state.rs
+++ b/bitrouter-api/src/mpp/state.rs
@@ -43,6 +43,7 @@ struct SolanaState {
     asset: bitrouter_config::config::SolanaAssetConfig,
     recipient: String,
     session_method: super::solana_session_method::SolanaSessionMethod,
+    suggested_deposit: Option<String>,
 }
 
 impl MppState {
@@ -186,6 +187,7 @@ impl MppState {
                 asset: solana.asset.clone(),
                 recipient: solana.recipient.clone(),
                 session_method,
+                suggested_deposit: solana.suggested_deposit.clone(),
             }),
         );
         Ok(())
@@ -422,6 +424,11 @@ fn solana_session_challenge(
 
     let config = state.session_method.config();
 
+    let deposit = options
+        .suggested_deposit
+        .map(|d| d.to_string())
+        .or_else(|| state.suggested_deposit.clone());
+
     let request = SolanaSessionChallengeRequest {
         asset: SolanaAsset {
             kind: state.asset.kind.clone(),
@@ -432,8 +439,8 @@ fn solana_session_challenge(
         channel_program: config.channel_program.clone(),
         network: Some(config.network.clone()),
         recipient: state.recipient.clone(),
-        session_defaults: options.suggested_deposit.map(|d| SolanaSessionDefaults {
-            suggested_deposit: Some(d.to_string()),
+        session_defaults: deposit.map(|d| SolanaSessionDefaults {
+            suggested_deposit: Some(d),
         }),
     };
 

--- a/bitrouter-config/src/config.rs
+++ b/bitrouter-config/src/config.rs
@@ -437,6 +437,12 @@ pub struct SolanaMppConfig {
     /// Payment asset configuration. Defaults to native SOL.
     #[serde(default)]
     pub asset: SolanaAssetConfig,
+
+    /// Default deposit amount (in base units) suggested to clients when
+    /// opening a session channel. Included in the 402 challenge as
+    /// `sessionDefaults.suggestedDeposit`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub suggested_deposit: Option<String>,
 }
 
 /// Payment asset descriptor for Solana MPP.


### PR DESCRIPTION
## Problem

The server's 402 session challenges don't include `sessionDefaults.suggestedDeposit`. The mppx client defaults to depositing `'0'` into the session channel when this field is absent, making post-use deductions always fail with `insufficient_balance`.

This means:
- Non-streaming requests succeed (deduction failure is only a warning), but the server never actually charges
- Streaming requests fail immediately because per-chunk deductions have zero available balance

## Fix

Add an optional `suggested_deposit` field to `SolanaMppConfig`:

```yaml
mpp:
  networks:
    solana:
      suggested_deposit: "100000"  # 0.10 USDC
```

When set, the server includes it in the 402 challenge's `sessionDefaults.suggestedDeposit`, so clients know how much to escrow when opening a session channel.

The challenge-level `options.suggested_deposit` (if provided by a caller) takes priority over the config default.

## Changes

- **bitrouter-config**: Add `suggested_deposit: Option<String>` to `SolanaMppConfig`
- **bitrouter-api**: Store it in `SolanaState`, use as fallback in `solana_session_challenge()`
