### PR TITLE
fix: tolerate responses stream events

### DIFF
--- a/bitrouter-api/src/router/mod.rs
+++ b/bitrouter-api/src/router/mod.rs
@@ -74,6 +74,7 @@ mod stream_observation {
                     ));
                 }
                 LanguageModelStreamPart::TextDelta { .. }
+                | LanguageModelStreamPart::ReasoningDelta { .. }
                 | LanguageModelStreamPart::ToolCall { .. }
                 | LanguageModelStreamPart::ToolInputStart { .. }
                 | LanguageModelStreamPart::ToolInputDelta { .. }

--- a/bitrouter-core/src/api/anthropic/messages/convert.rs
+++ b/bitrouter-core/src/api/anthropic/messages/convert.rs
@@ -1,6 +1,6 @@
 //! Conversion between Anthropic Messages format and core LanguageModel types.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::models::{
     language::{
@@ -149,6 +149,8 @@ pub struct StreamConverter {
     message_stopped: bool,
     active_text_block_index: Option<u32>,
     tool_id_to_index: HashMap<String, u32>,
+    started_tool_ids: HashSet<String>,
+    closed_tool_ids: HashSet<String>,
     next_block_index: u32,
 }
 
@@ -161,6 +163,8 @@ impl StreamConverter {
             message_stopped: false,
             active_text_block_index: None,
             tool_id_to_index: HashMap::new(),
+            started_tool_ids: HashSet::new(),
+            closed_tool_ids: HashSet::new(),
             next_block_index: 0,
         }
     }
@@ -195,40 +199,36 @@ impl StreamConverter {
                 events
             }
             LanguageModelStreamPart::ToolInputStart { id, tool_name, .. } => {
-                let mut events = self.stop_text_events();
-                let index = self.next_block_index;
-                self.tool_id_to_index.insert(id.clone(), index);
-                self.next_block_index += 1;
-                events.push(MessagesStreamEvent::ContentBlockStart {
-                    index,
-                    content_block: AnthropicContentBlock::ToolUse {
-                        id: id.clone(),
-                        name: tool_name.clone(),
-                        input: serde_json::json!({}),
-                    },
-                });
-                events
+                self.start_tool_events(id, tool_name)
             }
             LanguageModelStreamPart::ToolInputDelta { id, delta, .. } => {
-                let index = self
-                    .tool_id_to_index
-                    .get(id)
-                    .copied()
-                    .unwrap_or(self.next_block_index);
-                vec![MessagesStreamEvent::ContentBlockDelta {
+                if self.closed_tool_ids.contains(id) {
+                    return Vec::new();
+                }
+
+                let mut events = self.start_tool_events(id, "tool");
+                let Some(index) = self.tool_id_to_index.get(id).copied() else {
+                    return events;
+                };
+                events.push(MessagesStreamEvent::ContentBlockDelta {
                     index,
                     delta: MessagesStreamDelta::InputJsonDelta {
                         partial_json: delta.clone(),
                     },
-                }]
+                });
+                events
             }
             LanguageModelStreamPart::ToolInputEnd { id, .. } => {
-                let index = self
-                    .tool_id_to_index
-                    .get(id)
-                    .copied()
-                    .unwrap_or(self.next_block_index);
-                vec![MessagesStreamEvent::ContentBlockStop { index }]
+                if self.closed_tool_ids.contains(id) {
+                    return Vec::new();
+                }
+
+                let mut events = self.start_tool_events(id, "tool");
+                if let Some(index) = self.tool_id_to_index.get(id).copied() {
+                    events.push(MessagesStreamEvent::ContentBlockStop { index });
+                    self.closed_tool_ids.insert(id.clone());
+                }
+                events
             }
             LanguageModelStreamPart::ToolCall {
                 tool_call_id,
@@ -357,6 +357,31 @@ impl StreamConverter {
         if let Some(index) = self.active_text_block_index.take() {
             events.push(MessagesStreamEvent::ContentBlockStop { index });
         }
+        events
+    }
+
+    fn start_tool_events(&mut self, id: &str, tool_name: &str) -> Vec<MessagesStreamEvent> {
+        if self.closed_tool_ids.contains(id) {
+            return Vec::new();
+        }
+
+        let mut events = self.stop_text_events();
+        if self.started_tool_ids.contains(id) {
+            return events;
+        }
+
+        let index = self.next_block_index;
+        self.tool_id_to_index.insert(id.to_owned(), index);
+        self.started_tool_ids.insert(id.to_owned());
+        self.next_block_index += 1;
+        events.push(MessagesStreamEvent::ContentBlockStart {
+            index,
+            content_block: AnthropicContentBlock::ToolUse {
+                id: id.to_owned(),
+                name: tool_name.to_owned(),
+                input: serde_json::json!({}),
+            },
+        });
         events
     }
 }
@@ -500,5 +525,64 @@ fn map_finish_reason(reason: &LanguageModelFinishReason) -> String {
         LanguageModelFinishReason::ContentFilter => "end_turn".to_owned(),
         LanguageModelFinishReason::Error => "end_turn".to_owned(),
         LanguageModelFinishReason::Other(_) => "end_turn".to_owned(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stream_converter_starts_tool_block_for_delta_without_start() {
+        let mut converter = StreamConverter::new("claude-compatible".to_owned());
+
+        let events = converter.convert(&LanguageModelStreamPart::ToolInputDelta {
+            id: "call_1".to_owned(),
+            delta: r#"{"task":"plan"}"#.to_owned(),
+            provider_metadata: None,
+        });
+
+        assert!(matches!(
+            events.as_slice(),
+            [
+                MessagesStreamEvent::MessageStart { .. },
+                MessagesStreamEvent::ContentBlockStart { index: 0, content_block },
+                MessagesStreamEvent::ContentBlockDelta { index: 0, delta },
+            ] if matches!(
+                content_block,
+                AnthropicContentBlock::ToolUse { id, name, .. } if id == "call_1" && name == "tool"
+            ) && matches!(
+                delta,
+                MessagesStreamDelta::InputJsonDelta { partial_json } if partial_json == r#"{"task":"plan"}"#
+            )
+        ));
+    }
+
+    #[test]
+    fn stream_converter_ends_tool_block_for_end_without_start() {
+        let mut converter = StreamConverter::new("claude-compatible".to_owned());
+
+        let events = converter.convert(&LanguageModelStreamPart::ToolInputEnd {
+            id: "call_1".to_owned(),
+            provider_metadata: None,
+        });
+
+        assert!(matches!(
+            events.as_slice(),
+            [
+                MessagesStreamEvent::MessageStart { .. },
+                MessagesStreamEvent::ContentBlockStart { index: 0, content_block },
+                MessagesStreamEvent::ContentBlockStop { index: 0 },
+            ] if matches!(
+                content_block,
+                AnthropicContentBlock::ToolUse { id, name, .. } if id == "call_1" && name == "tool"
+            )
+        ));
+
+        let duplicate_events = converter.convert(&LanguageModelStreamPart::ToolInputEnd {
+            id: "call_1".to_owned(),
+            provider_metadata: None,
+        });
+        assert!(duplicate_events.is_empty());
     }
 }

--- a/bitrouter-core/src/api/anthropic/messages/types.rs
+++ b/bitrouter-core/src/api/anthropic/messages/types.rs
@@ -252,6 +252,8 @@ pub enum MessagesStreamEvent {
     Error {
         error: MessagesStreamError,
     },
+    #[serde(other)]
+    Unknown,
 }
 
 impl MessagesStreamEvent {
@@ -266,6 +268,7 @@ impl MessagesStreamEvent {
             Self::MessageStop => "message_stop",
             Self::Ping => "ping",
             Self::Error { .. } => "error",
+            Self::Unknown => "unknown",
         }
     }
 }
@@ -273,8 +276,23 @@ impl MessagesStreamEvent {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum MessagesStreamDelta {
-    TextDelta { text: String },
-    InputJsonDelta { partial_json: String },
+    TextDelta {
+        text: String,
+    },
+    InputJsonDelta {
+        partial_json: String,
+    },
+    ThinkingDelta {
+        thinking: String,
+    },
+    SignatureDelta {
+        signature: String,
+    },
+    CitationsDelta {
+        citation: serde_json::Value,
+    },
+    #[serde(other)]
+    Unknown,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/bitrouter-providers/Cargo.toml
+++ b/bitrouter-providers/Cargo.toml
@@ -14,11 +14,10 @@ openai = []
 anthropic = []
 google = []
 rest = []
-mcp = ["dep:tracing", "dep:rmcp"]
+mcp = ["dep:rmcp"]
 acp = [
     "dep:agent-client-protocol",
     "dep:async-trait",
-    "dep:tracing",
     "dep:bitrouter-config",
     "dep:flate2",
     "dep:tar",
@@ -28,7 +27,6 @@ acp = [
     "tokio/io-std",
 ]
 agentskills = [
-    "dep:tracing",
     "dep:serde-saphyr",
     "dep:chrono",
     "dep:uuid",
@@ -38,7 +36,7 @@ agentskills = [
 
 [dependencies]
 bitrouter-core.workspace = true
-tracing = { version = "0.1", optional = true }
+tracing = { version = "0.1" }
 
 base64 = "0.22"
 futures-core = "0.3"

--- a/bitrouter-providers/src/anthropic/messages/api.rs
+++ b/bitrouter-providers/src/anthropic/messages/api.rs
@@ -770,6 +770,10 @@ impl AnthropicSseParser {
                 raw_value: raw_value.clone(),
             });
         }
+        let event_type = raw_value
+            .get("type")
+            .and_then(JsonValue::as_str)
+            .map(str::to_owned);
 
         let event: MessagesStreamEvent = match serde_json::from_value(raw_value.clone()) {
             Ok(event) => event,
@@ -788,6 +792,26 @@ impl AnthropicSseParser {
         };
 
         parts.extend(self.state.apply_event(event));
+        if parts.is_empty()
+            && let Some(event_type) = event_type
+            && !matches!(
+                event_type.as_str(),
+                "message_start"
+                    | "content_block_start"
+                    | "content_block_delta"
+                    | "content_block_stop"
+                    | "message_delta"
+                    | "message_stop"
+                    | "ping"
+                    | "error"
+            )
+        {
+            tracing::debug!(
+                provider = ANTHROPIC_PROVIDER_NAME,
+                event_type = %event_type,
+                "ignored unsupported Anthropic stream event"
+            );
+        }
         parts
     }
 }

--- a/bitrouter-providers/src/anthropic/messages/api.rs
+++ b/bitrouter-providers/src/anthropic/messages/api.rs
@@ -797,10 +797,19 @@ struct AnthropicStreamState {
     metadata_emitted: bool,
     text_started: bool,
     tool_inputs: HashMap<u32, AnthropicToolInputState>,
+    block_types: HashMap<u32, AnthropicStreamBlockType>,
     usage: Option<LanguageModelUsage>,
     finish_reason:
         Option<bitrouter_core::models::language::finish_reason::LanguageModelFinishReason>,
     finished: bool,
+}
+
+#[derive(Clone, Copy)]
+enum AnthropicStreamBlockType {
+    Text,
+    ToolUse,
+    Reasoning,
+    Other,
 }
 
 #[derive(Default)]
@@ -836,6 +845,8 @@ impl AnthropicStreamState {
                 let mut parts = Vec::new();
                 match content_block {
                     AnthropicContentBlock::Text { .. } => {
+                        self.block_types
+                            .insert(index, AnthropicStreamBlockType::Text);
                         if !self.text_started {
                             parts.push(LanguageModelStreamPart::TextStart {
                                 id: STREAM_TEXT_ID.to_owned(),
@@ -845,6 +856,8 @@ impl AnthropicStreamState {
                         }
                     }
                     AnthropicContentBlock::ToolUse { id, name, .. } => {
+                        self.block_types
+                            .insert(index, AnthropicStreamBlockType::ToolUse);
                         let entry = self.tool_inputs.entry(index).or_default();
                         entry.id = Some(id.clone());
                         entry.name = Some(name.clone());
@@ -858,10 +871,20 @@ impl AnthropicStreamState {
                         });
                         entry.started = true;
                     }
+                    AnthropicContentBlock::Thinking { .. }
+                    | AnthropicContentBlock::RedactedThinking { .. } => {
+                        self.block_types
+                            .insert(index, AnthropicStreamBlockType::Reasoning);
+                        parts.push(LanguageModelStreamPart::ReasoningStart {
+                            id: index.to_string(),
+                            provider_metadata: None,
+                        });
+                    }
                     AnthropicContentBlock::Image { .. }
-                    | AnthropicContentBlock::ToolResult { .. }
-                    | AnthropicContentBlock::Thinking { .. }
-                    | AnthropicContentBlock::RedactedThinking { .. } => {}
+                    | AnthropicContentBlock::ToolResult { .. } => {
+                        self.block_types
+                            .insert(index, AnthropicStreamBlockType::Other);
+                    }
                 }
                 parts
             }
@@ -895,9 +918,41 @@ impl AnthropicStreamState {
                     }
                     parts
                 }
+                MessagesStreamDelta::ThinkingDelta { thinking } => {
+                    let mut parts = Vec::new();
+                    if !matches!(
+                        self.block_types.get(&index),
+                        Some(AnthropicStreamBlockType::Reasoning)
+                    ) {
+                        self.block_types
+                            .insert(index, AnthropicStreamBlockType::Reasoning);
+                        parts.push(LanguageModelStreamPart::ReasoningStart {
+                            id: index.to_string(),
+                            provider_metadata: None,
+                        });
+                    }
+                    parts.push(LanguageModelStreamPart::ReasoningDelta {
+                        id: index.to_string(),
+                        delta: thinking,
+                        provider_metadata: None,
+                    });
+                    parts
+                }
+                MessagesStreamDelta::SignatureDelta { .. }
+                | MessagesStreamDelta::CitationsDelta { .. }
+                | MessagesStreamDelta::Unknown => Vec::new(),
             },
             MessagesStreamEvent::ContentBlockStop { index } => {
                 let mut parts = Vec::new();
+                if matches!(
+                    self.block_types.remove(&index),
+                    Some(AnthropicStreamBlockType::Reasoning)
+                ) {
+                    parts.push(LanguageModelStreamPart::ReasoningEnd {
+                        id: index.to_string(),
+                        provider_metadata: None,
+                    });
+                }
                 if let Some(tool_state) = self.tool_inputs.get(&index)
                     && tool_state.started
                 {
@@ -939,6 +994,7 @@ impl AnthropicStreamState {
                     }),
                 }]
             }
+            MessagesStreamEvent::Unknown => Vec::new(),
         }
     }
 
@@ -1396,6 +1452,70 @@ mod tests {
         let mut parser = AnthropicSseParser::new(false);
         let parts = parser.push_bytes(&sse_event("ping", r#"{"type":"ping"}"#));
         assert!(parts.is_empty());
+    }
+
+    #[test]
+    fn parse_thinking_stream() {
+        let mut parser = AnthropicSseParser::new(false);
+
+        let start_parts = parser.push_bytes(&sse_event(
+            "content_block_start",
+            r#"{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":"","signature":null}}"#,
+        ));
+        assert!(
+            start_parts.iter().any(
+                |p| matches!(p, LanguageModelStreamPart::ReasoningStart { id, .. } if id == "0")
+            )
+        );
+
+        let delta_parts = parser.push_bytes(&sse_event(
+            "content_block_delta",
+            r#"{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Let me reason"}}"#,
+        ));
+        assert!(
+            delta_parts
+                .iter()
+                .any(|p| matches!(p, LanguageModelStreamPart::ReasoningDelta { id, delta, .. } if id == "0" && delta == "Let me reason"))
+        );
+
+        let signature_parts = parser.push_bytes(&sse_event(
+            "content_block_delta",
+            r#"{"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sig"}}"#,
+        ));
+        assert!(signature_parts.is_empty());
+
+        let stop_parts = parser.push_bytes(&sse_event(
+            "content_block_stop",
+            r#"{"type":"content_block_stop","index":0}"#,
+        ));
+        assert!(
+            stop_parts.iter().any(
+                |p| matches!(p, LanguageModelStreamPart::ReasoningEnd { id, .. } if id == "0")
+            )
+        );
+    }
+
+    #[test]
+    fn parse_unknown_anthropic_stream_events_are_ignored() {
+        let mut parser = AnthropicSseParser::new(false);
+
+        let event_parts = parser.push_bytes(&sse_event(
+            "unknown_event",
+            r#"{"type":"unknown_event","value":"future"}"#,
+        ));
+        assert!(
+            event_parts.is_empty(),
+            "unknown Anthropic stream events should be ignored: {event_parts:?}"
+        );
+
+        let delta_parts = parser.push_bytes(&sse_event(
+            "content_block_delta",
+            r#"{"type":"content_block_delta","index":0,"delta":{"type":"future_delta","value":"future"}}"#,
+        ));
+        assert!(
+            delta_parts.is_empty(),
+            "unknown Anthropic stream deltas should be ignored: {delta_parts:?}"
+        );
     }
 
     #[test]

--- a/bitrouter-providers/src/openai/responses/api.rs
+++ b/bitrouter-providers/src/openai/responses/api.rs
@@ -852,10 +852,14 @@ enum OpenAiResponsesStreamEvent {
     },
     #[serde(rename = "response.completed")]
     ResponseCompleted { response: ResponsesResponse },
+    #[serde(rename = "response.incomplete")]
+    ResponseIncomplete { response: ResponsesResponse },
     #[serde(rename = "response.failed")]
     ResponseFailed { response: ResponsesResponse },
     #[serde(rename = "error")]
     Error { error: ResponsesApiError },
+    #[serde(other)]
+    Unknown,
 }
 
 impl OpenAiResponsesStreamState {
@@ -1020,6 +1024,23 @@ impl OpenAiResponsesStreamState {
                 ));
                 self.finish_parts()
             }
+            OpenAiResponsesStreamEvent::ResponseIncomplete { response } => {
+                if let Some(usage) = response.usage {
+                    self.usage = Some(usage_to_language_model(usage));
+                }
+                self.finish_reason = Some(map_response_finish_reason(
+                    response.status.as_deref(),
+                    response
+                        .incomplete_details
+                        .as_ref()
+                        .and_then(|details| details.reason.as_deref()),
+                    response
+                        .output
+                        .iter()
+                        .any(|item| matches!(item, ResponsesOutputItem::FunctionCall { .. })),
+                ));
+                self.finish_parts()
+            }
             OpenAiResponsesStreamEvent::ResponseFailed { response } => {
                 self.finish_reason = Some(LanguageModelFinishReason::Error);
                 let mut parts = Vec::new();
@@ -1049,6 +1070,7 @@ impl OpenAiResponsesStreamState {
                 parts.extend(self.finish_parts());
                 parts
             }
+            OpenAiResponsesStreamEvent::Unknown => Vec::new(),
         }
     }
 
@@ -1433,5 +1455,82 @@ mod tests {
                 .iter()
                 .any(|part| matches!(part, LanguageModelStreamPart::Finish { .. }))
         );
+    }
+
+    #[test]
+    fn sse_parser_ignores_unknown_responses_events() {
+        let mut parser = OpenAiResponsesSseParser::new(false);
+
+        let reasoning_delta = json!({
+            "type": "response.reasoning_text.delta",
+            "sequence_number": 1,
+            "item_id": "rs_1",
+            "delta": "thinking"
+        });
+        let completed = json!({
+            "type": "response.completed",
+            "response": {
+                "id": "resp_1",
+                "created_at": 1,
+                "model": "gpt-5.5",
+                "status": "completed",
+                "output": [],
+                "usage": {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2}
+            }
+        });
+
+        let unknown_parts = parser.push_bytes(&sse_event(&reasoning_delta.to_string()));
+        assert!(
+            unknown_parts.is_empty(),
+            "unknown Responses events should be ignored, got {unknown_parts:?}"
+        );
+
+        let done_parts = parser.push_bytes(&sse_event(&completed.to_string()));
+        assert!(
+            done_parts
+                .iter()
+                .all(|part| !matches!(part, LanguageModelStreamPart::Error { .. })),
+            "unknown Responses events must not poison the stream: {done_parts:?}"
+        );
+        assert!(
+            done_parts
+                .iter()
+                .any(|part| matches!(part, LanguageModelStreamPart::Finish { .. }))
+        );
+    }
+
+    #[test]
+    fn sse_parser_handles_response_incomplete_as_finish() {
+        let mut parser = OpenAiResponsesSseParser::new(false);
+
+        let incomplete = json!({
+            "type": "response.incomplete",
+            "response": {
+                "id": "resp_1",
+                "created_at": 1,
+                "model": "gpt-5.5",
+                "status": "incomplete",
+                "output": [],
+                "usage": {"input_tokens": 3, "output_tokens": 4, "total_tokens": 7},
+                "incomplete_details": {"reason": "max_output_tokens"}
+            }
+        });
+
+        let parts = parser.push_bytes(&sse_event(&incomplete.to_string()));
+        assert!(
+            parts
+                .iter()
+                .all(|part| !matches!(part, LanguageModelStreamPart::Error { .. })),
+            "response.incomplete should not emit a stream error: {parts:?}"
+        );
+        assert!(parts.iter().any(|part| matches!(
+            part,
+            LanguageModelStreamPart::Finish {
+                finish_reason: LanguageModelFinishReason::Length,
+                usage,
+                ..
+            } if usage.input_tokens.total == Some(3)
+                && usage.output_tokens.total == Some(4)
+        )));
     }
 }

--- a/bitrouter-providers/src/openai/responses/api.rs
+++ b/bitrouter-providers/src/openai/responses/api.rs
@@ -36,6 +36,7 @@ use tokio_util::sync::CancellationToken;
 
 pub(crate) const OPENAI_PROVIDER_NAME: &str = "openai";
 const STREAM_TEXT_ID: &str = "text";
+const MAX_RESPONSES_CALL_ID_LEN: usize = 64;
 
 // ── Free-function conversions (replace From / TryFrom impls) ───────────────
 
@@ -430,6 +431,7 @@ fn map_response_finish_reason(
 
 fn convert_prompt(prompt: &[LanguageModelMessage]) -> Result<Vec<ResponsesInputItem>> {
     let mut input = Vec::new();
+    let mut call_ids = ResponsesCallIdMapper::from_prompt(prompt);
 
     for message in prompt {
         match message {
@@ -471,9 +473,10 @@ fn convert_prompt(prompt: &[LanguageModelMessage]) -> Result<Vec<ResponsesInputI
                             input: tool_input,
                             ..
                         } => {
+                            let call_id = call_ids.normalize(tool_call_id);
                             input.push(ResponsesInputItem::FunctionCall(ResponsesInputFunctionCall {
                                 item_type: "function_call".to_owned(),
-                                call_id: tool_call_id.clone(),
+                                call_id,
                                 name: tool_name.clone(),
                                 arguments: serde_json::to_string(tool_input).map_err(|error| {
                                     BitrouterError::invalid_request(
@@ -529,10 +532,11 @@ fn convert_prompt(prompt: &[LanguageModelMessage]) -> Result<Vec<ResponsesInputI
                             output,
                             ..
                         } => {
+                            let call_id = call_ids.normalize(tool_call_id);
                             input.push(ResponsesInputItem::FunctionCallOutput(
                                 ResponsesInputFunctionCallOutput {
                                     item_type: "function_call_output".to_owned(),
-                                    call_id: tool_call_id.clone(),
+                                    call_id,
                                     output: stringify_tool_output(output)?,
                                 },
                             ));
@@ -551,6 +555,72 @@ fn convert_prompt(prompt: &[LanguageModelMessage]) -> Result<Vec<ResponsesInputI
     }
 
     Ok(input)
+}
+
+#[derive(Default)]
+struct ResponsesCallIdMapper {
+    normalized: HashMap<String, String>,
+    next_id: usize,
+}
+
+impl ResponsesCallIdMapper {
+    fn from_prompt(prompt: &[LanguageModelMessage]) -> Self {
+        let mut mapper = Self::default();
+        for message in prompt {
+            match message {
+                LanguageModelMessage::Assistant { content, .. } => {
+                    for item in content {
+                        if let LanguageModelAssistantContent::ToolCall { tool_call_id, .. } = item {
+                            mapper.reserve_if_provider_safe(tool_call_id);
+                        }
+                    }
+                }
+                LanguageModelMessage::Tool { content, .. } => {
+                    for item in content {
+                        if let LanguageModelToolResult::ToolResult { tool_call_id, .. } = item {
+                            mapper.reserve_if_provider_safe(tool_call_id);
+                        }
+                    }
+                }
+                LanguageModelMessage::System { .. } | LanguageModelMessage::User { .. } => {}
+            }
+        }
+        mapper
+    }
+
+    fn reserve_if_provider_safe(&mut self, call_id: &str) {
+        if call_id.len() <= MAX_RESPONSES_CALL_ID_LEN {
+            self.normalized
+                .entry(call_id.to_owned())
+                .or_insert_with(|| call_id.to_owned());
+        }
+    }
+
+    fn normalize(&mut self, call_id: &str) -> String {
+        if let Some(normalized) = self.normalized.get(call_id) {
+            return normalized.clone();
+        }
+
+        let mut normalized = format!("br_call_{}", self.next_id);
+        self.next_id += 1;
+        while self
+            .normalized
+            .values()
+            .any(|existing| existing == &normalized)
+        {
+            normalized = format!("br_call_{}", self.next_id);
+            self.next_id += 1;
+        }
+        tracing::debug!(
+            provider = OPENAI_PROVIDER_NAME,
+            original_len = call_id.len(),
+            normalized = %normalized,
+            "normalized Responses call_id that exceeds provider length limit"
+        );
+        self.normalized
+            .insert(call_id.to_owned(), normalized.clone());
+        normalized
+    }
 }
 
 fn convert_image_input(data: &LanguageModelDataContent, media_type: &str) -> Result<String> {
@@ -763,6 +833,10 @@ impl OpenAiResponsesSseParser {
                 raw_value: raw_value.clone(),
             });
         }
+        let event_type = raw_value
+            .get("type")
+            .and_then(JsonValue::as_str)
+            .map(str::to_owned);
 
         if let Ok(error_envelope) =
             serde_json::from_value::<ResponsesErrorEnvelope>(raw_value.clone())
@@ -796,6 +870,28 @@ impl OpenAiResponsesSseParser {
         };
 
         parts.extend(self.state.apply_event(event));
+        if parts.is_empty()
+            && let Some(event_type) = event_type
+            && !matches!(
+                event_type.as_str(),
+                "response.created"
+                    | "response.output_item.added"
+                    | "response.output_text.delta"
+                    | "response.output_text.done"
+                    | "response.function_call_arguments.delta"
+                    | "response.function_call_arguments.done"
+                    | "response.completed"
+                    | "response.incomplete"
+                    | "response.failed"
+                    | "error"
+            )
+        {
+            tracing::debug!(
+                provider = OPENAI_PROVIDER_NAME,
+                event_type = %event_type,
+                "ignored unsupported Responses stream event"
+            );
+        }
         parts
     }
 }
@@ -1245,7 +1341,10 @@ mod tests {
     use bitrouter_core::models::language::{
         call_options::LanguageModelCallOptions,
         data_content::LanguageModelDataContent,
-        prompt::{LanguageModelAssistantContent, LanguageModelMessage, LanguageModelUserContent},
+        prompt::{
+            LanguageModelAssistantContent, LanguageModelMessage, LanguageModelToolResult,
+            LanguageModelToolResultOutput, LanguageModelUserContent,
+        },
     };
 
     #[test]
@@ -1348,6 +1447,135 @@ mod tests {
             },
             other => panic!("expected Items input, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn normalizes_long_call_ids_consistently() {
+        let long_call_id = format!("toolu_{}", "x".repeat(402));
+        let request = build_responses_request(
+            "gpt-5.5",
+            &LanguageModelCallOptions {
+                prompt: vec![
+                    LanguageModelMessage::Assistant {
+                        content: vec![LanguageModelAssistantContent::ToolCall {
+                            tool_call_id: long_call_id.clone(),
+                            tool_name: "todo_write".to_owned(),
+                            input: json!({"todos":[]}),
+                            provider_executed: None,
+                            provider_options: None,
+                        }],
+                        provider_options: None,
+                    },
+                    LanguageModelMessage::Tool {
+                        content: vec![LanguageModelToolResult::ToolResult {
+                            tool_call_id: long_call_id,
+                            tool_name: "todo_write".to_owned(),
+                            output: LanguageModelToolResultOutput::Text {
+                                value: "ok".to_owned(),
+                                provider_options: None,
+                            },
+                            provider_options: None,
+                        }],
+                        provider_options: None,
+                    },
+                ],
+                stream: None,
+                max_output_tokens: None,
+                temperature: None,
+                top_p: None,
+                top_k: None,
+                stop_sequences: None,
+                presence_penalty: None,
+                frequency_penalty: None,
+                response_format: None,
+                seed: None,
+                tools: None,
+                tool_choice: None,
+                include_raw_chunks: None,
+                abort_signal: None,
+                headers: None,
+                provider_options: None,
+            },
+            false,
+        )
+        .expect("request should build");
+
+        let ResponsesInput::Items(items) = request.input else {
+            panic!("expected items input");
+        };
+        let ResponsesInputItem::FunctionCall(call) = &items[0] else {
+            panic!("expected function call item");
+        };
+        let ResponsesInputItem::FunctionCallOutput(output) = &items[1] else {
+            panic!("expected function call output item");
+        };
+
+        assert_eq!(call.call_id, "br_call_0");
+        assert_eq!(output.call_id, call.call_id);
+        assert!(call.call_id.len() <= MAX_RESPONSES_CALL_ID_LEN);
+    }
+
+    #[test]
+    fn normalized_call_ids_avoid_short_id_collisions() {
+        let long_call_id = format!("toolu_{}", "x".repeat(402));
+        let request = build_responses_request(
+            "gpt-5.5",
+            &LanguageModelCallOptions {
+                prompt: vec![
+                    LanguageModelMessage::Assistant {
+                        content: vec![LanguageModelAssistantContent::ToolCall {
+                            tool_call_id: "br_call_0".to_owned(),
+                            tool_name: "existing".to_owned(),
+                            input: json!({}),
+                            provider_executed: None,
+                            provider_options: None,
+                        }],
+                        provider_options: None,
+                    },
+                    LanguageModelMessage::Assistant {
+                        content: vec![LanguageModelAssistantContent::ToolCall {
+                            tool_call_id: long_call_id,
+                            tool_name: "todo_write".to_owned(),
+                            input: json!({"todos":[]}),
+                            provider_executed: None,
+                            provider_options: None,
+                        }],
+                        provider_options: None,
+                    },
+                ],
+                stream: None,
+                max_output_tokens: None,
+                temperature: None,
+                top_p: None,
+                top_k: None,
+                stop_sequences: None,
+                presence_penalty: None,
+                frequency_penalty: None,
+                response_format: None,
+                seed: None,
+                tools: None,
+                tool_choice: None,
+                include_raw_chunks: None,
+                abort_signal: None,
+                headers: None,
+                provider_options: None,
+            },
+            false,
+        )
+        .expect("request should build");
+
+        let ResponsesInput::Items(items) = request.input else {
+            panic!("expected items input");
+        };
+        let ResponsesInputItem::FunctionCall(existing) = &items[0] else {
+            panic!("expected function call item");
+        };
+        let ResponsesInputItem::FunctionCall(normalized) = &items[1] else {
+            panic!("expected function call item");
+        };
+
+        assert_eq!(existing.call_id, "br_call_0");
+        assert_eq!(normalized.call_id, "br_call_1");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- handle terminal OpenAI Responses `response.incomplete` stream events as finish events
- ignore unknown forward-compatible Responses stream events instead of emitting `LanguageModelStreamPart::Error`
- add regression coverage for GPT-5.5-style reasoning events and incomplete terminal events

## Validation
- `cargo fmt -- --check`
- `cargo clippy --workspace --all-targets --all-features`
- `cargo test --workspace --all-features`


## Vercel AI SDK cross-check
- Vercel parses SSE with a generic JSON event stream parser, ignores OpenAI-style `[DONE]`, and then handles provider-specific stream chunks.
- OpenAI Responses: Vercel handles reasoning stream events and treats `response.completed`/`response.incomplete`/`response.failed` as terminal status events. BitRouter now handles `response.incomplete` and ignores future Responses events instead of emitting `StreamProtocol`.
- Anthropic Messages: Vercel handles `thinking_delta`, `signature_delta`, `citations_delta`, and provider evolution. BitRouter now accepts these delta variants, maps thinking deltas to reasoning stream parts, and ignores unknown Anthropic stream events/deltas.
- OpenAI Chat and Google Generate Content were reviewed: their current schemas already ignore extra fields and do not have the same typed event-union failure mode as Responses/Anthropic; existing provider error envelopes and malformed JSON still surface as stream errors.



## Claude Code `Content block not found` follow-up
- Root cause: downstream Anthropic framing could emit `content_block_delta` / `content_block_stop` for a tool block when an upstream provider produced tool argument delta/done parts without a corresponding tool start part. Strict clients abort with `Content block not found`, which BitRouter records as downstream `Cancelled`.
- Fix: the Anthropic stream converter now synthesizes a `tool_use` `content_block_start` before any orphaned tool delta/end, and suppresses duplicate tool stops.
- Regression coverage added for tool delta/end without start.
