### PR TITLE
fix(core): preserve mixed text and tool calls in generate result

### DIFF
--- a/bitrouter-api/src/router/anthropic/messages/tests.rs
+++ b/bitrouter-api/src/router/anthropic/messages/tests.rs
@@ -87,10 +87,10 @@ impl LanguageModel for MockModel {
         _options: LanguageModelCallOptions,
     ) -> Result<LanguageModelGenerateResult> {
         Ok(LanguageModelGenerateResult {
-            content: LanguageModelContent::Text {
+            content: vec![LanguageModelContent::Text {
                 text: "Hello from Anthropic mock!".to_owned(),
                 provider_metadata: None,
-            },
+            }],
             finish_reason: LanguageModelFinishReason::Stop,
             usage: LanguageModelUsage {
                 input_tokens: LanguageModelInputTokens {
@@ -194,14 +194,14 @@ impl LanguageModel for MockToolModel {
         _options: LanguageModelCallOptions,
     ) -> Result<LanguageModelGenerateResult> {
         Ok(LanguageModelGenerateResult {
-            content: LanguageModelContent::ToolCall {
+            content: vec![LanguageModelContent::ToolCall {
                 tool_call_id: "toolu_abc123".to_owned(),
                 tool_name: "get_weather".to_owned(),
                 tool_input: r#"{"location":"NYC"}"#.to_owned(),
                 provider_executed: None,
                 dynamic: None,
                 provider_metadata: None,
-            },
+            }],
             finish_reason: LanguageModelFinishReason::FunctionCall,
             usage: mock_usage(),
             provider_metadata: None,
@@ -260,10 +260,10 @@ impl LanguageModel for MockToolStreamModel {
         _options: LanguageModelCallOptions,
     ) -> Result<LanguageModelGenerateResult> {
         Ok(LanguageModelGenerateResult {
-            content: LanguageModelContent::Text {
+            content: vec![LanguageModelContent::Text {
                 text: String::new(),
                 provider_metadata: None,
-            },
+            }],
             finish_reason: LanguageModelFinishReason::Stop,
             usage: mock_usage(),
             provider_metadata: None,

--- a/bitrouter-api/src/router/google/generate_content/tests.rs
+++ b/bitrouter-api/src/router/google/generate_content/tests.rs
@@ -78,10 +78,10 @@ impl LanguageModel for MockModel {
         _options: LanguageModelCallOptions,
     ) -> Result<LanguageModelGenerateResult> {
         Ok(LanguageModelGenerateResult {
-            content: LanguageModelContent::Text {
+            content: vec![LanguageModelContent::Text {
                 text: "Hello from Google mock!".to_owned(),
                 provider_metadata: None,
-            },
+            }],
             finish_reason: LanguageModelFinishReason::Stop,
             usage: LanguageModelUsage {
                 input_tokens: LanguageModelInputTokens {
@@ -185,14 +185,14 @@ impl LanguageModel for MockToolModel {
         _options: LanguageModelCallOptions,
     ) -> Result<LanguageModelGenerateResult> {
         Ok(LanguageModelGenerateResult {
-            content: LanguageModelContent::ToolCall {
+            content: vec![LanguageModelContent::ToolCall {
                 tool_call_id: "call_abc123".to_owned(),
                 tool_name: "get_weather".to_owned(),
                 tool_input: r#"{"location":"NYC"}"#.to_owned(),
                 provider_executed: None,
                 dynamic: None,
                 provider_metadata: None,
-            },
+            }],
             finish_reason: LanguageModelFinishReason::FunctionCall,
             usage: mock_usage(),
             provider_metadata: None,

--- a/bitrouter-api/src/router/openai/chat/tests.rs
+++ b/bitrouter-api/src/router/openai/chat/tests.rs
@@ -103,10 +103,10 @@ impl LanguageModel for MockModel {
         _options: LanguageModelCallOptions,
     ) -> Result<LanguageModelGenerateResult> {
         Ok(LanguageModelGenerateResult {
-            content: LanguageModelContent::Text {
+            content: vec![LanguageModelContent::Text {
                 text: "Hello from mock model!".to_owned(),
                 provider_metadata: None,
-            },
+            }],
             finish_reason: LanguageModelFinishReason::Stop,
             usage: mock_usage(),
             provider_metadata: None,
@@ -164,14 +164,14 @@ impl LanguageModel for MockToolModel {
         _options: LanguageModelCallOptions,
     ) -> Result<LanguageModelGenerateResult> {
         Ok(LanguageModelGenerateResult {
-            content: LanguageModelContent::ToolCall {
+            content: vec![LanguageModelContent::ToolCall {
                 tool_call_id: "call_abc123".to_owned(),
                 tool_name: "write_file".to_owned(),
                 tool_input: r#"{"path":"test.txt","content":"hello"}"#.to_owned(),
                 provider_executed: None,
                 dynamic: None,
                 provider_metadata: None,
-            },
+            }],
             finish_reason: LanguageModelFinishReason::FunctionCall,
             usage: mock_usage(),
             provider_metadata: None,
@@ -231,10 +231,10 @@ impl LanguageModel for MockToolStreamModel {
         _options: LanguageModelCallOptions,
     ) -> Result<LanguageModelGenerateResult> {
         Ok(LanguageModelGenerateResult {
-            content: LanguageModelContent::Text {
+            content: vec![LanguageModelContent::Text {
                 text: String::new(),
                 provider_metadata: None,
-            },
+            }],
             finish_reason: LanguageModelFinishReason::Stop,
             usage: mock_usage(),
             provider_metadata: None,

--- a/bitrouter-api/src/router/openai/responses/tests.rs
+++ b/bitrouter-api/src/router/openai/responses/tests.rs
@@ -69,10 +69,10 @@ impl LanguageModel for MockModel {
         _options: LanguageModelCallOptions,
     ) -> Result<LanguageModelGenerateResult> {
         Ok(LanguageModelGenerateResult {
-            content: LanguageModelContent::Text {
+            content: vec![LanguageModelContent::Text {
                 text: "Hello from responses!".to_owned(),
                 provider_metadata: None,
-            },
+            }],
             finish_reason: LanguageModelFinishReason::Stop,
             usage: LanguageModelUsage {
                 input_tokens: LanguageModelInputTokens {
@@ -187,14 +187,14 @@ impl LanguageModel for MockToolModel {
         _options: LanguageModelCallOptions,
     ) -> Result<LanguageModelGenerateResult> {
         Ok(LanguageModelGenerateResult {
-            content: LanguageModelContent::ToolCall {
+            content: vec![LanguageModelContent::ToolCall {
                 tool_call_id: "call_abc123".to_owned(),
                 tool_name: "get_weather".to_owned(),
                 tool_input: r#"{"location":"Paris"}"#.to_owned(),
                 provider_executed: None,
                 dynamic: None,
                 provider_metadata: None,
-            },
+            }],
             finish_reason: LanguageModelFinishReason::FunctionCall,
             usage: mock_usage(),
             provider_metadata: None,

--- a/bitrouter-core/src/api/anthropic/messages/convert.rs
+++ b/bitrouter-core/src/api/anthropic/messages/convert.rs
@@ -356,26 +356,36 @@ fn convert_tool_choice(value: &AnthropicToolChoice) -> Option<LanguageModelToolC
     }
 }
 
-fn extract_response_content(content: &LanguageModelContent) -> Vec<AnthropicContentBlock> {
-    match content {
-        LanguageModelContent::Text { text, .. } => {
-            vec![AnthropicContentBlock::Text { text: text.clone() }]
+fn extract_response_content(blocks: &[LanguageModelContent]) -> Vec<AnthropicContentBlock> {
+    let mut out: Vec<AnthropicContentBlock> = Vec::with_capacity(blocks.len());
+    for block in blocks {
+        match block {
+            LanguageModelContent::Text { text, .. } => {
+                out.push(AnthropicContentBlock::Text { text: text.clone() });
+            }
+            LanguageModelContent::ToolCall {
+                tool_call_id,
+                tool_name,
+                tool_input,
+                ..
+            } => {
+                let input: serde_json::Value = serde_json::from_str(tool_input).unwrap_or_default();
+                out.push(AnthropicContentBlock::ToolUse {
+                    id: tool_call_id.clone(),
+                    name: tool_name.clone(),
+                    input,
+                });
+            }
+            LanguageModelContent::Reasoning { text, .. } => {
+                out.push(AnthropicContentBlock::Thinking {
+                    thinking: text.clone(),
+                    signature: None,
+                });
+            }
+            _ => {}
         }
-        LanguageModelContent::ToolCall {
-            tool_call_id,
-            tool_name,
-            tool_input,
-            ..
-        } => {
-            let input: serde_json::Value = serde_json::from_str(tool_input).unwrap_or_default();
-            vec![AnthropicContentBlock::ToolUse {
-                id: tool_call_id.clone(),
-                name: tool_name.clone(),
-                input,
-            }]
-        }
-        _ => vec![],
     }
+    out
 }
 
 fn map_finish_reason(reason: &LanguageModelFinishReason) -> String {

--- a/bitrouter-core/src/api/google/generate_content/convert.rs
+++ b/bitrouter-core/src/api/google/generate_content/convert.rs
@@ -383,32 +383,36 @@ fn convert_tool_config(config: GoogleToolConfig) -> Option<LanguageModelToolChoi
     }
 }
 
-fn extract_response_parts(content: &LanguageModelContent) -> Vec<GooglePart> {
-    match content {
-        LanguageModelContent::Text { text, .. } => vec![GooglePart {
-            text: Some(text.clone()),
-            inline_data: None,
-            function_call: None,
-            function_response: None,
-        }],
-        LanguageModelContent::ToolCall {
-            tool_name,
-            tool_input,
-            ..
-        } => {
-            let args: serde_json::Value = serde_json::from_str(tool_input).unwrap_or_default();
-            vec![GooglePart {
-                text: None,
+fn extract_response_parts(blocks: &[LanguageModelContent]) -> Vec<GooglePart> {
+    let mut out: Vec<GooglePart> = Vec::with_capacity(blocks.len());
+    for block in blocks {
+        match block {
+            LanguageModelContent::Text { text, .. } => out.push(GooglePart {
+                text: Some(text.clone()),
                 inline_data: None,
-                function_call: Some(GoogleFunctionCall {
-                    name: tool_name.clone(),
-                    args: Some(args),
-                }),
+                function_call: None,
                 function_response: None,
-            }]
+            }),
+            LanguageModelContent::ToolCall {
+                tool_name,
+                tool_input,
+                ..
+            } => {
+                let args: serde_json::Value = serde_json::from_str(tool_input).unwrap_or_default();
+                out.push(GooglePart {
+                    text: None,
+                    inline_data: None,
+                    function_call: Some(GoogleFunctionCall {
+                        name: tool_name.clone(),
+                        args: Some(args),
+                    }),
+                    function_response: None,
+                });
+            }
+            _ => {}
         }
-        _ => vec![],
     }
+    out
 }
 
 fn map_finish_reason(reason: &LanguageModelFinishReason) -> String {

--- a/bitrouter-core/src/api/openai/chat/convert.rs
+++ b/bitrouter-core/src/api/openai/chat/convert.rs
@@ -341,28 +341,42 @@ fn convert_tool_choice(value: &ChatToolChoice) -> Option<LanguageModelToolChoice
 }
 
 fn extract_content_and_tool_calls(
-    content: &LanguageModelContent,
+    blocks: &[LanguageModelContent],
 ) -> (Option<String>, Option<Vec<ChatResponseToolCall>>) {
-    match content {
-        LanguageModelContent::Text { text, .. } => (Some(text.clone()), None),
-        LanguageModelContent::ToolCall {
-            tool_call_id,
-            tool_name,
-            tool_input,
-            ..
-        } => (
-            None,
-            Some(vec![ChatResponseToolCall {
+    let mut text_parts: Vec<String> = Vec::new();
+    let mut tool_calls: Vec<ChatResponseToolCall> = Vec::new();
+
+    for block in blocks {
+        match block {
+            LanguageModelContent::Text { text, .. } => text_parts.push(text.clone()),
+            LanguageModelContent::ToolCall {
+                tool_call_id,
+                tool_name,
+                tool_input,
+                ..
+            } => tool_calls.push(ChatResponseToolCall {
                 id: tool_call_id.clone(),
                 r#type: "function".to_owned(),
                 function: ChatResponseToolCallFunction {
                     name: tool_name.clone(),
                     arguments: tool_input.clone(),
                 },
-            }]),
-        ),
-        _ => (None, None),
+            }),
+            _ => {}
+        }
     }
+
+    let content = if text_parts.is_empty() {
+        None
+    } else {
+        Some(text_parts.join(""))
+    };
+    let tool_calls = if tool_calls.is_empty() {
+        None
+    } else {
+        Some(tool_calls)
+    };
+    (content, tool_calls)
 }
 
 fn content_to_string(content: Option<ChatMessageContent>) -> String {
@@ -986,10 +1000,10 @@ mod tests {
     #[test]
     fn from_generate_result_text() {
         let result = LanguageModelGenerateResult {
-            content: LanguageModelContent::Text {
+            content: vec![LanguageModelContent::Text {
                 text: "Hello world".to_owned(),
                 provider_metadata: None,
-            },
+            }],
             finish_reason: LanguageModelFinishReason::Stop,
             usage: make_usage(10, 5),
             provider_metadata: None,
@@ -1016,14 +1030,14 @@ mod tests {
     #[test]
     fn from_generate_result_tool_call() {
         let result = LanguageModelGenerateResult {
-            content: LanguageModelContent::ToolCall {
+            content: vec![LanguageModelContent::ToolCall {
                 tool_call_id: "call_xyz".to_owned(),
                 tool_name: "get_weather".to_owned(),
                 tool_input: r#"{"location":"NYC"}"#.to_owned(),
                 provider_executed: None,
                 dynamic: None,
                 provider_metadata: None,
-            },
+            }],
             finish_reason: LanguageModelFinishReason::FunctionCall,
             usage: make_usage(15, 20),
             provider_metadata: None,
@@ -1044,6 +1058,49 @@ mod tests {
         assert_eq!(tc[0].r#type, "function");
         assert_eq!(tc[0].function.name, "get_weather");
         assert_eq!(tc[0].function.arguments, r#"{"location":"NYC"}"#);
+    }
+
+    // Regression test for issue #416: a generate result containing both
+    // assistant text and tool_call blocks must serialize as a single
+    // assistant choice with both `content` and `tool_calls` populated.
+    #[test]
+    fn from_generate_result_text_and_tool_calls() {
+        let result = LanguageModelGenerateResult {
+            content: vec![
+                LanguageModelContent::Text {
+                    text: "Let me check.".to_owned(),
+                    provider_metadata: None,
+                },
+                LanguageModelContent::ToolCall {
+                    tool_call_id: "call_a".to_owned(),
+                    tool_name: "get_weather".to_owned(),
+                    tool_input: r#"{"location":"NYC"}"#.to_owned(),
+                    provider_executed: None,
+                    dynamic: None,
+                    provider_metadata: None,
+                },
+            ],
+            finish_reason: LanguageModelFinishReason::FunctionCall,
+            usage: make_usage(10, 5),
+            provider_metadata: None,
+            request: None,
+            response_metadata: None,
+            warnings: None,
+        };
+        let resp = from_generate_result("gpt-4o", result);
+        assert_eq!(
+            resp.choices[0].message.content.as_deref(),
+            Some("Let me check.")
+        );
+        let tc = resp.choices[0]
+            .message
+            .tool_calls
+            .as_ref()
+            .expect("tool_calls missing");
+        assert_eq!(tc.len(), 1);
+        assert_eq!(tc[0].id, "call_a");
+        assert_eq!(tc[0].function.name, "get_weather");
+        assert_eq!(resp.choices[0].finish_reason.as_deref(), Some("tool_calls"));
     }
 
     // ── Conversion: StreamConverter ─────────────────────────────────────

--- a/bitrouter-core/src/api/openai/responses/convert.rs
+++ b/bitrouter-core/src/api/openai/responses/convert.rs
@@ -381,32 +381,47 @@ fn input_content_to_parts(content: Option<ResponsesInputContent>) -> Vec<Languag
     }
 }
 
-fn extract_output_items(content: &LanguageModelContent) -> Vec<ResponsesOutputItem> {
-    match content {
-        LanguageModelContent::Text { text, .. } => {
-            vec![ResponsesOutputItem::Message {
+fn extract_output_items(blocks: &[LanguageModelContent]) -> Vec<ResponsesOutputItem> {
+    let mut out: Vec<ResponsesOutputItem> = Vec::new();
+    let mut pending_text: Vec<ResponsesOutputContent> = Vec::new();
+
+    let flush_text = |pending: &mut Vec<ResponsesOutputContent>,
+                      out: &mut Vec<ResponsesOutputItem>| {
+        if !pending.is_empty() {
+            out.push(ResponsesOutputItem::Message {
                 id: Some(format!("msg-{}", generate_id())),
                 role: Some("assistant".to_owned()),
-                content: vec![ResponsesOutputContent::OutputText { text: text.clone() }],
+                content: std::mem::take(pending),
                 status: Some("completed".to_owned()),
-            }]
+            });
         }
-        LanguageModelContent::ToolCall {
-            tool_call_id,
-            tool_name,
-            tool_input,
-            ..
-        } => {
-            vec![ResponsesOutputItem::FunctionCall {
-                id: Some(format!("fc-{}", generate_id())),
-                call_id: tool_call_id.clone(),
-                name: tool_name.clone(),
-                arguments: tool_input.clone(),
-                status: Some("completed".to_owned()),
-            }]
+    };
+
+    for block in blocks {
+        match block {
+            LanguageModelContent::Text { text, .. } => {
+                pending_text.push(ResponsesOutputContent::OutputText { text: text.clone() });
+            }
+            LanguageModelContent::ToolCall {
+                tool_call_id,
+                tool_name,
+                tool_input,
+                ..
+            } => {
+                flush_text(&mut pending_text, &mut out);
+                out.push(ResponsesOutputItem::FunctionCall {
+                    id: Some(format!("fc-{}", generate_id())),
+                    call_id: tool_call_id.clone(),
+                    name: tool_name.clone(),
+                    arguments: tool_input.clone(),
+                    status: Some("completed".to_owned()),
+                });
+            }
+            _ => {}
         }
-        _ => vec![],
     }
+    flush_text(&mut pending_text, &mut out);
+    out
 }
 
 #[cfg(test)]
@@ -931,10 +946,10 @@ mod tests {
     #[test]
     fn from_generate_result_text() {
         let result = LanguageModelGenerateResult {
-            content: LanguageModelContent::Text {
+            content: vec![LanguageModelContent::Text {
                 text: "Hello world".to_owned(),
                 provider_metadata: None,
-            },
+            }],
             finish_reason: LanguageModelFinishReason::Stop,
             usage: make_usage(10, 5),
             provider_metadata: None,
@@ -976,14 +991,14 @@ mod tests {
     #[test]
     fn from_generate_result_tool_call() {
         let result = LanguageModelGenerateResult {
-            content: LanguageModelContent::ToolCall {
+            content: vec![LanguageModelContent::ToolCall {
                 tool_call_id: "call_xyz".to_owned(),
                 tool_name: "get_weather".to_owned(),
                 tool_input: r#"{"location":"NYC"}"#.to_owned(),
                 provider_executed: None,
                 dynamic: None,
                 provider_metadata: None,
-            },
+            }],
             finish_reason: LanguageModelFinishReason::FunctionCall,
             usage: make_usage(15, 20),
             provider_metadata: None,

--- a/bitrouter-core/src/hooks/mod.rs
+++ b/bitrouter-core/src/hooks/mod.rs
@@ -82,10 +82,12 @@ mod tests {
 
     fn test_generate_result() -> LanguageModelGenerateResult {
         LanguageModelGenerateResult {
-            content: crate::models::language::content::LanguageModelContent::Text {
-                text: String::new(),
-                provider_metadata: None,
-            },
+            content: vec![
+                crate::models::language::content::LanguageModelContent::Text {
+                    text: String::new(),
+                    provider_metadata: None,
+                },
+            ],
             finish_reason: LanguageModelFinishReason::Stop,
             usage: test_usage(),
             provider_metadata: None,

--- a/bitrouter-core/src/models/language/generate_result.rs
+++ b/bitrouter-core/src/models/language/generate_result.rs
@@ -12,8 +12,14 @@ use super::{
 /// Represents the result of a Language Model generation.
 #[derive(Debug, Clone)]
 pub struct LanguageModelGenerateResult {
-    /// The generated content
-    pub content: LanguageModelContent,
+    /// The generated content blocks, in the order returned by the provider.
+    ///
+    /// A single assistant turn may contain multiple ordered blocks, e.g.
+    /// explanatory text followed by one or more `tool-call` blocks. This is
+    /// required for compatibility with Anthropic Messages-style responses and
+    /// OpenAI-compatible chat completions that include both `message.content`
+    /// and `message.tool_calls` in the same choice.
+    pub content: Vec<LanguageModelContent>,
     /// The finish reason, if the generation is complete
     pub finish_reason: LanguageModelFinishReason,
     /// The usage information for this generation

--- a/bitrouter-guardrails/src/engine.rs
+++ b/bitrouter-guardrails/src/engine.rs
@@ -368,41 +368,43 @@ impl Guardrail {
 
         let mut all_violations = Vec::new();
 
-        match &mut result.content {
-            LanguageModelContent::Text { text, .. } => {
-                let inspection = self.inspect_downgoing_text(text);
-                if inspection.blocked {
-                    return Err(self.config.format_block_message(
-                        "downgoing text",
-                        &violation_descriptions(&inspection.violations),
-                    ));
+        for block in result.content.iter_mut() {
+            match block {
+                LanguageModelContent::Text { text, .. } => {
+                    let inspection = self.inspect_downgoing_text(text);
+                    if inspection.blocked {
+                        return Err(self.config.format_block_message(
+                            "downgoing text",
+                            &violation_descriptions(&inspection.violations),
+                        ));
+                    }
+                    *text = inspection.content;
+                    all_violations.extend(inspection.violations);
                 }
-                *text = inspection.content;
-                all_violations.extend(inspection.violations);
-            }
-            LanguageModelContent::Reasoning { text, .. } => {
-                let inspection = self.inspect_downgoing_text(text);
-                if inspection.blocked {
-                    return Err(self.config.format_block_message(
-                        "downgoing reasoning",
-                        &violation_descriptions(&inspection.violations),
-                    ));
+                LanguageModelContent::Reasoning { text, .. } => {
+                    let inspection = self.inspect_downgoing_text(text);
+                    if inspection.blocked {
+                        return Err(self.config.format_block_message(
+                            "downgoing reasoning",
+                            &violation_descriptions(&inspection.violations),
+                        ));
+                    }
+                    *text = inspection.content;
+                    all_violations.extend(inspection.violations);
                 }
-                *text = inspection.content;
-                all_violations.extend(inspection.violations);
-            }
-            LanguageModelContent::ToolCall { tool_input, .. } => {
-                let inspection = self.inspect_downgoing_text(tool_input);
-                if inspection.blocked {
-                    return Err(self.config.format_block_message(
-                        "downgoing tool call",
-                        &violation_descriptions(&inspection.violations),
-                    ));
+                LanguageModelContent::ToolCall { tool_input, .. } => {
+                    let inspection = self.inspect_downgoing_text(tool_input);
+                    if inspection.blocked {
+                        return Err(self.config.format_block_message(
+                            "downgoing tool call",
+                            &violation_descriptions(&inspection.violations),
+                        ));
+                    }
+                    *tool_input = inspection.content;
+                    all_violations.extend(inspection.violations);
                 }
-                *tool_input = inspection.content;
-                all_violations.extend(inspection.violations);
+                _ => {}
             }
-            _ => {}
         }
 
         Ok(all_violations)
@@ -689,14 +691,14 @@ mod tests {
         let g = Guardrail::new(config);
 
         let mut gen_result = LanguageModelGenerateResult {
-            content: LanguageModelContent::ToolCall {
+            content: vec![LanguageModelContent::ToolCall {
                 tool_call_id: "tc1".to_owned(),
                 tool_name: "bash".to_owned(),
                 tool_input: "rm -rf /".to_owned(),
                 provider_executed: None,
                 dynamic: None,
                 provider_metadata: None,
-            },
+            }],
             finish_reason: LanguageModelFinishReason::Stop,
             usage: default_usage(),
             provider_metadata: None,
@@ -936,14 +938,14 @@ mod tests {
         let g = Guardrail::new(config);
 
         let mut gen_result = LanguageModelGenerateResult {
-            content: LanguageModelContent::ToolCall {
+            content: vec![LanguageModelContent::ToolCall {
                 tool_call_id: "tc1".to_owned(),
                 tool_name: "bash".to_owned(),
                 tool_input: "rm -rf /".to_owned(),
                 provider_executed: None,
                 dynamic: None,
                 provider_metadata: None,
-            },
+            }],
             finish_reason: LanguageModelFinishReason::Stop,
             usage: default_usage(),
             provider_metadata: None,
@@ -968,14 +970,14 @@ mod tests {
         let g = Guardrail::new(config);
 
         let mut gen_result = LanguageModelGenerateResult {
-            content: LanguageModelContent::ToolCall {
+            content: vec![LanguageModelContent::ToolCall {
                 tool_call_id: "tc1".to_owned(),
                 tool_name: "bash".to_owned(),
                 tool_input: "rm -rf /".to_owned(),
                 provider_executed: None,
                 dynamic: None,
                 provider_metadata: None,
-            },
+            }],
             finish_reason: LanguageModelFinishReason::Stop,
             usage: default_usage(),
             provider_metadata: None,

--- a/bitrouter-providers/src/anthropic/messages/api.rs
+++ b/bitrouter-providers/src/anthropic/messages/api.rs
@@ -314,7 +314,7 @@ fn content_blocks_to_language_model_content(
     blocks: Vec<AnthropicContentBlock>,
     provider_metadata: Option<ProviderMetadata>,
     response_body: JsonValue,
-) -> Result<LanguageModelContent> {
+) -> Result<Vec<LanguageModelContent>> {
     if blocks.is_empty() {
         return Err(BitrouterError::invalid_response(
             Some(ANTHROPIC_PROVIDER_NAME),
@@ -323,88 +323,56 @@ fn content_blocks_to_language_model_content(
         ));
     }
 
-    if blocks.len() == 1 {
-        // len() == 1 guarantees next() returns Some.
-        // The else branch is a defensive fallback that cannot be reached.
-        let Some(block) = blocks.into_iter().next() else {
-            return Err(BitrouterError::invalid_response(
-                Some(ANTHROPIC_PROVIDER_NAME),
-                "expected single content block but iterator was empty",
-                Some(response_body),
-            ));
-        };
-        return match block {
-            AnthropicContentBlock::Text { text } => Ok(LanguageModelContent::Text {
-                text,
-                provider_metadata,
-            }),
-            AnthropicContentBlock::ToolUse { id, name, input } => {
-                Ok(LanguageModelContent::ToolCall {
-                    tool_call_id: id,
-                    tool_name: name,
-                    tool_input: serde_json::to_string(&input).map_err(|error| {
-                        BitrouterError::invalid_response(
-                            Some(ANTHROPIC_PROVIDER_NAME),
-                            format!("failed to serialize tool call input: {error}"),
-                            Some(response_body.clone()),
-                        )
-                    })?,
-                    provider_executed: None,
-                    dynamic: None,
-                    provider_metadata,
-                })
-            }
-            AnthropicContentBlock::Image { .. }
-            | AnthropicContentBlock::ToolResult { .. }
-            | AnthropicContentBlock::Thinking { .. }
-            | AnthropicContentBlock::RedactedThinking { .. } => {
-                Err(BitrouterError::invalid_response(
-                    Some(ANTHROPIC_PROVIDER_NAME),
-                    "unexpected content block type in response",
-                    Some(response_body),
-                ))
-            }
-        };
-    }
-
-    // Multiple blocks: find the first tool_use or concatenate texts
-    let mut texts = Vec::new();
-    let mut tool_use = None;
+    let mut out: Vec<LanguageModelContent> = Vec::with_capacity(blocks.len());
     for block in blocks {
         match block {
-            AnthropicContentBlock::Text { text } => texts.push(text),
-            AnthropicContentBlock::ToolUse { id, name, input } if tool_use.is_none() => {
-                tool_use = Some((id, name, input));
+            AnthropicContentBlock::Text { text } => {
+                out.push(LanguageModelContent::Text {
+                    text,
+                    provider_metadata: provider_metadata.clone(),
+                });
             }
-            AnthropicContentBlock::ToolUse { .. }
+            AnthropicContentBlock::ToolUse { id, name, input } => {
+                let tool_input = serde_json::to_string(&input).map_err(|error| {
+                    BitrouterError::invalid_response(
+                        Some(ANTHROPIC_PROVIDER_NAME),
+                        format!("failed to serialize tool call input: {error}"),
+                        Some(response_body.clone()),
+                    )
+                })?;
+                out.push(LanguageModelContent::ToolCall {
+                    tool_call_id: id,
+                    tool_name: name,
+                    tool_input,
+                    provider_executed: None,
+                    dynamic: None,
+                    provider_metadata: provider_metadata.clone(),
+                });
+            }
+            AnthropicContentBlock::Thinking { thinking, .. } => {
+                out.push(LanguageModelContent::Reasoning {
+                    text: thinking,
+                    provider_metadata: provider_metadata.clone(),
+                });
+            }
+            AnthropicContentBlock::RedactedThinking { .. }
             | AnthropicContentBlock::Image { .. }
-            | AnthropicContentBlock::ToolResult { .. }
-            | AnthropicContentBlock::Thinking { .. }
-            | AnthropicContentBlock::RedactedThinking { .. } => {}
+            | AnthropicContentBlock::ToolResult { .. } => {
+                // Skip block types that have no representation in an assistant
+                // generate result (or that should never appear in responses).
+            }
         }
     }
 
-    if let Some((id, name, input)) = tool_use {
-        return Ok(LanguageModelContent::ToolCall {
-            tool_call_id: id,
-            tool_name: name,
-            tool_input: serde_json::to_string(&input).map_err(|error| {
-                BitrouterError::invalid_response(
-                    Some(ANTHROPIC_PROVIDER_NAME),
-                    format!("failed to serialize tool call input: {error}"),
-                    Some(response_body.clone()),
-                )
-            })?,
-            provider_executed: None,
-            dynamic: None,
-            provider_metadata,
-        });
+    if out.is_empty() {
+        return Err(BitrouterError::invalid_response(
+            Some(ANTHROPIC_PROVIDER_NAME),
+            "message response contained no representable content blocks",
+            Some(response_body),
+        ));
     }
 
-    Ok(LanguageModelContent::Text {
-        text: texts.join(""),
-        provider_metadata,
-    })
+    Ok(out)
 }
 
 // ── Prompt conversion ───────────────────────────────────────────────────────
@@ -1637,9 +1605,10 @@ mod tests {
             text: "Hello".to_owned(),
         }];
         let result = content_blocks_to_language_model_content(blocks, None, json!({}));
-        assert!(result.is_ok());
+        let out = result.expect("should be ok");
+        assert_eq!(out.len(), 1);
         assert!(matches!(
-            result.unwrap(),
+            &out[0],
             LanguageModelContent::Text { text, .. } if text == "Hello"
         ));
     }
@@ -1652,15 +1621,16 @@ mod tests {
             input: json!({"location": "Paris"}),
         }];
         let result = content_blocks_to_language_model_content(blocks, None, json!({}));
-        assert!(result.is_ok());
+        let out = result.expect("should be ok");
+        assert_eq!(out.len(), 1);
         assert!(matches!(
-            result.unwrap(),
+            &out[0],
             LanguageModelContent::ToolCall { tool_name, .. } if tool_name == "get_weather"
         ));
     }
 
     #[test]
-    fn multiple_text_blocks_concatenated() {
+    fn multiple_text_blocks_preserved_in_order() {
         let blocks = vec![
             AnthropicContentBlock::Text {
                 text: "Hello ".to_owned(),
@@ -1670,15 +1640,20 @@ mod tests {
             },
         ];
         let result = content_blocks_to_language_model_content(blocks, None, json!({}));
-        assert!(result.is_ok());
+        let out = result.expect("should be ok");
+        assert_eq!(out.len(), 2);
         assert!(matches!(
-            result.unwrap(),
-            LanguageModelContent::Text { text, .. } if text == "Hello world!"
+            &out[0],
+            LanguageModelContent::Text { text, .. } if text == "Hello "
+        ));
+        assert!(matches!(
+            &out[1],
+            LanguageModelContent::Text { text, .. } if text == "world!"
         ));
     }
 
     #[test]
-    fn text_and_tool_use_blocks_tool_wins() {
+    fn text_and_tool_use_blocks_both_preserved() {
         let blocks = vec![
             AnthropicContentBlock::Text {
                 text: "Let me look that up.".to_owned(),
@@ -1690,9 +1665,14 @@ mod tests {
             },
         ];
         let result = content_blocks_to_language_model_content(blocks, None, json!({}));
-        assert!(result.is_ok());
+        let out = result.expect("should be ok");
+        assert_eq!(out.len(), 2);
         assert!(matches!(
-            result.unwrap(),
+            &out[0],
+            LanguageModelContent::Text { text, .. } if text == "Let me look that up."
+        ));
+        assert!(matches!(
+            &out[1],
             LanguageModelContent::ToolCall { tool_name, .. } if tool_name == "search"
         ));
     }

--- a/bitrouter-providers/src/google/generate_content/api.rs
+++ b/bitrouter-providers/src/google/generate_content/api.rs
@@ -336,7 +336,7 @@ fn candidate_to_language_model_content(
     candidate: &GenerateContentCandidate,
     provider_metadata: Option<ProviderMetadata>,
     response_body: JsonValue,
-) -> Result<LanguageModelContent> {
+) -> Result<Vec<LanguageModelContent>> {
     let parts = candidate
         .content
         .as_ref()
@@ -357,9 +357,21 @@ fn candidate_to_language_model_content(
         ));
     }
 
-    // Look for function call first
+    let mut out: Vec<LanguageModelContent> = Vec::new();
+    let mut text_buf = String::new();
+
     for part in parts {
+        if let Some(text) = part.text.as_deref() {
+            text_buf.push_str(text);
+            continue;
+        }
         if let Some(fc) = &part.function_call {
+            if !text_buf.is_empty() {
+                out.push(LanguageModelContent::Text {
+                    text: std::mem::take(&mut text_buf),
+                    provider_metadata: provider_metadata.clone(),
+                });
+            }
             let input_str = fc
                 .args
                 .as_ref()
@@ -374,28 +386,33 @@ fn candidate_to_language_model_content(
                 })?
                 .unwrap_or_else(|| "{}".to_owned());
 
-            return Ok(LanguageModelContent::ToolCall {
+            out.push(LanguageModelContent::ToolCall {
                 tool_call_id: fc.name.clone(),
                 tool_name: fc.name.clone(),
                 tool_input: input_str,
                 provider_executed: None,
                 dynamic: None,
-                provider_metadata,
+                provider_metadata: provider_metadata.clone(),
             });
         }
     }
 
-    // Concatenate text parts
-    let text: String = parts
-        .iter()
-        .filter_map(|p| p.text.as_deref())
-        .collect::<Vec<_>>()
-        .join("");
+    if !text_buf.is_empty() {
+        out.push(LanguageModelContent::Text {
+            text: text_buf,
+            provider_metadata: provider_metadata.clone(),
+        });
+    }
 
-    Ok(LanguageModelContent::Text {
-        text,
-        provider_metadata,
-    })
+    if out.is_empty() {
+        // Preserve previous behavior: emit empty text rather than erroring.
+        out.push(LanguageModelContent::Text {
+            text: String::new(),
+            provider_metadata,
+        });
+    }
+
+    Ok(out)
 }
 
 // ── Prompt conversion ───────────────────────────────────────────────────────

--- a/bitrouter-providers/src/openai/chat/api.rs
+++ b/bitrouter-providers/src/openai/chat/api.rs
@@ -367,29 +367,20 @@ fn message_to_language_model_content(
     message: ChatCompletionChoiceMessage,
     provider_metadata: Option<ProviderMetadata>,
     response_body: JsonValue,
-) -> Result<LanguageModelContent> {
-    match (message.content, message.tool_calls) {
-        (Some(content), None) => Ok(LanguageModelContent::Text {
-            text: content,
-            provider_metadata,
-        }),
-        (None, Some(tool_calls)) => {
-            if tool_calls.len() != 1 {
-                return Err(BitrouterError::invalid_response(
-                    Some(OPENAI_PROVIDER_NAME),
-                    "chat completion returned multiple tool calls, but bitrouter-core generate_result can only represent one top-level content item",
-                    Some(response_body),
-                ));
-            }
-            // len() == 1 is guaranteed here because len() != 1 returns early above.
-            // The else branch is a defensive fallback that cannot be reached.
-            let Some(tool_call) = tool_calls.into_iter().next() else {
-                return Err(BitrouterError::invalid_response(
-                    Some(OPENAI_PROVIDER_NAME),
-                    "expected single tool call but iterator was empty",
-                    Some(response_body),
-                ));
-            };
+) -> Result<Vec<LanguageModelContent>> {
+    let mut blocks: Vec<LanguageModelContent> = Vec::new();
+
+    if let Some(text) = message.content
+        && !text.is_empty()
+    {
+        blocks.push(LanguageModelContent::Text {
+            text,
+            provider_metadata: provider_metadata.clone(),
+        });
+    }
+
+    if let Some(tool_calls) = message.tool_calls {
+        for tool_call in tool_calls {
             let tool_input = serde_json::from_str::<JsonValue>(&tool_call.function.arguments)
                 .map_err(|error| {
                     BitrouterError::invalid_response(
@@ -398,32 +389,33 @@ fn message_to_language_model_content(
                         Some(response_body.clone()),
                     )
                 })?;
-            Ok(LanguageModelContent::ToolCall {
+            let serialized = serde_json::to_string(&tool_input).map_err(|error| {
+                BitrouterError::invalid_response(
+                    Some(OPENAI_PROVIDER_NAME),
+                    format!("failed to re-serialize tool call arguments: {error}"),
+                    Some(response_body.clone()),
+                )
+            })?;
+            blocks.push(LanguageModelContent::ToolCall {
                 tool_call_id: tool_call.id,
                 tool_name: tool_call.function.name,
-                tool_input: serde_json::to_string(&tool_input).map_err(|error| {
-                    BitrouterError::invalid_response(
-                        Some(OPENAI_PROVIDER_NAME),
-                        format!("failed to re-serialize tool call arguments: {error}"),
-                        Some(response_body.clone()),
-                    )
-                })?,
+                tool_input: serialized,
                 provider_executed: None,
                 dynamic: None,
-                provider_metadata,
-            })
+                provider_metadata: provider_metadata.clone(),
+            });
         }
-        (Some(_), Some(_)) => Err(BitrouterError::invalid_response(
-            Some(OPENAI_PROVIDER_NAME),
-            "chat completion returned both assistant text and tool calls in one choice, which bitrouter-core generate_result cannot represent as a single content value",
-            Some(response_body),
-        )),
-        (None, None) => Err(BitrouterError::invalid_response(
+    }
+
+    if blocks.is_empty() {
+        return Err(BitrouterError::invalid_response(
             Some(OPENAI_PROVIDER_NAME),
             "chat completion returned neither content nor tool calls",
             Some(response_body),
-        )),
+        ));
     }
+
+    Ok(blocks)
 }
 
 fn convert_prompt(prompt: &[LanguageModelMessage]) -> Result<Vec<ChatMessage>> {
@@ -1130,11 +1122,74 @@ fn next_sse_event_boundary(buffer: &[u8]) -> Option<(usize, usize)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bitrouter_core::api::openai::chat::types::{
+        ChatResponseToolCall, ChatResponseToolCallFunction,
+    };
     use bitrouter_core::models::language::{
         call_options::LanguageModelCallOptions,
         data_content::LanguageModelDataContent,
         prompt::{LanguageModelMessage, LanguageModelUserContent},
     };
+
+    // Regression test for issue #416: a chat completion choice that includes
+    // both assistant text and one or more tool_calls must be preserved as
+    // multiple ordered content blocks instead of returning a 502.
+    #[test]
+    fn message_with_text_and_tool_calls_yields_multiple_blocks() {
+        let message = ChatCompletionChoiceMessage {
+            role: "assistant".to_owned(),
+            content: Some("Let me look that up.".to_owned()),
+            refusal: None,
+            tool_calls: Some(vec![
+                ChatResponseToolCall {
+                    id: "call_1".to_owned(),
+                    r#type: "function".to_owned(),
+                    function: ChatResponseToolCallFunction {
+                        name: "get_weather".to_owned(),
+                        arguments: r#"{"location":"NYC"}"#.to_owned(),
+                    },
+                },
+                ChatResponseToolCall {
+                    id: "call_2".to_owned(),
+                    r#type: "function".to_owned(),
+                    function: ChatResponseToolCallFunction {
+                        name: "get_time".to_owned(),
+                        arguments: r#"{"tz":"UTC"}"#.to_owned(),
+                    },
+                },
+            ]),
+        };
+
+        let blocks = message_to_language_model_content(message, None, json!({}))
+            .expect("mixed content should be accepted");
+        assert_eq!(blocks.len(), 3);
+        assert!(matches!(
+            &blocks[0],
+            LanguageModelContent::Text { text, .. } if text == "Let me look that up."
+        ));
+        assert!(matches!(
+            &blocks[1],
+            LanguageModelContent::ToolCall { tool_call_id, tool_name, .. }
+                if tool_call_id == "call_1" && tool_name == "get_weather"
+        ));
+        assert!(matches!(
+            &blocks[2],
+            LanguageModelContent::ToolCall { tool_call_id, tool_name, .. }
+                if tool_call_id == "call_2" && tool_name == "get_time"
+        ));
+    }
+
+    #[test]
+    fn message_with_no_content_or_tool_calls_errors() {
+        let message = ChatCompletionChoiceMessage {
+            role: "assistant".to_owned(),
+            content: None,
+            refusal: None,
+            tool_calls: None,
+        };
+        let err = message_to_language_model_content(message, None, json!({})).unwrap_err();
+        assert!(format!("{err}").contains("neither content nor tool calls"));
+    }
 
     #[test]
     fn parses_openai_error_body() {

--- a/bitrouter-providers/src/openai/responses/api.rs
+++ b/bitrouter-providers/src/openai/responses/api.rs
@@ -233,9 +233,9 @@ pub(crate) fn response_to_generate_result(
     response_headers: Option<HeaderMap>,
     response_body: JsonValue,
 ) -> Result<LanguageModelGenerateResult> {
-    let mut text_segments = Vec::new();
+    let mut blocks: Vec<LanguageModelContent> = Vec::new();
     let mut refusal: Option<String> = None;
-    let mut first_function_call: Option<(String, String, String)> = None;
+    let mut has_function_call = false;
 
     for item in &response.output {
         match item {
@@ -243,7 +243,10 @@ pub(crate) fn response_to_generate_result(
                 for part in content {
                     match part {
                         ResponsesOutputContent::OutputText { text } => {
-                            text_segments.push(text.clone());
+                            blocks.push(LanguageModelContent::Text {
+                                text: text.clone(),
+                                provider_metadata: None,
+                            });
                         }
                         ResponsesOutputContent::Refusal { refusal: value } => {
                             refusal = Some(value.clone());
@@ -258,9 +261,15 @@ pub(crate) fn response_to_generate_result(
                 arguments,
                 ..
             } => {
-                if first_function_call.is_none() {
-                    first_function_call = Some((call_id.clone(), name.clone(), arguments.clone()));
-                }
+                has_function_call = true;
+                blocks.push(LanguageModelContent::ToolCall {
+                    tool_call_id: call_id.clone(),
+                    tool_name: name.clone(),
+                    tool_input: arguments.clone(),
+                    provider_executed: None,
+                    dynamic: None,
+                    provider_metadata: None,
+                });
             }
             ResponsesOutputItem::Unknown => {}
         }
@@ -273,30 +282,38 @@ pub(crate) fn response_to_generate_result(
             .incomplete_details
             .as_ref()
             .and_then(|details| details.reason.as_deref()),
-        first_function_call.is_some(),
+        has_function_call,
     );
 
-    let content = if let Some((call_id, tool_name, tool_input)) = first_function_call {
-        LanguageModelContent::ToolCall {
-            tool_call_id: call_id,
-            tool_name,
-            tool_input,
-            provider_executed: None,
-            dynamic: None,
-            provider_metadata: provider_metadata.clone(),
-        }
-    } else if !text_segments.is_empty() {
-        LanguageModelContent::Text {
-            text: text_segments.join("\n"),
-            provider_metadata: provider_metadata.clone(),
-        }
-    } else {
+    if blocks.is_empty() {
         return Err(BitrouterError::invalid_response(
             Some(OPENAI_PROVIDER_NAME),
             "responses result did not contain text or function_call output",
             Some(response_body),
         ));
-    };
+    }
+
+    // Attach provider_metadata to the first block so callers can see refusal
+    // info without losing per-block ordering. Other blocks keep `None`.
+    if let Some(meta) = provider_metadata.clone()
+        && let Some(first) = blocks.first_mut()
+    {
+        match first {
+            LanguageModelContent::Text {
+                provider_metadata: m,
+                ..
+            }
+            | LanguageModelContent::ToolCall {
+                provider_metadata: m,
+                ..
+            } => {
+                *m = Some(meta);
+            }
+            _ => {}
+        }
+    }
+
+    let content = blocks;
 
     Ok(LanguageModelGenerateResult {
         content,
@@ -1290,9 +1307,10 @@ mod tests {
         let result = response_to_generate_result(response, None, json!({}), None, json!({}))
             .expect("conversion should succeed");
 
+        assert_eq!(result.content.len(), 1);
         assert!(matches!(
-            result.content,
-            LanguageModelContent::Text { ref text, .. } if text == "hello"
+            &result.content[0],
+            LanguageModelContent::Text { text, .. } if text == "hello"
         ));
         assert!(matches!(
             result.finish_reason,

--- a/bitrouter/src/runtime/mcp_client.rs
+++ b/bitrouter/src/runtime/mcp_client.rs
@@ -608,7 +608,7 @@ fn convert_to_assistant_content(
 /// Convert a bitrouter LLM result back to MCP format.
 #[cfg(feature = "mcp")]
 fn convert_generate_result(
-    content: LanguageModelContent,
+    blocks: Vec<LanguageModelContent>,
     finish_reason: LanguageModelFinishReason,
 ) -> (SamplingContent, String) {
     let stop_reason = match finish_reason {
@@ -620,22 +620,35 @@ fn convert_generate_result(
         LanguageModelFinishReason::Other(_) => "endTurn",
     };
 
-    let sampling_content = match content {
-        LanguageModelContent::Text { text, .. } => SamplingContent::Text { text },
-        LanguageModelContent::ToolCall {
-            tool_call_id,
-            tool_name,
-            tool_input,
-            ..
-        } => SamplingContent::ToolUse {
-            id: tool_call_id,
-            name: tool_name,
-            input: serde_json::from_str(&tool_input)
+    // MCP sampling/createMessage expects a single SamplingContent. Prefer the
+    // first tool call (matches the previous semantics for tool-use turns);
+    // otherwise fall back to concatenated assistant text.
+    let mut text_buf = String::new();
+    let mut tool_use: Option<(String, String, String)> = None;
+    for block in blocks {
+        match block {
+            LanguageModelContent::Text { text, .. } => text_buf.push_str(&text),
+            LanguageModelContent::ToolCall {
+                tool_call_id,
+                tool_name,
+                tool_input,
+                ..
+            } if tool_use.is_none() => {
+                tool_use = Some((tool_call_id, tool_name, tool_input));
+            }
+            _ => {}
+        }
+    }
+
+    let sampling_content = if let Some((id, name, input)) = tool_use {
+        SamplingContent::ToolUse {
+            id,
+            name,
+            input: serde_json::from_str(&input)
                 .unwrap_or(serde_json::Value::Object(serde_json::Map::new())),
-        },
-        _ => SamplingContent::Text {
-            text: String::new(),
-        },
+        }
+    } else {
+        SamplingContent::Text { text: text_buf }
     };
 
     (sampling_content, stop_reason.to_owned())


### PR DESCRIPTION
Fixes #416.

`LanguageModelGenerateResult.content` was a singular `LanguageModelContent`, so an assistant turn containing both text and one or more `tool_calls` could not be represented. Providers (notably OpenAI Chat and Anthropic) returned a 502 Bad Gateway when an upstream such as OpenRouter emitted a mixed response.

This PR changes `content` to `Vec<LanguageModelContent>` and updates every producer and consumer to preserve all blocks in their original order.

### Changes
- **Providers**
  - `openai/chat`: emit ordered text + tool_call blocks instead of returning an error on mixed responses.
  - `anthropic/messages`: preserve every `Text`/`ToolUse`/`Thinking` block; `Thinking` ↔ `Reasoning` mapping in both directions.
  - `google/generate_content`: preserve text and each function_call in part order.
  - `openai/responses`: preserve text and each function_call, flushing pending text into `Message` items between function calls.
- **Core API egress** (`openai chat`, `anthropic messages`, `google generate_content`, `openai responses`): iterate the `Vec` and reconstruct the expected provider response shape.
- **Guardrails** & **MCP client**: iterate the `Vec`. MCP sampling content remains singular (protocol limitation), so the bridge keeps the first tool_call when present.

### Tests
- New regression test in `bitrouter-providers/src/openai/chat/api.rs` for a choice with both `content` and `tool_calls`.
- New egress test in `bitrouter-core/src/api/openai/chat/convert.rs` verifying both `content` and `tool_calls` are emitted.
- Updated existing fixtures across providers, core converters, guardrails, and `bitrouter-api` router tests.

### Validation
- `cargo fmt -- --check` ✅
- `cargo clippy --workspace --all-targets --all-features` ✅
- `cargo test --workspace --all-features` ✅

### Notes
- Streaming paths were not touched: `LanguageModelStreamPart` already supports interleaved text + tool deltas, and the bug was reproduced only on the non-streaming response path.