### PR TITLE
fix: add missing tokio/io-std feature

### DIFF
--- a/bitrouter-providers/Cargo.toml
+++ b/bitrouter-providers/Cargo.toml
@@ -24,6 +24,7 @@ acp = [
     "dep:tar",
     "dep:zip",
     "tokio/process",
+    "tokio/io-std",
 ]
 agentskills = [
     "dep:tracing",


### PR DESCRIPTION
## Summary

- Add `tokio/io-std` to the `acp` feature gate in `bitrouter-providers/Cargo.toml`

The proxy code (`acp/proxy.rs:528-529`) uses `tokio::io::stdin()` and `tokio::io::stdout()`, which require tokio's `io-std` feature. The `acp` feature only activated `tokio/process`. This compiled fine in the workspace because another crate transitively enabled `io-std`, but `cargo package --verify` during release compiles the crate in isolation — exposing the missing feature gate.

Fixes the release build error from v0.23.0.