### PR TITLE
refactor(bitrouter-api): add accounts/observe/guardrails features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1623,8 +1623,11 @@ version = "0.25.0"
 dependencies = [
  "alloy",
  "async-trait",
+ "bitrouter-accounts",
  "bitrouter-config",
  "bitrouter-core",
+ "bitrouter-guardrails",
+ "bitrouter-observe",
  "bs58",
  "ed25519-dalek",
  "futures-core",

--- a/bitrouter-api/Cargo.toml
+++ b/bitrouter-api/Cargo.toml
@@ -10,6 +10,9 @@ readme = "README.md"
 
 [features]
 default = []
+accounts = ["dep:bitrouter-accounts"]
+observe = ["dep:bitrouter-observe"]
+guardrails = ["dep:bitrouter-guardrails"]
 mpp-tempo = [
     "dep:mpp",
     "mpp/tempo",
@@ -33,6 +36,9 @@ mpp-solana = [
 [dependencies]
 bitrouter-core.workspace = true
 bitrouter-config = { workspace = true, optional = true }
+bitrouter-accounts = { workspace = true, optional = true }
+bitrouter-observe = { workspace = true, optional = true }
+bitrouter-guardrails = { workspace = true, optional = true }
 async-trait = { version = "0.1" }
 futures-core = { version = "0.3" }
 mpp = { package = "mpp-br", version = "0.9", default-features = false, features = [

--- a/bitrouter-api/README.md
+++ b/bitrouter-api/README.md
@@ -18,8 +18,25 @@ model resolution and execution to the routing contracts from `bitrouter-core`.
 
 ## Feature flags
 
-- `openai`, `anthropic`, `google` enable provider-compatible HTTP surfaces.
-- `mcp` enables the MCP routing surface.
+Each feature exists to pull a distinct dependency tree — pure module
+toggles are not features. The provider-compatible HTTP surfaces
+(OpenAI, Anthropic, Google, MCP) are always available without any
+feature.
 
-Default features keep the current API surface enabled:
-`openai`, `anthropic`, `google`, and `mcp`.
+Optional companion-crate facades:
+
+- `accounts` — re-export [`bitrouter-accounts`] (account/session/key
+  Warp filter builders and services). Pulls `sea-orm`.
+- `observe` — re-export [`bitrouter-observe`] (`ObserveStack`, spend
+  store, metrics). Pulls `sea-orm`.
+- `guardrails` — re-export [`bitrouter-guardrails`] (`Guardrail`,
+  `GuardedRouter`).
+
+Payment middleware:
+
+- `mpp-tempo` — Tempo-chain MPP server payment integration.
+- `mpp-solana` — Solana-chain MPP server payment integration.
+
+[`bitrouter-accounts`]: https://crates.io/crates/bitrouter-accounts
+[`bitrouter-observe`]: https://crates.io/crates/bitrouter-observe
+[`bitrouter-guardrails`]: https://crates.io/crates/bitrouter-guardrails

--- a/bitrouter-api/src/accounts.rs
+++ b/bitrouter-api/src/accounts.rs
@@ -1,0 +1,6 @@
+//! Re-exports of [`bitrouter_accounts`] for SDK consumers.
+//!
+//! Enabled by the `accounts` feature on `bitrouter-api`. Pulls
+//! `bitrouter-accounts` (and transitively `sea-orm`) into the build.
+
+pub use bitrouter_accounts::*;

--- a/bitrouter-api/src/guardrails.rs
+++ b/bitrouter-api/src/guardrails.rs
@@ -1,0 +1,6 @@
+//! Re-exports of [`bitrouter_guardrails`] for SDK consumers.
+//!
+//! Enabled by the `guardrails` feature on `bitrouter-api`. Pulls
+//! `bitrouter-guardrails` into the build.
+
+pub use bitrouter_guardrails::*;

--- a/bitrouter-api/src/lib.rs
+++ b/bitrouter-api/src/lib.rs
@@ -3,5 +3,12 @@ pub mod router;
 #[cfg(any(feature = "mpp-tempo", feature = "mpp-solana"))]
 pub mod mpp;
 
+#[cfg(feature = "accounts")]
+pub mod accounts;
+#[cfg(feature = "guardrails")]
+pub mod guardrails;
+#[cfg(feature = "observe")]
+pub mod observe;
+
 pub mod error;
 mod util;

--- a/bitrouter-api/src/observe.rs
+++ b/bitrouter-api/src/observe.rs
@@ -1,0 +1,6 @@
+//! Re-exports of [`bitrouter_observe`] for SDK consumers.
+//!
+//! Enabled by the `observe` feature on `bitrouter-api`. Pulls
+//! `bitrouter-observe` (and transitively `sea-orm`) into the build.
+
+pub use bitrouter_observe::*;


### PR DESCRIPTION
Closes #373. Part of #366.

Adds three new optional features on `bitrouter-api` that pull companion crates as optional deps:

| Feature | Pulls |
|---|---|
| `accounts` | `bitrouter-accounts` (+ sea-orm) |
| `observe` | `bitrouter-observe` (+ sea-orm) |
| `guardrails` | `bitrouter-guardrails` |

Each new module (`accounts.rs`, `observe.rs`, `guardrails.rs`) is a thin `pub use bitrouter_xxx::*;` re-export — no logic moves. The `bitrouter` binary still imports companion crates directly; bake-in PRs (#375, #376) will switch wiring to go through the SDK.

Verified locally: fmt, clippy --all-features, `cargo test -p bitrouter-api --all-features`, and `cargo tree` confirms each feature pulls the expected sub-crate.