### PR TITLE
refactor(bitrouter-api): drop no-op feature gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,18 +73,6 @@ jobs:
             feature_set: no-features
             cargo_args: --no-default-features
           - crate: bitrouter-api
-            feature_set: openai
-            cargo_args: --no-default-features --features openai
-          - crate: bitrouter-api
-            feature_set: anthropic
-            cargo_args: --no-default-features --features anthropic
-          - crate: bitrouter-api
-            feature_set: google
-            cargo_args: --no-default-features --features google
-          - crate: bitrouter-api
-            feature_set: mcp
-            cargo_args: --no-default-features --features mcp
-          - crate: bitrouter-api
             feature_set: mpp-tempo
             cargo_args: --no-default-features --features mpp-tempo
           - crate: bitrouter-api

--- a/bitrouter-api/Cargo.toml
+++ b/bitrouter-api/Cargo.toml
@@ -9,11 +9,7 @@ repository = "https://github.com/bitrouter/bitrouter"
 readme = "README.md"
 
 [features]
-default = ["openai", "anthropic", "google", "mcp"]
-mcp = []
-openai = []
-anthropic = []
-google = []
+default = []
 mpp-tempo = [
     "dep:mpp",
     "mpp/tempo",

--- a/bitrouter-api/src/error.rs
+++ b/bitrouter-api/src/error.rs
@@ -1,39 +1,30 @@
-#[cfg(any(feature = "openai", feature = "anthropic", feature = "google"))]
 use std::fmt;
 
-#[cfg(any(feature = "openai", feature = "anthropic", feature = "google"))]
 use bitrouter_core::errors::BitrouterError;
-#[cfg(any(feature = "openai", feature = "anthropic", feature = "google"))]
 use warp::reject::Reject;
 
 /// Wraps a [`BitrouterError`] so it can be used as a warp rejection.
 #[derive(Debug)]
-#[cfg(any(feature = "openai", feature = "anthropic", feature = "google"))]
 pub(crate) struct BitrouterRejection(pub BitrouterError);
 
-#[cfg(any(feature = "openai", feature = "anthropic", feature = "google"))]
 impl fmt::Display for BitrouterRejection {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }
 
-#[cfg(any(feature = "openai", feature = "anthropic", feature = "google"))]
 impl Reject for BitrouterRejection {}
 
 /// Wraps a generic message as a warp rejection.
 #[derive(Debug)]
-#[cfg(feature = "openai")]
 pub(crate) struct BadRequest(pub String);
 
-#[cfg(feature = "openai")]
 impl fmt::Display for BadRequest {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }
 
-#[cfg(feature = "openai")]
 impl Reject for BadRequest {}
 
 /// Converts a [`BitrouterRejection`] or [`BadRequest`] warp rejection into a
@@ -41,7 +32,6 @@ impl Reject for BadRequest {}
 ///
 /// Returns `Some(response)` if the rejection matches, `None` otherwise —
 /// allowing callers to fall through to other rejection handling.
-#[cfg(any(feature = "openai", feature = "anthropic", feature = "google"))]
 pub fn handle_bitrouter_rejection(err: &warp::Rejection) -> Option<warp::http::Response<String>> {
     use warp::http::StatusCode;
 
@@ -82,7 +72,6 @@ pub fn handle_bitrouter_rejection(err: &warp::Rejection) -> Option<warp::http::R
         return Some(response);
     }
 
-    #[cfg(feature = "openai")]
     if let Some(e) = err.find::<BadRequest>() {
         let body = serde_json::json!({
             "error": {

--- a/bitrouter-api/src/router/context.rs
+++ b/bitrouter-api/src/router/context.rs
@@ -3,13 +3,11 @@
 //! differ, but the resulting `RouteContext` is protocol-agnostic.
 
 /// Whether a string slice contains a fenced code block marker.
-#[cfg(any(feature = "openai", feature = "anthropic", feature = "google"))]
 fn has_code_fence(text: &str) -> bool {
     text.contains("```")
 }
 
 /// OpenAI Chat Completions context extraction.
-#[cfg(feature = "openai")]
 pub(crate) mod openai_chat {
     use super::*;
     use bitrouter_core::api::openai::chat::types::{
@@ -60,7 +58,6 @@ pub(crate) mod openai_chat {
 }
 
 /// OpenAI Responses API context extraction.
-#[cfg(feature = "openai")]
 pub(crate) mod openai_responses {
     use super::*;
     use bitrouter_core::api::openai::responses::types::{
@@ -127,7 +124,6 @@ pub(crate) mod openai_responses {
 }
 
 /// Anthropic Messages API context extraction.
-#[cfg(feature = "anthropic")]
 pub(crate) mod anthropic_messages {
     use super::*;
     use bitrouter_core::api::anthropic::messages::types::{
@@ -178,7 +174,6 @@ pub(crate) mod anthropic_messages {
 }
 
 /// Google GenerateContent API context extraction.
-#[cfg(feature = "google")]
 pub(crate) mod google_generate {
     use super::*;
     use bitrouter_core::api::google::generate_content::types::GenerateContentRequest;

--- a/bitrouter-api/src/router/mod.rs
+++ b/bitrouter-api/src/router/mod.rs
@@ -1,20 +1,15 @@
 pub mod admin;
 pub mod agents;
 pub mod agentskills;
-#[cfg(feature = "anthropic")]
 pub mod anthropic;
 pub(crate) mod context;
-#[cfg(feature = "google")]
 pub mod google;
-#[cfg(feature = "mcp")]
 pub mod mcp;
 pub mod models;
-#[cfg(feature = "openai")]
 pub mod openai;
 pub mod routes;
 pub mod tools;
 
-#[cfg(any(feature = "openai", feature = "anthropic", feature = "google"))]
 mod observe_ctx {
     use std::sync::Arc;
     use std::time::Instant;
@@ -35,5 +30,4 @@ mod observe_ctx {
     }
 }
 
-#[cfg(any(feature = "openai", feature = "anthropic", feature = "google"))]
 pub(crate) use observe_ctx::StreamObserveContext;

--- a/bitrouter-api/src/util.rs
+++ b/bitrouter-api/src/util.rs
@@ -1,8 +1,6 @@
-#[cfg(feature = "openai")]
 use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Generates a hex-encoded timestamp-based ID.
-#[cfg(feature = "openai")]
 pub(crate) fn generate_id() -> String {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)

--- a/bitrouter/Cargo.toml
+++ b/bitrouter/Cargo.toml
@@ -20,7 +20,7 @@ default = [
     "rest",
 ]
 rest = ["bitrouter-providers/rest"]
-mcp = ["bitrouter-api/mcp", "bitrouter-providers/mcp"]
+mcp = ["bitrouter-providers/mcp"]
 tui = ["dep:bitrouter-tui", "bitrouter-providers/acp"]
 sqlite = ["bitrouter-accounts/sqlite", "bitrouter-observe/sqlite"]
 postgres = ["bitrouter-accounts/postgres", "bitrouter-observe/postgres"]
@@ -43,11 +43,7 @@ mpp-solana = [
 [dependencies]
 # Internal crates
 bitrouter-accounts.workspace = true
-bitrouter-api = { workspace = true, features = [
-    "openai",
-    "anthropic",
-    "google",
-] }
+bitrouter-api = { workspace = true }
 bitrouter-config.workspace = true
 bitrouter-core.workspace = true
 bitrouter-guardrails.workspace = true


### PR DESCRIPTION
Closes #372. Part of #366.

Removes the `openai`/`anthropic`/`google`/`mcp` features from `bitrouter-api` since they gated no optional dependencies — pure module-visibility toggles that don't qualify as features per the rule codified in DEVELOPMENT.md.

- Drops feature definitions and corresponding `#[cfg]` blocks in lib.rs / router/mod.rs / router/context.rs / error.rs / util.rs.
- Drops the now-redundant `features = [...]` list on the binary's `bitrouter-api` dep.
- `bitrouter/mcp` keeps its passthrough to `bitrouter-providers/mcp` (which has real optional deps).
- Trims the obsolete per-feature CI matrix rows for the SDK; `no-features` / `mpp-tempo` / `all-features` remain.
- `mpp-tempo` and `mpp-solana` are unchanged; they gate real optional deps.

Verified locally: `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features`, `cargo test --workspace`, and `cargo build -p bitrouter-api --no-default-features`.