### PR TITLE
refactor(cargo): centralize internal deps under workspace.dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,17 @@ members = ["bitrouter", "bitrouter-*"]
 [workspace.package]
 version = "0.18.2"
 
+[workspace.dependencies]
+bitrouter-accounts = { path = "bitrouter-accounts", version = "0.18" }
+bitrouter-api = { path = "bitrouter-api", version = "0.18", default-features = false }
+bitrouter-blob = { path = "bitrouter-blob", version = "0.18" }
+bitrouter-config = { path = "bitrouter-config", version = "0.18" }
+bitrouter-core = { path = "bitrouter-core", version = "0.18" }
+bitrouter-guardrails = { path = "bitrouter-guardrails", version = "0.18" }
+bitrouter-observe = { path = "bitrouter-observe", version = "0.18" }
+bitrouter-providers = { path = "bitrouter-providers", version = "0.18" }
+bitrouter-tui = { path = "bitrouter-tui", version = "0.18" }
+
 # The profile that 'dist' will build with
 [profile.dist]
 inherits = "release"

--- a/bitrouter-accounts/Cargo.toml
+++ b/bitrouter-accounts/Cargo.toml
@@ -15,7 +15,7 @@ postgres = ["sea-orm/sqlx-postgres", "sea-orm-migration/sqlx-postgres"]
 mysql = ["sea-orm/sqlx-mysql", "sea-orm-migration/sqlx-mysql"]
 
 [dependencies]
-bitrouter-core = { path = "../bitrouter-core", version = "0.18" }
+bitrouter-core.workspace = true
 sea-orm = { version = "1.1", default-features = false, features = [
     "macros",
     "with-chrono",

--- a/bitrouter-api/Cargo.toml
+++ b/bitrouter-api/Cargo.toml
@@ -34,8 +34,8 @@ mpp-solana = [
 ]
 
 [dependencies]
-bitrouter-core = { path = "../bitrouter-core", version = "0.18" }
-bitrouter-config = { path = "../bitrouter-config", version = "0.18", optional = true }
+bitrouter-core.workspace = true
+bitrouter-config = { workspace = true, optional = true }
 async-trait = { version = "0.1" }
 futures-core = { version = "0.3" }
 mpp = { package = "mpp-br", version = "0.8.1", default-features = false, features = [

--- a/bitrouter-blob/Cargo.toml
+++ b/bitrouter-blob/Cargo.toml
@@ -16,7 +16,7 @@ fs = ["tokio/fs"]
 # gcs = ["google-cloud-storage"]
 
 [dependencies]
-bitrouter-core = { path = "../bitrouter-core", version = "0.18" }
+bitrouter-core.workspace = true
 tokio = { version = "1", features = ["io-util"] }
 
 [dev-dependencies]

--- a/bitrouter-config/Cargo.toml
+++ b/bitrouter-config/Cargo.toml
@@ -14,8 +14,8 @@ mpp-tempo = []
 mpp-solana = []
 
 [dependencies]
-bitrouter-core = { path = "../bitrouter-core", version = "0.18" }
-bitrouter-guardrails = { path = "../bitrouter-guardrails", version = "0.18" }
+bitrouter-core.workspace = true
+bitrouter-guardrails.workspace = true
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
 serde-saphyr = { version = "0.0" }

--- a/bitrouter-guardrails/Cargo.toml
+++ b/bitrouter-guardrails/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/bitrouter/bitrouter"
 readme = "README.md"
 
 [dependencies]
-bitrouter-core = { path = "../bitrouter-core", version = "0.18" }
+bitrouter-core.workspace = true
 futures-core = { version = "0.3" }
 regex = { version = "1.12" }
 serde = { version = "1.0", features = ["derive"] }

--- a/bitrouter-observe/Cargo.toml
+++ b/bitrouter-observe/Cargo.toml
@@ -15,7 +15,7 @@ postgres = ["sea-orm/sqlx-postgres", "sea-orm-migration/sqlx-postgres"]
 mysql = ["sea-orm/sqlx-mysql", "sea-orm-migration/sqlx-mysql"]
 
 [dependencies]
-bitrouter-core = { path = "../bitrouter-core", version = "0.18" }
+bitrouter-core.workspace = true
 sea-orm = { version = "1.1", default-features = false, features = [
     "macros",
     "with-chrono",

--- a/bitrouter-providers/Cargo.toml
+++ b/bitrouter-providers/Cargo.toml
@@ -15,11 +15,27 @@ anthropic = []
 google = []
 rest = []
 mcp = ["dep:tracing", "dep:rmcp"]
-acp = ["dep:agent-client-protocol", "dep:async-trait", "dep:tracing", "dep:bitrouter-config", "dep:flate2", "dep:tar", "dep:zip", "tokio/process"]
-agentskills = ["dep:tracing", "dep:serde-saphyr", "dep:chrono", "dep:uuid", "dep:bitrouter-config", "tokio/fs"]
+acp = [
+    "dep:agent-client-protocol",
+    "dep:async-trait",
+    "dep:tracing",
+    "dep:bitrouter-config",
+    "dep:flate2",
+    "dep:tar",
+    "dep:zip",
+    "tokio/process",
+]
+agentskills = [
+    "dep:tracing",
+    "dep:serde-saphyr",
+    "dep:chrono",
+    "dep:uuid",
+    "dep:bitrouter-config",
+    "tokio/fs",
+]
 
 [dependencies]
-bitrouter-core = { path = "../bitrouter-core", version = "0.18" }
+bitrouter-core.workspace = true
 tracing = { version = "0.1", optional = true }
 
 base64 = "0.22"
@@ -52,10 +68,12 @@ agent-client-protocol = { version = "0.10", optional = true }
 async-trait = { version = "0.1", optional = true }
 flate2 = { version = "1", optional = true }
 tar = { version = "0.4", optional = true }
-zip = { version = "2", optional = true, default-features = false, features = ["deflate"] }
+zip = { version = "2", optional = true, default-features = false, features = [
+    "deflate",
+] }
 
 # agentskills
-bitrouter-config = { path = "../bitrouter-config", version = "0.18", optional = true }
+bitrouter-config = { workspace = true, optional = true }
 chrono = { version = "0.4", optional = true }
 serde-saphyr = { version = "0.0", optional = true }
 uuid = { version = "1", features = ["v4"], optional = true }

--- a/bitrouter-tui/Cargo.toml
+++ b/bitrouter-tui/Cargo.toml
@@ -8,8 +8,8 @@ license = "Apache-2.0"
 repository = "https://github.com/bitrouter/bitrouter"
 
 [dependencies]
-bitrouter-config = { path = "../bitrouter-config" }
-bitrouter-providers = { path = "../bitrouter-providers", features = ["acp"] }
+bitrouter-config.workspace = true
+bitrouter-providers = { workspace = true, features = ["acp"] }
 crossterm = { version = "0.29", features = ["event-stream"] }
 futures = "0.3"
 ratatui = "0.30"

--- a/bitrouter/Cargo.toml
+++ b/bitrouter/Cargo.toml
@@ -43,19 +43,17 @@ mpp-solana = [
 
 [dependencies]
 # Internal crates
-bitrouter-accounts = { path = "../bitrouter-accounts", version = "0.18" }
-bitrouter-api = { path = "../bitrouter-api", version = "0.18", default-features = false, features = [
+bitrouter-accounts.workspace = true
+bitrouter-api = { workspace = true, features = [
     "openai",
     "anthropic",
     "google",
 ] }
-bitrouter-config = { path = "../bitrouter-config", version = "0.18" }
-bitrouter-core = { path = "../bitrouter-core", version = "0.18" }
-bitrouter-guardrails = { path = "../bitrouter-guardrails", version = "0.18" }
-bitrouter-observe = { path = "../bitrouter-observe", version = "0.18" }
-bitrouter-providers = { path = "../bitrouter-providers", version = "0.18", features = [
-    "agentskills",
-] }
+bitrouter-config.workspace = true
+bitrouter-core.workspace = true
+bitrouter-guardrails.workspace = true
+bitrouter-observe.workspace = true
+bitrouter-providers = { workspace = true, features = ["agentskills"] }
 
 # CLI
 clap = { version = "4.5", features = ["derive"] }
@@ -91,7 +89,7 @@ uuid = { version = "1", features = ["v4"] }
 warp = { version = "0.4.2", features = ["server"] }
 
 # TUI (optional)
-bitrouter-tui = { path = "../bitrouter-tui", version = "0.18", optional = true }
+bitrouter-tui = { workspace = true, optional = true }
 anyhow = { version = "1", optional = true }
 
 


### PR DESCRIPTION
Move all `bitrouter-*` internal crate dependencies to `[workspace.dependencies]` in the root Cargo.toml and reference them via `workspace = true` in each crate.

### Changes
- Added `[workspace.dependencies]` block in root `Cargo.toml` with all 9 internal crates
- Updated all 10 crate `Cargo.toml` files to use `workspace = true` references
- `bitrouter-api` workspace dep uses `default-features = false` since the binary selectively enables features

### Validation
- `cargo check --workspace` ✓
- `cargo clippy --workspace --all-targets --all-features` ✓
- `cargo test --workspace` ✓
- `cargo fmt -- --check` ✓