### PR TITLE
fix: apply Rust 1.95 clippy styles

### DIFF
--- a/bitrouter-guardrails/src/engine.rs
+++ b/bitrouter-guardrails/src/engine.rs
@@ -194,7 +194,7 @@ impl Guardrail {
 
         // Merge overlapping ranges, then apply in reverse offset order so
         // earlier replacements don't shift the byte positions of later ones.
-        redact_ranges.sort_by(|a, b| a.start.cmp(&b.start));
+        redact_ranges.sort_by_key(|a| a.start);
         let merged: Vec<std::ops::Range<usize>> =
             redact_ranges
                 .into_iter()

--- a/bitrouter-observe/src/metrics.rs
+++ b/bitrouter-observe/src/metrics.rs
@@ -413,11 +413,7 @@ fn error_rate(total: u64, errors: u64) -> f64 {
 }
 
 fn avg(total: u64, count: u64) -> Option<u64> {
-    if count == 0 {
-        None
-    } else {
-        Some(total / count)
-    }
+    total.checked_div(count)
 }
 
 fn system_time_to_unix_secs(t: SystemTime) -> u64 {

--- a/bitrouter-tui/src/app/key_handlers.rs
+++ b/bitrouter-tui/src/app/key_handlers.rs
@@ -140,10 +140,9 @@ impl App {
                 }
                 self.submit_input();
             }
-            KeyCode::Tab
-                if self.state.autocomplete.is_some() => {
-                    self.accept_autocomplete();
-                }
+            KeyCode::Tab if self.state.autocomplete.is_some() => {
+                self.accept_autocomplete();
+            }
             KeyCode::Esc => {
                 if self.state.autocomplete.is_some() {
                     self.close_autocomplete();
@@ -275,16 +274,16 @@ impl App {
     fn handle_tab_mode_key(&mut self, key: KeyEvent) {
         let tab_count = self.state.tabs.len();
         match key.code {
-            KeyCode::Char('h') | KeyCode::Left
-                if tab_count > 0 && self.state.active_tab > 0 => {
-                    let idx = self.state.active_tab - 1;
-                    self.switch_tab(idx);
-                }
+            KeyCode::Char('h') | KeyCode::Left if tab_count > 0 && self.state.active_tab > 0 => {
+                let idx = self.state.active_tab - 1;
+                self.switch_tab(idx);
+            }
             KeyCode::Char('l') | KeyCode::Right
-                if tab_count > 0 && self.state.active_tab + 1 < tab_count => {
-                    let idx = self.state.active_tab + 1;
-                    self.switch_tab(idx);
-                }
+                if tab_count > 0 && self.state.active_tab + 1 < tab_count =>
+            {
+                let idx = self.state.active_tab + 1;
+                self.switch_tab(idx);
+            }
             KeyCode::Char(c @ '1'..='9') => {
                 let idx = (c as usize) - ('1' as usize);
                 self.switch_tab(idx);

--- a/bitrouter-tui/src/app/key_handlers.rs
+++ b/bitrouter-tui/src/app/key_handlers.rs
@@ -140,11 +140,10 @@ impl App {
                 }
                 self.submit_input();
             }
-            KeyCode::Tab => {
-                if self.state.autocomplete.is_some() {
+            KeyCode::Tab
+                if self.state.autocomplete.is_some() => {
                     self.accept_autocomplete();
                 }
-            }
             KeyCode::Esc => {
                 if self.state.autocomplete.is_some() {
                     self.close_autocomplete();
@@ -276,18 +275,16 @@ impl App {
     fn handle_tab_mode_key(&mut self, key: KeyEvent) {
         let tab_count = self.state.tabs.len();
         match key.code {
-            KeyCode::Char('h') | KeyCode::Left => {
-                if tab_count > 0 && self.state.active_tab > 0 {
+            KeyCode::Char('h') | KeyCode::Left
+                if tab_count > 0 && self.state.active_tab > 0 => {
                     let idx = self.state.active_tab - 1;
                     self.switch_tab(idx);
                 }
-            }
-            KeyCode::Char('l') | KeyCode::Right => {
-                if tab_count > 0 && self.state.active_tab + 1 < tab_count {
+            KeyCode::Char('l') | KeyCode::Right
+                if tab_count > 0 && self.state.active_tab + 1 < tab_count => {
                     let idx = self.state.active_tab + 1;
                     self.switch_tab(idx);
                 }
-            }
             KeyCode::Char(c @ '1'..='9') => {
                 let idx = (c as usize) - ('1' as usize);
                 self.switch_tab(idx);

--- a/bitrouter-tui/src/app/modals.rs
+++ b/bitrouter-tui/src/app/modals.rs
@@ -19,10 +19,9 @@ impl App {
         match modal_kind {
             0 => self.handle_observability_key(key),
             1 => self.handle_command_palette_key(key),
-            2
-                if (key.code == KeyCode::Esc || key.code == KeyCode::Char('?')) => {
-                    self.state.modal = None;
-                }
+            2 if (key.code == KeyCode::Esc || key.code == KeyCode::Char('?')) => {
+                self.state.modal = None;
+            }
             _ => {}
         }
     }

--- a/bitrouter-tui/src/app/modals.rs
+++ b/bitrouter-tui/src/app/modals.rs
@@ -19,11 +19,10 @@ impl App {
         match modal_kind {
             0 => self.handle_observability_key(key),
             1 => self.handle_command_palette_key(key),
-            2 => {
-                if key.code == KeyCode::Esc || key.code == KeyCode::Char('?') {
+            2
+                if (key.code == KeyCode::Esc || key.code == KeyCode::Char('?')) => {
                     self.state.modal = None;
                 }
-            }
             _ => {}
         }
     }

--- a/bitrouter-tui/src/render.rs
+++ b/bitrouter-tui/src/render.rs
@@ -281,7 +281,9 @@ fn strip_unordered_list(line: &str) -> Option<(&str, &str)> {
     let indent = &line[..indent_len];
     let rest = if let Some(r) = stripped.strip_prefix("- ") {
         r
-    } else { stripped.strip_prefix("* ")? };
+    } else {
+        stripped.strip_prefix("* ")?
+    };
     Some((indent, rest))
 }
 

--- a/bitrouter-tui/src/render.rs
+++ b/bitrouter-tui/src/render.rs
@@ -281,11 +281,7 @@ fn strip_unordered_list(line: &str) -> Option<(&str, &str)> {
     let indent = &line[..indent_len];
     let rest = if let Some(r) = stripped.strip_prefix("- ") {
         r
-    } else if let Some(r) = stripped.strip_prefix("* ") {
-        r
-    } else {
-        return None;
-    };
+    } else { stripped.strip_prefix("* ")? };
     Some((indent, rest))
 }
 


### PR DESCRIPTION
Replace manual zero-check-then-divide pattern with `checked_div` in `bitrouter-observe` metrics `avg` function to resolve `clippy::manual_checked_ops` warning (Rust 1.95+).