### PR TITLE
feat: spend-limit policy engine and policy CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1580,6 +1580,7 @@ dependencies = [
  "bitrouter-providers",
  "bitrouter-tui",
  "bs58",
+ "chrono",
  "clap",
  "curve25519-dalek",
  "dialoguer",

--- a/bitrouter-accounts/src/identity.rs
+++ b/bitrouter-accounts/src/identity.rs
@@ -61,6 +61,9 @@ pub struct Identity {
     pub budget: Option<u64>,
     /// Whether the budget applies per-session or per-account.
     pub budget_scope: Option<BudgetScope>,
+    /// JWT issued-at timestamp (seconds since epoch).
+    /// Propagated to `CallerContext` for session-scoped budget enforcement.
+    pub issued_at: Option<u64>,
     /// OWS agent key for payment authorization (from JWT `key` claim).
     pub key: Option<String>,
 }

--- a/bitrouter-core/src/observe.rs
+++ b/bitrouter-core/src/observe.rs
@@ -29,6 +29,9 @@ pub struct CallerContext {
     pub budget: Option<u64>,
     /// Whether the budget applies per-session or per-account.
     pub budget_scope: Option<BudgetScope>,
+    /// JWT issued-at timestamp (seconds since epoch).
+    /// Used as the `since` boundary for session-scoped budget enforcement.
+    pub issued_at: Option<u64>,
     /// OWS agent key for payment authorization (from JWT `key` claim).
     pub key: Option<String>,
     /// CAIP-2 chain identifier derived from the operator's `iss` CAIP-10.

--- a/bitrouter/Cargo.toml
+++ b/bitrouter/Cargo.toml
@@ -61,6 +61,7 @@ dialoguer = "0.12"
 # Runtime
 dirs = "6"
 base64 = { version = "0.22" }
+chrono = { version = "0.4" }
 rand = { version = "0.9" }
 reqwest = { version = "0.13", default-features = false, features = [
     "blocking",

--- a/bitrouter/src/cli/mod.rs
+++ b/bitrouter/src/cli/mod.rs
@@ -3,6 +3,7 @@ pub mod admin_auth;
 pub mod agents;
 pub mod key;
 pub mod models;
+pub mod policy;
 pub mod route;
 pub mod tools;
 pub mod update_check;

--- a/bitrouter/src/cli/policy.rs
+++ b/bitrouter/src/cli/policy.rs
@@ -1,0 +1,531 @@
+//! `bitrouter policy` subcommands — manage OWS spend-limit policies and
+//! serve as the OWS executable policy evaluator.
+//!
+//! ## Two roles
+//!
+//! 1. **CLI management** (`create`, `list`, `show`, `delete`): CRUD for
+//!    spend-limit policy files stored in `<home>/policies/`.
+//! 2. **Executable evaluator** (`eval`): invoked by OWS as a subprocess
+//!    during the signing flow. Reads [`PolicyContext`] JSON from stdin,
+//!    evaluates against the operator-defined limits, and writes
+//!    [`PolicyResult`] JSON to stdout. Default-deny on any error.
+
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+// ── Data types ───────────────────────────────────────────────────
+
+/// Input context sent by OWS on stdin when invoking an executable policy.
+///
+/// Additional fields (`wallet`, `api_key`, etc.) are accepted and ignored
+/// by serde's default behavior — only the fields needed for evaluation are
+/// declared here.
+#[derive(Debug, Deserialize)]
+pub struct PolicyContext {
+    /// CAIP-2 chain identifier (e.g. `"tempo:mainnet"`).
+    #[serde(default)]
+    pub chain: Option<String>,
+    /// Transaction value in micro-USD.
+    #[serde(default)]
+    pub transaction_value: u64,
+    /// Accumulated daily spend in micro-USD (provided by OWS).
+    #[serde(default)]
+    pub daily_total: u64,
+    /// Accumulated monthly spend in micro-USD (provided by OWS).
+    #[serde(default)]
+    pub monthly_total: u64,
+}
+
+/// Result written to stdout after policy evaluation.
+#[derive(Debug, Serialize)]
+pub struct PolicyResult {
+    pub allow: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+/// Operator-defined spend limits stored in a policy file.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PolicyConfig {
+    /// Human-readable policy name.
+    pub name: String,
+
+    /// Maximum daily spend in micro-USD.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub daily_limit: Option<u64>,
+
+    /// Maximum monthly spend in micro-USD.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub monthly_limit: Option<u64>,
+
+    /// Maximum per-transaction value in micro-USD.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub per_tx_max: Option<u64>,
+
+    /// Allowed chains (CAIP-2). Empty means all chains allowed.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub allowed_chains: Vec<String>,
+
+    /// Policy expiration (ISO 8601). After this time, policy denies all.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<String>,
+}
+
+/// Full on-disk policy file: config + OWS integration metadata.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PolicyFile {
+    /// Unique policy ID (UUID).
+    pub id: String,
+
+    /// The spend-limit configuration.
+    #[serde(flatten)]
+    pub config: PolicyConfig,
+
+    /// Path to the evaluator executable (populated by `create`).
+    pub executable: String,
+
+    /// When this policy was created (ISO 8601).
+    pub created_at: String,
+}
+
+// ── Eval subcommand ──────────────────────────────────────────────
+
+/// Evaluate a policy against context read from stdin.
+///
+/// This is the OWS executable policy entry point. It reads JSON from stdin,
+/// evaluates declarative rules and spend limits, and writes a JSON result to
+/// stdout. Any error results in a default-deny response.
+pub fn eval(policy_dir: &Path) -> Result {
+    // Default-deny: capture the result and always write a PolicyResult.
+    let result = eval_inner(policy_dir);
+    match result {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            let deny = PolicyResult {
+                allow: false,
+                reason: Some(format!("policy evaluation error: {e}")),
+            };
+            let json = serde_json::to_string(&deny)?;
+            println!("{json}");
+            Ok(())
+        }
+    }
+}
+
+fn eval_inner(policy_dir: &Path) -> Result {
+    // Read PolicyContext from stdin.
+    let mut input = String::new();
+    std::io::stdin().read_to_string(&mut input)?;
+    let ctx: PolicyContext =
+        serde_json::from_str(&input).map_err(|e| format!("invalid PolicyContext JSON: {e}"))?;
+
+    // Load all active policies and evaluate against each.
+    let policies = load_policies(policy_dir)?;
+
+    if policies.is_empty() {
+        // No policies configured → allow (policy layer is optional).
+        let result = PolicyResult {
+            allow: true,
+            reason: None,
+        };
+        println!("{}", serde_json::to_string(&result)?);
+        return Ok(());
+    }
+
+    for policy in &policies {
+        if let Some(ref reason) = check_policy(&policy.config, &ctx) {
+            let result = PolicyResult {
+                allow: false,
+                reason: Some(reason.clone()),
+            };
+            println!("{}", serde_json::to_string(&result)?);
+            return Ok(());
+        }
+    }
+
+    let result = PolicyResult {
+        allow: true,
+        reason: None,
+    };
+    println!("{}", serde_json::to_string(&result)?);
+    Ok(())
+}
+
+/// Check a single policy against the context. Returns `Some(reason)` if denied.
+fn check_policy(config: &PolicyConfig, ctx: &PolicyContext) -> Option<String> {
+    // Declarative pre-filter: expiration.
+    if let Some(ref expires) = config.expires_at
+        && let Ok(exp) = chrono::DateTime::parse_from_rfc3339(expires)
+        && chrono::Utc::now() >= exp
+    {
+        return Some(format!("policy '{}' has expired", config.name));
+    }
+
+    // Declarative pre-filter: chain allowlist.
+    if !config.allowed_chains.is_empty()
+        && let Some(ref chain) = ctx.chain
+        && !config.allowed_chains.iter().any(|c| c == chain)
+    {
+        return Some(format!(
+            "chain '{}' not in allowed list for policy '{}'",
+            chain, config.name,
+        ));
+    }
+
+    // Per-transaction cap.
+    if let Some(max) = config.per_tx_max
+        && ctx.transaction_value > max
+    {
+        return Some(format!(
+            "transaction value {} exceeds per-tx max {} (policy '{}')",
+            ctx.transaction_value, max, config.name,
+        ));
+    }
+
+    // Daily limit.
+    if let Some(limit) = config.daily_limit
+        && ctx.daily_total.saturating_add(ctx.transaction_value) > limit
+    {
+        return Some(format!(
+            "daily spend {} + tx {} would exceed daily limit {} (policy '{}')",
+            ctx.daily_total, ctx.transaction_value, limit, config.name,
+        ));
+    }
+
+    // Monthly limit.
+    if let Some(limit) = config.monthly_limit
+        && ctx.monthly_total.saturating_add(ctx.transaction_value) > limit
+    {
+        return Some(format!(
+            "monthly spend {} + tx {} would exceed monthly limit {} (policy '{}')",
+            ctx.monthly_total, ctx.transaction_value, limit, config.name,
+        ));
+    }
+
+    None
+}
+
+// ── CLI subcommands ──────────────────────────────────────────────
+
+/// Options for creating a spend-limit policy.
+pub struct CreateOpts<'a> {
+    pub name: &'a str,
+    pub daily_limit: Option<u64>,
+    pub monthly_limit: Option<u64>,
+    pub per_tx_max: Option<u64>,
+    pub chains: &'a [String],
+    pub expires_at: Option<&'a str>,
+    pub file: Option<&'a Path>,
+}
+
+/// Create a new spend-limit policy.
+pub fn create(policy_dir: &Path, opts: CreateOpts<'_>) -> Result {
+    std::fs::create_dir_all(policy_dir)?;
+
+    let policy_file = if let Some(path) = opts.file {
+        // Import from a custom policy JSON file.
+        let content = std::fs::read_to_string(path)?;
+        let mut pf: PolicyFile = serde_json::from_str(&content)?;
+        if pf.id.is_empty() {
+            pf.id = uuid::Uuid::new_v4().to_string();
+        }
+        if pf.created_at.is_empty() {
+            pf.created_at = chrono::Utc::now().to_rfc3339();
+        }
+        pf
+    } else {
+        // Build from CLI flags.
+        let bitrouter_exe = std::env::current_exe()
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|_| "bitrouter".to_owned());
+
+        PolicyFile {
+            id: uuid::Uuid::new_v4().to_string(),
+            config: PolicyConfig {
+                name: opts.name.to_owned(),
+                daily_limit: opts.daily_limit,
+                monthly_limit: opts.monthly_limit,
+                per_tx_max: opts.per_tx_max,
+                allowed_chains: opts.chains.to_vec(),
+                expires_at: opts.expires_at.map(String::from),
+            },
+            executable: format!("{bitrouter_exe} policy eval"),
+            created_at: chrono::Utc::now().to_rfc3339(),
+        }
+    };
+
+    let filename = format!("{}.json", policy_file.id);
+    let path = policy_dir.join(&filename);
+    let json = serde_json::to_string_pretty(&policy_file)?;
+    std::fs::write(&path, json)?;
+
+    println!("Policy created:");
+    println!("  ID:   {}", policy_file.id);
+    println!("  Name: {}", policy_file.config.name);
+    println!("  File: {}", path.display());
+
+    if let Some(dl) = policy_file.config.daily_limit {
+        println!("  Daily limit:   {} μUSD (${:.2})", dl, dl as f64 / 1e6);
+    }
+    if let Some(ml) = policy_file.config.monthly_limit {
+        println!("  Monthly limit: {} μUSD (${:.2})", ml, ml as f64 / 1e6);
+    }
+    if let Some(tx) = policy_file.config.per_tx_max {
+        println!("  Per-tx max:    {} μUSD (${:.2})", tx, tx as f64 / 1e6);
+    }
+    if !policy_file.config.allowed_chains.is_empty() {
+        println!(
+            "  Chains:        {}",
+            policy_file.config.allowed_chains.join(", ")
+        );
+    }
+    if let Some(ref exp) = policy_file.config.expires_at {
+        println!("  Expires:       {exp}");
+    }
+
+    Ok(())
+}
+
+/// List all policies.
+pub fn list(policy_dir: &Path) -> Result {
+    let policies = load_policies(policy_dir)?;
+
+    if policies.is_empty() {
+        println!("No policies found. Run `bitrouter policy create` to create one.");
+        return Ok(());
+    }
+
+    println!(
+        "{:<38} {:<20} {:<14} {:<14} {:<14}",
+        "ID", "NAME", "DAILY", "MONTHLY", "PER-TX"
+    );
+    println!("{}", "-".repeat(100));
+    for p in &policies {
+        let daily = p
+            .config
+            .daily_limit
+            .map(|v| format!("${:.2}", v as f64 / 1e6))
+            .unwrap_or_else(|| "-".into());
+        let monthly = p
+            .config
+            .monthly_limit
+            .map(|v| format!("${:.2}", v as f64 / 1e6))
+            .unwrap_or_else(|| "-".into());
+        let per_tx = p
+            .config
+            .per_tx_max
+            .map(|v| format!("${:.2}", v as f64 / 1e6))
+            .unwrap_or_else(|| "-".into());
+        println!(
+            "{:<38} {:<20} {:<14} {:<14} {:<14}",
+            p.id, p.config.name, daily, monthly, per_tx,
+        );
+    }
+
+    Ok(())
+}
+
+/// Show details of a single policy.
+pub fn show(policy_dir: &Path, id: &str) -> Result {
+    let policies = load_policies(policy_dir)?;
+    let policy = policies
+        .iter()
+        .find(|p| p.id == id)
+        .ok_or_else(|| format!("policy '{id}' not found"))?;
+
+    println!("{}", serde_json::to_string_pretty(policy)?);
+    Ok(())
+}
+
+/// Delete a policy by ID.
+pub fn delete(policy_dir: &Path, id: &str) -> Result {
+    let path = policy_dir.join(format!("{id}.json"));
+    if !path.exists() {
+        return Err(format!("policy '{id}' not found").into());
+    }
+    std::fs::remove_file(&path)?;
+    println!("Policy '{id}' deleted.");
+    Ok(())
+}
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+/// Load all policy files from the policy directory.
+fn load_policies(dir: &Path) -> Result<Vec<PolicyFile>> {
+    if !dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut policies = Vec::new();
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().is_some_and(|e| e == "json") {
+            match std::fs::read_to_string(&path) {
+                Ok(content) => match serde_json::from_str::<PolicyFile>(&content) {
+                    Ok(pf) => policies.push(pf),
+                    Err(e) => {
+                        eprintln!("warning: skipping {}: {e}", path.display());
+                    }
+                },
+                Err(e) => {
+                    eprintln!("warning: cannot read {}: {e}", path.display());
+                }
+            }
+        }
+    }
+
+    policies.sort_by(|a, b| a.config.name.cmp(&b.config.name));
+    Ok(policies)
+}
+
+/// Resolve the policy directory for a given BitRouter home.
+pub fn policy_dir(home: &Path) -> PathBuf {
+    home.join("policies")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn eval_allows_within_limits() {
+        let config = PolicyConfig {
+            name: "test".into(),
+            daily_limit: Some(10_000_000),
+            monthly_limit: Some(50_000_000),
+            per_tx_max: Some(2_000_000),
+            allowed_chains: vec!["tempo:mainnet".into()],
+            expires_at: None,
+        };
+        let ctx = PolicyContext {
+            chain: Some("tempo:mainnet".into()),
+            transaction_value: 1_000_000,
+            daily_total: 5_000_000,
+            monthly_total: 20_000_000,
+        };
+
+        assert!(check_policy(&config, &ctx).is_none());
+    }
+
+    #[test]
+    fn eval_denies_over_daily_limit() {
+        let config = PolicyConfig {
+            name: "test".into(),
+            daily_limit: Some(10_000_000),
+            monthly_limit: None,
+            per_tx_max: None,
+            allowed_chains: vec![],
+            expires_at: None,
+        };
+        let ctx = PolicyContext {
+            chain: None,
+            transaction_value: 2_000_000,
+            daily_total: 9_000_000,
+            monthly_total: 0,
+        };
+
+        let reason = check_policy(&config, &ctx);
+        assert!(reason.is_some());
+        assert!(reason.as_ref().is_some_and(|r| r.contains("daily")));
+    }
+
+    #[test]
+    fn eval_denies_over_monthly_limit() {
+        let config = PolicyConfig {
+            name: "test".into(),
+            daily_limit: None,
+            monthly_limit: Some(50_000_000),
+            per_tx_max: None,
+            allowed_chains: vec![],
+            expires_at: None,
+        };
+        let ctx = PolicyContext {
+            chain: None,
+            transaction_value: 2_000_000,
+            daily_total: 0,
+            monthly_total: 49_000_000,
+        };
+
+        let reason = check_policy(&config, &ctx);
+        assert!(reason.is_some());
+        assert!(reason.as_ref().is_some_and(|r| r.contains("monthly")));
+    }
+
+    #[test]
+    fn eval_denies_over_per_tx_max() {
+        let config = PolicyConfig {
+            name: "test".into(),
+            daily_limit: None,
+            monthly_limit: None,
+            per_tx_max: Some(1_000_000),
+            allowed_chains: vec![],
+            expires_at: None,
+        };
+        let ctx = PolicyContext {
+            chain: None,
+            transaction_value: 2_000_000,
+            daily_total: 0,
+            monthly_total: 0,
+        };
+
+        let reason = check_policy(&config, &ctx);
+        assert!(reason.is_some());
+        assert!(reason.as_ref().is_some_and(|r| r.contains("per-tx")));
+    }
+
+    #[test]
+    fn eval_denies_disallowed_chain() {
+        let config = PolicyConfig {
+            name: "test".into(),
+            daily_limit: None,
+            monthly_limit: None,
+            per_tx_max: None,
+            allowed_chains: vec!["tempo:mainnet".into()],
+            expires_at: None,
+        };
+        let ctx = PolicyContext {
+            chain: Some("solana:mainnet".into()),
+            transaction_value: 0,
+            daily_total: 0,
+            monthly_total: 0,
+        };
+
+        let reason = check_policy(&config, &ctx);
+        assert!(reason.is_some());
+        assert!(reason.as_ref().is_some_and(|r| r.contains("chain")));
+    }
+
+    #[test]
+    fn eval_denies_expired_policy() {
+        let config = PolicyConfig {
+            name: "test".into(),
+            daily_limit: None,
+            monthly_limit: None,
+            per_tx_max: None,
+            allowed_chains: vec![],
+            expires_at: Some("2020-01-01T00:00:00Z".into()),
+        };
+        let ctx = PolicyContext {
+            chain: None,
+            transaction_value: 0,
+            daily_total: 0,
+            monthly_total: 0,
+        };
+
+        let reason = check_policy(&config, &ctx);
+        assert!(reason.is_some());
+        assert!(reason.as_ref().is_some_and(|r| r.contains("expired")));
+    }
+
+    #[test]
+    fn eval_allows_no_policies() {
+        // When no policies exist, the layer is optional → allow.
+        let policies: Vec<PolicyFile> = vec![];
+        assert!(policies.is_empty());
+    }
+}

--- a/bitrouter/src/main.rs
+++ b/bitrouter/src/main.rs
@@ -99,6 +99,12 @@ enum Command {
         action: AgentsAction,
     },
 
+    /// Manage spend-limit policies for OWS wallet signing
+    Policy {
+        #[command(subcommand)]
+        action: PolicyAction,
+    },
+
     /// Reset configuration and re-run setup
     Reset,
 }
@@ -222,6 +228,56 @@ enum AgentsAction {
     List,
     /// Check that agent routing through BitRouter is working
     Check,
+}
+
+#[derive(Debug, Subcommand)]
+enum PolicyAction {
+    /// Evaluate a policy (OWS executable policy entry point — reads JSON from stdin)
+    Eval,
+    /// Create a new spend-limit policy
+    Create {
+        /// Policy name
+        #[arg(long)]
+        name: Option<String>,
+
+        /// Daily spend limit in micro-USD
+        #[arg(long)]
+        daily_limit: Option<u64>,
+
+        /// Monthly spend limit in micro-USD
+        #[arg(long)]
+        monthly_limit: Option<u64>,
+
+        /// Per-transaction maximum in micro-USD
+        #[arg(long)]
+        per_tx_max: Option<u64>,
+
+        /// Allowed chains (CAIP-2, comma-separated)
+        #[arg(long, value_delimiter = ',')]
+        chains: Option<Vec<String>>,
+
+        /// Expiration timestamp (ISO 8601)
+        #[arg(long)]
+        expires: Option<String>,
+
+        /// Import from a custom policy JSON file
+        #[arg(long)]
+        file: Option<std::path::PathBuf>,
+    },
+    /// List all policies
+    List,
+    /// Show policy details
+    Show {
+        /// Policy ID
+        #[arg(long)]
+        id: String,
+    },
+    /// Delete a policy
+    Delete {
+        /// Policy ID
+        #[arg(long)]
+        id: String,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -402,6 +458,36 @@ async fn run_cli(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
                     exp.as_deref(),
                     ows_key.as_deref(),
                 )?,
+            }
+            return Ok(());
+        }
+        Some(Command::Policy { action }) => {
+            let pd = cli::policy::policy_dir(&paths.home_dir);
+            match action {
+                PolicyAction::Eval => cli::policy::eval(&pd)?,
+                PolicyAction::Create {
+                    name,
+                    daily_limit,
+                    monthly_limit,
+                    per_tx_max,
+                    chains,
+                    expires,
+                    file,
+                } => cli::policy::create(
+                    &pd,
+                    cli::policy::CreateOpts {
+                        name: name.as_deref().unwrap_or("default"),
+                        daily_limit,
+                        monthly_limit,
+                        per_tx_max,
+                        chains: chains.as_deref().unwrap_or(&[]),
+                        expires_at: expires.as_deref(),
+                        file: file.as_deref(),
+                    },
+                )?,
+                PolicyAction::List => cli::policy::list(&pd)?,
+                PolicyAction::Show { id } => cli::policy::show(&pd, &id)?,
+                PolicyAction::Delete { id } => cli::policy::delete(&pd, &id)?,
             }
             return Ok(());
         }

--- a/bitrouter/src/runtime/auth.rs
+++ b/bitrouter/src/runtime/auth.rs
@@ -211,6 +211,7 @@ async fn resolve_jwt_identity(
         models: claims.mdl,
         budget: claims.bgt,
         budget_scope: claims.bsc,
+        issued_at: claims.iat,
         key: claims.key,
     })
 }
@@ -285,6 +286,7 @@ fn open_identity() -> impl Filter<Extract = (Identity,), Error = warp::Rejection
             models: None,
             budget: None,
             budget_scope: None,
+            issued_at: None,
             key: None,
         })
     })

--- a/bitrouter/src/runtime/budget.rs
+++ b/bitrouter/src/runtime/budget.rs
@@ -1,0 +1,87 @@
+//! Pre-request budget enforcement.
+//!
+//! Compares the caller's accumulated spend (from the database) against the
+//! `bgt` claim in their JWT. If the accumulated spend meets or exceeds the
+//! budget, the request is rejected with HTTP 429.
+//!
+//! **Soft-margin**: the request that *crosses* the threshold is allowed
+//! through — only subsequent requests are rejected. This avoids the
+//! complexity of pre-estimating request cost.
+
+use std::sync::Arc;
+
+use bitrouter_core::auth::claims::BudgetScope;
+use bitrouter_core::observe::CallerContext;
+use bitrouter_observe::spend::store::SpendStore;
+
+/// Check the caller's budget before routing the request.
+///
+/// Returns the `CallerContext` unchanged when the budget is not exhausted
+/// (or when no budget is configured). Rejects with [`BudgetExhausted`]
+/// when accumulated spend meets or exceeds the budget.
+pub async fn check_budget(
+    caller: CallerContext,
+    spend_store: Arc<dyn SpendStore>,
+) -> Result<CallerContext, warp::Rejection> {
+    let (budget, scope) = match (caller.budget, caller.budget_scope) {
+        (Some(b), Some(s)) => (b, s),
+        // No budget claim → pass through without enforcement.
+        _ => return Ok(caller),
+    };
+
+    let account_id = match caller.account_id.as_deref() {
+        Some(id) => id,
+        // Anonymous callers cannot have budgets.
+        None => return Ok(caller),
+    };
+
+    // Compute the `since` boundary based on scope.
+    let since = match scope {
+        BudgetScope::Account => None,
+        BudgetScope::Session => {
+            // Use the JWT issued-at time as the session start boundary.
+            caller.issued_at.and_then(|ts| {
+                chrono::DateTime::from_timestamp(ts as i64, 0).map(|dt| dt.naive_utc())
+            })
+        }
+    };
+
+    let accumulated_usd = spend_store.query_total_spend(account_id, since, None).await;
+
+    // Convert budget from micro-USD to USD for comparison.
+    let budget_usd = budget as f64 / 1_000_000.0;
+
+    if accumulated_usd >= budget_usd {
+        return Err(warp::reject::custom(BudgetExhausted {
+            budget_usd,
+            accumulated_usd,
+            scope,
+        }));
+    }
+
+    Ok(caller)
+}
+
+/// Rejection type for exhausted budgets.
+#[derive(Debug)]
+pub struct BudgetExhausted {
+    pub budget_usd: f64,
+    pub accumulated_usd: f64,
+    pub scope: BudgetScope,
+}
+
+impl std::fmt::Display for BudgetExhausted {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let scope_label = match self.scope {
+            BudgetScope::Session => "session",
+            BudgetScope::Account => "account",
+        };
+        write!(
+            f,
+            "budget exhausted: {scope_label} spend ${:.6} >= budget ${:.6}",
+            self.accumulated_usd, self.budget_usd,
+        )
+    }
+}
+
+impl warp::reject::Reject for BudgetExhausted {}

--- a/bitrouter/src/runtime/mod.rs
+++ b/bitrouter/src/runtime/mod.rs
@@ -1,6 +1,7 @@
 pub mod agentskills_client;
 pub mod app;
 pub mod auth;
+pub mod budget;
 pub mod daemon;
 pub mod error;
 pub mod mcp_client;

--- a/bitrouter/src/runtime/server.rs
+++ b/bitrouter/src/runtime/server.rs
@@ -301,11 +301,17 @@ where
 
         // Build account filter that extracts caller context when auth is enabled,
         // or returns a default (empty) caller context when no database is configured.
+        // When a database is connected, budget enforcement is chained after auth:
+        // accumulated spend is compared against the JWT `bgt` claim.
+        let spend_store = observe.spend_store.clone();
         let account_filter = if self.db.is_some() {
             let auth_filter = auth::openai_auth(auth_ctx.clone());
+            let ss = spend_store.clone();
             warp::any()
                 .and(auth_filter)
                 .map(identity_to_caller_context)
+                .and(warp::any().map(move || ss.clone()))
+                .and_then(crate::runtime::budget::check_budget)
                 .boxed()
         } else {
             warp::any().map(CallerContext::default).boxed()
@@ -313,9 +319,12 @@ where
 
         let anthropic_account_filter = if self.db.is_some() {
             let auth_filter = auth::anthropic_auth(auth_ctx.clone());
+            let ss = spend_store.clone();
             warp::any()
                 .and(auth_filter)
                 .map(identity_to_caller_context)
+                .and(warp::any().map(move || ss.clone()))
+                .and_then(crate::runtime::budget::check_budget)
                 .boxed()
         } else {
             warp::any().map(CallerContext::default).boxed()
@@ -784,6 +793,7 @@ fn identity_to_caller_context(id: bitrouter_accounts::identity::Identity) -> Cal
         models: id.models,
         budget: id.budget,
         budget_scope: id.budget_scope,
+        issued_at: id.issued_at,
         key: id.key,
         chain: id.chain,
     }
@@ -867,6 +877,19 @@ async fn handle_auth_rejection(
         return Ok(Box::new(warp::reply::with_status(
             json,
             warp::http::StatusCode::UNAUTHORIZED,
+        )) as Box<dyn warp::Reply>);
+    }
+
+    if let Some(e) = rejection.find::<crate::runtime::budget::BudgetExhausted>() {
+        let json = warp::reply::json(&serde_json::json!({
+            "error": {
+                "message": e.to_string(),
+                "type": "budget_exhausted",
+            }
+        }));
+        return Ok(Box::new(warp::reply::with_status(
+            json,
+            warp::http::StatusCode::TOO_MANY_REQUESTS,
         )) as Box<dyn warp::Reply>);
     }
 


### PR DESCRIPTION
## Summary

Implements the two-layer spend-limit enforcement model and `bitrouter policy` CLI commands per #220.

### Layer 1 — Server-side budget enforcement (all providers)

- Pre-request middleware in `runtime/budget.rs` compares accumulated DB spend against the JWT `bgt` claim
- **Soft-margin**: the request that crosses the threshold is allowed through; subsequent requests are rejected
- Budget scope (`bsc` claim): `act` queries all-time spend, `ses` queries spend since JWT `iat` timestamp
- Returns **HTTP 429** with `budget_exhausted` error type when budget exceeded
- Wired into both OpenAI and Anthropic account filters (after auth, before routing)
- Skipped in no-DB mode (consistent with existing auth behavior)

### Layer 2 — OWS executable policy (default provider only)

- `bitrouter policy eval`: reads `PolicyContext` JSON from stdin, evaluates declarative rules (chain allowlist, expiration) as fast pre-filters, then checks daily/monthly/per-tx spend caps
- Writes `PolicyResult` JSON to stdout (`{ "allow": true/false, "reason": "..." }`)
- **Default-deny** on crash, timeout, or invalid input

### Policy CLI

| Command | Description |
|---------|-------------|
| `bitrouter policy create` | Create a policy with `--daily-limit`, `--monthly-limit`, `--per-tx-max`, `--chains`, `--expires`, or `--file` |
| `bitrouter policy list` | List all policies |
| `bitrouter policy show --id ID` | Show policy details |
| `bitrouter policy delete --id ID` | Delete a policy |
| `bitrouter policy eval` | OWS executable policy entry point |

### Infrastructure changes

- Added `issued_at: Option<u64>` to `Identity` and `CallerContext`, propagated from JWT `iat` through the auth pipeline
- Added `chrono` dependency to bitrouter binary crate
- 6 unit tests covering all policy evaluation rules (limits, chains, expiry, allow cases)

### Enforcement matrix

| Provider type | DB budget check (`bgt`) | OWS policy (`bitrouter policy eval`) | Spend recorded in DB |
|---------------|------------------------|--------------------------------------|----------------------|
| BYOK          | ✅ Yes                  | ❌ N/A (no wallet tx)                 | ✅ Yes               |
| Default       | ✅ Yes                  | ✅ Optional (wallet defense-in-depth) | ✅ Yes               |
| No DB mode    | ❌ Skipped              | ✅ Still active (OWS is independent)  | ❌ No                |

Closes #220