### PR TITLE
feat(api): thread request_id and metadata into observability events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1557,7 +1557,7 @@ dependencies = [
 
 [[package]]
 name = "bitrouter"
-version = "0.27.3"
+version = "0.28.0"
 dependencies = [
  "alloy",
  "anyhow",
@@ -1602,7 +1602,7 @@ dependencies = [
 
 [[package]]
 name = "bitrouter-accounts"
-version = "0.27.3"
+version = "0.28.0"
 dependencies = [
  "base64 0.22.1",
  "bitrouter-core",
@@ -1622,7 +1622,7 @@ dependencies = [
 
 [[package]]
 name = "bitrouter-api"
-version = "0.27.3"
+version = "0.28.0"
 dependencies = [
  "alloy",
  "async-trait",
@@ -1652,7 +1652,7 @@ dependencies = [
 
 [[package]]
 name = "bitrouter-blob"
-version = "0.27.3"
+version = "0.28.0"
 dependencies = [
  "bitrouter-core",
  "tempfile",
@@ -1661,7 +1661,7 @@ dependencies = [
 
 [[package]]
 name = "bitrouter-config"
-version = "0.27.3"
+version = "0.28.0"
 dependencies = [
  "bitrouter-core",
  "bitrouter-guardrails",
@@ -1675,7 +1675,7 @@ dependencies = [
 
 [[package]]
 name = "bitrouter-core"
-version = "0.27.3"
+version = "0.28.0"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -1703,7 +1703,7 @@ dependencies = [
 
 [[package]]
 name = "bitrouter-guardrails"
-version = "0.27.3"
+version = "0.28.0"
 dependencies = [
  "bitrouter-core",
  "futures-core",
@@ -1717,7 +1717,7 @@ dependencies = [
 
 [[package]]
 name = "bitrouter-observe"
-version = "0.27.3"
+version = "0.28.0"
 dependencies = [
  "bitrouter-core",
  "chrono",
@@ -1732,7 +1732,7 @@ dependencies = [
 
 [[package]]
 name = "bitrouter-providers"
-version = "0.27.3"
+version = "0.28.0"
 dependencies = [
  "agent-client-protocol",
  "async-trait",
@@ -1763,7 +1763,7 @@ dependencies = [
 
 [[package]]
 name = "bitrouter-tui"
-version = "0.27.3"
+version = "0.28.0"
 dependencies = [
  "bitrouter-config",
  "bitrouter-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,18 +3,18 @@ resolver = "3"
 members = ["bitrouter", "bitrouter-*"]
 
 [workspace.package]
-version = "0.27.3"
+version = "0.28.0"
 
 [workspace.dependencies]
-bitrouter-accounts = { path = "bitrouter-accounts", version = "0.27", default-features = false }
-bitrouter-api = { path = "bitrouter-api", version = "0.27", default-features = false }
-bitrouter-blob = { path = "bitrouter-blob", version = "0.27" }
-bitrouter-config = { path = "bitrouter-config", version = "0.27" }
-bitrouter-core = { path = "bitrouter-core", version = "0.27" }
-bitrouter-guardrails = { path = "bitrouter-guardrails", version = "0.27" }
-bitrouter-observe = { path = "bitrouter-observe", version = "0.27", default-features = false }
-bitrouter-providers = { path = "bitrouter-providers", version = "0.27" }
-bitrouter-tui = { path = "bitrouter-tui", version = "0.27" }
+bitrouter-accounts = { path = "bitrouter-accounts", version = "0.28", default-features = false }
+bitrouter-api = { path = "bitrouter-api", version = "0.28", default-features = false }
+bitrouter-blob = { path = "bitrouter-blob", version = "0.28" }
+bitrouter-config = { path = "bitrouter-config", version = "0.28" }
+bitrouter-core = { path = "bitrouter-core", version = "0.28" }
+bitrouter-guardrails = { path = "bitrouter-guardrails", version = "0.28" }
+bitrouter-observe = { path = "bitrouter-observe", version = "0.28", default-features = false }
+bitrouter-providers = { path = "bitrouter-providers", version = "0.28" }
+bitrouter-tui = { path = "bitrouter-tui", version = "0.28" }
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/bitrouter-api/src/mpp/metered_sse.rs
+++ b/bitrouter-api/src/mpp/metered_sse.rs
@@ -49,7 +49,7 @@ impl MeteredSseContext {
         for _ in 0..MAX_NEED_VOUCHER_RETRIES {
             match self
                 .payment_gate
-                .deduct(&self.backend_key, &self.channel_id, self.tick_cost)
+                .deduct(&self.backend_key, &self.channel_id, self.tick_cost, None)
                 .await
             {
                 Ok(()) => return true,

--- a/bitrouter-api/src/mpp/mod.rs
+++ b/bitrouter-api/src/mpp/mod.rs
@@ -19,6 +19,6 @@ pub use filter::{
     MppChallenge, MppPaymentContext, MppVerificationFailed, handle_mpp_rejection,
     mpp_payment_filter, verify_mpp_payment,
 };
-pub use payment_gate::PaymentGate;
+pub use payment_gate::{GateRequest, MetadataHook, PaymentGate};
 pub use pricing::{PricingLookup, calculate_usage_cost, cost_to_micro_units};
 pub use state::MppState;

--- a/bitrouter-api/src/mpp/payment_gate.rs
+++ b/bitrouter-api/src/mpp/payment_gate.rs
@@ -2,10 +2,37 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
+use bitrouter_core::observe::CallerContext;
+
 use super::filter::MppPaymentContext;
 
 /// Pinned boxed future used as the return type for [`PaymentGate`] methods.
 type GateFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+/// Hook invoked once per request to attach host-supplied metadata to the
+/// [`bitrouter_core::observe::RequestContext`].
+///
+/// Receives the authenticated [`CallerContext`] and the request's `Origin`
+/// header so hosts can record SDK-, user-, or deployment-specific context
+/// (funding source, recipient, origin URL, ...). The returned value lands
+/// verbatim in `RequestContext::metadata`.
+pub type MetadataHook =
+    Arc<dyn Fn(&CallerContext, &Option<String>) -> serde_json::Value + Send + Sync>;
+
+/// Per-request bundle assembled by the warp filter and consumed by the
+/// payment-gated handlers.
+///
+/// Groups the [`PaymentGate`] handle with the request-scoped `request_id`,
+/// host-supplied `metadata`, and the raw `Authorization` header so handlers
+/// keep a manageable argument count while still receiving everything they
+/// need to verify payment, populate observability events, and forward
+/// billing context to downstream observers.
+pub struct GateRequest {
+    pub gate: Arc<dyn PaymentGate>,
+    pub request_id: String,
+    pub metadata: serde_json::Value,
+    pub auth_header: Option<String>,
+}
 
 /// Trait abstracting payment verification and settlement for MPP handlers.
 ///
@@ -33,11 +60,17 @@ pub trait PaymentGate: Send + Sync {
     ///
     /// For session-based flows this debits from the payment channel store.
     /// Custom implementations may debit from a centralized balance instead.
+    ///
+    /// `request_id` (when `Some`) lets implementations correlate the debit
+    /// with the request row written by an [`crate::observe`] receipt observer
+    /// so billing fields can be filled in regardless of which side completes
+    /// first.
     fn deduct<'a>(
         &'a self,
         backend_key: &'a str,
         channel_id: &'a str,
         amount: u128,
+        request_id: Option<&'a str>,
     ) -> GateFuture<'a, Result<(), mpp::server::VerificationError>>;
 
     /// Wait for the next channel update on the given backend.
@@ -86,8 +119,9 @@ impl PaymentGate for Arc<dyn PaymentGate> {
         backend_key: &'a str,
         channel_id: &'a str,
         amount: u128,
+        request_id: Option<&'a str>,
     ) -> GateFuture<'a, Result<(), mpp::server::VerificationError>> {
-        (**self).deduct(backend_key, channel_id, amount)
+        (**self).deduct(backend_key, channel_id, amount, request_id)
     }
 
     fn wait_for_update<'a>(

--- a/bitrouter-api/src/mpp/state.rs
+++ b/bitrouter-api/src/mpp/state.rs
@@ -637,6 +637,7 @@ impl super::payment_gate::PaymentGate for MppState {
         backend_key: &'a str,
         channel_id: &'a str,
         amount: u128,
+        _request_id: Option<&'a str>,
     ) -> std::pin::Pin<
         Box<
             dyn std::future::Future<Output = Result<(), mpp::server::VerificationError>>

--- a/bitrouter-api/src/router/anthropic/messages/filters.rs
+++ b/bitrouter-api/src/router/anthropic/messages/filters.rs
@@ -16,6 +16,7 @@ use bitrouter_core::{
 use warp::Filter;
 
 use crate::error::BitrouterRejection;
+use crate::util::generate_id;
 
 use super::{convert, types::MessagesRequest};
 
@@ -178,6 +179,7 @@ pub fn messages_filter_with_payment_gate<T, R, A>(
     router: Arc<R>,
     observer: Arc<dyn ObserveCallback>,
     payment_gate: Arc<dyn crate::mpp::PaymentGate>,
+    metadata_hook: crate::mpp::MetadataHook,
     account_filter: A,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone
 where
@@ -189,7 +191,9 @@ where
         .and(warp::post())
         .and(account_filter)
         .and(warp::any().map(move || payment_gate.clone()))
+        .and(warp::any().map(move || metadata_hook.clone()))
         .and(warp::header::optional::<String>("authorization"))
+        .and(warp::header::optional::<String>("origin"))
         .and(crate::body::json::<MessagesRequest>())
         .and(warp::any().map(move || table.clone()))
         .and(warp::any().map(move || router.clone()))
@@ -197,20 +201,21 @@ where
         .and_then(
             |caller: CallerContext,
              gate: Arc<dyn crate::mpp::PaymentGate>,
+             metadata_hook: crate::mpp::MetadataHook,
              auth_header: Option<String>,
+             origin: Option<String>,
              request: MessagesRequest,
              table: Arc<T>,
              router: Arc<R>,
              observer: Arc<dyn ObserveCallback>| {
-                handle_messages_with_gate(
-                    caller,
+                let metadata = metadata_hook(&caller, &origin);
+                let gate_req = crate::mpp::GateRequest {
                     gate,
+                    request_id: generate_id(),
+                    metadata,
                     auth_header,
-                    request,
-                    table,
-                    router,
-                    observer,
-                )
+                };
+                handle_messages_with_gate(caller, gate_req, request, table, router, observer)
             },
         )
 }
@@ -230,23 +235,19 @@ where
     R: LanguageModelRouter + Send + Sync + 'static,
 {
     let payment_gate: Arc<dyn crate::mpp::PaymentGate> = mpp_state;
-    handle_messages_with_gate(
-        caller,
-        payment_gate,
+    let gate_req = crate::mpp::GateRequest {
+        gate: payment_gate,
+        request_id: generate_id(),
+        metadata: serde_json::Value::Null,
         auth_header,
-        request,
-        table,
-        router,
-        observer,
-    )
-    .await
+    };
+    handle_messages_with_gate(caller, gate_req, request, table, router, observer).await
 }
 
 #[cfg(any(feature = "payments-tempo", feature = "payments-solana"))]
 async fn handle_messages_with_gate<T, R>(
     caller: CallerContext,
-    payment_gate: Arc<dyn crate::mpp::PaymentGate>,
-    auth_header: Option<String>,
+    gate_req: crate::mpp::GateRequest,
     request: MessagesRequest,
     table: Arc<T>,
     router: Arc<R>,
@@ -256,6 +257,12 @@ where
     T: RoutingTable + crate::mpp::PricingLookup + Send + Sync + 'static,
     R: LanguageModelRouter + Send + Sync + 'static,
 {
+    let crate::mpp::GateRequest {
+        gate: payment_gate,
+        request_id,
+        metadata,
+        auth_header,
+    } = gate_req;
     let mpp_ctx = payment_gate
         .verify_payment(caller.chain.clone(), auth_header)
         .await?;
@@ -324,6 +331,8 @@ where
             tick_cost,
         };
 
+        let request_id_for_stream = request_id.clone();
+        let metadata_for_stream = metadata.clone();
         tokio::spawn(async move {
             let mut stream = stream_result.stream;
             let mut converter = convert::StreamConverter::new(model_id.clone());
@@ -371,10 +380,17 @@ where
                 model: target_model_id,
                 caller,
                 latency_ms,
+                request_id: request_id_for_stream,
+                metadata: metadata_for_stream,
             };
             if let Some(usage) = usage {
                 observer
-                    .on_request_success(RequestSuccessEvent { ctx, usage })
+                    .on_request_success(RequestSuccessEvent {
+                        ctx,
+                        usage,
+                        streamed: true,
+                        generation_time_ms: None,
+                    })
                     .await;
             } else if client_disconnected {
                 observer
@@ -421,7 +437,12 @@ where
 
                 if micro_units > 0
                     && let Err(e) = payment_gate
-                        .deduct(&mpp_ctx.backend_key, &mpp_ctx.channel_id, micro_units)
+                        .deduct(
+                            &mpp_ctx.backend_key,
+                            &mpp_ctx.channel_id,
+                            micro_units,
+                            Some(&request_id),
+                        )
                         .await
                 {
                     tracing::warn!(
@@ -439,8 +460,12 @@ where
                         model: target_model_id,
                         caller,
                         latency_ms: start.elapsed().as_millis() as u64,
+                        request_id,
+                        metadata,
                     },
                     usage: result.usage.clone(),
+                    streamed: false,
+                    generation_time_ms: None,
                 };
                 tokio::spawn(async move { observer.on_request_success(event).await });
 
@@ -465,6 +490,8 @@ where
                         model: target_model_id,
                         caller,
                         latency_ms: start.elapsed().as_millis() as u64,
+                        request_id,
+                        metadata,
                     },
                     error: e.clone(),
                 };
@@ -542,8 +569,12 @@ where
                         model: target_model_id,
                         caller,
                         latency_ms: start.elapsed().as_millis() as u64,
+                        request_id: String::new(),
+                        metadata: serde_json::Value::Null,
                     },
                     usage: result.usage.clone(),
+                    streamed: false,
+                    generation_time_ms: None,
                 };
                 tokio::spawn(async move { observer.on_request_success(event).await });
                 let response = convert::from_generate_result(&model_id, result);
@@ -557,6 +588,8 @@ where
                         model: target_model_id,
                         caller,
                         latency_ms: start.elapsed().as_millis() as u64,
+                        request_id: String::new(),
+                        metadata: serde_json::Value::Null,
                     },
                     error: e.clone(),
                 };
@@ -668,10 +701,17 @@ async fn handle_stream_with_observe(
             model: target_model,
             caller,
             latency_ms,
+            request_id: String::new(),
+            metadata: serde_json::Value::Null,
         };
         if let Some(usage) = usage {
             observer
-                .on_request_success(RequestSuccessEvent { ctx, usage })
+                .on_request_success(RequestSuccessEvent {
+                    ctx,
+                    usage,
+                    streamed: true,
+                    generation_time_ms: None,
+                })
                 .await;
         } else if client_disconnected {
             observer

--- a/bitrouter-api/src/router/google/generate_content/filters.rs
+++ b/bitrouter-api/src/router/google/generate_content/filters.rs
@@ -319,10 +319,17 @@ where
                 model: target_model_id,
                 caller,
                 latency_ms,
+                request_id: String::new(),
+                metadata: serde_json::Value::Null,
             };
             if let Some(usage) = usage {
                 observer
-                    .on_request_success(RequestSuccessEvent { ctx, usage })
+                    .on_request_success(RequestSuccessEvent {
+                        ctx,
+                        usage,
+                        streamed: true,
+                        generation_time_ms: None,
+                    })
                     .await;
             } else if client_disconnected {
                 observer
@@ -369,7 +376,7 @@ where
 
                 if micro_units > 0
                     && let Err(e) = payment_gate
-                        .deduct(&mpp_ctx.backend_key, &mpp_ctx.channel_id, micro_units)
+                        .deduct(&mpp_ctx.backend_key, &mpp_ctx.channel_id, micro_units, None)
                         .await
                 {
                     tracing::warn!(
@@ -387,8 +394,12 @@ where
                         model: target_model_id,
                         caller,
                         latency_ms: start.elapsed().as_millis() as u64,
+                        request_id: String::new(),
+                        metadata: serde_json::Value::Null,
                     },
                     usage: result.usage.clone(),
+                    streamed: false,
+                    generation_time_ms: None,
                 };
                 tokio::spawn(async move { observer.on_request_success(event).await });
 
@@ -413,6 +424,8 @@ where
                         model: target_model_id,
                         caller,
                         latency_ms: start.elapsed().as_millis() as u64,
+                        request_id: String::new(),
+                        metadata: serde_json::Value::Null,
                     },
                     error: e.clone(),
                 };
@@ -491,8 +504,12 @@ where
                         model: target_model_id,
                         caller,
                         latency_ms: start.elapsed().as_millis() as u64,
+                        request_id: String::new(),
+                        metadata: serde_json::Value::Null,
                     },
                     usage: result.usage.clone(),
+                    streamed: false,
+                    generation_time_ms: None,
                 };
                 tokio::spawn(async move { observer.on_request_success(event).await });
                 let response = convert::from_generate_result(&model_id, result);
@@ -506,6 +523,8 @@ where
                         model: target_model_id,
                         caller,
                         latency_ms: start.elapsed().as_millis() as u64,
+                        request_id: String::new(),
+                        metadata: serde_json::Value::Null,
                     },
                     error: e.clone(),
                 };
@@ -613,10 +632,17 @@ async fn handle_stream_with_observe(
             model: target_model,
             caller,
             latency_ms,
+            request_id: String::new(),
+            metadata: serde_json::Value::Null,
         };
         if let Some(usage) = usage {
             observer
-                .on_request_success(RequestSuccessEvent { ctx, usage })
+                .on_request_success(RequestSuccessEvent {
+                    ctx,
+                    usage,
+                    streamed: true,
+                    generation_time_ms: None,
+                })
                 .await;
         } else if client_disconnected {
             observer

--- a/bitrouter-api/src/router/openai/chat/filters.rs
+++ b/bitrouter-api/src/router/openai/chat/filters.rs
@@ -159,23 +159,19 @@ where
     R: LanguageModelRouter + Send + Sync + 'static,
 {
     let payment_gate: Arc<dyn crate::mpp::PaymentGate> = mpp_state;
-    handle_chat_completion_with_gate(
-        caller,
-        payment_gate,
+    let gate_req = crate::mpp::GateRequest {
+        gate: payment_gate,
+        request_id: generate_id(),
+        metadata: serde_json::Value::Null,
         auth_header,
-        request,
-        table,
-        router,
-        observer,
-    )
-    .await
+    };
+    handle_chat_completion_with_gate(caller, gate_req, request, table, router, observer).await
 }
 
 #[cfg(any(feature = "payments-tempo", feature = "payments-solana"))]
 async fn handle_chat_completion_with_gate<T, R>(
     caller: CallerContext,
-    payment_gate: Arc<dyn crate::mpp::PaymentGate>,
-    auth_header: Option<String>,
+    gate_req: crate::mpp::GateRequest,
     request: ChatCompletionRequest,
     table: Arc<T>,
     router: Arc<R>,
@@ -185,6 +181,12 @@ where
     T: RoutingTable + crate::mpp::PricingLookup + Send + Sync + 'static,
     R: LanguageModelRouter + Send + Sync + 'static,
 {
+    let crate::mpp::GateRequest {
+        gate: payment_gate,
+        request_id,
+        metadata,
+        auth_header,
+    } = gate_req;
     let mpp_ctx = payment_gate
         .verify_payment(caller.chain.clone(), auth_header)
         .await?;
@@ -264,6 +266,8 @@ where
             tick_cost,
         };
 
+        let request_id_for_stream = request_id.clone();
+        let metadata_for_stream = metadata.clone();
         tokio::spawn(async move {
             // Hold the close guard inside the task; channel is closed when the
             // task ends (success, error, or disconnect).
@@ -307,10 +311,17 @@ where
                 model: target_model_id,
                 caller,
                 latency_ms,
+                request_id: request_id_for_stream,
+                metadata: metadata_for_stream,
             };
             if let Some(usage) = usage {
                 observer
-                    .on_request_success(RequestSuccessEvent { ctx, usage })
+                    .on_request_success(RequestSuccessEvent {
+                        ctx,
+                        usage,
+                        streamed: true,
+                        generation_time_ms: None,
+                    })
                     .await;
             } else if client_disconnected {
                 observer
@@ -358,7 +369,12 @@ where
 
                 if micro_units > 0
                     && let Err(e) = payment_gate
-                        .deduct(&mpp_ctx.backend_key, &mpp_ctx.channel_id, micro_units)
+                        .deduct(
+                            &mpp_ctx.backend_key,
+                            &mpp_ctx.channel_id,
+                            micro_units,
+                            Some(&request_id),
+                        )
                         .await
                 {
                     tracing::warn!(
@@ -376,8 +392,12 @@ where
                         model: target_model_id,
                         caller,
                         latency_ms: start.elapsed().as_millis() as u64,
+                        request_id,
+                        metadata,
                     },
                     usage: result.usage.clone(),
+                    streamed: false,
+                    generation_time_ms: None,
                 };
                 tokio::spawn(async move { observer.on_request_success(event).await });
 
@@ -402,6 +422,8 @@ where
                         model: target_model_id,
                         caller,
                         latency_ms: start.elapsed().as_millis() as u64,
+                        request_id,
+                        metadata,
                     },
                     error: e.clone(),
                 };
@@ -455,6 +477,7 @@ pub fn chat_completions_filter_with_payment_gate<T, R, A>(
     router: Arc<R>,
     observer: Arc<dyn ObserveCallback>,
     payment_gate: Arc<dyn crate::mpp::PaymentGate>,
+    metadata_hook: crate::mpp::MetadataHook,
     account_filter: A,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone
 where
@@ -466,7 +489,9 @@ where
         .and(warp::post())
         .and(account_filter)
         .and(warp::any().map(move || payment_gate.clone()))
+        .and(warp::any().map(move || metadata_hook.clone()))
         .and(warp::header::optional::<String>("authorization"))
+        .and(warp::header::optional::<String>("origin"))
         .and(crate::body::json::<ChatCompletionRequest>())
         .and(warp::any().map(move || table.clone()))
         .and(warp::any().map(move || router.clone()))
@@ -474,20 +499,21 @@ where
         .and_then(
             |caller: CallerContext,
              gate: Arc<dyn crate::mpp::PaymentGate>,
+             metadata_hook: crate::mpp::MetadataHook,
              auth_header: Option<String>,
+             origin: Option<String>,
              request: ChatCompletionRequest,
              table: Arc<T>,
              router: Arc<R>,
              observer: Arc<dyn ObserveCallback>| {
-                handle_chat_completion_with_gate(
-                    caller,
+                let metadata = metadata_hook(&caller, &origin);
+                let gate_req = crate::mpp::GateRequest {
                     gate,
+                    request_id: generate_id(),
+                    metadata,
                     auth_header,
-                    request,
-                    table,
-                    router,
-                    observer,
-                )
+                };
+                handle_chat_completion_with_gate(caller, gate_req, request, table, router, observer)
             },
         )
 }
@@ -560,8 +586,12 @@ where
                         model: target_model_id,
                         caller,
                         latency_ms: start.elapsed().as_millis() as u64,
+                        request_id: String::new(),
+                        metadata: serde_json::Value::Null,
                     },
                     usage: result.usage.clone(),
+                    streamed: false,
+                    generation_time_ms: None,
                 };
                 tokio::spawn(async move { observer.on_request_success(event).await });
                 let response = convert::from_generate_result(&model_id, result);
@@ -575,6 +605,8 @@ where
                         model: target_model_id,
                         caller,
                         latency_ms: start.elapsed().as_millis() as u64,
+                        request_id: String::new(),
+                        metadata: serde_json::Value::Null,
                     },
                     error: e.clone(),
                 };
@@ -684,10 +716,17 @@ async fn handle_stream_with_observe(
             model: target_model,
             caller,
             latency_ms,
+            request_id: String::new(),
+            metadata: serde_json::Value::Null,
         };
         if let Some(usage) = usage {
             observer
-                .on_request_success(RequestSuccessEvent { ctx, usage })
+                .on_request_success(RequestSuccessEvent {
+                    ctx,
+                    usage,
+                    streamed: true,
+                    generation_time_ms: None,
+                })
                 .await;
         } else if client_disconnected {
             observer

--- a/bitrouter-api/src/router/openai/responses/filters.rs
+++ b/bitrouter-api/src/router/openai/responses/filters.rs
@@ -369,10 +369,17 @@ where
                 model: target_model_id,
                 caller,
                 latency_ms,
+                request_id: String::new(),
+                metadata: serde_json::Value::Null,
             };
             if let Some(usage) = usage {
                 observer
-                    .on_request_success(RequestSuccessEvent { ctx, usage })
+                    .on_request_success(RequestSuccessEvent {
+                        ctx,
+                        usage,
+                        streamed: true,
+                        generation_time_ms: None,
+                    })
                     .await;
             } else if client_disconnected {
                 observer
@@ -419,7 +426,7 @@ where
 
                 if micro_units > 0
                     && let Err(e) = payment_gate
-                        .deduct(&mpp_ctx.backend_key, &mpp_ctx.channel_id, micro_units)
+                        .deduct(&mpp_ctx.backend_key, &mpp_ctx.channel_id, micro_units, None)
                         .await
                 {
                     tracing::warn!(
@@ -437,8 +444,12 @@ where
                         model: target_model_id,
                         caller,
                         latency_ms: start.elapsed().as_millis() as u64,
+                        request_id: String::new(),
+                        metadata: serde_json::Value::Null,
                     },
                     usage: result.usage.clone(),
+                    streamed: false,
+                    generation_time_ms: None,
                 };
                 tokio::spawn(async move { observer.on_request_success(event).await });
 
@@ -463,6 +474,8 @@ where
                         model: target_model_id,
                         caller,
                         latency_ms: start.elapsed().as_millis() as u64,
+                        request_id: String::new(),
+                        metadata: serde_json::Value::Null,
                     },
                     error: e.clone(),
                 };
@@ -540,8 +553,12 @@ where
                         model: target_model_id,
                         caller,
                         latency_ms: start.elapsed().as_millis() as u64,
+                        request_id: String::new(),
+                        metadata: serde_json::Value::Null,
                     },
                     usage: result.usage.clone(),
+                    streamed: false,
+                    generation_time_ms: None,
                 };
                 tokio::spawn(async move { observer.on_request_success(event).await });
                 let response = convert::from_generate_result(&model_id, result);
@@ -555,6 +572,8 @@ where
                         model: target_model_id,
                         caller,
                         latency_ms: start.elapsed().as_millis() as u64,
+                        request_id: String::new(),
+                        metadata: serde_json::Value::Null,
                     },
                     error: e.clone(),
                 };
@@ -665,10 +684,17 @@ async fn handle_stream_with_observe(
             model: target_model,
             caller,
             latency_ms,
+            request_id: String::new(),
+            metadata: serde_json::Value::Null,
         };
         if let Some(usage) = usage {
             observer
-                .on_request_success(RequestSuccessEvent { ctx, usage })
+                .on_request_success(RequestSuccessEvent {
+                    ctx,
+                    usage,
+                    streamed: true,
+                    generation_time_ms: None,
+                })
                 .await;
         } else if client_disconnected {
             observer

--- a/bitrouter-core/src/observe.rs
+++ b/bitrouter-core/src/observe.rs
@@ -43,7 +43,7 @@ pub struct CallerContext {
 }
 
 /// Context about the request available to observation callbacks.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct RequestContext {
     /// The incoming model name (route key).
     pub route: String,
@@ -55,6 +55,15 @@ pub struct RequestContext {
     pub caller: CallerContext,
     /// End-to-end request latency in milliseconds.
     pub latency_ms: u64,
+    /// Correlation identifier assigned at ingress; used to join observability
+    /// events back to billing rows. Empty when the handler has no ID to
+    /// attach (e.g. zero-observability paths).
+    pub request_id: String,
+    /// Free-form metadata supplied by the host application via an ingress
+    /// hook (see `metadata_hook` on the gate-aware filters). Allows downstream
+    /// consumers to attach SDK- or deployment-specific context to receipts
+    /// without expanding `RequestContext` itself for every new field.
+    pub metadata: serde_json::Value,
 }
 
 /// Event emitted when a request completes successfully.
@@ -64,6 +73,12 @@ pub struct RequestSuccessEvent {
     pub ctx: RequestContext,
     /// Token usage reported by the model.
     pub usage: LanguageModelUsage,
+    /// Whether the response was streamed back to the client.
+    pub streamed: bool,
+    /// Time spent generating tokens, in milliseconds. `None` when the
+    /// generation phase is not separately measured (e.g. non-streaming
+    /// requests where end-to-end latency is the only signal available).
+    pub generation_time_ms: Option<u64>,
 }
 
 /// Event emitted when a request fails.

--- a/bitrouter-observe/src/metrics.rs
+++ b/bitrouter-observe/src/metrics.rs
@@ -438,6 +438,8 @@ mod tests {
             model: model.into(),
             caller: CallerContext::default(),
             latency_ms: 300,
+            request_id: String::new(),
+            metadata: serde_json::Value::Null,
         }
     }
 
@@ -473,6 +475,8 @@ mod tests {
             .on_request_success(RequestSuccessEvent {
                 ctx: test_ctx("fast", "openai", "gpt-4o-mini"),
                 usage: test_usage(100, 50),
+                streamed: false,
+                generation_time_ms: None,
             })
             .await;
 
@@ -504,6 +508,8 @@ mod tests {
                     model: "gpt-4o-mini".into(),
                     caller: CallerContext::default(),
                     latency_ms: 500,
+                    request_id: String::new(),
+                    metadata: serde_json::Value::Null,
                 },
                 error: bitrouter_core::errors::BitrouterError::transport(None, "timeout"),
             })
@@ -525,6 +531,8 @@ mod tests {
                 .on_request_success(RequestSuccessEvent {
                     ctx: test_ctx("fast", "openai", "gpt-4o-mini"),
                     usage: test_usage(50, 25),
+                    streamed: false,
+                    generation_time_ms: None,
                 })
                 .await;
         }
@@ -533,6 +541,8 @@ mod tests {
                 .on_request_success(RequestSuccessEvent {
                     ctx: test_ctx("fast", "anthropic", "claude-haiku"),
                     usage: test_usage(60, 30),
+                    streamed: false,
+                    generation_time_ms: None,
                 })
                 .await;
         }

--- a/bitrouter-observe/src/model_observer.rs
+++ b/bitrouter-observe/src/model_observer.rs
@@ -154,6 +154,8 @@ mod tests {
                 ..CallerContext::default()
             },
             latency_ms: 250,
+            request_id: String::new(),
+            metadata: serde_json::Value::Null,
         }
     }
 
@@ -178,6 +180,8 @@ mod tests {
                 },
                 raw: None,
             },
+            streamed: false,
+            generation_time_ms: None,
         };
 
         observer.on_request_success(event).await;


### PR DESCRIPTION
## Summary

Extends the observation surface so downstream observers (e.g. bitrouter-cloud's `ReceiptObserver`) can populate per-request billing/identity columns without re-deriving them from out-of-band sources.

## Changes

- **`bitrouter-core::observe`**
  - `RequestContext` gains `request_id: String` and `metadata: serde_json::Value`, plus a `Default` derive.
  - `RequestSuccessEvent` gains `streamed: bool` and `generation_time_ms: Option<u64>`.

- **`bitrouter-api::mpp`**
  - New `MetadataHook` type alias: `Arc<dyn Fn(&CallerContext, &Option<String>) -> serde_json::Value + Send + Sync>`.
  - New `GateRequest` bundle (gate handle + request_id + metadata + auth header) so payment-gated handlers stay within clippy's argument-count budget.
  - `PaymentGate::deduct` gains `request_id: Option<&'a str>` so custom gates can stamp the correlated request row in the same transaction.

- **Payment-gated filters** (`chat_completions_filter_with_payment_gate`, `messages_filter_with_payment_gate`)
  - Accept a `MetadataHook` and capture the `Origin` header.
  - Generate a correlation `request_id` per call (`generate_id()`), invoke the hook, and propagate both into `RequestContext` and the deduct call.

- **Workspace** bumped to `0.28.0`.

## Backward compatibility

- `RequestContext` / `RequestSuccessEvent` field additions are non-breaking for downstream code that constructs these via struct-update syntax with `..Default::default()`.
- `PaymentGate::deduct` adds a new required parameter — this is a breaking change for external implementors of the trait; existing in-tree callers (`MppState`, metered SSE) pass `None` to preserve current behaviour.
- The `*_with_mpp` filters (used by the `bitrouter` binary) construct a no-op `MetadataHook` internally, so binary behaviour is unchanged.

## Validation

- `cargo fmt -- --check` ✓
- `cargo clippy --workspace --all-features --all-targets` ✓ (no warnings)
- `cargo nextest run --all-features` ✓ (835/835)