### PR TITLE
fix(bitrouter): silence benign warp IncompleteMessage error log

### DIFF
--- a/bitrouter/src/main.rs
+++ b/bitrouter/src/main.rs
@@ -1107,12 +1107,18 @@ where
 }
 
 fn init_tracing() {
-    let _ = tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
-        )
-        .try_init();
+    // warp 0.4 logs every hyper connection-level error at ERROR (see
+    // warp::server::run), including benign `IncompleteMessage` events that fire
+    // when a client closes a keep-alive HTTP/1.1 socket between requests.
+    // Downgrade that target to WARN so those benign errors don't clutter logs.
+    // Explicit user directives in RUST_LOG still take precedence because they
+    // are parsed first and the most specific match wins.
+    let mut filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
+    if let Ok(directive) = "warp::server::run=warn".parse() {
+        filter = filter.add_directive(directive);
+    }
+    let _ = tracing_subscriber::fmt().with_env_filter(filter).try_init();
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Problem

When clients (e.g. Claude Code, the Anthropic SDK) finish consuming an SSE stream and then close their HTTP/1.1 keep-alive socket — instead of reusing it — warp surfaces the resulting hyper error as ERROR-level:

```
2026-05-03T18:10:32.109417Z  INFO finished processing with success status=200
2026-05-03T18:10:32.115794Z ERROR warp::server::run: server connection error: hyper::Error(IncompleteMessage)
2026-05-03T18:10:32.121983Z DEBUG received request   ← next request, fresh connection
```

Root cause: `warp 0.4.2` unconditionally logs every hyper connection-level error at ERROR ([`server.rs:337` & `:395`](https://github.com/seanmonstar/warp/blob/master/src/server.rs#L337)). `IncompleteMessage` is hyper's classification for a peer FIN/RST mid-keep-alive, which is benign — no request fails, no data is lost, the client just opted not to reuse the socket.

## Fix

Append a `warp::server::run=warn` directive to the default `EnvFilter` in `init_tracing()`. Benign disconnects move to WARN; explicit `RUST_LOG` overrides still win.

## Verification

- `cargo build -p bitrouter` ✅
- `cargo clippy -p bitrouter --all-targets --all-features -- -D warnings` ✅
- `cargo fmt -- --check` ✅
