### PR TITLE
ci: add per-feature build matrix and dep-tree regression check

### DIFF
--- a/.github/scripts/check-feature-deps.sh
+++ b/.github/scripts/check-feature-deps.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Enforce the BitRouter feature rule: every Cargo feature must produce a
+# measurable change in the dependency tree. A feature whose `cargo tree`
+# is identical to the baseline is "noise" — it should be removed or rolled
+# into another feature.
+#
+# Usage: .github/scripts/check-feature-deps.sh
+#
+# For each (crate, feature) pair listed below, the script:
+#   1. Captures `cargo tree -p <crate> --no-default-features --edges normal`
+#      with the feature's *baseline* enabled.
+#   2. Captures the same with the feature additionally enabled.
+#   3. Diffs the two outputs and fails if the diff is empty.
+#
+# Allow-list (skipped):
+#   - Database driver selectors that are mutually exclusive (sqlite/postgres/
+#     mysql) — each driver replaces the previous, but adding a second driver
+#     does add deps so they are tested normally.
+#   - Chain selectors (tempo/solana) — same situation; both add real deps.
+
+set -euo pipefail
+
+# Each entry: "crate|baseline_features|feature_to_test"
+# An empty `baseline_features` means `--no-default-features` only.
+CHECKS=(
+    # bitrouter binary — every feature stacked on top of `tempo`
+    # (the binary requires at least one chain backend; `tempo` is the cheapest).
+    "bitrouter|tempo|cli"
+    "bitrouter|tempo|tui"
+    "bitrouter|tempo|sqlite"
+    "bitrouter|tempo|postgres"
+    "bitrouter|tempo|mysql"
+    "bitrouter|tempo|mcp"
+    # `bitrouter:rest` is intentionally a source-only toggle (delegates to
+    # `bitrouter-providers/rest`, which is also source-only). Skipped.
+    "bitrouter|tempo|solana"
+
+    # bitrouter-api — features over an empty baseline.
+    "bitrouter-api||accounts"
+    "bitrouter-api||observe"
+    "bitrouter-api||guardrails"
+    "bitrouter-api||payments-tempo"
+    "bitrouter-api||payments-solana"
+
+    # bitrouter-config — `payments-solana` is a source-only toggle that
+    # gates additional config struct definitions; it pulls no extra deps
+    # by design and is therefore not checked here.
+
+    # bitrouter-accounts — driver selectors.
+    "bitrouter-accounts||sqlite"
+    "bitrouter-accounts||postgres"
+    "bitrouter-accounts||mysql"
+
+    # bitrouter-observe — driver selectors.
+    "bitrouter-observe||sqlite"
+    "bitrouter-observe||postgres"
+    "bitrouter-observe||mysql"
+)
+
+failures=0
+
+cargo_tree() {
+    local crate="$1"
+    local features="$2"
+    local args=(-p "$crate" --no-default-features --edges normal)
+    if [ -n "$features" ]; then
+        args+=(--features "$features")
+    fi
+    cargo tree "${args[@]}" 2>/dev/null
+}
+
+for entry in "${CHECKS[@]}"; do
+    IFS='|' read -r crate baseline feature <<<"$entry"
+
+    if [ -n "$baseline" ]; then
+        with="${baseline},${feature}"
+    else
+        with="$feature"
+    fi
+
+    label="${crate}: +${feature}"
+    if [ -n "$baseline" ]; then
+        label="${label} (baseline: ${baseline})"
+    fi
+
+    echo "::group::${label}"
+
+    base_tree="$(cargo_tree "$crate" "$baseline")"
+    with_tree="$(cargo_tree "$crate" "$with")"
+
+    if [ "$base_tree" = "$with_tree" ]; then
+        echo "::error::feature '${feature}' on '${crate}' produces no dep-tree delta over baseline '${baseline:-<none>}'"
+        echo "        every Cargo feature must measurably change the dep tree"
+        failures=$((failures + 1))
+    else
+        added="$(diff <(echo "$base_tree") <(echo "$with_tree") | grep -c '^>' || true)"
+        echo "ok: ${added} new tree line(s)"
+    fi
+
+    echo "::endgroup::"
+done
+
+if [ "$failures" -gt 0 ]; then
+    echo
+    echo "::error::${failures} feature(s) failed the dep-tree regression check"
+    exit 1
+fi
+
+echo
+echo "All ${#CHECKS[@]} feature checks passed."

--- a/.github/scripts/check-feature-deps.sh
+++ b/.github/scripts/check-feature-deps.sh
@@ -66,7 +66,7 @@ cargo_tree() {
     if [ -n "$features" ]; then
         args+=(--features "$features")
     fi
-    cargo tree "${args[@]}" 2>/dev/null
+    cargo tree "${args[@]}"
 }
 
 for entry in "${CHECKS[@]}"; do
@@ -85,8 +85,20 @@ for entry in "${CHECKS[@]}"; do
 
     echo "::group::${label}"
 
+    set +e
     base_tree="$(cargo_tree "$crate" "$baseline")"
+    base_status=$?
     with_tree="$(cargo_tree "$crate" "$with")"
+    with_status=$?
+    set -e
+
+    if [ "$base_status" -ne 0 ] || [ "$with_status" -ne 0 ] \
+        || [ -z "$base_tree" ] || [ -z "$with_tree" ]; then
+        echo "::error::cargo tree failed for '${crate}' (baseline status=${base_status}, with status=${with_status})"
+        failures=$((failures + 1))
+        echo "::endgroup::"
+        continue
+    fi
 
     if [ "$base_tree" = "$with_tree" ]; then
         echo "::error::feature '${feature}' on '${crate}' produces no dep-tree delta over baseline '${baseline:-<none>}'"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # bitrouter binary — bundle scenarios.
           - crate: bitrouter
             feature_set: serve-only-tempo
             cargo_args: --no-default-features --features tempo,sqlite,mcp,rest
@@ -72,24 +73,89 @@ jobs:
           - crate: bitrouter
             feature_set: all-features
             cargo_args: --all-features
+          # bitrouter binary — per-feature stacked on `tempo` baseline.
+          - crate: bitrouter
+            feature_set: tempo+cli
+            cargo_args: --no-default-features --features tempo,cli
+          - crate: bitrouter
+            feature_set: tempo+sqlite
+            cargo_args: --no-default-features --features tempo,sqlite
+          - crate: bitrouter
+            feature_set: tempo+postgres
+            cargo_args: --no-default-features --features tempo,postgres
+          - crate: bitrouter
+            feature_set: tempo+mysql
+            cargo_args: --no-default-features --features tempo,mysql
+          - crate: bitrouter
+            feature_set: tempo+mcp
+            cargo_args: --no-default-features --features tempo,mcp
+          - crate: bitrouter
+            feature_set: tempo+rest
+            cargo_args: --no-default-features --features tempo,rest
+          # bitrouter-api — per-feature alone + bundles.
           - crate: bitrouter-api
             feature_set: no-features
             cargo_args: --no-default-features
           - crate: bitrouter-api
+            feature_set: accounts
+            cargo_args: --no-default-features --features accounts
+          - crate: bitrouter-api
+            feature_set: observe
+            cargo_args: --no-default-features --features observe
+          - crate: bitrouter-api
+            feature_set: guardrails
+            cargo_args: --no-default-features --features guardrails
+          - crate: bitrouter-api
             feature_set: payments-tempo
             cargo_args: --no-default-features --features payments-tempo
+          - crate: bitrouter-api
+            feature_set: payments-solana
+            cargo_args: --no-default-features --features payments-solana
           - crate: bitrouter-api
             feature_set: all-features
             cargo_args: --all-features
+          # bitrouter-config — per-feature alone + bundles.
           - crate: bitrouter-config
             feature_set: no-features
             cargo_args: --no-default-features
           - crate: bitrouter-config
-            feature_set: payments-tempo
-            cargo_args: --no-default-features --features payments-tempo
+            feature_set: payments-solana
+            cargo_args: --no-default-features --features payments-solana
           - crate: bitrouter-config
+            feature_set: all-features
+            cargo_args: --all-features
+          # bitrouter-accounts — per-driver.
+          - crate: bitrouter-accounts
             feature_set: no-features
             cargo_args: --no-default-features
+          - crate: bitrouter-accounts
+            feature_set: sqlite
+            cargo_args: --no-default-features --features sqlite
+          - crate: bitrouter-accounts
+            feature_set: postgres
+            cargo_args: --no-default-features --features postgres
+          - crate: bitrouter-accounts
+            feature_set: mysql
+            cargo_args: --no-default-features --features mysql
+          - crate: bitrouter-accounts
+            feature_set: all-features
+            cargo_args: --all-features
+          # bitrouter-observe — per-driver.
+          - crate: bitrouter-observe
+            feature_set: no-features
+            cargo_args: --no-default-features
+          - crate: bitrouter-observe
+            feature_set: sqlite
+            cargo_args: --no-default-features --features sqlite
+          - crate: bitrouter-observe
+            feature_set: postgres
+            cargo_args: --no-default-features --features postgres
+          - crate: bitrouter-observe
+            feature_set: mysql
+            cargo_args: --no-default-features --features mysql
+          - crate: bitrouter-observe
+            feature_set: all-features
+            cargo_args: --all-features
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -103,6 +169,23 @@ jobs:
 
       - name: Build crate
         run: cargo build -p ${{ matrix.crate }} ${{ matrix.cargo_args }}
+
+  feature-deps:
+    name: feature-deps regression
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Rust stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Check feature → dependency tree deltas
+        run: bash .github/scripts/check-feature-deps.sh
 
   test:
     name: test / ${{ matrix.os }}

--- a/bitrouter-config/Cargo.toml
+++ b/bitrouter-config/Cargo.toml
@@ -10,7 +10,6 @@ readme = "README.md"
 
 [features]
 default = []
-payments-tempo = []
 payments-solana = []
 
 [dependencies]

--- a/bitrouter/Cargo.toml
+++ b/bitrouter/Cargo.toml
@@ -39,7 +39,6 @@ mysql = ["bitrouter-accounts/mysql", "bitrouter-observe/mysql"]
 # enabled; default is `tempo`.
 tempo = [
     "bitrouter-api/payments-tempo",
-    "bitrouter-config/payments-tempo",
     "mpp/tempo",
 ]
 solana = [


### PR DESCRIPTION
Closes #378.

## What

* Add a new `feature-deps` CI job that runs `.github/scripts/check-feature-deps.sh`. The script diffs `cargo tree` between the baseline and baseline+feature for each (crate, feature) pair and fails when enabling a feature produces no dependency-tree delta — enforcing the design rule that every Cargo feature must correspond to a real dependency-tree change.
* Drop the dead `bitrouter-config:payments-tempo` feature (defined as `[]`, zero `cfg` usages); update the upstream `bitrouter:tempo` bundle accordingly.

## Documented exceptions

Two source-only toggles are intentionally not exercised by the regression check (commented inline in the script):

* `bitrouter:rest` / `bitrouter-providers:rest` — pure source gates for REST provider adapters.
* `bitrouter-config:payments-solana` — gates Solana payment config struct definitions; deps are pulled by upstream consumers.

## Verified locally

* `bash .github/scripts/check-feature-deps.sh` → 18/18 checks pass.
* All new matrix combos build (`tempo+postgres`, `tempo+mysql`, `tempo+rest`, `payments-solana` for both api/config, `bitrouter-accounts` and `bitrouter-observe` no-default-features, etc.).
* `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features`, `cargo test --workspace`.