### PR TITLE
fix: add wallet variant to AuthConfig enum

### DIFF
--- a/bitrouter-config/src/config.rs
+++ b/bitrouter-config/src/config.rs
@@ -683,6 +683,8 @@ pub enum AuthConfig {
     X402,
     /// MPP (Machine Payment Protocol) — requests are paid via an EVM wallet.
     Mpp,
+    /// OWS wallet authentication — requests are signed by a local wallet.
+    Wallet,
     /// Extension point for non-standard auth methods.
     Custom {
         method: String,

--- a/bitrouter/src/runtime/router.rs
+++ b/bitrouter/src/runtime/router.rs
@@ -327,7 +327,9 @@ pub(crate) fn resolve_auth_header(config: &ProviderConfig) -> Option<(String, St
             let key = resolve_key(api_key, config);
             Some((header_name.clone(), key))
         }
-        Some(AuthConfig::X402 | AuthConfig::Mpp | AuthConfig::Custom { .. }) => None,
+        Some(
+            AuthConfig::X402 | AuthConfig::Mpp | AuthConfig::Wallet | AuthConfig::Custom { .. },
+        ) => None,
         None => {
             // Fall back to api_key field as Bearer token.
             config


### PR DESCRIPTION
The built-in tool provider YAML (`bitrouter-config/providers/tools/bitrouter.yaml`) uses `auth: { type: wallet }`, but the `AuthConfig` enum did not have a `Wallet` variant, causing a deserialization warning on every startup:

```
warning: invalid built-in tool provider YAML 'bitrouter': error: line 13 column 3: unknown variant `wallet`, expected one of bearer, header, x402, mpp, custom
```

**Changes:**
- Add `Wallet` unit variant to `AuthConfig` in `bitrouter-config/src/config.rs`, alongside `X402` and `Mpp`
- Update the `resolve_auth_header` match arm in `bitrouter/src/runtime/router.rs` to handle `Wallet` by returning `None` (no injected auth header), consistent with other payment-based auth types