### PR TITLE
fix(ci): replace release-plz dry-run with cargo package

### DIFF
--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   release-dry-run:
-    name: release-plz dry run
+    name: release dry run
     if: contains(github.event.pull_request.labels.*.name, 'release')
     runs-on: ubuntu-latest
     permissions:
@@ -26,10 +26,14 @@ jobs:
         with:
           save-if: false
 
-      - name: Run release-plz release --dry-run
-        uses: release-plz/action@v0.5
-        with:
-          command: release
-          dry_run: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # release-plz release --dry-run does not work reliably for
+      # workspace-internal dependency bumps because it skips the actual
+      # crates.io upload, so downstream crates cannot resolve the new
+      # version of their workspace dependency during packaging.
+      # See: https://github.com/release-plz/release-plz/issues/2501
+      #
+      # Instead, we run `cargo package --workspace` which resolves all
+      # workspace dependencies locally and validates that every crate
+      # can be packaged successfully.
+      - name: Validate packaging (cargo package --workspace)
+        run: cargo package --workspace


### PR DESCRIPTION
## Problem

`release-plz release --dry-run` fails when workspace crates bump across a semver boundary (e.g. 0.23 → 0.24). The dry-run skips the actual crates.io upload, so downstream workspace crates that depend on the bumped version cannot resolve it during packaging:

```
failed to select a version for the requirement `bitrouter-core = "^0.24"`
candidate versions found which didn't match: 0.23.1, 0.23.0, 0.22.1, ...
```

This is a known upstream limitation: https://github.com/release-plz/release-plz/issues/2501

## Fix

Replace `release-plz release --dry-run` with `cargo package --workspace`, which resolves workspace dependencies locally and validates that every crate can be packaged successfully without needing anything from the crates.io index.