### PR TITLE
refactor: rename mpp-* features to payments-*

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,8 +61,8 @@ jobs:
             feature_set: no-features
             cargo_args: --no-default-features
           - crate: bitrouter
-            feature_set: mpp-tempo
-            cargo_args: --no-default-features --features mpp-tempo
+            feature_set: payments-tempo
+            cargo_args: --no-default-features --features payments-tempo
           - crate: bitrouter
             feature_set: tui
             cargo_args: --no-default-features --features tui
@@ -73,8 +73,8 @@ jobs:
             feature_set: no-features
             cargo_args: --no-default-features
           - crate: bitrouter-api
-            feature_set: mpp-tempo
-            cargo_args: --no-default-features --features mpp-tempo
+            feature_set: payments-tempo
+            cargo_args: --no-default-features --features payments-tempo
           - crate: bitrouter-api
             feature_set: all-features
             cargo_args: --all-features
@@ -82,8 +82,8 @@ jobs:
             feature_set: no-features
             cargo_args: --no-default-features
           - crate: bitrouter-config
-            feature_set: mpp-tempo
-            cargo_args: --no-default-features --features mpp-tempo
+            feature_set: payments-tempo
+            cargo_args: --no-default-features --features payments-tempo
           - crate: bitrouter-config
             feature_set: no-features
             cargo_args: --no-default-features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### ⚠️ Breaking Changes
+
+- Renamed Cargo features `mpp-tempo` / `mpp-solana` to `payments-tempo` / `payments-solana` on the `bitrouter`, `bitrouter-api`, and `bitrouter-config` crates. Downstream users selecting these features in `Cargo.toml` must update the names. The implementation module remains `mpp` since it still wraps the MPP protocol.
+
 ## [0.25.0](https://github.com/bitrouter/bitrouter/compare/v0.24.4...v0.25.0)
 
 

--- a/bitrouter-api/Cargo.toml
+++ b/bitrouter-api/Cargo.toml
@@ -13,7 +13,7 @@ default = []
 accounts = ["dep:bitrouter-accounts"]
 observe = ["dep:bitrouter-observe"]
 guardrails = ["dep:bitrouter-guardrails"]
-mpp-tempo = [
+payments-tempo = [
     "dep:mpp",
     "mpp/tempo",
     "mpp/server",
@@ -23,11 +23,11 @@ mpp-tempo = [
     "dep:tempo-alloy",
     "dep:tempo-contracts",
 ]
-mpp-solana = [
+payments-solana = [
     "dep:mpp",
     "mpp/server",
     "dep:bitrouter-config",
-    "bitrouter-config/mpp-solana",
+    "bitrouter-config/payments-solana",
     "dep:ed25519-dalek",
     "dep:bs58",
     "dep:time",

--- a/bitrouter-api/README.md
+++ b/bitrouter-api/README.md
@@ -34,8 +34,8 @@ Optional companion-crate facades:
 
 Payment middleware:
 
-- `mpp-tempo` — Tempo-chain MPP server payment integration.
-- `mpp-solana` — Solana-chain MPP server payment integration.
+- `payments-tempo` — Tempo-chain MPP server payment integration.
+- `payments-solana` — Solana-chain MPP server payment integration.
 
 [`bitrouter-accounts`]: https://crates.io/crates/bitrouter-accounts
 [`bitrouter-observe`]: https://crates.io/crates/bitrouter-observe

--- a/bitrouter-api/src/lib.rs
+++ b/bitrouter-api/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod router;
 
-#[cfg(any(feature = "mpp-tempo", feature = "mpp-solana"))]
+#[cfg(any(feature = "payments-tempo", feature = "payments-solana"))]
 pub mod mpp;
 
 #[cfg(feature = "accounts")]

--- a/bitrouter-api/src/mpp/mod.rs
+++ b/bitrouter-api/src/mpp/mod.rs
@@ -5,13 +5,13 @@ mod payment_gate;
 mod pricing;
 mod state;
 
-#[cfg(feature = "mpp-solana")]
+#[cfg(feature = "payments-solana")]
 pub mod solana_channel_store;
-#[cfg(feature = "mpp-solana")]
+#[cfg(feature = "payments-solana")]
 pub mod solana_session_method;
-#[cfg(feature = "mpp-solana")]
+#[cfg(feature = "payments-solana")]
 pub mod solana_types;
-#[cfg(feature = "mpp-solana")]
+#[cfg(feature = "payments-solana")]
 pub mod solana_voucher;
 
 pub use close_guard::SessionCloseGuard;

--- a/bitrouter-api/src/mpp/state.rs
+++ b/bitrouter-api/src/mpp/state.rs
@@ -1,22 +1,22 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-#[cfg(feature = "mpp-tempo")]
+#[cfg(feature = "payments-tempo")]
 use bitrouter_config::TempoMppConfig;
-#[cfg(feature = "mpp-tempo")]
+#[cfg(feature = "payments-tempo")]
 use mpp::server::{
     Mpp, SessionMethodConfig, TempoChargeMethod, TempoConfig, TempoProvider, TempoSessionMethod,
 };
 
 use mpp::server::SessionChallengeOptions;
 
-#[cfg(feature = "mpp-tempo")]
+#[cfg(feature = "payments-tempo")]
 use mpp::protocol::methods::tempo::session_method::ChannelStore as TempoChannelStore;
 
-#[cfg(feature = "mpp-tempo")]
+#[cfg(feature = "payments-tempo")]
 use mpp::Address;
 
-#[cfg(feature = "mpp-tempo")]
+#[cfg(feature = "payments-tempo")]
 type TempoMpp = Mpp<TempoChargeMethod<TempoProvider>, TempoSessionMethod<TempoProvider>>;
 
 /// Wrapper that bridges `Arc<dyn mpp::Signer>` into `impl mpp::Signer`.
@@ -25,10 +25,10 @@ type TempoMpp = Mpp<TempoChargeMethod<TempoProvider>, TempoSessionMethod<TempoPr
 /// implements `Signer` but `Arc<dyn Signer>` does not. This newtype allows an
 /// `Arc`-shared signer to be passed to APIs that require `impl Signer + 'static`
 /// (such as `TempoSessionMethod::with_close_signer`).
-#[cfg(feature = "mpp-tempo")]
+#[cfg(feature = "payments-tempo")]
 struct ArcSigner(Arc<dyn mpp::Signer + Send + Sync>);
 
-#[cfg(feature = "mpp-tempo")]
+#[cfg(feature = "payments-tempo")]
 #[async_trait::async_trait]
 impl alloy::signers::Signer for ArcSigner {
     async fn sign_hash(
@@ -63,7 +63,7 @@ pub struct MppState {
 }
 
 enum MppBackend {
-    #[cfg(feature = "mpp-tempo")]
+    #[cfg(feature = "payments-tempo")]
     Tempo {
         mpp: TempoMpp,
         store: Arc<dyn TempoChannelStore>,
@@ -85,7 +85,7 @@ enum MppBackend {
         /// multiple channels close concurrently on the same signer.
         close_lock: tokio::sync::Mutex<()>,
     },
-    #[cfg(feature = "mpp-solana")]
+    #[cfg(feature = "payments-solana")]
     Solana(SolanaState),
 }
 
@@ -96,15 +96,15 @@ impl MppBackend {
     /// may differ from the CAIP-2 key used to register the backend.
     fn method_name(&self) -> &'static str {
         match self {
-            #[cfg(feature = "mpp-tempo")]
+            #[cfg(feature = "payments-tempo")]
             Self::Tempo { .. } => "tempo",
-            #[cfg(feature = "mpp-solana")]
+            #[cfg(feature = "payments-solana")]
             Self::Solana(_) => "solana",
         }
     }
 }
 
-#[cfg(feature = "mpp-solana")]
+#[cfg(feature = "payments-solana")]
 struct SolanaState {
     realm: String,
     secret_key: String,
@@ -131,7 +131,7 @@ impl MppState {
     /// `close_signer` is an optional trait-object signer for server-initiated
     /// channel close transactions. Callers provide any `alloy::signers::Signer`
     /// implementation (local key, KMS, hardware wallet, etc.) wrapped in `Arc`.
-    #[cfg(feature = "mpp-tempo")]
+    #[cfg(feature = "payments-tempo")]
     pub fn add_tempo(
         &mut self,
         tempo: &TempoMppConfig,
@@ -150,7 +150,7 @@ impl MppState {
     /// `close_signer` is an optional trait-object signer for server-initiated
     /// channel close transactions. Pass any `alloy::signers::Signer`
     /// implementation wrapped in `Arc`.
-    #[cfg(feature = "mpp-tempo")]
+    #[cfg(feature = "payments-tempo")]
     pub fn add_tempo_with_store(
         &mut self,
         tempo: &TempoMppConfig,
@@ -248,7 +248,7 @@ impl MppState {
     /// Add a Solana backend keyed by `"solana"`.
     ///
     /// Uses the default in-memory channel store.
-    #[cfg(feature = "mpp-solana")]
+    #[cfg(feature = "payments-solana")]
     pub fn add_solana(
         &mut self,
         solana: &bitrouter_config::SolanaMppConfig,
@@ -265,7 +265,7 @@ impl MppState {
     ///
     /// This allows injecting a custom (e.g. database-backed) store instead of
     /// the default in-memory store.
-    #[cfg(feature = "mpp-solana")]
+    #[cfg(feature = "payments-solana")]
     pub fn add_solana_with_store(
         &mut self,
         solana: &bitrouter_config::SolanaMppConfig,
@@ -418,14 +418,14 @@ impl MppState {
             mpp::server::VerificationError::new(format!("no backend for key: {backend_key}"))
         })?;
         match backend {
-            #[cfg(feature = "mpp-tempo")]
+            #[cfg(feature = "payments-tempo")]
             MppBackend::Tempo { store, .. } => {
                 mpp::protocol::methods::tempo::session_method::deduct_from_channel(
                     &**store, channel_id, amount,
                 )
                 .await?;
             }
-            #[cfg(feature = "mpp-solana")]
+            #[cfg(feature = "payments-solana")]
             MppBackend::Solana(state) => {
                 super::solana_channel_store::deduct_from_channel(
                     state.session_method.store(),
@@ -446,11 +446,11 @@ impl MppState {
             return;
         };
         match backend {
-            #[cfg(feature = "mpp-tempo")]
+            #[cfg(feature = "payments-tempo")]
             MppBackend::Tempo { store, .. } => {
                 store.wait_for_update(channel_id).await;
             }
-            #[cfg(feature = "mpp-solana")]
+            #[cfg(feature = "payments-solana")]
             MppBackend::Solana(state) => {
                 state
                     .session_method
@@ -472,12 +472,12 @@ impl MppState {
     ) -> Option<(u128, u128, u128)> {
         let (_key, backend) = self.backend_for_chain(backend_key)?;
         match backend {
-            #[cfg(feature = "mpp-tempo")]
+            #[cfg(feature = "payments-tempo")]
             MppBackend::Tempo { store, .. } => {
                 let ch = store.get_channel(channel_id).await.ok()??;
                 Some((ch.spent, ch.highest_voucher_amount, ch.deposit))
             }
-            #[cfg(feature = "mpp-solana")]
+            #[cfg(feature = "payments-solana")]
             MppBackend::Solana(state) => {
                 let ch = state
                     .session_method
@@ -508,7 +508,7 @@ impl MppState {
     /// them rather than propagate, since close failures do not affect the
     /// already-served response. The channel can be settled later if this fails.
     // TODO: implement server-side close for Solana sessions
-    #[cfg(feature = "mpp-tempo")]
+    #[cfg(feature = "payments-tempo")]
     pub async fn close_channel(&self, backend_key: &str, channel_id: &str) -> Result<(), String> {
         let (_key, backend) = self
             .backend_for_chain(backend_key)
@@ -538,7 +538,7 @@ impl MppState {
                         close_lock,
                     )
                 }
-                #[cfg(feature = "mpp-solana")]
+                #[cfg(feature = "payments-solana")]
                 MppBackend::Solana(_) => {
                     return Err("server-side close not implemented for Solana".into());
                 }
@@ -669,11 +669,11 @@ impl super::payment_gate::PaymentGate for MppState {
         backend_key: &'a str,
         channel_id: &'a str,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), String>> + Send + 'a>> {
-        #[cfg(feature = "mpp-tempo")]
+        #[cfg(feature = "payments-tempo")]
         {
             Box::pin(self.close_channel(backend_key, channel_id))
         }
-        #[cfg(not(feature = "mpp-tempo"))]
+        #[cfg(not(feature = "payments-tempo"))]
         {
             let _ = (backend_key, channel_id);
             Box::pin(std::future::ready(Ok(())))
@@ -687,7 +687,7 @@ fn backend_session_challenge(
     options: SessionChallengeOptions<'_>,
 ) -> Result<mpp::PaymentChallenge, mpp::MppError> {
     match backend {
-        #[cfg(feature = "mpp-tempo")]
+        #[cfg(feature = "payments-tempo")]
         MppBackend::Tempo {
             mpp,
             suggested_deposit,
@@ -711,7 +711,7 @@ fn backend_session_challenge(
                 .ok_or_else(|| mpp::MppError::InvalidConfig("recipient not configured".into()))?;
             mpp.session_challenge_with_details(amount, currency, recipient, options)
         }
-        #[cfg(feature = "mpp-solana")]
+        #[cfg(feature = "payments-solana")]
         MppBackend::Solana(state) => solana_session_challenge(state, amount, options),
     }
 }
@@ -721,16 +721,16 @@ async fn backend_verify_session(
     credential: &mpp::PaymentCredential,
 ) -> Result<mpp::server::SessionVerifyResult, mpp::server::VerificationError> {
     match backend {
-        #[cfg(feature = "mpp-tempo")]
+        #[cfg(feature = "payments-tempo")]
         MppBackend::Tempo { mpp, .. } => mpp.verify_session(credential).await,
-        #[cfg(feature = "mpp-solana")]
+        #[cfg(feature = "payments-solana")]
         MppBackend::Solana(state) => solana_verify_session(state, credential).await,
     }
 }
 
 // ── Solana helpers ───────────────────────────────────────────────────
 
-#[cfg(feature = "mpp-solana")]
+#[cfg(feature = "payments-solana")]
 fn solana_session_challenge(
     state: &SolanaState,
     _amount: &str,
@@ -786,7 +786,7 @@ fn solana_session_challenge(
     })
 }
 
-#[cfg(feature = "mpp-solana")]
+#[cfg(feature = "payments-solana")]
 async fn solana_verify_session(
     state: &SolanaState,
     credential: &mpp::PaymentCredential,
@@ -861,7 +861,7 @@ async fn solana_verify_session(
 /// transaction on the Tempo escrow contract.
 ///
 /// Returns the transaction hash on success.
-#[cfg(feature = "mpp-tempo")]
+#[cfg(feature = "payments-tempo")]
 #[allow(clippy::too_many_arguments)]
 async fn submit_close_tx(
     provider: &TempoProvider,

--- a/bitrouter-api/src/router/anthropic/messages/filters.rs
+++ b/bitrouter-api/src/router/anthropic/messages/filters.rs
@@ -140,7 +140,7 @@ where
 }
 
 /// Creates a warp filter for `/v1/messages` with MPP payment gating.
-#[cfg(any(feature = "mpp-tempo", feature = "mpp-solana"))]
+#[cfg(any(feature = "payments-tempo", feature = "payments-solana"))]
 pub fn messages_filter_with_mpp<T, R, A>(
     table: Arc<T>,
     router: Arc<R>,
@@ -165,7 +165,7 @@ where
         .and_then(handle_messages_with_mpp)
 }
 
-#[cfg(any(feature = "mpp-tempo", feature = "mpp-solana"))]
+#[cfg(any(feature = "payments-tempo", feature = "payments-solana"))]
 async fn handle_messages_with_mpp<T, R>(
     caller: CallerContext,
     mpp_state: Arc<crate::mpp::MppState>,

--- a/bitrouter-api/src/router/google/generate_content/filters.rs
+++ b/bitrouter-api/src/router/google/generate_content/filters.rs
@@ -161,7 +161,7 @@ where
 }
 
 /// Creates a warp filter for `/v1beta/models/:model` with MPP payment gating.
-#[cfg(any(feature = "mpp-tempo", feature = "mpp-solana"))]
+#[cfg(any(feature = "payments-tempo", feature = "payments-solana"))]
 pub fn generate_content_filter_with_mpp<T, R, A>(
     table: Arc<T>,
     router: Arc<R>,
@@ -198,7 +198,7 @@ where
         )
 }
 
-#[cfg(any(feature = "mpp-tempo", feature = "mpp-solana"))]
+#[cfg(any(feature = "payments-tempo", feature = "payments-solana"))]
 async fn handle_generate_content_with_mpp<T, R>(
     (model_action, request): (String, GenerateContentRequest),
     caller: CallerContext,

--- a/bitrouter-api/src/router/mcp/filters.rs
+++ b/bitrouter-api/src/router/mcp/filters.rs
@@ -818,7 +818,7 @@ struct McpObserveContext {
 /// short-circuit and return the management response with a payment receipt.
 ///
 /// `GET /mcp/sse` is served without payment verification (notification-only).
-#[cfg(any(feature = "mpp-tempo", feature = "mpp-solana"))]
+#[cfg(any(feature = "payments-tempo", feature = "payments-solana"))]
 pub fn mcp_server_filter_with_payment_gate<T, A>(
     server: Option<Arc<T>>,
     tool_call_handler: Option<Arc<dyn ToolCallHandler>>,
@@ -840,7 +840,7 @@ where
     .or(mcp_sse_filter(server))
 }
 
-#[cfg(any(feature = "mpp-tempo", feature = "mpp-solana"))]
+#[cfg(any(feature = "payments-tempo", feature = "payments-solana"))]
 fn mcp_jsonrpc_filter_with_payment_gate<T, A>(
     server: Option<Arc<T>>,
     tool_call_handler: Option<Arc<dyn ToolCallHandler>>,
@@ -865,7 +865,7 @@ where
         .and_then(handle_mcp_jsonrpc_with_gate::<T>)
 }
 
-#[cfg(any(feature = "mpp-tempo", feature = "mpp-solana"))]
+#[cfg(any(feature = "payments-tempo", feature = "payments-solana"))]
 async fn handle_mcp_jsonrpc_with_gate<T: McpServer>(
     caller: CallerContext,
     payment_gate: Arc<dyn crate::mpp::PaymentGate>,

--- a/bitrouter-api/src/router/mcp/mod.rs
+++ b/bitrouter-api/src/router/mcp/mod.rs
@@ -11,6 +11,6 @@ mod filters;
 mod tests;
 
 pub use admin::mcp_admin_filter;
-#[cfg(any(feature = "mpp-tempo", feature = "mpp-solana"))]
+#[cfg(any(feature = "payments-tempo", feature = "payments-solana"))]
 pub use filters::mcp_server_filter_with_payment_gate;
 pub use filters::{mcp_bridge_filter, mcp_server_filter, mcp_server_filter_with_observe};

--- a/bitrouter-api/src/router/openai/chat/filters.rs
+++ b/bitrouter-api/src/router/openai/chat/filters.rs
@@ -144,7 +144,7 @@ where
     handle_chat_completion(request, table, hooked).await
 }
 
-#[cfg(any(feature = "mpp-tempo", feature = "mpp-solana"))]
+#[cfg(any(feature = "payments-tempo", feature = "payments-solana"))]
 async fn handle_chat_completion_with_mpp<T, R>(
     caller: CallerContext,
     mpp_state: Arc<crate::mpp::MppState>,
@@ -171,7 +171,7 @@ where
     .await
 }
 
-#[cfg(any(feature = "mpp-tempo", feature = "mpp-solana"))]
+#[cfg(any(feature = "payments-tempo", feature = "payments-solana"))]
 async fn handle_chat_completion_with_gate<T, R>(
     caller: CallerContext,
     payment_gate: Arc<dyn crate::mpp::PaymentGate>,
@@ -417,7 +417,7 @@ where
 /// Requires JWT authentication. The JWT `chain` claim selects the payment
 /// backend. Requests must also carry a `Payment` credential in the
 /// `Authorization` header.
-#[cfg(any(feature = "mpp-tempo", feature = "mpp-solana"))]
+#[cfg(any(feature = "payments-tempo", feature = "payments-solana"))]
 pub fn chat_completions_filter_with_mpp<T, R, A>(
     table: Arc<T>,
     router: Arc<R>,
@@ -449,7 +449,7 @@ where
 /// [`crate::mpp::MppState`] directly. This allows downstream crates to
 /// provide custom payment logic (e.g. charge-based balance management)
 /// while reusing the full routing, streaming, and observation pipeline.
-#[cfg(any(feature = "mpp-tempo", feature = "mpp-solana"))]
+#[cfg(any(feature = "payments-tempo", feature = "payments-solana"))]
 pub fn chat_completions_filter_with_payment_gate<T, R, A>(
     table: Arc<T>,
     router: Arc<R>,

--- a/bitrouter-api/src/router/openai/responses/filters.rs
+++ b/bitrouter-api/src/router/openai/responses/filters.rs
@@ -140,7 +140,7 @@ where
 }
 
 /// Creates a warp filter for `/v1/responses` with MPP payment gating.
-#[cfg(any(feature = "mpp-tempo", feature = "mpp-solana"))]
+#[cfg(any(feature = "payments-tempo", feature = "payments-solana"))]
 pub fn responses_filter_with_mpp<T, R, A>(
     table: Arc<T>,
     router: Arc<R>,
@@ -170,7 +170,7 @@ where
 /// Like [`responses_filter_with_mpp`], but accepts any
 /// [`crate::mpp::PaymentGate`] implementation instead of requiring
 /// [`crate::mpp::MppState`] directly.
-#[cfg(any(feature = "mpp-tempo", feature = "mpp-solana"))]
+#[cfg(any(feature = "payments-tempo", feature = "payments-solana"))]
 pub fn responses_filter_with_payment_gate<T, R, A>(
     table: Arc<T>,
     router: Arc<R>,
@@ -213,7 +213,7 @@ where
         )
 }
 
-#[cfg(any(feature = "mpp-tempo", feature = "mpp-solana"))]
+#[cfg(any(feature = "payments-tempo", feature = "payments-solana"))]
 async fn handle_responses_with_mpp<T, R>(
     caller: CallerContext,
     mpp_state: Arc<crate::mpp::MppState>,
@@ -240,7 +240,7 @@ where
     .await
 }
 
-#[cfg(any(feature = "mpp-tempo", feature = "mpp-solana"))]
+#[cfg(any(feature = "payments-tempo", feature = "payments-solana"))]
 async fn handle_responses_with_gate<T, R>(
     caller: CallerContext,
     payment_gate: Arc<dyn crate::mpp::PaymentGate>,

--- a/bitrouter-config/Cargo.toml
+++ b/bitrouter-config/Cargo.toml
@@ -10,8 +10,8 @@ readme = "README.md"
 
 [features]
 default = []
-mpp-tempo = []
-mpp-solana = []
+payments-tempo = []
+payments-solana = []
 
 [dependencies]
 bitrouter-core.workspace = true

--- a/bitrouter-config/src/config.rs
+++ b/bitrouter-config/src/config.rs
@@ -551,7 +551,7 @@ pub struct MppNetworksConfig {
     pub tempo: Option<TempoMppConfig>,
 
     /// Solana network configuration.
-    #[cfg(feature = "mpp-solana")]
+    #[cfg(feature = "payments-solana")]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub solana: Option<SolanaMppConfig>,
 }
@@ -590,7 +590,7 @@ pub struct TempoMppConfig {
 }
 
 /// Solana-specific MPP configuration.
-#[cfg(feature = "mpp-solana")]
+#[cfg(feature = "payments-solana")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SolanaMppConfig {
     /// Recipient address for payments (Solana base58 pubkey, required).
@@ -615,7 +615,7 @@ pub struct SolanaMppConfig {
 }
 
 /// Payment asset descriptor for Solana MPP.
-#[cfg(feature = "mpp-solana")]
+#[cfg(feature = "payments-solana")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SolanaAssetConfig {
     /// Asset kind: `"sol"` for native SOL, `"spl"` for an SPL token.
@@ -635,7 +635,7 @@ pub struct SolanaAssetConfig {
     pub symbol: Option<String>,
 }
 
-#[cfg(feature = "mpp-solana")]
+#[cfg(feature = "payments-solana")]
 impl Default for SolanaAssetConfig {
     fn default() -> Self {
         Self {
@@ -647,17 +647,17 @@ impl Default for SolanaAssetConfig {
     }
 }
 
-#[cfg(feature = "mpp-solana")]
+#[cfg(feature = "payments-solana")]
 fn default_solana_asset_kind() -> String {
     "sol".into()
 }
 
-#[cfg(feature = "mpp-solana")]
+#[cfg(feature = "payments-solana")]
 fn default_solana_asset_decimals() -> u8 {
     9
 }
 
-#[cfg(feature = "mpp-solana")]
+#[cfg(feature = "payments-solana")]
 fn default_solana_network() -> String {
     "mainnet-beta".into()
 }

--- a/bitrouter-config/src/lib.rs
+++ b/bitrouter-config/src/lib.rs
@@ -8,7 +8,7 @@ pub mod routing;
 pub mod writer;
 
 pub use bitrouter_core::routers::routing_table::ApiProtocol;
-#[cfg(feature = "mpp-solana")]
+#[cfg(feature = "payments-solana")]
 pub use config::SolanaMppConfig;
 pub use config::{
     AgentA2aConfig, AgentConfig, AgentProtocol, AgentSessionConfig, AuthConfig, BinaryArchive,

--- a/bitrouter/Cargo.toml
+++ b/bitrouter/Cargo.toml
@@ -14,8 +14,8 @@ default = [
     "tui",
     "sqlite",
     "postgres",
-    "mpp-tempo",
-    "mpp-solana",
+    "payments-tempo",
+    "payments-solana",
     "mcp",
     "rest",
 ]
@@ -25,15 +25,15 @@ tui = ["dep:bitrouter-tui", "bitrouter-providers/acp"]
 sqlite = ["bitrouter-accounts/sqlite", "bitrouter-observe/sqlite"]
 postgres = ["bitrouter-accounts/postgres", "bitrouter-observe/postgres"]
 mysql = ["bitrouter-accounts/mysql", "bitrouter-observe/mysql"]
-mpp-tempo = [
-    "bitrouter-api/mpp-tempo",
-    "bitrouter-config/mpp-tempo",
+payments-tempo = [
+    "bitrouter-api/payments-tempo",
+    "bitrouter-config/payments-tempo",
     "dep:mpp",
     "dep:anyhow",
 ]
-mpp-solana = [
-    "bitrouter-api/mpp-solana",
-    "bitrouter-config/mpp-solana",
+payments-solana = [
+    "bitrouter-api/payments-solana",
+    "bitrouter-config/payments-solana",
     "dep:mpp",
     "dep:anyhow",
     "dep:bs58",

--- a/bitrouter/src/main.rs
+++ b/bitrouter/src/main.rs
@@ -664,7 +664,7 @@ async fn run_cli(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             print_first_run_guidance(&runtime);
             let base_client = reqwest::Client::new();
             let client_builder = reqwest_middleware::ClientBuilder::new(base_client);
-            #[cfg(feature = "mpp-tempo")]
+            #[cfg(feature = "payments-tempo")]
             let client_builder =
                 match crate::runtime::payment::build_payment_middleware(&runtime.config) {
                     Ok(Some(mw)) => client_builder.with(mw),

--- a/bitrouter/src/runtime/mod.rs
+++ b/bitrouter/src/runtime/mod.rs
@@ -7,10 +7,10 @@ pub mod daemon;
 pub mod error;
 pub mod mcp_client;
 pub mod migration;
-#[cfg(feature = "mpp-tempo")]
+#[cfg(feature = "payments-tempo")]
 pub mod ows_signer;
 pub mod paths;
-#[cfg(feature = "mpp-tempo")]
+#[cfg(feature = "payments-tempo")]
 pub mod payment;
 pub mod router;
 pub mod server;

--- a/bitrouter/src/runtime/payment/mod.rs
+++ b/bitrouter/src/runtime/payment/mod.rs
@@ -9,7 +9,7 @@
 //! - **Tempo charge** — signs a one-time TIP-20 transfer transaction
 //! - **Solana charge** — builds and broadcasts an SPL token transfer (feature-gated)
 
-#[cfg(feature = "mpp-solana")]
+#[cfg(feature = "payments-solana")]
 pub mod solana_charge;
 
 use std::path::Path;
@@ -25,7 +25,7 @@ use crate::runtime::ows_signer::OwsSigner;
 const DEFAULT_TEMPO_RPC_URL: &str = "https://rpc.moderato.tempo.xyz";
 
 /// Default Solana RPC URL (mainnet-beta).
-#[cfg(feature = "mpp-solana")]
+#[cfg(feature = "payments-solana")]
 const DEFAULT_SOLANA_RPC_URL: &str = "https://api.mainnet-beta.solana.com";
 
 /// reqwest-middleware 0.5 adapter that wraps an `mpp::client::MultiProvider`.
@@ -168,7 +168,7 @@ pub fn build_payment_middleware(
     multi.add(tempo_session);
 
     // Solana charge provider (behind feature flag).
-    #[cfg(feature = "mpp-solana")]
+    #[cfg(feature = "payments-solana")]
     {
         let solana_rpc = payment_config
             .solana_rpc_url

--- a/bitrouter/src/runtime/server.rs
+++ b/bitrouter/src/runtime/server.rs
@@ -22,22 +22,22 @@ use crate::runtime::error::Result;
 
 /// Conditional bound: when MPP features are enabled, the routing table must
 /// also implement `PricingLookup` so that handlers can compute per-request costs.
-#[cfg(any(feature = "mpp-tempo", feature = "mpp-solana"))]
+#[cfg(any(feature = "payments-tempo", feature = "payments-solana"))]
 pub(crate) trait ServerTableBound:
     AdminRoutingTable + ModelRegistry + bitrouter_api::mpp::PricingLookup
 {
 }
 
-#[cfg(any(feature = "mpp-tempo", feature = "mpp-solana"))]
+#[cfg(any(feature = "payments-tempo", feature = "payments-solana"))]
 impl<T: AdminRoutingTable + ModelRegistry + bitrouter_api::mpp::PricingLookup> ServerTableBound
     for T
 {
 }
 
-#[cfg(not(any(feature = "mpp-tempo", feature = "mpp-solana")))]
+#[cfg(not(any(feature = "payments-tempo", feature = "payments-solana")))]
 pub(crate) trait ServerTableBound: AdminRoutingTable + ModelRegistry {}
 
-#[cfg(not(any(feature = "mpp-tempo", feature = "mpp-solana")))]
+#[cfg(not(any(feature = "payments-tempo", feature = "payments-solana")))]
 impl<T: AdminRoutingTable + ModelRegistry> ServerTableBound for T {}
 
 pub struct ServerPlan<T, R> {
@@ -155,7 +155,7 @@ where
     /// 1. OWS wallet (if `wallet` config present)
     /// 2. Hex private key from `tempo.close_signer`
     /// 3. None (close signing disabled)
-    #[cfg(feature = "mpp-tempo")]
+    #[cfg(feature = "payments-tempo")]
     fn resolve_close_signer(
         tempo: &bitrouter_config::TempoMppConfig,
         config: &BitrouterConfig,
@@ -355,7 +355,7 @@ where
         // Model API routes with observation.
         // When MPP is enabled, payment-gated filters replace the standard
         // auth-gated filters. We use .boxed() to unify the filter types.
-        #[cfg(any(feature = "mpp-tempo", feature = "mpp-solana"))]
+        #[cfg(any(feature = "payments-tempo", feature = "payments-solana"))]
         let mpp_state: Option<Arc<bitrouter_api::mpp::MppState>> = {
             match self.config.mpp.as_ref().filter(|c| c.enabled) {
                 Some(mpp_config) => {
@@ -363,7 +363,7 @@ where
                     let secret_key = mpp_config.secret_key.as_deref();
                     let mut state = bitrouter_api::mpp::MppState::new(realm);
 
-                    #[cfg(feature = "mpp-tempo")]
+                    #[cfg(feature = "payments-tempo")]
                     if let Some(tempo) = mpp_config.networks.tempo.as_ref() {
                         let close_signer: Option<Arc<dyn mpp::Signer + Send + Sync>> =
                             match Self::resolve_close_signer(tempo, &self.config) {
@@ -385,7 +385,7 @@ where
                         tracing::info!("MPP Tempo backend enabled");
                     }
 
-                    #[cfg(feature = "mpp-solana")]
+                    #[cfg(feature = "payments-solana")]
                     if let Some(solana) = mpp_config.networks.solana.as_ref() {
                         state.add_solana(solana, secret_key).map_err(|e| {
                             bitrouter_config::ConfigError::ConfigParse(format!(
@@ -406,7 +406,7 @@ where
             }
         };
 
-        #[cfg(any(feature = "mpp-tempo", feature = "mpp-solana"))]
+        #[cfg(any(feature = "payments-tempo", feature = "payments-solana"))]
         let (chat, messages, responses, generate_content) = if let Some(ref mpp) = mpp_state {
             (
                 openai::chat::filters::chat_completions_filter_with_mpp(
@@ -483,28 +483,28 @@ where
             )
         };
 
-        #[cfg(not(any(feature = "mpp-tempo", feature = "mpp-solana")))]
+        #[cfg(not(any(feature = "payments-tempo", feature = "payments-solana")))]
         let chat = openai::chat::filters::chat_completions_filter_with_observe(
             self.table.clone(),
             guarded_router.clone(),
             observer.clone(),
             account_filter.clone(),
         );
-        #[cfg(not(any(feature = "mpp-tempo", feature = "mpp-solana")))]
+        #[cfg(not(any(feature = "payments-tempo", feature = "payments-solana")))]
         let messages = anthropic::messages::filters::messages_filter_with_observe(
             self.table.clone(),
             guarded_router.clone(),
             observer.clone(),
             anthropic_account_filter,
         );
-        #[cfg(not(any(feature = "mpp-tempo", feature = "mpp-solana")))]
+        #[cfg(not(any(feature = "payments-tempo", feature = "payments-solana")))]
         let responses = openai::responses::filters::responses_filter_with_observe(
             self.table.clone(),
             guarded_router.clone(),
             observer.clone(),
             account_filter.clone(),
         );
-        #[cfg(not(any(feature = "mpp-tempo", feature = "mpp-solana")))]
+        #[cfg(not(any(feature = "payments-tempo", feature = "payments-solana")))]
         let generate_content =
             google::generate_content::filters::generate_content_filter_with_observe(
                 self.table.clone(),
@@ -898,7 +898,7 @@ async fn handle_auth_rejection(
         )) as Box<dyn warp::Reply>);
     }
 
-    #[cfg(any(feature = "mpp-tempo", feature = "mpp-solana"))]
+    #[cfg(any(feature = "payments-tempo", feature = "payments-solana"))]
     if let Some(challenge) = rejection.find::<bitrouter_api::mpp::MppChallenge>() {
         match warp::http::Response::builder()
             .status(warp::http::StatusCode::PAYMENT_REQUIRED)
@@ -918,7 +918,7 @@ async fn handle_auth_rejection(
         }
     }
 
-    #[cfg(any(feature = "mpp-tempo", feature = "mpp-solana"))]
+    #[cfg(any(feature = "payments-tempo", feature = "payments-solana"))]
     if let Some(err) = rejection.find::<bitrouter_api::mpp::MppVerificationFailed>() {
         let json = warp::reply::json(&serde_json::json!({
             "error": {


### PR DESCRIPTION
Closes #374. Part of #366.

Renames Cargo features `mpp-tempo` / `mpp-solana` → `payments-tempo` / `payments-solana` on `bitrouter`, `bitrouter-api`, and `bitrouter-config`. The implementation module is still named `mpp` (it wraps that protocol). Feature dep lists and behaviour are unchanged.

**Breaking** for downstream `Cargo.toml` consumers selecting these features. Noted in CHANGELOG.

Verified locally: `--all-features`, `--no-default-features --features payments-tempo`, `--no-default-features --features payments-solana`, fmt, clippy, tests.