### PR TITLE
feat: add virtual keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1604,13 +1604,16 @@ dependencies = [
 name = "bitrouter-accounts"
 version = "0.27.0"
 dependencies = [
+ "base64 0.22.1",
  "bitrouter-core",
  "chrono",
+ "rand 0.9.4",
  "sea-orm",
  "sea-orm-migration",
  "serde",
  "serde-saphyr",
  "serde_json",
+ "sha2",
  "tokio",
  "tracing",
  "uuid",

--- a/bitrouter-accounts/Cargo.toml
+++ b/bitrouter-accounts/Cargo.toml
@@ -16,6 +16,7 @@ mysql = ["sea-orm/sqlx-mysql", "sea-orm-migration/sqlx-mysql"]
 
 [dependencies]
 bitrouter-core.workspace = true
+base64 = { version = "0.22" }
 sea-orm = { version = "1.1", default-features = false, features = [
     "macros",
     "with-chrono",
@@ -26,8 +27,10 @@ sea-orm-migration = { version = "1.1", default-features = false, features = [
     "runtime-tokio-rustls",
 ] }
 chrono = { version = "0.4", features = ["serde"] }
+rand = { version = "0.9" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
+sha2 = { version = "0.10" }
 uuid = { version = "1", features = ["v4", "serde"] }
 tracing = { version = "0.1" }
 warp = { version = "0.4" }

--- a/bitrouter-accounts/README.md
+++ b/bitrouter-accounts/README.md
@@ -3,4 +3,6 @@
 GitHub repository: [bitrouter/bitrouter](https://github.com/bitrouter/bitrouter)
 
 Provides account/session persistence, JWT key revocation storage, and virtual
-key storage for short `brv_...` credentials that map to stored JWTs.
+key storage for short `brv_...` credentials. Virtual key rows store the JWT and
+a hash of the virtual key; the raw virtual key itself is shown once and is not
+persisted.

--- a/bitrouter-accounts/README.md
+++ b/bitrouter-accounts/README.md
@@ -1,3 +1,6 @@
 # bitrouter-accounts
 
 GitHub repository: [bitrouter/bitrouter](https://github.com/bitrouter/bitrouter)
+
+Provides account/session persistence, JWT key revocation storage, and virtual
+key storage for short `brv_...` credentials that map to stored JWTs.

--- a/bitrouter-accounts/src/entity/mod.rs
+++ b/bitrouter-accounts/src/entity/mod.rs
@@ -4,3 +4,4 @@ pub mod revoked_key;
 pub mod rotated_pubkey;
 pub mod session;
 pub mod session_file;
+pub mod virtual_key;

--- a/bitrouter-accounts/src/entity/virtual_key.rs
+++ b/bitrouter-accounts/src/entity/virtual_key.rs
@@ -1,0 +1,22 @@
+//! Virtual key entity.
+//!
+//! A virtual key is a short opaque credential that maps 1-to-1 to a stored
+//! JWT. Only the SHA-256 hash of the virtual key is persisted; the raw
+//! virtual key is shown once to the caller at creation time.
+
+use chrono::NaiveDateTime;
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "virtual_keys")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub key_hash: String,
+    pub jwt: String,
+    pub created_at: NaiveDateTime,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/bitrouter-accounts/src/lib.rs
+++ b/bitrouter-accounts/src/lib.rs
@@ -9,7 +9,8 @@
 //!   [`migration::migrations()`](migration::migrations).
 //! - **Services** — [`AccountService`](service::AccountService),
 //!   [`SessionService`](service::SessionService), and
-//!   [`DbRevocationSet`](service::DbRevocationSet) for data operations.
+//!   [`DbRevocationSet`](service::DbRevocationSet),
+//!   [`VirtualKeyService`](service::VirtualKeyService) for data operations.
 //! - **Warp filter builders** — [`filters`] module exposes route constructors
 //!   parameterized by a caller-supplied auth filter.
 //!

--- a/bitrouter-accounts/src/migration/m20260429_000008_create_virtual_keys.rs
+++ b/bitrouter-accounts/src/migration/m20260429_000008_create_virtual_keys.rs
@@ -1,0 +1,35 @@
+use sea_orm_migration::{prelude::*, schema::*};
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(VirtualKeys::Table)
+                    .if_not_exists()
+                    .col(string(VirtualKeys::KeyHash).primary_key())
+                    .col(text(VirtualKeys::Jwt))
+                    .col(timestamp(VirtualKeys::CreatedAt))
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(VirtualKeys::Table).to_owned())
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+enum VirtualKeys {
+    Table,
+    KeyHash,
+    Jwt,
+    CreatedAt,
+}

--- a/bitrouter-accounts/src/migration/mod.rs
+++ b/bitrouter-accounts/src/migration/mod.rs
@@ -11,6 +11,7 @@ pub mod m20260310_000004_create_messages;
 pub mod m20260310_000005_create_session_files;
 pub mod m20260311_000006_jwt_auth;
 pub mod m20260405_000007_create_revoked_keys;
+pub mod m20260429_000008_create_virtual_keys;
 
 use sea_orm_migration::MigrationTrait;
 
@@ -24,5 +25,6 @@ pub fn migrations() -> Vec<Box<dyn MigrationTrait>> {
         Box::new(m20260310_000005_create_session_files::Migration),
         Box::new(m20260311_000006_jwt_auth::Migration),
         Box::new(m20260405_000007_create_revoked_keys::Migration),
+        Box::new(m20260429_000008_create_virtual_keys::Migration),
     ]
 }

--- a/bitrouter-accounts/src/service/mod.rs
+++ b/bitrouter-accounts/src/service/mod.rs
@@ -6,7 +6,12 @@
 pub mod account;
 pub mod revocation;
 pub mod session;
+pub mod virtual_key;
 
 pub use account::AccountService;
 pub use revocation::DbRevocationSet;
 pub use session::SessionService;
+pub use virtual_key::{
+    CreateVirtualKeyRequest, CreateVirtualKeyResponse, VIRTUAL_KEY_PREFIX, VirtualKeyService,
+    hash_virtual_key, is_virtual_key,
+};

--- a/bitrouter-accounts/src/service/virtual_key.rs
+++ b/bitrouter-accounts/src/service/virtual_key.rs
@@ -1,0 +1,138 @@
+//! Database-backed virtual key storage.
+//!
+//! Virtual keys are short opaque credentials that map 1-to-1 to stored JWTs.
+//! The database stores only a SHA-256 hash of the virtual key, not the raw
+//! key itself.
+
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use chrono::Utc;
+use sea_orm::{ActiveModelTrait, DatabaseConnection, EntityTrait, Set};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::entity::virtual_key;
+
+/// Prefix used for BitRouter virtual keys.
+pub const VIRTUAL_KEY_PREFIX: &str = "brv_";
+
+/// Request body used by HTTP clients that create a virtual key from a JWT.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct CreateVirtualKeyRequest {
+    pub jwt: String,
+}
+
+/// Response body returned when a virtual key is created.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct CreateVirtualKeyResponse {
+    pub key: String,
+}
+
+/// Return whether a credential has the BitRouter virtual-key shape.
+pub fn is_virtual_key(credential: &str) -> bool {
+    credential.starts_with(VIRTUAL_KEY_PREFIX)
+}
+
+/// Hash a virtual key for durable lookup.
+pub fn hash_virtual_key(key: &str) -> String {
+    URL_SAFE_NO_PAD.encode(Sha256::digest(key.as_bytes()))
+}
+
+/// Virtual key data operations.
+pub struct VirtualKeyService<'db> {
+    db: &'db DatabaseConnection,
+}
+
+impl<'db> VirtualKeyService<'db> {
+    pub fn new(db: &'db DatabaseConnection) -> Self {
+        Self { db }
+    }
+
+    /// Create a fresh virtual key that resolves to the provided JWT.
+    ///
+    /// The returned raw key is not persisted and should be shown once to the
+    /// caller. Persisted lookup uses only the key hash.
+    pub async fn create(&self, jwt: &str) -> Result<CreateVirtualKeyResponse, sea_orm::DbErr> {
+        let key = generate_virtual_key();
+        self.store(&key, jwt).await?;
+        Ok(CreateVirtualKeyResponse { key })
+    }
+
+    /// Store a caller-provided virtual key for tests or external key managers.
+    pub async fn store(&self, key: &str, jwt: &str) -> Result<(), sea_orm::DbErr> {
+        let model = virtual_key::ActiveModel {
+            key_hash: Set(hash_virtual_key(key)),
+            jwt: Set(jwt.to_owned()),
+            created_at: Set(Utc::now().naive_utc()),
+        };
+        model.insert(self.db).await?;
+        Ok(())
+    }
+
+    /// Resolve a virtual key to its stored JWT.
+    pub async fn resolve(&self, key: &str) -> Result<Option<String>, sea_orm::DbErr> {
+        let hash = hash_virtual_key(key);
+        let row = virtual_key::Entity::find_by_id(hash).one(self.db).await?;
+        Ok(row.map(|row| row.jwt))
+    }
+}
+
+fn generate_virtual_key() -> String {
+    let bytes: [u8; 24] = rand::random();
+    format!("{VIRTUAL_KEY_PREFIX}{}", URL_SAFE_NO_PAD.encode(bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sea_orm::{ColumnTrait, Database, EntityTrait, QueryFilter};
+    use sea_orm_migration::MigratorTrait;
+
+    async fn setup_test_db() -> Result<DatabaseConnection, Box<dyn std::error::Error>> {
+        let db = Database::connect("sqlite::memory:").await?;
+
+        struct TestMigrator;
+
+        impl MigratorTrait for TestMigrator {
+            fn migrations() -> Vec<Box<dyn sea_orm_migration::MigrationTrait>> {
+                crate::migration::migrations()
+            }
+        }
+
+        TestMigrator::up(&db, None).await?;
+        Ok(db)
+    }
+
+    #[tokio::test]
+    async fn create_resolves_without_storing_raw_key() -> Result<(), Box<dyn std::error::Error>> {
+        let db = setup_test_db().await?;
+        let service = VirtualKeyService::new(&db);
+        let jwt = "header.payload.signature";
+
+        let response = service.create(jwt).await?;
+
+        assert!(is_virtual_key(&response.key));
+        assert_eq!(service.resolve(&response.key).await?.as_deref(), Some(jwt));
+
+        let stored_raw_key = virtual_key::Entity::find()
+            .filter(virtual_key::Column::KeyHash.eq(&response.key))
+            .one(&db)
+            .await?;
+        assert!(stored_raw_key.is_none());
+
+        let stored_hash = virtual_key::Entity::find_by_id(hash_virtual_key(&response.key))
+            .one(&db)
+            .await?;
+        assert!(stored_hash.is_some());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn missing_virtual_key_resolves_to_none() -> Result<(), Box<dyn std::error::Error>> {
+        let db = setup_test_db().await?;
+        let service = VirtualKeyService::new(&db);
+
+        assert!(service.resolve("brv_missing").await?.is_none());
+        Ok(())
+    }
+}

--- a/bitrouter-api/README.md
+++ b/bitrouter-api/README.md
@@ -26,7 +26,8 @@ feature.
 Optional companion-crate facades:
 
 - `accounts` — re-export [`bitrouter-accounts`] (account/session/key
-  Warp filter builders and services). Pulls `sea-orm`.
+  Warp filter builders, revocation, and virtual-key services). Pulls
+  `sea-orm`.
 - `observe` — re-export [`bitrouter-observe`] (`ObserveStack`, spend
   store, metrics). Pulls `sea-orm`.
 - `guardrails` — re-export [`bitrouter-guardrails`] (`Guardrail`,

--- a/bitrouter/README.md
+++ b/bitrouter/README.md
@@ -77,6 +77,9 @@ bitrouter key create --name claude-agent --wallet default
 # Sign a JWT for agent access
 bitrouter key sign --wallet default --exp 30d --models openai:gpt-4o
 
+# Store the JWT on the running server and print a short virtual key instead
+bitrouter key sign --wallet default --exp 30d --models openai:gpt-4o --virtual-key
+
 # List and revoke keys
 bitrouter key list
 bitrouter key revoke --id <key-id>

--- a/bitrouter/README.md
+++ b/bitrouter/README.md
@@ -74,11 +74,11 @@ bitrouter wallet create --name default
 # Create an API key bound to a wallet
 bitrouter key create --name claude-agent --wallet default
 
-# Sign a JWT for agent access
+# Generate a short virtual key for agent access
 bitrouter key sign --wallet default --exp 30d --models openai:gpt-4o
 
-# Store the JWT on the running server and print a short virtual key instead
-bitrouter key sign --wallet default --exp 30d --models openai:gpt-4o --virtual-key
+# Print the raw JWT instead
+bitrouter key sign --wallet default --exp 30d --models openai:gpt-4o --raw
 
 # List and revoke keys
 bitrouter key list

--- a/bitrouter/src/cli/key.rs
+++ b/bitrouter/src/cli/key.rs
@@ -95,18 +95,22 @@ pub fn revoke_on_server(
     Ok(())
 }
 
+/// Options for signing a JWT or creating a virtual key.
+pub(crate) struct SignOptions<'a> {
+    pub(crate) wallet_name: &'a str,
+    pub(crate) models: Option<&'a [String]>,
+    pub(crate) budget: Option<u64>,
+    pub(crate) budget_scope: Option<&'a str>,
+    pub(crate) exp: Option<&'a str>,
+    pub(crate) ows_key: Option<&'a str>,
+    pub(crate) policy: Option<&'a str>,
+    pub(crate) virtual_key_target:
+        Option<(&'a bitrouter_config::BitrouterConfig, std::net::SocketAddr)>,
+}
+
 /// Sign a JWT for agent access — the operator mints tokens that agents
 /// present as bearer auth to the running BitRouter server.
-pub fn sign(
-    wallet_name: &str,
-    models: Option<&[String]>,
-    budget: Option<u64>,
-    budget_scope: Option<&str>,
-    exp: Option<&str>,
-    ows_key: Option<&str>,
-    policy: Option<&str>,
-    virtual_key_target: Option<(&bitrouter_config::BitrouterConfig, std::net::SocketAddr)>,
-) -> Result {
+pub(crate) fn sign(options: SignOptions<'_>) -> Result {
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use base64::Engine;
@@ -118,14 +122,19 @@ pub fn sign(
     use sha2::{Digest, Sha256};
 
     // 1. Load wallet and resolve Solana address for CAIP-10 iss.
-    let info = ows_lib::get_wallet(wallet_name, None)
-        .map_err(|e| format!("failed to load wallet '{wallet_name}': {e}"))?;
+    let info = ows_lib::get_wallet(options.wallet_name, None)
+        .map_err(|e| format!("failed to load wallet '{}': {e}", options.wallet_name))?;
 
     let sol_account = info
         .accounts
         .iter()
         .find(|a| a.chain_id.starts_with("solana:"))
-        .ok_or_else(|| format!("wallet '{wallet_name}' has no Solana account — cannot sign JWT"))?;
+        .ok_or_else(|| {
+            format!(
+                "wallet '{}' has no Solana account — cannot sign JWT",
+                options.wallet_name
+            )
+        })?;
 
     let caip10 = Caip10 {
         chain: Chain::solana_mainnet(),
@@ -133,7 +142,7 @@ pub fn sign(
     };
 
     // 2. Parse optional budget scope.
-    let bsc = match budget_scope {
+    let bsc = match options.budget_scope {
         Some("session" | "ses") => Some(BudgetScope::Session),
         Some("account" | "act") => Some(BudgetScope::Account),
         Some(other) => {
@@ -147,7 +156,7 @@ pub fn sign(
     // 3. Parse expiration duration and compute absolute timestamp.
     let now = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
 
-    let exp_ts = match exp {
+    let exp_ts = match options.exp {
         Some(raw) => Some(now + parse_duration_secs(raw)?),
         None => None,
     };
@@ -155,7 +164,7 @@ pub fn sign(
     // 4. Generate API key identity (`id` claim).
     //    - OWS-backed keys: deterministically derived via SHA-256 of the key string.
     //    - Standalone keys: randomly generated 32-byte value.
-    let key_id = match ows_key {
+    let key_id = match options.ows_key {
         Some(key_str) => {
             let hash = Sha256::digest(key_str.as_bytes());
             URL_SAFE_NO_PAD.encode(hash)
@@ -172,12 +181,12 @@ pub fn sign(
         iat: Some(now),
         exp: exp_ts,
         scp: Some(TokenScope::Api),
-        mdl: models.map(|m| m.to_vec()),
-        bgt: budget,
+        mdl: options.models.map(|m| m.to_vec()),
+        bgt: options.budget,
         bsc,
         id: Some(key_id),
-        key: ows_key.map(String::from),
-        pol: policy.map(String::from),
+        key: options.ows_key.map(String::from),
+        pol: options.policy.map(String::from),
         jti: None,
         aud: None,
         sub: None,
@@ -192,14 +201,14 @@ pub fn sign(
         .interact()?;
 
     let signer = OwsJwtSigner {
-        wallet_name: wallet_name.to_owned(),
+        wallet_name: options.wallet_name.to_owned(),
         passphrase,
         vault_path: None,
     };
 
     let jwt = token::sign(&claims, &signer).map_err(|e| format!("failed to sign JWT: {e}"))?;
 
-    if let Some((config, addr)) = virtual_key_target {
+    if let Some((config, addr)) = options.virtual_key_target {
         create_virtual_key_on_server(config, addr, &jwt)?;
     } else {
         println!("{jwt}");

--- a/bitrouter/src/cli/key.rs
+++ b/bitrouter/src/cli/key.rs
@@ -105,6 +105,7 @@ pub fn sign(
     exp: Option<&str>,
     ows_key: Option<&str>,
     policy: Option<&str>,
+    virtual_key_target: Option<(&bitrouter_config::BitrouterConfig, std::net::SocketAddr)>,
 ) -> Result {
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -198,7 +199,38 @@ pub fn sign(
 
     let jwt = token::sign(&claims, &signer).map_err(|e| format!("failed to sign JWT: {e}"))?;
 
-    println!("{jwt}");
+    if let Some((config, addr)) = virtual_key_target {
+        create_virtual_key_on_server(config, addr, &jwt)?;
+    } else {
+        println!("{jwt}");
+    }
+
+    Ok(())
+}
+
+/// Store a JWT on the running server and print the returned virtual key.
+pub fn create_virtual_key_on_server(
+    config: &bitrouter_config::BitrouterConfig,
+    addr: std::net::SocketAddr,
+    jwt: &str,
+) -> Result {
+    use bitrouter_accounts::service::{CreateVirtualKeyRequest, CreateVirtualKeyResponse};
+
+    let url = format!("http://{addr}/admin/keys/virtual");
+    let client = reqwest::blocking::Client::new();
+    let resp = crate::cli::admin_auth::request_with_admin_auth(config, client.post(&url))?
+        .json(&CreateVirtualKeyRequest {
+            jwt: jwt.to_owned(),
+        })
+        .send()?;
+
+    if resp.status().is_success() {
+        let body: CreateVirtualKeyResponse = resp.json()?;
+        println!("{}", body.key);
+    } else {
+        let msg = crate::cli::admin_auth::parse_error_message(resp)?;
+        return Err(format!("failed to create virtual key: {msg}").into());
+    }
 
     Ok(())
 }

--- a/bitrouter/src/main.rs
+++ b/bitrouter/src/main.rs
@@ -449,6 +449,10 @@ enum KeyAction {
         /// Policy ID to embed in the token (evaluated at request time)
         #[arg(long)]
         policy: Option<String>,
+
+        /// Store the JWT on the server and print a short virtual key instead
+        #[arg(long = "virtual-key", visible_alias = "virtual")]
+        virtual_key: bool,
     },
 }
 
@@ -579,15 +583,33 @@ async fn run_cli(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
                     exp,
                     ows_key,
                     policy,
-                } => cli::key::sign(
-                    &wallet,
-                    models.as_deref(),
-                    budget,
-                    budget_scope.as_deref(),
-                    exp.as_deref(),
-                    ows_key.as_deref(),
-                    policy.as_deref(),
-                )?,
+                    virtual_key,
+                } => {
+                    if virtual_key {
+                        let runtime: DefaultRuntime = load_or_warn_scaffold(&paths);
+                        cli::key::sign(
+                            &wallet,
+                            models.as_deref(),
+                            budget,
+                            budget_scope.as_deref(),
+                            exp.as_deref(),
+                            ows_key.as_deref(),
+                            policy.as_deref(),
+                            Some((&runtime.config, runtime.config.server.listen)),
+                        )?;
+                    } else {
+                        cli::key::sign(
+                            &wallet,
+                            models.as_deref(),
+                            budget,
+                            budget_scope.as_deref(),
+                            exp.as_deref(),
+                            ows_key.as_deref(),
+                            policy.as_deref(),
+                            None,
+                        )?;
+                    }
+                }
             }
             return Ok(());
         }

--- a/bitrouter/src/main.rs
+++ b/bitrouter/src/main.rs
@@ -585,30 +585,24 @@ async fn run_cli(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
                     policy,
                     virtual_key,
                 } => {
-                    if virtual_key {
-                        let runtime: DefaultRuntime = load_or_warn_scaffold(&paths);
-                        cli::key::sign(
-                            &wallet,
-                            models.as_deref(),
-                            budget,
-                            budget_scope.as_deref(),
-                            exp.as_deref(),
-                            ows_key.as_deref(),
-                            policy.as_deref(),
-                            Some((&runtime.config, runtime.config.server.listen)),
-                        )?;
+                    let runtime = if virtual_key {
+                        Some(load_or_warn_scaffold(&paths))
                     } else {
-                        cli::key::sign(
-                            &wallet,
-                            models.as_deref(),
-                            budget,
-                            budget_scope.as_deref(),
-                            exp.as_deref(),
-                            ows_key.as_deref(),
-                            policy.as_deref(),
-                            None,
-                        )?;
-                    }
+                        None
+                    };
+                    let virtual_key_target = runtime.as_ref().map(|runtime: &DefaultRuntime| {
+                        (&runtime.config, runtime.config.server.listen)
+                    });
+                    cli::key::sign(cli::key::SignOptions {
+                        wallet_name: &wallet,
+                        models: models.as_deref(),
+                        budget,
+                        budget_scope: budget_scope.as_deref(),
+                        exp: exp.as_deref(),
+                        ows_key: ows_key.as_deref(),
+                        policy: policy.as_deref(),
+                        virtual_key_target,
+                    })?;
                 }
             }
             return Ok(());

--- a/bitrouter/src/main.rs
+++ b/bitrouter/src/main.rs
@@ -420,7 +420,7 @@ enum KeyAction {
         #[arg(long)]
         id: String,
     },
-    /// Sign a JWT for agent access (operator mints tokens for agents)
+    /// Generate an agent access key (virtual by default)
     Sign {
         /// OWS wallet name to sign with (operator wallet)
         #[arg(long)]
@@ -450,9 +450,9 @@ enum KeyAction {
         #[arg(long)]
         policy: Option<String>,
 
-        /// Store the JWT on the server and print a short virtual key instead
-        #[arg(long = "virtual-key", visible_alias = "virtual")]
-        virtual_key: bool,
+        /// Print the raw JWT instead of storing it and returning a virtual key
+        #[arg(long)]
+        raw: bool,
     },
 }
 
@@ -583,13 +583,9 @@ async fn run_cli(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
                     exp,
                     ows_key,
                     policy,
-                    virtual_key,
+                    raw,
                 } => {
-                    let runtime = if virtual_key {
-                        Some(load_or_warn_scaffold(&paths))
-                    } else {
-                        None
-                    };
+                    let runtime = (!raw).then(|| load_or_warn_scaffold(&paths));
                     let virtual_key_target = runtime.as_ref().map(|runtime: &DefaultRuntime| {
                         (&runtime.config, runtime.config.server.listen)
                     });

--- a/bitrouter/src/runtime/auth.rs
+++ b/bitrouter/src/runtime/auth.rs
@@ -25,8 +25,9 @@ use warp::Filter;
 
 use bitrouter_accounts::identity::{AccountId, Identity, Scope};
 use bitrouter_accounts::service::AccountService;
+use bitrouter_accounts::service::VirtualKeyService;
 use bitrouter_core::auth::chain::Caip10;
-use bitrouter_core::auth::claims::TokenScope;
+use bitrouter_core::auth::claims::{BitrouterClaims, TokenScope};
 use bitrouter_core::auth::revocation::KeyRevocationSet;
 use bitrouter_core::auth::token as jwt_token;
 
@@ -56,6 +57,26 @@ impl JwtAuthContext {
     pub fn with_revocation_set(mut self, set: Arc<dyn KeyRevocationSet>) -> Self {
         self.revocation_set = Some(set);
         self
+    }
+
+    pub(crate) fn verify_jwt_claims(
+        &self,
+        credential: &str,
+    ) -> Result<BitrouterClaims, Unauthorized> {
+        let claims =
+            jwt_token::verify(credential).map_err(|_| Unauthorized("invalid JWT signature"))?;
+
+        jwt_token::check_expiration(&claims).map_err(|_| Unauthorized("JWT expired"))?;
+
+        if let Some(ref expected) = self.operator_caip10
+            && claims.iss != *expected
+        {
+            return Err(Unauthorized(
+                "JWT issuer does not match configured operator wallet",
+            ));
+        }
+
+        Ok(claims)
     }
 }
 
@@ -125,7 +146,24 @@ async fn resolve_identity(
     credential: &str,
     ctx: &JwtAuthContext,
 ) -> Result<Identity, warp::Rejection> {
-    resolve_jwt_identity(credential, ctx).await
+    let jwt = resolve_credential_jwt(credential, ctx).await?;
+    resolve_jwt_identity(&jwt, ctx).await
+}
+
+/// Resolve an inbound credential to the JWT that should be authenticated.
+async fn resolve_credential_jwt(
+    credential: &str,
+    ctx: &JwtAuthContext,
+) -> Result<String, warp::Rejection> {
+    if !bitrouter_accounts::service::is_virtual_key(credential) {
+        return Ok(credential.to_owned());
+    }
+
+    let svc = VirtualKeyService::new(&ctx.db);
+    svc.resolve(credential)
+        .await
+        .map_err(|_| warp::reject::custom(Unauthorized("virtual key lookup failed")))?
+        .ok_or_else(|| warp::reject::custom(Unauthorized("invalid virtual key")))
 }
 
 /// Resolve a JWT credential to an [`Identity`].
@@ -133,22 +171,10 @@ async fn resolve_jwt_identity(
     credential: &str,
     ctx: &JwtAuthContext,
 ) -> Result<Identity, warp::Rejection> {
-    // 1. Verify signature (detects algorithm from header, verifies against iss).
-    let claims = jwt_token::verify(credential)
-        .map_err(|_| warp::reject::custom(Unauthorized("invalid JWT signature")))?;
-
-    // 2. Check expiration.
-    jwt_token::check_expiration(&claims)
-        .map_err(|_| warp::reject::custom(Unauthorized("JWT expired")))?;
-
-    // 3. Verify iss matches the configured operator wallet (single trust root).
-    if let Some(ref expected) = ctx.operator_caip10
-        && claims.iss != *expected
-    {
-        return Err(warp::reject::custom(Unauthorized(
-            "JWT issuer does not match configured operator wallet",
-        )));
-    }
+    // 1-3. Verify signature, expiration, and configured operator issuer.
+    let claims = ctx
+        .verify_jwt_claims(credential)
+        .map_err(warp::reject::custom)?;
 
     // 3b. Check per-key revocation (if a revocation set is configured).
     if let Some(ref key_id) = claims.id
@@ -260,4 +286,70 @@ pub(crate) fn auth_gate(
     auth: impl Filter<Extract = (Identity,), Error = warp::Rejection> + Clone,
 ) -> impl Filter<Extract = (), Error = warp::Rejection> + Clone {
     auth.map(|_| ()).untuple_one()
+}
+
+#[cfg(test)]
+mod tests {
+    use bitrouter_accounts::service::VirtualKeyService;
+    use bitrouter_core::auth::chain::Chain;
+    use bitrouter_core::auth::claims::{BitrouterClaims, TokenScope};
+    use bitrouter_core::auth::keys::MasterKeypair;
+    use bitrouter_core::auth::token;
+    use sea_orm::Database;
+    use sea_orm_migration::MigratorTrait;
+
+    use super::*;
+
+    async fn setup_test_db() -> Result<DatabaseConnection, Box<dyn std::error::Error>> {
+        let db = Database::connect("sqlite::memory:").await?;
+
+        struct TestMigrator;
+
+        impl MigratorTrait for TestMigrator {
+            fn migrations() -> Vec<Box<dyn sea_orm_migration::MigrationTrait>> {
+                bitrouter_accounts::migration::migrations()
+            }
+        }
+
+        TestMigrator::up(&db, None).await?;
+        Ok(db)
+    }
+
+    #[tokio::test]
+    async fn virtual_key_resolves_to_stored_jwt_identity() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let db = setup_test_db().await?;
+        let keypair = MasterKeypair::generate();
+        let caip10 = keypair.caip10(&Chain::solana_mainnet())?;
+        let key_id = "virtual-key-test-id".to_owned();
+        let claims = BitrouterClaims {
+            iss: caip10.format(),
+            iat: Some(1_700_000_000),
+            exp: None,
+            scp: Some(TokenScope::Api),
+            mdl: Some(vec!["openai:gpt-4o".to_owned()]),
+            bgt: Some(1_000_000),
+            bsc: None,
+            id: Some(key_id.clone()),
+            key: None,
+            pol: Some("default".to_owned()),
+            jti: None,
+            aud: None,
+            sub: None,
+            host: None,
+        };
+        let jwt = token::sign(&claims, &keypair)?;
+        let virtual_key = VirtualKeyService::new(&db).create(&jwt).await?.key;
+        let ctx = JwtAuthContext::new(db, None);
+
+        let identity = resolve_identity(&virtual_key, &ctx)
+            .await
+            .map_err(|_| std::io::Error::other("virtual key auth failed"))?;
+
+        assert_eq!(identity.key_id.as_deref(), Some(key_id.as_str()));
+        assert_eq!(identity.models, Some(vec!["openai:gpt-4o".to_owned()]));
+        assert_eq!(identity.budget, Some(1_000_000));
+        assert_eq!(identity.policy_id.as_deref(), Some("default"));
+        Ok(())
+    }
 }

--- a/bitrouter/src/runtime/server.rs
+++ b/bitrouter/src/runtime/server.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use bitrouter_accounts::service::{CreateVirtualKeyRequest, VirtualKeyService};
 use bitrouter_api::router::{admin, agents, models, routes};
 use bitrouter_api::router::{anthropic, google, openai};
 use bitrouter_config::BitrouterConfig;
@@ -306,6 +307,19 @@ where
                 .and(warp::body::json::<KeyRevokeRequest>())
                 .and(warp::any().map(move || revocation_set.clone()))
                 .and_then(handle_key_revoke)
+        };
+
+        // Admin virtual-key endpoint — gated by management auth.
+        let admin_virtual_key_create = {
+            let db = self.db.clone();
+            let validation_ctx = auth_ctx.clone();
+            auth::auth_gate(auth::management_auth(auth_ctx.clone()))
+                .and(warp::path!("admin" / "keys" / "virtual"))
+                .and(warp::post())
+                .and(warp::body::json::<CreateVirtualKeyRequest>())
+                .and(warp::any().map(move || db.clone()))
+                .and(warp::any().map(move || validation_ctx.clone()))
+                .and_then(handle_virtual_key_create)
         };
 
         // Build account filter that extracts caller context (auth-gated) and
@@ -660,6 +674,7 @@ where
             .or(agent_list)
             .or(admin_routes)
             .or(admin_key_revoke)
+            .or(admin_virtual_key_create)
             .or(chat)
             .or(messages)
             .or(responses)
@@ -793,6 +808,39 @@ async fn handle_key_revoke(
         })),
         warp::http::StatusCode::OK,
     ))
+}
+
+/// Handle virtual key creation requests.
+async fn handle_virtual_key_create(
+    body: CreateVirtualKeyRequest,
+    db: Arc<DatabaseConnection>,
+    auth_ctx: Arc<JwtAuthContext>,
+) -> std::result::Result<impl warp::Reply, warp::Rejection> {
+    if let Err(e) = auth_ctx.verify_jwt_claims(&body.jwt) {
+        return Ok(warp::reply::with_status(
+            warp::reply::json(&serde_json::json!({
+                "error": { "message": e.0 }
+            })),
+            warp::http::StatusCode::BAD_REQUEST,
+        ));
+    }
+
+    let svc = VirtualKeyService::new(db.as_ref());
+    match svc.create(&body.jwt).await {
+        Ok(response) => Ok(warp::reply::with_status(
+            warp::reply::json(&response),
+            warp::http::StatusCode::OK,
+        )),
+        Err(e) => {
+            tracing::error!(error = %e, "failed to create virtual key");
+            Ok(warp::reply::with_status(
+                warp::reply::json(&serde_json::json!({
+                    "error": { "message": "failed to create virtual key" }
+                })),
+                warp::http::StatusCode::INTERNAL_SERVER_ERROR,
+            ))
+        }
+    }
 }
 
 /// Rejection handler that turns [`Unauthorized`] into a JSON 401 response


### PR DESCRIPTION
## Summary
- add database-backed virtual key storage in bitrouter-accounts with hashed brv_ key lookup and stored JWT mapping
- expose virtual key service/request/response types through the existing bitrouter-api accounts facade
- resolve brv_ credentials in runtime auth before the existing JWT verification, issuer, revocation, budget, and policy path
- add POST /admin/keys/virtual and make bitrouter key sign return a virtual key by default
- add bitrouter key sign --raw for users who need the raw JWT directly

## Storage model
Virtual key rows store the signed JWT and a hash of the brv_ virtual key. The raw virtual key is returned once to the user and is not persisted.

## Validation
- cargo clippy --all-features -- -D warnings
- cargo fmt -- --check
- cargo test --workspace