### PR TITLE
feat(observe)!: add request_id, metadata, streamed to events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1647,6 +1647,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+ "uuid",
  "warp",
 ]
 

--- a/bitrouter-api/Cargo.toml
+++ b/bitrouter-api/Cargo.toml
@@ -67,6 +67,7 @@ time = { version = "0.3", features = [
 tokio = { version = "1", features = ["macros", "rt", "sync"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tracing = { version = "0.1" }
+uuid = { version = "1", features = ["v4"] }
 warp = { version = "0.4" }
 
 [dev-dependencies]

--- a/bitrouter-api/src/mpp/gate_context.rs
+++ b/bitrouter-api/src/mpp/gate_context.rs
@@ -1,0 +1,21 @@
+//! Shared per-request context for `_with_payment_gate` / `_with_mpp` handlers.
+
+use std::sync::Arc;
+
+use bitrouter_core::observe::{CallerContext, MetadataHook, ObserveCallback};
+
+use super::PaymentGate;
+
+/// Bundled request-scoped state passed into `handle_*_with_gate` helpers.
+///
+/// Bundling these here keeps the per-handler signatures under
+/// clippy's `too_many_arguments` threshold while still making the
+/// individual fields directly accessible inside handlers.
+pub struct GateContext {
+    pub caller: CallerContext,
+    pub payment_gate: Arc<dyn PaymentGate>,
+    pub auth_header: Option<String>,
+    pub observer: Arc<dyn ObserveCallback>,
+    pub metadata_hook: MetadataHook,
+    pub origin: Option<String>,
+}

--- a/bitrouter-api/src/mpp/metered_sse.rs
+++ b/bitrouter-api/src/mpp/metered_sse.rs
@@ -29,6 +29,8 @@ pub struct MeteredSseContext {
     pub backend_key: String,
     pub channel_id: String,
     pub tick_cost: u128,
+    /// Optional stable correlation id for the request this stream serves.
+    pub request_id: Option<String>,
 }
 
 impl MeteredSseContext {
@@ -49,7 +51,12 @@ impl MeteredSseContext {
         for _ in 0..MAX_NEED_VOUCHER_RETRIES {
             match self
                 .payment_gate
-                .deduct(&self.backend_key, &self.channel_id, self.tick_cost)
+                .deduct(
+                    &self.backend_key,
+                    &self.channel_id,
+                    self.tick_cost,
+                    self.request_id.as_deref(),
+                )
                 .await
             {
                 Ok(()) => return true,

--- a/bitrouter-api/src/mpp/mod.rs
+++ b/bitrouter-api/src/mpp/mod.rs
@@ -1,5 +1,6 @@
 mod close_guard;
 mod filter;
+mod gate_context;
 pub mod metered_sse;
 mod payment_gate;
 mod pricing;
@@ -19,6 +20,7 @@ pub use filter::{
     MppChallenge, MppPaymentContext, MppVerificationFailed, handle_mpp_rejection,
     mpp_payment_filter, verify_mpp_payment,
 };
+pub use gate_context::GateContext;
 pub use payment_gate::PaymentGate;
 pub use pricing::{PricingLookup, calculate_usage_cost, cost_to_micro_units};
 pub use state::MppState;

--- a/bitrouter-api/src/mpp/payment_gate.rs
+++ b/bitrouter-api/src/mpp/payment_gate.rs
@@ -33,11 +33,17 @@ pub trait PaymentGate: Send + Sync {
     ///
     /// For session-based flows this debits from the payment channel store.
     /// Custom implementations may debit from a centralized balance instead.
+    ///
+    /// `request_id` is the upstream-generated correlation ID for the
+    /// request that triggered this deduction. It is `None` for streaming
+    /// per-tick deductions where receipts are not tracked at the request
+    /// level. Implementations that don't track receipts may ignore it.
     fn deduct<'a>(
         &'a self,
         backend_key: &'a str,
         channel_id: &'a str,
         amount: u128,
+        request_id: Option<&'a str>,
     ) -> GateFuture<'a, Result<(), mpp::server::VerificationError>>;
 
     /// Wait for the next channel update on the given backend.
@@ -86,8 +92,9 @@ impl PaymentGate for Arc<dyn PaymentGate> {
         backend_key: &'a str,
         channel_id: &'a str,
         amount: u128,
+        request_id: Option<&'a str>,
     ) -> GateFuture<'a, Result<(), mpp::server::VerificationError>> {
-        (**self).deduct(backend_key, channel_id, amount)
+        (**self).deduct(backend_key, channel_id, amount, request_id)
     }
 
     fn wait_for_update<'a>(

--- a/bitrouter-api/src/mpp/state.rs
+++ b/bitrouter-api/src/mpp/state.rs
@@ -637,6 +637,7 @@ impl super::payment_gate::PaymentGate for MppState {
         backend_key: &'a str,
         channel_id: &'a str,
         amount: u128,
+        request_id: Option<&'a str>,
     ) -> std::pin::Pin<
         Box<
             dyn std::future::Future<Output = Result<(), mpp::server::VerificationError>>
@@ -644,6 +645,7 @@ impl super::payment_gate::PaymentGate for MppState {
                 + 'a,
         >,
     > {
+        let _ = request_id;
         Box::pin(self.deduct(backend_key, channel_id, amount))
     }
 

--- a/bitrouter-api/src/router/anthropic/messages/filters.rs
+++ b/bitrouter-api/src/router/anthropic/messages/filters.rs
@@ -3,6 +3,8 @@
 use std::sync::Arc;
 use std::time::Instant;
 
+#[cfg(any(feature = "payments-tempo", feature = "payments-solana"))]
+use bitrouter_core::observe::MetadataHook;
 use bitrouter_core::{
     auth::access::is_model_allowed,
     errors::BitrouterError,
@@ -178,6 +180,7 @@ pub fn messages_filter_with_payment_gate<T, R, A>(
     router: Arc<R>,
     observer: Arc<dyn ObserveCallback>,
     payment_gate: Arc<dyn crate::mpp::PaymentGate>,
+    metadata_hook: MetadataHook,
     account_filter: A,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone
 where
@@ -190,27 +193,31 @@ where
         .and(account_filter)
         .and(warp::any().map(move || payment_gate.clone()))
         .and(warp::header::optional::<String>("authorization"))
+        .and(warp::header::optional::<String>("origin"))
         .and(crate::body::json::<MessagesRequest>())
         .and(warp::any().map(move || table.clone()))
         .and(warp::any().map(move || router.clone()))
         .and(warp::any().map(move || observer.clone()))
+        .and(warp::any().map(move || metadata_hook.clone()))
         .and_then(
             |caller: CallerContext,
              gate: Arc<dyn crate::mpp::PaymentGate>,
              auth_header: Option<String>,
+             origin: Option<String>,
              request: MessagesRequest,
              table: Arc<T>,
              router: Arc<R>,
-             observer: Arc<dyn ObserveCallback>| {
-                handle_messages_with_gate(
+             observer: Arc<dyn ObserveCallback>,
+             metadata_hook: MetadataHook| {
+                let gate_ctx = crate::mpp::GateContext {
                     caller,
-                    gate,
+                    payment_gate: gate,
                     auth_header,
-                    request,
-                    table,
-                    router,
                     observer,
-                )
+                    metadata_hook,
+                    origin,
+                };
+                handle_messages_with_gate(gate_ctx, request, table, router)
             },
         )
 }
@@ -230,32 +237,36 @@ where
     R: LanguageModelRouter + Send + Sync + 'static,
 {
     let payment_gate: Arc<dyn crate::mpp::PaymentGate> = mpp_state;
-    handle_messages_with_gate(
+    let gate_ctx = crate::mpp::GateContext {
         caller,
         payment_gate,
         auth_header,
-        request,
-        table,
-        router,
         observer,
-    )
-    .await
+        metadata_hook: bitrouter_core::observe::default_metadata_hook(),
+        origin: None,
+    };
+    handle_messages_with_gate(gate_ctx, request, table, router).await
 }
 
 #[cfg(any(feature = "payments-tempo", feature = "payments-solana"))]
 async fn handle_messages_with_gate<T, R>(
-    caller: CallerContext,
-    payment_gate: Arc<dyn crate::mpp::PaymentGate>,
-    auth_header: Option<String>,
+    gate_ctx: crate::mpp::GateContext,
     request: MessagesRequest,
     table: Arc<T>,
     router: Arc<R>,
-    observer: Arc<dyn ObserveCallback>,
 ) -> Result<Box<dyn warp::Reply>, warp::Rejection>
 where
     T: RoutingTable + crate::mpp::PricingLookup + Send + Sync + 'static,
     R: LanguageModelRouter + Send + Sync + 'static,
 {
+    let crate::mpp::GateContext {
+        caller,
+        payment_gate,
+        auth_header,
+        observer,
+        metadata_hook,
+        origin,
+    } = gate_ctx;
     let mpp_ctx = payment_gate
         .verify_payment(caller.chain.clone(), auth_header)
         .await?;
@@ -302,6 +313,8 @@ where
     let model_id = model.model_id().to_owned();
     let options = convert::to_call_options(request);
     let start = Instant::now();
+    let request_id = uuid::Uuid::new_v4().to_string();
+    let metadata = metadata_hook(&caller, &origin);
 
     if is_stream {
         let stream_result = model
@@ -322,6 +335,7 @@ where
             backend_key: mpp_ctx.backend_key.clone(),
             channel_id: mpp_ctx.channel_id.clone(),
             tick_cost,
+            request_id: Some(request_id.clone()),
         };
 
         tokio::spawn(async move {
@@ -371,10 +385,17 @@ where
                 model: target_model_id,
                 caller,
                 latency_ms,
+                request_id,
+                metadata,
             };
             if let Some(usage) = usage {
                 observer
-                    .on_request_success(RequestSuccessEvent { ctx, usage })
+                    .on_request_success(RequestSuccessEvent {
+                        ctx,
+                        usage,
+                        streamed: true,
+                        generation_time_ms: None,
+                    })
                     .await;
             } else if client_disconnected {
                 observer
@@ -421,7 +442,12 @@ where
 
                 if micro_units > 0
                     && let Err(e) = payment_gate
-                        .deduct(&mpp_ctx.backend_key, &mpp_ctx.channel_id, micro_units)
+                        .deduct(
+                            &mpp_ctx.backend_key,
+                            &mpp_ctx.channel_id,
+                            micro_units,
+                            Some(request_id.as_str()),
+                        )
                         .await
                 {
                     tracing::warn!(
@@ -439,8 +465,12 @@ where
                         model: target_model_id,
                         caller,
                         latency_ms: start.elapsed().as_millis() as u64,
+                        request_id,
+                        metadata,
                     },
                     usage: result.usage.clone(),
+                    streamed: false,
+                    generation_time_ms: None,
                 };
                 tokio::spawn(async move { observer.on_request_success(event).await });
 
@@ -465,6 +495,8 @@ where
                         model: target_model_id,
                         caller,
                         latency_ms: start.elapsed().as_millis() as u64,
+                        request_id,
+                        metadata,
                     },
                     error: e.clone(),
                 };
@@ -528,6 +560,8 @@ where
                 target_model: target_model_id,
                 caller,
                 start,
+                request_id: uuid::Uuid::new_v4().to_string(),
+                metadata: serde_json::Value::Null,
             },
         )
         .await
@@ -542,8 +576,12 @@ where
                         model: target_model_id,
                         caller,
                         latency_ms: start.elapsed().as_millis() as u64,
+                        request_id: uuid::Uuid::new_v4().to_string(),
+                        metadata: serde_json::Value::Null,
                     },
                     usage: result.usage.clone(),
+                    streamed: false,
+                    generation_time_ms: None,
                 };
                 tokio::spawn(async move { observer.on_request_success(event).await });
                 let response = convert::from_generate_result(&model_id, result);
@@ -557,6 +595,8 @@ where
                         model: target_model_id,
                         caller,
                         latency_ms: start.elapsed().as_millis() as u64,
+                        request_id: uuid::Uuid::new_v4().to_string(),
+                        metadata: serde_json::Value::Null,
                     },
                     error: e.clone(),
                 };
@@ -624,6 +664,8 @@ async fn handle_stream_with_observe(
         target_model,
         caller,
         start,
+        request_id,
+        metadata,
     } = ctx;
 
     tokio::spawn(async move {
@@ -668,10 +710,17 @@ async fn handle_stream_with_observe(
             model: target_model,
             caller,
             latency_ms,
+            request_id,
+            metadata,
         };
         if let Some(usage) = usage {
             observer
-                .on_request_success(RequestSuccessEvent { ctx, usage })
+                .on_request_success(RequestSuccessEvent {
+                    ctx,
+                    usage,
+                    streamed: true,
+                    generation_time_ms: None,
+                })
                 .await;
         } else if client_disconnected {
             observer

--- a/bitrouter-api/src/router/google/generate_content/filters.rs
+++ b/bitrouter-api/src/router/google/generate_content/filters.rs
@@ -258,6 +258,7 @@ where
     let model_id = model.model_id().to_owned();
     let options = convert::to_call_options(request);
     let start = Instant::now();
+    let request_id = uuid::Uuid::new_v4().to_string();
 
     if is_stream {
         let stream_result = model
@@ -278,6 +279,7 @@ where
             backend_key: mpp_ctx.backend_key.clone(),
             channel_id: mpp_ctx.channel_id.clone(),
             tick_cost,
+            request_id: Some(request_id.clone()),
         };
 
         tokio::spawn(async move {
@@ -319,10 +321,17 @@ where
                 model: target_model_id,
                 caller,
                 latency_ms,
+                request_id,
+                metadata: serde_json::Value::Null,
             };
             if let Some(usage) = usage {
                 observer
-                    .on_request_success(RequestSuccessEvent { ctx, usage })
+                    .on_request_success(RequestSuccessEvent {
+                        ctx,
+                        usage,
+                        streamed: true,
+                        generation_time_ms: None,
+                    })
                     .await;
             } else if client_disconnected {
                 observer
@@ -369,7 +378,12 @@ where
 
                 if micro_units > 0
                     && let Err(e) = payment_gate
-                        .deduct(&mpp_ctx.backend_key, &mpp_ctx.channel_id, micro_units)
+                        .deduct(
+                            &mpp_ctx.backend_key,
+                            &mpp_ctx.channel_id,
+                            micro_units,
+                            Some(request_id.as_str()),
+                        )
                         .await
                 {
                     tracing::warn!(
@@ -387,8 +401,12 @@ where
                         model: target_model_id,
                         caller,
                         latency_ms: start.elapsed().as_millis() as u64,
+                        request_id,
+                        metadata: serde_json::Value::Null,
                     },
                     usage: result.usage.clone(),
+                    streamed: false,
+                    generation_time_ms: None,
                 };
                 tokio::spawn(async move { observer.on_request_success(event).await });
 
@@ -413,6 +431,8 @@ where
                         model: target_model_id,
                         caller,
                         latency_ms: start.elapsed().as_millis() as u64,
+                        request_id,
+                        metadata: serde_json::Value::Null,
                     },
                     error: e.clone(),
                 };
@@ -477,6 +497,8 @@ where
                 target_model: target_model_id,
                 caller,
                 start,
+                request_id: uuid::Uuid::new_v4().to_string(),
+                metadata: serde_json::Value::Null,
             },
         )
         .await
@@ -491,8 +513,12 @@ where
                         model: target_model_id,
                         caller,
                         latency_ms: start.elapsed().as_millis() as u64,
+                        request_id: uuid::Uuid::new_v4().to_string(),
+                        metadata: serde_json::Value::Null,
                     },
                     usage: result.usage.clone(),
+                    streamed: false,
+                    generation_time_ms: None,
                 };
                 tokio::spawn(async move { observer.on_request_success(event).await });
                 let response = convert::from_generate_result(&model_id, result);
@@ -506,6 +532,8 @@ where
                         model: target_model_id,
                         caller,
                         latency_ms: start.elapsed().as_millis() as u64,
+                        request_id: uuid::Uuid::new_v4().to_string(),
+                        metadata: serde_json::Value::Null,
                     },
                     error: e.clone(),
                 };
@@ -576,6 +604,8 @@ async fn handle_stream_with_observe(
         target_model,
         caller,
         start,
+        request_id,
+        metadata,
     } = ctx;
 
     tokio::spawn(async move {
@@ -613,10 +643,17 @@ async fn handle_stream_with_observe(
             model: target_model,
             caller,
             latency_ms,
+            request_id,
+            metadata,
         };
         if let Some(usage) = usage {
             observer
-                .on_request_success(RequestSuccessEvent { ctx, usage })
+                .on_request_success(RequestSuccessEvent {
+                    ctx,
+                    usage,
+                    streamed: true,
+                    generation_time_ms: None,
+                })
                 .await;
         } else if client_disconnected {
             observer

--- a/bitrouter-api/src/router/mod.rs
+++ b/bitrouter-api/src/router/mod.rs
@@ -28,6 +28,10 @@ mod observe_ctx {
         pub target_model: String,
         pub caller: CallerContext,
         pub start: Instant,
+        /// Stable per-request correlation id.
+        pub request_id: String,
+        /// Opaque per-request metadata (see [`bitrouter_core::observe::MetadataHook`]).
+        pub metadata: serde_json::Value,
     }
 }
 

--- a/bitrouter-api/src/router/openai/chat/filters.rs
+++ b/bitrouter-api/src/router/openai/chat/filters.rs
@@ -3,6 +3,8 @@
 use std::sync::Arc;
 use std::time::Instant;
 
+#[cfg(any(feature = "payments-tempo", feature = "payments-solana"))]
+use bitrouter_core::observe::MetadataHook;
 use bitrouter_core::{
     auth::access::is_model_allowed,
     errors::BitrouterError,
@@ -159,32 +161,37 @@ where
     R: LanguageModelRouter + Send + Sync + 'static,
 {
     let payment_gate: Arc<dyn crate::mpp::PaymentGate> = mpp_state;
-    handle_chat_completion_with_gate(
+    let gate_ctx = crate::mpp::GateContext {
         caller,
         payment_gate,
         auth_header,
-        request,
-        table,
-        router,
         observer,
-    )
-    .await
+        metadata_hook: bitrouter_core::observe::default_metadata_hook(),
+        origin: None,
+    };
+    handle_chat_completion_with_gate(gate_ctx, request, table, router).await
 }
 
 #[cfg(any(feature = "payments-tempo", feature = "payments-solana"))]
 async fn handle_chat_completion_with_gate<T, R>(
-    caller: CallerContext,
-    payment_gate: Arc<dyn crate::mpp::PaymentGate>,
-    auth_header: Option<String>,
+    gate_ctx: crate::mpp::GateContext,
     request: ChatCompletionRequest,
     table: Arc<T>,
     router: Arc<R>,
-    observer: Arc<dyn ObserveCallback>,
 ) -> Result<Box<dyn warp::Reply>, warp::Rejection>
 where
     T: RoutingTable + crate::mpp::PricingLookup + Send + Sync + 'static,
     R: LanguageModelRouter + Send + Sync + 'static,
 {
+    let crate::mpp::GateContext {
+        caller,
+        payment_gate,
+        auth_header,
+        observer,
+        metadata_hook,
+        origin,
+    } = gate_ctx;
+
     let mpp_ctx = payment_gate
         .verify_payment(caller.chain.clone(), auth_header)
         .await?;
@@ -240,6 +247,8 @@ where
     let model_id = model.model_id().to_owned();
     let options = convert::to_call_options(request);
     let start = Instant::now();
+    let request_id = uuid::Uuid::new_v4().to_string();
+    let metadata = metadata_hook(&caller, &origin);
 
     if is_stream {
         let stream_result = model
@@ -262,6 +271,7 @@ where
             backend_key: mpp_ctx.backend_key.clone(),
             channel_id: mpp_ctx.channel_id.clone(),
             tick_cost,
+            request_id: Some(request_id.clone()),
         };
 
         tokio::spawn(async move {
@@ -307,10 +317,17 @@ where
                 model: target_model_id,
                 caller,
                 latency_ms,
+                request_id,
+                metadata,
             };
             if let Some(usage) = usage {
                 observer
-                    .on_request_success(RequestSuccessEvent { ctx, usage })
+                    .on_request_success(RequestSuccessEvent {
+                        ctx,
+                        usage,
+                        streamed: true,
+                        generation_time_ms: None,
+                    })
                     .await;
             } else if client_disconnected {
                 observer
@@ -358,7 +375,12 @@ where
 
                 if micro_units > 0
                     && let Err(e) = payment_gate
-                        .deduct(&mpp_ctx.backend_key, &mpp_ctx.channel_id, micro_units)
+                        .deduct(
+                            &mpp_ctx.backend_key,
+                            &mpp_ctx.channel_id,
+                            micro_units,
+                            Some(request_id.as_str()),
+                        )
                         .await
                 {
                     tracing::warn!(
@@ -376,8 +398,12 @@ where
                         model: target_model_id,
                         caller,
                         latency_ms: start.elapsed().as_millis() as u64,
+                        request_id,
+                        metadata,
                     },
                     usage: result.usage.clone(),
+                    streamed: false,
+                    generation_time_ms: None,
                 };
                 tokio::spawn(async move { observer.on_request_success(event).await });
 
@@ -402,6 +428,8 @@ where
                         model: target_model_id,
                         caller,
                         latency_ms: start.elapsed().as_millis() as u64,
+                        request_id,
+                        metadata,
                     },
                     error: e.clone(),
                 };
@@ -455,6 +483,7 @@ pub fn chat_completions_filter_with_payment_gate<T, R, A>(
     router: Arc<R>,
     observer: Arc<dyn ObserveCallback>,
     payment_gate: Arc<dyn crate::mpp::PaymentGate>,
+    metadata_hook: MetadataHook,
     account_filter: A,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone
 where
@@ -467,27 +496,31 @@ where
         .and(account_filter)
         .and(warp::any().map(move || payment_gate.clone()))
         .and(warp::header::optional::<String>("authorization"))
+        .and(warp::header::optional::<String>("origin"))
         .and(crate::body::json::<ChatCompletionRequest>())
         .and(warp::any().map(move || table.clone()))
         .and(warp::any().map(move || router.clone()))
         .and(warp::any().map(move || observer.clone()))
+        .and(warp::any().map(move || metadata_hook.clone()))
         .and_then(
             |caller: CallerContext,
              gate: Arc<dyn crate::mpp::PaymentGate>,
              auth_header: Option<String>,
+             origin: Option<String>,
              request: ChatCompletionRequest,
              table: Arc<T>,
              router: Arc<R>,
-             observer: Arc<dyn ObserveCallback>| {
-                handle_chat_completion_with_gate(
+             observer: Arc<dyn ObserveCallback>,
+             metadata_hook: MetadataHook| {
+                let gate_ctx = crate::mpp::GateContext {
                     caller,
-                    gate,
+                    payment_gate: gate,
                     auth_header,
-                    request,
-                    table,
-                    router,
                     observer,
-                )
+                    metadata_hook,
+                    origin,
+                };
+                handle_chat_completion_with_gate(gate_ctx, request, table, router)
             },
         )
 }
@@ -546,6 +579,8 @@ where
                 target_model: target_model_id,
                 caller,
                 start,
+                request_id: uuid::Uuid::new_v4().to_string(),
+                metadata: serde_json::Value::Null,
             },
         )
         .await
@@ -560,8 +595,12 @@ where
                         model: target_model_id,
                         caller,
                         latency_ms: start.elapsed().as_millis() as u64,
+                        request_id: uuid::Uuid::new_v4().to_string(),
+                        metadata: serde_json::Value::Null,
                     },
                     usage: result.usage.clone(),
+                    streamed: false,
+                    generation_time_ms: None,
                 };
                 tokio::spawn(async move { observer.on_request_success(event).await });
                 let response = convert::from_generate_result(&model_id, result);
@@ -575,6 +614,8 @@ where
                         model: target_model_id,
                         caller,
                         latency_ms: start.elapsed().as_millis() as u64,
+                        request_id: uuid::Uuid::new_v4().to_string(),
+                        metadata: serde_json::Value::Null,
                     },
                     error: e.clone(),
                 };
@@ -647,6 +688,8 @@ async fn handle_stream_with_observe(
         target_model,
         caller,
         start,
+        request_id,
+        metadata,
     } = ctx;
 
     tokio::spawn(async move {
@@ -684,10 +727,17 @@ async fn handle_stream_with_observe(
             model: target_model,
             caller,
             latency_ms,
+            request_id,
+            metadata,
         };
         if let Some(usage) = usage {
             observer
-                .on_request_success(RequestSuccessEvent { ctx, usage })
+                .on_request_success(RequestSuccessEvent {
+                    ctx,
+                    usage,
+                    streamed: true,
+                    generation_time_ms: None,
+                })
                 .await;
         } else if client_disconnected {
             observer

--- a/bitrouter-api/src/router/openai/responses/filters.rs
+++ b/bitrouter-api/src/router/openai/responses/filters.rs
@@ -3,6 +3,8 @@
 use std::sync::Arc;
 use std::time::Instant;
 
+#[cfg(any(feature = "payments-tempo", feature = "payments-solana"))]
+use bitrouter_core::observe::MetadataHook;
 use bitrouter_core::{
     auth::access::is_model_allowed,
     errors::BitrouterError,
@@ -176,6 +178,7 @@ pub fn responses_filter_with_payment_gate<T, R, A>(
     router: Arc<R>,
     observer: Arc<dyn ObserveCallback>,
     payment_gate: Arc<dyn crate::mpp::PaymentGate>,
+    metadata_hook: MetadataHook,
     account_filter: A,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone
 where
@@ -188,27 +191,31 @@ where
         .and(account_filter)
         .and(warp::any().map(move || payment_gate.clone()))
         .and(warp::header::optional::<String>("authorization"))
+        .and(warp::header::optional::<String>("origin"))
         .and(crate::body::json::<ResponsesRequest>())
         .and(warp::any().map(move || table.clone()))
         .and(warp::any().map(move || router.clone()))
         .and(warp::any().map(move || observer.clone()))
+        .and(warp::any().map(move || metadata_hook.clone()))
         .and_then(
             |caller: CallerContext,
              gate: Arc<dyn crate::mpp::PaymentGate>,
              auth_header: Option<String>,
+             origin: Option<String>,
              request: ResponsesRequest,
              table: Arc<T>,
              router: Arc<R>,
-             observer: Arc<dyn ObserveCallback>| {
-                handle_responses_with_gate(
+             observer: Arc<dyn ObserveCallback>,
+             metadata_hook: MetadataHook| {
+                let gate_ctx = crate::mpp::GateContext {
                     caller,
-                    gate,
+                    payment_gate: gate,
                     auth_header,
-                    request,
-                    table,
-                    router,
                     observer,
-                )
+                    metadata_hook,
+                    origin,
+                };
+                handle_responses_with_gate(gate_ctx, request, table, router)
             },
         )
 }
@@ -228,32 +235,36 @@ where
     R: LanguageModelRouter + Send + Sync + 'static,
 {
     let payment_gate: Arc<dyn crate::mpp::PaymentGate> = mpp_state;
-    handle_responses_with_gate(
+    let gate_ctx = crate::mpp::GateContext {
         caller,
         payment_gate,
         auth_header,
-        request,
-        table,
-        router,
         observer,
-    )
-    .await
+        metadata_hook: bitrouter_core::observe::default_metadata_hook(),
+        origin: None,
+    };
+    handle_responses_with_gate(gate_ctx, request, table, router).await
 }
 
 #[cfg(any(feature = "payments-tempo", feature = "payments-solana"))]
 async fn handle_responses_with_gate<T, R>(
-    caller: CallerContext,
-    payment_gate: Arc<dyn crate::mpp::PaymentGate>,
-    auth_header: Option<String>,
+    gate_ctx: crate::mpp::GateContext,
     request: ResponsesRequest,
     table: Arc<T>,
     router: Arc<R>,
-    observer: Arc<dyn ObserveCallback>,
 ) -> Result<Box<dyn warp::Reply>, warp::Rejection>
 where
     T: RoutingTable + crate::mpp::PricingLookup + Send + Sync + 'static,
     R: LanguageModelRouter + Send + Sync + 'static,
 {
+    let crate::mpp::GateContext {
+        caller,
+        payment_gate,
+        auth_header,
+        observer,
+        metadata_hook,
+        origin,
+    } = gate_ctx;
     let mpp_ctx = payment_gate
         .verify_payment(caller.chain.clone(), auth_header)
         .await?;
@@ -300,6 +311,8 @@ where
     let model_id = model.model_id().to_owned();
     let options = convert::to_call_options(request);
     let start = Instant::now();
+    let request_id = uuid::Uuid::new_v4().to_string();
+    let metadata = metadata_hook(&caller, &origin);
 
     if is_stream {
         let stream_result = model
@@ -320,6 +333,7 @@ where
             backend_key: mpp_ctx.backend_key.clone(),
             channel_id: mpp_ctx.channel_id.clone(),
             tick_cost,
+            request_id: Some(request_id.clone()),
         };
 
         tokio::spawn(async move {
@@ -369,10 +383,17 @@ where
                 model: target_model_id,
                 caller,
                 latency_ms,
+                request_id,
+                metadata,
             };
             if let Some(usage) = usage {
                 observer
-                    .on_request_success(RequestSuccessEvent { ctx, usage })
+                    .on_request_success(RequestSuccessEvent {
+                        ctx,
+                        usage,
+                        streamed: true,
+                        generation_time_ms: None,
+                    })
                     .await;
             } else if client_disconnected {
                 observer
@@ -419,7 +440,12 @@ where
 
                 if micro_units > 0
                     && let Err(e) = payment_gate
-                        .deduct(&mpp_ctx.backend_key, &mpp_ctx.channel_id, micro_units)
+                        .deduct(
+                            &mpp_ctx.backend_key,
+                            &mpp_ctx.channel_id,
+                            micro_units,
+                            Some(request_id.as_str()),
+                        )
                         .await
                 {
                     tracing::warn!(
@@ -437,8 +463,12 @@ where
                         model: target_model_id,
                         caller,
                         latency_ms: start.elapsed().as_millis() as u64,
+                        request_id,
+                        metadata,
                     },
                     usage: result.usage.clone(),
+                    streamed: false,
+                    generation_time_ms: None,
                 };
                 tokio::spawn(async move { observer.on_request_success(event).await });
 
@@ -463,6 +493,8 @@ where
                         model: target_model_id,
                         caller,
                         latency_ms: start.elapsed().as_millis() as u64,
+                        request_id,
+                        metadata,
                     },
                     error: e.clone(),
                 };
@@ -526,6 +558,8 @@ where
                 target_model: target_model_id,
                 caller,
                 start,
+                request_id: uuid::Uuid::new_v4().to_string(),
+                metadata: serde_json::Value::Null,
             },
         )
         .await
@@ -540,8 +574,12 @@ where
                         model: target_model_id,
                         caller,
                         latency_ms: start.elapsed().as_millis() as u64,
+                        request_id: uuid::Uuid::new_v4().to_string(),
+                        metadata: serde_json::Value::Null,
                     },
                     usage: result.usage.clone(),
+                    streamed: false,
+                    generation_time_ms: None,
                 };
                 tokio::spawn(async move { observer.on_request_success(event).await });
                 let response = convert::from_generate_result(&model_id, result);
@@ -555,6 +593,8 @@ where
                         model: target_model_id,
                         caller,
                         latency_ms: start.elapsed().as_millis() as u64,
+                        request_id: uuid::Uuid::new_v4().to_string(),
+                        metadata: serde_json::Value::Null,
                     },
                     error: e.clone(),
                 };
@@ -621,6 +661,8 @@ async fn handle_stream_with_observe(
         target_model,
         caller,
         start,
+        request_id,
+        metadata,
     } = ctx;
 
     tokio::spawn(async move {
@@ -665,10 +707,17 @@ async fn handle_stream_with_observe(
             model: target_model,
             caller,
             latency_ms,
+            request_id,
+            metadata,
         };
         if let Some(usage) = usage {
             observer
-                .on_request_success(RequestSuccessEvent { ctx, usage })
+                .on_request_success(RequestSuccessEvent {
+                    ctx,
+                    usage,
+                    streamed: true,
+                    generation_time_ms: None,
+                })
                 .await;
         } else if client_disconnected {
             observer

--- a/bitrouter-core/src/observe.rs
+++ b/bitrouter-core/src/observe.rs
@@ -55,6 +55,20 @@ pub struct RequestContext {
     pub caller: CallerContext,
     /// End-to-end request latency in milliseconds.
     pub latency_ms: u64,
+    /// Stable per-request correlation identifier.
+    ///
+    /// Generated once per inbound API request (typically a UUID v4) and
+    /// shared across observation events for that request, allowing
+    /// downstream stores to correlate streaming and non-streaming paths
+    /// with their billing rows.
+    pub request_id: String,
+    /// Extensible per-request metadata.
+    ///
+    /// Populated by upstream-defined hooks (see [`MetadataHook`]) so that
+    /// SDK consumers can attach opaque context (operator IDs, request
+    /// origin, custom tags) to billing/observation events without
+    /// modifying core types. Defaults to [`serde_json::Value::Null`].
+    pub metadata: serde_json::Value,
 }
 
 /// Event emitted when a request completes successfully.
@@ -64,6 +78,11 @@ pub struct RequestSuccessEvent {
     pub ctx: RequestContext,
     /// Token usage reported by the model.
     pub usage: LanguageModelUsage,
+    /// Whether the response was served as a streaming SSE response.
+    pub streamed: bool,
+    /// Wall-clock generation time in milliseconds, when measurable
+    /// distinctly from end-to-end latency. `None` when not available.
+    pub generation_time_ms: Option<u64>,
 }
 
 /// Event emitted when a request fails.
@@ -73,6 +92,19 @@ pub struct RequestFailureEvent {
     pub ctx: RequestContext,
     /// The error that caused the failure.
     pub error: BitrouterError,
+}
+
+/// Per-request hook that produces opaque metadata attached to [`RequestContext::metadata`].
+///
+/// The closure is invoked once per request inside the API handler, with the
+/// authenticated [`CallerContext`] and the optional `Origin` HTTP header.
+/// Upstream callers that don't need metadata pass [`default_metadata_hook`].
+pub type MetadataHook =
+    std::sync::Arc<dyn Fn(&CallerContext, &Option<String>) -> serde_json::Value + Send + Sync>;
+
+/// Returns a no-op [`MetadataHook`] that always yields `serde_json::Value::Null`.
+pub fn default_metadata_hook() -> MetadataHook {
+    std::sync::Arc::new(|_, _| serde_json::Value::Null)
 }
 
 /// Callback trait for observing completed API requests.

--- a/bitrouter-observe/src/metrics.rs
+++ b/bitrouter-observe/src/metrics.rs
@@ -438,6 +438,8 @@ mod tests {
             model: model.into(),
             caller: CallerContext::default(),
             latency_ms: 300,
+            request_id: String::new(),
+            metadata: serde_json::Value::Null,
         }
     }
 
@@ -473,6 +475,8 @@ mod tests {
             .on_request_success(RequestSuccessEvent {
                 ctx: test_ctx("fast", "openai", "gpt-4o-mini"),
                 usage: test_usage(100, 50),
+                streamed: false,
+                generation_time_ms: None,
             })
             .await;
 
@@ -504,6 +508,8 @@ mod tests {
                     model: "gpt-4o-mini".into(),
                     caller: CallerContext::default(),
                     latency_ms: 500,
+                    request_id: String::new(),
+                    metadata: serde_json::Value::Null,
                 },
                 error: bitrouter_core::errors::BitrouterError::transport(None, "timeout"),
             })
@@ -525,6 +531,8 @@ mod tests {
                 .on_request_success(RequestSuccessEvent {
                     ctx: test_ctx("fast", "openai", "gpt-4o-mini"),
                     usage: test_usage(50, 25),
+                    streamed: false,
+                    generation_time_ms: None,
                 })
                 .await;
         }
@@ -533,6 +541,8 @@ mod tests {
                 .on_request_success(RequestSuccessEvent {
                     ctx: test_ctx("fast", "anthropic", "claude-haiku"),
                     usage: test_usage(60, 30),
+                    streamed: false,
+                    generation_time_ms: None,
                 })
                 .await;
         }

--- a/bitrouter-observe/src/model_observer.rs
+++ b/bitrouter-observe/src/model_observer.rs
@@ -154,6 +154,8 @@ mod tests {
                 ..CallerContext::default()
             },
             latency_ms: 250,
+            request_id: String::new(),
+            metadata: serde_json::Value::Null,
         }
     }
 
@@ -178,6 +180,8 @@ mod tests {
                 },
                 raw: None,
             },
+            streamed: false,
+            generation_time_ms: None,
         };
 
         observer.on_request_success(event).await;


### PR DESCRIPTION
## Summary

Extends `ObserveCallback` events with billing-context fields and threads a per-request correlation id through `PaymentGate::deduct`, so downstream consumers (e.g. `bitrouter-cloud`) can populate `requests` table billing columns that are currently always NULL.

## What changed

**`bitrouter-core::observe`** — public types
- `RequestContext` gains `request_id: String` and `metadata: serde_json::Value`.
- `RequestSuccessEvent` gains `streamed: bool` and `generation_time_ms: Option<u64>`.
- New `MetadataHook` type alias and `default_metadata_hook()` helper for upstream-defined per-request metadata.

**`bitrouter-api::mpp`**
- `PaymentGate::deduct` gains `request_id: Option<&'a str>` so custom gate impls can correlate ledger entries with request rows. The default `MppState` impl ignores it.
- `MeteredSseContext` carries an optional `request_id` so streaming per-tick deductions correlate too.
- New `mpp::GateContext` struct bundles per-request payment-gate state to keep handler signatures concise.

**`bitrouter-api::router`** filters
- `chat_completions_filter_with_payment_gate`, `messages_filter_with_payment_gate`, `responses_filter_with_payment_gate` accept a `metadata_hook: MetadataHook` and capture the `Origin` HTTP header. Each request generates a stable UUID v4 that flows through to `deduct()` and observation events.
- `StreamObserveContext` threads `request_id` and `metadata` through SSE paths.
- All other filter variants (`_with_observe`, `_with_mpp`) generate fresh UUIDs and pass `Value::Null` so existing observers keep working unchanged.

**Tests** — `bitrouter-observe` test fixtures updated for the new fields.

## Breaking change

Direct consumers of `RequestContext`, `RequestSuccessEvent`, `PaymentGate`, and the `*_filter_with_payment_gate` filter signatures must update. Version bumps are handled by release CI.

## Verification

- `cargo fmt -- --check` ✓
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` ✓
- `cargo test --workspace --all-features` ✓ (all suites pass)
- `cargo build --workspace --all-features` ✓

## Follow-up

A downstream PR in `bitrouter-cloud` will consume the new release, supply a real `MetadataHook` that emits `funding_source` / `origin` / etc., and wire `request_id` through `debit_api_key_credits` to populate the previously-NULL billing columns.
