### PR TITLE
fix(anthropic): accept system field as both string and array of content blocks

### DIFF
--- a/bitrouter-api/src/router/anthropic/messages/tests.rs
+++ b/bitrouter-api/src/router/anthropic/messages/tests.rs
@@ -678,6 +678,35 @@ async fn messages_stream_tool_input_deltas() {
 }
 
 #[tokio::test]
+async fn messages_with_system_blocks() {
+    let table = Arc::new(MockTable);
+    let router = Arc::new(MockRouter);
+    let filter = messages_filter(table, router);
+
+    // Claude Code sends system as an array of content blocks
+    let body = serde_json::json!({
+        "model": "claude-3-5-sonnet-20241022",
+        "max_tokens": 512,
+        "system": [{"type": "text", "text": "You are a helpful assistant."}],
+        "messages": [
+            {"role": "user", "content": "Hello"}
+        ]
+    });
+
+    let res = warp::test::request()
+        .method("POST")
+        .path("/v1/messages")
+        .json(&body)
+        .reply(&filter)
+        .await;
+
+    assert_eq!(res.status(), 200);
+    let json: serde_json::Value = serde_json::from_slice(res.body()).unwrap();
+    assert_eq!(json["type"], "message");
+    assert_eq!(json["role"], "assistant");
+}
+
+#[tokio::test]
 async fn messages_missing_max_tokens() {
     let table = Arc::new(MockTable);
     let router = Arc::new(MockRouter);

--- a/bitrouter-core/src/api/anthropic/messages/convert.rs
+++ b/bitrouter-core/src/api/anthropic/messages/convert.rs
@@ -36,9 +36,10 @@ pub fn to_call_options(request: MessagesRequest) -> LanguageModelCallOptions {
     let mut prompt: Vec<LanguageModelMessage> = Vec::new();
 
     // Anthropic system message is a top-level field, not part of messages.
+    // Accept both plain string and array-of-content-blocks formats.
     if let Some(system) = request.system {
         prompt.push(LanguageModelMessage::System {
-            content: system,
+            content: system.into_text(),
             provider_options: None,
         });
     }

--- a/bitrouter-core/src/api/anthropic/messages/types.rs
+++ b/bitrouter-core/src/api/anthropic/messages/types.rs
@@ -4,13 +4,43 @@ use serde::{Deserialize, Serialize};
 
 // ── Request ─────────────────────────────────────────────────────────────────
 
+/// The `system` field accepts either a plain string or an array of content
+/// blocks (as sent by Claude Code and the current Anthropic SDK).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum SystemPrompt {
+    Text(String),
+    Blocks(Vec<SystemContentBlock>),
+}
+
+impl SystemPrompt {
+    /// Flatten any variant into a single string for internal use.
+    pub fn into_text(self) -> String {
+        match self {
+            Self::Text(s) => s,
+            Self::Blocks(blocks) => blocks
+                .into_iter()
+                .map(|b| b.text)
+                .collect::<Vec<_>>()
+                .join("\n"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SystemContentBlock {
+    #[serde(rename = "type")]
+    pub block_type: String,
+    pub text: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MessagesRequest {
     pub model: String,
     pub messages: Vec<AnthropicMessage>,
     pub max_tokens: u32,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub system: Option<String>,
+    pub system: Option<SystemPrompt>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub temperature: Option<f32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
Fixes #227

The Anthropic Messages API and Claude Code send the `system` field as an array of content blocks (`[{"type":"text","text":"..."}]`), but bitrouter only accepted a plain string, causing 400 errors when used as a proxy via `ANTHROPIC_BASE_URL`.

Introduces a `SystemPrompt` untagged enum that deserializes both formats and exposes `into_text()` to flatten them into the internal string representation. Adds a regression test for the array-of-blocks path.

Generated with [Claude Code](https://claude.ai/code)