### PR TITLE
chore(release): publish v0.23.1 and add release dry run workflow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["bitrouter", "bitrouter-*"]
 
 [workspace.package]
-version = "0.23.0"
+version = "0.23.1"
 
 [workspace.dependencies]
 bitrouter-accounts = { path = "bitrouter-accounts", version = "0.23" }


### PR DESCRIPTION
## Summary

- Bump workspace version from 0.23.0 to 0.23.1

The v0.23.0 release partially failed: `bitrouter-providers` 0.23.0 was published to crates.io without the `tokio/io-std` feature gate (fixed in #321), but `bitrouter-tui` and `bitrouter` couldn't publish because their `cargo publish --verify` pulls the broken 0.23.0 from the registry.

Bumping to 0.23.1 lets release-plz republish all crates, including the fixed `bitrouter-providers`.