### PR TITLE
feat(core,api)!: TargetOverlay + per-endpoint key overrides

### DIFF
--- a/bitrouter-api/src/mpp/gate_context.rs
+++ b/bitrouter-api/src/mpp/gate_context.rs
@@ -3,6 +3,7 @@
 use std::sync::Arc;
 
 use bitrouter_core::observe::{CallerContext, MetadataHook, ObserveCallback};
+use bitrouter_core::routers::router::DynTargetOverlay;
 
 use super::PaymentGate;
 
@@ -18,4 +19,8 @@ pub struct GateContext {
     pub observer: Arc<dyn ObserveCallback>,
     pub metadata_hook: MetadataHook,
     pub origin: Option<String>,
+    /// Optional per-request hook that mutates the routing target after
+    /// resolution. Invoked between `RoutingTable::route()` and
+    /// `LanguageModelRouter::route_model()`. `None` is the no-op default.
+    pub target_overlay: Option<Arc<DynTargetOverlay<'static>>>,
 }

--- a/bitrouter-api/src/router/admin.rs
+++ b/bitrouter-api/src/router/admin.rs
@@ -215,6 +215,8 @@ mod tests {
                     provider_name: "openai".to_owned(),
                     service_id: "gpt-4o".to_owned(),
                     api_protocol: ApiProtocol::Openai,
+                    api_key_override: None,
+                    api_base_override: None,
                 })
             } else {
                 Err(BitrouterError::invalid_request(

--- a/bitrouter-api/src/router/anthropic/messages/filters.rs
+++ b/bitrouter-api/src/router/anthropic/messages/filters.rs
@@ -13,7 +13,10 @@ use bitrouter_core::{
     observe::{
         CallerContext, ObserveCallback, RequestContext, RequestFailureEvent, RequestSuccessEvent,
     },
-    routers::{router::LanguageModelRouter, routing_table::RoutingTable},
+    routers::{
+        router::{DynTargetOverlay, LanguageModelRouter, TargetOverlay},
+        routing_table::RoutingTable,
+    },
 };
 use warp::Filter;
 
@@ -181,6 +184,7 @@ pub fn messages_filter_with_payment_gate<T, R, A>(
     observer: Arc<dyn ObserveCallback>,
     payment_gate: Arc<dyn crate::mpp::PaymentGate>,
     metadata_hook: MetadataHook,
+    target_overlay: Option<Arc<DynTargetOverlay<'static>>>,
     account_filter: A,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone
 where
@@ -199,6 +203,7 @@ where
         .and(warp::any().map(move || router.clone()))
         .and(warp::any().map(move || observer.clone()))
         .and(warp::any().map(move || metadata_hook.clone()))
+        .and(warp::any().map(move || target_overlay.clone()))
         .and_then(
             |caller: CallerContext,
              gate: Arc<dyn crate::mpp::PaymentGate>,
@@ -208,7 +213,8 @@ where
              table: Arc<T>,
              router: Arc<R>,
              observer: Arc<dyn ObserveCallback>,
-             metadata_hook: MetadataHook| {
+             metadata_hook: MetadataHook,
+             target_overlay: Option<Arc<DynTargetOverlay<'static>>>| {
                 let gate_ctx = crate::mpp::GateContext {
                     caller,
                     payment_gate: gate,
@@ -216,6 +222,7 @@ where
                     observer,
                     metadata_hook,
                     origin,
+                    target_overlay,
                 };
                 handle_messages_with_gate(gate_ctx, request, table, router)
             },
@@ -244,6 +251,10 @@ where
         observer,
         metadata_hook: bitrouter_core::observe::default_metadata_hook(),
         origin: None,
+        // _with_mpp does not expose a TargetOverlay constructor parameter;
+        // consumers needing per-request target mutation should use
+        // _with_payment_gate instead.
+        target_overlay: None,
     };
     handle_messages_with_gate(gate_ctx, request, table, router).await
 }
@@ -266,6 +277,7 @@ where
         observer,
         metadata_hook,
         origin,
+        target_overlay,
     } = gate_ctx;
     let mpp_ctx = payment_gate
         .verify_payment(caller.chain.clone(), auth_header)
@@ -297,10 +309,17 @@ where
         )));
     }
 
-    let target = table
+    let mut target = table
         .route(&incoming_model, &route_ctx)
         .await
         .map_err(|e| warp::reject::custom(BitrouterRejection(e)))?;
+
+    if let Some(ref overlay) = target_overlay {
+        overlay
+            .apply(&mut target, &caller)
+            .await
+            .map_err(|e| warp::reject::custom(BitrouterRejection(e)))?;
+    }
 
     let provider_name = target.provider_name.clone();
     let target_model_id = target.service_id.clone();

--- a/bitrouter-api/src/router/anthropic/messages/filters.rs
+++ b/bitrouter-api/src/router/anthropic/messages/filters.rs
@@ -5,6 +5,8 @@ use std::time::Instant;
 
 #[cfg(any(feature = "payments-tempo", feature = "payments-solana"))]
 use bitrouter_core::observe::MetadataHook;
+#[cfg(any(feature = "payments-tempo", feature = "payments-solana"))]
+use bitrouter_core::routers::router::{DynTargetOverlay, TargetOverlay};
 use bitrouter_core::{
     auth::access::is_model_allowed,
     errors::BitrouterError,
@@ -13,13 +15,8 @@ use bitrouter_core::{
     observe::{
         CallerContext, ObserveCallback, RequestContext, RequestFailureEvent, RequestSuccessEvent,
     },
-    routers::{
-        router::LanguageModelRouter,
-        routing_table::RoutingTable,
-    },
+    routers::{router::LanguageModelRouter, routing_table::RoutingTable},
 };
-#[cfg(any(feature = "payments-tempo", feature = "payments-solana"))]
-use bitrouter_core::routers::router::{DynTargetOverlay, TargetOverlay};
 use warp::Filter;
 
 use crate::error::BitrouterRejection;

--- a/bitrouter-api/src/router/anthropic/messages/filters.rs
+++ b/bitrouter-api/src/router/anthropic/messages/filters.rs
@@ -14,10 +14,12 @@ use bitrouter_core::{
         CallerContext, ObserveCallback, RequestContext, RequestFailureEvent, RequestSuccessEvent,
     },
     routers::{
-        router::{DynTargetOverlay, LanguageModelRouter, TargetOverlay},
+        router::LanguageModelRouter,
         routing_table::RoutingTable,
     },
 };
+#[cfg(any(feature = "payments-tempo", feature = "payments-solana"))]
+use bitrouter_core::routers::router::{DynTargetOverlay, TargetOverlay};
 use warp::Filter;
 
 use crate::error::BitrouterRejection;

--- a/bitrouter-api/src/router/anthropic/messages/tests.rs
+++ b/bitrouter-api/src/router/anthropic/messages/tests.rs
@@ -36,6 +36,8 @@ impl RoutingTable for MockTable {
             provider_name: "mock".to_owned(),
             service_id: incoming.to_owned(),
             api_protocol: ApiProtocol::Anthropic,
+            api_key_override: None,
+            api_base_override: None,
         })
     }
 }

--- a/bitrouter-api/src/router/google/generate_content/tests.rs
+++ b/bitrouter-api/src/router/google/generate_content/tests.rs
@@ -36,6 +36,8 @@ impl RoutingTable for MockTable {
             provider_name: "mock".to_owned(),
             service_id: incoming.to_owned(),
             api_protocol: ApiProtocol::Google,
+            api_key_override: None,
+            api_base_override: None,
         })
     }
 }

--- a/bitrouter-api/src/router/openai/chat/filters.rs
+++ b/bitrouter-api/src/router/openai/chat/filters.rs
@@ -14,10 +14,12 @@ use bitrouter_core::{
         CallerContext, ObserveCallback, RequestContext, RequestFailureEvent, RequestSuccessEvent,
     },
     routers::{
-        router::{DynTargetOverlay, LanguageModelRouter, TargetOverlay},
+        router::LanguageModelRouter,
         routing_table::RoutingTable,
     },
 };
+#[cfg(any(feature = "payments-tempo", feature = "payments-solana"))]
+use bitrouter_core::routers::router::{DynTargetOverlay, TargetOverlay};
 
 use crate::router::context::openai_chat;
 use warp::Filter;

--- a/bitrouter-api/src/router/openai/chat/filters.rs
+++ b/bitrouter-api/src/router/openai/chat/filters.rs
@@ -13,7 +13,10 @@ use bitrouter_core::{
     observe::{
         CallerContext, ObserveCallback, RequestContext, RequestFailureEvent, RequestSuccessEvent,
     },
-    routers::{router::LanguageModelRouter, routing_table::RoutingTable},
+    routers::{
+        router::{DynTargetOverlay, LanguageModelRouter, TargetOverlay},
+        routing_table::RoutingTable,
+    },
 };
 
 use crate::router::context::openai_chat;
@@ -168,6 +171,10 @@ where
         observer,
         metadata_hook: bitrouter_core::observe::default_metadata_hook(),
         origin: None,
+        // _with_mpp does not expose a TargetOverlay constructor parameter;
+        // consumers needing per-request target mutation should use
+        // _with_payment_gate instead.
+        target_overlay: None,
     };
     handle_chat_completion_with_gate(gate_ctx, request, table, router).await
 }
@@ -190,6 +197,7 @@ where
         observer,
         metadata_hook,
         origin,
+        target_overlay,
     } = gate_ctx;
 
     let mpp_ctx = payment_gate
@@ -231,10 +239,17 @@ where
         )));
     }
 
-    let target = table
+    let mut target = table
         .route(&incoming_model, &route_ctx)
         .await
         .map_err(|e| warp::reject::custom(BitrouterRejection(e)))?;
+
+    if let Some(ref overlay) = target_overlay {
+        overlay
+            .apply(&mut target, &caller)
+            .await
+            .map_err(|e| warp::reject::custom(BitrouterRejection(e)))?;
+    }
 
     let provider_name = target.provider_name.clone();
     let target_model_id = target.service_id.clone();
@@ -484,6 +499,7 @@ pub fn chat_completions_filter_with_payment_gate<T, R, A>(
     observer: Arc<dyn ObserveCallback>,
     payment_gate: Arc<dyn crate::mpp::PaymentGate>,
     metadata_hook: MetadataHook,
+    target_overlay: Option<Arc<DynTargetOverlay<'static>>>,
     account_filter: A,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone
 where
@@ -502,6 +518,7 @@ where
         .and(warp::any().map(move || router.clone()))
         .and(warp::any().map(move || observer.clone()))
         .and(warp::any().map(move || metadata_hook.clone()))
+        .and(warp::any().map(move || target_overlay.clone()))
         .and_then(
             |caller: CallerContext,
              gate: Arc<dyn crate::mpp::PaymentGate>,
@@ -511,7 +528,8 @@ where
              table: Arc<T>,
              router: Arc<R>,
              observer: Arc<dyn ObserveCallback>,
-             metadata_hook: MetadataHook| {
+             metadata_hook: MetadataHook,
+             target_overlay: Option<Arc<DynTargetOverlay<'static>>>| {
                 let gate_ctx = crate::mpp::GateContext {
                     caller,
                     payment_gate: gate,
@@ -519,6 +537,7 @@ where
                     observer,
                     metadata_hook,
                     origin,
+                    target_overlay,
                 };
                 handle_chat_completion_with_gate(gate_ctx, request, table, router)
             },

--- a/bitrouter-api/src/router/openai/chat/filters.rs
+++ b/bitrouter-api/src/router/openai/chat/filters.rs
@@ -5,6 +5,8 @@ use std::time::Instant;
 
 #[cfg(any(feature = "payments-tempo", feature = "payments-solana"))]
 use bitrouter_core::observe::MetadataHook;
+#[cfg(any(feature = "payments-tempo", feature = "payments-solana"))]
+use bitrouter_core::routers::router::{DynTargetOverlay, TargetOverlay};
 use bitrouter_core::{
     auth::access::is_model_allowed,
     errors::BitrouterError,
@@ -13,13 +15,8 @@ use bitrouter_core::{
     observe::{
         CallerContext, ObserveCallback, RequestContext, RequestFailureEvent, RequestSuccessEvent,
     },
-    routers::{
-        router::LanguageModelRouter,
-        routing_table::RoutingTable,
-    },
+    routers::{router::LanguageModelRouter, routing_table::RoutingTable},
 };
-#[cfg(any(feature = "payments-tempo", feature = "payments-solana"))]
-use bitrouter_core::routers::router::{DynTargetOverlay, TargetOverlay};
 
 use crate::router::context::openai_chat;
 use warp::Filter;

--- a/bitrouter-api/src/router/openai/chat/tests.rs
+++ b/bitrouter-api/src/router/openai/chat/tests.rs
@@ -52,6 +52,8 @@ impl RoutingTable for MockTable {
             provider_name: "mock".to_owned(),
             service_id: incoming.to_owned(),
             api_protocol: ApiProtocol::Openai,
+            api_key_override: None,
+            api_base_override: None,
         })
     }
 }

--- a/bitrouter-api/src/router/openai/responses/filters.rs
+++ b/bitrouter-api/src/router/openai/responses/filters.rs
@@ -13,7 +13,10 @@ use bitrouter_core::{
     observe::{
         CallerContext, ObserveCallback, RequestContext, RequestFailureEvent, RequestSuccessEvent,
     },
-    routers::{router::LanguageModelRouter, routing_table::RoutingTable},
+    routers::{
+        router::{DynTargetOverlay, LanguageModelRouter, TargetOverlay},
+        routing_table::RoutingTable,
+    },
 };
 use warp::Filter;
 
@@ -179,6 +182,7 @@ pub fn responses_filter_with_payment_gate<T, R, A>(
     observer: Arc<dyn ObserveCallback>,
     payment_gate: Arc<dyn crate::mpp::PaymentGate>,
     metadata_hook: MetadataHook,
+    target_overlay: Option<Arc<DynTargetOverlay<'static>>>,
     account_filter: A,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone
 where
@@ -197,6 +201,7 @@ where
         .and(warp::any().map(move || router.clone()))
         .and(warp::any().map(move || observer.clone()))
         .and(warp::any().map(move || metadata_hook.clone()))
+        .and(warp::any().map(move || target_overlay.clone()))
         .and_then(
             |caller: CallerContext,
              gate: Arc<dyn crate::mpp::PaymentGate>,
@@ -206,7 +211,8 @@ where
              table: Arc<T>,
              router: Arc<R>,
              observer: Arc<dyn ObserveCallback>,
-             metadata_hook: MetadataHook| {
+             metadata_hook: MetadataHook,
+             target_overlay: Option<Arc<DynTargetOverlay<'static>>>| {
                 let gate_ctx = crate::mpp::GateContext {
                     caller,
                     payment_gate: gate,
@@ -214,6 +220,7 @@ where
                     observer,
                     metadata_hook,
                     origin,
+                    target_overlay,
                 };
                 handle_responses_with_gate(gate_ctx, request, table, router)
             },
@@ -242,6 +249,10 @@ where
         observer,
         metadata_hook: bitrouter_core::observe::default_metadata_hook(),
         origin: None,
+        // _with_mpp does not expose a TargetOverlay constructor parameter;
+        // consumers needing per-request target mutation should use
+        // _with_payment_gate instead.
+        target_overlay: None,
     };
     handle_responses_with_gate(gate_ctx, request, table, router).await
 }
@@ -264,6 +275,7 @@ where
         observer,
         metadata_hook,
         origin,
+        target_overlay,
     } = gate_ctx;
     let mpp_ctx = payment_gate
         .verify_payment(caller.chain.clone(), auth_header)
@@ -295,10 +307,17 @@ where
         )));
     }
 
-    let target = table
+    let mut target = table
         .route(&incoming_model, &route_ctx)
         .await
         .map_err(|e| warp::reject::custom(BitrouterRejection(e)))?;
+
+    if let Some(ref overlay) = target_overlay {
+        overlay
+            .apply(&mut target, &caller)
+            .await
+            .map_err(|e| warp::reject::custom(BitrouterRejection(e)))?;
+    }
 
     let provider_name = target.provider_name.clone();
     let target_model_id = target.service_id.clone();

--- a/bitrouter-api/src/router/openai/responses/filters.rs
+++ b/bitrouter-api/src/router/openai/responses/filters.rs
@@ -5,6 +5,8 @@ use std::time::Instant;
 
 #[cfg(any(feature = "payments-tempo", feature = "payments-solana"))]
 use bitrouter_core::observe::MetadataHook;
+#[cfg(any(feature = "payments-tempo", feature = "payments-solana"))]
+use bitrouter_core::routers::router::{DynTargetOverlay, TargetOverlay};
 use bitrouter_core::{
     auth::access::is_model_allowed,
     errors::BitrouterError,
@@ -13,13 +15,8 @@ use bitrouter_core::{
     observe::{
         CallerContext, ObserveCallback, RequestContext, RequestFailureEvent, RequestSuccessEvent,
     },
-    routers::{
-        router::LanguageModelRouter,
-        routing_table::RoutingTable,
-    },
+    routers::{router::LanguageModelRouter, routing_table::RoutingTable},
 };
-#[cfg(any(feature = "payments-tempo", feature = "payments-solana"))]
-use bitrouter_core::routers::router::{DynTargetOverlay, TargetOverlay};
 use warp::Filter;
 
 use crate::error::BitrouterRejection;

--- a/bitrouter-api/src/router/openai/responses/filters.rs
+++ b/bitrouter-api/src/router/openai/responses/filters.rs
@@ -14,10 +14,12 @@ use bitrouter_core::{
         CallerContext, ObserveCallback, RequestContext, RequestFailureEvent, RequestSuccessEvent,
     },
     routers::{
-        router::{DynTargetOverlay, LanguageModelRouter, TargetOverlay},
+        router::LanguageModelRouter,
         routing_table::RoutingTable,
     },
 };
+#[cfg(any(feature = "payments-tempo", feature = "payments-solana"))]
+use bitrouter_core::routers::router::{DynTargetOverlay, TargetOverlay};
 use warp::Filter;
 
 use crate::error::BitrouterRejection;

--- a/bitrouter-api/src/router/openai/responses/tests.rs
+++ b/bitrouter-api/src/router/openai/responses/tests.rs
@@ -36,6 +36,8 @@ impl RoutingTable for MockTable {
             provider_name: "mock".to_owned(),
             service_id: incoming.to_owned(),
             api_protocol: ApiProtocol::Openai,
+            api_key_override: None,
+            api_base_override: None,
         })
     }
 }

--- a/bitrouter-config/src/routing.rs
+++ b/bitrouter-config/src/routing.rs
@@ -229,6 +229,8 @@ impl RoutingTable for ConfigRoutingTable {
                 provider_name: resolved.provider_name,
                 service_id: resolved.service_id,
                 api_protocol: resolved.api_protocol,
+                api_key_override: resolved.api_key_override,
+                api_base_override: resolved.api_base_override,
             });
         }
 
@@ -237,6 +239,8 @@ impl RoutingTable for ConfigRoutingTable {
             provider_name: resolved.provider_name,
             service_id: resolved.service_id,
             api_protocol: resolved.api_protocol,
+            api_key_override: resolved.api_key_override,
+            api_base_override: resolved.api_base_override,
         })
     }
 
@@ -559,6 +563,8 @@ impl RoutingTable for ConfigToolRoutingTable {
             provider_name: resolved.provider_name,
             service_id: resolved.service_id,
             api_protocol: resolved.api_protocol,
+            api_key_override: resolved.api_key_override,
+            api_base_override: resolved.api_base_override,
         })
     }
 
@@ -844,6 +850,41 @@ mod tests {
         let table = ConfigRoutingTable::new(test_providers(), HashMap::new());
         let result = table.resolve("nonexistent-model");
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn route_trait_propagates_endpoint_overrides() {
+        // Endpoint overrides resolved by `resolve()` are surfaced by the
+        // public `RoutingTable::route()` API on `RoutingTarget` so downstream
+        // consumers (e.g. NodeRouter) can honour them per request.
+        let mut models = HashMap::new();
+        models.insert(
+            "with-override".into(),
+            ModelConfig {
+                strategy: RoutingStrategy::Priority,
+                endpoints: vec![Endpoint {
+                    provider: "openai".into(),
+                    service_id: "gpt-4o".into(),
+                    api_protocol: None,
+                    api_key: Some("sk-byok".into()),
+                    api_base: Some("https://byok.example.com/v1".into()),
+                }],
+                ..Default::default()
+            },
+        );
+        let table = ConfigRoutingTable::new(test_providers(), models);
+
+        let target = table
+            .route("with-override", &RouteContext::default())
+            .await
+            .unwrap();
+        assert_eq!(target.provider_name, "openai");
+        assert_eq!(target.service_id, "gpt-4o");
+        assert_eq!(target.api_key_override.as_deref(), Some("sk-byok"));
+        assert_eq!(
+            target.api_base_override.as_deref(),
+            Some("https://byok.example.com/v1")
+        );
     }
 
     #[test]

--- a/bitrouter-core/src/routers/dynamic.rs
+++ b/bitrouter-core/src/routers/dynamic.rs
@@ -88,6 +88,8 @@ impl<T> DynamicRoutingTable<T> {
             provider_name: endpoint.provider.clone(),
             service_id: strip_ansi_escapes(&endpoint.service_id),
             api_protocol: endpoint.api_protocol.unwrap_or(ApiProtocol::Openai),
+            api_key_override: None,
+            api_base_override: None,
         })
     }
 }
@@ -246,6 +248,8 @@ mod tests {
                     provider_name: "openai".to_owned(),
                     service_id: "gpt-4o".to_owned(),
                     api_protocol: ApiProtocol::Openai,
+                    api_key_override: None,
+                    api_base_override: None,
                 })
             } else {
                 Err(BitrouterError::invalid_request(
@@ -448,12 +452,16 @@ mod tests {
                             provider_name: "anthropic".to_owned(),
                             service_id: "claude-sonnet-4-20250514".to_owned(),
                             api_protocol: ApiProtocol::Anthropic,
+                            api_key_override: None,
+                            api_base_override: None,
                         })
                     } else {
                         Ok(RoutingTarget {
                             provider_name: "openai".to_owned(),
                             service_id: "gpt-4o".to_owned(),
                             api_protocol: ApiProtocol::Openai,
+                            api_key_override: None,
+                            api_base_override: None,
                         })
                     }
                 } else {
@@ -509,12 +517,16 @@ mod tests {
                             provider_name: "anthropic".to_owned(),
                             service_id: "claude-sonnet-4-20250514".to_owned(),
                             api_protocol: ApiProtocol::Anthropic,
+                            api_key_override: None,
+                            api_base_override: None,
                         })
                     } else {
                         Ok(RoutingTarget {
                             provider_name: "openai".to_owned(),
                             service_id: "gpt-4o".to_owned(),
                             api_protocol: ApiProtocol::Openai,
+                            api_key_override: None,
+                            api_base_override: None,
                         })
                     }
                 } else {

--- a/bitrouter-core/src/routers/router.rs
+++ b/bitrouter-core/src/routers/router.rs
@@ -1,7 +1,10 @@
+use dynosaur::dynosaur;
+
 use crate::{
     agents::provider::DynAgentProvider,
     errors::Result,
     models::{image::image_model::DynImageModel, language::language_model::DynLanguageModel},
+    observe::CallerContext,
     routers::routing_table::RoutingTarget,
     tools::provider::DynToolProvider,
 };
@@ -55,4 +58,83 @@ pub trait ToolRouter {
         &self,
         target: RoutingTarget,
     ) -> impl Future<Output = Result<Box<DynToolProvider<'static>>>> + Send;
+}
+
+/// A hook that mutates a [`RoutingTarget`] after routing but before model
+/// instantiation, given the request's [`CallerContext`].
+///
+/// Used to inject per-caller credentials or base URLs into the target —
+/// for example, a "bring your own key" (BYOK) overlay that looks up the
+/// caller's stored API key for the resolved provider and sets
+/// [`RoutingTarget::api_key_override`].
+///
+/// Implementations should be cheap on the no-op path (e.g. anonymous caller,
+/// or caller with no overlay configured), since the hook runs on every
+/// request that the host filter receives.
+#[dynosaur(pub DynTargetOverlay = dyn(box) TargetOverlay)]
+pub trait TargetOverlay: Send + Sync {
+    /// Inspects `caller` and optionally mutates `target`.
+    ///
+    /// Returning `Err` aborts the request. Implementations should choose the
+    /// returned [`BitrouterError`](crate::errors::BitrouterError) variant
+    /// deliberately, because the host filter surfaces it to the client:
+    ///
+    /// - **Stored credential is invalid/expired/revoked**: return
+    ///   [`BitrouterError::AccessDenied`](crate::errors::BitrouterError::AccessDenied)
+    ///   — surfaces as `403`.
+    /// - **Decryption / parse failure on a stored credential**: return
+    ///   [`BitrouterError::InvalidRequest`](crate::errors::BitrouterError::InvalidRequest)
+    ///   — surfaces as `400` and signals "fix your stored credential."
+    /// - Reserve errors for genuine failures and return `Ok(())` for the
+    ///   common no-op case.
+    fn apply(
+        &self,
+        target: &mut RoutingTarget,
+        caller: &CallerContext,
+    ) -> impl Future<Output = Result<()>> + Send;
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::routers::routing_table::ApiProtocol;
+
+    struct StaticKeyOverlay {
+        key: String,
+    }
+
+    impl TargetOverlay for StaticKeyOverlay {
+        async fn apply(&self, target: &mut RoutingTarget, _caller: &CallerContext) -> Result<()> {
+            target.api_key_override = Some(self.key.clone());
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn dyn_overlay_mutates_target_through_arc() {
+        // Verifies the dynosaur-generated wrapper round-trips through Arc and
+        // applies the overlay's mutation to the target. This is the same
+        // shape filters use to invoke an overlay.
+        let overlay: Arc<DynTargetOverlay<'static>> =
+            Arc::from(DynTargetOverlay::new_box(StaticKeyOverlay {
+                key: "sk-byok-from-overlay".to_owned(),
+            }));
+        let mut target = RoutingTarget {
+            provider_name: "openai".to_owned(),
+            service_id: "gpt-4o".to_owned(),
+            api_protocol: ApiProtocol::Openai,
+            api_key_override: None,
+            api_base_override: None,
+        };
+        let caller = CallerContext::default();
+
+        overlay.apply(&mut target, &caller).await.unwrap();
+
+        assert_eq!(
+            target.api_key_override.as_deref(),
+            Some("sk-byok-from-overlay")
+        );
+    }
 }

--- a/bitrouter-core/src/routers/routing_table.rs
+++ b/bitrouter-core/src/routers/routing_table.rs
@@ -54,6 +54,19 @@ pub struct RoutingTarget {
     pub service_id: String,
     /// The resolved API protocol for this endpoint.
     pub api_protocol: ApiProtocol,
+    /// Per-target API key override.
+    ///
+    /// When `Some`, downstream model/tool routers should prefer this credential
+    /// over the provider's default `api_key`. Populated by per-endpoint
+    /// configuration (see `Endpoint.api_key`) or by a [`TargetOverlay`] that
+    /// runs after routing.
+    pub api_key_override: Option<String>,
+    /// Per-target API base URL override.
+    ///
+    /// When `Some`, downstream model/tool routers should prefer this base URL
+    /// over the provider's default `api_base`. Populated by per-endpoint
+    /// configuration (see `Endpoint.api_base`) or by a [`TargetOverlay`].
+    pub api_base_override: Option<String>,
 }
 
 /// A single entry in the route listing, describing a configured route.

--- a/bitrouter/src/runtime/mcp_client.rs
+++ b/bitrouter/src/runtime/mcp_client.rs
@@ -457,6 +457,8 @@ fn match_hint(hint: &str, routes: &[RouteEntry]) -> Option<RoutingTarget> {
                 provider_name: route.provider.clone(),
                 service_id: route.name.clone(),
                 api_protocol: route.protocol,
+                api_key_override: None,
+                api_base_override: None,
             });
         }
     }

--- a/bitrouter/src/runtime/router.rs
+++ b/bitrouter/src/runtime/router.rs
@@ -649,6 +649,8 @@ mod tests {
             provider_name: "test-rest".into(),
             service_id: "search".into(),
             api_protocol: ApiProtocol::Rest,
+            api_key_override: None,
+            api_base_override: None,
         };
 
         let provider = router.route_tool(target).await;
@@ -670,6 +672,8 @@ mod tests {
             provider_name: "missing".into(),
             service_id: "foo".into(),
             api_protocol: ApiProtocol::Rest,
+            api_key_override: None,
+            api_base_override: None,
         };
         assert!(router.route_tool(target).await.is_err());
     }


### PR DESCRIPTION
## Summary

Adds the primitives needed for per-caller credential injection (e.g. a "bring your own key" overlay in a downstream cloud deployment) without forking the routing pipeline. The change is additive at the type level and the breaking-change marker is for one positional-argument addition on three filter constructors (see below).

## Why

Today, two gaps make per-request credential injection awkward:

1. `Endpoint.api_key` and `Endpoint.api_base` (per-endpoint config overrides) are resolved by `ConfigRoutingTable` into `ResolvedTarget` — and then **dropped** at the `RoutingTable` trait boundary. The public `RoutingTarget` carries only `provider_name`, `service_id`, `api_protocol`, so `LanguageModelRouter::route_model()` never sees them.
2. Neither `RoutingTable::route()` nor `LanguageModelRouter::route_model()` sees the request's `CallerContext`, so a downstream router has no way to look up "the credential for *this caller* on the resolved provider."

Both are solvable inside `bitrouter-core` + `bitrouter-config` + `bitrouter-api` with additive primitives.

## What

- **`bitrouter-core`** — `RoutingTarget` gains `api_key_override: Option<String>` and `api_base_override: Option<String>`. New `TargetOverlay` trait (dynosaur-wrapped as `DynTargetOverlay`) provides the post-route, pre-instantiate hook with `(&mut RoutingTarget, &CallerContext)`. The trait doc-comment specifies the expected `BitrouterError` variants for credential failures so client-visible errors stay actionable (`AccessDenied` -> 403, `InvalidRequest` -> 400).
- **`bitrouter-config`** — `ConfigRoutingTable::route()` and `ConfigToolRoutingTable::route()` now propagate the override fields from `ResolvedTarget` into `RoutingTarget`. Fixes the silent drop.
- **`bitrouter-api`** — `GateContext` carries `Option<Arc<DynTargetOverlay<'static>>>`. The three `*_filter_with_payment_gate` constructors take it as an explicit positional argument; the `*_with_mpp` peers default it to `None` (with an inline comment explaining why). The handlers invoke the overlay between `table.route()` and `router.route_model()`.

## Breaking change

`chat_completions_filter_with_payment_gate`, `messages_filter_with_payment_gate`, and `responses_filter_with_payment_gate` gain a `target_overlay: Option<Arc<DynTargetOverlay<'static>>>` parameter, placed before `account_filter`. Existing callers can pass `None` to retain current behaviour.

`RoutingTarget` field additions are technically struct-API changes, but I checked the repo for destructuring patterns — only construction sites exist, all updated in this PR.

## Test plan

- [x] `cargo fmt -- --check` clean
- [x] `cargo clippy --all-features --all-targets` clean (no warnings)
- [x] `cargo test --all-features` — all tests pass except one pre-existing failure (`bitrouter-config::config::tests::load_with_custom_derived_provider`) which fails on clean `origin/main` due to env-prefix substitution picking up a local `OPENAI_BASE_URL`. Unrelated to this change.
- [x] New unit tests:
  - `bitrouter-core::routers::router::tests::dyn_overlay_mutates_target_through_arc` — exercises the dynosaur wrapper round-trip and `Arc<DynTargetOverlay>` invocation shape that filters use.
  - `bitrouter-config::routing::tests::route_trait_propagates_endpoint_overrides` — locks in the trait-level fix for the silent drop of `Endpoint.api_key`/`api_base`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)