### PR TITLE
fix(api): keep model SSE streams alive

### DIFF
--- a/bitrouter-api/Cargo.toml
+++ b/bitrouter-api/Cargo.toml
@@ -72,5 +72,5 @@ warp = { version = "0.4" }
 [dev-dependencies]
 regex = { version = "1.12" }
 tempfile = { version = "3" }
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "test-util"] }
 warp = { version = "0.4", features = ["test"] }

--- a/bitrouter-api/src/router/anthropic/messages/filters.rs
+++ b/bitrouter-api/src/router/anthropic/messages/filters.rs
@@ -21,6 +21,8 @@ use super::{convert, types::MessagesRequest};
 
 use crate::router::context::anthropic_messages;
 
+const SSE_KEEP_ALIVE_INTERVAL: std::time::Duration = std::time::Duration::from_secs(15);
+
 /// Creates a warp filter for the `/v1/messages` endpoint.
 ///
 /// This is the zero-observability variant. For spend tracking and metrics,
@@ -401,7 +403,7 @@ where
         });
 
         let sse_stream = tokio_stream::wrappers::ReceiverStream::new(rx);
-        let reply = warp::sse::reply(sse_stream);
+        let reply = sse_reply(sse_stream);
         if let Ok(receipt_header) = mpp::format_receipt(&mpp_ctx.receipt) {
             Ok(Box::new(warp::reply::with_header(
                 reply,
@@ -601,7 +603,7 @@ async fn handle_stream(
     });
 
     let sse_stream = tokio_stream::wrappers::ReceiverStream::new(rx);
-    Ok(Box::new(warp::sse::reply(sse_stream)))
+    Ok(Box::new(sse_reply(sse_stream)))
 }
 
 async fn handle_stream_with_observe(
@@ -698,5 +700,17 @@ async fn handle_stream_with_observe(
     });
 
     let sse_stream = tokio_stream::wrappers::ReceiverStream::new(rx);
-    Ok(Box::new(warp::sse::reply(sse_stream)))
+    Ok(Box::new(sse_reply(sse_stream)))
+}
+
+fn sse_reply<S>(sse_stream: S) -> impl warp::Reply
+where
+    S: futures_core::TryStream<Ok = warp::sse::Event> + Send + Sync + 'static,
+    S::Error: std::error::Error + Send + Sync + 'static,
+{
+    warp::sse::reply(
+        warp::sse::keep_alive()
+            .interval(SSE_KEEP_ALIVE_INTERVAL)
+            .stream(sse_stream),
+    )
 }

--- a/bitrouter-api/src/router/anthropic/messages/filters.rs
+++ b/bitrouter-api/src/router/anthropic/messages/filters.rs
@@ -21,8 +21,6 @@ use super::{convert, types::MessagesRequest};
 
 use crate::router::context::anthropic_messages;
 
-const SSE_KEEP_ALIVE_INTERVAL: std::time::Duration = std::time::Duration::from_secs(15);
-
 /// Creates a warp filter for the `/v1/messages` endpoint.
 ///
 /// This is the zero-observability variant. For spend tracking and metrics,
@@ -403,7 +401,7 @@ where
         });
 
         let sse_stream = tokio_stream::wrappers::ReceiverStream::new(rx);
-        let reply = sse_reply(sse_stream);
+        let reply = crate::router::sse::reply(sse_stream);
         if let Ok(receipt_header) = mpp::format_receipt(&mpp_ctx.receipt) {
             Ok(Box::new(warp::reply::with_header(
                 reply,
@@ -603,7 +601,7 @@ async fn handle_stream(
     });
 
     let sse_stream = tokio_stream::wrappers::ReceiverStream::new(rx);
-    Ok(Box::new(sse_reply(sse_stream)))
+    Ok(Box::new(crate::router::sse::reply(sse_stream)))
 }
 
 async fn handle_stream_with_observe(
@@ -700,17 +698,5 @@ async fn handle_stream_with_observe(
     });
 
     let sse_stream = tokio_stream::wrappers::ReceiverStream::new(rx);
-    Ok(Box::new(sse_reply(sse_stream)))
-}
-
-fn sse_reply<S>(sse_stream: S) -> impl warp::Reply
-where
-    S: futures_core::TryStream<Ok = warp::sse::Event> + Send + Sync + 'static,
-    S::Error: std::error::Error + Send + Sync + 'static,
-{
-    warp::sse::reply(
-        warp::sse::keep_alive()
-            .interval(SSE_KEEP_ALIVE_INTERVAL)
-            .stream(sse_stream),
-    )
+    Ok(Box::new(crate::router::sse::reply(sse_stream)))
 }

--- a/bitrouter-api/src/router/anthropic/messages/tests.rs
+++ b/bitrouter-api/src/router/anthropic/messages/tests.rs
@@ -67,6 +67,15 @@ impl LanguageModelRouter for MockToolStreamRouter {
     }
 }
 
+struct MockSlowStreamRouter;
+impl LanguageModelRouter for MockSlowStreamRouter {
+    async fn route_model(&self, target: RoutingTarget) -> Result<Box<DynLanguageModel<'static>>> {
+        Ok(DynLanguageModel::new_box(MockSlowStreamModel {
+            model_id: target.service_id,
+        }))
+    }
+}
+
 #[derive(Clone)]
 struct MockModel {
     model_id: String,
@@ -322,6 +331,69 @@ impl LanguageModel for MockToolStreamModel {
     }
 }
 
+#[derive(Clone)]
+struct MockSlowStreamModel {
+    model_id: String,
+}
+
+impl LanguageModel for MockSlowStreamModel {
+    fn provider_name(&self) -> &str {
+        "mock"
+    }
+    fn model_id(&self) -> &str {
+        &self.model_id
+    }
+    async fn supported_urls(&self) -> HashMap<String, Regex> {
+        HashMap::new()
+    }
+    async fn generate(
+        &self,
+        _options: LanguageModelCallOptions,
+    ) -> Result<LanguageModelGenerateResult> {
+        Ok(LanguageModelGenerateResult {
+            content: vec![LanguageModelContent::Text {
+                text: "slow stream fallback".to_owned(),
+                provider_metadata: None,
+            }],
+            finish_reason: LanguageModelFinishReason::Stop,
+            usage: mock_usage(),
+            provider_metadata: None,
+            request: None,
+            response_metadata: None,
+            warnings: None,
+        })
+    }
+    async fn stream(
+        &self,
+        _options: LanguageModelCallOptions,
+    ) -> Result<LanguageModelStreamResult> {
+        let (tx, rx) = tokio::sync::mpsc::channel(8);
+        tokio::spawn(async move {
+            let _ = tx
+                .send(LanguageModelStreamPart::TextDelta {
+                    id: "0".to_owned(),
+                    delta: "Hello".to_owned(),
+                    provider_metadata: None,
+                })
+                .await;
+            tokio::time::sleep(std::time::Duration::from_secs(16)).await;
+            let _ = tx
+                .send(LanguageModelStreamPart::Finish {
+                    usage: mock_usage(),
+                    finish_reason: LanguageModelFinishReason::Stop,
+                    provider_metadata: None,
+                })
+                .await;
+        });
+
+        Ok(LanguageModelStreamResult {
+            stream: Box::pin(tokio_stream::wrappers::ReceiverStream::new(rx)),
+            request: None,
+            response: None,
+        })
+    }
+}
+
 fn parse_sse_body(body: &[u8]) -> Vec<(Option<String>, String)> {
     String::from_utf8_lossy(body)
         .replace("\r\n", "\n")
@@ -458,6 +530,41 @@ async fn messages_streaming_sends_sse_events() {
 
     assert_eq!(events[2].0, None);
     assert_eq!(events[2].1, "[DONE]");
+}
+
+#[tokio::test(start_paused = true)]
+async fn messages_streaming_sends_keep_alive_comments_during_idle_gap() {
+    let table = Arc::new(MockTable);
+    let router = Arc::new(MockSlowStreamRouter);
+    let filter = messages_filter(table, router);
+
+    let body = serde_json::json!({
+        "model": "claude-3-5-sonnet-20241022",
+        "max_tokens": 1024,
+        "stream": true,
+        "messages": [
+            {"role": "user", "content": "Hello"}
+        ]
+    });
+
+    let res = warp::test::request()
+        .method("POST")
+        .path("/v1/messages")
+        .json(&body)
+        .reply(&filter)
+        .await;
+
+    assert_eq!(res.status(), 200);
+    assert_eq!(res.headers()["content-type"], "text/event-stream");
+
+    let raw_body = String::from_utf8_lossy(res.body());
+    assert!(
+        raw_body.contains(":\n\n"),
+        "expected downstream SSE keep-alive comment in body: {raw_body}"
+    );
+
+    let events = parse_sse_body(res.body());
+    assert_eq!(events.last().map(|(_, data)| data.as_str()), Some("[DONE]"));
 }
 
 #[tokio::test]

--- a/bitrouter-api/src/router/google/generate_content/filters.rs
+++ b/bitrouter-api/src/router/google/generate_content/filters.rs
@@ -349,7 +349,7 @@ where
         });
 
         let sse_stream = tokio_stream::wrappers::ReceiverStream::new(rx);
-        let reply = warp::sse::reply(sse_stream);
+        let reply = crate::router::sse::reply(sse_stream);
         if let Ok(receipt_header) = mpp::format_receipt(&mpp_ctx.receipt) {
             Ok(Box::new(warp::reply::with_header(
                 reply,
@@ -550,7 +550,7 @@ async fn handle_stream(
     });
 
     let sse_stream = tokio_stream::wrappers::ReceiverStream::new(rx);
-    Ok(Box::new(warp::sse::reply(sse_stream)))
+    Ok(Box::new(crate::router::sse::reply(sse_stream)))
 }
 
 async fn handle_stream_with_observe(
@@ -643,5 +643,5 @@ async fn handle_stream_with_observe(
     });
 
     let sse_stream = tokio_stream::wrappers::ReceiverStream::new(rx);
-    Ok(Box::new(warp::sse::reply(sse_stream)))
+    Ok(Box::new(crate::router::sse::reply(sse_stream)))
 }

--- a/bitrouter-api/src/router/mod.rs
+++ b/bitrouter-api/src/router/mod.rs
@@ -8,6 +8,7 @@ pub mod mcp;
 pub mod models;
 pub mod openai;
 pub mod routes;
+pub(crate) mod sse;
 pub mod tools;
 
 mod observe_ctx {

--- a/bitrouter-api/src/router/openai/chat/filters.rs
+++ b/bitrouter-api/src/router/openai/chat/filters.rs
@@ -337,7 +337,7 @@ where
         });
 
         let sse_stream = tokio_stream::wrappers::ReceiverStream::new(rx);
-        let reply = warp::sse::reply(sse_stream);
+        let reply = crate::router::sse::reply(sse_stream);
         if let Ok(receipt_header) = mpp::format_receipt(&mpp_ctx.receipt) {
             Ok(Box::new(warp::reply::with_header(
                 reply,
@@ -620,7 +620,7 @@ async fn handle_stream(
     });
 
     let sse_stream = tokio_stream::wrappers::ReceiverStream::new(rx);
-    Ok(Box::new(warp::sse::reply(sse_stream)))
+    Ok(Box::new(crate::router::sse::reply(sse_stream)))
 }
 
 async fn handle_stream_with_observe(
@@ -714,7 +714,7 @@ async fn handle_stream_with_observe(
     });
 
     let sse_stream = tokio_stream::wrappers::ReceiverStream::new(rx);
-    Ok(Box::new(warp::sse::reply(sse_stream)))
+    Ok(Box::new(crate::router::sse::reply(sse_stream)))
 }
 
 /// Creates a rejection handler that converts [`BitrouterRejection`] and [`BadRequest`]

--- a/bitrouter-api/src/router/openai/responses/filters.rs
+++ b/bitrouter-api/src/router/openai/responses/filters.rs
@@ -399,7 +399,7 @@ where
         });
 
         let sse_stream = tokio_stream::wrappers::ReceiverStream::new(rx);
-        let reply = warp::sse::reply(sse_stream);
+        let reply = crate::router::sse::reply(sse_stream);
         if let Ok(receipt_header) = mpp::format_receipt(&mpp_ctx.receipt) {
             Ok(Box::new(warp::reply::with_header(
                 reply,
@@ -598,7 +598,7 @@ async fn handle_stream(
     });
 
     let sse_stream = tokio_stream::wrappers::ReceiverStream::new(rx);
-    Ok(Box::new(warp::sse::reply(sse_stream)))
+    Ok(Box::new(crate::router::sse::reply(sse_stream)))
 }
 
 async fn handle_stream_with_observe(
@@ -695,5 +695,5 @@ async fn handle_stream_with_observe(
     });
 
     let sse_stream = tokio_stream::wrappers::ReceiverStream::new(rx);
-    Ok(Box::new(warp::sse::reply(sse_stream)))
+    Ok(Box::new(crate::router::sse::reply(sse_stream)))
 }

--- a/bitrouter-api/src/router/sse.rs
+++ b/bitrouter-api/src/router/sse.rs
@@ -1,0 +1,15 @@
+use std::time::Duration;
+
+const KEEP_ALIVE_INTERVAL: Duration = Duration::from_secs(15);
+
+pub(crate) fn reply<S>(sse_stream: S) -> impl warp::Reply
+where
+    S: futures_core::TryStream<Ok = warp::sse::Event> + Send + Sync + 'static,
+    S::Error: std::error::Error + Send + Sync + 'static,
+{
+    warp::sse::reply(
+        warp::sse::keep_alive()
+            .interval(KEEP_ALIVE_INTERVAL)
+            .stream(sse_stream),
+    )
+}


### PR DESCRIPTION
## Summary

- Wrap all model streaming SSE replies with a shared `bitrouter-api` keepalive helper so downstream clients receive comment frames during idle semantic gaps.
- Applies to Anthropic Messages, OpenAI Chat Completions, OpenAI Responses, and Google GenerateContent streaming responses.
- Add a paused-time Anthropic regression test that simulates a slow stream and asserts a downstream keepalive comment is emitted before `[DONE]`.

Fixes #422

## Validation

- `cargo test -p bitrouter-api --features payments-tempo,payments-solana`
- `cargo fmt --all -- --check`
- `cargo clippy -p bitrouter-api --features payments-tempo,payments-solana`
