### PR TITLE
fix: cc, messages API and copilot compatibility

### DIFF
--- a/bitrouter-api/src/router/anthropic/messages/filters.rs
+++ b/bitrouter-api/src/router/anthropic/messages/filters.rs
@@ -385,9 +385,24 @@ where
                     break;
                 }
             }
-            let _ = tx
-                .send(Ok(warp::sse::Event::default().data("[DONE]")))
-                .await;
+            if !client_disconnected {
+                let events = converter.finish();
+                if !events.is_empty() && !metered.deduct_or_pause(&tx).await {
+                    client_disconnected = true;
+                }
+                if !client_disconnected {
+                    for event in events {
+                        let data = serde_json::to_string(&event).unwrap_or_default();
+                        let sse = Ok(warp::sse::Event::default()
+                            .event(event.event_type())
+                            .data(data));
+                        if tx.send(sse).await.is_err() {
+                            client_disconnected = true;
+                            break;
+                        }
+                    }
+                }
+            }
 
             let latency_ms = start.elapsed().as_millis() as u64;
             let ctx = RequestContext {
@@ -632,9 +647,15 @@ async fn handle_stream(
                 }
             }
         }
-        let _ = tx
-            .send(Ok(warp::sse::Event::default().data("[DONE]")))
-            .await;
+        for event in converter.finish() {
+            let data = serde_json::to_string(&event).unwrap_or_default();
+            let sse = Ok(warp::sse::Event::default()
+                .event(event.event_type())
+                .data(data));
+            if tx.send(sse).await.is_err() {
+                break;
+            }
+        }
     });
 
     let sse_stream = tokio_stream::wrappers::ReceiverStream::new(rx);
@@ -689,9 +710,18 @@ async fn handle_stream_with_observe(
                 break;
             }
         }
-        let _ = tx
-            .send(Ok(warp::sse::Event::default().data("[DONE]")))
-            .await;
+        if !client_disconnected {
+            for event in converter.finish() {
+                let data = serde_json::to_string(&event).unwrap_or_default();
+                let sse = Ok(warp::sse::Event::default()
+                    .event(event.event_type())
+                    .data(data));
+                if tx.send(sse).await.is_err() {
+                    client_disconnected = true;
+                    break;
+                }
+            }
+        }
 
         let latency_ms = start.elapsed().as_millis() as u64;
         let ctx = RequestContext {

--- a/bitrouter-api/src/router/anthropic/messages/filters.rs
+++ b/bitrouter-api/src/router/anthropic/messages/filters.rs
@@ -359,18 +359,11 @@ where
         tokio::spawn(async move {
             let mut stream = stream_result.stream;
             let mut converter = convert::StreamConverter::new(model_id.clone());
-            use bitrouter_core::models::language::stream_part::LanguageModelStreamPart;
             use tokio_stream::StreamExt as _;
-            let mut usage = None;
+            let mut observation = crate::router::StreamObservation::new();
             let mut client_disconnected = false;
             while let Some(part) = stream.next().await {
-                if let LanguageModelStreamPart::Finish {
-                    usage: ref finish_usage,
-                    ..
-                } = part
-                {
-                    usage = Some(finish_usage.clone());
-                }
+                observation.record_part(&part);
                 let events = converter.convert(&part);
                 if !events.is_empty() && !metered.deduct_or_pause(&tx).await {
                     client_disconnected = true;
@@ -406,36 +399,22 @@ where
                 request_id,
                 metadata,
             };
-            if let Some(usage) = usage {
-                observer
-                    .on_request_success(RequestSuccessEvent {
-                        ctx,
-                        usage,
-                        streamed: true,
-                        generation_time_ms: None,
-                    })
-                    .await;
-            } else if client_disconnected {
-                observer
-                    .on_request_failure(RequestFailureEvent {
-                        ctx,
-                        error: bitrouter_core::errors::BitrouterError::cancelled(
-                            None,
-                            "client disconnected during stream",
-                        ),
-                    })
-                    .await;
-            } else {
-                observer
-                    .on_request_failure(RequestFailureEvent {
-                        ctx,
-                        error: bitrouter_core::errors::BitrouterError::stream_protocol(
-                            None,
-                            "stream completed without finish event",
-                            None,
-                        ),
-                    })
-                    .await;
+            match observation.outcome(client_disconnected) {
+                Ok(usage) => {
+                    observer
+                        .on_request_success(RequestSuccessEvent {
+                            ctx,
+                            usage,
+                            streamed: true,
+                            generation_time_ms: None,
+                        })
+                        .await;
+                }
+                Err(error) => {
+                    observer
+                        .on_request_failure(RequestFailureEvent { ctx, error })
+                        .await;
+                }
             }
         });
 
@@ -689,18 +668,11 @@ async fn handle_stream_with_observe(
     tokio::spawn(async move {
         let mut stream = stream_result.stream;
         let mut converter = convert::StreamConverter::new(target_model.clone());
-        use bitrouter_core::models::language::stream_part::LanguageModelStreamPart;
         use tokio_stream::StreamExt as _;
-        let mut usage = None;
+        let mut observation = crate::router::StreamObservation::new();
         let mut client_disconnected = false;
         while let Some(part) = stream.next().await {
-            if let LanguageModelStreamPart::Finish {
-                usage: ref finish_usage,
-                ..
-            } = part
-            {
-                usage = Some(finish_usage.clone());
-            }
+            observation.record_part(&part);
             let mut send_failed = false;
             for event in converter.convert(&part) {
                 let data = serde_json::to_string(&event).unwrap_or_default();
@@ -731,36 +703,22 @@ async fn handle_stream_with_observe(
             request_id,
             metadata,
         };
-        if let Some(usage) = usage {
-            observer
-                .on_request_success(RequestSuccessEvent {
-                    ctx,
-                    usage,
-                    streamed: true,
-                    generation_time_ms: None,
-                })
-                .await;
-        } else if client_disconnected {
-            observer
-                .on_request_failure(RequestFailureEvent {
-                    ctx,
-                    error: bitrouter_core::errors::BitrouterError::cancelled(
-                        None,
-                        "client disconnected during stream",
-                    ),
-                })
-                .await;
-        } else {
-            observer
-                .on_request_failure(RequestFailureEvent {
-                    ctx,
-                    error: bitrouter_core::errors::BitrouterError::stream_protocol(
-                        None,
-                        "stream completed without finish event",
-                        None,
-                    ),
-                })
-                .await;
+        match observation.outcome(client_disconnected) {
+            Ok(usage) => {
+                observer
+                    .on_request_success(RequestSuccessEvent {
+                        ctx,
+                        usage,
+                        streamed: true,
+                        generation_time_ms: None,
+                    })
+                    .await;
+            }
+            Err(error) => {
+                observer
+                    .on_request_failure(RequestFailureEvent { ctx, error })
+                    .await;
+            }
         }
     });
 

--- a/bitrouter-api/src/router/anthropic/messages/tests.rs
+++ b/bitrouter-api/src/router/anthropic/messages/tests.rs
@@ -569,17 +569,40 @@ async fn messages_streaming_sends_sse_events() {
     assert_eq!(res.headers()["content-type"], "text/event-stream");
 
     let events = parse_sse_body(res.body());
-    assert_eq!(events.len(), 3);
+    assert_eq!(events.len(), 6);
 
-    assert_eq!(events[0].0.as_deref(), Some("content_block_delta"));
-    let delta: Value = serde_json::from_str(&events[0].1).unwrap();
+    assert_eq!(events[0].0.as_deref(), Some("message_start"));
+    let start: Value = serde_json::from_str(&events[0].1).unwrap();
+    assert_eq!(start["type"], "message_start");
+    assert_eq!(start["message"]["type"], "message");
+    assert_eq!(start["message"]["role"], "assistant");
+    assert_eq!(start["message"]["model"], "claude-3-5-sonnet-20241022");
+    assert_eq!(
+        start["message"]["content"].as_array().map(Vec::len),
+        Some(0)
+    );
+
+    assert_eq!(events[1].0.as_deref(), Some("content_block_start"));
+    let block_start: Value = serde_json::from_str(&events[1].1).unwrap();
+    assert_eq!(block_start["type"], "content_block_start");
+    assert_eq!(block_start["index"], 0);
+    assert_eq!(block_start["content_block"]["type"], "text");
+    assert_eq!(block_start["content_block"]["text"], "");
+
+    assert_eq!(events[2].0.as_deref(), Some("content_block_delta"));
+    let delta: Value = serde_json::from_str(&events[2].1).unwrap();
     assert_eq!(delta["type"], "content_block_delta");
     assert_eq!(delta["index"], 0);
     assert_eq!(delta["delta"]["type"], "text_delta");
     assert_eq!(delta["delta"]["text"], "Hello");
 
-    assert_eq!(events[1].0.as_deref(), Some("message_delta"));
-    let finish: Value = serde_json::from_str(&events[1].1).unwrap();
+    assert_eq!(events[3].0.as_deref(), Some("content_block_stop"));
+    let block_stop: Value = serde_json::from_str(&events[3].1).unwrap();
+    assert_eq!(block_stop["type"], "content_block_stop");
+    assert_eq!(block_stop["index"], 0);
+
+    assert_eq!(events[4].0.as_deref(), Some("message_delta"));
+    let finish: Value = serde_json::from_str(&events[4].1).unwrap();
     assert_eq!(finish["type"], "message_delta");
     assert_eq!(finish["delta"]["type"], "message_delta");
     assert_eq!(finish["delta"]["stop_reason"], "end_turn");
@@ -592,8 +615,9 @@ async fn messages_streaming_sends_sse_events() {
             .starts_with("msg-")
     );
 
-    assert_eq!(events[2].0, None);
-    assert_eq!(events[2].1, "[DONE]");
+    assert_eq!(events[5].0.as_deref(), Some("message_stop"));
+    let stop: Value = serde_json::from_str(&events[5].1).unwrap();
+    assert_eq!(stop["type"], "message_stop");
 }
 
 #[tokio::test(start_paused = true)]
@@ -628,7 +652,10 @@ async fn messages_streaming_sends_keep_alive_comments_during_idle_gap() {
     );
 
     let events = parse_sse_body(res.body());
-    assert_eq!(events.last().map(|(_, data)| data.as_str()), Some("[DONE]"));
+    assert_eq!(
+        events.last().map(|(event, _)| event.as_deref()),
+        Some(Some("message_stop"))
+    );
 }
 
 #[tokio::test]

--- a/bitrouter-api/src/router/anthropic/messages/tests.rs
+++ b/bitrouter-api/src/router/anthropic/messages/tests.rs
@@ -78,6 +78,15 @@ impl LanguageModelRouter for MockSlowStreamRouter {
     }
 }
 
+struct MockNoFinishStreamRouter;
+impl LanguageModelRouter for MockNoFinishStreamRouter {
+    async fn route_model(&self, target: RoutingTarget) -> Result<Box<DynLanguageModel<'static>>> {
+        Ok(DynLanguageModel::new_box(MockNoFinishStreamModel {
+            model_id: target.service_id,
+        }))
+    }
+}
+
 #[derive(Clone)]
 struct MockModel {
     model_id: String,
@@ -387,6 +396,59 @@ impl LanguageModel for MockSlowStreamModel {
                 })
                 .await;
         });
+
+        Ok(LanguageModelStreamResult {
+            stream: Box::pin(tokio_stream::wrappers::ReceiverStream::new(rx)),
+            request: None,
+            response: None,
+        })
+    }
+}
+
+#[derive(Clone)]
+struct MockNoFinishStreamModel {
+    model_id: String,
+}
+
+impl LanguageModel for MockNoFinishStreamModel {
+    fn provider_name(&self) -> &str {
+        "mock"
+    }
+    fn model_id(&self) -> &str {
+        &self.model_id
+    }
+    async fn supported_urls(&self) -> HashMap<String, Regex> {
+        HashMap::new()
+    }
+    async fn generate(
+        &self,
+        _options: LanguageModelCallOptions,
+    ) -> Result<LanguageModelGenerateResult> {
+        Ok(LanguageModelGenerateResult {
+            content: vec![LanguageModelContent::Text {
+                text: "stream without usage".to_owned(),
+                provider_metadata: None,
+            }],
+            finish_reason: LanguageModelFinishReason::Stop,
+            usage: mock_usage(),
+            provider_metadata: None,
+            request: None,
+            response_metadata: None,
+            warnings: None,
+        })
+    }
+    async fn stream(
+        &self,
+        _options: LanguageModelCallOptions,
+    ) -> Result<LanguageModelStreamResult> {
+        let (tx, rx) = tokio::sync::mpsc::channel(8);
+        let _ = tx
+            .send(LanguageModelStreamPart::TextDelta {
+                id: "0".to_owned(),
+                delta: "Hello".to_owned(),
+                provider_metadata: None,
+            })
+            .await;
 
         Ok(LanguageModelStreamResult {
             stream: Box::pin(tokio_stream::wrappers::ReceiverStream::new(rx)),
@@ -999,6 +1061,39 @@ async fn messages_observe_success() {
 async fn messages_observe_streaming_success() {
     let table = Arc::new(MockTable);
     let router = Arc::new(MockRouter);
+    let observer = Arc::new(MockObserver::new());
+    let filter = messages_filter_with_observe(
+        table,
+        router,
+        observer.clone(),
+        warp::any().and_then(|| async { Ok::<_, warp::Rejection>(CallerContext::default()) }),
+    );
+
+    let body = serde_json::json!({
+        "model": "claude-3-5-sonnet-20241022",
+        "max_tokens": 1024,
+        "stream": true,
+        "messages": [{"role": "user", "content": "Hello"}]
+    });
+
+    let res = warp::test::request()
+        .method("POST")
+        .path("/v1/messages")
+        .json(&body)
+        .reply(&filter)
+        .await;
+
+    assert_eq!(res.status(), 200);
+
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    assert_eq!(observer.success_count.load(Ordering::SeqCst), 1);
+    assert_eq!(observer.failure_count.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn messages_observe_streaming_without_finish_counts_success() {
+    let table = Arc::new(MockTable);
+    let router = Arc::new(MockNoFinishStreamRouter);
     let observer = Arc::new(MockObserver::new());
     let filter = messages_filter_with_observe(
         table,

--- a/bitrouter-api/src/router/context.rs
+++ b/bitrouter-api/src/router/context.rs
@@ -97,7 +97,9 @@ pub(crate) mod openai_responses {
                             }
                             ResponsesInputContent::Parts(parts) => {
                                 for part in parts {
-                                    if let ResponsesInputContentPart::InputText { text } = part {
+                                    if let ResponsesInputContentPart::InputText { text }
+                                    | ResponsesInputContentPart::OutputText { text } = part
+                                    {
                                         char_count += text.len();
                                         if !has_code_blocks && has_code_fence(text) {
                                             has_code_blocks = true;

--- a/bitrouter-api/src/router/google/generate_content/filters.rs
+++ b/bitrouter-api/src/router/google/generate_content/filters.rs
@@ -285,18 +285,11 @@ where
         tokio::spawn(async move {
             let mut stream = stream_result.stream;
             let mut converter = convert::StreamConverter::new(model_id);
-            use bitrouter_core::models::language::stream_part::LanguageModelStreamPart;
             use tokio_stream::StreamExt as _;
-            let mut usage = None;
+            let mut observation = crate::router::StreamObservation::new();
             let mut client_disconnected = false;
             while let Some(part) = stream.next().await {
-                if let LanguageModelStreamPart::Finish {
-                    usage: ref finish_usage,
-                    ..
-                } = part
-                {
-                    usage = Some(finish_usage.clone());
-                }
+                observation.record_part(&part);
                 if let Some(chunk) = converter.convert(&part) {
                     if !metered.deduct_or_pause(&tx).await {
                         client_disconnected = true;
@@ -324,36 +317,22 @@ where
                 request_id,
                 metadata: serde_json::Value::Null,
             };
-            if let Some(usage) = usage {
-                observer
-                    .on_request_success(RequestSuccessEvent {
-                        ctx,
-                        usage,
-                        streamed: true,
-                        generation_time_ms: None,
-                    })
-                    .await;
-            } else if client_disconnected {
-                observer
-                    .on_request_failure(RequestFailureEvent {
-                        ctx,
-                        error: bitrouter_core::errors::BitrouterError::cancelled(
-                            None,
-                            "client disconnected during stream",
-                        ),
-                    })
-                    .await;
-            } else {
-                observer
-                    .on_request_failure(RequestFailureEvent {
-                        ctx,
-                        error: bitrouter_core::errors::BitrouterError::stream_protocol(
-                            None,
-                            "stream completed without finish event",
-                            None,
-                        ),
-                    })
-                    .await;
+            match observation.outcome(client_disconnected) {
+                Ok(usage) => {
+                    observer
+                        .on_request_success(RequestSuccessEvent {
+                            ctx,
+                            usage,
+                            streamed: true,
+                            generation_time_ms: None,
+                        })
+                        .await;
+                }
+                Err(error) => {
+                    observer
+                        .on_request_failure(RequestFailureEvent { ctx, error })
+                        .await;
+                }
             }
         });
 
@@ -611,18 +590,11 @@ async fn handle_stream_with_observe(
     tokio::spawn(async move {
         let mut stream = stream_result.stream;
         let mut converter = convert::StreamConverter::new(model_id);
-        use bitrouter_core::models::language::stream_part::LanguageModelStreamPart;
         use tokio_stream::StreamExt as _;
-        let mut usage = None;
+        let mut observation = crate::router::StreamObservation::new();
         let mut client_disconnected = false;
         while let Some(part) = stream.next().await {
-            if let LanguageModelStreamPart::Finish {
-                usage: ref finish_usage,
-                ..
-            } = part
-            {
-                usage = Some(finish_usage.clone());
-            }
+            observation.record_part(&part);
             if let Some(chunk) = converter.convert(&part) {
                 let data = serde_json::to_string(&chunk).unwrap_or_default();
                 let sse = Ok(warp::sse::Event::default().data(data));
@@ -646,36 +618,22 @@ async fn handle_stream_with_observe(
             request_id,
             metadata,
         };
-        if let Some(usage) = usage {
-            observer
-                .on_request_success(RequestSuccessEvent {
-                    ctx,
-                    usage,
-                    streamed: true,
-                    generation_time_ms: None,
-                })
-                .await;
-        } else if client_disconnected {
-            observer
-                .on_request_failure(RequestFailureEvent {
-                    ctx,
-                    error: bitrouter_core::errors::BitrouterError::cancelled(
-                        None,
-                        "client disconnected during stream",
-                    ),
-                })
-                .await;
-        } else {
-            observer
-                .on_request_failure(RequestFailureEvent {
-                    ctx,
-                    error: bitrouter_core::errors::BitrouterError::stream_protocol(
-                        None,
-                        "stream completed without finish event",
-                        None,
-                    ),
-                })
-                .await;
+        match observation.outcome(client_disconnected) {
+            Ok(usage) => {
+                observer
+                    .on_request_success(RequestSuccessEvent {
+                        ctx,
+                        usage,
+                        streamed: true,
+                        generation_time_ms: None,
+                    })
+                    .await;
+            }
+            Err(error) => {
+                observer
+                    .on_request_failure(RequestFailureEvent { ctx, error })
+                    .await;
+            }
         }
     });
 

--- a/bitrouter-api/src/router/mod.rs
+++ b/bitrouter-api/src/router/mod.rs
@@ -36,3 +36,102 @@ mod observe_ctx {
 }
 
 pub(crate) use observe_ctx::StreamObserveContext;
+
+mod stream_observation {
+    use bitrouter_core::{
+        errors::BitrouterError,
+        models::language::{
+            stream_part::LanguageModelStreamPart,
+            usage::{LanguageModelInputTokens, LanguageModelOutputTokens, LanguageModelUsage},
+        },
+    };
+
+    pub(crate) struct StreamObservation {
+        usage: Option<LanguageModelUsage>,
+        saw_output: bool,
+        error: Option<BitrouterError>,
+    }
+
+    impl StreamObservation {
+        pub(crate) fn new() -> Self {
+            Self {
+                usage: None,
+                saw_output: false,
+                error: None,
+            }
+        }
+
+        pub(crate) fn record_part(&mut self, part: &LanguageModelStreamPart) {
+            match part {
+                LanguageModelStreamPart::Finish { usage, .. } => {
+                    self.usage = Some(usage.clone());
+                }
+                LanguageModelStreamPart::Error { error } => {
+                    self.error = Some(BitrouterError::stream_protocol(
+                        None,
+                        "upstream stream emitted an error part",
+                        Some(error.clone()),
+                    ));
+                }
+                LanguageModelStreamPart::TextDelta { .. }
+                | LanguageModelStreamPart::ToolCall { .. }
+                | LanguageModelStreamPart::ToolInputStart { .. }
+                | LanguageModelStreamPart::ToolInputDelta { .. }
+                | LanguageModelStreamPart::ToolInputEnd { .. }
+                | LanguageModelStreamPart::File { .. }
+                | LanguageModelStreamPart::ToolApprovalRequest { .. }
+                | LanguageModelStreamPart::UrlSource { .. }
+                | LanguageModelStreamPart::DocumentSource { .. }
+                | LanguageModelStreamPart::ToolResult { .. } => {
+                    self.saw_output = true;
+                }
+                _ => {}
+            }
+        }
+
+        pub(crate) fn outcome(
+            self,
+            client_disconnected: bool,
+        ) -> std::result::Result<LanguageModelUsage, BitrouterError> {
+            if client_disconnected {
+                return Err(BitrouterError::cancelled(
+                    None,
+                    "client disconnected during stream",
+                ));
+            }
+            if let Some(error) = self.error {
+                return Err(error);
+            }
+            if let Some(usage) = self.usage {
+                return Ok(usage);
+            }
+            if self.saw_output {
+                return Ok(empty_usage());
+            }
+            Err(BitrouterError::stream_protocol(
+                None,
+                "stream completed without finish event",
+                None,
+            ))
+        }
+    }
+
+    fn empty_usage() -> LanguageModelUsage {
+        LanguageModelUsage {
+            input_tokens: LanguageModelInputTokens {
+                total: None,
+                no_cache: None,
+                cache_read: None,
+                cache_write: None,
+            },
+            output_tokens: LanguageModelOutputTokens {
+                total: None,
+                text: None,
+                reasoning: None,
+            },
+            raw: None,
+        }
+    }
+}
+
+pub(crate) use stream_observation::StreamObservation;

--- a/bitrouter-api/src/router/openai/chat/filters.rs
+++ b/bitrouter-api/src/router/openai/chat/filters.rs
@@ -295,18 +295,11 @@ where
 
             let mut stream = stream_result.stream;
             let mut converter = convert::StreamConverter::new(model_id, stream_id);
-            use bitrouter_core::models::language::stream_part::LanguageModelStreamPart;
             use tokio_stream::StreamExt as _;
-            let mut usage = None;
+            let mut observation = crate::router::StreamObservation::new();
             let mut client_disconnected = false;
             while let Some(part) = stream.next().await {
-                if let LanguageModelStreamPart::Finish {
-                    usage: ref finish_usage,
-                    ..
-                } = part
-                {
-                    usage = Some(finish_usage.clone());
-                }
+                observation.record_part(&part);
                 if let Some(chunk) = converter.convert(&part) {
                     if !metered.deduct_or_pause(&tx).await {
                         client_disconnected = true;
@@ -334,36 +327,22 @@ where
                 request_id,
                 metadata,
             };
-            if let Some(usage) = usage {
-                observer
-                    .on_request_success(RequestSuccessEvent {
-                        ctx,
-                        usage,
-                        streamed: true,
-                        generation_time_ms: None,
-                    })
-                    .await;
-            } else if client_disconnected {
-                observer
-                    .on_request_failure(RequestFailureEvent {
-                        ctx,
-                        error: bitrouter_core::errors::BitrouterError::cancelled(
-                            None,
-                            "client disconnected during stream",
-                        ),
-                    })
-                    .await;
-            } else {
-                observer
-                    .on_request_failure(RequestFailureEvent {
-                        ctx,
-                        error: bitrouter_core::errors::BitrouterError::stream_protocol(
-                            None,
-                            "stream completed without finish event",
-                            None,
-                        ),
-                    })
-                    .await;
+            match observation.outcome(client_disconnected) {
+                Ok(usage) => {
+                    observer
+                        .on_request_success(RequestSuccessEvent {
+                            ctx,
+                            usage,
+                            streamed: true,
+                            generation_time_ms: None,
+                        })
+                        .await;
+                }
+                Err(error) => {
+                    observer
+                        .on_request_failure(RequestFailureEvent { ctx, error })
+                        .await;
+                }
             }
         });
 
@@ -713,18 +692,11 @@ async fn handle_stream_with_observe(
     tokio::spawn(async move {
         let mut stream = stream_result.stream;
         let mut converter = convert::StreamConverter::new(model_id, stream_id);
-        use bitrouter_core::models::language::stream_part::LanguageModelStreamPart;
         use tokio_stream::StreamExt as _;
-        let mut usage = None;
+        let mut observation = crate::router::StreamObservation::new();
         let mut client_disconnected = false;
         while let Some(part) = stream.next().await {
-            if let LanguageModelStreamPart::Finish {
-                usage: ref finish_usage,
-                ..
-            } = part
-            {
-                usage = Some(finish_usage.clone());
-            }
+            observation.record_part(&part);
             if let Some(chunk) = converter.convert(&part) {
                 let data = serde_json::to_string(&chunk).unwrap_or_default();
                 let event = Ok(warp::sse::Event::default().data(data));
@@ -748,36 +720,22 @@ async fn handle_stream_with_observe(
             request_id,
             metadata,
         };
-        if let Some(usage) = usage {
-            observer
-                .on_request_success(RequestSuccessEvent {
-                    ctx,
-                    usage,
-                    streamed: true,
-                    generation_time_ms: None,
-                })
-                .await;
-        } else if client_disconnected {
-            observer
-                .on_request_failure(RequestFailureEvent {
-                    ctx,
-                    error: bitrouter_core::errors::BitrouterError::cancelled(
-                        None,
-                        "client disconnected during stream",
-                    ),
-                })
-                .await;
-        } else {
-            observer
-                .on_request_failure(RequestFailureEvent {
-                    ctx,
-                    error: bitrouter_core::errors::BitrouterError::stream_protocol(
-                        None,
-                        "stream completed without finish event",
-                        None,
-                    ),
-                })
-                .await;
+        match observation.outcome(client_disconnected) {
+            Ok(usage) => {
+                observer
+                    .on_request_success(RequestSuccessEvent {
+                        ctx,
+                        usage,
+                        streamed: true,
+                        generation_time_ms: None,
+                    })
+                    .await;
+            }
+            Err(error) => {
+                observer
+                    .on_request_failure(RequestFailureEvent { ctx, error })
+                    .await;
+            }
         }
     });
 

--- a/bitrouter-api/src/router/openai/responses/filters.rs
+++ b/bitrouter-api/src/router/openai/responses/filters.rs
@@ -357,18 +357,11 @@ where
         tokio::spawn(async move {
             let mut stream = stream_result.stream;
             let mut converter = convert::StreamConverter::new();
-            use bitrouter_core::models::language::stream_part::LanguageModelStreamPart;
             use tokio_stream::StreamExt as _;
-            let mut usage = None;
+            let mut observation = crate::router::StreamObservation::new();
             let mut client_disconnected = false;
             while let Some(part) = stream.next().await {
-                if let LanguageModelStreamPart::Finish {
-                    usage: ref finish_usage,
-                    ..
-                } = part
-                {
-                    usage = Some(finish_usage.clone());
-                }
+                observation.record_part(&part);
                 let events = converter.convert(&part);
                 if !events.is_empty() && !metered.deduct_or_pause(&tx).await {
                     client_disconnected = true;
@@ -404,36 +397,22 @@ where
                 request_id,
                 metadata,
             };
-            if let Some(usage) = usage {
-                observer
-                    .on_request_success(RequestSuccessEvent {
-                        ctx,
-                        usage,
-                        streamed: true,
-                        generation_time_ms: None,
-                    })
-                    .await;
-            } else if client_disconnected {
-                observer
-                    .on_request_failure(RequestFailureEvent {
-                        ctx,
-                        error: bitrouter_core::errors::BitrouterError::cancelled(
-                            None,
-                            "client disconnected during stream",
-                        ),
-                    })
-                    .await;
-            } else {
-                observer
-                    .on_request_failure(RequestFailureEvent {
-                        ctx,
-                        error: bitrouter_core::errors::BitrouterError::stream_protocol(
-                            None,
-                            "stream completed without finish event",
-                            None,
-                        ),
-                    })
-                    .await;
+            match observation.outcome(client_disconnected) {
+                Ok(usage) => {
+                    observer
+                        .on_request_success(RequestSuccessEvent {
+                            ctx,
+                            usage,
+                            streamed: true,
+                            generation_time_ms: None,
+                        })
+                        .await;
+                }
+                Err(error) => {
+                    observer
+                        .on_request_failure(RequestFailureEvent { ctx, error })
+                        .await;
+                }
             }
         });
 
@@ -686,18 +665,11 @@ async fn handle_stream_with_observe(
     tokio::spawn(async move {
         let mut stream = stream_result.stream;
         let mut converter = convert::StreamConverter::new();
-        use bitrouter_core::models::language::stream_part::LanguageModelStreamPart;
         use tokio_stream::StreamExt as _;
-        let mut usage = None;
+        let mut observation = crate::router::StreamObservation::new();
         let mut client_disconnected = false;
         while let Some(part) = stream.next().await {
-            if let LanguageModelStreamPart::Finish {
-                usage: ref finish_usage,
-                ..
-            } = part
-            {
-                usage = Some(finish_usage.clone());
-            }
+            observation.record_part(&part);
             let mut send_failed = false;
             for event in converter.convert(&part) {
                 let data = serde_json::to_string(&event).unwrap_or_default();
@@ -728,36 +700,22 @@ async fn handle_stream_with_observe(
             request_id,
             metadata,
         };
-        if let Some(usage) = usage {
-            observer
-                .on_request_success(RequestSuccessEvent {
-                    ctx,
-                    usage,
-                    streamed: true,
-                    generation_time_ms: None,
-                })
-                .await;
-        } else if client_disconnected {
-            observer
-                .on_request_failure(RequestFailureEvent {
-                    ctx,
-                    error: bitrouter_core::errors::BitrouterError::cancelled(
-                        None,
-                        "client disconnected during stream",
-                    ),
-                })
-                .await;
-        } else {
-            observer
-                .on_request_failure(RequestFailureEvent {
-                    ctx,
-                    error: bitrouter_core::errors::BitrouterError::stream_protocol(
-                        None,
-                        "stream completed without finish event",
-                        None,
-                    ),
-                })
-                .await;
+        match observation.outcome(client_disconnected) {
+            Ok(usage) => {
+                observer
+                    .on_request_success(RequestSuccessEvent {
+                        ctx,
+                        usage,
+                        streamed: true,
+                        generation_time_ms: None,
+                    })
+                    .await;
+            }
+            Err(error) => {
+                observer
+                    .on_request_failure(RequestFailureEvent { ctx, error })
+                    .await;
+            }
         }
     });
 

--- a/bitrouter-core/src/api/anthropic/messages/convert.rs
+++ b/bitrouter-core/src/api/anthropic/messages/convert.rs
@@ -144,6 +144,10 @@ pub fn from_generate_result(
 /// Stateful converter that tracks content-block indices across streaming events.
 pub struct StreamConverter {
     model_id: String,
+    message_id: String,
+    message_started: bool,
+    message_stopped: bool,
+    active_text_block_index: Option<u32>,
     tool_id_to_index: HashMap<String, u32>,
     next_block_index: u32,
 }
@@ -152,6 +156,10 @@ impl StreamConverter {
     pub fn new(model_id: String) -> Self {
         Self {
             model_id,
+            message_id: format!("msg-{}", generate_id()),
+            message_started: false,
+            message_stopped: false,
+            active_text_block_index: None,
             tool_id_to_index: HashMap::new(),
             next_block_index: 0,
         }
@@ -160,26 +168,46 @@ impl StreamConverter {
     /// Converts a [`LanguageModelStreamPart`] into Anthropic SSE events.
     pub fn convert(&mut self, part: &LanguageModelStreamPart) -> Vec<MessagesStreamEvent> {
         match part {
+            LanguageModelStreamPart::StreamStart { .. }
+            | LanguageModelStreamPart::ResponseMetadata { .. } => self.start_message_events(),
+            LanguageModelStreamPart::TextStart { .. } => self.start_text_events(),
             LanguageModelStreamPart::TextDelta { delta, .. } => {
-                vec![MessagesStreamEvent::ContentBlockDelta {
-                    index: 0,
+                let mut events = self.start_text_events();
+                let index = self.active_text_block_index.unwrap_or(0);
+                events.push(MessagesStreamEvent::ContentBlockDelta {
+                    index,
                     delta: MessagesStreamDelta::TextDelta {
                         text: delta.clone(),
                     },
-                }]
+                });
+                events
+            }
+            LanguageModelStreamPart::TextEnd { .. } => self.stop_text_events(),
+            LanguageModelStreamPart::Error { error } => {
+                let mut events = self.start_message_events();
+                self.message_stopped = true;
+                events.push(MessagesStreamEvent::Error {
+                    error: crate::api::anthropic::messages::types::MessagesStreamError {
+                        error_type: "provider_error".to_owned(),
+                        message: error.to_string(),
+                    },
+                });
+                events
             }
             LanguageModelStreamPart::ToolInputStart { id, tool_name, .. } => {
+                let mut events = self.stop_text_events();
                 let index = self.next_block_index;
                 self.tool_id_to_index.insert(id.clone(), index);
                 self.next_block_index += 1;
-                vec![MessagesStreamEvent::ContentBlockStart {
+                events.push(MessagesStreamEvent::ContentBlockStart {
                     index,
                     content_block: AnthropicContentBlock::ToolUse {
                         id: id.clone(),
                         name: tool_name.clone(),
                         input: serde_json::json!({}),
                     },
-                }]
+                });
+                events
             }
             LanguageModelStreamPart::ToolInputDelta { id, delta, .. } => {
                 let index = self
@@ -208,9 +236,10 @@ impl StreamConverter {
                 tool_input,
                 ..
             } => {
+                let mut events = self.stop_text_events();
                 let index = self.next_block_index;
                 self.next_block_index += 1;
-                vec![
+                events.extend([
                     MessagesStreamEvent::ContentBlockStart {
                         index,
                         content_block: AnthropicContentBlock::ToolUse {
@@ -226,14 +255,16 @@ impl StreamConverter {
                         },
                     },
                     MessagesStreamEvent::ContentBlockStop { index },
-                ]
+                ]);
+                events
             }
             LanguageModelStreamPart::Finish {
                 finish_reason,
                 usage,
                 ..
             } => {
-                vec![MessagesStreamEvent::MessageDelta {
+                let mut events = self.stop_text_events();
+                events.push(MessagesStreamEvent::MessageDelta {
                     delta: MessagesMessageDelta {
                         delta_type: "message_delta".to_owned(),
                         stop_reason: Some(map_finish_reason(finish_reason)),
@@ -246,14 +277,87 @@ impl StreamConverter {
                         cache_read_input_tokens: usage.input_tokens.cache_read,
                     }),
                     message: Some(MessagesStreamMessage {
-                        id: format!("msg-{}", generate_id()),
+                        id: self.message_id.clone(),
                         model: self.model_id.clone(),
                         role: "assistant".to_owned(),
                     }),
-                }]
+                });
+                events.push(MessagesStreamEvent::MessageStop);
+                self.message_stopped = true;
+                events
             }
             _ => vec![],
         }
+    }
+
+    /// Emits terminal Anthropic stream events when an upstream closes cleanly
+    /// without a final finish part.
+    pub fn finish(&mut self) -> Vec<MessagesStreamEvent> {
+        if self.message_stopped {
+            return Vec::new();
+        }
+
+        let mut events = self.stop_text_events();
+        events.push(MessagesStreamEvent::MessageDelta {
+            delta: MessagesMessageDelta {
+                delta_type: "message_delta".to_owned(),
+                stop_reason: Some("end_turn".to_owned()),
+                stop_sequence: None,
+            },
+            usage: None,
+            message: Some(MessagesStreamMessage {
+                id: self.message_id.clone(),
+                model: self.model_id.clone(),
+                role: "assistant".to_owned(),
+            }),
+        });
+        events.push(MessagesStreamEvent::MessageStop);
+        self.message_stopped = true;
+        events
+    }
+
+    fn start_message_events(&mut self) -> Vec<MessagesStreamEvent> {
+        if self.message_started {
+            return Vec::new();
+        }
+
+        self.message_started = true;
+        vec![MessagesStreamEvent::MessageStart {
+            message: MessagesResponse {
+                id: self.message_id.clone(),
+                response_type: "message".to_owned(),
+                role: "assistant".to_owned(),
+                content: Vec::new(),
+                model: self.model_id.clone(),
+                stop_reason: None,
+                stop_sequence: None,
+                usage: None,
+            },
+        }]
+    }
+
+    fn start_text_events(&mut self) -> Vec<MessagesStreamEvent> {
+        let mut events = self.start_message_events();
+        if self.active_text_block_index.is_none() {
+            let index = self.next_block_index;
+            self.next_block_index += 1;
+            self.active_text_block_index = Some(index);
+            events.push(MessagesStreamEvent::ContentBlockStart {
+                index,
+                content_block: AnthropicContentBlock::Text {
+                    text: String::new(),
+                },
+            });
+        }
+        events
+    }
+
+    fn stop_text_events(&mut self) -> Vec<MessagesStreamEvent> {
+        let mut events = self.start_message_events();
+        if let Some(index) = self.active_text_block_index.take() {
+            events.push(MessagesStreamEvent::ContentBlockStop { index });
+        }
+        events
     }
 }
 

--- a/bitrouter-core/src/api/openai/responses/convert.rs
+++ b/bitrouter-core/src/api/openai/responses/convert.rs
@@ -345,7 +345,8 @@ fn input_content_to_string(content: Option<ResponsesInputContent>) -> String {
         Some(ResponsesInputContent::Parts(parts)) => parts
             .into_iter()
             .filter_map(|p| match p {
-                ResponsesInputContentPart::InputText { text } => Some(text),
+                ResponsesInputContentPart::InputText { text }
+                | ResponsesInputContentPart::OutputText { text } => Some(text),
                 ResponsesInputContentPart::InputImage { .. } => None,
             })
             .collect::<Vec<_>>()
@@ -363,10 +364,13 @@ fn input_content_to_parts(content: Option<ResponsesInputContent>) -> Vec<Languag
         Some(ResponsesInputContent::Parts(parts)) => parts
             .into_iter()
             .map(|p| match p {
-                ResponsesInputContentPart::InputText { text } => LanguageModelUserContent::Text {
-                    text,
-                    provider_options: None,
-                },
+                ResponsesInputContentPart::InputText { text }
+                | ResponsesInputContentPart::OutputText { text } => {
+                    LanguageModelUserContent::Text {
+                        text,
+                        provider_options: None,
+                    }
+                }
                 ResponsesInputContentPart::InputImage { image_url } => {
                     LanguageModelUserContent::File {
                         filename: None,
@@ -438,8 +442,8 @@ mod tests {
     };
 
     use super::super::types::{
-        ResponsesOutputContent, ResponsesOutputItem, ResponsesRequest, ResponsesResponse,
-        ResponsesStreamEvent, ResponsesUsage,
+        ResponsesInputMessage, ResponsesOutputContent, ResponsesOutputItem, ResponsesRequest,
+        ResponsesResponse, ResponsesStreamEvent, ResponsesUsage,
     };
 
     // ── Request Deserialization ─────────────────────────────────────────
@@ -587,6 +591,82 @@ mod tests {
             }
             other => panic!("expected Items input, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn deserialize_assistant_output_text_input_content() {
+        let json = r#"{
+            "model": "gpt-5.5",
+            "input": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [
+                        {"type": "output_text", "text": "previous assistant reply"}
+                    ]
+                }
+            ]
+        }"#;
+        let req: ResponsesRequest = serde_json::from_str(json).expect("parse failed");
+        match &req.input {
+            ResponsesInput::Items(items) => {
+                assert_eq!(items.len(), 1);
+                match &items[0] {
+                    ResponsesInputItem::Message(msg) => {
+                        assert_eq!(msg.role, "assistant");
+                        match msg.content.as_ref() {
+                            Some(ResponsesInputContent::Parts(parts)) => {
+                                assert_eq!(parts.len(), 1);
+                                assert!(matches!(
+                                    &parts[0],
+                                    ResponsesInputContentPart::OutputText { text }
+                                        if text == "previous assistant reply"
+                                ));
+                            }
+                            other => panic!("expected Parts content, got {other:?}"),
+                        }
+                    }
+                    other => panic!("expected Message, got {other:?}"),
+                }
+            }
+            other => panic!("expected Items input, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn serialize_assistant_output_text_input_content() {
+        let req = ResponsesRequest {
+            model: "gpt-5.5".to_owned(),
+            input: ResponsesInput::Items(vec![ResponsesInputItem::Message(
+                ResponsesInputMessage {
+                    item_type: "message".to_owned(),
+                    role: "assistant".to_owned(),
+                    content: Some(ResponsesInputContent::Parts(vec![
+                        ResponsesInputContentPart::OutputText {
+                            text: "previous assistant reply".to_owned(),
+                        },
+                    ])),
+                },
+            )]),
+            temperature: None,
+            top_p: None,
+            max_output_tokens: None,
+            stream: None,
+            tools: None,
+            tool_choice: None,
+            parallel_tool_calls: None,
+            text: None,
+        };
+
+        let val = serde_json::to_value(&req).expect("serialize failed");
+        assert_eq!(val["model"], "gpt-5.5");
+        assert_eq!(val["input"][0]["type"], "message");
+        assert_eq!(val["input"][0]["role"], "assistant");
+        assert_eq!(val["input"][0]["content"][0]["type"], "output_text");
+        assert_eq!(
+            val["input"][0]["content"][0]["text"],
+            "previous assistant reply"
+        );
     }
 
     // ── Response Serialization ──────────────────────────────────────────

--- a/bitrouter-core/src/api/openai/responses/types.rs
+++ b/bitrouter-core/src/api/openai/responses/types.rs
@@ -116,6 +116,7 @@ pub enum ResponsesInputContent {
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ResponsesInputContentPart {
     InputText { text: String },
+    OutputText { text: String },
     InputImage { image_url: String },
 }
 

--- a/bitrouter-providers/src/openai/responses/api.rs
+++ b/bitrouter-providers/src/openai/responses/api.rs
@@ -463,7 +463,7 @@ fn convert_prompt(prompt: &[LanguageModelMessage]) -> Result<Vec<ResponsesInputI
                     match item {
                         LanguageModelAssistantContent::Text { text, .. } => {
                             text_content
-                                .push(ResponsesInputContentPart::InputText { text: text.clone() });
+                                .push(ResponsesInputContentPart::OutputText { text: text.clone() });
                         }
                         LanguageModelAssistantContent::ToolCall {
                             tool_call_id,
@@ -1223,7 +1223,7 @@ mod tests {
     use bitrouter_core::models::language::{
         call_options::LanguageModelCallOptions,
         data_content::LanguageModelDataContent,
-        prompt::{LanguageModelMessage, LanguageModelUserContent},
+        prompt::{LanguageModelAssistantContent, LanguageModelMessage, LanguageModelUserContent},
     };
 
     #[test]
@@ -1273,6 +1273,57 @@ mod tests {
             ResponsesInput::Items(items) => {
                 assert!(matches!(items[0], ResponsesInputItem::Message(..)));
             }
+            other => panic!("expected Items input, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn builds_assistant_history_with_output_text() {
+        let request = build_responses_request(
+            "gpt-5.5",
+            &LanguageModelCallOptions {
+                prompt: vec![LanguageModelMessage::Assistant {
+                    content: vec![LanguageModelAssistantContent::Text {
+                        text: "previous assistant reply".to_owned(),
+                        provider_options: None,
+                    }],
+                    provider_options: None,
+                }],
+                stream: None,
+                max_output_tokens: None,
+                temperature: None,
+                top_p: None,
+                top_k: None,
+                stop_sequences: None,
+                presence_penalty: None,
+                frequency_penalty: None,
+                response_format: None,
+                seed: None,
+                tools: None,
+                tool_choice: None,
+                include_raw_chunks: None,
+                abort_signal: None,
+                headers: None,
+                provider_options: None,
+            },
+            false,
+        )
+        .expect("request should build");
+
+        match &request.input {
+            ResponsesInput::Items(items) => match &items[0] {
+                ResponsesInputItem::Message(message) => match message.content.as_ref() {
+                    Some(ResponsesInputContent::Parts(parts)) => {
+                        assert!(matches!(
+                            &parts[0],
+                            ResponsesInputContentPart::OutputText { text }
+                                if text == "previous assistant reply"
+                        ));
+                    }
+                    other => panic!("expected Parts content, got {other:?}"),
+                },
+                other => panic!("expected Message, got {other:?}"),
+            },
             other => panic!("expected Items input, got {other:?}"),
         }
     }

--- a/bitrouter/src/runtime/copilot.rs
+++ b/bitrouter/src/runtime/copilot.rs
@@ -24,14 +24,22 @@ pub fn copilot_default_headers() -> HashMap<String, String> {
     headers
 }
 
-/// Returns `true` when a model ID should use the Anthropic Messages API
-/// instead of the default OpenAI Chat Completions API.
+/// Returns `true` when a model ID should use the Anthropic Messages API.
 ///
 /// The Copilot API uses different protocols per model family: Claude models
-/// use the Anthropic Messages API (`POST /v1/messages`), while all other
-/// models use OpenAI Chat Completions (`POST /chat/completions`).
+/// use the Anthropic Messages API (`POST /v1/messages`).
 pub fn is_anthropic_model(model_id: &str) -> bool {
     model_id.starts_with("claude-") || model_id.starts_with("claude_")
+}
+
+/// Returns `true` when a Copilot OpenAI-family model should use the Responses
+/// API instead of Chat Completions.
+///
+/// Some Copilot-hosted OpenAI models are exposed to Copilot clients but reject
+/// the `/chat/completions` endpoint with "model is not accessible" errors.
+pub fn is_responses_model(model_id: &str) -> bool {
+    let model_id = model_id.to_ascii_lowercase();
+    model_id == "gpt-5.5" || (model_id.starts_with("gpt-5.") && model_id.contains("-codex"))
 }
 
 /// Derives the Anthropic-compatible API base from the provider's base URL.
@@ -87,6 +95,17 @@ mod tests {
         assert!(is_anthropic_model("claude-opus-4.6"));
         assert!(!is_anthropic_model("gpt-5.4"));
         assert!(!is_anthropic_model("gemini-2.5-pro"));
+    }
+
+    #[test]
+    fn copilot_response_models_detected() {
+        assert!(is_responses_model("gpt-5.5"));
+        assert!(is_responses_model("gpt-5.1-codex"));
+        assert!(is_responses_model("gpt-5.1-codex-mini"));
+        assert!(is_responses_model("gpt-5.3-codex"));
+        assert!(!is_responses_model("gpt-5.4"));
+        assert!(!is_responses_model("gpt-5-mini"));
+        assert!(!is_responses_model("claude-sonnet-4.6"));
     }
 
     #[test]

--- a/bitrouter/src/runtime/router.rs
+++ b/bitrouter/src/runtime/router.rs
@@ -14,6 +14,7 @@ use reqwest_middleware::ClientWithMiddleware;
 
 use super::copilot::{
     COPILOT_PROVIDER, anthropic_api_base, copilot_default_headers, is_anthropic_model,
+    is_responses_model,
 };
 
 #[cfg(feature = "mcp")]
@@ -162,6 +163,14 @@ impl LanguageModelRouter for Router {
             return Ok(DynLanguageModel::new_box(model));
         }
 
+        if is_copilot && is_responses_model(&target.service_id) {
+            let mut config = self.build_openai_config(&target.provider_name, provider)?;
+            merge_copilot_headers(&mut config.default_headers)?;
+            let model =
+                OpenAiResponsesModel::with_client(target.service_id, self.client.clone(), config);
+            return Ok(DynLanguageModel::new_box(model));
+        }
+
         // Phase 2: Inject Copilot-specific headers for non-Claude models.
         let copilot_headers = if is_copilot {
             Some(copilot_default_headers())
@@ -267,6 +276,7 @@ use bitrouter_providers::google::generate_content::provider::{
     GoogleConfig, GoogleGenerativeAiModel,
 };
 use bitrouter_providers::openai::chat::provider::{OpenAiChatCompletionsModel, OpenAiConfig};
+use bitrouter_providers::openai::responses::provider::OpenAiResponsesModel;
 
 // ── Tool router ──────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- route Copilot gpt-5.5 and GPT-5 Codex variants through the OpenAI Responses provider instead of chat completions
- serialize assistant-history Responses content as output_text while preserving input_text handling for user input
- treat clean streams that emit output but omit final usage/finish metadata as successful observations, avoiding false StreamProtocol spend failures
- add focused serde, provider, and stream-observation regression tests

## Validation
- cargo fmt -- --check
- cargo clippy --workspace --all-targets --all-features
- cargo test --workspace
- cargo test -p bitrouter-core api::openai::responses::convert::tests -- --nocapture
- cargo test -p bitrouter-api router::anthropic::messages::tests -- --nocapture
- cargo test -p bitrouter-api router::openai::responses::tests -- --nocapture
- cargo test -p bitrouter-api router::openai::chat::tests -- --nocapture
- cargo test -p bitrouter-api router::google::generate_content::tests -- --nocapture


Additional investigation:
- Claude Code’s stream client aborts the request controller when SSE iteration ends early or errors; this shows up in BitRouter logs as Hyper `IncompleteMessage` plus spend `Cancelled`.
- BitRouter’s Anthropic-compatible `/v1/messages` stream was emitting content deltas without the full Anthropic lifecycle (`message_start`, `content_block_start`, `content_block_stop`, `message_stop`) and used an OpenAI-style `[DONE]` sentinel. Strict Anthropic clients can treat that as malformed/incomplete and close/retry.
- Updated `/v1/messages` streaming to emit spec-compatible Anthropic framing and regression-tested the full event sequence.
