### PR TITLE
fix(rejection): handle BitrouterRejection in recover handler

### DIFF
--- a/bitrouter-api/src/error.rs
+++ b/bitrouter-api/src/error.rs
@@ -35,3 +35,71 @@ impl fmt::Display for BadRequest {
 
 #[cfg(feature = "openai")]
 impl Reject for BadRequest {}
+
+/// Converts a [`BitrouterRejection`] or [`BadRequest`] warp rejection into a
+/// structured JSON error response.
+///
+/// Returns `Some(response)` if the rejection matches, `None` otherwise —
+/// allowing callers to fall through to other rejection handling.
+#[cfg(any(feature = "openai", feature = "anthropic", feature = "google"))]
+pub fn handle_bitrouter_rejection(err: &warp::Rejection) -> Option<warp::http::Response<String>> {
+    use warp::http::StatusCode;
+
+    if let Some(e) = err.find::<BitrouterRejection>() {
+        let (status, error_type) = match &e.0 {
+            BitrouterError::InvalidRequest { .. } | BitrouterError::UnsupportedFeature { .. } => {
+                (StatusCode::BAD_REQUEST, "invalid_request_error")
+            }
+            BitrouterError::AccessDenied { .. } => (StatusCode::FORBIDDEN, "access_denied"),
+            BitrouterError::Cancelled { .. } => (StatusCode::BAD_REQUEST, "cancelled"),
+            BitrouterError::Provider { context, .. } => {
+                let status = context
+                    .status_code
+                    .and_then(|code| StatusCode::from_u16(code).ok())
+                    .unwrap_or(StatusCode::BAD_GATEWAY);
+                (status, "provider_error")
+            }
+            BitrouterError::Transport { .. }
+            | BitrouterError::ResponseDecode { .. }
+            | BitrouterError::InvalidResponse { .. }
+            | BitrouterError::StreamProtocol { .. } => (StatusCode::BAD_GATEWAY, "upstream_error"),
+        };
+
+        let body = serde_json::json!({
+            "error": {
+                "message": e.0.to_string(),
+                "type": error_type,
+            }
+        })
+        .to_string();
+
+        let response = warp::http::Response::builder()
+            .status(status)
+            .header("content-type", "application/json")
+            .body(body)
+            .ok()?;
+
+        return Some(response);
+    }
+
+    #[cfg(feature = "openai")]
+    if let Some(e) = err.find::<BadRequest>() {
+        let body = serde_json::json!({
+            "error": {
+                "message": e.to_string(),
+                "type": "invalid_request_error",
+            }
+        })
+        .to_string();
+
+        let response = warp::http::Response::builder()
+            .status(StatusCode::BAD_REQUEST)
+            .header("content-type", "application/json")
+            .body(body)
+            .ok()?;
+
+        return Some(response);
+    }
+
+    None
+}

--- a/bitrouter-api/src/lib.rs
+++ b/bitrouter-api/src/lib.rs
@@ -3,5 +3,5 @@ pub mod router;
 #[cfg(any(feature = "mpp-tempo", feature = "mpp-solana"))]
 pub mod mpp;
 
-mod error;
+pub mod error;
 mod util;

--- a/bitrouter/src/runtime/server.rs
+++ b/bitrouter/src/runtime/server.rs
@@ -723,6 +723,10 @@ async fn handle_auth_rejection(
         )) as Box<dyn warp::Reply>);
     }
 
+    if let Some(resp) = bitrouter_api::error::handle_bitrouter_rejection(&rejection) {
+        return Ok(Box::new(resp) as Box<dyn warp::Reply>);
+    }
+
     Err(rejection)
 }
 


### PR DESCRIPTION
Replace hardcoded SOL asset in Solana session challenges with a configurable `SolanaAssetConfig` on `SolanaMppConfig`. Defaults to native SOL (kind=sol, decimals=9) for backward compatibility.

**Changes:**

- `bitrouter-config`: Add `SolanaAssetConfig` struct with `kind`, `decimals`, `mint`, `symbol` fields (defaults to SOL)
- `bitrouter-config`: Add `asset: SolanaAssetConfig` field to `SolanaMppConfig`
- `bitrouter-api`: Replace hardcoded `currency: "SOL"` in `SolanaState` with `asset: SolanaAssetConfig`
- `bitrouter-api`: Use configured asset in `solana_session_challenge()` instead of hardcoded values

**Motivation:**
The Solana session challenge was hardcoded to emit `asset: { kind: "sol", decimals: 9 }`. This broke the `@solana/mpp` SDK's `SwigSessionAuthorizer` which uses `resolveOnChainSpendLimit()` to compare on-chain Swig role limits against the challenged asset type. For USDC payments, the server must now send `kind: "spl"` with the USDC mint address.

**Config example:**

```yaml
mpp:
  networks:
    solana:
      recipient: ${RECIPIENT_ADDRESS_SOLANA}
      channel_program: ${MPP_SOLANA_CHANNEL_PROGRAM}
      asset:
        kind: spl
        decimals: 6
        mint: EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
        symbol: USDC
```
