### PR TITLE
refactor(bitrouter): bake accounts in as core feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### ⚠️ Breaking Changes
 
+- DB-backed accounts, sessions, JWT auth, and persistent spend tracking are now **baked into the `bitrouter` binary unconditionally**. The previous "open proxy mode" (no database = no auth) has been removed. The `bitrouter` binary now requires a reachable database at startup; failures to connect or migrate are fatal. The `sqlite` / `postgres` / `mysql` Cargo features remain only as the storage-backend selector (default: `sqlite`). The default feature set no longer includes `postgres` — enable it explicitly if you need it. `JwtAuthContext::is_open` and the open-proxy passthrough have been removed.
 - Renamed Cargo features `mpp-tempo` / `mpp-solana` to `payments-tempo` / `payments-solana` on the `bitrouter`, `bitrouter-api`, and `bitrouter-config` crates. Downstream users selecting these features in `Cargo.toml` must update the names. The implementation module remains `mpp` since it still wraps the MPP protocol.
 
 ## [0.25.0](https://github.com/bitrouter/bitrouter/compare/v0.24.4...v0.25.0)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,13 +6,13 @@ members = ["bitrouter", "bitrouter-*"]
 version = "0.25.0"
 
 [workspace.dependencies]
-bitrouter-accounts = { path = "bitrouter-accounts", version = "0.25" }
+bitrouter-accounts = { path = "bitrouter-accounts", version = "0.25", default-features = false }
 bitrouter-api = { path = "bitrouter-api", version = "0.25", default-features = false }
 bitrouter-blob = { path = "bitrouter-blob", version = "0.25" }
 bitrouter-config = { path = "bitrouter-config", version = "0.25" }
 bitrouter-core = { path = "bitrouter-core", version = "0.25" }
 bitrouter-guardrails = { path = "bitrouter-guardrails", version = "0.25" }
-bitrouter-observe = { path = "bitrouter-observe", version = "0.25" }
+bitrouter-observe = { path = "bitrouter-observe", version = "0.25", default-features = false }
 bitrouter-providers = { path = "bitrouter-providers", version = "0.25" }
 bitrouter-tui = { path = "bitrouter-tui", version = "0.25" }
 

--- a/bitrouter/Cargo.toml
+++ b/bitrouter/Cargo.toml
@@ -13,7 +13,6 @@ readme = "README.md"
 default = [
     "tui",
     "sqlite",
-    "postgres",
     "payments-tempo",
     "payments-solana",
     "mcp",
@@ -22,6 +21,9 @@ default = [
 rest = ["bitrouter-providers/rest"]
 mcp = ["bitrouter-providers/mcp"]
 tui = ["dep:bitrouter-tui", "bitrouter-providers/acp"]
+# Database driver selection. Exactly one driver must be enabled (default: sqlite).
+# Accounts, sessions, JWT auth, and persistent spend tracking are baked into the
+# binary unconditionally — these features only choose the storage backend.
 sqlite = ["bitrouter-accounts/sqlite", "bitrouter-observe/sqlite"]
 postgres = ["bitrouter-accounts/postgres", "bitrouter-observe/postgres"]
 mysql = ["bitrouter-accounts/mysql", "bitrouter-observe/mysql"]
@@ -42,12 +44,12 @@ payments-solana = [
 
 [dependencies]
 # Internal crates
-bitrouter-accounts.workspace = true
+bitrouter-accounts = { workspace = true }
 bitrouter-api = { workspace = true }
 bitrouter-config.workspace = true
 bitrouter-core.workspace = true
 bitrouter-guardrails.workspace = true
-bitrouter-observe.workspace = true
+bitrouter-observe = { workspace = true }
 bitrouter-providers = { workspace = true, features = ["agentskills"] }
 
 # CLI

--- a/bitrouter/src/main.rs
+++ b/bitrouter/src/main.rs
@@ -6,6 +6,7 @@ mod init;
 mod runtime;
 
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use crate::runtime::{AppRuntime, PathOverrides, RuntimePaths, resolve_home};
 use clap::{Parser, Subcommand};
@@ -624,31 +625,7 @@ async fn run_cli(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
     // All remaining commands need tracing and a loaded runtime.
     init_tracing();
 
-    let mut runtime: DefaultRuntime = load_or_warn_scaffold(&paths);
-
-    // Connect to database for commands that start the server.
-    if matches!(cli.command, Some(Command::Serve)) {
-        let env_file = paths.env_file.exists().then_some(paths.env_file.as_path());
-        let db_url = crate::runtime::resolve_database_url(
-            cli.database_url.as_deref(),
-            &runtime.config,
-            &paths.home_dir,
-            env_file,
-        );
-        let mut db_opts = sea_orm::ConnectOptions::new(&db_url);
-        db_opts.sqlx_logging_level(tracing::log::LevelFilter::Debug);
-        match sea_orm::Database::connect(db_opts).await {
-            Ok(db) => {
-                if let Err(e) = crate::runtime::migrate(&db).await {
-                    tracing::warn!("database migration failed: {e}");
-                }
-                runtime.db = Some(std::sync::Arc::new(db));
-            }
-            Err(e) => {
-                tracing::warn!("database connection failed ({db_url}): {e}");
-            }
-        }
-    }
+    let runtime: DefaultRuntime = load_or_warn_scaffold(&paths);
 
     // When an OWS wallet is configured and OWS_PASSPHRASE is not already set,
     // prompt interactively (if a TTY is attached) or warn the user.
@@ -661,6 +638,31 @@ async fn run_cli(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
 
     match cli.command {
         Some(Command::Serve) => {
+            // Connect to database. Accounts, sessions, JWT auth, and persistent
+            // spend tracking are baked in unconditionally — startup fails fast
+            // if the database is unreachable or migrations cannot apply.
+            let env_file = paths.env_file.exists().then_some(paths.env_file.as_path());
+            let db_url = crate::runtime::resolve_database_url(
+                cli.database_url.as_deref(),
+                &runtime.config,
+                &paths.home_dir,
+                env_file,
+            );
+            let mut db_opts = sea_orm::ConnectOptions::new(&db_url);
+            db_opts.sqlx_logging_level(tracing::log::LevelFilter::Debug);
+            let db = sea_orm::Database::connect(db_opts).await.map_err(|e| {
+                crate::runtime::error::RuntimeError::Other(format!(
+                    "database connection failed: {e}. Check `database.url` in {} or BITROUTER_DATABASE_URL.",
+                    paths.config_file.display()
+                ))
+            })?;
+            crate::runtime::migrate(&db).await.map_err(|e| {
+                crate::runtime::error::RuntimeError::Other(format!(
+                    "database migration failed: {e}"
+                ))
+            })?;
+            let db = Arc::new(db);
+
             print_first_run_guidance(&runtime);
             let base_client = reqwest::Client::new();
             let client_builder = reqwest_middleware::ClientBuilder::new(base_client);
@@ -679,7 +681,7 @@ async fn run_cli(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
                 runtime.config.providers.clone(),
             )
             .with_token_store(paths.token_store_file.clone());
-            runtime.serve_with_reload(model_router).await?
+            runtime.serve_with_reload(db, model_router).await?
         }
         Some(Command::Start) => runtime.start().await?,
         Some(Command::Stop) => runtime.stop().await?,

--- a/bitrouter/src/runtime/app.rs
+++ b/bitrouter/src/runtime/app.rs
@@ -33,7 +33,6 @@ pub struct AppRuntime<R> {
     pub config: BitrouterConfig,
     pub paths: RuntimePaths,
     pub routing_table: R,
-    pub db: Option<Arc<DatabaseConnection>>,
 }
 
 impl<R: ServerTableBound + Send + Sync + 'static> AppRuntime<R> {
@@ -104,7 +103,6 @@ impl
             config,
             paths,
             routing_table,
-            db: None,
         })
     }
 
@@ -127,17 +125,23 @@ impl
             config,
             paths,
             routing_table,
-            db: None,
         }
     }
 
     /// Start the server with configuration hot-reload enabled.
     ///
+    /// Requires a connected database — accounts, sessions, JWT auth, and
+    /// persistent spend tracking are baked in unconditionally.
+    ///
     /// When the server receives a reload signal (SIGHUP on Unix, flag file on
     /// Windows), it re-reads the configuration file from disk and replaces the
     /// inner routing and tool tables without dropping in-flight requests or
     /// dynamic routes.
-    pub async fn serve_with_reload<M>(self, model_router: M) -> Result<()>
+    pub async fn serve_with_reload<M>(
+        self,
+        db: Arc<DatabaseConnection>,
+        model_router: M,
+    ) -> Result<()>
     where
         M: bitrouter_core::routers::router::LanguageModelRouter + Send + Sync + 'static,
     {
@@ -210,28 +214,22 @@ impl
             Ok(())
         };
 
-        let mut plan =
-            crate::runtime::server::ServerPlan::new(self.config, table, Arc::new(model_router))
-                .with_paths(paths)
-                .with_tool_registry(tool_registry)
-                .with_policy_resolver(shared_policy_resolver)
-                .with_reload(reload_fn);
+        let mut plan = crate::runtime::server::ServerPlan::new(
+            self.config,
+            table,
+            Arc::new(model_router),
+            db.clone(),
+        )
+        .with_paths(paths)
+        .with_tool_registry(tool_registry)
+        .with_policy_resolver(shared_policy_resolver)
+        .with_reload(reload_fn);
 
-        // Wire per-key revocation set. Use DB-backed persistence when a
-        // database is configured; fall back to in-memory (lost on restart).
+        // Wire DB-backed per-key revocation set.
         let revocation_set: Arc<dyn bitrouter_core::auth::revocation::KeyRevocationSet> =
-            if let Some(ref db) = self.db {
-                Arc::new(bitrouter_accounts::service::DbRevocationSet::new(
-                    db.clone(),
-                ))
-            } else {
-                Arc::new(bitrouter_core::auth::revocation::InMemoryRevocationSet::new())
-            };
+            Arc::new(bitrouter_accounts::service::DbRevocationSet::new(db));
         plan = plan.with_revocation_set(revocation_set);
 
-        if let Some(db) = self.db {
-            plan = plan.with_db(db);
-        }
         plan.serve().await
     }
 }

--- a/bitrouter/src/runtime/auth.rs
+++ b/bitrouter/src/runtime/auth.rs
@@ -15,8 +15,8 @@
 //! | Anthropic  | `x-api-key: <token>` or `Authorization: Bearer` |
 //! | Management | `Authorization: Bearer <token>`                 |
 //!
-//! When no database is configured, auth is disabled and all requests are
-//! allowed through (open proxy mode).
+//! Authentication is always enforced — the bitrouter binary requires a
+//! database connection at startup.
 
 use std::sync::Arc;
 
@@ -34,7 +34,7 @@ use bitrouter_core::auth::token as jwt_token;
 #[derive(Clone)]
 pub struct JwtAuthContext {
     /// Database connection for account lookups (auto-creation).
-    db: Option<DatabaseConnection>,
+    db: DatabaseConnection,
     /// The operator's CAIP-10 identity resolved from wallet config at startup.
     /// When set, JWTs must have `iss` matching this identity.
     operator_caip10: Option<String>,
@@ -44,7 +44,7 @@ pub struct JwtAuthContext {
 }
 
 impl JwtAuthContext {
-    pub fn new(db: Option<DatabaseConnection>, operator_caip10: Option<String>) -> Self {
+    pub fn new(db: DatabaseConnection, operator_caip10: Option<String>) -> Self {
         Self {
             db,
             operator_caip10,
@@ -56,11 +56,6 @@ impl JwtAuthContext {
     pub fn with_revocation_set(mut self, set: Arc<dyn KeyRevocationSet>) -> Self {
         self.revocation_set = Some(set);
         self
-    }
-
-    /// Returns `true` when no database is configured (open proxy mode).
-    pub fn is_open(&self) -> bool {
-        self.db.is_none()
     }
 }
 
@@ -169,13 +164,7 @@ async fn resolve_jwt_identity(
     let chain = Caip10::parse(&claims.iss).ok().map(|c| c.chain.caip2());
 
     // 5. Resolve account from DB using CAIP-10 iss.
-    let Some(ref db) = ctx.db else {
-        return Err(warp::reject::custom(Unauthorized(
-            "authentication requires a database",
-        )));
-    };
-
-    let svc = AccountService::new(db);
+    let svc = AccountService::new(&ctx.db);
     let account = svc
         .find_or_create_by_pubkey(&claims.iss)
         .await
@@ -210,14 +199,9 @@ async fn resolve_jwt_identity(
 // ── composite auth filters ────────────────────────────────────
 
 /// Build an auth filter for OpenAI-protocol routes (`Authorization: Bearer`).
-///
-/// When auth is disabled (no DB), returns a passthrough identity.
 pub fn openai_auth(
     ctx: Arc<JwtAuthContext>,
 ) -> impl Filter<Extract = (Identity,), Error = warp::Rejection> + Clone {
-    if ctx.is_open() {
-        return open_identity().boxed();
-    }
     let ctx = ctx.clone();
     bearer_credential()
         .and(warp::any().map(move || ctx.clone()))
@@ -231,14 +215,10 @@ pub fn openai_auth(
 ///
 /// Accepts credentials from either `x-api-key` (standard Anthropic) or
 /// `Authorization: Bearer` (used by clients like Claude Code that set
-/// `ANTHROPIC_AUTH_TOKEN`). When auth is disabled (no DB), returns a
-/// passthrough identity.
+/// `ANTHROPIC_AUTH_TOKEN`).
 pub fn anthropic_auth(
     ctx: Arc<JwtAuthContext>,
 ) -> impl Filter<Extract = (Identity,), Error = warp::Rejection> + Clone {
-    if ctx.is_open() {
-        return open_identity().boxed();
-    }
     let ctx = ctx.clone();
     any_credential()
         .and(warp::any().map(move || ctx.clone()))
@@ -249,14 +229,9 @@ pub fn anthropic_auth(
 }
 
 /// Build an auth filter for management routes. Accepts both Bearer and x-api-key.
-///
-/// When auth is disabled (no DB), returns a passthrough identity.
 pub fn management_auth(
     ctx: Arc<JwtAuthContext>,
 ) -> impl Filter<Extract = (Identity,), Error = warp::Rejection> + Clone {
-    if ctx.is_open() {
-        return open_identity().boxed();
-    }
     let ctx = ctx.clone();
     any_credential()
         .and(warp::any().map(move || ctx.clone()))
@@ -264,27 +239,6 @@ pub fn management_auth(
             resolve_identity(&credential, &ctx).await
         })
         .boxed()
-}
-
-/// Passthrough filter when auth is disabled — produces an anonymous admin identity.
-///
-/// Uses a deterministic all-zero UUID so open-mode spend logs are consistently
-/// attributable rather than scattered across random IDs.
-fn open_identity() -> impl Filter<Extract = (Identity,), Error = warp::Rejection> + Clone {
-    warp::any().and_then(|| async {
-        Ok::<_, warp::Rejection>(Identity {
-            account_id: AccountId(uuid::Uuid::nil()),
-            scope: Scope::Admin,
-            key_id: None,
-            chain: None,
-            models: None,
-            budget: None,
-            budget_scope: None,
-            issued_at: None,
-            key: None,
-            policy_id: None,
-        })
-    })
 }
 
 // ── rejection types ───────────────────────────────────────────

--- a/bitrouter/src/runtime/error.rs
+++ b/bitrouter/src/runtime/error.rs
@@ -12,4 +12,6 @@ pub enum RuntimeError {
     Config(#[from] bitrouter_config::ConfigError),
     #[error("io error: {0}")]
     Io(#[from] io::Error),
+    #[error("{0}")]
+    Other(String),
 }

--- a/bitrouter/src/runtime/server.rs
+++ b/bitrouter/src/runtime/server.rs
@@ -44,7 +44,7 @@ pub struct ServerPlan<T, R> {
     config: BitrouterConfig,
     table: Arc<T>,
     router: Arc<R>,
-    db: Option<Arc<DatabaseConnection>>,
+    db: Arc<DatabaseConnection>,
     paths: Option<crate::runtime::paths::RuntimePaths>,
     reload_fn: Option<Arc<dyn Fn() -> std::result::Result<(), String> + Send + Sync>>,
     /// Pre-built config-authoritative tool registry with policy enforcement.
@@ -77,23 +77,23 @@ where
     T: ServerTableBound + Send + Sync + 'static,
     R: LanguageModelRouter + Send + Sync + 'static,
 {
-    pub fn new(config: BitrouterConfig, table: Arc<T>, router: Arc<R>) -> Self {
+    pub fn new(
+        config: BitrouterConfig,
+        table: Arc<T>,
+        router: Arc<R>,
+        db: Arc<DatabaseConnection>,
+    ) -> Self {
         Self {
             config,
             table,
             router,
-            db: None,
+            db,
             paths: None,
             reload_fn: None,
             tool_registry: None,
             policy_resolver: None,
             revocation_set: None,
         }
-    }
-
-    pub fn with_db(mut self, db: Arc<DatabaseConnection>) -> Self {
-        self.db = Some(db);
-        self
     }
 
     pub fn with_paths(mut self, paths: crate::runtime::paths::RuntimePaths) -> Self {
@@ -221,10 +221,7 @@ where
                 .map_err(|e| tracing::warn!("could not resolve operator CAIP-10: {e}"))
                 .ok()
         });
-        let mut auth_ctx = JwtAuthContext::new(
-            self.db.as_ref().map(|db| db.as_ref().clone()),
-            operator_caip10,
-        );
+        let mut auth_ctx = JwtAuthContext::new(self.db.as_ref().clone(), operator_caip10);
         if let Some(revocation_set) = self.revocation_set.clone() {
             auth_ctx = auth_ctx.with_revocation_set(revocation_set);
         }
@@ -233,9 +230,7 @@ where
         // Build the observation stack: spend tracking + metrics for all service types.
         let mut observe_builder = ObserveStack::builder();
 
-        if let Some(ref db) = self.db {
-            observe_builder = observe_builder.with_db(db.as_ref());
-        }
+        observe_builder = observe_builder.with_db(self.db.as_ref());
 
         let providers = self.config.providers.clone();
         observe_builder = observe_builder.model_pricing(move |provider, model| {
@@ -321,12 +316,11 @@ where
                 .and_then(handle_key_revoke)
         };
 
-        // Build account filter that extracts caller context when auth is enabled,
-        // or returns a default (empty) caller context when no database is configured.
-        // When a database is connected, budget enforcement is chained after auth:
-        // accumulated spend is compared against the JWT `bgt` claim.
+        // Build account filter that extracts caller context (auth-gated) and
+        // chains budget enforcement: accumulated spend is compared against the
+        // JWT `bgt` claim.
         let spend_store = observe.spend_store.clone();
-        let account_filter = if self.db.is_some() {
+        let account_filter = {
             let auth_filter = auth::openai_auth(auth_ctx.clone());
             let ss = spend_store.clone();
             warp::any()
@@ -335,11 +329,9 @@ where
                 .and(warp::any().map(move || ss.clone()))
                 .and_then(crate::runtime::budget::check_budget)
                 .boxed()
-        } else {
-            warp::any().map(CallerContext::default).boxed()
         };
 
-        let anthropic_account_filter = if self.db.is_some() {
+        let anthropic_account_filter = {
             let auth_filter = auth::anthropic_auth(auth_ctx.clone());
             let ss = spend_store.clone();
             warp::any()
@@ -348,8 +340,6 @@ where
                 .and(warp::any().map(move || ss.clone()))
                 .and_then(crate::runtime::budget::check_budget)
                 .boxed()
-        } else {
-            warp::any().map(CallerContext::default).boxed()
         };
 
         // Model API routes with observation.
@@ -635,16 +625,10 @@ where
         #[cfg(feature = "mcp")]
         let admin_mcp_routes = {
             use bitrouter_api::router::mcp as mcp_api;
-            if self.db.is_some() {
-                auth::auth_gate(auth::management_auth(auth_ctx.clone()))
-                    .and(mcp_api::mcp_admin_filter(mcp_admin_registry))
-                    .map(|r| Box::new(r) as Box<dyn warp::Reply>)
-                    .boxed()
-            } else {
-                mcp_api::mcp_admin_filter(mcp_admin_registry)
-                    .map(|r| Box::new(r) as Box<dyn warp::Reply>)
-                    .boxed()
-            }
+            auth::auth_gate(auth::management_auth(auth_ctx.clone()))
+                .and(mcp_api::mcp_admin_filter(mcp_admin_registry))
+                .map(|r| Box::new(r) as Box<dyn warp::Reply>)
+                .boxed()
         };
         #[cfg(not(feature = "mcp"))]
         let admin_mcp_routes = warp::path!("mcp" / "admin" / ..)
@@ -740,41 +724,25 @@ where
         };
 
         // ── Serve ────────────────────────────────────────────────────
-        if let Some(ref db) = self.db {
-            let db_conn = db.as_ref().clone();
-            let mgmt_auth = auth::management_auth(auth_ctx.clone());
-            let acct =
-                bitrouter_accounts::filters::account_routes(db_conn.clone(), mgmt_auth.clone());
-            let sess = bitrouter_accounts::filters::session_routes(db_conn, mgmt_auth);
+        let db_conn = self.db.as_ref().clone();
+        let mgmt_auth = auth::management_auth(auth_ctx.clone());
+        let acct = bitrouter_accounts::filters::account_routes(db_conn.clone(), mgmt_auth.clone());
+        let sess = bitrouter_accounts::filters::session_routes(db_conn, mgmt_auth);
 
-            let all = all_routes
-                .or(acct)
-                .or(sess)
-                .recover(handle_auth_rejection)
-                .with(warp::trace::request());
+        let all = all_routes
+            .or(acct)
+            .or(sess)
+            .recover(handle_auth_rejection)
+            .with(warp::trace::request());
 
-            // Pre-check that the address is available (warp's bind panics on failure).
-            check_addr_available(addr)?;
-            tracing::info!(%addr, "server listening (JWT auth enabled)");
-            let server = warp::serve(all)
-                .bind(addr)
-                .await
-                .graceful(shutdown_signal());
-            server.run().await;
-        } else {
-            let all = all_routes
-                .recover(handle_auth_rejection)
-                .with(warp::trace::request());
-
-            // Pre-check that the address is available (warp's bind panics on failure).
-            check_addr_available(addr)?;
-            tracing::info!(%addr, "server listening (auth disabled — no database configured)");
-            let server = warp::serve(all)
-                .bind(addr)
-                .await
-                .graceful(shutdown_signal());
-            server.run().await;
-        }
+        // Pre-check that the address is available (warp's bind panics on failure).
+        check_addr_available(addr)?;
+        tracing::info!(%addr, "server listening (JWT auth enabled)");
+        let server = warp::serve(all)
+            .bind(addr)
+            .await
+            .graceful(shutdown_signal());
+        server.run().await;
 
         tracing::info!("server stopped");
         Ok(())


### PR DESCRIPTION
Closes #375. Part of #366.

Bakes DB-backed accounts/sessions/JWT auth/persistent spend into the `bitrouter` binary unconditionally. Open-proxy mode (no DB = no auth) is removed.

**Highlights**
- Default features drop `postgres` (`sqlite` only by default; `postgres`/`mysql` opt-in).
- Workspace pulls `bitrouter-accounts`/`bitrouter-observe` with `default-features = false` so the per-driver Cargo features actually select the storage backend (verified via `cargo tree -e features`: only `sqlx-sqlite` is enabled by default now).
- `JwtAuthContext.db` and `ServerPlan.db` are non-optional. `is_open()`, `open_identity()`, and the three `if ctx.is_open()` passthrough branches are gone.
- `AppRuntime.db` field is removed entirely — `serve_with_reload(db, model_router)` now takes the connection explicitly. This keeps non-serve commands (`status`, `init`, `route`, `reload`) lightweight; only `serve` needs a DB.
- `bitrouter serve` connects + migrates the DB up-front, and both failures are **fatal** (previously logged a warning and continued in degraded mode). The DB URL is no longer leaked on connection failure.
- Always-DB-backed `KeyRevocationSet`; in-memory fallback removed.

**Verification**
- `cargo build -p bitrouter` ✅
- `cargo clippy --workspace --all-targets --all-features` ✅
- `cargo test --workspace` ✅
- `cargo tree -p bitrouter -e features | grep sqlx-` shows only sqlx-sqlite.

**Out of scope (follow-ups)**
- Pre-flighting DB before `bitrouter start`/`restart` (these spawn child `serve` and don't currently propagate `--db`); the child will surface the new fatal error itself.
- Requiring an operator wallet (separate hardening; not in #375).
