### PR TITLE
feat(providers): add OpenCode Zen and Go built-in provider support

### DIFF
--- a/.github/workflows/models.yml
+++ b/.github/workflows/models.yml
@@ -54,6 +54,8 @@ jobs:
             [moonshot]=moonshotai
             [qwen]=alibaba
             [github-copilot]=github-copilot
+            [opencode-zen]=opencode
+            [opencode-go]=opencode-go
           )
 
           # jq filter that converts a models.dev provider's models into
@@ -166,6 +168,61 @@ jobs:
 
           echo ""
           echo "Updated $updated provider file(s)"
+
+      - name: Verify protocol dispatch coverage
+        run: |
+          set -euo pipefail
+
+          API="/tmp/models-dev-api.json"
+
+          # Models that need Anthropic dispatch in zen.rs but don't start
+          # with "claude-". These are identified by provider.npm == "@ai-sdk/anthropic".
+          echo "Zen models requiring Anthropic dispatch (provider.npm == @ai-sdk/anthropic):"
+          jq -r '.opencode.models | to_entries[] | select(.value.provider?.npm == "@ai-sdk/anthropic") | .key' "$API" | sort
+
+          echo ""
+          echo "Zen models requiring Google dispatch (provider.npm == @ai-sdk/google):"
+          jq -r '.opencode.models | to_entries[] | select(.value.provider?.npm == "@ai-sdk/google") | .key' "$API" | sort
+
+          echo ""
+          echo "Zen models requiring OpenAI Responses dispatch (provider.npm == @ai-sdk/openai):"
+          jq -r '.opencode.models | to_entries[] | select(.value.provider?.npm == "@ai-sdk/openai") | .key' "$API" | sort
+
+          echo ""
+          echo "Go models requiring Anthropic dispatch (provider.npm == @ai-sdk/anthropic):"
+          jq -r '."opencode-go".models | to_entries[] | select(.value.provider?.npm == "@ai-sdk/anthropic") | .key' "$API" | sort
+
+          echo ""
+          echo "Verify these are covered in bitrouter/src/runtime/zen.rs and go.rs"
+          echo "Non-claude Anthropic models must be listed in ZEN_ANTHROPIC_MODELS"
+          echo "Go Anthropic models must be listed in is_anthropic_model()"
+
+          # Extract non-claude Anthropic models and check they're in the Rust source
+          non_claude_anthropic=$(jq -r '.opencode.models | to_entries[] | select(.value.provider?.npm == "@ai-sdk/anthropic") | select(.key | startswith("claude-") | not) | .key' "$API")
+          go_anthropic=$(jq -r '."opencode-go".models | to_entries[] | select(.value.provider?.npm == "@ai-sdk/anthropic") | .key' "$API")
+
+          missing=0
+          for model in $non_claude_anthropic; do
+            if ! grep -q "\"$model\"" bitrouter/src/runtime/zen.rs; then
+              echo "❌ Zen model '$model' needs Anthropic dispatch but is not in zen.rs ZEN_ANTHROPIC_MODELS"
+              missing=$((missing + 1))
+            fi
+          done
+
+          for model in $go_anthropic; do
+            if ! grep -q "\"$model\"" bitrouter/src/runtime/go.rs; then
+              echo "❌ Go model '$model' needs Anthropic dispatch but is not in go.rs is_anthropic_model()"
+              missing=$((missing + 1))
+            fi
+          done
+
+          if [ "$missing" -gt 0 ]; then
+            echo ""
+            echo "⚠ $missing model(s) missing from dispatch modules — update zen.rs/go.rs before merging"
+            exit 1
+          fi
+
+          echo "✓ All models with non-default protocols are covered by dispatch modules"
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ npx skills add BitRouterAI/agent-skills
 | Anthropic  | ✅     | Messages API                     |
 | Google     | ✅     | Generative AI API                |
 | OpenRouter | ✅     | Chat Completions + Responses API |
+| OpenCode Zen | ✅  | Curated models across OpenAI, Anthropic, Google protocols |
+| OpenCode Go  | ✅  | Low-cost subscription for open coding models |
 
 Want to see another provider supported? [Open an issue](https://github.com/bitrouter/bitrouter/issues) or submit a PR — contributions are welcome. If you're a provider interested in first-party integration, reach out on [Discord](https://discord.gg/G3zVrZDa5C).
 

--- a/bitrouter-config/providers/models/opencode-go.yaml
+++ b/bitrouter-config/providers/models/opencode-go.yaml
@@ -1,0 +1,172 @@
+api_protocol: openai
+api_base: https://opencode.ai/zen/go/v1
+env_prefix: OPENCODE_GO
+models:
+  deepseek-v4-flash:
+    name: DeepSeek V4 Flash
+    max_input_tokens: 1000000
+    max_output_tokens: 384000
+    pricing:
+      input_tokens:
+        no_cache: 0.14
+        cache_read: 0.0028
+      output_tokens:
+        text: 0.28
+  deepseek-v4-pro:
+    name: DeepSeek V4 Pro
+    max_input_tokens: 1000000
+    max_output_tokens: 384000
+    pricing:
+      input_tokens:
+        no_cache: 1.74
+        cache_read: 0.0145
+      output_tokens:
+        text: 3.48
+  glm-5:
+    name: GLM-5
+    max_input_tokens: 202752
+    max_output_tokens: 32768
+    pricing:
+      input_tokens:
+        no_cache: 1.0
+        cache_read: 0.2
+      output_tokens:
+        text: 3.2
+  glm-5.1:
+    name: GLM-5.1
+    max_input_tokens: 202752
+    max_output_tokens: 32768
+    pricing:
+      input_tokens:
+        no_cache: 1.4
+        cache_read: 0.26
+      output_tokens:
+        text: 4.4
+  kimi-k2.5:
+    name: Kimi K2.5
+    max_input_tokens: 262144
+    max_output_tokens: 65536
+    input_modalities:
+      - text
+      - image
+      - video
+    pricing:
+      input_tokens:
+        no_cache: 0.6
+        cache_read: 0.1
+      output_tokens:
+        text: 3.0
+  kimi-k2.6:
+    name: Kimi K2.6
+    max_input_tokens: 262144
+    max_output_tokens: 65536
+    input_modalities:
+      - text
+      - image
+      - video
+    pricing:
+      input_tokens:
+        no_cache: 0.32
+        cache_read: 0.054
+      output_tokens:
+        text: 1.34
+  mimo-v2-omni:
+    name: MiMo V2 Omni
+    max_input_tokens: 262144
+    max_output_tokens: 128000
+    input_modalities:
+      - text
+      - image
+      - audio
+      - file
+    pricing:
+      input_tokens:
+        no_cache: 0.4
+        cache_read: 0.08
+      output_tokens:
+        text: 2.0
+  mimo-v2-pro:
+    name: MiMo V2 Pro
+    max_input_tokens: 1048576
+    max_output_tokens: 128000
+    pricing:
+      input_tokens:
+        no_cache: 1.0
+        cache_read: 0.2
+      output_tokens:
+        text: 3.0
+  mimo-v2.5:
+    name: MiMo V2.5
+    max_input_tokens: 1000000
+    max_output_tokens: 128000
+    input_modalities:
+      - text
+      - image
+      - audio
+      - file
+    pricing:
+      input_tokens:
+        no_cache: 0.4
+        cache_read: 0.08
+      output_tokens:
+        text: 2.0
+  mimo-v2.5-pro:
+    name: MiMo V2.5 Pro
+    max_input_tokens: 1048576
+    max_output_tokens: 128000
+    pricing:
+      input_tokens:
+        no_cache: 1.0
+        cache_read: 0.2
+      output_tokens:
+        text: 3.0
+  minimax-m2.5:
+    name: MiniMax M2.5
+    max_input_tokens: 204800
+    max_output_tokens: 65536
+    pricing:
+      input_tokens:
+        no_cache: 0.3
+        cache_read: 0.03
+      output_tokens:
+        text: 1.2
+  minimax-m2.7:
+    name: MiniMax M2.7
+    max_input_tokens: 204800
+    max_output_tokens: 131072
+    pricing:
+      input_tokens:
+        no_cache: 0.3
+        cache_read: 0.06
+      output_tokens:
+        text: 1.2
+  qwen3.5-plus:
+    name: Qwen3.5 Plus
+    max_input_tokens: 262144
+    max_output_tokens: 65536
+    input_modalities:
+      - text
+      - image
+      - video
+    pricing:
+      input_tokens:
+        no_cache: 0.2
+        cache_read: 0.02
+        cache_write: 0.25
+      output_tokens:
+        text: 1.2
+  qwen3.6-plus:
+    name: Qwen3.6 Plus
+    max_input_tokens: 262144
+    max_output_tokens: 65536
+    input_modalities:
+      - text
+      - image
+      - video
+    pricing:
+      input_tokens:
+        no_cache: 0.5
+        cache_read: 0.05
+        cache_write: 0.625
+      output_tokens:
+        text: 3.0

--- a/bitrouter-config/providers/models/opencode-zen.yaml
+++ b/bitrouter-config/providers/models/opencode-zen.yaml
@@ -1,0 +1,718 @@
+api_protocol: openai
+api_base: https://opencode.ai/zen/v1
+env_prefix: OPENCODE_ZEN
+api_version: v1
+models:
+  big-pickle:
+    name: Big Pickle
+    max_input_tokens: 200000
+    max_output_tokens: 128000
+    pricing:
+      input_tokens:
+        no_cache: 0.0
+        cache_read: 0.0
+        cache_write: 0.0
+      output_tokens:
+        text: 0.0
+  claude-3-5-haiku:
+    name: Claude Haiku 3.5
+    max_input_tokens: 200000
+    max_output_tokens: 8192
+    input_modalities:
+      - text
+      - image
+      - file
+    pricing:
+      input_tokens:
+        no_cache: 0.8
+        cache_read: 0.08
+        cache_write: 1.0
+      output_tokens:
+        text: 4.0
+  claude-haiku-4-5:
+    name: Claude Haiku 4.5
+    max_input_tokens: 200000
+    max_output_tokens: 64000
+    input_modalities:
+      - text
+      - image
+      - file
+    pricing:
+      input_tokens:
+        no_cache: 1.0
+        cache_read: 0.1
+        cache_write: 1.25
+      output_tokens:
+        text: 5.0
+  claude-opus-4-1:
+    name: Claude Opus 4.1
+    max_input_tokens: 200000
+    max_output_tokens: 32000
+    input_modalities:
+      - text
+      - image
+      - file
+    pricing:
+      input_tokens:
+        no_cache: 15.0
+        cache_read: 1.5
+        cache_write: 18.75
+      output_tokens:
+        text: 75.0
+  claude-opus-4-5:
+    name: Claude Opus 4.5
+    max_input_tokens: 200000
+    max_output_tokens: 64000
+    input_modalities:
+      - text
+      - image
+      - file
+    pricing:
+      input_tokens:
+        no_cache: 5.0
+        cache_read: 0.5
+        cache_write: 6.25
+      output_tokens:
+        text: 25.0
+  claude-opus-4-6:
+    name: Claude Opus 4.6
+    max_input_tokens: 1000000
+    max_output_tokens: 128000
+    input_modalities:
+      - text
+      - image
+      - file
+    pricing:
+      input_tokens:
+        no_cache: 5.0
+        cache_read: 0.5
+        cache_write: 6.25
+      output_tokens:
+        text: 25.0
+  claude-opus-4-7:
+    name: Claude Opus 4.7
+    max_input_tokens: 1000000
+    max_output_tokens: 128000
+    input_modalities:
+      - text
+      - image
+      - file
+    pricing:
+      input_tokens:
+        no_cache: 5.0
+        cache_read: 0.5
+        cache_write: 6.25
+      output_tokens:
+        text: 25.0
+  claude-sonnet-4:
+    name: Claude Sonnet 4
+    max_input_tokens: 1000000
+    max_output_tokens: 64000
+    input_modalities:
+      - text
+      - image
+      - file
+    pricing:
+      input_tokens:
+        no_cache: 3.0
+        cache_read: 0.3
+        cache_write: 3.75
+      output_tokens:
+        text: 15.0
+  claude-sonnet-4-5:
+    name: Claude Sonnet 4.5
+    max_input_tokens: 1000000
+    max_output_tokens: 64000
+    input_modalities:
+      - text
+      - image
+      - file
+    pricing:
+      input_tokens:
+        no_cache: 3.0
+        cache_read: 0.3
+        cache_write: 3.75
+      output_tokens:
+        text: 15.0
+  claude-sonnet-4-6:
+    name: Claude Sonnet 4.6
+    max_input_tokens: 1000000
+    max_output_tokens: 64000
+    input_modalities:
+      - text
+      - image
+      - file
+    pricing:
+      input_tokens:
+        no_cache: 3.0
+        cache_read: 0.3
+        cache_write: 3.75
+      output_tokens:
+        text: 15.0
+  gemini-3-flash:
+    name: Gemini 3 Flash
+    max_input_tokens: 1048576
+    max_output_tokens: 65536
+    input_modalities:
+      - text
+      - image
+      - video
+      - audio
+      - file
+    pricing:
+      input_tokens:
+        no_cache: 0.5
+        cache_read: 0.05
+      output_tokens:
+        text: 3.0
+  gemini-3-pro:
+    name: Gemini 3 Pro
+    max_input_tokens: 1048576
+    max_output_tokens: 65536
+    input_modalities:
+      - text
+      - image
+      - video
+      - audio
+      - file
+    pricing:
+      input_tokens:
+        no_cache: 1.25
+        cache_read: 0.125
+      output_tokens:
+        text: 5.0
+  gemini-3.1-pro:
+    name: Gemini 3.1 Pro
+    max_input_tokens: 1048576
+    max_output_tokens: 65536
+    input_modalities:
+      - text
+      - image
+      - video
+      - audio
+      - file
+    pricing:
+      input_tokens:
+        no_cache: 2.0
+        cache_read: 0.2
+      output_tokens:
+        text: 12.0
+  glm-4.6:
+    name: GLM 4.6
+    max_input_tokens: 128000
+    max_output_tokens: 4096
+    pricing:
+      input_tokens:
+        no_cache: 0.35
+        cache_read: 0.035
+      output_tokens:
+        text: 1.4
+  glm-4.7:
+    name: GLM 4.7
+    max_input_tokens: 128000
+    max_output_tokens: 4096
+    pricing:
+      input_tokens:
+        no_cache: 0.5
+        cache_read: 0.05
+      output_tokens:
+        text: 2.0
+  glm-5:
+    name: GLM-5
+    max_input_tokens: 204800
+    max_output_tokens: 131072
+    pricing:
+      input_tokens:
+        no_cache: 1.0
+        cache_read: 0.2
+      output_tokens:
+        text: 3.2
+  glm-5-free:
+    name: GLM-5 Free
+    max_input_tokens: 128000
+    max_output_tokens: 4096
+    pricing:
+      input_tokens:
+        no_cache: 0.0
+        cache_read: 0.0
+      output_tokens:
+        text: 0.0
+  glm-5.1:
+    name: GLM-5.1
+    max_input_tokens: 204800
+    max_output_tokens: 131072
+    pricing:
+      input_tokens:
+        no_cache: 1.4
+        cache_read: 0.26
+      output_tokens:
+        text: 4.4
+  gpt-5:
+    name: GPT-5
+    max_input_tokens: 272000
+    max_output_tokens: 128000
+    input_modalities:
+      - text
+      - image
+    pricing:
+      input_tokens:
+        no_cache: 1.07
+        cache_read: 0.107
+      output_tokens:
+        text: 8.5
+  gpt-5-codex:
+    name: GPT-5 Codex
+    max_input_tokens: 272000
+    max_output_tokens: 128000
+    input_modalities:
+      - text
+      - image
+    pricing:
+      input_tokens:
+        no_cache: 1.07
+        cache_read: 0.107
+      output_tokens:
+        text: 8.5
+  gpt-5-nano:
+    name: GPT-5 Nano
+    max_input_tokens: 272000
+    max_output_tokens: 128000
+    input_modalities:
+      - text
+      - image
+    pricing:
+      input_tokens:
+        no_cache: 0.0
+        cache_read: 0.0
+      output_tokens:
+        text: 0.0
+  gpt-5.1:
+    name: GPT-5.1
+    max_input_tokens: 272000
+    max_output_tokens: 128000
+    input_modalities:
+      - text
+      - image
+    pricing:
+      input_tokens:
+        no_cache: 1.07
+        cache_read: 0.107
+      output_tokens:
+        text: 8.5
+  gpt-5.1-codex:
+    name: GPT-5.1 Codex
+    max_input_tokens: 272000
+    max_output_tokens: 128000
+    input_modalities:
+      - text
+      - image
+    pricing:
+      input_tokens:
+        no_cache: 1.07
+        cache_read: 0.107
+      output_tokens:
+        text: 8.5
+  gpt-5.1-codex-max:
+    name: GPT-5.1 Codex Max
+    max_input_tokens: 272000
+    max_output_tokens: 128000
+    input_modalities:
+      - text
+      - image
+    pricing:
+      input_tokens:
+        no_cache: 1.25
+        cache_read: 0.125
+      output_tokens:
+        text: 10.0
+  gpt-5.1-codex-mini:
+    name: GPT-5.1 Codex Mini
+    max_input_tokens: 272000
+    max_output_tokens: 128000
+    input_modalities:
+      - text
+      - image
+    pricing:
+      input_tokens:
+        no_cache: 0.25
+        cache_read: 0.025
+      output_tokens:
+        text: 2.0
+  gpt-5.2:
+    name: GPT-5.2
+    max_input_tokens: 272000
+    max_output_tokens: 128000
+    input_modalities:
+      - text
+      - image
+    pricing:
+      input_tokens:
+        no_cache: 1.75
+        cache_read: 0.175
+      output_tokens:
+        text: 14.0
+  gpt-5.2-codex:
+    name: GPT-5.2 Codex
+    max_input_tokens: 272000
+    max_output_tokens: 128000
+    input_modalities:
+      - text
+      - image
+      - file
+    pricing:
+      input_tokens:
+        no_cache: 1.75
+        cache_read: 0.175
+      output_tokens:
+        text: 14.0
+  gpt-5.3-codex:
+    name: GPT-5.3 Codex
+    max_input_tokens: 272000
+    max_output_tokens: 128000
+    input_modalities:
+      - text
+      - image
+      - file
+    pricing:
+      input_tokens:
+        no_cache: 1.75
+        cache_read: 0.175
+      output_tokens:
+        text: 14.0
+  gpt-5.3-codex-spark:
+    name: GPT-5.3 Codex Spark
+    max_input_tokens: 128000
+    max_output_tokens: 128000
+    pricing:
+      input_tokens:
+        no_cache: 1.75
+        cache_read: 0.175
+      output_tokens:
+        text: 14.0
+  gpt-5.4:
+    name: GPT-5.4
+    max_input_tokens: 922000
+    max_output_tokens: 128000
+    input_modalities:
+      - text
+      - image
+      - file
+    pricing:
+      input_tokens:
+        no_cache: 2.5
+        cache_read: 0.25
+      output_tokens:
+        text: 15.0
+  gpt-5.4-mini:
+    name: GPT-5.4 Mini
+    max_input_tokens: 272000
+    max_output_tokens: 128000
+    input_modalities:
+      - text
+      - image
+      - file
+    pricing:
+      input_tokens:
+        no_cache: 0.75
+        cache_read: 0.075
+      output_tokens:
+        text: 4.5
+  gpt-5.4-nano:
+    name: GPT-5.4 Nano
+    max_input_tokens: 272000
+    max_output_tokens: 128000
+    input_modalities:
+      - text
+      - image
+      - file
+    pricing:
+      input_tokens:
+        no_cache: 0.2
+        cache_read: 0.02
+      output_tokens:
+        text: 1.25
+  gpt-5.4-pro:
+    name: GPT-5.4 Pro
+    max_input_tokens: 922000
+    max_output_tokens: 128000
+    input_modalities:
+      - text
+      - image
+      - file
+    pricing:
+      input_tokens:
+        no_cache: 30.0
+        cache_read: 30.0
+      output_tokens:
+        text: 180.0
+  gpt-5.5:
+    name: GPT-5.5
+    max_input_tokens: 922000
+    max_output_tokens: 128000
+    input_modalities:
+      - text
+      - image
+      - file
+    pricing:
+      input_tokens:
+        no_cache: 5.0
+        cache_read: 0.5
+      output_tokens:
+        text: 30.0
+  gpt-5.5-pro:
+    name: GPT-5.5 Pro
+    max_input_tokens: 922000
+    max_output_tokens: 128000
+    input_modalities:
+      - text
+      - image
+      - file
+    pricing:
+      input_tokens:
+        no_cache: 30.0
+        cache_read: 30.0
+      output_tokens:
+        text: 180.0
+  grok-code:
+    name: Grok Code Fast 1
+    max_input_tokens: 131072
+    max_output_tokens: 131072
+    pricing:
+      input_tokens:
+        no_cache: 0.3
+        cache_read: 0.03
+      output_tokens:
+        text: 1.5
+  hy3-preview-free:
+    name: Hy3 Preview Free
+    max_input_tokens: 256000
+    max_output_tokens: 64000
+    pricing:
+      input_tokens:
+        no_cache: 0.0
+        cache_read: 0.0
+      output_tokens:
+        text: 0.0
+  kimi-k2:
+    name: Kimi K2
+    max_input_tokens: 131072
+    max_output_tokens: 65536
+    pricing:
+      input_tokens:
+        no_cache: 0.4
+        cache_read: 0.04
+      output_tokens:
+        text: 2.0
+  kimi-k2-thinking:
+    name: Kimi K2 Thinking
+    max_input_tokens: 131072
+    max_output_tokens: 65536
+    pricing:
+      input_tokens:
+        no_cache: 1.2
+        cache_read: 0.12
+      output_tokens:
+        text: 6.0
+  kimi-k2.5:
+    name: Kimi K2.5
+    max_input_tokens: 262144
+    max_output_tokens: 65536
+    input_modalities:
+      - text
+      - image
+      - video
+    pricing:
+      input_tokens:
+        no_cache: 0.6
+        cache_read: 0.1
+      output_tokens:
+        text: 3.0
+  kimi-k2.5-free:
+    name: Kimi K2.5 Free
+    max_input_tokens: 131072
+    max_output_tokens: 65536
+    pricing:
+      input_tokens:
+        no_cache: 0.0
+        cache_read: 0.0
+      output_tokens:
+        text: 0.0
+  kimi-k2.6:
+    name: Kimi K2.6
+    max_input_tokens: 262144
+    max_output_tokens: 65536
+    input_modalities:
+      - text
+      - image
+      - video
+    pricing:
+      input_tokens:
+        no_cache: 0.95
+        cache_read: 0.16
+      output_tokens:
+        text: 4.0
+  ling-2.6-flash-free:
+    name: Ling 2.6 Flash Free
+    max_input_tokens: 131072
+    max_output_tokens: 65536
+    pricing:
+      input_tokens:
+        no_cache: 0.0
+        cache_read: 0.0
+      output_tokens:
+        text: 0.0
+  mimo-v2-flash-free:
+    name: MiMo V2 Flash Free
+    max_input_tokens: 262144
+    max_output_tokens: 65536
+    pricing:
+      input_tokens:
+        no_cache: 0.0
+        cache_read: 0.0
+      output_tokens:
+        text: 0.0
+  mimo-v2-omni-free:
+    name: MiMo V2 Omni Free
+    max_input_tokens: 262144
+    max_output_tokens: 128000
+    input_modalities:
+      - text
+      - image
+      - audio
+      - file
+    pricing:
+      input_tokens:
+        no_cache: 0.0
+        cache_read: 0.0
+      output_tokens:
+        text: 0.0
+  mimo-v2-pro-free:
+    name: MiMo V2 Pro Free
+    max_input_tokens: 262144
+    max_output_tokens: 128000
+    pricing:
+      input_tokens:
+        no_cache: 0.0
+        cache_read: 0.0
+      output_tokens:
+        text: 0.0
+  minimax-m2.1:
+    name: MiniMax M2.1
+    max_input_tokens: 204800
+    max_output_tokens: 131072
+    pricing:
+      input_tokens:
+        no_cache: 0.15
+        cache_read: 0.03
+      output_tokens:
+        text: 0.6
+  minimax-m2.1-free:
+    name: MiniMax M2.1 Free
+    max_input_tokens: 128000
+    max_output_tokens: 65536
+    pricing:
+      input_tokens:
+        no_cache: 0.0
+        cache_read: 0.0
+      output_tokens:
+        text: 0.0
+  minimax-m2.5:
+    name: MiniMax M2.5
+    max_input_tokens: 204800
+    max_output_tokens: 131072
+    pricing:
+      input_tokens:
+        no_cache: 0.3
+        cache_read: 0.06
+      output_tokens:
+        text: 1.2
+  minimax-m2.5-free:
+    name: MiniMax M2.5 Free
+    max_input_tokens: 204800
+    max_output_tokens: 131072
+    pricing:
+      input_tokens:
+        no_cache: 0.0
+        cache_read: 0.0
+      output_tokens:
+        text: 0.0
+  minimax-m2.7:
+    name: MiniMax M2.7
+    max_input_tokens: 204800
+    max_output_tokens: 131072
+    pricing:
+      input_tokens:
+        no_cache: 0.3
+        cache_read: 0.06
+      output_tokens:
+        text: 1.2
+  nemotron-3-super-free:
+    name: Nemotron 3 Super Free
+    max_input_tokens: 204800
+    max_output_tokens: 128000
+    pricing:
+      input_tokens:
+        no_cache: 0.0
+        cache_read: 0.0
+      output_tokens:
+        text: 0.0
+  qwen3-coder:
+    name: Qwen3 Coder 480B
+    max_input_tokens: 262144
+    max_output_tokens: 65536
+    pricing:
+      input_tokens:
+        no_cache: 0.35
+        cache_read: 0.035
+      output_tokens:
+        text: 1.4
+  qwen3.5-plus:
+    name: Qwen3.5 Plus
+    max_input_tokens: 262144
+    max_output_tokens: 65536
+    input_modalities:
+      - text
+      - image
+      - video
+    pricing:
+      input_tokens:
+        no_cache: 0.2
+        cache_read: 0.02
+        cache_write: 0.25
+      output_tokens:
+        text: 1.2
+  qwen3.6-plus:
+    name: Qwen3.6 Plus
+    max_input_tokens: 262144
+    max_output_tokens: 65536
+    input_modalities:
+      - text
+      - image
+      - video
+    pricing:
+      input_tokens:
+        no_cache: 0.5
+        cache_read: 0.05
+        cache_write: 0.625
+      output_tokens:
+        text: 3.0
+  qwen3.6-plus-free:
+    name: Qwen3.6 Plus Free
+    max_input_tokens: 131072
+    max_output_tokens: 65536
+    pricing:
+      input_tokens:
+        no_cache: 0.0
+        cache_read: 0.0
+      output_tokens:
+        text: 0.0
+  trinity-large-preview-free:
+    name: Trinity Large Preview Free
+    max_input_tokens: 131072
+    max_output_tokens: 65536
+    pricing:
+      input_tokens:
+        no_cache: 0.0
+        cache_read: 0.0
+      output_tokens:
+        text: 0.0

--- a/bitrouter-config/src/config.rs
+++ b/bitrouter-config/src/config.rs
@@ -436,6 +436,13 @@ pub struct ProviderConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub default_headers: Option<HashMap<String, String>>,
 
+    /// API version segment inserted into the URL path.
+    ///
+    /// Used by the Google Generative AI adapter to select between `v1beta`
+    /// and `v1` URL paths. Ignored by other adapters.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub api_version: Option<String>,
+
     /// Per-model metadata and pricing catalog.
     ///
     /// Keys are upstream model IDs (e.g. `"gpt-4o"`). Values carry optional

--- a/bitrouter-config/src/registry.rs
+++ b/bitrouter-config/src/registry.rs
@@ -38,6 +38,14 @@ const PROVIDER_DEFS: &[(&str, &str)] = &[
         "github-copilot",
         include_str!("../providers/models/github-copilot.yaml"),
     ),
+    (
+        "opencode-zen",
+        include_str!("../providers/models/opencode-zen.yaml"),
+    ),
+    (
+        "opencode-go",
+        include_str!("../providers/models/opencode-go.yaml"),
+    ),
 ];
 
 /// Raw YAML shape for built-in provider files.
@@ -46,6 +54,8 @@ struct ProviderDef {
     api_protocol: ApiProtocol,
     api_base: String,
     env_prefix: String,
+    #[serde(default)]
+    api_version: Option<String>,
     #[serde(default)]
     auth: Option<AuthConfig>,
     #[serde(default)]
@@ -79,6 +89,7 @@ pub fn builtin_provider_defs() -> HashMap<String, BuiltinProvider> {
                         api_protocol: Some(def.api_protocol),
                         api_base: Some(def.api_base),
                         env_prefix: Some(def.env_prefix),
+                        api_version: def.api_version,
                         auth: def.auth,
                         models: if def.models.is_empty() {
                             None
@@ -272,6 +283,9 @@ pub fn merge_provider(base: &mut ProviderConfig, overlay: ProviderConfig) {
     if overlay.models.is_some() {
         base.models = overlay.models;
     }
+    if overlay.api_version.is_some() {
+        base.api_version = overlay.api_version;
+    }
 }
 
 /// Resolves all provider derivation chains and applies `env_prefix` overrides.
@@ -354,6 +368,9 @@ fn resolve_derives(
         }
         if child.models.is_none() {
             child.models = parent.models;
+        }
+        if child.api_version.is_none() {
+            child.api_version = parent.api_version;
         }
         child.derives = None;
     }

--- a/bitrouter-providers/src/google/generate_content/provider.rs
+++ b/bitrouter-providers/src/google/generate_content/provider.rs
@@ -29,11 +29,14 @@ use bitrouter_core::api::google::generate_content::types::GenerateContentRespons
 
 const GOOGLE_DEFAULT_BASE_URL: &str = "https://generativelanguage.googleapis.com";
 
+const GOOGLE_DEFAULT_API_VERSION: &str = "v1beta";
+
 #[derive(Debug, Clone)]
 pub struct GoogleConfig {
     pub api_key: String,
     pub base_url: String,
     pub default_headers: HeaderMap,
+    pub api_version: String,
 }
 
 impl GoogleConfig {
@@ -42,6 +45,7 @@ impl GoogleConfig {
             api_key: api_key.into(),
             base_url: GOOGLE_DEFAULT_BASE_URL.to_owned(),
             default_headers: HeaderMap::new(),
+            api_version: GOOGLE_DEFAULT_API_VERSION.to_owned(),
         }
     }
 }
@@ -199,8 +203,9 @@ impl GoogleGenerativeAiModel {
             "generateContent"
         };
         let endpoint = format!(
-            "{}/v1beta/models/{}:{}",
+            "{}/{}/models/{}:{}",
             self.config.base_url.trim_end_matches('/'),
+            self.config.api_version,
             self.model_id,
             action,
         );

--- a/bitrouter/src/init.rs
+++ b/bitrouter/src/init.rs
@@ -29,6 +29,8 @@ const PROVIDERS: &[(&str, &str)] = &[
     ("anthropic", "Anthropic"),
     ("google", "Google"),
     ("github-copilot", "GitHub Copilot"),
+    ("opencode-zen", "OpenCode Zen"),
+    ("opencode-go", "OpenCode Go"),
 ];
 
 pub fn run_init(paths: &RuntimePaths) -> Result<InitOutcome, Box<dyn std::error::Error>> {

--- a/bitrouter/src/runtime/go.rs
+++ b/bitrouter/src/runtime/go.rs
@@ -1,0 +1,62 @@
+//! OpenCode Go provider-specific request configuration.
+//!
+//! The Go API serves models across multiple protocols depending on model
+//! family. Most models use the OpenAI Chat Completions API, but some
+//! (MiniMax M2.7, Qwen3.5/3.6 Plus) use the Anthropic Messages API.
+//!
+//! This module provides the model ID → protocol dispatch logic and
+//! base URL derivation, following the same pattern as the Copilot module.
+
+/// The built-in provider name used for OpenCode Go.
+pub const GO_PROVIDER: &str = "opencode-go";
+
+/// Returns `true` when a Go model ID should use the Anthropic Messages API.
+///
+/// Derived from the `provider.npm == "@ai-sdk/anthropic"` field in models.dev.
+pub fn is_anthropic_model(model_id: &str) -> bool {
+    matches!(model_id, "minimax-m2.7" | "qwen3.5-plus" | "qwen3.6-plus")
+}
+
+/// Derives the Anthropic-compatible API base from the Go provider's base URL.
+///
+/// The Anthropic adapter appends `/v1/messages` itself, so we strip any
+/// trailing `/v1` from the Go base URL to avoid double-pathing.
+pub fn anthropic_api_base(provider_api_base: Option<&str>) -> String {
+    let base = provider_api_base
+        .unwrap_or("https://opencode.ai/zen/go/v1")
+        .trim_end_matches('/');
+    base.strip_suffix("/v1").unwrap_or(base).to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn go_anthropic_models_detected() {
+        assert!(is_anthropic_model("minimax-m2.7"));
+        assert!(is_anthropic_model("qwen3.5-plus"));
+        assert!(is_anthropic_model("qwen3.6-plus"));
+    }
+
+    #[test]
+    fn go_non_anthropic_models() {
+        assert!(!is_anthropic_model("glm-5.1"));
+        assert!(!is_anthropic_model("kimi-k2.6"));
+        assert!(!is_anthropic_model("deepseek-v4-pro"));
+        assert!(!is_anthropic_model("mimo-v2-pro"));
+        assert!(!is_anthropic_model("minimax-m2.5"));
+    }
+
+    #[test]
+    fn anthropic_base_url_strips_v1() {
+        assert_eq!(
+            anthropic_api_base(Some("https://opencode.ai/zen/go/v1")),
+            "https://opencode.ai/zen/go"
+        );
+        assert_eq!(
+            anthropic_api_base(Some("https://opencode.ai/zen/go/v1/")),
+            "https://opencode.ai/zen/go"
+        );
+    }
+}

--- a/bitrouter/src/runtime/mod.rs
+++ b/bitrouter/src/runtime/mod.rs
@@ -6,6 +6,7 @@ pub mod copilot;
 #[cfg(feature = "cli")]
 pub mod daemon;
 pub mod error;
+pub mod go;
 pub mod http_client;
 pub mod mcp_client;
 pub mod migration;
@@ -15,6 +16,7 @@ pub mod paths;
 pub mod payment;
 pub mod router;
 pub mod server;
+pub mod zen;
 
 pub use app::{AppRuntime, resolve_database_url};
 pub use migration::migrate;

--- a/bitrouter/src/runtime/router.rs
+++ b/bitrouter/src/runtime/router.rs
@@ -16,6 +16,15 @@ use super::copilot::{
     COPILOT_PROVIDER, anthropic_api_base, copilot_default_headers, is_anthropic_model,
     is_responses_model,
 };
+use super::go::{
+    GO_PROVIDER, anthropic_api_base as go_anthropic_api_base,
+    is_anthropic_model as go_is_anthropic_model,
+};
+use super::zen::{
+    ZEN_PROVIDER, anthropic_api_base as zen_anthropic_api_base,
+    google_api_base as zen_google_api_base, is_anthropic_model as zen_is_anthropic_model,
+    is_google_model as zen_is_google_model, is_responses_model as zen_is_responses_model,
+};
 
 #[cfg(feature = "mcp")]
 use bitrouter_providers::mcp::client::upstream::UpstreamConnection;
@@ -110,12 +119,17 @@ impl Router {
             .api_base
             .clone()
             .unwrap_or_else(|| "https://generativelanguage.googleapis.com".into());
+        let api_version = provider
+            .api_version
+            .clone()
+            .unwrap_or_else(|| "v1beta".into());
 
         let default_headers = parse_headers(provider.default_headers.as_ref())?;
 
         Ok(GoogleConfig {
             api_key,
             base_url,
+            api_version,
             default_headers,
         })
     }
@@ -177,6 +191,93 @@ impl LanguageModelRouter for Router {
         } else {
             None
         };
+
+        // ── OpenCode Zen dispatch ────────────────────────────────────
+        // Zen serves models across multiple protocols from a single provider.
+        // Claude and select models use Anthropic, Gemini uses Google,
+        // GPT uses OpenAI Responses, and the rest use Chat Completions.
+        let is_zen = target.provider_name == ZEN_PROVIDER;
+
+        if is_zen && zen_is_anthropic_model(&target.service_id) {
+            let api_key = self.resolve_api_key(&target.provider_name, provider);
+            let base_url = zen_anthropic_api_base(provider.api_base.as_deref());
+            let mut default_headers = parse_headers(provider.default_headers.as_ref())?;
+            default_headers.insert(
+                reqwest::header::AUTHORIZATION,
+                HeaderValue::from_str(&format!("Bearer {api_key}")).map_err(|e| {
+                    BitrouterError::invalid_request(
+                        None,
+                        format!("invalid Authorization header: {e}"),
+                        None,
+                    )
+                })?,
+            );
+            let config = AnthropicConfig {
+                api_key: String::new(),
+                base_url,
+                api_version: "2023-06-01".into(),
+                default_headers,
+            };
+            let model =
+                AnthropicMessagesModel::with_client(target.service_id, self.client.clone(), config);
+            return Ok(DynLanguageModel::new_box(model));
+        }
+
+        if is_zen && zen_is_google_model(&target.service_id) {
+            let api_key = self.resolve_api_key(&target.provider_name, provider);
+            let base_url = zen_google_api_base(provider.api_base.as_deref());
+            let api_version = provider.api_version.clone().unwrap_or_else(|| "v1".into());
+            let default_headers = parse_headers(provider.default_headers.as_ref())?;
+            let config = GoogleConfig {
+                api_key,
+                base_url,
+                api_version,
+                default_headers,
+            };
+            let model = GoogleGenerativeAiModel::with_client(
+                target.service_id,
+                self.client.clone(),
+                config,
+            );
+            return Ok(DynLanguageModel::new_box(model));
+        }
+
+        if is_zen && zen_is_responses_model(&target.service_id) {
+            let config = self.build_openai_config(&target.provider_name, provider)?;
+            let model =
+                OpenAiResponsesModel::with_client(target.service_id, self.client.clone(), config);
+            return Ok(DynLanguageModel::new_box(model));
+        }
+
+        // ── OpenCode Go dispatch ─────────────────────────────────────
+        // Go serves most models via Chat Completions but MiniMax M2.7 and
+        // Qwen3.5/3.6 Plus use the Anthropic Messages API.
+        let is_go = target.provider_name == GO_PROVIDER;
+
+        if is_go && go_is_anthropic_model(&target.service_id) {
+            let api_key = self.resolve_api_key(&target.provider_name, provider);
+            let base_url = go_anthropic_api_base(provider.api_base.as_deref());
+            let mut default_headers = parse_headers(provider.default_headers.as_ref())?;
+            default_headers.insert(
+                reqwest::header::AUTHORIZATION,
+                HeaderValue::from_str(&format!("Bearer {api_key}")).map_err(|e| {
+                    BitrouterError::invalid_request(
+                        None,
+                        format!("invalid Authorization header: {e}"),
+                        None,
+                    )
+                })?,
+            );
+            let config = AnthropicConfig {
+                api_key: String::new(),
+                base_url,
+                api_version: "2023-06-01".into(),
+                default_headers,
+            };
+            let model =
+                AnthropicMessagesModel::with_client(target.service_id, self.client.clone(), config);
+            return Ok(DynLanguageModel::new_box(model));
+        }
 
         match target.api_protocol {
             ApiProtocol::Openai => {

--- a/bitrouter/src/runtime/zen.rs
+++ b/bitrouter/src/runtime/zen.rs
@@ -1,0 +1,140 @@
+//! OpenCode Zen provider-specific request configuration.
+//!
+//! The Zen API serves models across multiple protocols depending on model
+//! family: Claude models use the Anthropic Messages API, Gemini models use
+//! the Google Generative AI API, GPT models use the OpenAI Responses API,
+//! and all others use the OpenAI Chat Completions API.
+//!
+//! This module provides the model ID → protocol dispatch logic and
+//! base URL derivation, following the same pattern as the Copilot module.
+
+use std::collections::HashSet;
+use std::sync::LazyLock;
+
+/// The built-in provider name used for OpenCode Zen.
+pub const ZEN_PROVIDER: &str = "opencode-zen";
+
+/// Model IDs that use the Anthropic Messages API on Zen.
+///
+/// Derived from the `provider.npm == "@ai-sdk/anthropic"` field in models.dev.
+/// Some models (big-pickle, free-tier minimax, qwen) use the Anthropic
+/// protocol despite not being Claude models.
+static ZEN_ANTHROPIC_MODELS: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
+    let mut s = HashSet::new();
+    s.insert("big-pickle");
+    s.insert("minimax-m2.1-free");
+    s.insert("minimax-m2.5-free");
+    s.insert("qwen3.5-plus");
+    s.insert("qwen3.6-plus");
+    s
+});
+
+/// Returns `true` when a Zen model ID should use the Anthropic Messages API.
+pub fn is_anthropic_model(model_id: &str) -> bool {
+    model_id.starts_with("claude-")
+        || model_id.starts_with("claude_")
+        || ZEN_ANTHROPIC_MODELS.contains(model_id)
+}
+
+/// Returns `true` when a Zen model ID should use the Google Generative AI API.
+pub fn is_google_model(model_id: &str) -> bool {
+    model_id.starts_with("gemini-")
+}
+
+/// Returns `true` when a Zen model ID should use the OpenAI Responses API.
+///
+/// All GPT family models on Zen use the Responses endpoint.
+pub fn is_responses_model(model_id: &str) -> bool {
+    model_id.starts_with("gpt-5") || model_id == "gpt-5"
+}
+
+/// Derives the Anthropic-compatible API base from the Zen provider's base URL.
+///
+/// The Anthropic adapter appends `/v1/messages` itself, so we strip any
+/// trailing `/v1` from the Zen base URL to avoid double-pathing.
+pub fn anthropic_api_base(provider_api_base: Option<&str>) -> String {
+    let base = provider_api_base
+        .unwrap_or("https://opencode.ai/zen/v1")
+        .trim_end_matches('/');
+    base.strip_suffix("/v1").unwrap_or(base).to_owned()
+}
+
+/// Derives the Google-compatible API base from the Zen provider's base URL.
+///
+/// The Google adapter appends `/{api_version}/models/{model}:action` itself,
+/// so we strip any trailing `/v1` to get the scheme+host root.
+pub fn google_api_base(provider_api_base: Option<&str>) -> String {
+    let base = provider_api_base
+        .unwrap_or("https://opencode.ai/zen/v1")
+        .trim_end_matches('/');
+    base.strip_suffix("/v1").unwrap_or(base).to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn claude_models_detected_as_anthropic() {
+        assert!(is_anthropic_model("claude-sonnet-4-6"));
+        assert!(is_anthropic_model("claude-haiku-4-5"));
+        assert!(is_anthropic_model("claude-opus-4-7"));
+        assert!(is_anthropic_model("claude-3-5-haiku"));
+    }
+
+    #[test]
+    fn non_claude_anthropic_models_detected() {
+        assert!(is_anthropic_model("big-pickle"));
+        assert!(is_anthropic_model("qwen3.5-plus"));
+        assert!(is_anthropic_model("qwen3.6-plus"));
+        assert!(is_anthropic_model("minimax-m2.5-free"));
+        assert!(is_anthropic_model("minimax-m2.1-free"));
+    }
+
+    #[test]
+    fn openai_models_not_anthropic() {
+        assert!(!is_anthropic_model("gpt-5.5"));
+        assert!(!is_anthropic_model("glm-5.1"));
+        assert!(!is_anthropic_model("minimax-m2.7"));
+    }
+
+    #[test]
+    fn gemini_models_detected_as_google() {
+        assert!(is_google_model("gemini-3-flash"));
+        assert!(is_google_model("gemini-3.1-pro"));
+        assert!(!is_google_model("gpt-5.4"));
+    }
+
+    #[test]
+    fn gpt_models_detected_as_responses() {
+        assert!(is_responses_model("gpt-5.5"));
+        assert!(is_responses_model("gpt-5.4-pro"));
+        assert!(is_responses_model("gpt-5.4-mini"));
+        assert!(is_responses_model("gpt-5-nano"));
+        assert!(is_responses_model("gpt-5"));
+        assert!(is_responses_model("gpt-5.1-codex"));
+        assert!(is_responses_model("gpt-5.3-codex-spark"));
+        assert!(!is_responses_model("claude-sonnet-4-6"));
+        assert!(!is_responses_model("glm-5.1"));
+    }
+
+    #[test]
+    fn anthropic_base_url_strips_v1() {
+        assert_eq!(
+            anthropic_api_base(Some("https://opencode.ai/zen/v1")),
+            "https://opencode.ai/zen"
+        );
+        assert_eq!(
+            anthropic_api_base(Some("https://opencode.ai/zen/v1/")),
+            "https://opencode.ai/zen"
+        );
+    }
+
+    #[test]
+    fn google_base_url_strips_v1() {
+        assert_eq!(
+            google_api_base(Some("https://opencode.ai/zen/v1")),
+            "https://opencode.ai/zen"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Add first-class support for **OpenCode Zen** (curated multi-protocol model gateway) and **OpenCode Go** (low-cost subscription for open coding models) as built-in providers
- Enable automatic model sync for both providers from [models.dev](https://models.dev/api.json) via the existing CI workflow
- Make Google adapter `api_version` configurable to support Zen's Gemini models (which use `/v1/` instead of the default `/v1beta/`)

## Changes

### Multi-protocol dispatch (Zen & Go)

Zen serves models across **4 protocols** from a single provider — OpenAI Responses, Anthropic Messages, Google Generative AI, and OpenAI Chat Completions — following the same dispatch pattern used by the GitHub Copilot provider:

- **Zen Anthropic**: Claude models + `big-pickle`, `minimax-m2.1-free`, `minimax-m2.5-free`, `qwen3.5-plus`, `qwen3.6-plus` (per `provider.npm == "@ai-sdk/anthropic"` in models.dev)
- **Zen Google**: `gemini-*` models (per `provider.npm == "@ai-sdk/google"`)
- **Zen Responses**: `gpt-5*` models (per `provider.npm == "@ai-sdk/openai"`)
- **Zen Chat**: all other models (default `@ai-sdk/openai-compatible`)
- **Go Anthropic**: `minimax-m2.7`, `qwen3.5-plus`, `qwen3.6-plus`
- **Go Chat**: all other Go models

### New files

| File | Description |
|------|-------------|
| `bitrouter-config/providers/models/opencode-zen.yaml` | 59 models with pricing from models.dev |
| `bitrouter-config/providers/models/opencode-go.yaml` | 14 models with pricing from models.dev |
| `bitrouter/src/runtime/zen.rs` | Model ID → protocol dispatch + base URL derivation |
| `bitrouter/src/runtime/go.rs` | Model ID → protocol dispatch + base URL derivation |

### Modified files

| File | Change |
|------|--------|
| `bitrouter-providers/.../provider.rs` | Add `api_version` to `GoogleConfig`, replace hardcoded `v1beta` with configurable version |
| `bitrouter-config/src/config.rs` | Add `api_version: Option<String>` to `ProviderConfig` |
| `bitrouter-config/src/registry.rs` | Add `api_version` to `ProviderDef`, `merge_provider`, `resolve_derives`; register `opencode-zen` and `opencode-go` in `PROVIDER_DEFS` |
| `bitrouter/src/runtime/router.rs` | Wire `api_version` through `build_google_config`; add Zen/Go dispatch blocks in `route_model()` |
| `bitrouter/src/runtime/mod.rs` | Add `pub mod go; pub mod zen;` |
| `bitrouter/src/init.rs` | Add "OpenCode Zen" and "OpenCode Go" to setup wizard |
| `.github/workflows/models.yml` | Add `opencode-zen`→`opencode` and `opencode-go`→`opencode-go` to `PROVIDER_MAP`; add protocol dispatch coverage verification step |
| `README.md` | Add OpenCode Zen and Go to Supported Providers table |

### CI verification step

The CI workflow now checks that models requiring non-default protocols (Anthropic, Google) are covered by the Rust dispatch modules (`zen.rs`, `go.rs`). If models.dev adds a new model with `provider.npm == "@ai-sdk/anthropic"` that isn't in the dispatch list, the step fails with guidance to update the Rust source.

## Test plan

- [x] `cargo nextest run --all-features` — 866/866 pass
- [x] `cargo clippy --all-features -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] Unit tests in `zen.rs` and `go.rs` verify protocol detection and base URL derivation