### PR TITLE
feat(observe): include latency_ms and error_info in spend log line

### DIFF
--- a/bitrouter-observe/src/spend/sea_orm_store.rs
+++ b/bitrouter-observe/src/spend/sea_orm_store.rs
@@ -54,6 +54,8 @@ impl SpendStore for SeaOrmSpendStore {
             let service_type_str = log.service_type.to_string();
             let service_name_str = log.service_name.clone();
             let success = log.success;
+            let latency_ms_log = latency_ms;
+            let error_info_log = log.error_info.clone();
 
             let active = spend_log::ActiveModel {
                 id: Set(log.id),
@@ -79,6 +81,8 @@ impl SpendStore for SeaOrmSpendStore {
                     service_type = %service_type_str,
                     service_name = %service_name_str,
                     success = success,
+                    latency_ms = latency_ms_log,
+                    error_info = error_info_log.as_deref().unwrap_or(""),
                     "spend log recorded",
                 );
             }


### PR DESCRIPTION
## Motivation

When a streaming model request ends with `success=false`, the existing `spend log recorded` tracing line shows only `service_type`, `service_name`, and `success`. That makes it impossible to tell from the log alone whether the failure was:

- a real upstream provider error,
- a transport / network problem,
- or a client disconnect mid-stream (e.g. Claude Code closing the SSE connection).

In #394 we diagnosed exactly such a case where a deferred `success=false` log was actually a benign client-disconnect on a previous streaming request, but the only way to confirm it was to inspect the database column.

## Change

Add `latency_ms` and `error_info` as structured fields on the `spend log recorded` tracing line. `error_info` already carries the `BitrouterError` variant name (`Cancelled`, `Transport`, `Provider`, `StreamProtocol`, …) populated by `ModelSpendObserver::on_request_failure`, so operators can immediately distinguish failure modes without round-tripping to the database.

No schema or behavior changes — only the tracing line is enriched.

## Validation

- `cargo fmt -- --check`
- `cargo build -p bitrouter-observe`
- `cargo test --workspace --all-features`