### PR TITLE
fix: map responses tool stream ids

### DIFF
--- a/bitrouter-api/src/router/anthropic/messages/tests.rs
+++ b/bitrouter-api/src/router/anthropic/messages/tests.rs
@@ -577,6 +577,8 @@ async fn messages_streaming_sends_sse_events() {
     assert_eq!(start["message"]["type"], "message");
     assert_eq!(start["message"]["role"], "assistant");
     assert_eq!(start["message"]["model"], "claude-3-5-sonnet-20241022");
+    assert_eq!(start["message"]["usage"]["input_tokens"], 0);
+    assert_eq!(start["message"]["usage"]["output_tokens"], 0);
     assert_eq!(
         start["message"]["content"].as_array().map(Vec::len),
         Some(0)
@@ -606,6 +608,8 @@ async fn messages_streaming_sends_sse_events() {
     assert_eq!(finish["type"], "message_delta");
     assert_eq!(finish["delta"]["type"], "message_delta");
     assert_eq!(finish["delta"]["stop_reason"], "end_turn");
+    assert_eq!(finish["usage"]["input_tokens"], 12);
+    assert_eq!(finish["usage"]["output_tokens"], 6);
     assert_eq!(finish["message"]["model"], "claude-3-5-sonnet-20241022");
     assert_eq!(finish["message"]["role"], "assistant");
     assert!(

--- a/bitrouter-core/src/api/anthropic/messages/convert.rs
+++ b/bitrouter-core/src/api/anthropic/messages/convert.rs
@@ -271,8 +271,8 @@ impl StreamConverter {
                         stop_sequence: None,
                     },
                     usage: Some(MessagesUsage {
-                        input_tokens: usage.input_tokens.total,
-                        output_tokens: usage.output_tokens.total,
+                        input_tokens: Some(usage.input_tokens.total.unwrap_or(0)),
+                        output_tokens: Some(usage.output_tokens.total.unwrap_or(0)),
                         cache_creation_input_tokens: usage.input_tokens.cache_write,
                         cache_read_input_tokens: usage.input_tokens.cache_read,
                     }),
@@ -304,7 +304,7 @@ impl StreamConverter {
                 stop_reason: Some("end_turn".to_owned()),
                 stop_sequence: None,
             },
-            usage: None,
+            usage: Some(empty_stream_usage()),
             message: Some(MessagesStreamMessage {
                 id: self.message_id.clone(),
                 model: self.model_id.clone(),
@@ -331,7 +331,7 @@ impl StreamConverter {
                 model: self.model_id.clone(),
                 stop_reason: None,
                 stop_sequence: None,
-                usage: None,
+                usage: Some(empty_stream_usage()),
             },
         }]
     }
@@ -528,6 +528,15 @@ fn map_finish_reason(reason: &LanguageModelFinishReason) -> String {
     }
 }
 
+fn empty_stream_usage() -> MessagesUsage {
+    MessagesUsage {
+        input_tokens: Some(0),
+        output_tokens: Some(0),
+        cache_creation_input_tokens: None,
+        cache_read_input_tokens: None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -584,5 +593,55 @@ mod tests {
             provider_metadata: None,
         });
         assert!(duplicate_events.is_empty());
+    }
+
+    #[test]
+    fn stream_converter_message_start_includes_usage() {
+        let mut converter = StreamConverter::new("claude-compatible".to_owned());
+
+        let events = converter.convert(&LanguageModelStreamPart::TextStart {
+            id: "text".to_owned(),
+            provider_metadata: None,
+        });
+
+        assert!(matches!(
+            events.first(),
+            Some(MessagesStreamEvent::MessageStart { message })
+                if message.usage.as_ref().is_some_and(|usage|
+                    usage.input_tokens == Some(0) && usage.output_tokens == Some(0)
+                )
+        ));
+    }
+
+    #[test]
+    fn stream_converter_finish_includes_token_counts() {
+        let mut converter = StreamConverter::new("claude-compatible".to_owned());
+
+        let events = converter.convert(&LanguageModelStreamPart::Finish {
+            usage: crate::models::language::usage::LanguageModelUsage {
+                input_tokens: crate::models::language::usage::LanguageModelInputTokens {
+                    total: None,
+                    no_cache: None,
+                    cache_read: None,
+                    cache_write: None,
+                },
+                output_tokens: crate::models::language::usage::LanguageModelOutputTokens {
+                    total: None,
+                    text: None,
+                    reasoning: None,
+                },
+                raw: None,
+            },
+            finish_reason: LanguageModelFinishReason::Stop,
+            provider_metadata: None,
+        });
+
+        assert!(events.iter().any(|event| matches!(
+            event,
+            MessagesStreamEvent::MessageDelta {
+                usage: Some(usage),
+                ..
+            } if usage.input_tokens == Some(0) && usage.output_tokens == Some(0)
+        )));
     }
 }

--- a/bitrouter-providers/src/openai/responses/api.rs
+++ b/bitrouter-providers/src/openai/responses/api.rs
@@ -611,7 +611,7 @@ impl ResponsesCallIdMapper {
             normalized = format!("br_call_{}", self.next_id);
             self.next_id += 1;
         }
-        tracing::debug!(
+        tracing::trace!(
             provider = OPENAI_PROVIDER_NAME,
             original_len = call_id.len(),
             normalized = %normalized,
@@ -901,6 +901,7 @@ struct OpenAiToolInputState {
     tool_name: Option<String>,
     started: bool,
     emitted_arguments: bool,
+    argument_buffer: String,
 }
 
 #[derive(Default)]
@@ -991,6 +992,14 @@ impl OpenAiResponsesStreamState {
                     ..
                 } => {
                     if let Some(id) = id {
+                        tracing::debug!(
+                            provider = OPENAI_PROVIDER_NAME,
+                            item_id = %id,
+                            call_id = %call_id,
+                            tool_name = %name,
+                            arguments_len = arguments.len(),
+                            "Responses tool call item added"
+                        );
                         self.tool_item_ids.insert(id, call_id.clone());
                     }
                     let tool_state = self.tool_inputs.entry(call_id.clone()).or_default();
@@ -1008,6 +1017,7 @@ impl OpenAiResponsesStreamState {
                         tool_state.started = true;
                     }
                     if !arguments.is_empty() {
+                        tool_state.argument_buffer.push_str(&arguments);
                         parts.push(LanguageModelStreamPart::ToolInputDelta {
                             id: call_id,
                             delta: arguments,
@@ -1089,6 +1099,7 @@ impl OpenAiResponsesStreamState {
                     tool_state.started = true;
                 }
                 if !delta.is_empty() {
+                    tool_state.argument_buffer.push_str(&delta);
                     parts.push(LanguageModelStreamPart::ToolInputDelta {
                         id,
                         delta,
@@ -1120,17 +1131,28 @@ impl OpenAiResponsesStreamState {
                     });
                     tool_state.started = true;
                 }
-                if let Some(arguments) = arguments
-                    && !arguments.is_empty()
+                let done_arguments_len = arguments.as_ref().map_or(0, String::len);
+                let skipped_done_arguments = done_arguments_len > 0 && tool_state.emitted_arguments;
+                if let Some(done_arguments) = arguments
+                    && !done_arguments.is_empty()
                     && !tool_state.emitted_arguments
                 {
+                    tool_state.argument_buffer.push_str(&done_arguments);
                     parts.push(LanguageModelStreamPart::ToolInputDelta {
                         id: id.clone(),
-                        delta: arguments,
+                        delta: done_arguments,
                         provider_metadata: None,
                     });
                     tool_state.emitted_arguments = true;
                 }
+                log_tool_arguments_done(
+                    &id,
+                    tool_state.tool_name.as_deref(),
+                    &tool_state.argument_buffer,
+                    tool_state.emitted_arguments,
+                    done_arguments_len,
+                    skipped_done_arguments,
+                );
                 parts.push(LanguageModelStreamPart::ToolInputEnd {
                     id,
                     provider_metadata: None,
@@ -1276,6 +1298,79 @@ impl OpenAiResponsesStreamState {
             "Responses function_call_arguments event omitted item_id and call_id"
         );
         "tool".to_owned()
+    }
+}
+
+fn log_tool_arguments_done(
+    call_id: &str,
+    tool_name: Option<&str>,
+    arguments: &str,
+    emitted_arguments: bool,
+    done_arguments_len: usize,
+    skipped_done_arguments: bool,
+) {
+    let summary = summarize_json(arguments);
+    tracing::debug!(
+        provider = OPENAI_PROVIDER_NAME,
+        call_id = %call_id,
+        tool_name = tool_name.unwrap_or("tool"),
+        arguments_len = arguments.len(),
+        done_arguments_len,
+        emitted_arguments,
+        skipped_done_arguments,
+        json_valid = summary.valid,
+        json_kind = summary.kind,
+        json_keys = summary.keys.as_deref().unwrap_or(""),
+        "Responses tool call arguments completed"
+    );
+}
+
+struct JsonSummary {
+    valid: bool,
+    kind: &'static str,
+    keys: Option<String>,
+}
+
+fn summarize_json(value: &str) -> JsonSummary {
+    match serde_json::from_str::<JsonValue>(value) {
+        Ok(JsonValue::Object(object)) => {
+            let keys = object.keys().take(8).cloned().collect::<Vec<_>>().join(",");
+            JsonSummary {
+                valid: true,
+                kind: "object",
+                keys: Some(keys),
+            }
+        }
+        Ok(JsonValue::Array(_)) => JsonSummary {
+            valid: true,
+            kind: "array",
+            keys: None,
+        },
+        Ok(JsonValue::String(_)) => JsonSummary {
+            valid: true,
+            kind: "string",
+            keys: None,
+        },
+        Ok(JsonValue::Number(_)) => JsonSummary {
+            valid: true,
+            kind: "number",
+            keys: None,
+        },
+        Ok(JsonValue::Bool(_)) => JsonSummary {
+            valid: true,
+            kind: "bool",
+            keys: None,
+        },
+        Ok(JsonValue::Null) => JsonSummary {
+            valid: true,
+            kind: "null",
+            keys: None,
+        },
+        Err(_) => JsonSummary {
+            valid: false,
+            kind: "invalid",
+            keys: None,
+        },
     }
 }
 

--- a/bitrouter-providers/src/openai/responses/api.rs
+++ b/bitrouter-providers/src/openai/responses/api.rs
@@ -876,6 +876,7 @@ impl OpenAiResponsesSseParser {
                 event_type.as_str(),
                 "response.created"
                     | "response.output_item.added"
+                    | "response.output_item.done"
                     | "response.output_text.delta"
                     | "response.output_text.done"
                     | "response.function_call_arguments.delta"
@@ -902,6 +903,8 @@ struct OpenAiToolInputState {
     started: bool,
     emitted_arguments: bool,
     argument_buffer: String,
+    pending_done: bool,
+    ended: bool,
 }
 
 #[derive(Default)]
@@ -923,6 +926,8 @@ enum OpenAiResponsesStreamEvent {
     ResponseCreated { response: ResponsesResponse },
     #[serde(rename = "response.output_item.added")]
     ResponseOutputItemAdded { item: ResponsesOutputItem },
+    #[serde(rename = "response.output_item.done")]
+    ResponseOutputItemDone { item: ResponsesOutputItem },
     #[serde(rename = "response.output_text.delta")]
     ResponseOutputTextDelta {
         #[serde(default)]
@@ -983,52 +988,12 @@ impl OpenAiResponsesStreamState {
                 }
                 parts
             }
-            OpenAiResponsesStreamEvent::ResponseOutputItemAdded { item } => match item {
-                ResponsesOutputItem::FunctionCall {
-                    id,
-                    call_id,
-                    name,
-                    arguments,
-                    ..
-                } => {
-                    if let Some(id) = id {
-                        tracing::debug!(
-                            provider = OPENAI_PROVIDER_NAME,
-                            item_id = %id,
-                            call_id = %call_id,
-                            tool_name = %name,
-                            arguments_len = arguments.len(),
-                            "Responses tool call item added"
-                        );
-                        self.tool_item_ids.insert(id, call_id.clone());
-                    }
-                    let tool_state = self.tool_inputs.entry(call_id.clone()).or_default();
-                    tool_state.tool_name = Some(name.clone());
-                    let mut parts = Vec::new();
-                    if !tool_state.started {
-                        parts.push(LanguageModelStreamPart::ToolInputStart {
-                            id: call_id.clone(),
-                            tool_name: name,
-                            provider_executed: None,
-                            dynamic: None,
-                            title: None,
-                            provider_metadata: None,
-                        });
-                        tool_state.started = true;
-                    }
-                    if !arguments.is_empty() {
-                        tool_state.argument_buffer.push_str(&arguments);
-                        parts.push(LanguageModelStreamPart::ToolInputDelta {
-                            id: call_id,
-                            delta: arguments,
-                            provider_metadata: None,
-                        });
-                        tool_state.emitted_arguments = true;
-                    }
-                    parts
-                }
-                _ => Vec::new(),
-            },
+            OpenAiResponsesStreamEvent::ResponseOutputItemAdded { item } => {
+                self.apply_output_item(item, false)
+            }
+            OpenAiResponsesStreamEvent::ResponseOutputItemDone { item } => {
+                self.apply_output_item(item, true)
+            }
             OpenAiResponsesStreamEvent::ResponseOutputTextDelta { item_id, delta } => {
                 let text_id = item_id.unwrap_or_else(|| STREAM_TEXT_ID.to_owned());
                 let mut parts = Vec::new();
@@ -1084,13 +1049,12 @@ impl OpenAiResponsesStreamState {
                 let id = self.resolve_tool_call_id(item_id.as_deref(), call_id.as_deref());
                 let tool_state = self.tool_inputs.entry(id.clone()).or_default();
                 let mut parts = Vec::new();
-                if !tool_state.started {
+                if !tool_state.started
+                    && let Some(tool_name) = tool_state.tool_name.clone()
+                {
                     parts.push(LanguageModelStreamPart::ToolInputStart {
                         id: id.clone(),
-                        tool_name: tool_state
-                            .tool_name
-                            .clone()
-                            .unwrap_or_else(|| "tool".to_owned()),
+                        tool_name,
                         provider_executed: None,
                         dynamic: None,
                         title: None,
@@ -1100,12 +1064,14 @@ impl OpenAiResponsesStreamState {
                 }
                 if !delta.is_empty() {
                     tool_state.argument_buffer.push_str(&delta);
-                    parts.push(LanguageModelStreamPart::ToolInputDelta {
-                        id,
-                        delta,
-                        provider_metadata: None,
-                    });
-                    tool_state.emitted_arguments = true;
+                    if tool_state.started {
+                        parts.push(LanguageModelStreamPart::ToolInputDelta {
+                            id,
+                            delta,
+                            provider_metadata: None,
+                        });
+                        tool_state.emitted_arguments = true;
+                    }
                 }
                 parts
             }
@@ -1117,13 +1083,12 @@ impl OpenAiResponsesStreamState {
                 let id = self.resolve_tool_call_id(item_id.as_deref(), call_id.as_deref());
                 let mut parts = Vec::new();
                 let tool_state = self.tool_inputs.entry(id.clone()).or_default();
-                if !tool_state.started {
+                if !tool_state.started
+                    && let Some(tool_name) = tool_state.tool_name.clone()
+                {
                     parts.push(LanguageModelStreamPart::ToolInputStart {
                         id: id.clone(),
-                        tool_name: tool_state
-                            .tool_name
-                            .clone()
-                            .unwrap_or_else(|| "tool".to_owned()),
+                        tool_name,
                         provider_executed: None,
                         dynamic: None,
                         title: None,
@@ -1132,18 +1097,21 @@ impl OpenAiResponsesStreamState {
                     tool_state.started = true;
                 }
                 let done_arguments_len = arguments.as_ref().map_or(0, String::len);
-                let skipped_done_arguments = done_arguments_len > 0 && tool_state.emitted_arguments;
+                let skipped_done_arguments =
+                    done_arguments_len > 0 && !tool_state.argument_buffer.is_empty();
                 if let Some(done_arguments) = arguments
                     && !done_arguments.is_empty()
-                    && !tool_state.emitted_arguments
+                    && tool_state.argument_buffer.is_empty()
                 {
                     tool_state.argument_buffer.push_str(&done_arguments);
-                    parts.push(LanguageModelStreamPart::ToolInputDelta {
-                        id: id.clone(),
-                        delta: done_arguments,
-                        provider_metadata: None,
-                    });
-                    tool_state.emitted_arguments = true;
+                    if tool_state.started {
+                        parts.push(LanguageModelStreamPart::ToolInputDelta {
+                            id: id.clone(),
+                            delta: done_arguments,
+                            provider_metadata: None,
+                        });
+                        tool_state.emitted_arguments = true;
+                    }
                 }
                 log_tool_arguments_done(
                     &id,
@@ -1153,13 +1121,25 @@ impl OpenAiResponsesStreamState {
                     done_arguments_len,
                     skipped_done_arguments,
                 );
-                parts.push(LanguageModelStreamPart::ToolInputEnd {
-                    id,
-                    provider_metadata: None,
-                });
+                if tool_state.started && !tool_state.ended {
+                    parts.push(LanguageModelStreamPart::ToolInputEnd {
+                        id,
+                        provider_metadata: None,
+                    });
+                    tool_state.ended = true;
+                } else {
+                    tool_state.pending_done = true;
+                    tracing::debug!(
+                        provider = OPENAI_PROVIDER_NAME,
+                        call_id = %id,
+                        arguments_len = tool_state.argument_buffer.len(),
+                        "buffered Responses tool call arguments until tool name is known"
+                    );
+                }
                 parts
             }
             OpenAiResponsesStreamEvent::ResponseCompleted { response } => {
+                let mut parts = self.apply_response_output_items(&response);
                 if let Some(usage) = response.usage {
                     self.usage = Some(usage_to_language_model(usage));
                 }
@@ -1174,9 +1154,11 @@ impl OpenAiResponsesStreamState {
                         .iter()
                         .any(|item| matches!(item, ResponsesOutputItem::FunctionCall { .. })),
                 ));
-                self.finish_parts()
+                parts.extend(self.finish_parts());
+                parts
             }
             OpenAiResponsesStreamEvent::ResponseIncomplete { response } => {
+                let mut parts = self.apply_response_output_items(&response);
                 if let Some(usage) = response.usage {
                     self.usage = Some(usage_to_language_model(usage));
                 }
@@ -1191,7 +1173,8 @@ impl OpenAiResponsesStreamState {
                         .iter()
                         .any(|item| matches!(item, ResponsesOutputItem::FunctionCall { .. })),
                 ));
-                self.finish_parts()
+                parts.extend(self.finish_parts());
+                parts
             }
             OpenAiResponsesStreamEvent::ResponseFailed { response } => {
                 self.finish_reason = Some(LanguageModelFinishReason::Error);
@@ -1226,6 +1209,94 @@ impl OpenAiResponsesStreamState {
         }
     }
 
+    fn apply_response_output_items(
+        &mut self,
+        response: &ResponsesResponse,
+    ) -> Vec<LanguageModelStreamPart> {
+        let mut parts = Vec::new();
+        for item in &response.output {
+            parts.extend(self.apply_output_item(item.clone(), true));
+        }
+        parts
+    }
+
+    fn apply_output_item(
+        &mut self,
+        item: ResponsesOutputItem,
+        item_done: bool,
+    ) -> Vec<LanguageModelStreamPart> {
+        let ResponsesOutputItem::FunctionCall {
+            id,
+            call_id,
+            name,
+            arguments,
+            ..
+        } = item
+        else {
+            return Vec::new();
+        };
+
+        if let Some(id) = id {
+            tracing::debug!(
+                provider = OPENAI_PROVIDER_NAME,
+                item_id = %id,
+                call_id = %call_id,
+                tool_name = %name,
+                arguments_len = arguments.len(),
+                item_done,
+                "Responses tool call item received"
+            );
+            self.tool_item_ids.insert(id, call_id.clone());
+        }
+
+        let tool_state = self.tool_inputs.entry(call_id.clone()).or_default();
+        tool_state.tool_name = Some(name.clone());
+        let mut parts = Vec::new();
+        if !tool_state.started {
+            parts.push(LanguageModelStreamPart::ToolInputStart {
+                id: call_id.clone(),
+                tool_name: name,
+                provider_executed: None,
+                dynamic: None,
+                title: None,
+                provider_metadata: None,
+            });
+            tool_state.started = true;
+        }
+
+        if !arguments.is_empty() && tool_state.argument_buffer.is_empty() {
+            tool_state.argument_buffer.push_str(&arguments);
+        }
+
+        if !tool_state.argument_buffer.is_empty() && !tool_state.emitted_arguments {
+            parts.push(LanguageModelStreamPart::ToolInputDelta {
+                id: call_id.clone(),
+                delta: tool_state.argument_buffer.clone(),
+                provider_metadata: None,
+            });
+            tool_state.emitted_arguments = true;
+        }
+
+        if (tool_state.pending_done || item_done) && !tool_state.ended {
+            log_tool_arguments_done(
+                &call_id,
+                tool_state.tool_name.as_deref(),
+                &tool_state.argument_buffer,
+                tool_state.emitted_arguments,
+                0,
+                false,
+            );
+            parts.push(LanguageModelStreamPart::ToolInputEnd {
+                id: call_id,
+                provider_metadata: None,
+            });
+            tool_state.pending_done = false;
+            tool_state.ended = true;
+        }
+
+        parts
+    }
+
     fn finish_parts(&mut self) -> Vec<LanguageModelStreamPart> {
         if self.finished {
             return Vec::new();
@@ -1246,13 +1317,15 @@ impl OpenAiResponsesStreamState {
         let mut tool_ids = self.tool_inputs.keys().cloned().collect::<Vec<_>>();
         tool_ids.sort();
         for id in tool_ids {
-            if let Some(state) = self.tool_inputs.get(&id)
+            if let Some(state) = self.tool_inputs.get_mut(&id)
                 && state.started
+                && !state.ended
             {
                 parts.push(LanguageModelStreamPart::ToolInputEnd {
-                    id,
+                    id: id.clone(),
                     provider_metadata: None,
                 });
+                state.ended = true;
             }
         }
 
@@ -2016,6 +2089,53 @@ mod tests {
         assert!(done_parts.iter().any(|part| matches!(
             part,
             LanguageModelStreamPart::ToolInputEnd { id, .. } if id == "call_tool_1"
+        )));
+    }
+
+    #[test]
+    fn sse_parser_buffers_arguments_until_tool_name_arrives() {
+        let mut parser = OpenAiResponsesSseParser::new(false);
+
+        let arguments_done = json!({
+            "type": "response.function_call_arguments.done",
+            "call_id": "call_tool_1",
+            "arguments": "{\"description\":\"Search files\",\"prompt\":\"Inspect code\",\"subagent_type\":\"Explore\"}"
+        });
+        let item_done = json!({
+            "type": "response.output_item.done",
+            "item": {
+                "type": "function_call",
+                "id": "fc_item_1",
+                "call_id": "call_tool_1",
+                "name": "Task",
+                "arguments": ""
+            }
+        });
+
+        let buffered_parts = parser.push_bytes(&sse_event(&arguments_done.to_string()));
+        assert!(
+            buffered_parts.is_empty(),
+            "unnamed tool arguments should not emit a fallback tool call: {buffered_parts:?}"
+        );
+
+        let named_parts = parser.push_bytes(&sse_event(&item_done.to_string()));
+        assert!(named_parts.iter().any(|part| matches!(
+            part,
+            LanguageModelStreamPart::ToolInputStart { id, tool_name, .. }
+                if id == "call_tool_1" && tool_name == "Task"
+        )));
+        assert!(named_parts.iter().any(|part| matches!(
+            part,
+            LanguageModelStreamPart::ToolInputDelta { id, delta, .. }
+                if id == "call_tool_1" && delta.contains("\"subagent_type\":\"Explore\"")
+        )));
+        assert!(named_parts.iter().any(|part| matches!(
+            part,
+            LanguageModelStreamPart::ToolInputEnd { id, .. } if id == "call_tool_1"
+        )));
+        assert!(named_parts.iter().all(|part| !matches!(
+            part,
+            LanguageModelStreamPart::ToolInputStart { tool_name, .. } if tool_name == "tool"
         )));
     }
 }

--- a/bitrouter-providers/src/openai/responses/api.rs
+++ b/bitrouter-providers/src/openai/responses/api.rs
@@ -900,6 +900,7 @@ impl OpenAiResponsesSseParser {
 struct OpenAiToolInputState {
     tool_name: Option<String>,
     started: bool,
+    emitted_arguments: bool,
 }
 
 #[derive(Default)]
@@ -908,6 +909,7 @@ struct OpenAiResponsesStreamState {
     text_started: bool,
     text_id: Option<String>,
     tool_inputs: HashMap<String, OpenAiToolInputState>,
+    tool_item_ids: HashMap<String, String>,
     usage: Option<LanguageModelUsage>,
     finish_reason: Option<LanguageModelFinishReason>,
     finished: bool,
@@ -937,12 +939,16 @@ enum OpenAiResponsesStreamEvent {
     ResponseFunctionCallArgumentsDelta {
         #[serde(default)]
         item_id: Option<String>,
+        #[serde(default)]
+        call_id: Option<String>,
         delta: String,
     },
     #[serde(rename = "response.function_call_arguments.done")]
     ResponseFunctionCallArgumentsDone {
         #[serde(default)]
         item_id: Option<String>,
+        #[serde(default)]
+        call_id: Option<String>,
         #[serde(default)]
         arguments: Option<String>,
     },
@@ -978,11 +984,15 @@ impl OpenAiResponsesStreamState {
             }
             OpenAiResponsesStreamEvent::ResponseOutputItemAdded { item } => match item {
                 ResponsesOutputItem::FunctionCall {
+                    id,
                     call_id,
                     name,
                     arguments,
                     ..
                 } => {
+                    if let Some(id) = id {
+                        self.tool_item_ids.insert(id, call_id.clone());
+                    }
                     let tool_state = self.tool_inputs.entry(call_id.clone()).or_default();
                     tool_state.tool_name = Some(name.clone());
                     let mut parts = Vec::new();
@@ -1003,6 +1013,7 @@ impl OpenAiResponsesStreamState {
                             delta: arguments,
                             provider_metadata: None,
                         });
+                        tool_state.emitted_arguments = true;
                     }
                     parts
                 }
@@ -1055,8 +1066,12 @@ impl OpenAiResponsesStreamState {
                 }
                 parts
             }
-            OpenAiResponsesStreamEvent::ResponseFunctionCallArgumentsDelta { item_id, delta } => {
-                let id = item_id.unwrap_or_else(|| "tool".to_owned());
+            OpenAiResponsesStreamEvent::ResponseFunctionCallArgumentsDelta {
+                item_id,
+                call_id,
+                delta,
+            } => {
+                let id = self.resolve_tool_call_id(item_id.as_deref(), call_id.as_deref());
                 let tool_state = self.tool_inputs.entry(id.clone()).or_default();
                 let mut parts = Vec::new();
                 if !tool_state.started {
@@ -1079,23 +1094,42 @@ impl OpenAiResponsesStreamState {
                         delta,
                         provider_metadata: None,
                     });
+                    tool_state.emitted_arguments = true;
                 }
                 parts
             }
             OpenAiResponsesStreamEvent::ResponseFunctionCallArgumentsDone {
                 item_id,
+                call_id,
                 arguments,
             } => {
-                let id = item_id.unwrap_or_else(|| "tool".to_owned());
+                let id = self.resolve_tool_call_id(item_id.as_deref(), call_id.as_deref());
                 let mut parts = Vec::new();
+                let tool_state = self.tool_inputs.entry(id.clone()).or_default();
+                if !tool_state.started {
+                    parts.push(LanguageModelStreamPart::ToolInputStart {
+                        id: id.clone(),
+                        tool_name: tool_state
+                            .tool_name
+                            .clone()
+                            .unwrap_or_else(|| "tool".to_owned()),
+                        provider_executed: None,
+                        dynamic: None,
+                        title: None,
+                        provider_metadata: None,
+                    });
+                    tool_state.started = true;
+                }
                 if let Some(arguments) = arguments
                     && !arguments.is_empty()
+                    && !tool_state.emitted_arguments
                 {
                     parts.push(LanguageModelStreamPart::ToolInputDelta {
                         id: id.clone(),
                         delta: arguments,
                         provider_metadata: None,
                     });
+                    tool_state.emitted_arguments = true;
                 }
                 parts.push(LanguageModelStreamPart::ToolInputEnd {
                     id,
@@ -1210,6 +1244,38 @@ impl OpenAiResponsesStreamState {
         });
 
         parts
+    }
+
+    fn resolve_tool_call_id(&self, item_id: Option<&str>, call_id: Option<&str>) -> String {
+        if let Some(call_id) = call_id {
+            return call_id.to_owned();
+        }
+
+        if let Some(item_id) = item_id {
+            if let Some(call_id) = self.tool_item_ids.get(item_id) {
+                return call_id.clone();
+            }
+
+            tracing::debug!(
+                provider = OPENAI_PROVIDER_NAME,
+                item_id = %item_id,
+                "Responses function_call_arguments event referenced an unknown item_id"
+            );
+            return item_id.to_owned();
+        }
+
+        if self.tool_inputs.len() == 1
+            && let Some(call_id) = self.tool_inputs.keys().next()
+        {
+            return call_id.clone();
+        }
+
+        tracing::debug!(
+            provider = OPENAI_PROVIDER_NAME,
+            active_tool_count = self.tool_inputs.len(),
+            "Responses function_call_arguments event omitted item_id and call_id"
+        );
+        "tool".to_owned()
     }
 }
 
@@ -1759,6 +1825,102 @@ mod tests {
                 ..
             } if usage.input_tokens.total == Some(3)
                 && usage.output_tokens.total == Some(4)
+        )));
+    }
+
+    #[test]
+    fn sse_parser_maps_function_argument_item_id_to_call_id() {
+        let mut parser = OpenAiResponsesSseParser::new(false);
+
+        let item_added = json!({
+            "type": "response.output_item.added",
+            "item": {
+                "type": "function_call",
+                "id": "fc_item_1",
+                "call_id": "call_tool_1",
+                "name": "todo_write",
+                "arguments": ""
+            }
+        });
+        let delta = json!({
+            "type": "response.function_call_arguments.delta",
+            "item_id": "fc_item_1",
+            "delta": "{\"todos\":"
+        });
+        let done = json!({
+            "type": "response.function_call_arguments.done",
+            "item_id": "fc_item_1",
+            "arguments": "{\"todos\":[{\"content\":\"ok\"}]}"
+        });
+
+        let start_parts = parser.push_bytes(&sse_event(&item_added.to_string()));
+        assert!(start_parts.iter().any(|part| matches!(
+            part,
+            LanguageModelStreamPart::ToolInputStart {
+                id,
+                tool_name,
+                ..
+            } if id == "call_tool_1" && tool_name == "todo_write"
+        )));
+
+        let delta_parts = parser.push_bytes(&sse_event(&delta.to_string()));
+        assert!(delta_parts.iter().any(|part| matches!(
+            part,
+            LanguageModelStreamPart::ToolInputDelta { id, delta, .. }
+                if id == "call_tool_1" && delta == "{\"todos\":"
+        )));
+        assert!(delta_parts.iter().all(|part| !matches!(
+            part,
+            LanguageModelStreamPart::ToolInputStart {
+                id,
+                tool_name,
+                ..
+            } if id == "fc_item_1" || tool_name == "tool"
+        )));
+
+        let done_parts = parser.push_bytes(&sse_event(&done.to_string()));
+        assert!(
+            done_parts
+                .iter()
+                .all(|part| !matches!(part, LanguageModelStreamPart::ToolInputDelta { .. }))
+        );
+        assert!(done_parts.iter().any(|part| matches!(
+            part,
+            LanguageModelStreamPart::ToolInputEnd { id, .. } if id == "call_tool_1"
+        )));
+    }
+
+    #[test]
+    fn sse_parser_uses_done_arguments_when_no_deltas_arrived() {
+        let mut parser = OpenAiResponsesSseParser::new(false);
+
+        let item_added = json!({
+            "type": "response.output_item.added",
+            "item": {
+                "type": "function_call",
+                "id": "fc_item_1",
+                "call_id": "call_tool_1",
+                "name": "todo_write",
+                "arguments": ""
+            }
+        });
+        let done = json!({
+            "type": "response.function_call_arguments.done",
+            "item_id": "fc_item_1",
+            "arguments": "{\"todos\":[{\"content\":\"ok\"}]}"
+        });
+
+        let _ = parser.push_bytes(&sse_event(&item_added.to_string()));
+        let done_parts = parser.push_bytes(&sse_event(&done.to_string()));
+
+        assert!(done_parts.iter().any(|part| matches!(
+            part,
+            LanguageModelStreamPart::ToolInputDelta { id, delta, .. }
+                if id == "call_tool_1" && delta == "{\"todos\":[{\"content\":\"ok\"}]}"
+        )));
+        assert!(done_parts.iter().any(|part| matches!(
+            part,
+            LanguageModelStreamPart::ToolInputEnd { id, .. } if id == "call_tool_1"
         )));
     }
 }


### PR DESCRIPTION
## Summary
- map OpenAI Responses function-call argument stream item IDs back to their call IDs
- keep streamed tool argument deltas under the same internal tool ID as the tool start
- avoid appending complete arguments.done payloads after argument deltas already streamed

## Tests
- cargo fmt -- --check
- cargo clippy --workspace --all-targets --all-features
- cargo test --workspace --all-features