### PR TITLE
feat(config): add full and minimal config templates with tests

### DIFF
--- a/bitrouter-config/src/config.rs
+++ b/bitrouter-config/src/config.rs
@@ -917,4 +917,107 @@ tools:
         let search = &config.tools["search_code"];
         assert_eq!(search.endpoints[0].api_protocol, Some(ApiProtocol::Mcp));
     }
+
+    #[test]
+    fn full_template_deserializes() {
+        let yaml = include_str!("../templates/full.yaml");
+        let config = BitrouterConfig::load_from_str(yaml, None).unwrap();
+
+        // Server
+        assert_eq!(config.server.listen, "127.0.0.1:8787".parse().unwrap());
+        assert_eq!(config.server.log_level, "info");
+
+        // Database
+        assert!(config.database.url.is_some());
+
+        // Providers: builtins + user-defined
+        assert!(config.providers.contains_key("openai"));
+        assert!(config.providers.contains_key("anthropic"));
+        assert!(config.providers.contains_key("google"));
+        assert!(config.providers.contains_key("my-proxy"));
+        assert!(config.providers.contains_key("custom-llm"));
+        assert!(config.providers.contains_key("github-mcp"));
+        assert!(config.providers.contains_key("header-auth-provider"));
+        assert!(config.providers.contains_key("paid-provider"));
+
+        // Derived provider inherits api_protocol
+        let my_proxy = &config.providers["my-proxy"];
+        assert_eq!(my_proxy.api_protocol, Some(ApiProtocol::Openai));
+        assert!(my_proxy.derives.is_none()); // resolved
+
+        // Custom provider
+        let custom = &config.providers["custom-llm"];
+        assert_eq!(custom.api_protocol, Some(ApiProtocol::Openai));
+        let models = custom.models.as_ref().unwrap();
+        assert!(models.contains_key("my-model-7b"));
+
+        // Model routing
+        assert_eq!(config.models.len(), 3);
+        assert!(config.models.contains_key("smart"));
+        assert!(config.models.contains_key("fast"));
+        assert!(config.models.contains_key("coding"));
+        assert_eq!(config.models["smart"].strategy, RoutingStrategy::Priority);
+        assert_eq!(config.models["fast"].strategy, RoutingStrategy::LoadBalance);
+
+        // Tool routing
+        assert!(config.tools.contains_key("create_issue"));
+        assert!(config.tools.contains_key("web_search"));
+
+        // Guardrails
+        assert!(config.guardrails.enabled);
+        assert!(!config.guardrails.disabled_patterns.is_empty());
+        assert!(!config.guardrails.custom_patterns.is_empty());
+        assert!(!config.guardrails.upgoing.is_empty());
+        assert!(!config.guardrails.downgoing.is_empty());
+
+        // Wallet
+        let wallet = config.wallet.as_ref().unwrap();
+        assert_eq!(wallet.name, "my-wallet");
+        assert!(wallet.payment.is_some());
+
+        // MPP
+        let mpp = config.mpp.as_ref().unwrap();
+        assert!(mpp.enabled);
+    }
+
+    #[test]
+    fn minimal_template_deserializes() {
+        let yaml = include_str!("../templates/minimal.yaml");
+        let config = BitrouterConfig::load_from_str(yaml, None).unwrap();
+
+        // Comments-only YAML deserializes with all defaults
+        assert_eq!(config.server.listen, "127.0.0.1:8787".parse().unwrap());
+        assert_eq!(config.server.log_level, "info");
+
+        // Builtins merged (inherit_defaults defaults to true)
+        assert!(config.inherit_defaults);
+        assert!(config.providers.contains_key("openai"));
+        assert!(config.providers.contains_key("anthropic"));
+        assert!(config.providers.contains_key("google"));
+        assert!(config.providers.contains_key("bitrouter"));
+
+        // No custom models or tools defined
+        assert!(config.models.is_empty());
+
+        // No wallet or MPP
+        assert!(config.wallet.is_none());
+        assert!(config.mpp.is_none());
+
+        // Guardrails enabled by default
+        assert!(config.guardrails.enabled);
+    }
+
+    #[test]
+    fn empty_string_deserializes() {
+        let config = BitrouterConfig::load_from_str("", None).unwrap();
+
+        // All defaults applied
+        assert_eq!(config.server.listen, "127.0.0.1:8787".parse().unwrap());
+        assert!(config.inherit_defaults);
+        assert!(config.providers.contains_key("openai"));
+        assert!(config.providers.contains_key("anthropic"));
+        assert!(config.providers.contains_key("google"));
+        assert!(config.models.is_empty());
+        assert!(config.guardrails.enabled);
+    }
 }

--- a/bitrouter-config/templates/full.yaml
+++ b/bitrouter-config/templates/full.yaml
@@ -1,0 +1,280 @@
+# ============================================================================
+# BitRouter — Full Configuration Reference
+# ============================================================================
+# Place this file at <home>/bitrouter.yaml (default: ~/.bitrouter/bitrouter.yaml)
+#
+# Environment variable substitution: use ${VAR_NAME} anywhere in this file.
+# Variables are resolved from the process environment and <home>/.env.
+# Unresolved variables become empty strings.
+# ============================================================================
+
+# ── Server ──────────────────────────────────────────────────────────────────
+
+server:
+  # Address and port for the HTTP API server.
+  listen: "127.0.0.1:8787"
+
+  # Tracing log level: trace, debug, info, warn, error
+  log_level: info
+
+  # Unix domain socket for daemon control (start/stop/reload).
+  # Relative paths are resolved from <home>/run/.
+  control:
+    socket: bitrouter.sock
+
+# ── Database ────────────────────────────────────────────────────────────────
+
+database:
+  # Connection URL. Supports sqlite://, postgres://, mysql://.
+  # Default: sqlite://<home>/bitrouter.db?mode=rwc
+  #
+  # Resolution priority:
+  #   1. --db CLI flag
+  #   2. BITROUTER_DATABASE_URL env var
+  #   3. This field
+  #   4. Default SQLite in home directory
+  url: "sqlite://bitrouter.db?mode=rwc"
+
+# ── Provider Inheritance ────────────────────────────────────────────────────
+
+# When true (default), built-in providers (openai, anthropic, google,
+# openrouter, deepseek, minimax, zai, moonshot, qwen, bitrouter) are
+# merged into the provider set. User overrides take precedence.
+# Set to false to use ONLY the providers declared below.
+inherit_defaults: true
+
+# ── Providers ───────────────────────────────────────────────────────────────
+#
+# Each provider represents an upstream LLM or tool API.
+# Built-in providers already define api_protocol, api_base, env_prefix,
+# and a full model catalog — you only need to supply api_key.
+
+providers:
+  # Override a built-in provider (only the fields you set are changed).
+  openai:
+    api_key: "${OPENAI_API_KEY}"
+
+  anthropic:
+    api_key: "${ANTHROPIC_API_KEY}"
+
+  google:
+    api_key: "${GOOGLE_API_KEY}"
+
+  # Custom provider inheriting from a built-in.
+  # `derives` copies api_protocol, api_base, model catalog, etc.
+  my-proxy:
+    derives: openai
+    api_base: "https://api.mycompany.com/v1"
+    api_key: "${MY_PROXY_API_KEY}"
+
+  # Fully custom provider (no inheritance).
+  custom-llm:
+    api_protocol: openai # openai | anthropic | google | mcp | rest
+    api_base: "https://llm.example.com/v1"
+    api_key: "${CUSTOM_LLM_KEY}"
+    env_prefix: CUSTOM_LLM # auto-reads CUSTOM_LLM_API_KEY, CUSTOM_LLM_BASE_URL
+    default_headers:
+      x-project-id: "my-project"
+    models:
+      my-model-7b:
+        name: "My Model 7B"
+        description: "Custom fine-tuned model"
+        max_input_tokens: 32768
+        max_output_tokens: 4096
+        input_modalities: [text]
+        output_modalities: [text]
+        pricing:
+          input_tokens:
+            no_cache: 0.50
+            cache_read: 0.25
+            cache_write: 0.75
+          output_tokens:
+            text: 1.50
+            reasoning: 3.00
+
+  # MCP tool provider with bridge mode.
+  github-mcp:
+    api_protocol: mcp
+    api_base: "https://api.githubcopilot.com/mcp"
+    api_key: "${GITHUB_TOKEN}"
+    bridge: true # expose as POST /mcp/github-mcp
+
+  # Provider with custom auth.
+  header-auth-provider:
+    derives: openai
+    api_base: "https://api.example.com/v1"
+    auth:
+      type: header
+      header_name: "x-api-key"
+      api_key: "${HEADER_AUTH_KEY}"
+
+  # Provider using MPP (Machine Payment Protocol) auth.
+  paid-provider:
+    derives: openai
+    api_base: "https://paid.example.com/v1"
+    auth:
+      type: mpp
+
+# ── Model Routing ───────────────────────────────────────────────────────────
+#
+# Virtual model names that route to one or more provider endpoints.
+# Without this section, bare model names route to the default `bitrouter`
+# provider (if it exists and has an api_key).
+
+models:
+  # Priority routing: try endpoints in order, failover on error.
+  smart:
+    strategy: priority
+    endpoints:
+      - provider: anthropic
+        service_id: claude-sonnet-4-20250514
+      - provider: openai
+        service_id: gpt-4o
+    name: "Smart"
+    max_input_tokens: 200000
+    max_output_tokens: 16384
+
+  # Load-balanced routing: round-robin across endpoints.
+  fast:
+    strategy: load_balance
+    endpoints:
+      - provider: openai
+        service_id: gpt-4o-mini
+        api_key: "${OPENAI_KEY_POOL_A}" # per-endpoint override
+      - provider: openai
+        service_id: gpt-4o-mini
+        api_key: "${OPENAI_KEY_POOL_B}"
+
+  # Cross-provider failover.
+  coding:
+    strategy: priority
+    endpoints:
+      - provider: anthropic
+        service_id: claude-sonnet-4-20250514
+      - provider: openai
+        service_id: gpt-4o
+      - provider: google
+        service_id: gemini-2.5-pro
+
+# ── Tool Routing ────────────────────────────────────────────────────────────
+#
+# Virtual tool names that route to upstream MCP or REST tool providers.
+
+tools:
+  create_issue:
+    strategy: priority
+    endpoints:
+      - provider: github-mcp
+        service_id: create_issue
+    description: "Create a GitHub issue"
+    input_schema:
+      type: object
+      properties:
+        repo:
+          type: string
+        title:
+          type: string
+        body:
+          type: string
+      required: [repo, title]
+    skill: "github-issues" # references a SKILL.md for agent guidance
+
+  web_search:
+    endpoints:
+      - provider: exa
+        service_id: search
+    pricing:
+      default: 0.001 # $0.001 per invocation
+      overrides:
+        search: 0.002
+
+# ── Guardrails ──────────────────────────────────────────────────────────────
+#
+# Local firewall for AI agent traffic. Inspects content flowing both
+# upgoing (user → LLM) and downgoing (LLM → user).
+#
+# Built-in patterns: api_keys, private_keys, credentials, pii_emails,
+#   pii_phone_numbers, ip_addresses, suspicious_commands
+# Actions: warn (default), redact, block
+
+guardrails:
+  enabled: true
+
+  # Disable specific built-in patterns.
+  disabled_patterns:
+    - ip_addresses
+    - pii_phone_numbers
+
+  # User-defined regex patterns.
+  custom_patterns:
+    - name: internal_token
+      regex: "myapp_[A-Za-z0-9]{32}"
+      direction: upgoing # upgoing | downgoing | both
+
+  # Per-pattern action overrides for outbound traffic (user → LLM).
+  upgoing:
+    api_keys: redact
+    private_keys: block
+    credentials: redact
+
+  # Per-pattern action overrides for inbound traffic (LLM → user).
+  downgoing:
+    suspicious_commands: block
+
+  # Per-custom-pattern action overrides.
+  custom_upgoing:
+    internal_token: block
+
+  # Block message configuration.
+  block_message:
+    include_details: true
+    include_help_link: true
+
+  # Tool access guardrails.
+  tools:
+    enabled: true
+    providers:
+      github-mcp:
+        filter:
+          deny: [delete_repo, delete_branch]
+        param_restrictions:
+          rules:
+            create_issue:
+              deny: [assignees]
+              action: strip # strip | reject
+
+# ── Wallet ──────────────────────────────────────────────────────────────────
+#
+# OWS (Open Wallet Standard) wallet for signing and payment operations.
+# The passphrase is read from OWS_PASSPHRASE env var at startup.
+
+wallet:
+  name: "my-wallet"
+  vault_path: "~/.ows" # optional, defaults to OWS standard path
+  payment:
+    tempo_rpc_url: "https://rpc.moderato.tempo.xyz"
+    solana_rpc_url: "https://api.mainnet-beta.solana.com"
+    session_max_deposit: 10000000 # cap server-suggested deposits (base units)
+    session_default_deposit: 1000000
+
+# ── MPP (Machine Payment Protocol) ─────────────────────────────────────────
+#
+# Server-side payment gating. Returns 402 Payment Required to clients
+# and validates payment proofs before forwarding requests.
+
+mpp:
+  enabled: true
+  realm: "bitrouter.example.com"
+  secret_key: "${MPP_SECRET_KEY}"
+  networks:
+    tempo:
+      recipient: "0x1234567890abcdef1234567890abcdef12345678"
+      escrow_contract: "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+      rpc_url: "${TEMPO_RPC_URL}"
+      currency: "${TEMPO_TOKEN_ADDRESS}"
+      fee_payer: false
+      default_deposit: "5000000"
+
+# ── Solana RPC ──────────────────────────────────────────────────────────────
+
+solana_rpc_url: "https://api.mainnet-beta.solana.com"

--- a/bitrouter-config/templates/minimal.yaml
+++ b/bitrouter-config/templates/minimal.yaml
@@ -1,0 +1,23 @@
+# BitRouter configuration
+# See https://docs.bitrouter.ai/docs/guide/configuration
+#
+# BitRouter works out of the box with an empty config.
+# All built-in providers (OpenAI, Anthropic, Google, etc.) are available
+# automatically — just set their API keys in .env or the environment.
+#
+# To add a custom provider, uncomment and adjust:
+#
+# providers:
+#   my-provider:
+#     derives: openai
+#     api_base: "https://api.example.com/v1"
+#     api_key: "${MY_PROVIDER_API_KEY}"
+#
+# To define model routes:
+#
+# models:
+#   my-model:
+#     strategy: priority
+#     endpoints:
+#       - provider: openai
+#         model_id: gpt-4o

--- a/bitrouter/src/runtime/paths.rs
+++ b/bitrouter/src/runtime/paths.rs
@@ -102,24 +102,7 @@ fn scaffold_home(home: &Path) -> std::io::Result<()> {
     if !config_path.exists() {
         std::fs::write(
             &config_path,
-            "\
-# BitRouter configuration
-# See https://github.com/bitrouter/bitrouter for documentation.
-#
-# server:
-#   listen: \"127.0.0.1:8787\"
-#
-# providers:
-#   openai:
-#     api_key: \"${OPENAI_API_KEY}\"
-#
-# models:
-#   my-model:
-#     strategy: priority
-#     endpoints:
-#       - provider: openai
-#         model_id: gpt-4o
-",
+            include_str!("../../../bitrouter-config/templates/minimal.yaml"),
         )?;
     }
 


### PR DESCRIPTION
## Summary

- Add `bitrouter-config/templates/full.yaml` — comprehensive config reference covering every field (server, database, providers, models, tools, guardrails, wallet, MPP)
- Add `bitrouter-config/templates/minimal.yaml` — comments-only template for new BitRouter home directories
- Add deserialization tests: `full_template_deserializes`, `minimal_template_deserializes`, `empty_string_deserializes`
- Update `scaffold_home()` to use `include_str!` from the minimal template instead of a hardcoded string

## Context

BitRouter works with an empty config (all built-in providers are available automatically). The minimal template generated by `bitrouter init` / `scaffold_home()` is now comments-only, guiding users to add custom providers or model routes only when needed.

The full template serves as a living reference — its deserialization test ensures it stays in sync with config type changes.