### PR TITLE
fix(runtime): add timeouts to upstream HTTP client

### DIFF
--- a/bitrouter-api/src/lib.rs
+++ b/bitrouter-api/src/lib.rs
@@ -1,3 +1,33 @@
+//! Reusable Warp filters for BitRouter's HTTP surface.
+//!
+//! # Configuring the upstream HTTP client
+//!
+//! The filters in this crate are transport-agnostic: they delegate to a
+//! [`bitrouter_core::routers::router::LanguageModelRouter`] implementation
+//! supplied by the embedder. That router is responsible for owning the
+//! `reqwest::Client` (or `reqwest_middleware::ClientWithMiddleware`) used
+//! for upstream provider calls.
+//!
+//! **SDK users should configure that client with sensible timeouts.** A
+//! bare `reqwest::Client::new()` has *no* timeouts, so a stalled upstream
+//! SSE stream will leave the inbound request hanging indefinitely instead
+//! of surfacing an `upstream_error` to the caller. At minimum, set:
+//!
+//! - `connect_timeout` — bound TCP+TLS handshake (e.g. `30s`).
+//! - `read_timeout` — bound the gap *between* response-body bytes (e.g.
+//!   `120s`). This catches mid-stream stalls without capping the overall
+//!   stream duration, so legitimate long-running streams still complete.
+//! - `pool_idle_timeout` — recycle dead pooled connections.
+//! - `tcp_keepalive` — detect half-open connections.
+//!
+//! The reference binary's `bitrouter::runtime::http_client::build_upstream_client`
+//! shows a working configuration that embedders can copy.
+//!
+//! Avoid using `reqwest::ClientBuilder::timeout` for routers that proxy
+//! streaming endpoints (Anthropic Messages, OpenAI streaming chat, etc.):
+//! it caps the *entire* request duration including the streamed body and
+//! will truncate long responses.
+
 pub mod router;
 
 #[cfg(any(feature = "payments-tempo", feature = "payments-solana"))]

--- a/bitrouter/src/main.rs
+++ b/bitrouter/src/main.rs
@@ -727,7 +727,7 @@ async fn run_cli(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             let db = Arc::new(db);
 
             print_first_run_guidance(&runtime);
-            let base_client = reqwest::Client::new();
+            let base_client = crate::runtime::http_client::build_upstream_client();
             let client_builder = reqwest_middleware::ClientBuilder::new(base_client);
             let client_builder =
                 match crate::runtime::payment::build_payment_middleware(&runtime.config) {

--- a/bitrouter/src/runtime/http_client.rs
+++ b/bitrouter/src/runtime/http_client.rs
@@ -1,0 +1,57 @@
+//! Shared `reqwest` client construction for upstream HTTP calls.
+//!
+//! Centralises timeout configuration so model and tool routers fail fast on
+//! stalled upstream providers instead of leaving requests hanging
+//! indefinitely. The defaults are chosen to bound mid-stream stalls while
+//! still allowing slow first-token generation.
+
+use std::time::Duration;
+
+/// Maximum time allowed to establish a TCP+TLS connection to upstream.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Maximum time allowed between successive bytes on a response body.
+///
+/// Bounds idle stalls on streaming (SSE) responses without limiting the
+/// total stream duration. Generous enough to accommodate long first-token
+/// latencies on reasoning models, short enough to surface dead connections
+/// in a reasonable time window.
+const READ_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// How long an idle pooled connection is kept before being closed.
+const POOL_IDLE_TIMEOUT: Duration = Duration::from_secs(90);
+
+/// TCP keepalive interval used to detect half-open connections to upstream.
+const TCP_KEEPALIVE: Duration = Duration::from_secs(60);
+
+/// Build the shared `reqwest::Client` used for upstream model and tool
+/// calls.
+///
+/// Falls back to `reqwest::Client::new()` if the configured builder fails
+/// (which only happens when the TLS backend cannot be initialised); the
+/// fallback preserves prior behaviour rather than aborting the server.
+pub fn build_upstream_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .connect_timeout(CONNECT_TIMEOUT)
+        .read_timeout(READ_TIMEOUT)
+        .pool_idle_timeout(POOL_IDLE_TIMEOUT)
+        .tcp_keepalive(TCP_KEEPALIVE)
+        .build()
+        .unwrap_or_else(|error| {
+            tracing::warn!(
+                "failed to build upstream HTTP client with timeouts ({error}); \
+                 falling back to default client"
+            );
+            reqwest::Client::new()
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_upstream_client_succeeds() {
+        let _client = build_upstream_client();
+    }
+}

--- a/bitrouter/src/runtime/mod.rs
+++ b/bitrouter/src/runtime/mod.rs
@@ -6,6 +6,7 @@ pub mod copilot;
 #[cfg(feature = "cli")]
 pub mod daemon;
 pub mod error;
+pub mod http_client;
 pub mod mcp_client;
 pub mod migration;
 #[cfg(feature = "tempo")]

--- a/bitrouter/src/runtime/server.rs
+++ b/bitrouter/src/runtime/server.rs
@@ -527,7 +527,7 @@ where
             self.config.providers.clone(),
             #[cfg(feature = "mcp")]
             Arc::new(mcp_connections),
-            Arc::new(reqwest::Client::new()),
+            Arc::new(crate::runtime::http_client::build_upstream_client()),
         ));
 
         if lazy_tool_router.has_providers() {


### PR DESCRIPTION
## Problem

When using `bitrouter serve` as a backend for Claude Code, requests would occasionally hang with no response — bitrouter neither returned an error nor a result. Logs showed requests sitting for 100+ seconds before eventually failing with 502, e.g.:

```
11:44:30.802  INFO request{method=POST path=/v1/messages}: processing request
...
11:46:27.862 ERROR request{method=POST path=/v1/messages}: unable to process request (internal error) status=502
```

## Root cause

The shared `reqwest::Client` used for upstream model/tool calls is constructed via `reqwest::Client::new()` (in `bitrouter/src/main.rs` and `bitrouter/src/runtime/server.rs`) with **no timeouts**. When an upstream SSE stream stalls mid-flight (network hiccup, upstream provider stall), the Anthropic adapter's `drive_sse_stream` awaits `bytes_stream.next()` indefinitely, so the request appears stuck until the OS / TCP keepalive eventually tears the connection down.

## Fix

Centralise upstream client construction in a new `runtime::http_client::build_upstream_client()` and configure sane timeouts:

- `connect_timeout` = 30s
- `read_timeout` = 120s — per-chunk inactivity timeout; bounds mid-stream stalls **without** capping legitimate long streams
- `pool_idle_timeout` = 90s
- `tcp_keepalive` = 60s

Used in both the model router (`main.rs`) and the lazy tool router (`server.rs`).

With this change, a stalled upstream surfaces as a prompt 502 `upstream_error` to the caller instead of hanging.

## Validation

- `cargo fmt -- --check`
- `cargo clippy -p bitrouter --all-features --all-targets`
- `cargo test -p bitrouter --all-features`