### PR TITLE
feat(api): add PaymentGate trait for pluggable payment verification

### DIFF
--- a/bitrouter-api/src/mpp/close_guard.rs
+++ b/bitrouter-api/src/mpp/close_guard.rs
@@ -1,27 +1,30 @@
 use std::sync::Arc;
 
-use super::state::MppState;
+use super::payment_gate::PaymentGate;
 
-/// RAII guard that closes a Tempo payment channel when dropped.
+/// RAII guard that closes a payment channel when dropped.
 ///
 /// Move this into the request handler's `tokio::spawn` block (streaming) or
 /// hold it in the handler scope (non-streaming). When the guard is dropped —
 /// whether due to success, error, or client disconnect — it spawns a detached
-/// tokio task that submits the on-chain `close()` transaction using the
-/// highest voucher the server received during the session.
+/// tokio task that calls [`PaymentGate::close_channel`].
 ///
 /// Close failures are logged but never propagate; the channel can be settled
 /// later if the close transaction fails.
 pub struct SessionCloseGuard {
-    mpp_state: Arc<MppState>,
+    payment_gate: Arc<dyn PaymentGate>,
     backend_key: String,
     channel_id: String,
 }
 
 impl SessionCloseGuard {
-    pub fn new(mpp_state: Arc<MppState>, backend_key: String, channel_id: String) -> Self {
+    pub fn new(
+        payment_gate: Arc<dyn PaymentGate>,
+        backend_key: String,
+        channel_id: String,
+    ) -> Self {
         Self {
-            mpp_state,
+            payment_gate,
             backend_key,
             channel_id,
         }
@@ -29,14 +32,13 @@ impl SessionCloseGuard {
 }
 
 impl Drop for SessionCloseGuard {
-    #[cfg(feature = "mpp-tempo")]
     fn drop(&mut self) {
-        let mpp_state = Arc::clone(&self.mpp_state);
+        let payment_gate = Arc::clone(&self.payment_gate);
         let backend_key = self.backend_key.clone();
         let channel_id = self.channel_id.clone();
 
         tokio::spawn(async move {
-            if let Err(e) = mpp_state.close_channel(&backend_key, &channel_id).await {
+            if let Err(e) = payment_gate.close_channel(&backend_key, &channel_id).await {
                 tracing::warn!(
                     channel_id = %channel_id,
                     error = %e,
@@ -44,11 +46,5 @@ impl Drop for SessionCloseGuard {
                 );
             }
         });
-    }
-
-    #[cfg(not(feature = "mpp-tempo"))]
-    fn drop(&mut self) {
-        // Channel close is only implemented for Tempo currently.
-        let _ = (&self.mpp_state, &self.backend_key, &self.channel_id);
     }
 }

--- a/bitrouter-api/src/mpp/filter.rs
+++ b/bitrouter-api/src/mpp/filter.rs
@@ -55,12 +55,16 @@ pub fn mpp_payment_filter(
     warp::header::optional::<String>("authorization")
         .and(warp::any().map(move || state.clone()))
         .and(warp::any().map(move || chain.clone()))
-        .and_then(verify_payment)
+        .and_then(
+            |auth_header: Option<String>, state: Arc<MppState>, chain: Option<String>| async move {
+                verify_payment_impl(auth_header, &state, chain).await
+            },
+        )
 }
 
-async fn verify_payment(
+pub(crate) async fn verify_payment_impl(
     auth_header: Option<String>,
-    state: Arc<MppState>,
+    state: &MppState,
     chain: Option<String>,
 ) -> Result<MppPaymentContext, warp::Rejection> {
     // Check if the Authorization header contains a Payment credential.
@@ -154,7 +158,7 @@ pub async fn verify_mpp_payment(
     chain: Option<String>,
     auth_header: Option<String>,
 ) -> Result<MppPaymentContext, warp::Rejection> {
-    verify_payment(auth_header, state, chain).await
+    verify_payment_impl(auth_header, &state, chain).await
 }
 
 /// Converts MPP-related warp rejections into proper HTTP 402 responses.

--- a/bitrouter-api/src/mpp/metered_sse.rs
+++ b/bitrouter-api/src/mpp/metered_sse.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use mpp::server::sse::NeedVoucherEvent;
 use tokio::sync::mpsc;
 
-use super::MppState;
+use super::payment_gate::PaymentGate;
 
 /// Default poll interval when `wait_for_update` returns immediately.
 const DEFAULT_POLL_INTERVAL_MS: u64 = 100;
@@ -25,7 +25,7 @@ const MAX_NEED_VOUCHER_RETRIES: u32 = 60;
 /// costs from the payment channel and emit `payment-need-voucher` events
 /// when the balance is exhausted.
 pub struct MeteredSseContext {
-    pub mpp_state: Arc<MppState>,
+    pub payment_gate: Arc<dyn PaymentGate>,
     pub backend_key: String,
     pub channel_id: String,
     pub tick_cost: u128,
@@ -48,7 +48,7 @@ impl MeteredSseContext {
 
         for _ in 0..MAX_NEED_VOUCHER_RETRIES {
             match self
-                .mpp_state
+                .payment_gate
                 .deduct(&self.backend_key, &self.channel_id, self.tick_cost)
                 .await
             {
@@ -56,7 +56,7 @@ impl MeteredSseContext {
                 Err(_) => {
                     // Emit need-voucher event.
                     if let Some((settled, authorized, deposit)) = self
-                        .mpp_state
+                        .payment_gate
                         .channel_balance(&self.backend_key, &self.channel_id)
                         .await
                     {
@@ -76,7 +76,7 @@ impl MeteredSseContext {
 
                     // Wait for channel update or poll interval.
                     tokio::select! {
-                        () = self.mpp_state.wait_for_update(&self.backend_key, &self.channel_id) => {},
+                        () = self.payment_gate.wait_for_update(&self.backend_key, &self.channel_id) => {},
                         () = tokio::time::sleep(tokio::time::Duration::from_millis(DEFAULT_POLL_INTERVAL_MS)) => {},
                     }
                 }

--- a/bitrouter-api/src/mpp/mod.rs
+++ b/bitrouter-api/src/mpp/mod.rs
@@ -1,6 +1,7 @@
 mod close_guard;
 mod filter;
 pub mod metered_sse;
+mod payment_gate;
 mod pricing;
 mod state;
 
@@ -18,5 +19,6 @@ pub use filter::{
     MppChallenge, MppPaymentContext, MppVerificationFailed, handle_mpp_rejection,
     mpp_payment_filter, verify_mpp_payment,
 };
+pub use payment_gate::PaymentGate;
 pub use pricing::{PricingLookup, calculate_usage_cost, cost_to_micro_units};
 pub use state::MppState;

--- a/bitrouter-api/src/mpp/payment_gate.rs
+++ b/bitrouter-api/src/mpp/payment_gate.rs
@@ -1,0 +1,116 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use super::filter::MppPaymentContext;
+
+/// Pinned boxed future used as the return type for [`PaymentGate`] methods.
+type GateFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+/// Trait abstracting payment verification and settlement for MPP handlers.
+///
+/// Allows downstream crates to provide custom payment logic (e.g. charge-based
+/// balance management) while reusing the routing filters and handlers from
+/// `bitrouter-api`.
+///
+/// [`super::MppState`] provides the default implementation that delegates to
+/// configured Tempo / Solana session backends.
+pub trait PaymentGate: Send + Sync {
+    /// Verify payment before request processing.
+    ///
+    /// `chain` is the CAIP-2 chain identifier from the caller's JWT claims.
+    /// `auth_header` is the raw `Authorization` header value.
+    ///
+    /// Returns [`MppPaymentContext`] on success. If no valid credential is
+    /// present, rejects with a [`super::MppChallenge`] (402 Payment Required).
+    fn verify_payment(
+        &self,
+        chain: Option<String>,
+        auth_header: Option<String>,
+    ) -> GateFuture<'_, Result<MppPaymentContext, warp::Rejection>>;
+
+    /// Deduct `amount` micro-units from the channel in the specified backend.
+    ///
+    /// For session-based flows this debits from the payment channel store.
+    /// Custom implementations may debit from a centralized balance instead.
+    fn deduct<'a>(
+        &'a self,
+        backend_key: &'a str,
+        channel_id: &'a str,
+        amount: u128,
+    ) -> GateFuture<'a, Result<(), mpp::server::VerificationError>>;
+
+    /// Wait for the next channel update on the given backend.
+    ///
+    /// Used by metered SSE to pause until a new voucher arrives (or balance
+    /// is replenished).
+    fn wait_for_update<'a>(
+        &'a self,
+        backend_key: &'a str,
+        channel_id: &'a str,
+    ) -> GateFuture<'a, ()>;
+
+    /// Retrieve channel balance info for the NeedVoucher event.
+    ///
+    /// Returns `(settled, authorized, deposit)` in micro-units, or `None`
+    /// if the channel is not found.
+    fn channel_balance<'a>(
+        &'a self,
+        backend_key: &'a str,
+        channel_id: &'a str,
+    ) -> GateFuture<'a, Option<(u128, u128, u128)>>;
+
+    /// Close a payment channel.
+    ///
+    /// For Tempo, this submits an on-chain close transaction. Custom
+    /// implementations may no-op if there is no channel to close.
+    fn close_channel<'a>(
+        &'a self,
+        backend_key: &'a str,
+        channel_id: &'a str,
+    ) -> GateFuture<'a, Result<(), String>>;
+}
+
+/// Blanket implementation: `Arc<dyn PaymentGate>` itself implements `PaymentGate`.
+impl PaymentGate for Arc<dyn PaymentGate> {
+    fn verify_payment(
+        &self,
+        chain: Option<String>,
+        auth_header: Option<String>,
+    ) -> GateFuture<'_, Result<MppPaymentContext, warp::Rejection>> {
+        (**self).verify_payment(chain, auth_header)
+    }
+
+    fn deduct<'a>(
+        &'a self,
+        backend_key: &'a str,
+        channel_id: &'a str,
+        amount: u128,
+    ) -> GateFuture<'a, Result<(), mpp::server::VerificationError>> {
+        (**self).deduct(backend_key, channel_id, amount)
+    }
+
+    fn wait_for_update<'a>(
+        &'a self,
+        backend_key: &'a str,
+        channel_id: &'a str,
+    ) -> GateFuture<'a, ()> {
+        (**self).wait_for_update(backend_key, channel_id)
+    }
+
+    fn channel_balance<'a>(
+        &'a self,
+        backend_key: &'a str,
+        channel_id: &'a str,
+    ) -> GateFuture<'a, Option<(u128, u128, u128)>> {
+        (**self).channel_balance(backend_key, channel_id)
+    }
+
+    fn close_channel<'a>(
+        &'a self,
+        backend_key: &'a str,
+        channel_id: &'a str,
+    ) -> GateFuture<'a, Result<(), String>> {
+        (**self).close_channel(backend_key, channel_id)
+    }
+}

--- a/bitrouter-api/src/mpp/state.rs
+++ b/bitrouter-api/src/mpp/state.rs
@@ -616,6 +616,71 @@ impl MppState {
     }
 }
 
+impl super::payment_gate::PaymentGate for MppState {
+    fn verify_payment(
+        &self,
+        chain: Option<String>,
+        auth_header: Option<String>,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<
+                    Output = Result<super::filter::MppPaymentContext, warp::Rejection>,
+                > + Send
+                + '_,
+        >,
+    > {
+        Box::pin(super::filter::verify_payment_impl(auth_header, self, chain))
+    }
+
+    fn deduct<'a>(
+        &'a self,
+        backend_key: &'a str,
+        channel_id: &'a str,
+        amount: u128,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<Output = Result<(), mpp::server::VerificationError>>
+                + Send
+                + 'a,
+        >,
+    > {
+        Box::pin(self.deduct(backend_key, channel_id, amount))
+    }
+
+    fn wait_for_update<'a>(
+        &'a self,
+        backend_key: &'a str,
+        channel_id: &'a str,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + 'a>> {
+        Box::pin(self.wait_for_update(backend_key, channel_id))
+    }
+
+    fn channel_balance<'a>(
+        &'a self,
+        backend_key: &'a str,
+        channel_id: &'a str,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Option<(u128, u128, u128)>> + Send + 'a>>
+    {
+        Box::pin(self.channel_balance(backend_key, channel_id))
+    }
+
+    fn close_channel<'a>(
+        &'a self,
+        backend_key: &'a str,
+        channel_id: &'a str,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), String>> + Send + 'a>> {
+        #[cfg(feature = "mpp-tempo")]
+        {
+            Box::pin(self.close_channel(backend_key, channel_id))
+        }
+        #[cfg(not(feature = "mpp-tempo"))]
+        {
+            let _ = (backend_key, channel_id);
+            Box::pin(std::future::ready(Ok(())))
+        }
+    }
+}
+
 fn backend_session_challenge(
     backend: &MppBackend,
     amount: &str,

--- a/bitrouter-api/src/router/anthropic/messages/filters.rs
+++ b/bitrouter-api/src/router/anthropic/messages/filters.rs
@@ -176,9 +176,10 @@ where
     T: RoutingTable + crate::mpp::PricingLookup + Send + Sync + 'static,
     R: LanguageModelRouter + Send + Sync + 'static,
 {
-    let mpp_ctx =
-        crate::mpp::verify_mpp_payment(mpp_state.clone(), caller.chain.clone(), auth_header)
-            .await?;
+    let payment_gate: Arc<dyn crate::mpp::PaymentGate> = mpp_state;
+    let mpp_ctx = payment_gate
+        .verify_payment(caller.chain.clone(), auth_header)
+        .await?;
 
     if let Some(ref management) = mpp_ctx.management_response {
         let reply = warp::reply::json(management);
@@ -237,7 +238,7 @@ where
         );
 
         let metered = crate::mpp::metered_sse::MeteredSseContext {
-            mpp_state: mpp_state.clone(),
+            payment_gate: payment_gate.clone(),
             backend_key: mpp_ctx.backend_key.clone(),
             channel_id: mpp_ctx.channel_id.clone(),
             tick_cost,
@@ -339,7 +340,7 @@ where
                 let micro_units = crate::mpp::cost_to_micro_units(cost_usd);
 
                 if micro_units > 0
-                    && let Err(e) = mpp_state
+                    && let Err(e) = payment_gate
                         .deduct(&mpp_ctx.backend_key, &mpp_ctx.channel_id, micro_units)
                         .await
                 {

--- a/bitrouter-api/src/router/google/generate_content/filters.rs
+++ b/bitrouter-api/src/router/google/generate_content/filters.rs
@@ -209,9 +209,10 @@ where
     T: RoutingTable + crate::mpp::PricingLookup + Send + Sync + 'static,
     R: LanguageModelRouter + Send + Sync + 'static,
 {
-    let mpp_ctx =
-        crate::mpp::verify_mpp_payment(mpp_state.clone(), caller.chain.clone(), auth_header)
-            .await?;
+    let payment_gate: Arc<dyn crate::mpp::PaymentGate> = mpp_state;
+    let mpp_ctx = payment_gate
+        .verify_payment(caller.chain.clone(), auth_header)
+        .await?;
 
     if let Some(ref management) = mpp_ctx.management_response {
         let reply = warp::reply::json(management);
@@ -269,7 +270,7 @@ where
         );
 
         let metered = crate::mpp::metered_sse::MeteredSseContext {
-            mpp_state: mpp_state.clone(),
+            payment_gate: payment_gate.clone(),
             backend_key: mpp_ctx.backend_key.clone(),
             channel_id: mpp_ctx.channel_id.clone(),
             tick_cost,
@@ -363,7 +364,7 @@ where
                 let micro_units = crate::mpp::cost_to_micro_units(cost_usd);
 
                 if micro_units > 0
-                    && let Err(e) = mpp_state
+                    && let Err(e) = payment_gate
                         .deduct(&mpp_ctx.backend_key, &mpp_ctx.channel_id, micro_units)
                         .await
                 {

--- a/bitrouter-api/src/router/openai/chat/filters.rs
+++ b/bitrouter-api/src/router/openai/chat/filters.rs
@@ -155,9 +155,36 @@ where
     T: RoutingTable + crate::mpp::PricingLookup + Send + Sync + 'static,
     R: LanguageModelRouter + Send + Sync + 'static,
 {
-    let mpp_ctx =
-        crate::mpp::verify_mpp_payment(mpp_state.clone(), caller.chain.clone(), auth_header)
-            .await?;
+    let payment_gate: Arc<dyn crate::mpp::PaymentGate> = mpp_state;
+    handle_chat_completion_with_gate(
+        caller,
+        payment_gate,
+        auth_header,
+        request,
+        table,
+        router,
+        observer,
+    )
+    .await
+}
+
+#[cfg(any(feature = "mpp-tempo", feature = "mpp-solana"))]
+async fn handle_chat_completion_with_gate<T, R>(
+    caller: CallerContext,
+    payment_gate: Arc<dyn crate::mpp::PaymentGate>,
+    auth_header: Option<String>,
+    request: ChatCompletionRequest,
+    table: Arc<T>,
+    router: Arc<R>,
+    observer: Arc<dyn ObserveCallback>,
+) -> Result<Box<dyn warp::Reply>, warp::Rejection>
+where
+    T: RoutingTable + crate::mpp::PricingLookup + Send + Sync + 'static,
+    R: LanguageModelRouter + Send + Sync + 'static,
+{
+    let mpp_ctx = payment_gate
+        .verify_payment(caller.chain.clone(), auth_header)
+        .await?;
 
     // Management actions (channel open/topUp/close) short-circuit request processing.
     if let Some(ref management) = mpp_ctx.management_response {
@@ -175,7 +202,7 @@ where
     // Guard closes the payment channel on-chain when the request finishes.
     // Moved into the streaming task or dropped at handler scope end.
     let _close_guard = crate::mpp::SessionCloseGuard::new(
-        mpp_state.clone(),
+        payment_gate.clone(),
         mpp_ctx.backend_key.clone(),
         mpp_ctx.channel_id.clone(),
     );
@@ -227,7 +254,7 @@ where
         );
 
         let metered = crate::mpp::metered_sse::MeteredSseContext {
-            mpp_state: mpp_state.clone(),
+            payment_gate: payment_gate.clone(),
             backend_key: mpp_ctx.backend_key.clone(),
             channel_id: mpp_ctx.channel_id.clone(),
             tick_cost,
@@ -326,7 +353,7 @@ where
                 let micro_units = crate::mpp::cost_to_micro_units(cost_usd);
 
                 if micro_units > 0
-                    && let Err(e) = mpp_state
+                    && let Err(e) = payment_gate
                         .deduct(&mpp_ctx.backend_key, &mpp_ctx.channel_id, micro_units)
                         .await
                 {
@@ -409,6 +436,56 @@ where
         .and(warp::any().map(move || router.clone()))
         .and(warp::any().map(move || observer.clone()))
         .and_then(handle_chat_completion_with_mpp)
+}
+
+/// Creates a warp filter for `/v1/chat/completions` with a custom [`PaymentGate`].
+///
+/// Like [`chat_completions_filter_with_mpp`], but accepts any
+/// [`crate::mpp::PaymentGate`] implementation instead of requiring
+/// [`crate::mpp::MppState`] directly. This allows downstream crates to
+/// provide custom payment logic (e.g. charge-based balance management)
+/// while reusing the full routing, streaming, and observation pipeline.
+#[cfg(any(feature = "mpp-tempo", feature = "mpp-solana"))]
+pub fn chat_completions_filter_with_payment_gate<T, R, A>(
+    table: Arc<T>,
+    router: Arc<R>,
+    observer: Arc<dyn ObserveCallback>,
+    payment_gate: Arc<dyn crate::mpp::PaymentGate>,
+    account_filter: A,
+) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone
+where
+    T: RoutingTable + crate::mpp::PricingLookup + Send + Sync + 'static,
+    R: LanguageModelRouter + Send + Sync + 'static,
+    A: Filter<Extract = (CallerContext,), Error = warp::Rejection> + Clone + Send + Sync + 'static,
+{
+    warp::path!("v1" / "chat" / "completions")
+        .and(warp::post())
+        .and(account_filter)
+        .and(warp::any().map(move || payment_gate.clone()))
+        .and(warp::header::optional::<String>("authorization"))
+        .and(warp::body::json::<ChatCompletionRequest>())
+        .and(warp::any().map(move || table.clone()))
+        .and(warp::any().map(move || router.clone()))
+        .and(warp::any().map(move || observer.clone()))
+        .and_then(
+            |caller: CallerContext,
+             gate: Arc<dyn crate::mpp::PaymentGate>,
+             auth_header: Option<String>,
+             request: ChatCompletionRequest,
+             table: Arc<T>,
+             router: Arc<R>,
+             observer: Arc<dyn ObserveCallback>| {
+                handle_chat_completion_with_gate(
+                    caller,
+                    gate,
+                    auth_header,
+                    request,
+                    table,
+                    router,
+                    observer,
+                )
+            },
+        )
 }
 
 async fn handle_chat_completion_with_observe<T, R>(

--- a/bitrouter-api/src/router/openai/responses/filters.rs
+++ b/bitrouter-api/src/router/openai/responses/filters.rs
@@ -162,6 +162,54 @@ where
         .and_then(handle_responses_with_mpp)
 }
 
+/// Creates a warp filter for `/v1/responses` with a custom [`PaymentGate`].
+///
+/// Like [`responses_filter_with_mpp`], but accepts any
+/// [`crate::mpp::PaymentGate`] implementation instead of requiring
+/// [`crate::mpp::MppState`] directly.
+#[cfg(any(feature = "mpp-tempo", feature = "mpp-solana"))]
+pub fn responses_filter_with_payment_gate<T, R, A>(
+    table: Arc<T>,
+    router: Arc<R>,
+    observer: Arc<dyn ObserveCallback>,
+    payment_gate: Arc<dyn crate::mpp::PaymentGate>,
+    account_filter: A,
+) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone
+where
+    T: RoutingTable + crate::mpp::PricingLookup + Send + Sync + 'static,
+    R: LanguageModelRouter + Send + Sync + 'static,
+    A: Filter<Extract = (CallerContext,), Error = warp::Rejection> + Clone + Send + Sync + 'static,
+{
+    warp::path!("v1" / "responses")
+        .and(warp::post())
+        .and(account_filter)
+        .and(warp::any().map(move || payment_gate.clone()))
+        .and(warp::header::optional::<String>("authorization"))
+        .and(warp::body::json::<ResponsesRequest>())
+        .and(warp::any().map(move || table.clone()))
+        .and(warp::any().map(move || router.clone()))
+        .and(warp::any().map(move || observer.clone()))
+        .and_then(
+            |caller: CallerContext,
+             gate: Arc<dyn crate::mpp::PaymentGate>,
+             auth_header: Option<String>,
+             request: ResponsesRequest,
+             table: Arc<T>,
+             router: Arc<R>,
+             observer: Arc<dyn ObserveCallback>| {
+                handle_responses_with_gate(
+                    caller,
+                    gate,
+                    auth_header,
+                    request,
+                    table,
+                    router,
+                    observer,
+                )
+            },
+        )
+}
+
 #[cfg(any(feature = "mpp-tempo", feature = "mpp-solana"))]
 async fn handle_responses_with_mpp<T, R>(
     caller: CallerContext,
@@ -176,9 +224,36 @@ where
     T: RoutingTable + crate::mpp::PricingLookup + Send + Sync + 'static,
     R: LanguageModelRouter + Send + Sync + 'static,
 {
-    let mpp_ctx =
-        crate::mpp::verify_mpp_payment(mpp_state.clone(), caller.chain.clone(), auth_header)
-            .await?;
+    let payment_gate: Arc<dyn crate::mpp::PaymentGate> = mpp_state;
+    handle_responses_with_gate(
+        caller,
+        payment_gate,
+        auth_header,
+        request,
+        table,
+        router,
+        observer,
+    )
+    .await
+}
+
+#[cfg(any(feature = "mpp-tempo", feature = "mpp-solana"))]
+async fn handle_responses_with_gate<T, R>(
+    caller: CallerContext,
+    payment_gate: Arc<dyn crate::mpp::PaymentGate>,
+    auth_header: Option<String>,
+    request: ResponsesRequest,
+    table: Arc<T>,
+    router: Arc<R>,
+    observer: Arc<dyn ObserveCallback>,
+) -> Result<Box<dyn warp::Reply>, warp::Rejection>
+where
+    T: RoutingTable + crate::mpp::PricingLookup + Send + Sync + 'static,
+    R: LanguageModelRouter + Send + Sync + 'static,
+{
+    let mpp_ctx = payment_gate
+        .verify_payment(caller.chain.clone(), auth_header)
+        .await?;
 
     if let Some(ref management) = mpp_ctx.management_response {
         let reply = warp::reply::json(management);
@@ -237,7 +312,7 @@ where
         );
 
         let metered = crate::mpp::metered_sse::MeteredSseContext {
-            mpp_state: mpp_state.clone(),
+            payment_gate: payment_gate.clone(),
             backend_key: mpp_ctx.backend_key.clone(),
             channel_id: mpp_ctx.channel_id.clone(),
             tick_cost,
@@ -339,7 +414,7 @@ where
                 let micro_units = crate::mpp::cost_to_micro_units(cost_usd);
 
                 if micro_units > 0
-                    && let Err(e) = mpp_state
+                    && let Err(e) = payment_gate
                         .deduct(&mpp_ctx.backend_key, &mpp_ctx.channel_id, micro_units)
                         .await
                 {


### PR DESCRIPTION
Introduce `PaymentGate` trait in `bitrouter-api::mpp` that abstracts payment verification, deduction, and channel management. This enables downstream crates (e.g. bitrouter-node) to inject custom payment logic while reusing the full routing, streaming, and observation pipeline.

## Changes

- Add `PaymentGate` trait with `verify_payment`, `deduct`, `wait_for_update`, `channel_balance`, and `close_channel` methods
- Implement `PaymentGate` for `MppState` (backward compatible)
- Add `chat_completions_filter_with_payment_gate` and `responses_filter_with_payment_gate` filter variants
- Refactor `SessionCloseGuard` and `MeteredSseContext` to use `Arc<dyn PaymentGate>` instead of `Arc<MppState>`
- Refactor all MPP handlers (OpenAI/Anthropic/Google) to convert `Arc<MppState>` to `Arc<dyn PaymentGate>` internally

## Motivation

`bitrouter-node` needs to implement custom payment logic (Solana charge + centralized balance) while reusing the routing filters from `bitrouter-api`. The existing handlers are hard-coded to `MppState`, making it impossible to inject alternative payment strategies.

## Backward Compatibility

- `MppState` implements `PaymentGate`, so existing `_with_mpp` filter variants work unchanged
- No public API signatures changed for existing functions
- New `_with_payment_gate` variants are additive
