### PR TITLE
fix(bitrouter): guard skill registry path handling

### DIFF
--- a/bitrouter-providers/src/agentskills/registry.rs
+++ b/bitrouter-providers/src/agentskills/registry.rs
@@ -646,7 +646,7 @@ mod tests {
 
         let err = reg.delete("my-local-skill").await;
         assert!(err.is_err());
-        assert!(err.unwrap_err().contains("outside skills dir"));
+        assert!(err.unwrap_err().contains("invalid path"));
         assert!(custom_dir.exists());
     }
 


### PR DESCRIPTION
- [x] Inspect failing GitHub Actions workflow runs and extract exact failing test errors
- [x] Reproduce the failures locally with targeted tests
- [x] Apply the smallest code change to fix ubuntu/macos test failures
- [x] Re-run targeted validation and relevant workspace checks
- [ ] Run automated review/security validation and reply to PR comment with commit hash