### PR TITLE
feat(auth): unified JWT auth with operator-signed delegation model

### DIFF
--- a/bitrouter-accounts/src/identity.rs
+++ b/bitrouter-accounts/src/identity.rs
@@ -7,7 +7,7 @@
 
 use std::fmt;
 
-use bitrouter_core::auth::claims::{BudgetRange, BudgetScope};
+use bitrouter_core::auth::claims::BudgetScope;
 use uuid::Uuid;
 
 /// Opaque account identifier.
@@ -50,18 +50,15 @@ pub struct Identity {
     pub account_id: AccountId,
     /// What this caller is permitted to do.
     pub scope: Scope,
-    /// CAIP-2 chain identifier from the JWT `chain` claim (e.g.
-    /// `"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"`, `"eip155:4217"`).
+    /// CAIP-2 chain identifier derived from the operator's `iss` CAIP-10.
     /// Used to select the payment network backend for MPP.
     pub chain: Option<String>,
     /// Optional model-name patterns this caller may access.
     pub models: Option<Vec<String>>,
-    /// Optional tool-name patterns this caller may access.
-    pub tools: Option<Vec<String>>,
     /// Budget limit in micro USD (1 USD = 1,000,000 μUSD).
     pub budget: Option<u64>,
     /// Whether the budget applies per-session or per-account.
     pub budget_scope: Option<BudgetScope>,
-    /// The range over which the budget is measured.
-    pub budget_range: Option<BudgetRange>,
+    /// OWS agent key for payment authorization (from JWT `key` claim).
+    pub key: Option<String>,
 }

--- a/bitrouter-core/src/auth/access.rs
+++ b/bitrouter-core/src/auth/access.rs
@@ -1,13 +1,10 @@
-//! Access control — glob-based allowlist matching for models and tools.
+//! Access control — glob-based allowlist matching for models.
 
 /// Returns `true` if the requested name is allowed given a glob-based allowlist.
 ///
 /// When `patterns` is empty, all names are allowed.
 /// Each pattern supports `*` as a wildcard that matches any sequence of
 /// characters (e.g., `"openai/*"` matches `"openai/gpt-4o"`).
-///
-/// Used for both model names (e.g., `"openai/gpt-4o"`) and tool names
-/// (e.g., `"github/search"`).
 fn is_pattern_allowed(requested: &str, patterns: &[String]) -> bool {
     if patterns.is_empty() {
         return true;
@@ -17,14 +14,6 @@ fn is_pattern_allowed(requested: &str, patterns: &[String]) -> bool {
 
 /// Returns `true` if the requested model is allowed given the allowlist.
 pub fn is_model_allowed(requested: &str, patterns: &[String]) -> bool {
-    is_pattern_allowed(requested, patterns)
-}
-
-/// Returns `true` if the requested tool is allowed given the allowlist.
-///
-/// Tool names follow `{server}/{tool}` format, so patterns like
-/// `"github/*"` or `"*/search"` work naturally.
-pub fn is_tool_allowed(requested: &str, patterns: &[String]) -> bool {
     is_pattern_allowed(requested, patterns)
 }
 
@@ -111,49 +100,5 @@ mod tests {
     fn star_matches_everything() {
         let patterns = vec!["*".to_string()];
         assert!(is_model_allowed("anything/at/all", &patterns));
-    }
-
-    // ── is_tool_allowed tests ────────────────────────────────────
-
-    #[test]
-    fn tool_empty_patterns_allow_all() {
-        assert!(is_tool_allowed("github/search", &[]));
-    }
-
-    #[test]
-    fn tool_exact_match() {
-        let patterns = vec!["github/search".to_string()];
-        assert!(is_tool_allowed("github/search", &patterns));
-        assert!(!is_tool_allowed("github/get_file", &patterns));
-    }
-
-    #[test]
-    fn tool_wildcard_suffix() {
-        let patterns = vec!["github/*".to_string()];
-        assert!(is_tool_allowed("github/search", &patterns));
-        assert!(is_tool_allowed("github/get_file", &patterns));
-        assert!(!is_tool_allowed("slack/post_message", &patterns));
-    }
-
-    #[test]
-    fn tool_wildcard_prefix() {
-        let patterns = vec!["*/search".to_string()];
-        assert!(is_tool_allowed("github/search", &patterns));
-        assert!(is_tool_allowed("jira/search", &patterns));
-        assert!(!is_tool_allowed("github/get_file", &patterns));
-    }
-
-    #[test]
-    fn tool_multiple_patterns() {
-        let patterns = vec!["github/*".to_string(), "slack/post_message".to_string()];
-        assert!(is_tool_allowed("github/search", &patterns));
-        assert!(is_tool_allowed("slack/post_message", &patterns));
-        assert!(!is_tool_allowed("slack/list_channels", &patterns));
-    }
-
-    #[test]
-    fn tool_star_matches_all() {
-        let patterns = vec!["*".to_string()];
-        assert!(is_tool_allowed("anything/at/all", &patterns));
     }
 }

--- a/bitrouter-core/src/auth/claims.rs
+++ b/bitrouter-core/src/auth/claims.rs
@@ -1,30 +1,33 @@
 //! JWT claims types for the BitRouter authentication protocol.
 //!
-//! These types define the payload of a BitRouter JWT. The `iss` claim carries
-//! the signer's CAIP-10 account identifier (e.g.
-//! `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp:<base58_pubkey>`), which the
-//! server uses for both signature verification and account resolution.
+//! These types define the payload of a BitRouter JWT. The operator's OWS
+//! wallet signs all tokens — both admin JWTs and agent access JWTs. The
+//! `iss` claim carries the operator's CAIP-10 identity (e.g.
+//! `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp:<base58_pubkey>`), and the
+//! server verifies that `iss` matches the configured operator wallet.
+//!
+//! Field keys are kept to ≤3 characters to minimize encoded JWT size.
+//! The chain is derived from `iss` (CAIP-10 encodes CAIP-2), so no
+//! separate chain field is needed.
 
 use serde::{Deserialize, Serialize};
 
 /// JWT claims for BitRouter authentication tokens.
 ///
-/// Tokens are self-signed by the account holder's web3 wallet key. The
-/// CAIP-10 address in `iss` is the sole identity — the token has zero
-/// knowledge of the underlying account ID or server-side state.
+/// Tokens are signed by the operator's OWS wallet. The CAIP-10 address
+/// in `iss` identifies the operator; the server verifies the signature
+/// against the operator's known public key from config.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BitrouterClaims {
-    /// CAIP-10 account identifier of the signer.
+    /// CAIP-10 account identifier of the operator wallet.
+    ///
+    /// The chain (CAIP-2) is derived from this field, so no separate
+    /// chain claim is needed.
     ///
     /// Examples:
     /// - `"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp:DRpb..."`
     /// - `"eip155:8453:0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B"`
     pub iss: String,
-
-    /// CAIP-2 chain identifier indicating which chain was used to sign.
-    ///
-    /// Examples: `"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"`, `"eip155:8453"`.
-    pub chain: String,
 
     /// Issued-at UNIX timestamp (seconds since epoch).
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -36,62 +39,60 @@ pub struct BitrouterClaims {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub exp: Option<u64>,
 
-    /// Authorization scope granted by this token.
-    pub scope: TokenScope,
+    /// Authorization scope: `"adm"` (admin) or `"api"` (agent access).
+    /// Defaults to `Api` when absent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scp: Option<TokenScope>,
 
     /// Optional allowlist of model name patterns this token may access.
     /// When `None`, all models configured on the server are accessible.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub models: Option<Vec<String>>,
-
-    /// Optional allowlist of tool name patterns this token may access.
-    /// Tool names are `{server}/{tool}`, so patterns like `"github/*"` work.
-    /// When `None`, all tools are accessible.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub tools: Option<Vec<String>>,
+    pub mdl: Option<Vec<String>>,
 
     /// Budget limit in micro USD (1 USD = 1,000,000 μUSD).
     /// Matches on-chain stablecoin precision (6 decimals).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub budget: Option<u64>,
+    pub bgt: Option<u64>,
 
     /// Whether the budget applies per-session or per-account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub budget_scope: Option<BudgetScope>,
+    pub bsc: Option<BudgetScope>,
 
-    /// The range over which the budget is measured.
+    /// OWS agent key for payment authorization.
+    /// When present, the server validates the key against the OWS vault
+    /// and uses its associated policies for spending enforcement.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub budget_range: Option<BudgetRange>,
+    pub key: Option<String>,
+}
+
+impl BitrouterClaims {
+    /// Resolved scope — defaults to [`TokenScope::Api`] when `scp` is absent.
+    pub fn scope(&self) -> TokenScope {
+        self.scp.unwrap_or(TokenScope::Api)
+    }
 }
 
 /// Token authorization scope.
 ///
-/// - `Admin`: Account management operations (rotate key, manage sessions).
-///   Scoped to the caller's own account — NOT global server admin.
-/// - `Api`: LLM inference endpoints only.
+/// - `Admin`: Management operations (route admin, key management).
+/// - `Api`: LLM inference and tool access endpoints.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
 pub enum TokenScope {
+    /// Admin management scope.
+    #[serde(rename = "adm")]
     Admin,
+    /// API / agent access scope (default when `scp` is absent).
+    #[serde(rename = "api")]
     Api,
 }
 
 /// Budget scope — determines what the budget limit applies to.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
 pub enum BudgetScope {
     /// Budget applies independently to each chat session.
+    #[serde(rename = "ses")]
     Session,
     /// Budget applies to the entire account across all sessions.
+    #[serde(rename = "act")]
     Account,
-}
-
-/// Budget range — the window over which the budget is measured.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "type", rename_all = "lowercase")]
-pub enum BudgetRange {
-    /// Budget covers the next N conversation rounds.
-    Rounds { count: u32 },
-    /// Budget covers a time period (in seconds).
-    Duration { seconds: u64 },
 }

--- a/bitrouter-core/src/auth/mod.rs
+++ b/bitrouter-core/src/auth/mod.rs
@@ -2,9 +2,9 @@
 //!
 //! Defines the open JWT claims standard shared between the bitrouter CLI,
 //! self-hosted servers, and the BitRouter cloud service. JWTs are signed
-//! with web3 wallet keys — Ed25519 for Solana (`SOL_EDDSA`) or EIP-191
-//! secp256k1 for EVM chains (`EIP191K`). Users hold the private seed,
-//! servers verify signatures and resolve accounts by CAIP-10 identity.
+//! by the operator's OWS wallet — Ed25519 for Solana (`SOL_EDDSA`) or
+//! EIP-191 secp256k1 for EVM chains (`EIP191K`). The server verifies
+//! signatures against the configured operator wallet identity.
 
 pub mod access;
 pub mod chain;

--- a/bitrouter-core/src/auth/token.rs
+++ b/bitrouter-core/src/auth/token.rs
@@ -6,6 +6,9 @@
 //! - **EIP191K** — EVM-style EIP-191 prefixed secp256k1 ECDSA.
 //!
 //! Token format: `base64url(header).base64url(claims).base64url(signature)`
+//!
+//! The signing chain is derived from the CAIP-10 `iss` claim (which encodes
+//! CAIP-2 chain info), so no separate `chain` field is needed in the payload.
 
 use alloy_primitives::Signature as EvmSignature;
 use base64::Engine;
@@ -19,21 +22,12 @@ use crate::auth::keys::JwtSigner;
 
 /// Sign a set of claims into a JWT string using any [`JwtSigner`].
 ///
-/// The algorithm and signing method are determined by the chain in the claims:
+/// The algorithm is derived from the chain encoded in `claims.iss` (CAIP-10):
 /// - Solana → SOL_EDDSA (Ed25519 over raw message)
 /// - EVM → EIP191K (EIP-191 prefixed secp256k1 ECDSA)
 pub fn sign(claims: &BitrouterClaims, signer: &dyn JwtSigner) -> Result<String, JwtError> {
     let caip10 = Caip10::parse(&claims.iss)?;
     let alg = caip10.chain.jwt_algorithm();
-
-    // Reject tokens where the explicit `chain` field contradicts `iss`.
-    let expected_chain = caip10.chain.caip2();
-    if claims.chain != expected_chain {
-        return Err(JwtError::Verification(format!(
-            "chain mismatch: claims.chain is {}, iss implies {}",
-            claims.chain, expected_chain
-        )));
-    }
 
     let header_b64 = URL_SAFE_NO_PAD.encode(alg.header_json().as_bytes());
     let payload = serde_json::to_vec(claims).map_err(|e| JwtError::Signing(e.to_string()))?;
@@ -65,7 +59,7 @@ pub fn verify(token: &str) -> Result<BitrouterClaims, JwtError> {
         .decode(sig_b64)
         .map_err(|e| JwtError::MalformedToken(format!("bad signature encoding: {e}")))?;
 
-    // Decode claims (unverified) to determine chain.
+    // Decode claims (unverified) to determine chain from iss.
     let (_, payload_b64) = message
         .split_once('.')
         .ok_or_else(|| JwtError::MalformedToken("expected header.payload".into()))?;
@@ -78,23 +72,14 @@ pub fn verify(token: &str) -> Result<BitrouterClaims, JwtError> {
     // Parse algorithm from header.
     let alg = decode_algorithm(message)?;
 
-    // Parse CAIP-10 identity from iss.
+    // Parse CAIP-10 identity from iss — chain is derived from this.
     let caip10 = Caip10::parse(&claims.iss)?;
 
-    // Verify the algorithm matches the chain.
+    // Verify the algorithm matches the chain derived from iss.
     let expected_alg = caip10.chain.jwt_algorithm();
     if alg != expected_alg {
         return Err(JwtError::Verification(format!(
             "algorithm mismatch: header says {alg}, chain expects {expected_alg}"
-        )));
-    }
-
-    // Ensure the CAIP-2 chain in the claims matches the chain implied by iss.
-    let expected_chain = caip10.chain.caip2();
-    if claims.chain != expected_chain {
-        return Err(JwtError::Verification(format!(
-            "chain mismatch: claims.chain is {}, iss implies {}",
-            claims.chain, expected_chain
         )));
     }
 
@@ -224,15 +209,13 @@ mod tests {
         let caip10 = kp.caip10(&chain).expect("caip10");
         BitrouterClaims {
             iss: caip10.format(),
-            chain: chain.caip2(),
             iat: Some(1_700_000_000),
             exp: None,
-            scope: TokenScope::Api,
-            models: None,
-            tools: None,
-            budget: None,
-            budget_scope: None,
-            budget_range: None,
+            scp: Some(TokenScope::Api),
+            mdl: None,
+            bgt: None,
+            bsc: None,
+            key: None,
         }
     }
 
@@ -241,15 +224,13 @@ mod tests {
         let caip10 = kp.caip10(&chain).expect("caip10");
         BitrouterClaims {
             iss: caip10.format(),
-            chain: chain.caip2(),
             iat: Some(1_700_000_000),
             exp: None,
-            scope: TokenScope::Api,
-            models: None,
-            tools: None,
-            budget: None,
-            budget_scope: None,
-            budget_range: None,
+            scp: Some(TokenScope::Api),
+            mdl: None,
+            bgt: None,
+            bsc: None,
+            key: None,
         }
     }
 
@@ -260,7 +241,7 @@ mod tests {
         let token = sign(&claims, &kp).expect("sign");
         let decoded = verify(&token).expect("verify");
         assert_eq!(decoded.iss, claims.iss);
-        assert_eq!(decoded.scope, TokenScope::Api);
+        assert_eq!(decoded.scope(), TokenScope::Api);
     }
 
     #[test]
@@ -270,7 +251,7 @@ mod tests {
         let token = sign(&claims, &kp).expect("sign");
         let decoded = verify(&token).expect("verify");
         assert_eq!(decoded.iss, claims.iss);
-        assert_eq!(decoded.scope, TokenScope::Api);
+        assert_eq!(decoded.scope(), TokenScope::Api);
     }
 
     #[test]
@@ -312,22 +293,19 @@ mod tests {
         let token = sign(&claims, &kp).expect("sign");
         let decoded = decode_unverified(&token).expect("decode");
         assert_eq!(decoded.iss, claims.iss);
-        assert_eq!(decoded.chain, claims.chain);
     }
 
     #[test]
     fn check_expiration_passes_for_future() {
         let claims = BitrouterClaims {
             iss: String::new(),
-            chain: String::new(),
             iat: None,
             exp: Some(u64::MAX),
-            scope: TokenScope::Api,
-            models: None,
-            tools: None,
-            budget: None,
-            budget_scope: None,
-            budget_range: None,
+            scp: Some(TokenScope::Api),
+            mdl: None,
+            bgt: None,
+            bsc: None,
+            key: None,
         };
         check_expiration(&claims).expect("not expired");
     }
@@ -336,15 +314,13 @@ mod tests {
     fn check_expiration_fails_for_past() {
         let claims = BitrouterClaims {
             iss: String::new(),
-            chain: String::new(),
             iat: None,
             exp: Some(1),
-            scope: TokenScope::Api,
-            models: None,
-            tools: None,
-            budget: None,
-            budget_scope: None,
-            budget_range: None,
+            scp: Some(TokenScope::Api),
+            mdl: None,
+            bgt: None,
+            bsc: None,
+            key: None,
         };
         assert!(check_expiration(&claims).is_err());
     }
@@ -353,15 +329,13 @@ mod tests {
     fn check_expiration_passes_for_none() {
         let claims = BitrouterClaims {
             iss: String::new(),
-            chain: String::new(),
             iat: None,
             exp: None,
-            scope: TokenScope::Api,
-            models: None,
-            tools: None,
-            budget: None,
-            budget_scope: None,
-            budget_range: None,
+            scp: Some(TokenScope::Api),
+            mdl: None,
+            bgt: None,
+            bsc: None,
+            key: None,
         };
         check_expiration(&claims).expect("no exp means valid");
     }
@@ -404,43 +378,45 @@ mod tests {
     }
 
     #[test]
-    fn sign_rejects_chain_mismatch() {
+    fn scope_defaults_to_api_when_absent() {
         let kp = MasterKeypair::generate();
-        let sol_chain = Chain::solana_mainnet();
-        let caip10 = kp.caip10(&sol_chain).expect("caip10");
-        // iss is Solana but chain field claims EVM.
-        let bad_claims = BitrouterClaims {
+        let chain = Chain::solana_mainnet();
+        let caip10 = kp.caip10(&chain).expect("caip10");
+        let claims = BitrouterClaims {
             iss: caip10.format(),
-            chain: Chain::base().caip2(),
             iat: None,
             exp: None,
-            scope: TokenScope::Api,
-            models: None,
-            tools: None,
-            budget: None,
-            budget_scope: None,
-            budget_range: None,
+            scp: None, // absent
+            mdl: None,
+            bgt: None,
+            bsc: None,
+            key: None,
         };
-        assert!(sign(&bad_claims, &kp).is_err());
+        let token = sign(&claims, &kp).expect("sign");
+        let decoded = verify(&token).expect("verify");
+        assert_eq!(decoded.scope(), TokenScope::Api);
+        assert!(decoded.scp.is_none());
     }
 
     #[test]
-    fn verify_rejects_chain_mismatch_in_payload() {
+    fn key_claim_roundtrips() {
         let kp = MasterKeypair::generate();
-        // Sign a valid Solana token, then tamper the chain field in the payload.
-        let claims = test_claims_solana(&kp);
+        let chain = Chain::solana_mainnet();
+        let caip10 = kp.caip10(&chain).expect("caip10");
+        let claims = BitrouterClaims {
+            iss: caip10.format(),
+            iat: None,
+            exp: None,
+            scp: Some(TokenScope::Api),
+            mdl: Some(vec!["gpt-4o".to_string()]),
+            bgt: Some(50_000_000),
+            bsc: Some(crate::auth::claims::BudgetScope::Session),
+            key: Some("ows_key_abc123".to_string()),
+        };
         let token = sign(&claims, &kp).expect("sign");
-
-        let parts: Vec<&str> = token.split('.').collect();
-        // Replace chain with EVM chain while keeping Solana iss.
-        let mut tampered_claims = claims.clone();
-        tampered_claims.chain = Chain::base().caip2();
-        let new_payload_b64 = URL_SAFE_NO_PAD.encode(
-            serde_json::to_vec(&tampered_claims)
-                .expect("ser")
-                .as_slice(),
-        );
-        let tampered = format!("{}.{}.{}", parts[0], new_payload_b64, parts[2]);
-        assert!(verify(&tampered).is_err());
+        let decoded = verify(&token).expect("verify");
+        assert_eq!(decoded.key.as_deref(), Some("ows_key_abc123"));
+        assert_eq!(decoded.mdl, Some(vec!["gpt-4o".to_string()]));
+        assert_eq!(decoded.bgt, Some(50_000_000));
     }
 }

--- a/bitrouter-core/src/observe.rs
+++ b/bitrouter-core/src/observe.rs
@@ -8,7 +8,7 @@
 use std::future::Future;
 use std::pin::Pin;
 
-use crate::auth::claims::{BudgetRange, BudgetScope};
+use crate::auth::claims::BudgetScope;
 use crate::errors::BitrouterError;
 use crate::models::language::usage::LanguageModelUsage;
 
@@ -23,15 +23,14 @@ pub struct CallerContext {
     pub account_id: Option<String>,
     /// Optional model-name patterns this caller may access.
     pub models: Option<Vec<String>>,
-    /// Optional tool-name patterns this caller may access.
-    pub tools: Option<Vec<String>>,
     /// Budget limit in micro USD.
     pub budget: Option<u64>,
     /// Whether the budget applies per-session or per-account.
     pub budget_scope: Option<BudgetScope>,
-    /// The range over which the budget is measured.
-    pub budget_range: Option<BudgetRange>,
-    /// CAIP-2 chain identifier from JWT claims (e.g. `"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"`).
+    /// OWS agent key for payment authorization (from JWT `key` claim).
+    pub key: Option<String>,
+    /// CAIP-2 chain identifier derived from the operator's `iss` CAIP-10.
+    /// Used for MPP payment network selection.
     pub chain: Option<String>,
 }
 

--- a/bitrouter/src/cli/admin_auth.rs
+++ b/bitrouter/src/cli/admin_auth.rs
@@ -98,7 +98,7 @@ fn ows_sign_admin_jwt(wallet: &bitrouter_config::config::WalletConfig) -> Result
 
     let chain = Chain::solana_mainnet();
     let caip10 = Caip10 {
-        chain: chain.clone(),
+        chain,
         address: sol_account.address.clone(),
     };
 
@@ -109,15 +109,13 @@ fn ows_sign_admin_jwt(wallet: &bitrouter_config::config::WalletConfig) -> Result
 
     let claims = BitrouterClaims {
         iss: caip10.format(),
-        chain: chain.caip2(),
         iat: Some(now),
         exp: Some(now + 300), // 5 minutes
-        scope: TokenScope::Admin,
-        models: None,
-        tools: None,
-        budget: None,
-        budget_scope: None,
-        budget_range: None,
+        scp: Some(TokenScope::Admin),
+        mdl: None,
+        bgt: None,
+        bsc: None,
+        key: None,
     };
 
     let signer = OwsJwtSigner::new(wallet)?;

--- a/bitrouter/src/cli/key.rs
+++ b/bitrouter/src/cli/key.rs
@@ -88,3 +88,181 @@ pub fn revoke(id: &str) -> Result {
 
     Ok(())
 }
+
+/// Sign a JWT for agent access — the operator mints tokens that agents
+/// present as bearer auth to the running BitRouter server.
+pub fn sign(
+    wallet_name: &str,
+    models: Option<&[String]>,
+    budget: Option<u64>,
+    budget_scope: Option<&str>,
+    exp: Option<&str>,
+    ows_key: Option<&str>,
+) -> Result {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use bitrouter_core::auth::chain::{Caip10, Chain};
+    use bitrouter_core::auth::claims::{BitrouterClaims, BudgetScope, TokenScope};
+    use bitrouter_core::auth::token;
+    use dialoguer::Password;
+
+    // 1. Load wallet and resolve Solana address for CAIP-10 iss.
+    let info = ows_lib::get_wallet(wallet_name, None)
+        .map_err(|e| format!("failed to load wallet '{wallet_name}': {e}"))?;
+
+    let sol_account = info
+        .accounts
+        .iter()
+        .find(|a| a.chain_id.starts_with("solana:"))
+        .ok_or_else(|| format!("wallet '{wallet_name}' has no Solana account — cannot sign JWT"))?;
+
+    let caip10 = Caip10 {
+        chain: Chain::solana_mainnet(),
+        address: sol_account.address.clone(),
+    };
+
+    // 2. Parse optional budget scope.
+    let bsc = match budget_scope {
+        Some("session" | "ses") => Some(BudgetScope::Session),
+        Some("account" | "act") => Some(BudgetScope::Account),
+        Some(other) => {
+            return Err(
+                format!("invalid budget scope '{other}': use 'session' or 'account'").into(),
+            );
+        }
+        None => None,
+    };
+
+    // 3. Parse expiration duration and compute absolute timestamp.
+    let now = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
+
+    let exp_ts = match exp {
+        Some(raw) => Some(now + parse_duration_secs(raw)?),
+        None => None,
+    };
+
+    // 4. Construct claims.
+    let claims = BitrouterClaims {
+        iss: caip10.format(),
+        iat: Some(now),
+        exp: exp_ts,
+        scp: Some(TokenScope::Api),
+        mdl: models.map(|m| m.to_vec()),
+        bgt: budget,
+        bsc,
+        key: ows_key.map(String::from),
+    };
+
+    // 5. Prompt passphrase and sign.
+    let theme = ColorfulTheme::default();
+    let passphrase = Password::with_theme(&theme)
+        .with_prompt("Wallet owner passphrase")
+        .allow_empty_password(true)
+        .interact()?;
+
+    let signer = OwsJwtSigner {
+        wallet_name: wallet_name.to_owned(),
+        passphrase,
+        vault_path: None,
+    };
+
+    let jwt = token::sign(&claims, &signer).map_err(|e| format!("failed to sign JWT: {e}"))?;
+
+    println!("{jwt}");
+
+    Ok(())
+}
+
+/// Parse a human-readable duration string into seconds.
+///
+/// Accepts raw seconds (e.g. `"3600"`) or suffixed durations:
+/// `"30s"`, `"12h"`, `"7d"`, `"1m"` (m = minutes).
+fn parse_duration_secs(input: &str) -> Result<u64> {
+    let input = input.trim();
+    if input.is_empty() {
+        return Err("empty duration".into());
+    }
+
+    let last = input.as_bytes()[input.len() - 1];
+    if last.is_ascii_digit() {
+        return input
+            .parse::<u64>()
+            .map_err(|_| format!("invalid duration '{input}'").into());
+    }
+
+    let (num_str, multiplier) = match last {
+        b's' => (&input[..input.len() - 1], 1u64),
+        b'm' => (&input[..input.len() - 1], 60),
+        b'h' => (&input[..input.len() - 1], 3_600),
+        b'd' => (&input[..input.len() - 1], 86_400),
+        _ => return Err(format!("unknown duration suffix '{}'", last as char).into()),
+    };
+
+    let n: u64 = num_str
+        .parse()
+        .map_err(|_| format!("invalid duration number '{num_str}'"))?;
+
+    Ok(n * multiplier)
+}
+
+/// OWS-backed JWT signer for the `key sign` command.
+///
+/// Decrypts the wallet key on each signing call. Key material is zeroized
+/// on drop by the OWS SDK.
+struct OwsJwtSigner {
+    wallet_name: String,
+    passphrase: String,
+    vault_path: Option<String>,
+}
+
+impl bitrouter_core::auth::keys::JwtSigner for OwsJwtSigner {
+    fn sign_ed25519(
+        &self,
+        message: &[u8],
+    ) -> std::result::Result<Vec<u8>, bitrouter_core::auth::JwtError> {
+        let vault = self.vault_path.as_deref().map(std::path::Path::new);
+        let key = ows_lib::decrypt_signing_key(
+            &self.wallet_name,
+            ows_core::ChainType::Solana,
+            &self.passphrase,
+            None,
+            vault,
+        )
+        .map_err(|e| bitrouter_core::auth::JwtError::Signing(e.to_string()))?;
+
+        let signer = ows_signer::signer_for_chain(ows_core::ChainType::Solana);
+        let output = signer
+            .sign(key.expose(), message)
+            .map_err(|e| bitrouter_core::auth::JwtError::Signing(e.to_string()))?;
+
+        Ok(output.signature)
+    }
+
+    fn sign_eip191(
+        &self,
+        message: &[u8],
+    ) -> std::result::Result<Vec<u8>, bitrouter_core::auth::JwtError> {
+        let vault = self.vault_path.as_deref().map(std::path::Path::new);
+        let key = ows_lib::decrypt_signing_key(
+            &self.wallet_name,
+            ows_core::ChainType::Evm,
+            &self.passphrase,
+            None,
+            vault,
+        )
+        .map_err(|e| bitrouter_core::auth::JwtError::Signing(e.to_string()))?;
+
+        let prefix = format!("\x19Ethereum Signed Message:\n{}", message.len());
+        let mut data = Vec::with_capacity(prefix.len() + message.len());
+        data.extend_from_slice(prefix.as_bytes());
+        data.extend_from_slice(message);
+        let hash = alloy::primitives::keccak256(&data);
+
+        let signer = ows_signer::signer_for_chain(ows_core::ChainType::Evm);
+        let output = signer
+            .sign(key.expose(), hash.as_ref())
+            .map_err(|e| bitrouter_core::auth::JwtError::Signing(e.to_string()))?;
+
+        Ok(output.signature)
+    }
+}

--- a/bitrouter/src/main.rs
+++ b/bitrouter/src/main.rs
@@ -232,6 +232,32 @@ enum KeyAction {
         #[arg(long)]
         id: String,
     },
+    /// Sign a JWT for agent access (operator mints tokens for agents)
+    Sign {
+        /// OWS wallet name to sign with (operator wallet)
+        #[arg(long)]
+        wallet: String,
+
+        /// Model name patterns the agent may access (comma-separated)
+        #[arg(long, value_delimiter = ',')]
+        models: Option<Vec<String>>,
+
+        /// Budget limit in micro USD (1 USD = 1,000,000 μUSD)
+        #[arg(long)]
+        budget: Option<u64>,
+
+        /// Budget scope: "session" or "account"
+        #[arg(long)]
+        budget_scope: Option<String>,
+
+        /// Expiration duration (e.g. "30d", "12h", "3600s", or raw seconds)
+        #[arg(long)]
+        exp: Option<String>,
+
+        /// OWS agent key ID to bind to this token
+        #[arg(long)]
+        ows_key: Option<String>,
+    },
 }
 
 #[tokio::main]
@@ -327,6 +353,21 @@ async fn run_cli(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
                 } => cli::key::create(&name, &wallet, &policy, expires_at.as_deref())?,
                 KeyAction::List => cli::key::list()?,
                 KeyAction::Revoke { id } => cli::key::revoke(&id)?,
+                KeyAction::Sign {
+                    wallet,
+                    models,
+                    budget,
+                    budget_scope,
+                    exp,
+                    ows_key,
+                } => cli::key::sign(
+                    &wallet,
+                    models.as_deref(),
+                    budget,
+                    budget_scope.as_deref(),
+                    exp.as_deref(),
+                    ows_key.as_deref(),
+                )?,
             }
             return Ok(());
         }

--- a/bitrouter/src/runtime/auth.rs
+++ b/bitrouter/src/runtime/auth.rs
@@ -1,9 +1,11 @@
 //! JWT authentication filters for the bitrouter gateway.
 //!
-//! Implements self-signed EdDSA (Ed25519) JWT authentication:
+//! Implements operator-signed JWT authentication:
 //!
-//! - **JWT path**: The JWT `iss` claim carries the signer's CAIP-10 identity.
-//!   The server verifies the Ed25519/EIP-191 signature before any DB interaction.
+//! - **JWT path**: The operator's OWS wallet signs all JWTs. The `iss`
+//!   claim carries the operator's CAIP-10 identity. The server verifies
+//!   the signature and checks that `iss` matches the configured operator
+//!   wallet — this is the single trust root.
 //!
 //! Credentials are extracted from the protocol-appropriate header:
 //!
@@ -23,6 +25,7 @@ use warp::Filter;
 
 use bitrouter_accounts::identity::{AccountId, Identity, Scope};
 use bitrouter_accounts::service::AccountService;
+use bitrouter_core::auth::chain::Caip10;
 use bitrouter_core::auth::claims::TokenScope;
 use bitrouter_core::auth::token as jwt_token;
 
@@ -31,11 +34,17 @@ use bitrouter_core::auth::token as jwt_token;
 pub struct JwtAuthContext {
     /// Database connection for account lookups (auto-creation).
     db: Option<DatabaseConnection>,
+    /// The operator's CAIP-10 identity resolved from wallet config at startup.
+    /// When set, JWTs must have `iss` matching this identity.
+    operator_caip10: Option<String>,
 }
 
 impl JwtAuthContext {
-    pub fn new(db: Option<DatabaseConnection>) -> Self {
-        Self { db }
+    pub fn new(db: Option<DatabaseConnection>, operator_caip10: Option<String>) -> Self {
+        Self {
+            db,
+            operator_caip10,
+        }
     }
 
     /// Returns `true` when no database is configured (open proxy mode).
@@ -136,7 +145,19 @@ async fn resolve_jwt_identity(
     jwt_token::check_expiration(&claims)
         .map_err(|_| warp::reject::custom(Unauthorized("JWT expired")))?;
 
-    // 3. Resolve account from DB using CAIP-10 iss.
+    // 3. Verify iss matches the configured operator wallet (single trust root).
+    if let Some(ref expected) = ctx.operator_caip10
+        && claims.iss != *expected
+    {
+        return Err(warp::reject::custom(Unauthorized(
+            "JWT issuer does not match configured operator wallet",
+        )));
+    }
+
+    // 4. Derive chain from iss (CAIP-10 → CAIP-2).
+    let chain = Caip10::parse(&claims.iss).ok().map(|c| c.chain.caip2());
+
+    // 5. Resolve account from DB using CAIP-10 iss.
     let Some(ref db) = ctx.db else {
         return Err(warp::reject::custom(Unauthorized(
             "authentication requires a database",
@@ -155,8 +176,8 @@ async fn resolve_jwt_identity(
         )));
     };
 
-    // 4. Build identity with account-relative scope.
-    let scope = match claims.scope {
+    // 6. Build identity with resolved scope and permissions.
+    let scope = match claims.scope() {
         TokenScope::Admin => Scope::Admin,
         TokenScope::Api => Scope::Api,
     };
@@ -164,12 +185,11 @@ async fn resolve_jwt_identity(
     Ok(Identity {
         account_id: AccountId(account.id),
         scope,
-        chain: Some(claims.chain),
-        models: claims.models,
-        tools: claims.tools,
-        budget: claims.budget,
-        budget_scope: claims.budget_scope,
-        budget_range: claims.budget_range,
+        chain,
+        models: claims.mdl,
+        budget: claims.bgt,
+        budget_scope: claims.bsc,
+        key: claims.key,
     })
 }
 
@@ -240,10 +260,9 @@ fn open_identity() -> impl Filter<Extract = (Identity,), Error = warp::Rejection
             scope: Scope::Admin,
             chain: None,
             models: None,
-            tools: None,
             budget: None,
             budget_scope: None,
-            budget_range: None,
+            key: None,
         })
     })
 }

--- a/bitrouter/src/runtime/server.rs
+++ b/bitrouter/src/runtime/server.rs
@@ -157,9 +157,15 @@ where
             tracing::info!("guardrails enabled");
         }
 
-        // Build JWT auth context.
+        // Build JWT auth context with operator identity from wallet config.
+        let operator_caip10 = self.config.wallet.as_ref().and_then(|wallet| {
+            resolve_operator_caip10(wallet)
+                .map_err(|e| tracing::warn!("could not resolve operator CAIP-10: {e}"))
+                .ok()
+        });
         let auth_ctx = Arc::new(JwtAuthContext::new(
             self.db.as_ref().map(|db| db.as_ref().clone()),
+            operator_caip10,
         ));
 
         // Build spend store: SeaORM-backed if DB is available, otherwise in-memory.
@@ -709,10 +715,9 @@ fn identity_to_caller_context(id: bitrouter_accounts::identity::Identity) -> Cal
     CallerContext {
         account_id: Some(id.account_id.0.to_string()),
         models: id.models,
-        tools: id.tools,
         budget: id.budget,
         budget_scope: id.budget_scope,
-        budget_range: id.budget_range,
+        key: id.key,
         chain: id.chain,
     }
 }
@@ -724,6 +729,35 @@ fn auth_gate(
     + Clone,
 ) -> impl Filter<Extract = (), Error = warp::Rejection> + Clone {
     auth.map(|_| ()).untuple_one()
+}
+
+/// Resolve the operator's CAIP-10 identity from wallet config.
+///
+/// Loads the OWS wallet metadata and finds the Solana account address to
+/// construct the full CAIP-10 identity. This identity is used as the single
+/// trust root for JWT verification — only JWTs with `iss` matching this
+/// identity are accepted.
+fn resolve_operator_caip10(
+    wallet: &bitrouter_config::config::WalletConfig,
+) -> std::result::Result<String, String> {
+    use bitrouter_core::auth::chain::{Caip10, Chain};
+
+    let vault = wallet.vault_path.as_deref().map(std::path::Path::new);
+    let info = ows_lib::get_wallet(&wallet.name, vault)
+        .map_err(|e| format!("failed to load wallet '{}': {e}", wallet.name))?;
+
+    let sol_account = info
+        .accounts
+        .iter()
+        .find(|a| a.chain_id.starts_with("solana:"))
+        .ok_or_else(|| format!("wallet '{}' has no Solana account", wallet.name))?;
+
+    let caip10 = Caip10 {
+        chain: Chain::solana_mainnet(),
+        address: sol_account.address.clone(),
+    };
+
+    Ok(caip10.format())
 }
 
 /// Rejection handler that turns [`Unauthorized`] into a JSON 401 response


### PR DESCRIPTION
## Summary

Redesign JWT auth so the operator's OWS wallet is the single signing authority for all tokens (admin and agent access). This replaces the old self-signed model with an operator-signed delegation model.

## Changes

### Core type changes (`bitrouter-core`)
- **Claims redesign**: Remove `chain`, `tools`, `budget_range` fields; rename `scope`→`scp`, `models`→`mdl`, `budget`→`bgt`, `budget_scope`→`bsc`; add `key` field for OWS agent key binding
- **Shorter serde names**: `TokenScope`: `admin/api` → `adm/api`; `BudgetScope`: `session/account` → `ses/act`
- **Chain derivation**: Chain now derived from `iss` (CAIP-10 → CAIP-2) at auth time, not stored in JWT
- **Remove tool allowlist**: `is_tool_allowed()` removed — had no external callers
- **Identity/CallerContext**: Updated to match new claims (removed tools/budget_range, added key)

### Runtime auth (`bitrouter`)
- `JwtAuthContext` gains `operator_caip10` field for trust-root verification
- Server resolves operator identity from OWS wallet at startup via `resolve_operator_caip10()`
- JWT `iss` must match configured operator wallet when present (single trust root)
- Graceful fallback when no wallet configured

### CLI (`bitrouter`)
- **`key sign`**: New command for operators to mint agent access JWTs
  - `--wallet`: OWS wallet to sign with
  - `--models`: Comma-separated model patterns
  - `--budget`: Micro USD limit
  - `--budget-scope`: `session` or `account`
  - `--exp`: Human-readable duration (`30d`, `12h`, `3600s`, or raw seconds)
  - `--ows-key`: Agent key ID binding
- Admin JWT creation updated to new claims format

## JWT format (before → after)

| Field | Before | After |
|-------|--------|-------|
| Chain | `chain: "solana:5eykt..."` | Derived from `iss` |
| Scope | `scope: "admin"` | `scp: "adm"` |
| Models | `models: [...]` | `mdl: [...]` |
| Budget | `budget: 1000` | `bgt: 1000` |
| Budget scope | `budget_scope: "session"` | `bsc: "ses"` |
| Tools | `tools: [...]` | Removed |
| Budget range | `budget_range: "low"` | Removed |
| Agent key | — | `key: "key-uuid"` |

Closes #219