### PR TITLE
feat: CLI/TUI shared agents ops + headless-CLI consistency pass

### DIFF
--- a/bitrouter-providers/Cargo.toml
+++ b/bitrouter-providers/Cargo.toml
@@ -19,8 +19,10 @@ acp = [
     "dep:agent-client-protocol",
     "dep:async-trait",
     "dep:bitrouter-config",
+    "dep:dirs",
     "dep:flate2",
     "dep:tar",
+    "dep:thiserror",
     "dep:zip",
     "tokio/fs",
     "tokio/process",
@@ -66,8 +68,10 @@ rmcp = { version = "1.3", optional = true, default-features = false, features = 
 # acp
 agent-client-protocol = { version = "0.10", optional = true }
 async-trait = { version = "0.1", optional = true }
+dirs = { version = "6", optional = true }
 flate2 = { version = "1", optional = true }
 tar = { version = "0.4", optional = true }
+thiserror = { version = "2.0", optional = true }
 zip = { version = "8.5", optional = true, default-features = false, features = [
     "deflate",
 ] }

--- a/bitrouter-providers/src/acp/eager.rs
+++ b/bitrouter-providers/src/acp/eager.rs
@@ -27,7 +27,7 @@ use super::state::{self, InstallMethod, InstallRecord, now_unix_seconds};
 use super::types::InstallProgress;
 
 /// Outcome of a successful install.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct InstalledAgent {
     pub agent_id: String,
     pub method: InstallMethod,

--- a/bitrouter-providers/src/acp/mod.rs
+++ b/bitrouter-providers/src/acp/mod.rs
@@ -7,6 +7,7 @@
 pub mod discovery;
 pub mod eager;
 pub mod install;
+pub mod ops;
 pub mod platform;
 pub mod provider;
 pub mod proxy;

--- a/bitrouter-providers/src/acp/ops.rs
+++ b/bitrouter-providers/src/acp/ops.rs
@@ -1,0 +1,329 @@
+//! High-level ACP agent operations shared by the CLI and TUI.
+//!
+//! Each function returns structured, format-agnostic data. The caller
+//! decides how to render it. Long-running operations return an [`OpHandle`]
+//! carrying a progress channel and a task handle.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use bitrouter_config::BitrouterConfig;
+use bitrouter_config::acp::registry_agent_to_config;
+use serde::Serialize;
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+
+use super::eager::{self, InstalledAgent};
+use super::registry;
+use super::state::{self, InstallRecord};
+use super::types::InstallProgress;
+
+/// Paths needed by ACP operations, grouped so callers don't need to import
+/// the binary's path module.
+#[derive(Debug, Clone)]
+pub struct AcpPaths {
+    pub cache_dir: PathBuf,
+    pub agents_dir: PathBuf,
+    pub agent_state_file: PathBuf,
+}
+
+/// Error type for ACP operations.
+#[derive(Debug, thiserror::Error)]
+pub enum OpError {
+    #[error("not found: {kind} '{id}'")]
+    NotFound { kind: &'static str, id: String },
+
+    #[error("registry: {0}")]
+    Registry(String),
+
+    #[error("install: {0}")]
+    Install(String),
+
+    #[error("uninstall: {0}")]
+    Uninstall(String),
+
+    #[error("io: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+impl OpError {
+    /// Stable CLI exit-code mapping.
+    pub fn exit_code(&self) -> i32 {
+        match self {
+            OpError::NotFound { .. } => 4,
+            OpError::Registry(_) => 8,
+            OpError::Install(_) | OpError::Uninstall(_) => 9,
+            OpError::Io(_) => 1,
+        }
+    }
+}
+
+/// Handle for a long-running agent operation.
+///
+/// Read [`progress`] events until `None` (channel closed), then await
+/// [`result`] for the final outcome.
+pub struct OpHandle<R> {
+    pub progress: mpsc::Receiver<InstallProgress>,
+    pub result: JoinHandle<Result<R, OpError>>,
+}
+
+/// Summary of a single agent across registry, config, and install state.
+#[derive(Debug, Clone, Serialize)]
+pub struct AgentInfo {
+    pub id: String,
+    pub version: Option<String>,
+    pub installed: Option<InstallRecord>,
+    pub on_path: bool,
+    pub from_registry: bool,
+}
+
+/// Full result of the `list_agents` operation.
+#[derive(Debug, Clone, Serialize)]
+pub struct AgentList {
+    pub registry_version: Option<String>,
+    pub registry_url: String,
+    pub agents: Vec<AgentInfo>,
+    pub warnings: Vec<String>,
+}
+
+/// Result of the `check_routing` operation.
+#[derive(Debug, Clone, Serialize)]
+pub struct RoutingCheck {
+    pub server_reachable: bool,
+    pub listen_addr: String,
+    pub shim_entries: Vec<ShimEntry>,
+    pub discovered_on_path: Vec<String>,
+    pub discovered_distributable: Vec<String>,
+}
+
+/// Shim installation status for one agent.
+#[derive(Debug, Clone, Serialize)]
+pub struct ShimEntry {
+    pub agent_id: String,
+    pub shim_installed: bool,
+    pub shim_path: PathBuf,
+}
+
+/// Merge registry + config + install state into a structured agent list.
+pub async fn list_agents(
+    config: &BitrouterConfig,
+    paths: &AcpPaths,
+    refresh: bool,
+) -> Result<AgentList, OpError> {
+    let cache_file = paths.cache_dir.join("acp-registry.json");
+    let registry_url = registry::resolve_registry_url(config.acp_registry_url.as_deref());
+
+    let mut warnings = Vec::new();
+    let registry_result = if refresh {
+        registry::fetch_registry_fresh(&cache_file, &registry_url).await
+    } else {
+        registry::fetch_registry(&cache_file, registry::DEFAULT_TTL_SECS, &registry_url).await
+    };
+
+    let mut known = bitrouter_config::builtin_agent_defs();
+    for (name, agent_config) in &config.agents {
+        known.insert(name.clone(), agent_config.clone());
+    }
+
+    let (registry_version, registry_map) = match registry_result {
+        Ok(index) => {
+            let mut map = HashMap::new();
+            for agent in &index.agents {
+                known.insert(agent.id.clone(), registry_agent_to_config(agent));
+                map.insert(agent.id.clone(), agent.clone());
+            }
+            (Some(index.version), map)
+        }
+        Err(e) => {
+            warnings.push(format!("registry unavailable: {e}"));
+            (None, HashMap::new())
+        }
+    };
+
+    state::overlay_install_state_sync(&mut known, &paths.agent_state_file);
+    let records: HashMap<String, InstallRecord> = state::load_state_sync(&paths.agent_state_file)
+        .into_iter()
+        .map(|r| (r.id.clone(), r))
+        .collect();
+
+    let discovered = super::discovery::discover_agents(&known);
+
+    let mut names: Vec<_> = known.keys().cloned().collect();
+    names.sort();
+
+    let agents = names
+        .into_iter()
+        .map(|name| {
+            let on_path = discovered.iter().any(|d| d.name == name);
+            let installed = records.get(&name).cloned();
+            let from_registry = registry_map.contains_key(&name);
+            let version = registry_map.get(&name).map(|r| r.version.clone());
+            AgentInfo {
+                id: name,
+                version,
+                installed,
+                on_path,
+                from_registry,
+            }
+        })
+        .collect();
+
+    Ok(AgentList {
+        registry_version,
+        registry_url,
+        agents,
+        warnings,
+    })
+}
+
+/// Install an agent by id from the ACP registry.
+///
+/// Returns an [`OpHandle`] immediately. Read progress events until `None`,
+/// then await `result` for the installation outcome.
+pub fn install_agent(
+    agent_id: &str,
+    config: &BitrouterConfig,
+    paths: &AcpPaths,
+) -> OpHandle<InstalledAgent> {
+    let agent_id = agent_id.to_owned();
+    let cache_file = paths.cache_dir.join("acp-registry.json");
+    let install_dir = paths.agents_dir.join(&agent_id);
+    let state_file = paths.agent_state_file.clone();
+    let registry_url = registry::resolve_registry_url(config.acp_registry_url.as_deref());
+
+    let (progress_tx, progress_rx) = mpsc::channel(32);
+
+    let result = tokio::spawn(async move {
+        let index =
+            registry::fetch_registry(&cache_file, registry::DEFAULT_TTL_SECS, &registry_url)
+                .await
+                .map_err(OpError::Registry)?;
+
+        let registry_agent = index
+            .agents
+            .iter()
+            .find(|a| a.id == agent_id)
+            .ok_or_else(|| OpError::NotFound {
+                kind: "agent",
+                id: agent_id.clone(),
+            })?;
+
+        let agent_config = registry_agent_to_config(registry_agent);
+        let version = registry_agent.version.clone();
+
+        eager::install_agent(
+            &agent_id,
+            &agent_config,
+            &install_dir,
+            &state_file,
+            &version,
+            progress_tx,
+        )
+        .await
+        .map_err(OpError::Install)
+    });
+
+    OpHandle {
+        progress: progress_rx,
+        result,
+    }
+}
+
+/// Uninstall a previously installed agent.
+pub async fn uninstall_agent(agent_id: &str, paths: &AcpPaths) -> Result<(), OpError> {
+    let install_dir = paths.agents_dir.join(agent_id);
+    eager::uninstall_agent(agent_id, &install_dir, &paths.agent_state_file)
+        .await
+        .map_err(OpError::Uninstall)
+}
+
+/// Update one or all installed agents by reinstalling from the registry.
+///
+/// Progress events are discarded. Call [`install_agent`] directly when
+/// per-agent progress streaming is needed.
+pub async fn update_agents(
+    target: Option<&str>,
+    config: &BitrouterConfig,
+    paths: &AcpPaths,
+) -> Result<Vec<InstalledAgent>, OpError> {
+    let records = state::load_state_sync(&paths.agent_state_file);
+
+    let targets: Vec<String> = match target {
+        Some(id) => {
+            if !records.iter().any(|r| r.id == id) {
+                return Err(OpError::NotFound {
+                    kind: "installed agent",
+                    id: id.to_owned(),
+                });
+            }
+            vec![id.to_owned()]
+        }
+        None => records.iter().map(|r| r.id.clone()).collect(),
+    };
+
+    let mut results = Vec::new();
+    for id in &targets {
+        let mut handle = install_agent(id, config, paths);
+        while handle.progress.recv().await.is_some() {}
+        let installed = handle
+            .result
+            .await
+            .map_err(|e| OpError::Install(e.to_string()))??;
+        results.push(installed);
+    }
+    Ok(results)
+}
+
+/// Check that agent routing through BitRouter is properly configured.
+pub fn check_routing(config: &BitrouterConfig) -> RoutingCheck {
+    let listen = config.server.listen;
+
+    let mut known = bitrouter_config::builtin_agent_defs();
+    for (name, agent_config) in &config.agents {
+        known.insert(name.clone(), agent_config.clone());
+    }
+
+    let discovered_agents = super::discovery::discover_agents(&known);
+
+    let shim_dir = dirs::home_dir()
+        .map(|h| h.join(".local").join("bin"))
+        .unwrap_or_else(|| PathBuf::from(".local/bin"));
+    let platform = super::shim::Platform::current();
+
+    let shim_entries: Vec<ShimEntry> = discovered_agents
+        .iter()
+        .filter(|a| super::shim::shim_env_for(&a.name, listen).is_some())
+        .map(|a| {
+            let shim_path = super::shim::shim_path_for(platform, &shim_dir, &a.name);
+            let shim_installed = super::shim::is_installed(&shim_path);
+            ShimEntry {
+                agent_id: a.name.clone(),
+                shim_installed,
+                shim_path,
+            }
+        })
+        .collect();
+
+    let server_reachable =
+        std::net::TcpStream::connect_timeout(&listen, std::time::Duration::from_secs(2)).is_ok();
+
+    use super::types::AgentAvailability;
+    let discovered_on_path: Vec<String> = discovered_agents
+        .iter()
+        .filter(|a| matches!(a.availability, AgentAvailability::OnPath(_)))
+        .map(|a| a.name.clone())
+        .collect();
+    let discovered_distributable: Vec<String> = discovered_agents
+        .iter()
+        .filter(|a| matches!(a.availability, AgentAvailability::Distributable))
+        .map(|a| a.name.clone())
+        .collect();
+
+    RoutingCheck {
+        server_reachable,
+        listen_addr: listen.to_string(),
+        shim_entries,
+        discovered_on_path,
+        discovered_distributable,
+    }
+}

--- a/bitrouter-tui/src/app/agent_lifecycle.rs
+++ b/bitrouter-tui/src/app/agent_lifecycle.rs
@@ -121,12 +121,46 @@ impl App {
         let state_file = self.state.config.agent_state_file.clone();
 
         tokio::spawn(async move {
+            use bitrouter_providers::acp::types::InstallProgress;
+
             let (progress_tx, progress_rx) = mpsc::channel(32);
-            let reporter = super::slash::spawn_progress_forwarder(
-                progress_rx,
-                agent_id_owned.clone(),
-                event_tx.clone(),
-            );
+            let agent_id_for_progress = agent_id_owned.clone();
+            let event_tx_for_progress = event_tx.clone();
+            let reporter = tokio::spawn(async move {
+                let mut rx = progress_rx;
+                while let Some(p) = rx.recv().await {
+                    let evt = match p {
+                        InstallProgress::Downloading {
+                            bytes_received,
+                            total,
+                        } => {
+                            let percent = total
+                                .filter(|&t| t > 0)
+                                .map(|t| ((bytes_received * 100) / t) as u8)
+                                .unwrap_or(0);
+                            AppEvent::InstallProgress {
+                                agent_id: agent_id_for_progress.clone(),
+                                percent,
+                            }
+                        }
+                        InstallProgress::Extracting => AppEvent::InstallProgress {
+                            agent_id: agent_id_for_progress.clone(),
+                            percent: 95,
+                        },
+                        InstallProgress::Done(path) => AppEvent::InstallComplete {
+                            agent_id: agent_id_for_progress.clone(),
+                            binary_path: path,
+                        },
+                        InstallProgress::Failed(msg) => AppEvent::InstallFailed {
+                            agent_id: agent_id_for_progress.clone(),
+                            message: msg,
+                        },
+                    };
+                    if event_tx_for_progress.send(evt).await.is_err() {
+                        break;
+                    }
+                }
+            });
 
             let result =
                 install_binary_agent(&agent_id_owned, &install_dir, &platforms, progress_tx).await;

--- a/bitrouter-tui/src/app/helpers.rs
+++ b/bitrouter-tui/src/app/helpers.rs
@@ -1,8 +1,19 @@
+use bitrouter_providers::acp::ops::AcpPaths;
+
 use crate::model::{ActivityEntry, ContentBlock, EntryKind, SystemNotice};
 
 use super::App;
 
 impl App {
+    /// Build [`AcpPaths`] from the TUI config.
+    pub(super) fn acp_paths(&self) -> AcpPaths {
+        AcpPaths {
+            cache_dir: self.state.config.cache_dir.clone(),
+            agents_dir: self.state.config.agents_dir.clone(),
+            agent_state_file: self.state.config.agent_state_file.clone(),
+        }
+    }
+
     /// Push a system message to a specific session.
     pub(super) fn push_system_msg_to_session(&mut self, session_idx: usize, text: &str) {
         if let Some(session) = self.state.session_store.active.get_mut(session_idx) {

--- a/bitrouter-tui/src/app/slash.rs
+++ b/bitrouter-tui/src/app/slash.rs
@@ -7,7 +7,7 @@
 //! about slashes.
 
 use bitrouter_config::BitrouterConfig;
-use bitrouter_config::acp::registry_agent_to_config;
+use bitrouter_providers::acp::ops;
 use bitrouter_providers::acp::types::InstallProgress;
 use tokio::sync::mpsc;
 
@@ -241,46 +241,36 @@ impl App {
     }
 
     fn slash_agents_list(&mut self, refresh: bool) {
-        let cache_file = self.state.config.cache_dir.join("acp-registry.json");
-        let state_file = self.state.config.agent_state_file.clone();
-        let registry_override = self.bitrouter_config.acp_registry_url.clone();
+        let paths = self.acp_paths();
+        let config = self.bitrouter_config.clone();
         let event_tx = self.event_tx.clone();
 
         tokio::spawn(async move {
-            use bitrouter_providers::acp::registry;
-            use bitrouter_providers::acp::state;
-
-            let url = registry::resolve_registry_url(registry_override.as_deref());
-            let fetch = if refresh {
-                registry::fetch_registry_fresh(&cache_file, &url).await
-            } else {
-                registry::fetch_registry(&cache_file, registry::DEFAULT_TTL_SECS, &url).await
+            let list = match ops::list_agents(&config, &paths, refresh).await {
+                Ok(l) => l,
+                Err(e) => {
+                    send_system_lines(&event_tx, vec![format!("agents list failed: {e}")]).await;
+                    return;
+                }
             };
 
             let mut lines: Vec<String> = Vec::new();
-            let records = state::load_state(&state_file).await.unwrap_or_default();
-
-            match fetch {
-                Ok(index) => {
-                    lines.push(format!(
-                        "Agents ({} in registry v{}):",
-                        index.agents.len(),
-                        index.version
-                    ));
-                    let mut agents = index.agents.clone();
-                    agents.sort_by(|a, b| a.id.cmp(&b.id));
-                    for a in &agents {
-                        let installed = records.iter().find(|r| r.id == a.id);
-                        let mark = match installed {
-                            Some(r) => format!("[{}]", r.method),
-                            None => "[ ]".to_owned(),
-                        };
-                        lines.push(format!("  {mark} {:<22} v{}", a.id, a.version));
-                    }
-                }
-                Err(e) => lines.push(format!("Registry unavailable: {e}")),
+            for warning in &list.warnings {
+                lines.push(format!("warning: {warning}"));
             }
-
+            let header = match &list.registry_version {
+                Some(v) => format!("Agents ({} in registry v{v}):", list.agents.len()),
+                None => format!("Agents ({}):", list.agents.len()),
+            };
+            lines.push(header);
+            for info in &list.agents {
+                let mark = match &info.installed {
+                    Some(r) => format!("[{}]", r.method),
+                    None => "[ ]".to_owned(),
+                };
+                let version = info.version.as_deref().unwrap_or("-");
+                lines.push(format!("  {mark} {:<22} {version}", info.id));
+            }
             send_system_lines(&event_tx, lines).await;
         });
     }
@@ -288,71 +278,65 @@ impl App {
     fn slash_agents_install(&mut self, id: String, bitrouter_config: &BitrouterConfig) {
         self.push_system_msg(&format!("Installing {id}..."));
 
-        let cache_file = self.state.config.cache_dir.join("acp-registry.json");
-        let state_file = self.state.config.agent_state_file.clone();
-        let install_dir = self.state.config.agents_dir.join(&id);
-        let registry_override = bitrouter_config.acp_registry_url.clone();
+        let paths = self.acp_paths();
+        let config = bitrouter_config.clone();
         let event_tx = self.event_tx.clone();
 
         tokio::spawn(async move {
-            use bitrouter_providers::acp::{eager, registry};
+            let mut handle = ops::install_agent(&id, &config, &paths);
+            let agent_id = id.clone();
+            let tx = event_tx.clone();
 
-            let url = registry::resolve_registry_url(registry_override.as_deref());
-            let index =
-                match registry::fetch_registry(&cache_file, registry::DEFAULT_TTL_SECS, &url).await
-                {
-                    Ok(i) => i,
-                    Err(e) => {
-                        send_system_lines(&event_tx, vec![format!("Registry unavailable: {e}")])
-                            .await;
-                        return;
+            while let Some(p) = handle.progress.recv().await {
+                let evt = match p {
+                    InstallProgress::Downloading {
+                        bytes_received,
+                        total,
+                    } => {
+                        let percent = total
+                            .filter(|&t| t > 0)
+                            .map(|t| ((bytes_received * 100) / t) as u8)
+                            .unwrap_or(0);
+                        AppEvent::InstallProgress {
+                            agent_id: agent_id.clone(),
+                            percent,
+                        }
                     }
+                    InstallProgress::Extracting => AppEvent::InstallProgress {
+                        agent_id: agent_id.clone(),
+                        percent: 95,
+                    },
+                    InstallProgress::Done(path) => AppEvent::InstallComplete {
+                        agent_id: agent_id.clone(),
+                        binary_path: path,
+                    },
+                    InstallProgress::Failed(msg) => AppEvent::InstallFailed {
+                        agent_id: agent_id.clone(),
+                        message: msg,
+                    },
                 };
+                if tx.send(evt).await.is_err() {
+                    break;
+                }
+            }
 
-            let Some(agent) = index.agents.iter().find(|a| a.id == id) else {
-                send_system_lines(
-                    &event_tx,
-                    vec![format!("Agent '{id}' not found in registry")],
-                )
-                .await;
-                return;
-            };
-
-            let agent_config = registry_agent_to_config(agent);
-            let (tx, rx) = mpsc::channel(32);
-
-            let reporter = spawn_progress_forwarder(rx, id.clone(), event_tx.clone());
-
-            let result = eager::install_agent(
-                &id,
-                &agent_config,
-                &install_dir,
-                &state_file,
-                &agent.version,
-                tx,
-            )
-            .await;
-            let _ = reporter.await;
-
-            let line = match result {
-                Ok(installed) => format!(
-                    "✓ {} installed via {}",
-                    installed.agent_id, installed.method
-                ),
-                Err(e) => format!("✗ install failed: {e}"),
+            let line = match handle.result.await {
+                Ok(Ok(installed)) => {
+                    format!("✓ {} installed via {}", installed.agent_id, installed.method)
+                }
+                Ok(Err(e)) => format!("✗ install failed: {e}"),
+                Err(_) => format!("✗ install task failed"),
             };
             send_system_lines(&event_tx, vec![line]).await;
         });
     }
 
     fn slash_agents_uninstall(&mut self, id: String) {
-        let install_dir = self.state.config.agents_dir.join(&id);
-        let state_file = self.state.config.agent_state_file.clone();
+        let paths = self.acp_paths();
         let event_tx = self.event_tx.clone();
 
         tokio::spawn(async move {
-            use bitrouter_providers::acp::eager;
-            let line = match eager::uninstall_agent(&id, &install_dir, &state_file).await {
+            let line = match ops::uninstall_agent(&id, &paths).await {
                 Ok(()) => format!("✓ {id} uninstalled"),
                 Err(e) => format!("✗ uninstall failed: {e}"),
             };
@@ -361,11 +345,8 @@ impl App {
     }
 
     fn slash_agents_update(&mut self, id: Option<String>, bitrouter_config: &BitrouterConfig) {
-        // `load_state_sync` is acceptable here because we're already on
-        // the TUI's render/event-handling path (no active async ctx to
-        // block) and the file is a small JSON array.
-        let state_file = self.state.config.agent_state_file.clone();
-        let records = bitrouter_providers::acp::state::load_state_sync(&state_file);
+        let paths = self.acp_paths();
+        let records = bitrouter_providers::acp::state::load_state_sync(&paths.agent_state_file);
         if records.is_empty() {
             self.push_system_msg("(no agents installed)");
             return;
@@ -849,51 +830,6 @@ const HELP_TEXT: &[&str] = &[
     "  /obs             observability summary",
     "  /help or ?       this help",
 ];
-
-/// Spawn a task that forwards [`InstallProgress`] events to the app's
-/// [`AppEvent`] channel with real-percent computation.  Shared by the
-/// slash-install path and (when invoked) the update path so progress
-/// semantics stay consistent with `agent_lifecycle::start_binary_install`.
-pub(super) fn spawn_progress_forwarder(
-    mut rx: mpsc::Receiver<InstallProgress>,
-    agent_id: String,
-    tx: mpsc::Sender<AppEvent>,
-) -> tokio::task::JoinHandle<()> {
-    tokio::spawn(async move {
-        while let Some(p) = rx.recv().await {
-            let evt = match p {
-                InstallProgress::Downloading {
-                    bytes_received,
-                    total,
-                } => {
-                    let percent = total
-                        .filter(|&t| t > 0)
-                        .map(|t| ((bytes_received * 100) / t) as u8)
-                        .unwrap_or(0);
-                    AppEvent::InstallProgress {
-                        agent_id: agent_id.clone(),
-                        percent,
-                    }
-                }
-                InstallProgress::Extracting => AppEvent::InstallProgress {
-                    agent_id: agent_id.clone(),
-                    percent: 95,
-                },
-                InstallProgress::Done(path) => AppEvent::InstallComplete {
-                    agent_id: agent_id.clone(),
-                    binary_path: path,
-                },
-                InstallProgress::Failed(msg) => AppEvent::InstallFailed {
-                    agent_id: agent_id.clone(),
-                    message: msg,
-                },
-            };
-            if tx.send(evt).await.is_err() {
-                break;
-            }
-        }
-    })
-}
 
 async fn send_system_lines(tx: &mpsc::Sender<AppEvent>, lines: Vec<String>) {
     for line in lines {

--- a/bitrouter-tui/src/app/slash.rs
+++ b/bitrouter-tui/src/app/slash.rs
@@ -322,10 +322,13 @@ impl App {
 
             let line = match handle.result.await {
                 Ok(Ok(installed)) => {
-                    format!("✓ {} installed via {}", installed.agent_id, installed.method)
+                    format!(
+                        "✓ {} installed via {}",
+                        installed.agent_id, installed.method
+                    )
                 }
                 Ok(Err(e)) => format!("✗ install failed: {e}"),
-                Err(_) => format!("✗ install task failed"),
+                Err(_) => "✗ install task failed".to_string(),
             };
             send_system_lines(&event_tx, vec![line]).await;
         });

--- a/bitrouter/src/cli/agents.rs
+++ b/bitrouter/src/cli/agents.rs
@@ -75,11 +75,7 @@ pub async fn run_install(
                 total,
             } => {
                 if let Some(t) = total {
-                    let pct = if t > 0 {
-                        bytes_received.saturating_mul(100) / t
-                    } else {
-                        0
-                    };
+                    let pct = bytes_received.saturating_mul(100).checked_div(t).unwrap_or(0);
                     eprintln!("  [{id}] downloading: {pct}%");
                 } else {
                     eprintln!("  [{id}] downloading...");
@@ -142,11 +138,7 @@ pub async fn run_update(
                     total,
                 } => {
                     if let Some(t) = total {
-                        let pct = if t > 0 {
-                            bytes_received.saturating_mul(100) / t
-                        } else {
-                            0
-                        };
+                        let pct = bytes_received.saturating_mul(100).checked_div(t).unwrap_or(0);
                         eprintln!("  [{id}] downloading: {pct}%");
                     } else {
                         eprintln!("  [{id}] downloading...");

--- a/bitrouter/src/cli/agents.rs
+++ b/bitrouter/src/cli/agents.rs
@@ -201,7 +201,11 @@ pub fn render_check_text(check: &RoutingCheck, w: &mut impl Write) -> io::Result
     if check.server_reachable {
         writeln!(w, "  \u{2713} BitRouter reachable at {}", check.listen_addr)?;
     } else {
-        writeln!(w, "  \u{2717} BitRouter not reachable at {}", check.listen_addr)?;
+        writeln!(
+            w,
+            "  \u{2717} BitRouter not reachable at {}",
+            check.listen_addr
+        )?;
         writeln!(w, "    Start the server: bitrouter serve")?;
     }
 

--- a/bitrouter/src/cli/agents.rs
+++ b/bitrouter/src/cli/agents.rs
@@ -75,7 +75,10 @@ pub async fn run_install(
                 total,
             } => {
                 if let Some(t) = total {
-                    let pct = bytes_received.saturating_mul(100).checked_div(t).unwrap_or(0);
+                    let pct = bytes_received
+                        .saturating_mul(100)
+                        .checked_div(t)
+                        .unwrap_or(0);
                     eprintln!("  [{id}] downloading: {pct}%");
                 } else {
                     eprintln!("  [{id}] downloading...");
@@ -138,7 +141,10 @@ pub async fn run_update(
                     total,
                 } => {
                     if let Some(t) = total {
-                        let pct = bytes_received.saturating_mul(100).checked_div(t).unwrap_or(0);
+                        let pct = bytes_received
+                            .saturating_mul(100)
+                            .checked_div(t)
+                            .unwrap_or(0);
                         eprintln!("  [{id}] downloading: {pct}%");
                     } else {
                         eprintln!("  [{id}] downloading...");

--- a/bitrouter/src/cli/agents.rs
+++ b/bitrouter/src/cli/agents.rs
@@ -1,92 +1,61 @@
 //! `bitrouter agents` subcommand — list, install, uninstall, update, and
 //! check ACP agents.
 
-use bitrouter_config::BitrouterConfig;
-use bitrouter_config::acp::registry_agent_to_config;
-use bitrouter_providers::acp::eager;
-use bitrouter_providers::acp::registry;
-use bitrouter_providers::acp::state;
-use bitrouter_providers::acp::types::InstallProgress;
-use tokio::sync::mpsc;
+use std::io::{self, Write};
 
+use bitrouter_config::BitrouterConfig;
+use bitrouter_providers::acp::ops::{self, AcpPaths, AgentList, RoutingCheck};
+use bitrouter_providers::acp::types::InstallProgress;
+
+use crate::cli::OutputFormat;
 use crate::runtime::paths::RuntimePaths;
 
-/// Run the `agents list` subcommand — prints every agent available
-/// across (a) the config, (b) the ACP registry, and (c) installed
-/// ledger, plus PATH availability.
-pub async fn run_list(
-    config: &BitrouterConfig,
-    paths: &RuntimePaths,
-    refresh: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let cache_file = paths.cache_dir.join("acp-registry.json");
-    let registry_url = registry::resolve_registry_url(config.acp_registry_url.as_deref());
-
-    let registry_result = if refresh {
-        registry::fetch_registry_fresh(&cache_file, &registry_url).await
-    } else {
-        registry::fetch_registry(&cache_file, registry::DEFAULT_TTL_SECS, &registry_url).await
-    };
-
-    // Merge: registry > config > built-in.
-    let mut known = bitrouter_config::builtin_agent_defs();
-    for (name, agent_config) in &config.agents {
-        known.insert(name.clone(), agent_config.clone());
+fn paths_from_runtime(paths: &RuntimePaths) -> AcpPaths {
+    AcpPaths {
+        cache_dir: paths.cache_dir.clone(),
+        agents_dir: paths.agents_dir.clone(),
+        agent_state_file: paths.agent_state_file.clone(),
     }
+}
 
-    let registry_map = match &registry_result {
-        Ok(index) => {
-            let mut map = std::collections::HashMap::new();
-            for agent in &index.agents {
-                known.insert(agent.id.clone(), registry_agent_to_config(agent));
-                map.insert(agent.id.clone(), agent.clone());
-            }
-            map
-        }
-        Err(e) => {
-            eprintln!("  warning: registry unavailable ({e}); using built-ins only");
-            std::collections::HashMap::new()
-        }
-    };
-
-    state::overlay_install_state_sync(&mut known, &paths.agent_state_file);
-    let records: std::collections::HashMap<String, state::InstallRecord> =
-        state::load_state_sync(&paths.agent_state_file)
-            .into_iter()
-            .map(|r| (r.id.clone(), r))
-            .collect();
-
-    if known.is_empty() {
-        println!("  (no agents configured)");
+pub fn render_list_text(list: &AgentList, w: &mut impl Write) -> io::Result<()> {
+    if list.agents.is_empty() {
+        writeln!(w, "  (no agents configured)")?;
         return Ok(());
     }
-
-    let discovered = bitrouter_providers::acp::discovery::discover_agents(&known);
-
-    let mut names: Vec<_> = known.keys().cloned().collect();
-    names.sort();
-
-    println!();
-    println!("  Agents");
-    println!("  ──────");
-    println!();
-
-    for name in &names {
-        let on_path = discovered.iter().any(|d| &d.name == name);
-        let installed = records.get(name);
-        let status = match (installed, on_path) {
+    for warning in &list.warnings {
+        eprintln!("  warning: {warning}");
+    }
+    eprintln!();
+    eprintln!("  Agents");
+    eprintln!("  ──────");
+    eprintln!();
+    for info in &list.agents {
+        let status = match (&info.installed, info.on_path) {
             (Some(rec), _) => format!("\u{2713} installed ({})", rec.method),
             (None, true) => "\u{2713} on PATH".to_owned(),
             (None, false) => "\u{2717} not installed".to_owned(),
         };
-        let version = registry_map
-            .get(name)
-            .map(|r| r.version.as_str())
-            .unwrap_or("-");
-        println!("  {name:20}  {version:10}  {status}");
+        let version = info.version.as_deref().unwrap_or("-");
+        writeln!(w, "  {:<20}  {:<10}  {status}", info.id, version)?;
     }
-    println!();
+    writeln!(w)?;
+    Ok(())
+}
 
+/// Run the `agents list` subcommand.
+pub async fn run_list(
+    config: &BitrouterConfig,
+    paths: &RuntimePaths,
+    refresh: bool,
+    output: OutputFormat,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let acp_paths = paths_from_runtime(paths);
+    let list = ops::list_agents(config, &acp_paths, refresh).await?;
+    match output {
+        OutputFormat::Text => render_list_text(&list, &mut io::stdout())?,
+        OutputFormat::Json => serde_json::to_writer(io::stdout(), &list)?,
+    }
     Ok(())
 }
 
@@ -96,65 +65,32 @@ pub async fn run_install(
     config: &BitrouterConfig,
     paths: &RuntimePaths,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let cache_file = paths.cache_dir.join("acp-registry.json");
-    let registry_url = registry::resolve_registry_url(config.acp_registry_url.as_deref());
-
-    let index = registry::fetch_registry(&cache_file, registry::DEFAULT_TTL_SECS, &registry_url)
-        .await
-        .map_err(|e| format!("registry unavailable: {e}"))?;
-
-    let registry_agent = index
-        .agents
-        .iter()
-        .find(|a| a.id == agent_id)
-        .ok_or_else(|| format!("agent '{agent_id}' not found in registry"))?;
-
-    let agent_config = registry_agent_to_config(registry_agent);
-    let install_dir = paths.agent_install_dir(agent_id);
-    let (progress_tx, mut progress_rx) = mpsc::channel(32);
-
-    // Pipe progress to stdout.
-    let id_copy = agent_id.to_owned();
-    let reporter = tokio::spawn(async move {
-        while let Some(p) = progress_rx.recv().await {
-            match p {
-                InstallProgress::Downloading {
-                    bytes_received,
-                    total,
-                } => {
-                    if let Some(t) = total {
-                        let pct = (t > 0)
-                            .then(|| bytes_received.saturating_mul(100).checked_div(t))
-                            .flatten()
-                            .unwrap_or(0);
-                        println!("  [{id_copy}] downloading: {pct}%");
+    let acp_paths = paths_from_runtime(paths);
+    let mut handle = ops::install_agent(agent_id, config, &acp_paths);
+    let id = agent_id.to_owned();
+    while let Some(p) = handle.progress.recv().await {
+        match p {
+            InstallProgress::Downloading {
+                bytes_received,
+                total,
+            } => {
+                if let Some(t) = total {
+                    let pct = if t > 0 {
+                        bytes_received.saturating_mul(100) / t
                     } else {
-                        println!("  [{id_copy}] downloading...");
-                    }
+                        0
+                    };
+                    eprintln!("  [{id}] downloading: {pct}%");
+                } else {
+                    eprintln!("  [{id}] downloading...");
                 }
-                InstallProgress::Extracting => println!("  [{id_copy}] extracting..."),
-                InstallProgress::Done(path) => println!("  [{id_copy}] done: {}", path.display()),
-                InstallProgress::Failed(msg) => eprintln!("  [{id_copy}] failed: {msg}"),
             }
+            InstallProgress::Extracting => eprintln!("  [{id}] extracting..."),
+            InstallProgress::Done(path) => eprintln!("  [{id}] done: {}", path.display()),
+            InstallProgress::Failed(msg) => eprintln!("  [{id}] failed: {msg}"),
         }
-    });
-
-    let result = eager::install_agent(
-        agent_id,
-        &agent_config,
-        &install_dir,
-        &paths.agent_state_file,
-        &registry_agent.version,
-        progress_tx,
-    )
-    .await;
-
-    // Drop side: closing progress_tx is implicit via the move; the
-    // reporter task will exit when the channel is empty+closed.
-    let _ = reporter.await;
-
-    let installed = result.map_err(|e| format!("install failed: {e}"))?;
-    println!();
+    }
+    let installed = handle.result.await??;
     println!(
         "  \u{2713} {} installed via {}",
         installed.agent_id, installed.method
@@ -167,10 +103,8 @@ pub async fn run_uninstall(
     agent_id: &str,
     paths: &RuntimePaths,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let install_dir = paths.agent_install_dir(agent_id);
-    eager::uninstall_agent(agent_id, &install_dir, &paths.agent_state_file)
-        .await
-        .map_err(|e| format!("uninstall failed: {e}"))?;
+    let acp_paths = paths_from_runtime(paths);
+    ops::uninstall_agent(agent_id, &acp_paths).await?;
     println!("  \u{2713} {agent_id} uninstalled");
     Ok(())
 }
@@ -181,128 +115,127 @@ pub async fn run_update(
     config: &BitrouterConfig,
     paths: &RuntimePaths,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let records = state::load_state_sync(&paths.agent_state_file);
+    let acp_paths = paths_from_runtime(paths);
+    let records = bitrouter_providers::acp::state::load_state_sync(&paths.agent_state_file);
     if records.is_empty() {
         println!("  (no agents installed)");
         return Ok(());
     }
 
-    let targets: Vec<&str> = match agent_id {
+    let targets: Vec<String> = match agent_id {
         Some(id) => {
             if !records.iter().any(|r| r.id == id) {
                 return Err(format!("agent '{id}' is not installed").into());
             }
-            vec![id]
+            vec![id.to_owned()]
         }
-        None => records.iter().map(|r| r.id.as_str()).collect(),
+        None => records.iter().map(|r| r.id.clone()).collect(),
     };
 
-    for id in targets {
-        println!("  → updating {id}");
-        run_install(id, config, paths).await?;
+    for id in &targets {
+        eprintln!("  → updating {id}");
+        let mut handle = ops::install_agent(id, config, &acp_paths);
+        while let Some(p) = handle.progress.recv().await {
+            match p {
+                InstallProgress::Downloading {
+                    bytes_received,
+                    total,
+                } => {
+                    if let Some(t) = total {
+                        let pct = if t > 0 {
+                            bytes_received.saturating_mul(100) / t
+                        } else {
+                            0
+                        };
+                        eprintln!("  [{id}] downloading: {pct}%");
+                    } else {
+                        eprintln!("  [{id}] downloading...");
+                    }
+                }
+                InstallProgress::Extracting => eprintln!("  [{id}] extracting..."),
+                InstallProgress::Done(path) => eprintln!("  [{id}] done: {}", path.display()),
+                InstallProgress::Failed(msg) => eprintln!("  [{id}] failed: {msg}"),
+            }
+        }
+        let installed = handle.result.await??;
+        println!(
+            "  \u{2713} {} installed via {}",
+            installed.agent_id, installed.method
+        );
     }
     Ok(())
 }
 
-/// Run the `agents check` subcommand — verify that agent routing through
-/// BitRouter is properly configured and working.
-///
-/// Checks three things:
-/// 1. Routing shims are installed at `~/.local/bin/<agent>`
-/// 2. BitRouter is reachable at the configured listen address
-/// 3. Agents are discovered on PATH or distributable
-pub fn run_check(config: &BitrouterConfig) -> Result<(), Box<dyn std::error::Error>> {
-    let listen = config.server.listen;
+pub fn render_check_text(check: &RoutingCheck, w: &mut impl Write) -> io::Result<()> {
+    eprintln!();
+    eprintln!("  Agent Routing Check");
+    eprintln!("  ───────────────────");
+    eprintln!();
 
-    println!();
-    println!("  Agent Routing Check");
-    println!("  ───────────────────");
-    println!();
-
-    // 1. Discover agents and check shim presence per agent.
-    let mut known = bitrouter_config::builtin_agent_defs();
-    for (name, agent_config) in &config.agents {
-        known.insert(name.clone(), agent_config.clone());
-    }
-    let discovered = bitrouter_providers::acp::discovery::discover_agents(&known);
-
-    let shim_dir = dirs::home_dir()
-        .map(|h| h.join(".local").join("bin"))
-        .unwrap_or_else(|| std::path::PathBuf::from(".local/bin"));
-    let platform = bitrouter_providers::acp::shim::Platform::current();
-
-    let mut needs_shim: Vec<String> = Vec::new();
-    let mut shim_count = 0usize;
-
-    for entry in &discovered {
-        if bitrouter_providers::acp::shim::shim_env_for(&entry.name, listen).is_none() {
-            continue;
-        }
-        let shim_path =
-            bitrouter_providers::acp::shim::shim_path_for(platform, &shim_dir, &entry.name);
-        if bitrouter_providers::acp::shim::is_installed(&shim_path) {
-            println!("  \u{2713} {} shim → {}", entry.name, shim_path.display());
-            shim_count += 1;
-        } else {
-            println!("  \u{2717} {} shim not installed", entry.name);
-            needs_shim.push(entry.name.clone());
-        }
-    }
-
-    if shim_count == 0 && needs_shim.is_empty() {
-        println!("  (no agents with a known routing mapping discovered)");
-    }
-
-    if !needs_shim.is_empty() {
-        println!();
-        println!(
-            "  Run `bitrouter init` to install shims for: {}",
-            needs_shim.join(", ")
-        );
-    }
-
-    // 2. Check BitRouter is reachable (TCP connect probe).
-    println!();
-    match std::net::TcpStream::connect_timeout(&listen, std::time::Duration::from_secs(2)) {
-        Ok(_) => {
-            println!("  \u{2713} BitRouter reachable at {listen}");
-        }
-        Err(_) => {
-            println!("  \u{2717} BitRouter not reachable at {listen}");
-            println!("    Start the server: bitrouter serve");
-        }
-    }
-
-    // 3. Surface agent discovery summary.
-    println!();
-    if discovered.is_empty() {
-        println!("  \u{2717} No ACP agents discovered");
+    if check.shim_entries.is_empty() {
+        eprintln!("  (no agents with a known routing mapping discovered)");
     } else {
-        use bitrouter_providers::acp::types::AgentAvailability;
-
-        let on_path: Vec<&str> = discovered
-            .iter()
-            .filter(|a| matches!(a.availability, AgentAvailability::OnPath(_)))
-            .map(|a| a.name.as_str())
-            .collect();
-        let distributable: Vec<&str> = discovered
-            .iter()
-            .filter(|a| matches!(a.availability, AgentAvailability::Distributable))
-            .map(|a| a.name.as_str())
-            .collect();
-
-        if !on_path.is_empty() {
-            println!("  \u{2713} Agents on PATH: {}", on_path.join(", "));
+        let mut needs_shim: Vec<&str> = Vec::new();
+        for entry in &check.shim_entries {
+            if entry.shim_installed {
+                eprintln!(
+                    "  \u{2713} {} shim \u{2192} {}",
+                    entry.agent_id,
+                    entry.shim_path.display()
+                );
+            } else {
+                eprintln!("  \u{2717} {} shim not installed", entry.agent_id);
+                needs_shim.push(&entry.agent_id);
+            }
         }
-        if !distributable.is_empty() {
-            println!(
-                "  \u{2713} Agents available (auto-install): {}",
-                distributable.join(", ")
+        if !needs_shim.is_empty() {
+            eprintln!();
+            eprintln!(
+                "  Run `bitrouter init` to install shims for: {}",
+                needs_shim.join(", ")
             );
         }
     }
 
-    println!();
+    eprintln!();
+    if check.server_reachable {
+        writeln!(w, "  \u{2713} BitRouter reachable at {}", check.listen_addr)?;
+    } else {
+        writeln!(w, "  \u{2717} BitRouter not reachable at {}", check.listen_addr)?;
+        writeln!(w, "    Start the server: bitrouter serve")?;
+    }
 
+    eprintln!();
+    if check.discovered_on_path.is_empty() && check.discovered_distributable.is_empty() {
+        eprintln!("  \u{2717} No ACP agents discovered");
+    } else {
+        if !check.discovered_on_path.is_empty() {
+            eprintln!(
+                "  \u{2713} Agents on PATH: {}",
+                check.discovered_on_path.join(", ")
+            );
+        }
+        if !check.discovered_distributable.is_empty() {
+            eprintln!(
+                "  \u{2713} Agents available (auto-install): {}",
+                check.discovered_distributable.join(", ")
+            );
+        }
+    }
+
+    eprintln!();
+    Ok(())
+}
+
+/// Run the `agents check` subcommand.
+pub fn run_check(
+    config: &BitrouterConfig,
+    output: OutputFormat,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let check = ops::check_routing(config);
+    match output {
+        OutputFormat::Text => render_check_text(&check, &mut io::stdout())?,
+        OutputFormat::Json => serde_json::to_writer(io::stdout(), &check)?,
+    }
     Ok(())
 }

--- a/bitrouter/src/cli/mod.rs
+++ b/bitrouter/src/cli/mod.rs
@@ -15,3 +15,11 @@ pub mod route;
 pub mod tools;
 pub mod update_check;
 pub mod wallet;
+
+/// Output format for read commands.
+#[derive(Debug, Clone, Copy, Default, clap::ValueEnum)]
+pub enum OutputFormat {
+    #[default]
+    Text,
+    Json,
+}

--- a/bitrouter/src/cli/models.rs
+++ b/bitrouter/src/cli/models.rs
@@ -1,41 +1,94 @@
 //! `bitrouter models` subcommand — list routable models from config.
 
-use bitrouter_config::{BitrouterConfig, RoutingStrategy};
+use std::io::{self, Write};
 
-/// Run the `models list` subcommand — prints all configured models.
-pub fn run_list(config: &BitrouterConfig) -> Result<(), Box<dyn std::error::Error>> {
+use bitrouter_config::{BitrouterConfig, RoutingStrategy};
+use serde::Serialize;
+
+use super::OutputFormat;
+
+#[derive(Debug, Serialize)]
+pub struct ModelEntry {
+    pub name: String,
+    pub providers: Vec<String>,
+    pub strategy: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ModelListData {
+    pub models: Vec<ModelEntry>,
+}
+
+pub fn query_list(config: &BitrouterConfig) -> ModelListData {
     if config.models.is_empty() {
-        // Fallback: list per-provider model catalogs (same as ConfigRoutingTable).
-        let mut any = false;
+        let mut models = Vec::new();
         for (provider_name, provider) in &config.providers {
-            if let Some(models) = &provider.models {
-                for model_id in models.keys() {
-                    println!("  {model_id}  [{provider_name}]");
-                    any = true;
+            if let Some(model_map) = &provider.models {
+                for model_id in model_map.keys() {
+                    models.push(ModelEntry {
+                        name: model_id.clone(),
+                        providers: vec![provider_name.clone()],
+                        strategy: "priority".to_owned(),
+                    });
                 }
             }
         }
-        if !any {
-            println!("  (no models configured)");
-        }
-        return Ok(());
+        models.sort_by(|a, b| a.name.cmp(&b.name));
+        return ModelListData { models };
     }
 
     let mut entries: Vec<_> = config.models.iter().collect();
     entries.sort_by_key(|(name, _)| (*name).clone());
 
-    for (model_name, model_config) in entries {
-        let providers: Vec<&str> = model_config
-            .endpoints
-            .iter()
-            .map(|ep| ep.provider.as_str())
-            .collect();
-        let strategy = match model_config.strategy {
-            RoutingStrategy::Priority => "priority",
-            RoutingStrategy::LoadBalance => "load_balance",
-        };
-        println!("  {model_name}  [{}]  {strategy}", providers.join(","));
-    }
+    let models = entries
+        .into_iter()
+        .map(|(model_name, model_config)| {
+            let providers: Vec<String> = model_config
+                .endpoints
+                .iter()
+                .map(|ep| ep.provider.clone())
+                .collect();
+            let strategy = match model_config.strategy {
+                RoutingStrategy::Priority => "priority",
+                RoutingStrategy::LoadBalance => "load_balance",
+            };
+            ModelEntry {
+                name: model_name.clone(),
+                providers,
+                strategy: strategy.to_owned(),
+            }
+        })
+        .collect();
 
+    ModelListData { models }
+}
+
+pub fn render_list_text(data: &ModelListData, w: &mut impl Write) -> io::Result<()> {
+    if data.models.is_empty() {
+        writeln!(w, "  (no models configured)")?;
+        return Ok(());
+    }
+    for entry in &data.models {
+        writeln!(
+            w,
+            "  {}  [{}]  {}",
+            entry.name,
+            entry.providers.join(","),
+            entry.strategy
+        )?;
+    }
+    Ok(())
+}
+
+/// Run the `models list` subcommand.
+pub fn run_list(
+    config: &BitrouterConfig,
+    output: OutputFormat,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let data = query_list(config);
+    match output {
+        OutputFormat::Text => render_list_text(&data, &mut io::stdout())?,
+        OutputFormat::Json => serde_json::to_writer(io::stdout(), &data)?,
+    }
     Ok(())
 }

--- a/bitrouter/src/cli/providers.rs
+++ b/bitrouter/src/cli/providers.rs
@@ -3,50 +3,85 @@
 //! Add/remove of individual providers is handled by `bitrouter init`
 //! (re-runnable) rather than duplicating the interactive wizard here.
 
+use std::io::{self, Write};
+
 use bitrouter_config::BitrouterConfig;
+use serde::Serialize;
 
-/// Print every provider in the merged config: name, api_base, and whether
-/// an API key is configured.
-pub fn run_list(config: &BitrouterConfig) -> Result<(), Box<dyn std::error::Error>> {
-    if config.providers.is_empty() {
-        println!("  (no providers configured)");
-        return Ok(());
-    }
+use super::OutputFormat;
 
+#[derive(Debug, Serialize)]
+pub struct ProviderEntry {
+    pub name: String,
+    pub api_base: Option<String>,
+    pub auth_kind: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ProviderListData {
+    pub providers: Vec<ProviderEntry>,
+}
+
+pub fn query_list(config: &BitrouterConfig) -> ProviderListData {
     let mut names: Vec<&String> = config.providers.keys().collect();
     names.sort();
+    let providers = names
+        .into_iter()
+        .map(|name| {
+            let p = &config.providers[name];
+            let auth_kind = if p.api_key.is_some() {
+                "api_key".to_owned()
+            } else if p.auth.is_some() {
+                "oauth".to_owned()
+            } else {
+                "none".to_owned()
+            };
+            ProviderEntry {
+                name: name.clone(),
+                api_base: p.api_base.clone(),
+                auth_kind,
+            }
+        })
+        .collect();
+    ProviderListData { providers }
+}
 
-    println!();
-    println!("  Providers");
-    println!("  ─────────");
-    println!();
-
-    for name in names {
-        let provider = &config.providers[name];
-        let api_base = provider
-            .api_base
-            .as_deref()
-            .unwrap_or("(derives from base)");
-        let key_status = if provider.api_key.is_some() {
-            "\u{2713} key set"
-        } else if provider.auth.is_some() {
-            "\u{2713} OAuth"
-        } else {
-            "\u{2717} no credentials"
-        };
-        println!("  {name:20}  {api_base:40}  {key_status}");
+pub fn render_list_text(data: &ProviderListData, w: &mut impl Write) -> io::Result<()> {
+    if data.providers.is_empty() {
+        writeln!(w, "  (no providers configured)")?;
+        return Ok(());
     }
-    println!();
+    eprintln!();
+    eprintln!("  Providers");
+    eprintln!("  ─────────");
+    eprintln!();
+    for entry in &data.providers {
+        let api_base = entry.api_base.as_deref().unwrap_or("(derives from base)");
+        let key_status = match entry.auth_kind.as_str() {
+            "api_key" => "\u{2713} key set",
+            "oauth" => "\u{2713} OAuth",
+            _ => "\u{2717} no credentials",
+        };
+        writeln!(w, "  {:<20}  {:<40}  {key_status}", entry.name, api_base)?;
+    }
+    writeln!(w)?;
+    Ok(())
+}
 
+/// Print every provider in the merged config.
+pub fn run_list(
+    config: &BitrouterConfig,
+    output: OutputFormat,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let data = query_list(config);
+    match output {
+        OutputFormat::Text => render_list_text(&data, &mut io::stdout())?,
+        OutputFormat::Json => serde_json::to_writer(io::stdout(), &data)?,
+    }
     Ok(())
 }
 
 /// Switch between `default` (BitRouter Cloud) and `byok` (Bring Your Own Keys).
-///
-/// This is a *soft* switch — it prints guidance.  The actual change is
-/// durable only via `bitrouter init`.  We detect the current mode by
-/// looking at whether any non-bitrouter provider has an API key
-/// configured.
 pub fn run_use(mode: &str, config: &BitrouterConfig) -> Result<(), Box<dyn std::error::Error>> {
     let mode = mode.trim().to_lowercase();
 

--- a/bitrouter/src/cli/route.rs
+++ b/bitrouter/src/cli/route.rs
@@ -5,8 +5,8 @@ use std::net::SocketAddr;
 
 use serde::Serialize;
 
-use crate::cli::admin_auth::{admin_get, parse_error_message, request_with_admin_auth};
 use crate::cli::OutputFormat;
+use crate::cli::admin_auth::{admin_get, parse_error_message, request_with_admin_auth};
 
 /// Options for the `route add` subcommand.
 pub struct RouteAddOpts {

--- a/bitrouter/src/cli/route.rs
+++ b/bitrouter/src/cli/route.rs
@@ -1,8 +1,12 @@
 //! CLI subcommand for managing runtime routes via the admin API.
 
+use std::io::{self, Write};
 use std::net::SocketAddr;
 
+use serde::Serialize;
+
 use crate::cli::admin_auth::{admin_get, parse_error_message, request_with_admin_auth};
+use crate::cli::OutputFormat;
 
 /// Options for the `route add` subcommand.
 pub struct RouteAddOpts {
@@ -11,59 +15,110 @@ pub struct RouteAddOpts {
     pub strategy: Option<String>,
 }
 
-/// Run the `route list` subcommand — prints all routes from the running daemon.
-pub fn run_list(
+#[derive(Debug, Serialize)]
+pub struct RouteEndpoint {
+    pub provider: String,
+    pub service_id: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RouteEntry {
+    pub name: String,
+    pub source: String,
+    pub endpoints: Vec<RouteEndpoint>,
+    pub strategy: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RouteListData {
+    pub routes: Vec<RouteEntry>,
+}
+
+pub fn query_list(
     config: &bitrouter_config::BitrouterConfig,
     addr: SocketAddr,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<RouteListData, Box<dyn std::error::Error>> {
     let resp = admin_get(config, addr, "/admin/routes")?;
-
     if !resp.status().is_success() {
         let msg = parse_error_message(resp)?;
         return Err(format!("failed to list routes: {msg}").into());
     }
-
     let body: serde_json::Value = resp.json()?;
-    let routes = body["routes"].as_array();
-    match routes {
-        Some(routes) if !routes.is_empty() => {
-            for route in routes {
-                let model = route["name"].as_str().unwrap_or("?");
-                let source = route["source"].as_str().unwrap_or("?");
-                let endpoints = route["endpoints"].as_array();
-
-                let targets: Vec<String> = endpoints
+    let raw_routes = body["routes"].as_array();
+    let routes = match raw_routes {
+        Some(raw) if !raw.is_empty() => raw
+            .iter()
+            .map(|route| {
+                let name = route["name"].as_str().unwrap_or("?").to_owned();
+                let source = route["source"].as_str().unwrap_or("?").to_owned();
+                let strategy = route["strategy"].as_str().unwrap_or("").to_owned();
+                let endpoints = route["endpoints"]
+                    .as_array()
                     .map(|eps| {
                         eps.iter()
-                            .map(|ep| {
-                                let provider = ep["provider"].as_str().unwrap_or("?");
-                                let service_id = ep["service_id"].as_str().unwrap_or("?");
-                                if service_id.is_empty() {
-                                    provider.to_owned()
-                                } else {
-                                    format!("{provider}:{service_id}")
-                                }
+                            .map(|ep| RouteEndpoint {
+                                provider: ep["provider"].as_str().unwrap_or("?").to_owned(),
+                                service_id: ep["service_id"].as_str().unwrap_or("").to_owned(),
                             })
                             .collect()
                     })
                     .unwrap_or_default();
+                RouteEntry {
+                    name,
+                    source,
+                    endpoints,
+                    strategy,
+                }
+            })
+            .collect(),
+        _ => vec![],
+    };
+    Ok(RouteListData { routes })
+}
 
-                let strategy = route["strategy"].as_str().unwrap_or("");
-                let strategy_suffix = if strategy.is_empty() {
-                    String::new()
+pub fn render_list_text(data: &RouteListData, w: &mut impl Write) -> io::Result<()> {
+    if data.routes.is_empty() {
+        writeln!(w, "  (no routes configured)")?;
+        return Ok(());
+    }
+    for route in &data.routes {
+        let targets: Vec<String> = route
+            .endpoints
+            .iter()
+            .map(|ep| {
+                if ep.service_id.is_empty() {
+                    ep.provider.clone()
                 } else {
-                    format!(" ({strategy})")
-                };
+                    format!("{}:{}", ep.provider, ep.service_id)
+                }
+            })
+            .collect();
+        let strategy_suffix = if route.strategy.is_empty() {
+            String::new()
+        } else {
+            format!(" ({})", route.strategy)
+        };
+        writeln!(
+            w,
+            "  {}  \u{2192}  {}{strategy_suffix}  [{}]",
+            route.name,
+            targets.join(", "),
+            route.source
+        )?;
+    }
+    Ok(())
+}
 
-                println!(
-                    "  {model}  →  {}{strategy_suffix}  [{source}]",
-                    targets.join(", ")
-                );
-            }
-        }
-        _ => {
-            println!("  (no routes configured)");
-        }
+/// Run the `route list` subcommand.
+pub fn run_list(
+    config: &bitrouter_config::BitrouterConfig,
+    addr: SocketAddr,
+    output: OutputFormat,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let data = query_list(config, addr)?;
+    match output {
+        OutputFormat::Text => render_list_text(&data, &mut io::stdout())?,
+        OutputFormat::Json => serde_json::to_writer(io::stdout(), &data)?,
     }
     Ok(())
 }
@@ -107,7 +162,7 @@ pub fn run_add(
     Ok(())
 }
 
-/// Run the `route rm` subcommand — removes a dynamic route.
+/// Run the `route delete` / `route rm` subcommand — removes a dynamic route.
 pub fn run_remove(
     config: &bitrouter_config::BitrouterConfig,
     addr: SocketAddr,

--- a/bitrouter/src/cli/tools.rs
+++ b/bitrouter/src/cli/tools.rs
@@ -6,8 +6,8 @@ use std::net::SocketAddr;
 
 use serde::Serialize;
 
-use crate::cli::admin_auth::{admin_get, parse_error_message};
 use crate::cli::OutputFormat;
+use crate::cli::admin_auth::{admin_get, parse_error_message};
 
 #[derive(Debug, Serialize)]
 pub struct ToolEntry {

--- a/bitrouter/src/cli/tools.rs
+++ b/bitrouter/src/cli/tools.rs
@@ -1,72 +1,146 @@
 //! `bitrouter tools` subcommand — inspect MCP tools and servers on a running daemon,
 //! and discover tools from MCP upstreams for config authoring.
 
+use std::io::{self, Write};
 use std::net::SocketAddr;
 
-use crate::cli::admin_auth::{admin_get, parse_error_message};
+use serde::Serialize;
 
-/// Run the `tools list` subcommand — prints all tools from the running daemon.
-pub fn run_list(
+use crate::cli::admin_auth::{admin_get, parse_error_message};
+use crate::cli::OutputFormat;
+
+#[derive(Debug, Serialize)]
+pub struct ToolEntry {
+    pub name: String,
+    pub provider: String,
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ToolListData {
+    pub tools: Vec<ToolEntry>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ServerEntry {
+    pub name: String,
+    pub tool_count: u64,
+    pub filtered: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ToolStatusData {
+    pub servers: Vec<ServerEntry>,
+}
+
+pub fn query_list(
     config: &bitrouter_config::BitrouterConfig,
     addr: SocketAddr,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<ToolListData, Box<dyn std::error::Error>> {
     let resp = admin_get(config, addr, "/admin/tools")?;
-
     if !resp.status().is_success() {
         let msg = parse_error_message(resp)?;
         return Err(format!("failed to list tools: {msg}").into());
     }
-
     let body: serde_json::Value = resp.json()?;
-    let tools = body["tools"].as_array();
-    match tools {
-        Some(tools) if !tools.is_empty() => {
-            for tool in tools {
-                let name = tool["name"].as_str().unwrap_or("?");
-                let server = tool["provider"].as_str().unwrap_or("?");
-                let desc = tool["description"].as_str().unwrap_or("");
+    let tools = body["tools"]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .map(|t| ToolEntry {
+                    name: t["name"].as_str().unwrap_or("?").to_owned(),
+                    provider: t["provider"].as_str().unwrap_or("?").to_owned(),
+                    description: t["description"]
+                        .as_str()
+                        .filter(|s| !s.is_empty())
+                        .map(str::to_owned),
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    Ok(ToolListData { tools })
+}
 
-                if desc.is_empty() {
-                    println!("  {name}  [{server}]");
-                } else {
-                    println!("  {name}  [{server}]  — {desc}");
-                }
-            }
-        }
-        _ => {
-            println!("  (no tools available)");
+pub fn render_list_text(data: &ToolListData, w: &mut impl Write) -> io::Result<()> {
+    if data.tools.is_empty() {
+        writeln!(w, "  (no tools available)")?;
+        return Ok(());
+    }
+    for tool in &data.tools {
+        if let Some(ref desc) = tool.description {
+            writeln!(w, "  {}  [{}]  \u{2014} {desc}", tool.name, tool.provider)?;
+        } else {
+            writeln!(w, "  {}  [{}]", tool.name, tool.provider)?;
         }
     }
     Ok(())
 }
 
-/// Run the `tools status` subcommand — shows upstream server health.
-pub fn run_status(
+pub fn query_status(
     config: &bitrouter_config::BitrouterConfig,
     addr: SocketAddr,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<ToolStatusData, Box<dyn std::error::Error>> {
     let resp = admin_get(config, addr, "/admin/tools/upstreams")?;
-
     if !resp.status().is_success() {
         let msg = parse_error_message(resp)?;
         return Err(format!("failed to get tool status: {msg}").into());
     }
-
     let body: serde_json::Value = resp.json()?;
-    let servers = body["servers"].as_array();
-    match servers {
-        Some(servers) if !servers.is_empty() => {
-            for server in servers {
-                let name = server["name"].as_str().unwrap_or("?");
-                let tool_count = server["tool_count"].as_u64().unwrap_or(0);
-                let has_filter = server["filter"].is_object();
-                let filter_info = if has_filter { " (filtered)" } else { "" };
-                println!("  {name}    {tool_count} tools{filter_info}");
-            }
-        }
-        _ => {
-            println!("  (no MCP servers configured)");
-        }
+    let servers = body["servers"]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .map(|s| ServerEntry {
+                    name: s["name"].as_str().unwrap_or("?").to_owned(),
+                    tool_count: s["tool_count"].as_u64().unwrap_or(0),
+                    filtered: s["filter"].is_object(),
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    Ok(ToolStatusData { servers })
+}
+
+pub fn render_status_text(data: &ToolStatusData, w: &mut impl Write) -> io::Result<()> {
+    if data.servers.is_empty() {
+        writeln!(w, "  (no MCP servers configured)")?;
+        return Ok(());
+    }
+    for server in &data.servers {
+        let filter_info = if server.filtered { " (filtered)" } else { "" };
+        writeln!(
+            w,
+            "  {}    {} tools{filter_info}",
+            server.name, server.tool_count
+        )?;
+    }
+    Ok(())
+}
+
+/// Run the `tools list` subcommand.
+pub fn run_list(
+    config: &bitrouter_config::BitrouterConfig,
+    addr: SocketAddr,
+    output: OutputFormat,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let data = query_list(config, addr)?;
+    match output {
+        OutputFormat::Text => render_list_text(&data, &mut io::stdout())?,
+        OutputFormat::Json => serde_json::to_writer(io::stdout(), &data)?,
+    }
+    Ok(())
+}
+
+/// Run the `tools status` subcommand.
+pub fn run_status(
+    config: &bitrouter_config::BitrouterConfig,
+    addr: SocketAddr,
+    output: OutputFormat,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let data = query_status(config, addr)?;
+    match output {
+        OutputFormat::Text => render_status_text(&data, &mut io::stdout())?,
+        OutputFormat::Json => serde_json::to_writer(io::stdout(), &data)?,
     }
     Ok(())
 }
@@ -122,7 +196,6 @@ pub async fn run_discover(
     eprintln!("Discovered {} tools from '{provider_name}'.", tools.len());
     eprintln!();
 
-    // Output YAML stanzas for pasting into bitrouter.yaml.
     println!("# Discovered from provider \"{provider_name}\"");
     println!("# Paste under the `tools:` section of your bitrouter.yaml");
     println!();
@@ -134,11 +207,9 @@ pub async fn run_discover(
         println!("      - provider: {provider_name}");
         println!("        tool_id: {}", tool.name);
         if let Some(ref desc) = tool.description {
-            // Escape double quotes in YAML string.
             let escaped = desc.replace('"', "\\\"");
             println!("    description: \"{escaped}\"");
         }
-        // Include input_schema if it has properties.
         if tool.input_schema.is_object() && tool.input_schema.get("properties").is_some() {
             println!(
                 "    input_schema: {}",

--- a/bitrouter/src/main.rs
+++ b/bitrouter/src/main.rs
@@ -53,6 +53,11 @@ struct Cli {
     #[arg(long, global = true)]
     no_tui: bool,
 
+    /// Output format for read commands. Defaults to `text` on a TTY, `json` when piped.
+    #[cfg(feature = "cli")]
+    #[arg(long, short = 'o', global = true, value_enum)]
+    output: Option<cli::OutputFormat>,
+
     #[command(subcommand)]
     command: Option<Command>,
 }
@@ -189,6 +194,12 @@ enum RouteAction {
         strategy: String,
     },
     /// Remove a dynamic route
+    Delete {
+        /// Model name to remove
+        model: String,
+    },
+    /// Remove a dynamic route (alias for `delete`)
+    #[command(hide = true)]
     Rm {
         /// Model name to remove
         model: String,
@@ -484,6 +495,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 async fn run_cli(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
+    // Resolve output format: explicit flag overrides TTY auto-detection.
+    #[cfg(feature = "cli")]
+    let output = cli.output.unwrap_or_else(|| {
+        use std::io::IsTerminal;
+        if std::io::stdout().is_terminal() {
+            cli::OutputFormat::Text
+        } else {
+            cli::OutputFormat::Json
+        }
+    });
+
     // Resolve paths early — init needs them but not a loaded runtime
     let paths = resolve_home(cli.home_dir.as_deref());
     let overrides = PathOverrides {
@@ -671,8 +693,8 @@ async fn run_cli(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             let runtime: DefaultRuntime = load_or_warn_scaffold(&paths);
             let addr = runtime.config.server.listen;
             match action {
-                ToolsAction::List => cli::tools::run_list(&runtime.config, addr)?,
-                ToolsAction::Status => cli::tools::run_status(&runtime.config, addr)?,
+                ToolsAction::List => cli::tools::run_list(&runtime.config, addr, output)?,
+                ToolsAction::Status => cli::tools::run_status(&runtime.config, addr, output)?,
                 ToolsAction::Discover { provider } => {
                     cli::tools::run_discover(&runtime.config, &provider).await?
                 }
@@ -682,7 +704,7 @@ async fn run_cli(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
         Some(Command::Models { action }) => {
             let runtime: DefaultRuntime = load_or_warn_scaffold(&paths);
             match action {
-                ModelsAction::List => cli::models::run_list(&runtime.config)?,
+                ModelsAction::List => cli::models::run_list(&runtime.config, output)?,
             }
             return Ok(());
         }
@@ -701,9 +723,9 @@ async fn run_cli(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             let runtime: DefaultRuntime = load_or_warn_scaffold(&paths);
             match action {
                 AgentsAction::List { refresh } => {
-                    cli::agents::run_list(&runtime.config, &paths, refresh).await?
+                    cli::agents::run_list(&runtime.config, &paths, refresh, output).await?
                 }
-                AgentsAction::Check => cli::agents::run_check(&runtime.config)?,
+                AgentsAction::Check => cli::agents::run_check(&runtime.config, output)?,
                 AgentsAction::Install { id } => {
                     cli::agents::run_install(&id, &runtime.config, &paths).await?
                 }
@@ -722,7 +744,7 @@ async fn run_cli(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
         Some(Command::Providers { action }) => {
             let runtime: DefaultRuntime = load_or_warn_scaffold(&paths);
             match action {
-                ProvidersAction::List => cli::providers::run_list(&runtime.config)?,
+                ProvidersAction::List => cli::providers::run_list(&runtime.config, output)?,
                 ProvidersAction::Use { mode } => cli::providers::run_use(&mode, &runtime.config)?,
             }
             return Ok(());
@@ -731,7 +753,7 @@ async fn run_cli(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             let runtime: DefaultRuntime = load_or_warn_scaffold(&paths);
             let addr = runtime.config.server.listen;
             match action {
-                RouteAction::List => cli::route::run_list(&runtime.config, addr)?,
+                RouteAction::List => cli::route::run_list(&runtime.config, addr, output)?,
                 RouteAction::Add {
                     model,
                     endpoints,
@@ -745,7 +767,9 @@ async fn run_cli(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
                         strategy: Some(strategy),
                     },
                 )?,
-                RouteAction::Rm { model } => cli::route::run_remove(&runtime.config, addr, &model)?,
+                RouteAction::Delete { model } | RouteAction::Rm { model } => {
+                    cli::route::run_remove(&runtime.config, addr, &model)?
+                }
             }
             return Ok(());
         }

--- a/bitrouter/src/runtime/paths.rs
+++ b/bitrouter/src/runtime/paths.rs
@@ -49,12 +49,6 @@ impl RuntimePaths {
             home_dir: home,
         }
     }
-
-    #[cfg(feature = "tui")]
-    /// Return the flat install directory for the given agent id.
-    pub fn agent_install_dir(&self, agent_id: &str) -> PathBuf {
-        self.agents_dir.join(agent_id)
-    }
 }
 
 /// Overrides that can be applied to individual paths after resolution.


### PR DESCRIPTION
Implements all three phases from #450:

## Phase 1 — acp::ops extraction
Add `bitrouter-providers/src/acp/ops.rs` with shared agents operations. Re-point CLI and TUI at unified ops layer, removing ~250 LOC of duplication.

## Phase 2 — CLI compute/render split
Split route, providers, models, tools modules into query_* + render_*_text pairs with Serialize result structs.

## Phase 3 — Output flag + consistency pass
Add global --output <text|json> flag with TTY auto-detect. Move decorative banners to stderr. Add route delete alias.

Closes #450

Generated with [Claude Code](https://claude.ai/code)