### PR TITLE
fix: propagate reasoning content across all streaming protocols

### DIFF
--- a/bitrouter-api/src/router/openai/responses/filters.rs
+++ b/bitrouter-api/src/router/openai/responses/filters.rs
@@ -118,7 +118,7 @@ where
     let options = convert::to_call_options(request);
 
     if is_stream {
-        handle_stream(&model, options).await
+        handle_stream(&model, options, model_id).await
     } else {
         let result = model
             .generate(options)
@@ -366,14 +366,22 @@ where
             request_id: Some(request_id.clone()),
         };
 
+        let stream_model_id = model_id.clone();
         tokio::spawn(async move {
             let mut stream = stream_result.stream;
-            let mut converter = convert::StreamConverter::new();
+            let mut converter = convert::StreamConverter::new(stream_model_id);
             use tokio_stream::StreamExt as _;
             let mut observation = crate::router::StreamObservation::new();
             let mut client_disconnected = false;
+            let mut saw_finish = false;
             while let Some(part) = stream.next().await {
                 observation.record_part(&part);
+                if matches!(
+                    part,
+                    bitrouter_core::models::language::stream_part::LanguageModelStreamPart::Finish { .. }
+                ) {
+                    saw_finish = true;
+                }
                 let events = converter.convert(&part);
                 if !events.is_empty() && !metered.deduct_or_pause(&tx).await {
                     client_disconnected = true;
@@ -395,9 +403,22 @@ where
                     break;
                 }
             }
-            let _ = tx
-                .send(Ok(warp::sse::Event::default().data("[DONE]")))
-                .await;
+            // Ensure the stream closes with `response.completed` per the
+            // Responses spec; Codex CLI retries otherwise.
+            // https://platform.openai.com/docs/api-reference/responses-streaming
+            if !saw_finish && !client_disconnected {
+                for event in converter.finish() {
+                    let data = serde_json::to_string(&event).unwrap_or_default();
+                    let sse = Ok(warp::sse::Event::default()
+                        .event(&event.event_type)
+                        .data(data));
+                    if tx.send(sse).await.is_err() {
+                        client_disconnected = true;
+                        break;
+                    }
+                }
+            }
+            // Responses SSE has no [DONE] terminator.
 
             let latency_ms = start.elapsed().as_millis() as u64;
             let ctx = RequestContext {
@@ -568,6 +589,7 @@ where
         handle_stream_with_observe(
             &model,
             options,
+            model_id,
             crate::router::StreamObserveContext {
                 observer,
                 route: incoming_model,
@@ -628,6 +650,7 @@ where
 async fn handle_stream(
     model: &(impl LanguageModel + ?Sized),
     options: bitrouter_core::models::language::call_options::LanguageModelCallOptions,
+    model_id: String,
 ) -> Result<Box<dyn warp::Reply>, warp::Rejection> {
     let stream_result = model
         .stream(options)
@@ -639,9 +662,16 @@ async fn handle_stream(
 
     tokio::spawn(async move {
         let mut stream = stream_result.stream;
-        let mut converter = convert::StreamConverter::new();
+        let mut converter = convert::StreamConverter::new(model_id);
         use tokio_stream::StreamExt as _;
+        let mut saw_finish = false;
         'outer: while let Some(part) = stream.next().await {
+            if matches!(
+                part,
+                bitrouter_core::models::language::stream_part::LanguageModelStreamPart::Finish { .. }
+            ) {
+                saw_finish = true;
+            }
             for event in converter.convert(&part) {
                 let data = serde_json::to_string(&event).unwrap_or_default();
                 let sse = Ok(warp::sse::Event::default()
@@ -652,9 +682,24 @@ async fn handle_stream(
                 }
             }
         }
-        let _ = tx
-            .send(Ok(warp::sse::Event::default().data("[DONE]")))
-            .await;
+        // Upstream closed without a Finish part — synthesize a final
+        // `response.completed` so strict clients (e.g. Codex CLI) don't
+        // hit "stream closed before response.completed" and retry.
+        // https://platform.openai.com/docs/api-reference/responses-streaming
+        if !saw_finish {
+            for event in converter.finish() {
+                let data = serde_json::to_string(&event).unwrap_or_default();
+                let sse = Ok(warp::sse::Event::default()
+                    .event(&event.event_type)
+                    .data(data));
+                if tx.send(sse).await.is_err() {
+                    break;
+                }
+            }
+        }
+        // Responses SSE has no [DONE] terminator; `response.completed` is
+        // the canonical close. Emitting [DONE] here would cause Codex to
+        // surface a parse error and retry.
     });
 
     let sse_stream = tokio_stream::wrappers::ReceiverStream::new(rx);
@@ -664,6 +709,7 @@ async fn handle_stream(
 async fn handle_stream_with_observe(
     model: &(impl LanguageModel + ?Sized),
     options: bitrouter_core::models::language::call_options::LanguageModelCallOptions,
+    model_id: String,
     ctx: crate::router::StreamObserveContext,
 ) -> Result<Box<dyn warp::Reply>, warp::Rejection> {
     let stream_result = model
@@ -688,12 +734,19 @@ async fn handle_stream_with_observe(
 
     tokio::spawn(async move {
         let mut stream = stream_result.stream;
-        let mut converter = convert::StreamConverter::new();
+        let mut converter = convert::StreamConverter::new(model_id);
         use tokio_stream::StreamExt as _;
         let mut observation = crate::router::StreamObservation::new();
         let mut client_disconnected = false;
+        let mut saw_finish = false;
         while let Some(part) = stream.next().await {
             observation.record_part(&part);
+            if matches!(
+                part,
+                bitrouter_core::models::language::stream_part::LanguageModelStreamPart::Finish { .. }
+            ) {
+                saw_finish = true;
+            }
             let mut send_failed = false;
             for event in converter.convert(&part) {
                 let data = serde_json::to_string(&event).unwrap_or_default();
@@ -710,9 +763,23 @@ async fn handle_stream_with_observe(
                 break;
             }
         }
-        let _ = tx
-            .send(Ok(warp::sse::Event::default().data("[DONE]")))
-            .await;
+        // Synthesize `response.completed` when the upstream stopped without
+        // a Finish so Codex CLI sees a well-formed terminator instead of
+        // raising "stream closed before response.completed" and retrying.
+        // https://platform.openai.com/docs/api-reference/responses-streaming
+        if !saw_finish && !client_disconnected {
+            for event in converter.finish() {
+                let data = serde_json::to_string(&event).unwrap_or_default();
+                let sse = Ok(warp::sse::Event::default()
+                    .event(&event.event_type)
+                    .data(data));
+                if tx.send(sse).await.is_err() {
+                    client_disconnected = true;
+                    break;
+                }
+            }
+        }
+        // Responses SSE has no [DONE] terminator.
 
         let latency_ms = start.elapsed().as_millis() as u64;
         let ctx = RequestContext {

--- a/bitrouter-api/src/router/openai/responses/tests.rs
+++ b/bitrouter-api/src/router/openai/responses/tests.rs
@@ -339,22 +339,59 @@ async fn responses_streaming_sends_sse_events() {
     assert_eq!(res.headers()["content-type"], "text/event-stream");
 
     let events = parse_sse_body(res.body());
-    assert_eq!(events.len(), 3);
+    // Canonical Responses lifecycle for a single text delta + finish:
+    // response.created, response.in_progress, response.output_item.added,
+    // response.content_part.added, response.output_text.delta,
+    // response.output_text.done, response.content_part.done,
+    // response.output_item.done, response.completed.
+    // https://platform.openai.com/docs/api-reference/responses-streaming
+    let event_types: Vec<Option<&str>> = events.iter().map(|(e, _)| e.as_deref()).collect();
+    assert_eq!(event_types[0], Some("response.created"));
+    assert_eq!(event_types[1], Some("response.in_progress"));
+    assert!(event_types.contains(&Some("response.output_item.added")));
+    assert!(event_types.contains(&Some("response.content_part.added")));
+    assert!(event_types.contains(&Some("response.output_text.delta")));
+    assert!(event_types.contains(&Some("response.output_text.done")));
+    assert!(event_types.contains(&Some("response.content_part.done")));
+    assert!(event_types.contains(&Some("response.output_item.done")));
+    assert_eq!(event_types.last(), Some(&Some("response.completed")));
 
-    assert_eq!(events[0].0.as_deref(), Some("response.output_text.delta"));
-    let delta: Value = serde_json::from_str(&events[0].1).unwrap();
-    assert_eq!(delta["type"], "response.output_text.delta");
+    // response.created must carry the full response envelope so strict
+    // clients (Codex) can adopt the response id and model immediately.
+    let created: Value = serde_json::from_str(&events[0].1).unwrap();
+    assert_eq!(created["type"], "response.created");
+    assert!(created["response"].is_object());
+    assert_eq!(created["sequence_number"], 0);
+
+    // Every event carries a monotonic sequence_number.
+    for (i, (_, data)) in events.iter().enumerate() {
+        let v: Value = serde_json::from_str(data).unwrap();
+        assert_eq!(v["sequence_number"], i as i64, "event {i}");
+    }
+
+    // Find the delta event and confirm payload shape.
+    let delta = events
+        .iter()
+        .find(|(t, _)| t.as_deref() == Some("response.output_text.delta"))
+        .map(|(_, d)| serde_json::from_str::<Value>(d).unwrap())
+        .expect("delta present");
+    assert_eq!(delta["delta"], "Hello");
     assert_eq!(delta["output_index"], 0);
     assert_eq!(delta["content_index"], 0);
-    assert_eq!(delta["delta"], "Hello");
+    assert!(delta["item_id"].is_string());
 
-    assert_eq!(events[1].0.as_deref(), Some("response.completed"));
-    let finish: Value = serde_json::from_str(&events[1].1).unwrap();
-    assert_eq!(finish["type"], "response.completed");
-    assert!(finish.get("delta").is_none() || finish["delta"].is_null());
+    // response.completed must carry the final response with usage so Codex
+    // doesn't fail with "stream closed before response.completed".
+    let completed = events
+        .iter()
+        .find(|(t, _)| t.as_deref() == Some("response.completed"))
+        .map(|(_, d)| serde_json::from_str::<Value>(d).unwrap())
+        .expect("completed present");
+    assert_eq!(completed["response"]["status"], "completed");
+    assert!(completed["response"]["usage"].is_object());
 
-    assert_eq!(events[2].0, None);
-    assert_eq!(events[2].1, "[DONE]");
+    // Responses SSE has no [DONE] terminator.
+    assert!(events.iter().all(|(_, data)| data != "[DONE]"));
 }
 
 #[tokio::test]
@@ -565,17 +602,21 @@ async fn responses_stream_tool_calls() {
     assert_eq!(res.status(), 200);
 
     let events = parse_sse_body(res.body());
-    // ToolCall produces: output_item.added, arguments.delta, arguments.done, output_item.done
-    // Then Finish produces: response.completed
-    // Then [DONE]
-    assert!(events.len() >= 5);
+    // Tool call lifecycle: response.created, response.in_progress,
+    // response.output_item.added, response.function_call_arguments.delta,
+    // response.function_call_arguments.done, response.output_item.done,
+    // response.completed. No [DONE] terminator.
+    assert!(events.len() >= 7);
 
     let event_types: Vec<Option<&str>> = events.iter().map(|(e, _)| e.as_deref()).collect();
+    assert_eq!(event_types[0], Some("response.created"));
+    assert_eq!(event_types[1], Some("response.in_progress"));
     assert!(event_types.contains(&Some("response.output_item.added")));
     assert!(event_types.contains(&Some("response.function_call_arguments.delta")));
     assert!(event_types.contains(&Some("response.function_call_arguments.done")));
     assert!(event_types.contains(&Some("response.output_item.done")));
     assert!(event_types.contains(&Some("response.completed")));
+    assert!(events.iter().all(|(_, data)| data != "[DONE]"));
 
     // Check the `arguments.done` event has the full arguments
     let done_event = events

--- a/bitrouter-core/src/api/anthropic/messages/convert.rs
+++ b/bitrouter-core/src/api/anthropic/messages/convert.rs
@@ -148,6 +148,7 @@ pub struct StreamConverter {
     message_started: bool,
     message_stopped: bool,
     active_text_block_index: Option<u32>,
+    active_thinking_block_index: Option<u32>,
     tool_id_to_index: HashMap<String, u32>,
     started_tool_ids: HashSet<String>,
     closed_tool_ids: HashSet<String>,
@@ -162,6 +163,7 @@ impl StreamConverter {
             message_started: false,
             message_stopped: false,
             active_text_block_index: None,
+            active_thinking_block_index: None,
             tool_id_to_index: HashMap::new(),
             started_tool_ids: HashSet::new(),
             closed_tool_ids: HashSet::new(),
@@ -187,6 +189,24 @@ impl StreamConverter {
                 events
             }
             LanguageModelStreamPart::TextEnd { .. } => self.stop_text_events(),
+            // Anthropic extended thinking surfaces as a `thinking` content
+            // block with `thinking_delta` events, optionally followed by a
+            // `signature_delta`. We only emit the text deltas here — signatures
+            // come through provider_metadata if/when surfaced.
+            // https://docs.claude.com/en/docs/build-with-claude/extended-thinking#streaming-extended-thinking
+            LanguageModelStreamPart::ReasoningStart { .. } => self.start_thinking_events(),
+            LanguageModelStreamPart::ReasoningDelta { delta, .. } => {
+                let mut events = self.start_thinking_events();
+                let index = self.active_thinking_block_index.unwrap_or(0);
+                events.push(MessagesStreamEvent::ContentBlockDelta {
+                    index,
+                    delta: MessagesStreamDelta::ThinkingDelta {
+                        thinking: delta.clone(),
+                    },
+                });
+                events
+            }
+            LanguageModelStreamPart::ReasoningEnd { .. } => self.stop_thinking_events(),
             LanguageModelStreamPart::Error { error } => {
                 let mut events = self.start_message_events();
                 self.message_stopped = true;
@@ -264,6 +284,7 @@ impl StreamConverter {
                 ..
             } => {
                 let mut events = self.stop_text_events();
+                events.extend(self.stop_thinking_events());
                 events.push(MessagesStreamEvent::MessageDelta {
                     delta: MessagesMessageDelta {
                         delta_type: "message_delta".to_owned(),
@@ -298,6 +319,7 @@ impl StreamConverter {
         }
 
         let mut events = self.stop_text_events();
+        events.extend(self.stop_thinking_events());
         events.push(MessagesStreamEvent::MessageDelta {
             delta: MessagesMessageDelta {
                 delta_type: "message_delta".to_owned(),
@@ -337,7 +359,7 @@ impl StreamConverter {
     }
 
     fn start_text_events(&mut self) -> Vec<MessagesStreamEvent> {
-        let mut events = self.start_message_events();
+        let mut events = self.stop_thinking_events();
         if self.active_text_block_index.is_none() {
             let index = self.next_block_index;
             self.next_block_index += 1;
@@ -360,12 +382,38 @@ impl StreamConverter {
         events
     }
 
+    fn start_thinking_events(&mut self) -> Vec<MessagesStreamEvent> {
+        let mut events = self.start_message_events();
+        if self.active_thinking_block_index.is_none() {
+            let index = self.next_block_index;
+            self.next_block_index += 1;
+            self.active_thinking_block_index = Some(index);
+            events.push(MessagesStreamEvent::ContentBlockStart {
+                index,
+                content_block: AnthropicContentBlock::Thinking {
+                    thinking: String::new(),
+                    signature: None,
+                },
+            });
+        }
+        events
+    }
+
+    fn stop_thinking_events(&mut self) -> Vec<MessagesStreamEvent> {
+        let mut events = self.start_message_events();
+        if let Some(index) = self.active_thinking_block_index.take() {
+            events.push(MessagesStreamEvent::ContentBlockStop { index });
+        }
+        events
+    }
+
     fn start_tool_events(&mut self, id: &str, tool_name: &str) -> Vec<MessagesStreamEvent> {
         if self.closed_tool_ids.contains(id) {
             return Vec::new();
         }
 
         let mut events = self.stop_text_events();
+        events.extend(self.stop_thinking_events());
         if self.started_tool_ids.contains(id) {
             return events;
         }
@@ -611,6 +659,135 @@ mod tests {
                     usage.input_tokens == Some(0) && usage.output_tokens == Some(0)
                 )
         ));
+    }
+
+    #[test]
+    fn stream_converter_reasoning_emits_thinking_content_block() {
+        // Regression test for issue #448: when forwarding ReasoningStart/
+        // Delta/End to an Anthropic-format client, the converter must
+        // emit a `thinking` content_block_start, `thinking_delta` events,
+        // and a content_block_stop. Without this, /v1/messages clients
+        // see no SSE traffic until visible text arrives (~1 minute delay
+        // for thinking-enabled upstreams).
+        let mut converter = StreamConverter::new("claude-opus-4".to_owned());
+
+        let start_events = converter.convert(&LanguageModelStreamPart::ReasoningStart {
+            id: "r1".to_owned(),
+            provider_metadata: None,
+        });
+        assert!(start_events.iter().any(|e| matches!(
+            e,
+            MessagesStreamEvent::ContentBlockStart {
+                content_block: AnthropicContentBlock::Thinking { .. },
+                ..
+            }
+        )));
+
+        let delta_events = converter.convert(&LanguageModelStreamPart::ReasoningDelta {
+            id: "r1".to_owned(),
+            delta: "Let me think".to_owned(),
+            provider_metadata: None,
+        });
+        assert!(delta_events.iter().any(|e| matches!(
+            e,
+            MessagesStreamEvent::ContentBlockDelta {
+                delta: MessagesStreamDelta::ThinkingDelta { thinking },
+                ..
+            } if thinking == "Let me think"
+        )));
+
+        let end_events = converter.convert(&LanguageModelStreamPart::ReasoningEnd {
+            id: "r1".to_owned(),
+            provider_metadata: None,
+        });
+        assert!(
+            end_events
+                .iter()
+                .any(|e| matches!(e, MessagesStreamEvent::ContentBlockStop { .. }))
+        );
+    }
+
+    #[test]
+    fn stream_converter_text_after_reasoning_closes_thinking_block() {
+        // When reasoning is followed directly by visible text without an
+        // explicit ReasoningEnd (some upstreams elide it), the converter
+        // must still close the thinking block before opening the text
+        // block — otherwise the client sees overlapping content blocks
+        // on the same index, which Anthropic clients reject.
+        let mut converter = StreamConverter::new("claude-opus-4".to_owned());
+
+        converter.convert(&LanguageModelStreamPart::ReasoningStart {
+            id: "r1".to_owned(),
+            provider_metadata: None,
+        });
+        converter.convert(&LanguageModelStreamPart::ReasoningDelta {
+            id: "r1".to_owned(),
+            delta: "...".to_owned(),
+            provider_metadata: None,
+        });
+
+        let events = converter.convert(&LanguageModelStreamPart::TextDelta {
+            id: "t1".to_owned(),
+            delta: "Hello".to_owned(),
+            provider_metadata: None,
+        });
+        let block_stop_idx = events
+            .iter()
+            .position(|e| matches!(e, MessagesStreamEvent::ContentBlockStop { index: 0 }))
+            .expect("thinking block must close before text starts");
+        let block_start_idx = events
+            .iter()
+            .position(|e| {
+                matches!(
+                    e,
+                    MessagesStreamEvent::ContentBlockStart {
+                        content_block: AnthropicContentBlock::Text { .. },
+                        ..
+                    }
+                )
+            })
+            .expect("text content block start must follow");
+        assert!(block_stop_idx < block_start_idx);
+    }
+
+    #[test]
+    fn stream_converter_finish_closes_open_thinking_block() {
+        // If the upstream finishes mid-thinking (no explicit ReasoningEnd
+        // before Finish), the converter must still close the thinking
+        // block to produce a valid Anthropic stream.
+        let mut converter = StreamConverter::new("claude-opus-4".to_owned());
+
+        converter.convert(&LanguageModelStreamPart::ReasoningStart {
+            id: "r1".to_owned(),
+            provider_metadata: None,
+        });
+        let events = converter.convert(&LanguageModelStreamPart::Finish {
+            usage: crate::models::language::usage::LanguageModelUsage {
+                input_tokens: crate::models::language::usage::LanguageModelInputTokens {
+                    total: None,
+                    no_cache: None,
+                    cache_read: None,
+                    cache_write: None,
+                },
+                output_tokens: crate::models::language::usage::LanguageModelOutputTokens {
+                    total: None,
+                    text: None,
+                    reasoning: None,
+                },
+                raw: None,
+            },
+            finish_reason: LanguageModelFinishReason::Stop,
+            provider_metadata: None,
+        });
+        let stop_idx = events
+            .iter()
+            .position(|e| matches!(e, MessagesStreamEvent::ContentBlockStop { .. }))
+            .expect("thinking block must close on finish");
+        let message_stop_idx = events
+            .iter()
+            .position(|e| matches!(e, MessagesStreamEvent::MessageStop))
+            .expect("message_stop must follow");
+        assert!(stop_idx < message_stop_idx);
     }
 
     #[test]

--- a/bitrouter-core/src/api/google/generate_content/convert.rs
+++ b/bitrouter-core/src/api/google/generate_content/convert.rs
@@ -193,11 +193,30 @@ impl StreamConverter {
                     inline_data: None,
                     function_call: None,
                     function_response: None,
+                    thought: None,
                 }],
                 None,
                 None,
                 None,
             )),
+            // Gemini 2.5+ streams thought summaries as `text` parts with
+            // `thought: true`. We mirror that on the output side so clients
+            // see reasoning chunks alongside visible text.
+            // https://ai.google.dev/gemini-api/docs/thinking#streaming-thoughts
+            LanguageModelStreamPart::ReasoningDelta { delta, .. } => Some(self.make_chunk(
+                vec![GooglePart {
+                    text: Some(delta.clone()),
+                    inline_data: None,
+                    function_call: None,
+                    function_response: None,
+                    thought: Some(true),
+                }],
+                None,
+                None,
+                None,
+            )),
+            LanguageModelStreamPart::ReasoningStart { .. }
+            | LanguageModelStreamPart::ReasoningEnd { .. } => None,
             LanguageModelStreamPart::ToolCall {
                 tool_name,
                 tool_input,
@@ -213,6 +232,7 @@ impl StreamConverter {
                             args: Some(args),
                         }),
                         function_response: None,
+                        thought: None,
                     }],
                     None,
                     None,
@@ -248,6 +268,7 @@ impl StreamConverter {
                                 args: Some(args),
                             }),
                             function_response: None,
+                            thought: None,
                         }],
                         None,
                         None,
@@ -270,6 +291,7 @@ impl StreamConverter {
                         inline_data: None,
                         function_call: None,
                         function_response: None,
+                        thought: None,
                     }],
                     Some(map_finish_reason(finish_reason)),
                     Some(GenerateContentUsageMetadata {
@@ -320,6 +342,14 @@ fn convert_model_parts(parts: Option<Vec<GooglePart>>) -> Vec<LanguageModelAssis
                     tool_name: fc.name,
                     input: fc.args.unwrap_or_default(),
                     provider_executed: None,
+                    provider_options: None,
+                })
+            } else if p.thought.unwrap_or(false) {
+                // Gemini marks thought summaries with `thought: true`; treat
+                // those as reasoning rather than visible assistant text.
+                // https://ai.google.dev/gemini-api/docs/thinking#thought-summaries
+                p.text.map(|text| LanguageModelAssistantContent::Reasoning {
+                    text,
                     provider_options: None,
                 })
             } else {
@@ -392,6 +422,17 @@ fn extract_response_parts(blocks: &[LanguageModelContent]) -> Vec<GooglePart> {
                 inline_data: None,
                 function_call: None,
                 function_response: None,
+                thought: None,
+            }),
+            // Per Gemini thinking docs, thought summaries appear as text parts
+            // flagged with `thought: true`.
+            // https://ai.google.dev/gemini-api/docs/thinking#thought-summaries
+            LanguageModelContent::Reasoning { text, .. } => out.push(GooglePart {
+                text: Some(text.clone()),
+                inline_data: None,
+                function_call: None,
+                function_response: None,
+                thought: Some(true),
             }),
             LanguageModelContent::ToolCall {
                 tool_name,
@@ -407,6 +448,7 @@ fn extract_response_parts(blocks: &[LanguageModelContent]) -> Vec<GooglePart> {
                         args: Some(args),
                     }),
                     function_response: None,
+                    thought: None,
                 });
             }
             _ => {}
@@ -423,5 +465,108 @@ fn map_finish_reason(reason: &LanguageModelFinishReason) -> String {
         LanguageModelFinishReason::ContentFilter => "SAFETY".to_owned(),
         LanguageModelFinishReason::Error => "OTHER".to_owned(),
         LanguageModelFinishReason::Other(other) => other.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stream_converter_reasoning_delta_emits_thought_part() {
+        // Regression test for issue #448: ReasoningDelta must surface as
+        // a Gemini text part flagged with `thought: true` so clients
+        // distinguish thinking from visible output.
+        let mut conv = StreamConverter::new("gemini-2.5-pro".to_owned());
+        let chunk = conv
+            .convert(&LanguageModelStreamPart::ReasoningDelta {
+                id: "r1".to_owned(),
+                delta: "Thinking".to_owned(),
+                provider_metadata: None,
+            })
+            .expect("reasoning chunk emitted");
+        let parts = chunk
+            .candidates
+            .as_ref()
+            .and_then(|c| c.first())
+            .and_then(|c| c.content.as_ref())
+            .and_then(|c| c.parts.as_ref())
+            .expect("parts present");
+        assert_eq!(parts.len(), 1);
+        assert_eq!(parts[0].text.as_deref(), Some("Thinking"));
+        assert_eq!(parts[0].thought, Some(true));
+    }
+
+    #[test]
+    fn stream_converter_reasoning_start_and_end_drop() {
+        let mut conv = StreamConverter::new("gemini-2.5-pro".to_owned());
+        assert!(
+            conv.convert(&LanguageModelStreamPart::ReasoningStart {
+                id: "r1".to_owned(),
+                provider_metadata: None,
+            })
+            .is_none()
+        );
+        assert!(
+            conv.convert(&LanguageModelStreamPart::ReasoningEnd {
+                id: "r1".to_owned(),
+                provider_metadata: None,
+            })
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn convert_model_parts_routes_thought_to_reasoning() {
+        // Multi-turn echo-back: a `thought: true` part on the input side
+        // must become a Reasoning assistant content block, not Text.
+        let parts = vec![
+            GooglePart {
+                text: Some("inner monologue".to_owned()),
+                inline_data: None,
+                function_call: None,
+                function_response: None,
+                thought: Some(true),
+            },
+            GooglePart {
+                text: Some("visible reply".to_owned()),
+                inline_data: None,
+                function_call: None,
+                function_response: None,
+                thought: None,
+            },
+        ];
+        let converted = convert_model_parts(Some(parts));
+        assert_eq!(converted.len(), 2);
+        assert!(matches!(
+            &converted[0],
+            LanguageModelAssistantContent::Reasoning { text, .. } if text == "inner monologue"
+        ));
+        assert!(matches!(
+            &converted[1],
+            LanguageModelAssistantContent::Text { text, .. } if text == "visible reply"
+        ));
+    }
+
+    #[test]
+    fn extract_response_parts_emits_thought_for_reasoning_block() {
+        // Non-streaming response: a LanguageModelContent::Reasoning
+        // becomes a Gemini text part flagged with `thought: true`.
+        let blocks = vec![
+            LanguageModelContent::Reasoning {
+                text: "thinking".to_owned(),
+                provider_metadata: None,
+            },
+            LanguageModelContent::Text {
+                text: "answer".to_owned(),
+                provider_metadata: None,
+            },
+        ];
+        let parts = extract_response_parts(&blocks);
+        assert_eq!(parts.len(), 2);
+        assert_eq!(parts[0].thought, Some(true));
+        assert_eq!(parts[0].text.as_deref(), Some("thinking"));
+        assert_eq!(parts[1].thought, None);
+        assert_eq!(parts[1].text.as_deref(), Some("answer"));
     }
 }

--- a/bitrouter-core/src/api/google/generate_content/types.rs
+++ b/bitrouter-core/src/api/google/generate_content/types.rs
@@ -31,7 +31,7 @@ pub struct GoogleContent {
     pub parts: Option<Vec<GooglePart>>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GooglePart {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -42,6 +42,12 @@ pub struct GooglePart {
     pub function_call: Option<GoogleFunctionCall>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub function_response: Option<GoogleFunctionResponse>,
+    /// Set to `true` for thought summaries when thinking is enabled on
+    /// Gemini 2.5+ models. The `text` field still carries the content, but
+    /// it must be routed to reasoning rather than visible output.
+    /// <https://ai.google.dev/gemini-api/docs/thinking#thought-summaries>
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thought: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/bitrouter-core/src/api/openai/chat/convert.rs
+++ b/bitrouter-core/src/api/openai/chat/convert.rs
@@ -142,6 +142,21 @@ impl StreamConverter {
                 ChatCompletionChunkDelta {
                     role: None,
                     content: Some(delta.clone()),
+                    reasoning_content: None,
+                    tool_calls: None,
+                },
+                None,
+                None,
+            )),
+            // OpenAI-compatible providers with extended thinking (DeepSeek,
+            // GLM, Aliyun, etc.) stream chain-of-thought via the
+            // `reasoning_content` delta field on Chat Completions chunks.
+            // https://api-docs.deepseek.com/guides/reasoning_model
+            LanguageModelStreamPart::ReasoningDelta { delta, .. } => Some(self.make_chunk(
+                ChatCompletionChunkDelta {
+                    role: None,
+                    content: None,
+                    reasoning_content: Some(delta.clone()),
                     tool_calls: None,
                 },
                 None,
@@ -155,6 +170,7 @@ impl StreamConverter {
                     ChatCompletionChunkDelta {
                         role: None,
                         content: None,
+                        reasoning_content: None,
                         tool_calls: Some(vec![ChatResponseToolCallDelta {
                             index,
                             id: Some(id.clone()),
@@ -179,6 +195,7 @@ impl StreamConverter {
                     ChatCompletionChunkDelta {
                         role: None,
                         content: None,
+                        reasoning_content: None,
                         tool_calls: Some(vec![ChatResponseToolCallDelta {
                             index,
                             id: None,
@@ -205,6 +222,7 @@ impl StreamConverter {
                     ChatCompletionChunkDelta {
                         role: None,
                         content: None,
+                        reasoning_content: None,
                         tool_calls: Some(vec![ChatResponseToolCallDelta {
                             index,
                             id: Some(tool_call_id.clone()),
@@ -230,6 +248,7 @@ impl StreamConverter {
                     ChatCompletionChunkDelta {
                         role: None,
                         content: None,
+                        reasoning_content: None,
                         tool_calls: None,
                     },
                     Some(map_finish_reason(finish_reason)),
@@ -726,6 +745,7 @@ mod tests {
                 delta: ChatCompletionChunkDelta {
                     role: Some("assistant".to_owned()),
                     content: Some("Hello".to_owned()),
+                    reasoning_content: None,
                     tool_calls: None,
                 },
                 finish_reason: None,
@@ -753,6 +773,7 @@ mod tests {
                 delta: ChatCompletionChunkDelta {
                     role: None,
                     content: None,
+                    reasoning_content: None,
                     tool_calls: Some(vec![ChatResponseToolCallDelta {
                         index: 0,
                         id: Some("call_abc".to_owned()),
@@ -787,6 +808,7 @@ mod tests {
                 delta: ChatCompletionChunkDelta {
                     role: None,
                     content: None,
+                    reasoning_content: None,
                     tool_calls: None,
                 },
                 finish_reason: Some("stop".to_owned()),
@@ -1120,6 +1142,51 @@ mod tests {
         assert_eq!(chunk.choices[0].delta.content.as_deref(), Some("Hello"));
         assert!(chunk.choices[0].delta.tool_calls.is_none());
         assert!(chunk.choices[0].finish_reason.is_none());
+    }
+
+    #[test]
+    fn stream_converter_reasoning_delta_maps_to_reasoning_content() {
+        // Regression test for issue #448: when the core emits a
+        // ReasoningDelta (e.g. forwarded from a DeepSeek/GLM upstream), the
+        // OpenAI Chat output converter must surface it via the
+        // `reasoning_content` delta field so clients render thinking
+        // in real time.
+        let mut conv = StreamConverter::new("deepseek-r1".to_owned(), "stream-r1".to_owned());
+        let part = LanguageModelStreamPart::ReasoningDelta {
+            id: "r1".to_owned(),
+            delta: "thinking...".to_owned(),
+            provider_metadata: None,
+        };
+        let chunk = conv.convert(&part).expect("reasoning chunk emitted");
+        assert_eq!(
+            chunk.choices[0].delta.reasoning_content.as_deref(),
+            Some("thinking...")
+        );
+        assert!(chunk.choices[0].delta.content.is_none());
+        assert!(chunk.choices[0].delta.tool_calls.is_none());
+    }
+
+    #[test]
+    fn stream_converter_reasoning_start_and_end_drop() {
+        // ReasoningStart/End have no Chat Completions equivalent — the
+        // content boundary is implicit from the presence of
+        // `reasoning_content`/`content` fields. They must not produce
+        // empty chunks that confuse clients.
+        let mut conv = StreamConverter::new("deepseek-r1".to_owned(), "stream-r2".to_owned());
+        assert!(
+            conv.convert(&LanguageModelStreamPart::ReasoningStart {
+                id: "r1".to_owned(),
+                provider_metadata: None,
+            })
+            .is_none()
+        );
+        assert!(
+            conv.convert(&LanguageModelStreamPart::ReasoningEnd {
+                id: "r1".to_owned(),
+                provider_metadata: None,
+            })
+            .is_none()
+        );
     }
 
     #[test]

--- a/bitrouter-core/src/api/openai/chat/types.rs
+++ b/bitrouter-core/src/api/openai/chat/types.rs
@@ -263,6 +263,11 @@ pub struct ChatCompletionChunkDelta {
     pub role: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub content: Option<String>,
+    // Reasoning/thinking content emitted by OpenAI-compatible providers with
+    // extended thinking support (e.g. DeepSeek, GLM).
+    // https://platform.openai.com/docs/guides/reasoning
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning_content: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tool_calls: Option<Vec<ChatResponseToolCallDelta>>,
 }

--- a/bitrouter-core/src/api/openai/responses/convert.rs
+++ b/bitrouter-core/src/api/openai/responses/convert.rs
@@ -151,6 +151,39 @@ impl StreamConverter {
                     item: None,
                 }]
             }
+            // OpenAI Responses streams reasoning summaries via
+            // `response.reasoning_text.delta` / `.done` events.
+            // https://platform.openai.com/docs/api-reference/responses-streaming/response/reasoning_text/delta
+            LanguageModelStreamPart::ReasoningDelta { delta, .. } => {
+                vec![ResponsesStreamEvent {
+                    event_type: "response.reasoning_text.delta".to_owned(),
+                    item_id: None,
+                    output_index: Some(0),
+                    content_index: Some(0),
+                    delta: Some(delta.clone()),
+                    call_id: None,
+                    name: None,
+                    arguments: None,
+                    item: None,
+                }]
+            }
+            LanguageModelStreamPart::ReasoningEnd { .. } => {
+                vec![ResponsesStreamEvent {
+                    event_type: "response.reasoning_text.done".to_owned(),
+                    item_id: None,
+                    output_index: Some(0),
+                    content_index: Some(0),
+                    delta: None,
+                    call_id: None,
+                    name: None,
+                    arguments: None,
+                    item: None,
+                }]
+            }
+            // ReasoningStart has no dedicated Responses event; the first
+            // `.delta` is sufficient. We swallow it so it doesn't show up
+            // as a Raw passthrough.
+            LanguageModelStreamPart::ReasoningStart { .. } => vec![],
             LanguageModelStreamPart::ToolCall {
                 tool_call_id,
                 tool_name,
@@ -1125,6 +1158,46 @@ mod tests {
         assert_eq!(events[0].delta.as_deref(), Some("Hello"));
         assert_eq!(events[0].output_index, Some(0));
         assert_eq!(events[0].content_index, Some(0));
+    }
+
+    #[test]
+    fn stream_converter_reasoning_delta_emits_reasoning_text_delta() {
+        // Regression test for issue #448: ReasoningDelta must surface as
+        // a `response.reasoning_text.delta` event so Responses-format
+        // clients render thinking in real time.
+        let mut conv = StreamConverter::new();
+        let events = conv.convert(&LanguageModelStreamPart::ReasoningDelta {
+            id: "r1".to_owned(),
+            delta: "Hmm".to_owned(),
+            provider_metadata: None,
+        });
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].event_type, "response.reasoning_text.delta");
+        assert_eq!(events[0].delta.as_deref(), Some("Hmm"));
+    }
+
+    #[test]
+    fn stream_converter_reasoning_end_emits_reasoning_text_done() {
+        let mut conv = StreamConverter::new();
+        let events = conv.convert(&LanguageModelStreamPart::ReasoningEnd {
+            id: "r1".to_owned(),
+            provider_metadata: None,
+        });
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].event_type, "response.reasoning_text.done");
+        assert!(events[0].delta.is_none());
+    }
+
+    #[test]
+    fn stream_converter_reasoning_start_swallowed() {
+        // ReasoningStart has no dedicated Responses event; the first
+        // `.delta` is sufficient. Must produce zero events.
+        let mut conv = StreamConverter::new();
+        let events = conv.convert(&LanguageModelStreamPart::ReasoningStart {
+            id: "r1".to_owned(),
+            provider_metadata: None,
+        });
+        assert!(events.is_empty());
     }
 
     #[test]

--- a/bitrouter-core/src/api/openai/responses/convert.rs
+++ b/bitrouter-core/src/api/openai/responses/convert.rs
@@ -938,16 +938,27 @@ impl StreamConverter {
         &self,
         usage: Option<&crate::models::language::usage::LanguageModelUsage>,
     ) -> ResponsesResponse {
-        let usage = usage.map(|u| ResponsesUsage {
-            input_tokens: u.input_tokens.total,
-            output_tokens: u.output_tokens.total,
-            total_tokens: u
-                .input_tokens
-                .total
-                .zip(u.output_tokens.total)
-                .map(|(i, o)| i + o),
-            input_tokens_details: None,
-            output_tokens_details: None,
+        // Codex CLI's `ResponseCompletedUsage` types input/output/total as
+        // non-optional `i64` (see codex-rs/codex-api/src/sse/responses.rs),
+        // so any `null` inside the usage object fails the response.completed
+        // parse and the stream hangs. Default unknown counts to 0 and always
+        // emit the three core fields together; if no counts are known at
+        // all, omit `usage` entirely so codex falls back to `usage: None`.
+        let usage = usage.and_then(|u| {
+            let input = u.input_tokens.total;
+            let output = u.output_tokens.total;
+            if input.is_none() && output.is_none() {
+                return None;
+            }
+            let input = input.unwrap_or(0);
+            let output = output.unwrap_or(0);
+            Some(ResponsesUsage {
+                input_tokens: Some(input),
+                output_tokens: Some(output),
+                total_tokens: Some(input.saturating_add(output)),
+                input_tokens_details: None,
+                output_tokens_details: None,
+            })
         });
         ResponsesResponse {
             id: self.response_id.clone(),
@@ -2166,6 +2177,114 @@ mod tests {
         assert_eq!(usage.total_tokens, Some(55));
         assert_eq!(resp.status.as_deref(), Some("completed"));
         assert_eq!(resp.output.len(), 1);
+    }
+
+    #[test]
+    fn stream_converter_completed_payload_parses_as_codex_response_completed() {
+        // Lock the contract with codex-rs/codex-api/src/sse/responses.rs::
+        // ResponseCompletedUsage where input_tokens / output_tokens /
+        // total_tokens are typed `i64` (not Option). A `null` value inside
+        // the usage object fails the parse, the stream errors out, the
+        // oneshot LastResponse channel never fires, and the Codex TUI hangs.
+        #[derive(serde::Deserialize)]
+        #[allow(dead_code)]
+        struct CodexResponseCompleted {
+            id: String,
+            #[serde(default)]
+            usage: Option<CodexUsage>,
+            #[serde(default)]
+            end_turn: Option<bool>,
+        }
+        #[derive(serde::Deserialize)]
+        #[allow(dead_code)]
+        struct CodexUsage {
+            input_tokens: i64,
+            output_tokens: i64,
+            total_tokens: i64,
+        }
+
+        let mut conv = StreamConverter::new("test-model");
+        conv.convert(&LanguageModelStreamPart::TextDelta {
+            id: "t1".to_owned(),
+            delta: "Hi".to_owned(),
+            provider_metadata: None,
+        });
+        let events = conv.convert(&LanguageModelStreamPart::Finish {
+            usage: make_usage(11, 22),
+            finish_reason: LanguageModelFinishReason::Stop,
+            provider_metadata: None,
+        });
+        let completed = events
+            .iter()
+            .find(|e| e.event_type == "response.completed")
+            .and_then(|e| e.response.as_ref())
+            .expect("response.completed present");
+        let json = serde_json::to_value(completed).expect("serialize");
+        // The whole JSON shape must round-trip into Codex's struct.
+        let parsed: CodexResponseCompleted =
+            serde_json::from_value(json.clone()).expect("Codex parses response.completed");
+        assert_eq!(parsed.id, completed.id);
+        let usage = parsed.usage.expect("usage present");
+        assert_eq!(usage.input_tokens, 11);
+        assert_eq!(usage.output_tokens, 22);
+        assert_eq!(usage.total_tokens, 33);
+        // And there must be no JSON null inside usage that would break the parse.
+        let usage_obj = json["usage"].as_object().expect("usage object");
+        for key in ["input_tokens", "output_tokens", "total_tokens"] {
+            assert!(
+                !usage_obj[key].is_null(),
+                "usage.{key} must not be null in response.completed"
+            );
+        }
+    }
+
+    #[test]
+    fn stream_converter_completed_omits_usage_when_upstream_has_none() {
+        // If the upstream provides no token counts at all, the usage object
+        // is omitted entirely rather than emitting nulls. Codex's
+        // `usage: Option<ResponseCompletedUsage>` deserializes None cleanly.
+        use crate::models::language::usage::{
+            LanguageModelInputTokens, LanguageModelOutputTokens, LanguageModelUsage,
+        };
+        let empty_usage = LanguageModelUsage {
+            input_tokens: LanguageModelInputTokens {
+                total: None,
+                no_cache: None,
+                cache_read: None,
+                cache_write: None,
+            },
+            output_tokens: LanguageModelOutputTokens {
+                total: None,
+                text: None,
+                reasoning: None,
+            },
+            raw: None,
+        };
+        let mut conv = StreamConverter::new("test-model");
+        conv.convert(&LanguageModelStreamPart::TextDelta {
+            id: "t1".to_owned(),
+            delta: "Hi".to_owned(),
+            provider_metadata: None,
+        });
+        let events = conv.convert(&LanguageModelStreamPart::Finish {
+            usage: empty_usage,
+            finish_reason: LanguageModelFinishReason::Stop,
+            provider_metadata: None,
+        });
+        let completed = events
+            .iter()
+            .find(|e| e.event_type == "response.completed")
+            .and_then(|e| e.response.as_ref())
+            .expect("response.completed present");
+        assert!(
+            completed.usage.is_none(),
+            "usage must be omitted when no token counts"
+        );
+        let json = serde_json::to_value(completed).expect("serialize");
+        assert!(
+            json.get("usage").is_none(),
+            "usage key must be absent from serialized JSON, got {json}"
+        );
     }
 
     #[test]

--- a/bitrouter-core/src/api/openai/responses/convert.rs
+++ b/bitrouter-core/src/api/openai/responses/convert.rs
@@ -32,16 +32,31 @@ pub fn extract_model_name(request: &ResponsesRequest) -> &str {
 
 /// Converts a [`ResponsesRequest`] into [`LanguageModelCallOptions`].
 pub fn to_call_options(request: ResponsesRequest) -> LanguageModelCallOptions {
-    let prompt = match request.input {
-        ResponsesInput::Text(text) => vec![LanguageModelMessage::User {
+    let mut prompt = Vec::new();
+    // `instructions` is the canonical developer prompt on Responses; lift it
+    // into a System message so the routed model sees it regardless of the
+    // upstream protocol.
+    // https://platform.openai.com/docs/api-reference/responses/create#responses-create-instructions
+    if let Some(text) = request
+        .instructions
+        .as_ref()
+        .filter(|t| !t.trim().is_empty())
+    {
+        prompt.push(LanguageModelMessage::System {
+            content: text.clone(),
+            provider_options: None,
+        });
+    }
+    match request.input {
+        ResponsesInput::Text(text) => prompt.push(LanguageModelMessage::User {
             content: vec![LanguageModelUserContent::Text {
                 text,
                 provider_options: None,
             }],
             provider_options: None,
-        }],
-        ResponsesInput::Items(items) => convert_input_items(items),
-    };
+        }),
+        ResponsesInput::Items(items) => prompt.extend(convert_input_items(items)),
+    }
 
     let tools = request.tools.map(|tools| {
         tools
@@ -985,7 +1000,7 @@ fn convert_input_items(items: Vec<ResponsesInputItem>) -> Vec<LanguageModelMessa
                         tool_call_id: fco.call_id,
                         tool_name: String::new(),
                         output: LanguageModelToolResultOutput::Text {
-                            value: fco.output,
+                            value: stringify_function_call_output(&fco.output),
                             provider_options: None,
                         },
                         provider_options: None,
@@ -1006,9 +1021,48 @@ fn convert_input_items(items: Vec<ResponsesInputItem>) -> Vec<LanguageModelMessa
                     provider_options: None,
                 });
             }
+            // Unknown / unsupported item types (reasoning, web_search_call,
+            // image_generation_call, local_shell_call, compaction, ...) are
+            // accepted on the wire so strict clients like Codex CLI don't
+            // get 400s, but bitrouter can't replay them to a non-Responses
+            // upstream — silently drop. The downstream model still sees the
+            // surrounding messages and reasoning resumes from scratch.
+            ResponsesInputItem::Unknown(_) => {}
         }
     }
     messages
+}
+
+/// Codex CLI's `function_call_output.output` may be a plain string or a
+/// structured object with `content`/`content_items` (multimodal tool outputs).
+/// We collapse the structured form to plain text so the routed model — which
+/// often only accepts a string tool result — receives a usable value.
+/// <https://platform.openai.com/docs/api-reference/responses/create#input>
+fn stringify_function_call_output(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(s) => s.clone(),
+        serde_json::Value::Null => String::new(),
+        serde_json::Value::Object(map) => {
+            if let Some(serde_json::Value::String(s)) = map.get("content") {
+                return s.clone();
+            }
+            if let Some(serde_json::Value::Array(items)) = map.get("content_items") {
+                let pieces: Vec<String> = items
+                    .iter()
+                    .filter_map(|item| {
+                        item.get("text")
+                            .and_then(|t| t.as_str())
+                            .map(|s| s.to_owned())
+                    })
+                    .collect();
+                if !pieces.is_empty() {
+                    return pieces.join("\n");
+                }
+            }
+            serde_json::to_string(value).unwrap_or_default()
+        }
+        other => serde_json::to_string(other).unwrap_or_default(),
+    }
 }
 
 fn input_content_to_string(content: Option<ResponsesInputContent>) -> String {
@@ -1320,6 +1374,7 @@ mod tests {
                     ])),
                 },
             )]),
+            instructions: None,
             temperature: None,
             top_p: None,
             max_output_tokens: None,
@@ -2155,5 +2210,171 @@ mod tests {
         }"#;
         let req: ResponsesRequest = serde_json::from_str(json).expect("parse failed");
         assert_eq!(extract_model_name(&req), "gpt-4o-mini");
+    }
+
+    // ── Codex CLI compatibility ─────────────────────────────────────────
+
+    #[test]
+    fn deserialize_codex_multi_turn_request_with_reasoning_items() {
+        // Regression for the 400 reported when Codex CLI sends a multi-turn
+        // request: `input` contains `reasoning`, `web_search_call`, and
+        // other item types from previous turns. Our untagged enum must
+        // accept (and silently drop) anything it doesn't model, instead of
+        // failing the whole request.
+        // https://platform.openai.com/docs/api-reference/responses/create#input
+        let json = r#"{
+            "model": "opencode-go:glm-5.1",
+            "instructions": "You are a coding agent running in the Codex CLI.",
+            "input": [
+                {
+                    "type": "message",
+                    "role": "developer",
+                    "content": [{"type": "input_text", "text": "<permissions instructions>"}]
+                },
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "hi"}]
+                },
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "Hello!"}]
+                },
+                {
+                    "type": "reasoning",
+                    "id": "rs_abc",
+                    "summary": [],
+                    "content": [{"type": "reasoning_text", "text": "I should greet."}],
+                    "encrypted_content": null
+                },
+                {
+                    "type": "web_search_call",
+                    "id": "ws_1",
+                    "status": "completed",
+                    "action": {"type": "search", "query": "weather"}
+                },
+                {
+                    "type": "local_shell_call",
+                    "call_id": "ls_1",
+                    "status": "completed",
+                    "action": {"type": "exec", "command": ["ls"]}
+                }
+            ],
+            "tool_choice": "auto",
+            "parallel_tool_calls": false,
+            "stream": true,
+            "store": false,
+            "include": ["reasoning.encrypted_content"],
+            "prompt_cache_key": "thread-1"
+        }"#;
+        let req: ResponsesRequest = serde_json::from_str(json).expect("Codex payload must parse");
+        assert_eq!(
+            req.instructions.as_deref(),
+            Some("You are a coding agent running in the Codex CLI.")
+        );
+        match &req.input {
+            ResponsesInput::Items(items) => {
+                assert_eq!(items.len(), 6);
+                // Reasoning, web_search_call, local_shell_call fall through
+                // to the catch-all variant.
+                assert!(matches!(items[3], ResponsesInputItem::Unknown(_)));
+                assert!(matches!(items[4], ResponsesInputItem::Unknown(_)));
+                assert!(matches!(items[5], ResponsesInputItem::Unknown(_)));
+            }
+            other => panic!("expected Items, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn to_call_options_lifts_instructions_to_system_message() {
+        // Codex sends the entire system prompt via the top-level
+        // `instructions` field, not as a message. `to_call_options` must
+        // synthesize a System message so the routed model sees it.
+        let json = r#"{
+            "model": "opencode-go:glm-5.1",
+            "instructions": "Be precise.",
+            "input": [{"type": "message", "role": "user", "content": [{"type": "input_text", "text": "Hi"}]}]
+        }"#;
+        let req: ResponsesRequest = serde_json::from_str(json).expect("parse");
+        let opts = to_call_options(req);
+        assert!(matches!(
+            opts.prompt.first(),
+            Some(LanguageModelMessage::System { content, .. }) if content == "Be precise."
+        ));
+        assert!(matches!(
+            opts.prompt.get(1),
+            Some(LanguageModelMessage::User { .. })
+        ));
+    }
+
+    #[test]
+    fn to_call_options_skips_unknown_items() {
+        // Unknown input items (reasoning, web_search_call, ...) must not
+        // produce phantom messages in the converted prompt.
+        let json = r#"{
+            "model": "opencode-go:glm-5.1",
+            "input": [
+                {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "Hi"}]},
+                {"type": "reasoning", "id": "rs_1", "summary": [], "content": [{"type":"reasoning_text","text":"..."}]}
+            ]
+        }"#;
+        let req: ResponsesRequest = serde_json::from_str(json).expect("parse");
+        let opts = to_call_options(req);
+        assert_eq!(opts.prompt.len(), 1);
+        assert!(matches!(opts.prompt[0], LanguageModelMessage::User { .. }));
+    }
+
+    #[test]
+    fn function_call_output_accepts_string_or_content_object() {
+        // The Responses API allows `output` to be either a plain string or
+        // a structured `{content: "..."}` / `{content_items: [...]}` object
+        // (Codex emits the structured form for multimodal tool results).
+        let plain = r#"{
+            "model": "x",
+            "input": [
+                {"type": "function_call_output", "call_id": "c1", "output": "result text"}
+            ]
+        }"#;
+        let req: ResponsesRequest = serde_json::from_str(plain).expect("plain output parses");
+        let opts = to_call_options(req);
+        match &opts.prompt[0] {
+            LanguageModelMessage::Tool { content, .. } => match &content[0] {
+                LanguageModelToolResult::ToolResult { output, .. } => match output {
+                    LanguageModelToolResultOutput::Text { value, .. } => {
+                        assert_eq!(value, "result text")
+                    }
+                    other => panic!("expected Text output, got {other:?}"),
+                },
+                other => panic!("expected ToolResult, got {other:?}"),
+            },
+            other => panic!("expected Tool message, got {other:?}"),
+        }
+
+        let structured = r#"{
+            "model": "x",
+            "input": [
+                {
+                    "type": "function_call_output",
+                    "call_id": "c1",
+                    "output": {"content_items": [{"type": "input_text", "text": "first"}, {"type": "input_text", "text": "second"}]}
+                }
+            ]
+        }"#;
+        let req: ResponsesRequest =
+            serde_json::from_str(structured).expect("structured output parses");
+        let opts = to_call_options(req);
+        match &opts.prompt[0] {
+            LanguageModelMessage::Tool { content, .. } => match &content[0] {
+                LanguageModelToolResult::ToolResult { output, .. } => match output {
+                    LanguageModelToolResultOutput::Text { value, .. } => {
+                        assert_eq!(value, "first\nsecond")
+                    }
+                    other => panic!("expected Text output, got {other:?}"),
+                },
+                other => panic!("expected ToolResult, got {other:?}"),
+            },
+            other => panic!("expected Tool message, got {other:?}"),
+        }
     }
 }

--- a/bitrouter-core/src/api/openai/responses/convert.rs
+++ b/bitrouter-core/src/api/openai/responses/convert.rs
@@ -987,11 +987,34 @@ fn convert_input_items(items: Vec<ResponsesInputItem>) -> Vec<LanguageModelMessa
                         provider_options: None,
                     });
                 }
+                "assistant" => {
+                    // Codex CLI sends prior assistant turns with role=assistant
+                    // and `output_text` content. Routing them through `User`
+                    // produces consecutive user messages with no assistant
+                    // turns between them; upstreams like Z.ai/GLM reject the
+                    // chat-completions payload as malformed
+                    // ("The prompt parameter was not received normally").
+                    // Codex commonly emits assistant messages with empty text
+                    // because the visible content lives in a sibling
+                    // `reasoning` item (which bitrouter can't replay to
+                    // chat-completions upstreams); drop those empty shells
+                    // rather than emit a vacuous Assistant message.
+                    let parts = input_content_to_assistant_parts(msg.content);
+                    if !parts.is_empty() {
+                        messages.push(LanguageModelMessage::Assistant {
+                            content: parts,
+                            provider_options: None,
+                        });
+                    }
+                }
                 _ => {
-                    messages.push(LanguageModelMessage::User {
-                        content: input_content_to_parts(msg.content),
-                        provider_options: None,
-                    });
+                    let parts = input_content_to_parts(msg.content);
+                    if !parts.is_empty() {
+                        messages.push(LanguageModelMessage::User {
+                            content: parts,
+                            provider_options: None,
+                        });
+                    }
                 }
             },
             ResponsesInputItem::FunctionCallOutput(fco) => {
@@ -1021,16 +1044,92 @@ fn convert_input_items(items: Vec<ResponsesInputItem>) -> Vec<LanguageModelMessa
                     provider_options: None,
                 });
             }
-            // Unknown / unsupported item types (reasoning, web_search_call,
-            // image_generation_call, local_shell_call, compaction, ...) are
-            // accepted on the wire so strict clients like Codex CLI don't
-            // get 400s, but bitrouter can't replay them to a non-Responses
-            // upstream — silently drop. The downstream model still sees the
-            // surrounding messages and reasoning resumes from scratch.
-            ResponsesInputItem::Unknown(_) => {}
+            ResponsesInputItem::Unknown(value) => {
+                // Codex CLI emits `reasoning` items separately from the
+                // assistant message: extract the text and surface it as
+                // Reasoning content on an Assistant message. Providers that
+                // support extended thinking (Anthropic) will round-trip it;
+                // chat-completions providers strip it per their own
+                // convert_prompt (see openai/chat/api.rs).
+                if let Some(reasoning_text) = extract_reasoning_text(&value)
+                    && !reasoning_text.is_empty()
+                {
+                    messages.push(LanguageModelMessage::Assistant {
+                        content: vec![LanguageModelAssistantContent::Reasoning {
+                            text: reasoning_text,
+                            provider_options: None,
+                        }],
+                        provider_options: None,
+                    });
+                }
+                // Other unknown item types (web_search_call, local_shell_call,
+                // image_generation_call, custom_tool_call, compaction, ...)
+                // are silently dropped — bitrouter can't replay them to a
+                // non-Responses upstream.
+            }
         }
     }
     messages
+}
+
+/// Extracts the concatenated text from a `reasoning` input item's `content`
+/// array. Codex CLI's shape per [`codex_protocol::models::ResponseItem`]:
+/// `{type: "reasoning", id, summary, content: [{type:"reasoning_text", text}], encrypted_content}`.
+/// Returns `None` for any other item type so callers can ignore non-reasoning
+/// unknowns.
+/// <https://platform.openai.com/docs/api-reference/responses/create#input>
+fn extract_reasoning_text(value: &serde_json::Value) -> Option<String> {
+    let obj = value.as_object()?;
+    if obj.get("type").and_then(|t| t.as_str()) != Some("reasoning") {
+        return None;
+    }
+    let content = obj.get("content").and_then(|c| c.as_array())?;
+    let mut pieces = Vec::new();
+    for item in content {
+        if let Some(text) = item.get("text").and_then(|t| t.as_str())
+            && !text.is_empty()
+        {
+            pieces.push(text.to_owned());
+        }
+    }
+    if pieces.is_empty() {
+        None
+    } else {
+        Some(pieces.join(""))
+    }
+}
+
+fn input_content_to_assistant_parts(
+    content: Option<ResponsesInputContent>,
+) -> Vec<LanguageModelAssistantContent> {
+    match content {
+        Some(ResponsesInputContent::Text(s)) if !s.is_empty() => {
+            vec![LanguageModelAssistantContent::Text {
+                text: s,
+                provider_options: None,
+            }]
+        }
+        Some(ResponsesInputContent::Parts(parts)) => parts
+            .into_iter()
+            .filter_map(|p| match p {
+                // Both `input_text` and `output_text` carry user-visible
+                // assistant text on the wire; collapse to Text content.
+                ResponsesInputContentPart::InputText { text }
+                | ResponsesInputContentPart::OutputText { text } => {
+                    if text.is_empty() {
+                        None
+                    } else {
+                        Some(LanguageModelAssistantContent::Text {
+                            text,
+                            provider_options: None,
+                        })
+                    }
+                }
+                ResponsesInputContentPart::InputImage { .. } => None,
+            })
+            .collect(),
+        _ => Vec::new(),
+    }
 }
 
 /// Codex CLI's `function_call_output.output` may be a plain string or a
@@ -2309,14 +2408,92 @@ mod tests {
     }
 
     #[test]
-    fn to_call_options_skips_unknown_items() {
-        // Unknown input items (reasoning, web_search_call, ...) must not
-        // produce phantom messages in the converted prompt.
+    fn to_call_options_lifts_reasoning_items_to_assistant_reasoning() {
+        // Reasoning input items become Assistant messages with Reasoning
+        // content so providers that round-trip thinking (Anthropic) see them.
+        // Chat-completions providers strip Reasoning per their own
+        // convert_prompt and skip the empty assistant turn that remains.
         let json = r#"{
             "model": "opencode-go:glm-5.1",
             "input": [
                 {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "Hi"}]},
-                {"type": "reasoning", "id": "rs_1", "summary": [], "content": [{"type":"reasoning_text","text":"..."}]}
+                {"type": "reasoning", "id": "rs_1", "summary": [], "content": [{"type":"reasoning_text","text":"thinking..."}]}
+            ]
+        }"#;
+        let req: ResponsesRequest = serde_json::from_str(json).expect("parse");
+        let opts = to_call_options(req);
+        assert_eq!(opts.prompt.len(), 2);
+        assert!(matches!(opts.prompt[0], LanguageModelMessage::User { .. }));
+        match &opts.prompt[1] {
+            LanguageModelMessage::Assistant { content, .. } => {
+                assert_eq!(content.len(), 1);
+                assert!(matches!(
+                    &content[0],
+                    LanguageModelAssistantContent::Reasoning { text, .. } if text == "thinking..."
+                ));
+            }
+            other => panic!("expected Assistant Reasoning, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn to_call_options_drops_other_unknown_items() {
+        // Non-reasoning Unknown items (web_search_call, etc.) still drop.
+        let json = r#"{
+            "model": "x",
+            "input": [
+                {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "Hi"}]},
+                {"type": "web_search_call", "id": "ws_1", "status": "completed"}
+            ]
+        }"#;
+        let req: ResponsesRequest = serde_json::from_str(json).expect("parse");
+        let opts = to_call_options(req);
+        assert_eq!(opts.prompt.len(), 1);
+        assert!(matches!(opts.prompt[0], LanguageModelMessage::User { .. }));
+    }
+
+    #[test]
+    fn to_call_options_maps_assistant_role_to_assistant_message() {
+        // Codex CLI sends prior turns with role=assistant; they must NOT be
+        // demoted to User. Z.ai/GLM rejects payloads with no assistant turns
+        // ("The prompt parameter was not received normally").
+        let json = r#"{
+            "model": "opencode-go:glm-5.1",
+            "input": [
+                {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "Hi"}]},
+                {"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": "Hello"}]},
+                {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "Continue"}]}
+            ]
+        }"#;
+        let req: ResponsesRequest = serde_json::from_str(json).expect("parse");
+        let opts = to_call_options(req);
+        assert_eq!(opts.prompt.len(), 3);
+        assert!(matches!(opts.prompt[0], LanguageModelMessage::User { .. }));
+        match &opts.prompt[1] {
+            LanguageModelMessage::Assistant { content, .. } => {
+                assert!(matches!(
+                    &content[0],
+                    LanguageModelAssistantContent::Text { text, .. } if text == "Hello"
+                ));
+            }
+            other => panic!("expected Assistant, got {other:?}"),
+        }
+        assert!(matches!(opts.prompt[2], LanguageModelMessage::User { .. }));
+    }
+
+    #[test]
+    fn to_call_options_drops_empty_assistant_messages_from_codex() {
+        // Codex CLI commonly emits assistant messages with empty
+        // `output_text` because the visible content lives in a sibling
+        // reasoning item. Dropping these prevents an invalid chat-completions
+        // payload where many consecutive empty assistant turns confuse the
+        // upstream's prompt-shape validator.
+        let json = r#"{
+            "model": "opencode-go:glm-5.1",
+            "input": [
+                {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "Hi"}]},
+                {"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": ""}]},
+                {"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": ""}]}
             ]
         }"#;
         let req: ResponsesRequest = serde_json::from_str(json).expect("parse");

--- a/bitrouter-core/src/api/openai/responses/convert.rs
+++ b/bitrouter-core/src/api/openai/responses/convert.rs
@@ -115,208 +115,845 @@ pub fn from_generate_result(
 
 // ── Streaming ───────────────────────────────────────────────────────────────
 
-/// Stateful converter that tracks output item indices across streaming events.
+/// Stateful converter that emits a canonical OpenAI Responses streaming
+/// lifecycle: `response.created` → `response.in_progress` → per-item
+/// `output_item.added` (+ `content_part.added` for messages) → delta events
+/// → `*.done` events → `response.completed`. Every emitted event carries a
+/// monotonically-increasing `sequence_number`.
+///
+/// Strict clients such as Codex CLI close the stream with
+/// "stream closed before response.completed" if any of this is missing or
+/// out of order, then retry immediately.
+/// <https://platform.openai.com/docs/api-reference/responses-streaming>
 pub struct StreamConverter {
-    tool_id_to_index: HashMap<String, u32>,
+    model_id: String,
+    response_id: String,
+    created_at: i64,
+    sequence_number: u64,
+    /// `response.created` / `response.in_progress` are emitted lazily on the
+    /// first delivered stream part so the response object can carry the
+    /// upstream response id once `ResponseMetadata` arrives.
+    created_emitted: bool,
+    /// True once `response.completed` (or `failed`/`incomplete`) has been
+    /// written. Further calls are no-ops to keep the SSE stream well-formed.
+    completed_emitted: bool,
+    /// Active output item index — incremented every time a new item opens.
     next_output_index: u32,
+    /// Open message item carrying streaming text.
+    text_item: Option<MessageItemState>,
+    /// Open reasoning item carrying streaming chain-of-thought.
+    reasoning_item: Option<ReasoningItemState>,
+    /// Open function-call items keyed by upstream tool id, in arrival order.
+    tool_items: HashMap<String, ToolItemState>,
+    tool_order: Vec<String>,
+    /// Completed output items, in emission order — populated as items close
+    /// and replayed on `response.completed` so the final envelope mirrors
+    /// the non-streaming response.
+    completed_output: Vec<ResponsesOutputItem>,
 }
 
-impl Default for StreamConverter {
-    fn default() -> Self {
-        Self::new()
-    }
+struct MessageItemState {
+    item_id: String,
+    output_index: u32,
+    /// Concatenated text deltas; finalized into `output_text.done.text`.
+    accumulated_text: String,
+}
+
+struct ReasoningItemState {
+    item_id: String,
+    output_index: u32,
+    accumulated_text: String,
+}
+
+struct ToolItemState {
+    item_id: String,
+    output_index: u32,
+    call_id: String,
+    tool_name: String,
+    accumulated_args: String,
 }
 
 impl StreamConverter {
-    pub fn new() -> Self {
+    /// Creates a converter bound to a target model id. The response id is
+    /// generated locally and surfaced in the `response.created` envelope so
+    /// clients can correlate the stream with downstream telemetry.
+    pub fn new(model_id: impl Into<String>) -> Self {
         Self {
-            tool_id_to_index: HashMap::new(),
+            model_id: model_id.into(),
+            response_id: format!("resp-{}", generate_id()),
+            created_at: now_unix(),
+            sequence_number: 0,
+            created_emitted: false,
+            completed_emitted: false,
             next_output_index: 0,
+            text_item: None,
+            reasoning_item: None,
+            tool_items: HashMap::new(),
+            tool_order: Vec::new(),
+            completed_output: Vec::new(),
         }
     }
 
-    /// Converts a [`LanguageModelStreamPart`] into Responses SSE events.
+    /// Converts a [`LanguageModelStreamPart`] into one or more canonical
+    /// Responses SSE events. Returns an empty vector for parts that have no
+    /// direct mapping (e.g. `StreamStart`).
     pub fn convert(&mut self, part: &LanguageModelStreamPart) -> Vec<ResponsesStreamEvent> {
+        if self.completed_emitted {
+            return Vec::new();
+        }
+
+        // Adopt the upstream response id *before* emitting `response.created`
+        // so the envelope carries the canonical id from the very first event.
+        // Multi-turn chaining via `previous_response_id` depends on this.
+        if !self.created_emitted
+            && let LanguageModelStreamPart::ResponseMetadata {
+                id: Some(upstream), ..
+            } = part
+        {
+            self.response_id = upstream.clone();
+        }
+
+        let mut events = self.emit_created_if_needed();
+
         match part {
-            LanguageModelStreamPart::TextDelta { delta, .. } => {
-                vec![ResponsesStreamEvent {
-                    event_type: "response.output_text.delta".to_owned(),
-                    item_id: None,
-                    output_index: Some(0),
-                    content_index: Some(0),
-                    delta: Some(delta.clone()),
-                    call_id: None,
-                    name: None,
-                    arguments: None,
-                    item: None,
-                }]
+            LanguageModelStreamPart::ResponseMetadata { id, .. } => {
+                // Late metadata (after `response.created` already emitted)
+                // still updates the in-progress id for downstream telemetry.
+                if let Some(upstream) = id.as_deref() {
+                    self.response_id = upstream.to_owned();
+                }
             }
-            // OpenAI Responses streams reasoning summaries via
-            // `response.reasoning_text.delta` / `.done` events.
-            // https://platform.openai.com/docs/api-reference/responses-streaming/response/reasoning_text/delta
+            LanguageModelStreamPart::TextStart { .. } => {
+                events.extend(self.close_reasoning_item());
+                self.open_text_item(&mut events);
+            }
+            LanguageModelStreamPart::TextDelta { delta, .. } => {
+                events.extend(self.close_reasoning_item());
+                self.open_text_item(&mut events);
+                let (item_id, output_index) = {
+                    let item = self
+                        .text_item
+                        .as_mut()
+                        .expect("text item just opened above");
+                    item.accumulated_text.push_str(delta);
+                    (item.item_id.clone(), item.output_index)
+                };
+                events.push(self.make_event(
+                    "response.output_text.delta",
+                    ResponsesStreamEvent {
+                        event_type: String::new(),
+                        sequence_number: 0,
+                        response: None,
+                        item_id: Some(item_id),
+                        output_index: Some(output_index),
+                        content_index: Some(0),
+                        delta: Some(delta.clone()),
+                        text: None,
+                        call_id: None,
+                        name: None,
+                        arguments: None,
+                        item: None,
+                        part: None,
+                    },
+                ));
+            }
+            LanguageModelStreamPart::TextEnd { .. } => {
+                events.extend(self.close_text_item());
+            }
+            LanguageModelStreamPart::ReasoningStart { .. } => {
+                events.extend(self.close_text_item());
+                self.open_reasoning_item(&mut events);
+            }
             LanguageModelStreamPart::ReasoningDelta { delta, .. } => {
-                vec![ResponsesStreamEvent {
-                    event_type: "response.reasoning_text.delta".to_owned(),
-                    item_id: None,
-                    output_index: Some(0),
-                    content_index: Some(0),
-                    delta: Some(delta.clone()),
-                    call_id: None,
-                    name: None,
-                    arguments: None,
-                    item: None,
-                }]
+                events.extend(self.close_text_item());
+                self.open_reasoning_item(&mut events);
+                let (item_id, output_index) = {
+                    let item = self
+                        .reasoning_item
+                        .as_mut()
+                        .expect("reasoning item just opened above");
+                    item.accumulated_text.push_str(delta);
+                    (item.item_id.clone(), item.output_index)
+                };
+                events.push(self.make_event(
+                    "response.reasoning_text.delta",
+                    ResponsesStreamEvent {
+                        event_type: String::new(),
+                        sequence_number: 0,
+                        response: None,
+                        item_id: Some(item_id),
+                        output_index: Some(output_index),
+                        content_index: Some(0),
+                        delta: Some(delta.clone()),
+                        text: None,
+                        call_id: None,
+                        name: None,
+                        arguments: None,
+                        item: None,
+                        part: None,
+                    },
+                ));
             }
             LanguageModelStreamPart::ReasoningEnd { .. } => {
-                vec![ResponsesStreamEvent {
-                    event_type: "response.reasoning_text.done".to_owned(),
-                    item_id: None,
-                    output_index: Some(0),
-                    content_index: Some(0),
-                    delta: None,
-                    call_id: None,
-                    name: None,
-                    arguments: None,
-                    item: None,
-                }]
+                events.extend(self.close_reasoning_item());
             }
-            // ReasoningStart has no dedicated Responses event; the first
-            // `.delta` is sufficient. We swallow it so it doesn't show up
-            // as a Raw passthrough.
-            LanguageModelStreamPart::ReasoningStart { .. } => vec![],
+            LanguageModelStreamPart::ToolInputStart { id, tool_name, .. } => {
+                events.extend(self.close_text_item());
+                events.extend(self.close_reasoning_item());
+                self.open_tool_item(id, tool_name, &mut events);
+            }
+            LanguageModelStreamPart::ToolInputDelta { id, delta, .. } => {
+                events.extend(self.close_text_item());
+                events.extend(self.close_reasoning_item());
+                if !self.tool_items.contains_key(id) {
+                    self.open_tool_item(id, "tool", &mut events);
+                }
+                let (item_id, output_index, call_id) = {
+                    let item = self
+                        .tool_items
+                        .get_mut(id)
+                        .expect("tool item just opened above");
+                    item.accumulated_args.push_str(delta);
+                    (
+                        item.item_id.clone(),
+                        item.output_index,
+                        item.call_id.clone(),
+                    )
+                };
+                events.push(self.make_event(
+                    "response.function_call_arguments.delta",
+                    ResponsesStreamEvent {
+                        event_type: String::new(),
+                        sequence_number: 0,
+                        response: None,
+                        item_id: Some(item_id),
+                        output_index: Some(output_index),
+                        content_index: None,
+                        delta: Some(delta.clone()),
+                        text: None,
+                        call_id: Some(call_id),
+                        name: None,
+                        arguments: None,
+                        item: None,
+                        part: None,
+                    },
+                ));
+            }
+            LanguageModelStreamPart::ToolInputEnd { id, .. } => {
+                events.extend(self.close_tool_item(id));
+            }
             LanguageModelStreamPart::ToolCall {
                 tool_call_id,
                 tool_name,
                 tool_input,
                 ..
             } => {
-                let index = self.next_output_index;
-                self.next_output_index += 1;
-                let item_id = format!("fc-{}", generate_id());
-                let item = serde_json::json!({
-                    "type": "function_call",
-                    "id": item_id,
-                    "call_id": tool_call_id,
-                    "name": tool_name,
-                    "arguments": tool_input,
-                    "status": "completed"
-                });
-                vec![
+                // Single-shot tool call: open, emit full arguments, close.
+                events.extend(self.close_text_item());
+                events.extend(self.close_reasoning_item());
+                self.open_tool_item(tool_call_id, tool_name, &mut events);
+                let (item_id, output_index, call_id) = {
+                    let item = self
+                        .tool_items
+                        .get_mut(tool_call_id)
+                        .expect("tool item just opened above");
+                    item.accumulated_args.push_str(tool_input);
+                    (
+                        item.item_id.clone(),
+                        item.output_index,
+                        item.call_id.clone(),
+                    )
+                };
+                events.push(self.make_event(
+                    "response.function_call_arguments.delta",
                     ResponsesStreamEvent {
-                        event_type: "response.output_item.added".to_owned(),
-                        item_id: None,
-                        output_index: Some(index),
-                        content_index: None,
-                        delta: None,
-                        call_id: None,
-                        name: None,
-                        arguments: None,
-                        item: Some(serde_json::json!({
-                            "type": "function_call",
-                            "id": item_id,
-                            "call_id": tool_call_id,
-                            "name": tool_name,
-                            "arguments": "",
-                            "status": "in_progress"
-                        })),
-                    },
-                    ResponsesStreamEvent {
-                        event_type: "response.function_call_arguments.delta".to_owned(),
-                        item_id: None,
-                        output_index: Some(index),
+                        event_type: String::new(),
+                        sequence_number: 0,
+                        response: None,
+                        item_id: Some(item_id),
+                        output_index: Some(output_index),
                         content_index: None,
                         delta: Some(tool_input.clone()),
-                        call_id: Some(tool_call_id.clone()),
+                        text: None,
+                        call_id: Some(call_id),
                         name: None,
                         arguments: None,
                         item: None,
+                        part: None,
                     },
+                ));
+                events.extend(self.close_tool_item(tool_call_id));
+            }
+            LanguageModelStreamPart::Finish { usage, .. } => {
+                events.extend(self.close_text_item());
+                events.extend(self.close_reasoning_item());
+                let pending: Vec<String> = self.tool_order.clone();
+                for id in pending {
+                    events.extend(self.close_tool_item(&id));
+                }
+                let response = self.build_completed_response(Some(usage));
+                events.push(self.make_event(
+                    "response.completed",
                     ResponsesStreamEvent {
-                        event_type: "response.function_call_arguments.done".to_owned(),
+                        event_type: String::new(),
+                        sequence_number: 0,
+                        response: Some(response),
                         item_id: None,
-                        output_index: Some(index),
+                        output_index: None,
                         content_index: None,
                         delta: None,
-                        call_id: Some(tool_call_id.clone()),
-                        name: None,
-                        arguments: Some(tool_input.clone()),
-                        item: None,
-                    },
-                    ResponsesStreamEvent {
-                        event_type: "response.output_item.done".to_owned(),
-                        item_id: None,
-                        output_index: Some(index),
-                        content_index: None,
-                        delta: None,
+                        text: None,
                         call_id: None,
                         name: None,
                         arguments: None,
-                        item: Some(item),
+                        item: None,
+                        part: None,
                     },
-                ]
+                ));
+                self.completed_emitted = true;
             }
-            LanguageModelStreamPart::ToolInputStart { id, tool_name, .. } => {
-                let index = self.next_output_index;
-                self.tool_id_to_index.insert(id.clone(), index);
-                self.next_output_index += 1;
-                let item_id = format!("fc-{}", generate_id());
-                vec![ResponsesStreamEvent {
-                    event_type: "response.output_item.added".to_owned(),
-                    item_id: None,
-                    output_index: Some(index),
-                    content_index: None,
-                    delta: None,
-                    call_id: None,
-                    name: Some(tool_name.clone()),
-                    arguments: None,
-                    item: Some(serde_json::json!({
-                        "type": "function_call",
-                        "id": item_id,
-                        "call_id": id,
-                        "name": tool_name,
-                        "arguments": "",
-                        "status": "in_progress"
-                    })),
-                }]
-            }
-            LanguageModelStreamPart::ToolInputDelta { id, delta, .. } => {
-                let index = self
-                    .tool_id_to_index
-                    .get(id)
-                    .copied()
-                    .unwrap_or(self.next_output_index);
-                vec![ResponsesStreamEvent {
-                    event_type: "response.function_call_arguments.delta".to_owned(),
-                    item_id: None,
-                    output_index: Some(index),
-                    content_index: None,
-                    delta: Some(delta.clone()),
-                    call_id: Some(id.clone()),
-                    name: None,
-                    arguments: None,
-                    item: None,
-                }]
-            }
-            LanguageModelStreamPart::ToolInputEnd { .. } => {
-                // No specific event needed; the arguments.done will come from
-                // the caller if needed, or the finish event signals completion.
-                vec![]
-            }
-            LanguageModelStreamPart::Finish { .. } => {
-                vec![ResponsesStreamEvent {
-                    event_type: "response.completed".to_owned(),
+            // Stream lifecycle markers without a direct Responses event.
+            LanguageModelStreamPart::StreamStart { .. }
+            | LanguageModelStreamPart::Raw { .. }
+            | LanguageModelStreamPart::Error { .. }
+            | LanguageModelStreamPart::File { .. }
+            | LanguageModelStreamPart::ToolApprovalRequest { .. }
+            | LanguageModelStreamPart::UrlSource { .. }
+            | LanguageModelStreamPart::DocumentSource { .. }
+            | LanguageModelStreamPart::ToolResult { .. } => {}
+        }
+
+        events
+    }
+
+    /// Closes any still-open items and emits a synthetic `response.completed`
+    /// if the upstream stream ended without a `Finish` part. Returns the
+    /// resulting events so the handler can flush them before tearing down
+    /// the SSE channel.
+    pub fn finish(&mut self) -> Vec<ResponsesStreamEvent> {
+        if self.completed_emitted {
+            return Vec::new();
+        }
+        let mut events = self.emit_created_if_needed();
+        events.extend(self.close_text_item());
+        events.extend(self.close_reasoning_item());
+        let pending: Vec<String> = self.tool_order.clone();
+        for id in pending {
+            events.extend(self.close_tool_item(&id));
+        }
+        let response = self.build_completed_response(None);
+        events.push(self.make_event(
+            "response.completed",
+            ResponsesStreamEvent {
+                event_type: String::new(),
+                sequence_number: 0,
+                response: Some(response),
+                item_id: None,
+                output_index: None,
+                content_index: None,
+                delta: None,
+                text: None,
+                call_id: None,
+                name: None,
+                arguments: None,
+                item: None,
+                part: None,
+            },
+        ));
+        self.completed_emitted = true;
+        events
+    }
+
+    fn emit_created_if_needed(&mut self) -> Vec<ResponsesStreamEvent> {
+        if self.created_emitted {
+            return Vec::new();
+        }
+        self.created_emitted = true;
+        let in_progress_response = self.build_in_progress_response();
+        vec![
+            self.make_event(
+                "response.created",
+                ResponsesStreamEvent {
+                    event_type: String::new(),
+                    sequence_number: 0,
+                    response: Some(in_progress_response.clone()),
                     item_id: None,
                     output_index: None,
                     content_index: None,
                     delta: None,
+                    text: None,
                     call_id: None,
                     name: None,
                     arguments: None,
                     item: None,
-                }]
-            }
-            _ => vec![],
+                    part: None,
+                },
+            ),
+            self.make_event(
+                "response.in_progress",
+                ResponsesStreamEvent {
+                    event_type: String::new(),
+                    sequence_number: 0,
+                    response: Some(in_progress_response),
+                    item_id: None,
+                    output_index: None,
+                    content_index: None,
+                    delta: None,
+                    text: None,
+                    call_id: None,
+                    name: None,
+                    arguments: None,
+                    item: None,
+                    part: None,
+                },
+            ),
+        ]
+    }
+
+    fn open_text_item(&mut self, events: &mut Vec<ResponsesStreamEvent>) {
+        if self.text_item.is_some() {
+            return;
         }
+        let output_index = self.next_output_index;
+        self.next_output_index += 1;
+        let item_id = format!("msg-{}", generate_id());
+        let state = MessageItemState {
+            item_id: item_id.clone(),
+            output_index,
+            accumulated_text: String::new(),
+        };
+        let in_progress_item = serde_json::json!({
+            "type": "message",
+            "id": item_id,
+            "role": "assistant",
+            "content": [],
+            "status": "in_progress",
+        });
+        events.push(self.make_event(
+            "response.output_item.added",
+            ResponsesStreamEvent {
+                event_type: String::new(),
+                sequence_number: 0,
+                response: None,
+                item_id: None,
+                output_index: Some(output_index),
+                content_index: None,
+                delta: None,
+                text: None,
+                call_id: None,
+                name: None,
+                arguments: None,
+                item: Some(in_progress_item),
+                part: None,
+            },
+        ));
+        let part = serde_json::json!({
+            "type": "output_text",
+            "text": "",
+            "annotations": [],
+        });
+        events.push(self.make_event(
+            "response.content_part.added",
+            ResponsesStreamEvent {
+                event_type: String::new(),
+                sequence_number: 0,
+                response: None,
+                item_id: Some(item_id),
+                output_index: Some(output_index),
+                content_index: Some(0),
+                delta: None,
+                text: None,
+                call_id: None,
+                name: None,
+                arguments: None,
+                item: None,
+                part: Some(part),
+            },
+        ));
+        self.text_item = Some(state);
+    }
+
+    fn close_text_item(&mut self) -> Vec<ResponsesStreamEvent> {
+        let Some(state) = self.text_item.take() else {
+            return Vec::new();
+        };
+        let final_text = state.accumulated_text.clone();
+        let part = serde_json::json!({
+            "type": "output_text",
+            "text": final_text,
+            "annotations": [],
+        });
+        let final_item = serde_json::json!({
+            "type": "message",
+            "id": state.item_id,
+            "role": "assistant",
+            "content": [part.clone()],
+            "status": "completed",
+        });
+        self.completed_output.push(ResponsesOutputItem::Message {
+            id: Some(state.item_id.clone()),
+            role: Some("assistant".to_owned()),
+            content: vec![ResponsesOutputContent::OutputText {
+                text: final_text.clone(),
+            }],
+            status: Some("completed".to_owned()),
+        });
+        let mut events = Vec::with_capacity(4);
+        events.push(self.make_event(
+            "response.output_text.done",
+            ResponsesStreamEvent {
+                event_type: String::new(),
+                sequence_number: 0,
+                response: None,
+                item_id: Some(state.item_id.clone()),
+                output_index: Some(state.output_index),
+                content_index: Some(0),
+                delta: None,
+                text: Some(final_text),
+                call_id: None,
+                name: None,
+                arguments: None,
+                item: None,
+                part: None,
+            },
+        ));
+        events.push(self.make_event(
+            "response.content_part.done",
+            ResponsesStreamEvent {
+                event_type: String::new(),
+                sequence_number: 0,
+                response: None,
+                item_id: Some(state.item_id.clone()),
+                output_index: Some(state.output_index),
+                content_index: Some(0),
+                delta: None,
+                text: None,
+                call_id: None,
+                name: None,
+                arguments: None,
+                item: None,
+                part: Some(part),
+            },
+        ));
+        events.push(self.make_event(
+            "response.output_item.done",
+            ResponsesStreamEvent {
+                event_type: String::new(),
+                sequence_number: 0,
+                response: None,
+                item_id: None,
+                output_index: Some(state.output_index),
+                content_index: None,
+                delta: None,
+                text: None,
+                call_id: None,
+                name: None,
+                arguments: None,
+                item: Some(final_item),
+                part: None,
+            },
+        ));
+        events
+    }
+
+    fn open_reasoning_item(&mut self, events: &mut Vec<ResponsesStreamEvent>) {
+        if self.reasoning_item.is_some() {
+            return;
+        }
+        let output_index = self.next_output_index;
+        self.next_output_index += 1;
+        let item_id = format!("rs-{}", generate_id());
+        let state = ReasoningItemState {
+            item_id: item_id.clone(),
+            output_index,
+            accumulated_text: String::new(),
+        };
+        let in_progress_item = serde_json::json!({
+            "type": "reasoning",
+            "id": item_id,
+            "summary": [],
+            "content": [],
+            "status": "in_progress",
+        });
+        events.push(self.make_event(
+            "response.output_item.added",
+            ResponsesStreamEvent {
+                event_type: String::new(),
+                sequence_number: 0,
+                response: None,
+                item_id: None,
+                output_index: Some(output_index),
+                content_index: None,
+                delta: None,
+                text: None,
+                call_id: None,
+                name: None,
+                arguments: None,
+                item: Some(in_progress_item),
+                part: None,
+            },
+        ));
+        let part = serde_json::json!({
+            "type": "reasoning_text",
+            "text": "",
+        });
+        events.push(self.make_event(
+            "response.content_part.added",
+            ResponsesStreamEvent {
+                event_type: String::new(),
+                sequence_number: 0,
+                response: None,
+                item_id: Some(item_id),
+                output_index: Some(output_index),
+                content_index: Some(0),
+                delta: None,
+                text: None,
+                call_id: None,
+                name: None,
+                arguments: None,
+                item: None,
+                part: Some(part),
+            },
+        ));
+        self.reasoning_item = Some(state);
+    }
+
+    fn close_reasoning_item(&mut self) -> Vec<ResponsesStreamEvent> {
+        let Some(state) = self.reasoning_item.take() else {
+            return Vec::new();
+        };
+        let final_text = state.accumulated_text.clone();
+        let part = serde_json::json!({
+            "type": "reasoning_text",
+            "text": final_text,
+        });
+        let final_item = serde_json::json!({
+            "type": "reasoning",
+            "id": state.item_id,
+            "summary": [],
+            "content": [part.clone()],
+            "status": "completed",
+        });
+        let mut events = Vec::with_capacity(3);
+        events.push(self.make_event(
+            "response.reasoning_text.done",
+            ResponsesStreamEvent {
+                event_type: String::new(),
+                sequence_number: 0,
+                response: None,
+                item_id: Some(state.item_id.clone()),
+                output_index: Some(state.output_index),
+                content_index: Some(0),
+                delta: None,
+                text: Some(final_text),
+                call_id: None,
+                name: None,
+                arguments: None,
+                item: None,
+                part: None,
+            },
+        ));
+        events.push(self.make_event(
+            "response.content_part.done",
+            ResponsesStreamEvent {
+                event_type: String::new(),
+                sequence_number: 0,
+                response: None,
+                item_id: Some(state.item_id.clone()),
+                output_index: Some(state.output_index),
+                content_index: Some(0),
+                delta: None,
+                text: None,
+                call_id: None,
+                name: None,
+                arguments: None,
+                item: None,
+                part: Some(part),
+            },
+        ));
+        events.push(self.make_event(
+            "response.output_item.done",
+            ResponsesStreamEvent {
+                event_type: String::new(),
+                sequence_number: 0,
+                response: None,
+                item_id: None,
+                output_index: Some(state.output_index),
+                content_index: None,
+                delta: None,
+                text: None,
+                call_id: None,
+                name: None,
+                arguments: None,
+                item: Some(final_item),
+                part: None,
+            },
+        ));
+        events
+    }
+
+    fn open_tool_item(
+        &mut self,
+        upstream_id: &str,
+        tool_name: &str,
+        events: &mut Vec<ResponsesStreamEvent>,
+    ) {
+        if self.tool_items.contains_key(upstream_id) {
+            return;
+        }
+        let output_index = self.next_output_index;
+        self.next_output_index += 1;
+        let item_id = format!("fc-{}", generate_id());
+        let state = ToolItemState {
+            item_id: item_id.clone(),
+            output_index,
+            call_id: upstream_id.to_owned(),
+            tool_name: tool_name.to_owned(),
+            accumulated_args: String::new(),
+        };
+        let in_progress_item = serde_json::json!({
+            "type": "function_call",
+            "id": item_id,
+            "call_id": upstream_id,
+            "name": tool_name,
+            "arguments": "",
+            "status": "in_progress",
+        });
+        events.push(self.make_event(
+            "response.output_item.added",
+            ResponsesStreamEvent {
+                event_type: String::new(),
+                sequence_number: 0,
+                response: None,
+                item_id: None,
+                output_index: Some(output_index),
+                content_index: None,
+                delta: None,
+                text: None,
+                call_id: None,
+                name: None,
+                arguments: None,
+                item: Some(in_progress_item),
+                part: None,
+            },
+        ));
+        self.tool_items.insert(upstream_id.to_owned(), state);
+        self.tool_order.push(upstream_id.to_owned());
+    }
+
+    fn close_tool_item(&mut self, upstream_id: &str) -> Vec<ResponsesStreamEvent> {
+        let Some(state) = self.tool_items.remove(upstream_id) else {
+            return Vec::new();
+        };
+        self.tool_order.retain(|id| id != upstream_id);
+        let final_args = state.accumulated_args.clone();
+        let final_item = serde_json::json!({
+            "type": "function_call",
+            "id": state.item_id,
+            "call_id": state.call_id,
+            "name": state.tool_name,
+            "arguments": final_args,
+            "status": "completed",
+        });
+        self.completed_output
+            .push(ResponsesOutputItem::FunctionCall {
+                id: Some(state.item_id.clone()),
+                call_id: state.call_id.clone(),
+                name: state.tool_name.clone(),
+                arguments: final_args.clone(),
+                status: Some("completed".to_owned()),
+            });
+        let mut events = Vec::with_capacity(2);
+        events.push(self.make_event(
+            "response.function_call_arguments.done",
+            ResponsesStreamEvent {
+                event_type: String::new(),
+                sequence_number: 0,
+                response: None,
+                item_id: Some(state.item_id.clone()),
+                output_index: Some(state.output_index),
+                content_index: None,
+                delta: None,
+                text: None,
+                call_id: Some(state.call_id),
+                name: None,
+                arguments: Some(final_args),
+                item: None,
+                part: None,
+            },
+        ));
+        events.push(self.make_event(
+            "response.output_item.done",
+            ResponsesStreamEvent {
+                event_type: String::new(),
+                sequence_number: 0,
+                response: None,
+                item_id: None,
+                output_index: Some(state.output_index),
+                content_index: None,
+                delta: None,
+                text: None,
+                call_id: None,
+                name: None,
+                arguments: None,
+                item: Some(final_item),
+                part: None,
+            },
+        ));
+        events
+    }
+
+    fn build_in_progress_response(&self) -> ResponsesResponse {
+        ResponsesResponse {
+            id: self.response_id.clone(),
+            object: Some("response".to_owned()),
+            created_at: self.created_at,
+            model: self.model_id.clone(),
+            output: Vec::new(),
+            usage: None,
+            status: Some("in_progress".to_owned()),
+            incomplete_details: None,
+            error: None,
+        }
+    }
+
+    fn build_completed_response(
+        &self,
+        usage: Option<&crate::models::language::usage::LanguageModelUsage>,
+    ) -> ResponsesResponse {
+        let usage = usage.map(|u| ResponsesUsage {
+            input_tokens: u.input_tokens.total,
+            output_tokens: u.output_tokens.total,
+            total_tokens: u
+                .input_tokens
+                .total
+                .zip(u.output_tokens.total)
+                .map(|(i, o)| i + o),
+            input_tokens_details: None,
+            output_tokens_details: None,
+        });
+        ResponsesResponse {
+            id: self.response_id.clone(),
+            object: Some("response".to_owned()),
+            created_at: self.created_at,
+            model: self.model_id.clone(),
+            output: self.completed_output.clone(),
+            usage,
+            status: Some("completed".to_owned()),
+            incomplete_details: None,
+            error: None,
+        }
+    }
+
+    fn make_event(
+        &mut self,
+        event_type: &str,
+        mut event: ResponsesStreamEvent,
+    ) -> ResponsesStreamEvent {
+        event.event_type = event_type.to_owned();
+        event.sequence_number = self.sequence_number;
+        self.sequence_number += 1;
+        event
     }
 }
 
@@ -774,31 +1411,40 @@ mod tests {
     fn serialize_streaming_events() {
         let text_delta = ResponsesStreamEvent {
             event_type: "response.output_text.delta".to_owned(),
-            item_id: None,
+            sequence_number: 5,
+            response: None,
+            item_id: Some("msg-1".to_owned()),
             output_index: Some(0),
             content_index: Some(0),
             delta: Some("Hello".to_owned()),
+            text: None,
             call_id: None,
             name: None,
             arguments: None,
             item: None,
+            part: None,
         };
         let val = serde_json::to_value(&text_delta).expect("serialize failed");
         assert_eq!(val["type"], "response.output_text.delta");
+        assert_eq!(val["sequence_number"], 5);
         assert_eq!(val["delta"], "Hello");
         assert_eq!(val["output_index"], 0);
         assert_eq!(val["content_index"], 0);
 
         let fn_delta = ResponsesStreamEvent {
             event_type: "response.function_call_arguments.delta".to_owned(),
-            item_id: None,
+            sequence_number: 6,
+            response: None,
+            item_id: Some("fc-1".to_owned()),
             output_index: Some(1),
             content_index: None,
             delta: Some(r#"{"loc"#.to_owned()),
+            text: None,
             call_id: Some("call_1".to_owned()),
             name: None,
             arguments: None,
             item: None,
+            part: None,
         };
         let val = serde_json::to_value(&fn_delta).expect("serialize failed");
         assert_eq!(val["type"], "response.function_call_arguments.delta");
@@ -807,14 +1453,18 @@ mod tests {
 
         let completed = ResponsesStreamEvent {
             event_type: "response.completed".to_owned(),
+            sequence_number: 7,
+            response: None,
             item_id: None,
             output_index: None,
             content_index: None,
             delta: None,
+            text: None,
             call_id: None,
             name: None,
             arguments: None,
             item: None,
+            part: None,
         };
         let val = serde_json::to_value(&completed).expect("serialize failed");
         assert_eq!(val["type"], "response.completed");
@@ -1145,64 +1795,100 @@ mod tests {
     // ── Conversion: StreamConverter ─────────────────────────────────────
 
     #[test]
-    fn stream_converter_text_delta() {
-        let mut conv = StreamConverter::new();
+    fn stream_converter_text_delta_emits_full_lifecycle_prefix() {
+        // The first delta of a stream must be preceded by the canonical
+        // lifecycle preamble — `response.created`, `response.in_progress`,
+        // `response.output_item.added` (message), `response.content_part.added`
+        // (output_text) — before the actual `response.output_text.delta`.
+        // Codex CLI errors on streams that skip any of these and retries.
+        // https://platform.openai.com/docs/api-reference/responses-streaming
+        let mut conv = StreamConverter::new("test-model");
         let part = LanguageModelStreamPart::TextDelta {
             id: "t1".to_owned(),
             delta: "Hello".to_owned(),
             provider_metadata: None,
         };
         let events = conv.convert(&part);
-        assert_eq!(events.len(), 1);
-        assert_eq!(events[0].event_type, "response.output_text.delta");
-        assert_eq!(events[0].delta.as_deref(), Some("Hello"));
-        assert_eq!(events[0].output_index, Some(0));
-        assert_eq!(events[0].content_index, Some(0));
+        assert_eq!(events.len(), 5);
+        assert_eq!(events[0].event_type, "response.created");
+        assert!(events[0].response.is_some());
+        assert_eq!(events[1].event_type, "response.in_progress");
+        assert_eq!(events[2].event_type, "response.output_item.added");
+        let item = events[2].item.as_ref().expect("item present");
+        assert_eq!(item["type"], "message");
+        assert_eq!(item["status"], "in_progress");
+        assert_eq!(events[3].event_type, "response.content_part.added");
+        let part = events[3].part.as_ref().expect("part present");
+        assert_eq!(part["type"], "output_text");
+        assert_eq!(events[4].event_type, "response.output_text.delta");
+        assert_eq!(events[4].delta.as_deref(), Some("Hello"));
+        assert_eq!(events[4].output_index, Some(0));
+        assert_eq!(events[4].content_index, Some(0));
+
+        // Every event must carry a monotonic sequence_number starting from 0.
+        for (i, e) in events.iter().enumerate() {
+            assert_eq!(e.sequence_number, i as u64);
+        }
     }
 
     #[test]
-    fn stream_converter_reasoning_delta_emits_reasoning_text_delta() {
+    fn stream_converter_reasoning_delta_emits_reasoning_lifecycle() {
         // Regression test for issue #448: ReasoningDelta must surface as
-        // a `response.reasoning_text.delta` event so Responses-format
+        // `response.reasoning_text.delta` wrapped in a reasoning output
+        // item, with the full lifecycle preamble so Responses-format
         // clients render thinking in real time.
-        let mut conv = StreamConverter::new();
+        let mut conv = StreamConverter::new("test-model");
         let events = conv.convert(&LanguageModelStreamPart::ReasoningDelta {
             id: "r1".to_owned(),
             delta: "Hmm".to_owned(),
             provider_metadata: None,
         });
-        assert_eq!(events.len(), 1);
-        assert_eq!(events[0].event_type, "response.reasoning_text.delta");
-        assert_eq!(events[0].delta.as_deref(), Some("Hmm"));
+        assert_eq!(events[0].event_type, "response.created");
+        assert_eq!(events[1].event_type, "response.in_progress");
+        assert_eq!(events[2].event_type, "response.output_item.added");
+        assert_eq!(events[2].item.as_ref().expect("item")["type"], "reasoning");
+        assert_eq!(events[3].event_type, "response.content_part.added");
+        assert_eq!(
+            events[3].part.as_ref().expect("part")["type"],
+            "reasoning_text"
+        );
+        assert_eq!(events[4].event_type, "response.reasoning_text.delta");
+        assert_eq!(events[4].delta.as_deref(), Some("Hmm"));
     }
 
     #[test]
-    fn stream_converter_reasoning_end_emits_reasoning_text_done() {
-        let mut conv = StreamConverter::new();
+    fn stream_converter_reasoning_end_closes_open_item() {
+        // ReasoningEnd received before any reasoning content opened the
+        // item: emit only the lifecycle preamble (no spurious .done).
+        let mut conv = StreamConverter::new("test-model");
         let events = conv.convert(&LanguageModelStreamPart::ReasoningEnd {
             id: "r1".to_owned(),
             provider_metadata: None,
         });
-        assert_eq!(events.len(), 1);
-        assert_eq!(events[0].event_type, "response.reasoning_text.done");
-        assert!(events[0].delta.is_none());
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].event_type, "response.created");
+        assert_eq!(events[1].event_type, "response.in_progress");
     }
 
     #[test]
-    fn stream_converter_reasoning_start_swallowed() {
-        // ReasoningStart has no dedicated Responses event; the first
-        // `.delta` is sufficient. Must produce zero events.
-        let mut conv = StreamConverter::new();
+    fn stream_converter_reasoning_start_opens_item() {
+        // ReasoningStart eagerly opens the reasoning output item so
+        // subsequent deltas can attach without further preamble.
+        let mut conv = StreamConverter::new("test-model");
         let events = conv.convert(&LanguageModelStreamPart::ReasoningStart {
             id: "r1".to_owned(),
             provider_metadata: None,
         });
-        assert!(events.is_empty());
+        assert_eq!(events.len(), 4);
+        assert_eq!(events[0].event_type, "response.created");
+        assert_eq!(events[1].event_type, "response.in_progress");
+        assert_eq!(events[2].event_type, "response.output_item.added");
+        assert_eq!(events[3].event_type, "response.content_part.added");
     }
 
     #[test]
-    fn stream_converter_tool_call() {
-        let mut conv = StreamConverter::new();
+    fn stream_converter_tool_call_emits_lifecycle_and_function_call_events() {
+        let mut conv = StreamConverter::new("test-model");
         let part = LanguageModelStreamPart::ToolCall {
             tool_call_id: "call_full".to_owned(),
             tool_name: "calculator".to_owned(),
@@ -1212,42 +1898,37 @@ mod tests {
             provider_metadata: None,
         };
         let events = conv.convert(&part);
-        assert_eq!(events.len(), 4);
-
-        // First: output_item.added
-        assert_eq!(events[0].event_type, "response.output_item.added");
-        assert_eq!(events[0].output_index, Some(0));
-        let item = events[0].item.as_ref().expect("item missing");
+        // created, in_progress, output_item.added, function_call_arguments.delta,
+        // function_call_arguments.done, output_item.done
+        assert_eq!(events.len(), 6);
+        assert_eq!(events[0].event_type, "response.created");
+        assert_eq!(events[1].event_type, "response.in_progress");
+        assert_eq!(events[2].event_type, "response.output_item.added");
+        let item = events[2].item.as_ref().expect("item missing");
         assert_eq!(item["type"], "function_call");
         assert_eq!(item["status"], "in_progress");
-
-        // Second: function_call_arguments.delta
         assert_eq!(
-            events[1].event_type,
+            events[3].event_type,
             "response.function_call_arguments.delta"
         );
-        assert_eq!(events[1].delta.as_deref(), Some(r#"{"expr":"2+2"}"#));
-        assert_eq!(events[1].call_id.as_deref(), Some("call_full"));
-
-        // Third: function_call_arguments.done
+        assert_eq!(events[3].delta.as_deref(), Some(r#"{"expr":"2+2"}"#));
+        assert_eq!(events[3].call_id.as_deref(), Some("call_full"));
         assert_eq!(
-            events[2].event_type,
+            events[4].event_type,
             "response.function_call_arguments.done"
         );
-        assert_eq!(events[2].arguments.as_deref(), Some(r#"{"expr":"2+2"}"#));
-
-        // Fourth: output_item.done
-        assert_eq!(events[3].event_type, "response.output_item.done");
-        let done_item = events[3].item.as_ref().expect("item missing");
+        assert_eq!(events[4].arguments.as_deref(), Some(r#"{"expr":"2+2"}"#));
+        assert_eq!(events[5].event_type, "response.output_item.done");
+        let done_item = events[5].item.as_ref().expect("item missing");
         assert_eq!(done_item["status"], "completed");
         assert_eq!(done_item["name"], "calculator");
     }
 
     #[test]
     fn stream_converter_tool_input_start_delta() {
-        let mut conv = StreamConverter::new();
+        let mut conv = StreamConverter::new("test-model");
 
-        // Start event
+        // Start event: created + in_progress + output_item.added
         let start = LanguageModelStreamPart::ToolInputStart {
             id: "call_a".to_owned(),
             tool_name: "search".to_owned(),
@@ -1257,16 +1938,14 @@ mod tests {
             provider_metadata: None,
         };
         let events = conv.convert(&start);
-        assert_eq!(events.len(), 1);
-        assert_eq!(events[0].event_type, "response.output_item.added");
-        assert_eq!(events[0].output_index, Some(0));
-        assert_eq!(events[0].name.as_deref(), Some("search"));
-        let item = events[0].item.as_ref().expect("item missing");
+        assert_eq!(events.len(), 3);
+        assert_eq!(events[2].event_type, "response.output_item.added");
+        let item = events[2].item.as_ref().expect("item missing");
         assert_eq!(item["type"], "function_call");
         assert_eq!(item["name"], "search");
         assert_eq!(item["status"], "in_progress");
 
-        // Delta event uses the tracked index
+        // Delta event: function_call_arguments.delta only
         let delta = LanguageModelStreamPart::ToolInputDelta {
             id: "call_a".to_owned(),
             delta: r#"{"query":"rust"}"#.to_owned(),
@@ -1284,45 +1963,154 @@ mod tests {
     }
 
     #[test]
-    fn stream_converter_tool_input_end_is_empty() {
-        let mut conv = StreamConverter::new();
-        let part = LanguageModelStreamPart::ToolInputEnd {
+    fn stream_converter_tool_input_end_emits_done_when_open() {
+        let mut conv = StreamConverter::new("test-model");
+        // Open first, then close.
+        conv.convert(&LanguageModelStreamPart::ToolInputStart {
+            id: "call_a".to_owned(),
+            tool_name: "search".to_owned(),
+            provider_executed: None,
+            dynamic: None,
+            title: None,
+            provider_metadata: None,
+        });
+        let events = conv.convert(&LanguageModelStreamPart::ToolInputEnd {
             id: "call_a".to_owned(),
             provider_metadata: None,
-        };
-        let events = conv.convert(&part);
-        assert!(events.is_empty());
+        });
+        assert_eq!(events.len(), 2);
+        assert_eq!(
+            events[0].event_type,
+            "response.function_call_arguments.done"
+        );
+        assert_eq!(events[1].event_type, "response.output_item.done");
     }
 
     #[test]
-    fn stream_converter_finish() {
-        let mut conv = StreamConverter::new();
-        let part = LanguageModelStreamPart::Finish {
+    fn stream_converter_finish_emits_completed_with_usage_and_output() {
+        let mut conv = StreamConverter::new("test-model");
+        // Emit some text first so the final response has output items.
+        conv.convert(&LanguageModelStreamPart::TextDelta {
+            id: "t1".to_owned(),
+            delta: "Hello".to_owned(),
+            provider_metadata: None,
+        });
+        let events = conv.convert(&LanguageModelStreamPart::Finish {
             usage: make_usage(25, 30),
             finish_reason: LanguageModelFinishReason::Stop,
             provider_metadata: None,
-        };
-        let events = conv.convert(&part);
-        assert_eq!(events.len(), 1);
-        assert_eq!(events[0].event_type, "response.completed");
-        assert!(events[0].delta.is_none());
-        assert!(events[0].output_index.is_none());
+        });
+        // output_text.done, content_part.done, output_item.done, response.completed
+        assert_eq!(events.len(), 4);
+        assert_eq!(events[3].event_type, "response.completed");
+        let resp = events[3].response.as_ref().expect("response present");
+        let usage = resp.usage.as_ref().expect("usage present");
+        assert_eq!(usage.input_tokens, Some(25));
+        assert_eq!(usage.output_tokens, Some(30));
+        assert_eq!(usage.total_tokens, Some(55));
+        assert_eq!(resp.status.as_deref(), Some("completed"));
+        assert_eq!(resp.output.len(), 1);
     }
 
     #[test]
-    fn stream_converter_ignores_unknown_parts() {
-        let mut conv = StreamConverter::new();
+    fn stream_converter_text_start_opens_message_item() {
+        let mut conv = StreamConverter::new("test-model");
         let part = LanguageModelStreamPart::TextStart {
             id: "t1".to_owned(),
             provider_metadata: None,
         };
         let events = conv.convert(&part);
-        assert!(events.is_empty());
+        assert_eq!(events.len(), 4);
+        assert_eq!(events[0].event_type, "response.created");
+        assert_eq!(events[1].event_type, "response.in_progress");
+        assert_eq!(events[2].event_type, "response.output_item.added");
+        assert_eq!(events[3].event_type, "response.content_part.added");
+    }
+
+    #[test]
+    fn stream_converter_finish_method_synthesizes_completed() {
+        // If the upstream closes without a Finish part, the handler is
+        // expected to call `finish()` to terminate the SSE stream with a
+        // valid `response.completed` envelope. Otherwise Codex CLI raises
+        // "stream closed before response.completed" and retries.
+        let mut conv = StreamConverter::new("test-model");
+        conv.convert(&LanguageModelStreamPart::TextDelta {
+            id: "t1".to_owned(),
+            delta: "Hi".to_owned(),
+            provider_metadata: None,
+        });
+        let events = conv.finish();
+        assert!(events.iter().any(|e| e.event_type == "response.completed"));
+    }
+
+    #[test]
+    fn stream_converter_no_done_terminator_emitted() {
+        // The Responses streaming protocol terminates with `response.completed`,
+        // not with a `[DONE]` sentinel. The converter must never emit one.
+        let mut conv = StreamConverter::new("test-model");
+        let mut all_events = Vec::new();
+        all_events.extend(conv.convert(&LanguageModelStreamPart::TextDelta {
+            id: "t1".to_owned(),
+            delta: "x".to_owned(),
+            provider_metadata: None,
+        }));
+        all_events.extend(conv.convert(&LanguageModelStreamPart::Finish {
+            usage: make_usage(1, 1),
+            finish_reason: LanguageModelFinishReason::Stop,
+            provider_metadata: None,
+        }));
+        assert!(all_events.iter().all(|e| !e.event_type.contains("[DONE]")
+            && e.event_type != "done"
+            && e.delta.as_deref() != Some("[DONE]")));
+    }
+
+    #[test]
+    fn stream_converter_sequence_numbers_monotonic_across_calls() {
+        let mut conv = StreamConverter::new("test-model");
+        let mut all = Vec::new();
+        all.extend(conv.convert(&LanguageModelStreamPart::TextDelta {
+            id: "t1".to_owned(),
+            delta: "a".to_owned(),
+            provider_metadata: None,
+        }));
+        all.extend(conv.convert(&LanguageModelStreamPart::TextDelta {
+            id: "t1".to_owned(),
+            delta: "b".to_owned(),
+            provider_metadata: None,
+        }));
+        all.extend(conv.convert(&LanguageModelStreamPart::Finish {
+            usage: make_usage(1, 1),
+            finish_reason: LanguageModelFinishReason::Stop,
+            provider_metadata: None,
+        }));
+        for (i, e) in all.iter().enumerate() {
+            assert_eq!(e.sequence_number, i as u64, "event {i}: {:?}", e.event_type);
+        }
+    }
+
+    #[test]
+    fn stream_converter_response_id_adopts_upstream_metadata() {
+        // When the upstream provides a response id via ResponseMetadata,
+        // the converter must adopt it *before* emitting `response.created`
+        // so the envelope carries the canonical id for downstream chaining
+        // via `previous_response_id`.
+        let mut conv = StreamConverter::new("test-model");
+        let preamble = conv.convert(&LanguageModelStreamPart::ResponseMetadata {
+            id: Some("resp-from-upstream".to_owned()),
+            timestamp: None,
+            model_id: None,
+        });
+        let created = preamble
+            .iter()
+            .find(|e| e.event_type == "response.created")
+            .and_then(|e| e.response.as_ref())
+            .expect("response.created present with response envelope");
+        assert_eq!(created.id, "resp-from-upstream");
     }
 
     #[test]
     fn stream_converter_multiple_tools_sequential_indices() {
-        let mut conv = StreamConverter::new();
+        let mut conv = StreamConverter::new("test-model");
 
         let start1 = LanguageModelStreamPart::ToolInputStart {
             id: "call_a".to_owned(),
@@ -1333,7 +2121,11 @@ mod tests {
             provider_metadata: None,
         };
         let events1 = conv.convert(&start1);
-        assert_eq!(events1[0].output_index, Some(0));
+        let added1 = events1
+            .iter()
+            .find(|e| e.event_type == "response.output_item.added")
+            .expect("output_item.added present");
+        assert_eq!(added1.output_index, Some(0));
 
         let start2 = LanguageModelStreamPart::ToolInputStart {
             id: "call_b".to_owned(),
@@ -1344,7 +2136,11 @@ mod tests {
             provider_metadata: None,
         };
         let events2 = conv.convert(&start2);
-        assert_eq!(events2[0].output_index, Some(1));
+        let added2 = events2
+            .iter()
+            .find(|e| e.event_type == "response.output_item.added")
+            .expect("output_item.added present");
+        assert_eq!(added2.output_index, Some(1));
     }
 
     // ── extract_model_name ──────────────────────────────────────────────

--- a/bitrouter-core/src/api/openai/responses/convert.rs
+++ b/bitrouter-core/src/api/openai/responses/convert.rs
@@ -734,62 +734,64 @@ impl StreamConverter {
             "content": [part.clone()],
             "status": "completed",
         });
-        let mut events = Vec::with_capacity(3);
-        events.push(self.make_event(
-            "response.reasoning_text.done",
-            ResponsesStreamEvent {
-                event_type: String::new(),
-                sequence_number: 0,
-                response: None,
-                item_id: Some(state.item_id.clone()),
-                output_index: Some(state.output_index),
-                content_index: Some(0),
-                delta: None,
-                text: Some(final_text),
-                call_id: None,
-                name: None,
-                arguments: None,
-                item: None,
-                part: None,
-            },
-        ));
-        events.push(self.make_event(
-            "response.content_part.done",
-            ResponsesStreamEvent {
-                event_type: String::new(),
-                sequence_number: 0,
-                response: None,
-                item_id: Some(state.item_id.clone()),
-                output_index: Some(state.output_index),
-                content_index: Some(0),
-                delta: None,
-                text: None,
-                call_id: None,
-                name: None,
-                arguments: None,
-                item: None,
-                part: Some(part),
-            },
-        ));
-        events.push(self.make_event(
-            "response.output_item.done",
-            ResponsesStreamEvent {
-                event_type: String::new(),
-                sequence_number: 0,
-                response: None,
-                item_id: None,
-                output_index: Some(state.output_index),
-                content_index: None,
-                delta: None,
-                text: None,
-                call_id: None,
-                name: None,
-                arguments: None,
-                item: Some(final_item),
-                part: None,
-            },
-        ));
-        events
+        // `vec!` ordering is left-to-right, so `make_event` is invoked once
+        // per slot and `sequence_number` is assigned in emission order.
+        vec![
+            self.make_event(
+                "response.reasoning_text.done",
+                ResponsesStreamEvent {
+                    event_type: String::new(),
+                    sequence_number: 0,
+                    response: None,
+                    item_id: Some(state.item_id.clone()),
+                    output_index: Some(state.output_index),
+                    content_index: Some(0),
+                    delta: None,
+                    text: Some(final_text),
+                    call_id: None,
+                    name: None,
+                    arguments: None,
+                    item: None,
+                    part: None,
+                },
+            ),
+            self.make_event(
+                "response.content_part.done",
+                ResponsesStreamEvent {
+                    event_type: String::new(),
+                    sequence_number: 0,
+                    response: None,
+                    item_id: Some(state.item_id.clone()),
+                    output_index: Some(state.output_index),
+                    content_index: Some(0),
+                    delta: None,
+                    text: None,
+                    call_id: None,
+                    name: None,
+                    arguments: None,
+                    item: None,
+                    part: Some(part),
+                },
+            ),
+            self.make_event(
+                "response.output_item.done",
+                ResponsesStreamEvent {
+                    event_type: String::new(),
+                    sequence_number: 0,
+                    response: None,
+                    item_id: None,
+                    output_index: Some(state.output_index),
+                    content_index: None,
+                    delta: None,
+                    text: None,
+                    call_id: None,
+                    name: None,
+                    arguments: None,
+                    item: Some(final_item),
+                    part: None,
+                },
+            ),
+        ]
     }
 
     fn open_tool_item(
@@ -863,44 +865,44 @@ impl StreamConverter {
                 arguments: final_args.clone(),
                 status: Some("completed".to_owned()),
             });
-        let mut events = Vec::with_capacity(2);
-        events.push(self.make_event(
-            "response.function_call_arguments.done",
-            ResponsesStreamEvent {
-                event_type: String::new(),
-                sequence_number: 0,
-                response: None,
-                item_id: Some(state.item_id.clone()),
-                output_index: Some(state.output_index),
-                content_index: None,
-                delta: None,
-                text: None,
-                call_id: Some(state.call_id),
-                name: None,
-                arguments: Some(final_args),
-                item: None,
-                part: None,
-            },
-        ));
-        events.push(self.make_event(
-            "response.output_item.done",
-            ResponsesStreamEvent {
-                event_type: String::new(),
-                sequence_number: 0,
-                response: None,
-                item_id: None,
-                output_index: Some(state.output_index),
-                content_index: None,
-                delta: None,
-                text: None,
-                call_id: None,
-                name: None,
-                arguments: None,
-                item: Some(final_item),
-                part: None,
-            },
-        ));
-        events
+        vec![
+            self.make_event(
+                "response.function_call_arguments.done",
+                ResponsesStreamEvent {
+                    event_type: String::new(),
+                    sequence_number: 0,
+                    response: None,
+                    item_id: Some(state.item_id.clone()),
+                    output_index: Some(state.output_index),
+                    content_index: None,
+                    delta: None,
+                    text: None,
+                    call_id: Some(state.call_id),
+                    name: None,
+                    arguments: Some(final_args),
+                    item: None,
+                    part: None,
+                },
+            ),
+            self.make_event(
+                "response.output_item.done",
+                ResponsesStreamEvent {
+                    event_type: String::new(),
+                    sequence_number: 0,
+                    response: None,
+                    item_id: None,
+                    output_index: Some(state.output_index),
+                    content_index: None,
+                    delta: None,
+                    text: None,
+                    call_id: None,
+                    name: None,
+                    arguments: None,
+                    item: Some(final_item),
+                    part: None,
+                },
+            ),
+        ]
     }
 
     fn build_in_progress_response(&self) -> ResponsesResponse {

--- a/bitrouter-core/src/api/openai/responses/types.rs
+++ b/bitrouter-core/src/api/openai/responses/types.rs
@@ -13,6 +13,12 @@ use serde::{Deserialize, Serialize};
 pub struct ResponsesRequest {
     pub model: String,
     pub input: ResponsesInput,
+    /// Top-level developer prompt (Codex CLI sends the entire system prompt
+    /// here rather than as a system message). Mapped to a System message at
+    /// the head of the prompt in `to_call_options`.
+    /// <https://platform.openai.com/docs/api-reference/responses/create#responses-create-instructions>
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub instructions: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub temperature: Option<f32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -54,17 +60,26 @@ pub enum ResponsesInput {
 /// Input items for the Responses API.
 ///
 /// Uses `#[serde(untagged)]` so proxy clients can omit the `"type"` field on
-/// message items.  Variants are ordered most-specific-first so serde tries the
+/// message items. Variants are ordered most-specific-first so serde tries the
 /// variant with more required fields before the less specific one.
 ///
 /// Each inner struct carries a `type` field with a default value so that
 /// serialisation always includes the discriminator required by the upstream API.
+///
+/// The final `Unknown` variant is a permissive catch-all that lets unfamiliar
+/// item types (e.g. `reasoning`, `web_search_call`, `local_shell_call`,
+/// `image_generation_call`) deserialize without rejecting the whole request.
+/// Codex CLI surfaces all of these in `input` on multi-turn requests; the
+/// upstream models bitrouter routes to can't consume them, so we accept and
+/// silently drop them downstream.
+/// <https://platform.openai.com/docs/api-reference/responses/create>
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum ResponsesInputItem {
     FunctionCall(ResponsesInputFunctionCall),
     FunctionCallOutput(ResponsesInputFunctionCallOutput),
     Message(ResponsesInputMessage),
+    Unknown(serde_json::Value),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -85,7 +100,12 @@ pub struct ResponsesInputFunctionCallOutput {
     #[serde(rename = "type", default = "default_function_call_output_type")]
     pub item_type: String,
     pub call_id: String,
-    pub output: String,
+    /// Wire encoding may be either a plain string or an object with
+    /// `content` / `content_items` (the structured form Codex sends for
+    /// multimodal tool outputs). We accept any JSON value here and stringify
+    /// downstream so the routed model receives a plain-text representation.
+    /// <https://platform.openai.com/docs/api-reference/responses/create#input>
+    pub output: serde_json::Value,
 }
 
 fn default_function_call_output_type() -> String {

--- a/bitrouter-core/src/api/openai/responses/types.rs
+++ b/bitrouter-core/src/api/openai/responses/types.rs
@@ -267,10 +267,23 @@ pub struct ResponsesErrorEnvelope {
 /// Flat SSE event structure used by the proxy layer to emit Responses-format
 /// server-sent events to the client.  This is **not** the same as the
 /// provider's inbound stream-event enum which parses upstream SSE.
+///
+/// The Responses streaming protocol assigns a monotonic `sequence_number` to
+/// every event and wraps the start/end of the stream in `response.created` /
+/// `response.completed` envelopes that carry the full response object. Codex
+/// and other strict clients reject streams that omit these.
+/// <https://platform.openai.com/docs/api-reference/responses-streaming>
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ResponsesStreamEvent {
     #[serde(rename = "type")]
     pub event_type: String,
+    /// Monotonic event index within the stream; required on every event.
+    pub sequence_number: u64,
+    /// Full response payload — present on `response.created`,
+    /// `response.in_progress`, `response.completed`, `response.failed`,
+    /// `response.incomplete`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response: Option<ResponsesResponse>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub item_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -279,12 +292,20 @@ pub struct ResponsesStreamEvent {
     pub content_index: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub delta: Option<String>,
+    /// Final authoritative text on `response.output_text.done` /
+    /// `response.reasoning_text.done`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub call_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub arguments: Option<String>,
+    /// Item payload — present on `response.output_item.added`/`done`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub item: Option<serde_json::Value>,
+    /// Content part payload — present on `response.content_part.added`/`done`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub part: Option<serde_json::Value>,
 }

--- a/bitrouter-core/src/api/openai/responses/types.rs
+++ b/bitrouter-core/src/api/openai/responses/types.rs
@@ -234,11 +234,18 @@ pub enum ResponsesOutputContent {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ResponsesUsage {
-    #[serde(default)]
+    // Strict consumers (Codex CLI) require these three fields as non-null
+    // integers when the `usage` object is present — they're typed `i64` in
+    // codex-rs/codex-api/src/sse/responses.rs::ResponseCompletedUsage and
+    // any `null` value fails the response.completed parse. Skip-on-None so
+    // the streaming converter can construct a partial usage object only
+    // when at least one field is known; in practice the converter always
+    // sets all three together.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub input_tokens: Option<u32>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub output_tokens: Option<u32>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub total_tokens: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub input_tokens_details: Option<ResponsesInputTokensDetails>,

--- a/bitrouter-providers/src/anthropic/messages/api.rs
+++ b/bitrouter-providers/src/anthropic/messages/api.rs
@@ -512,14 +512,12 @@ fn convert_assistant_content(
                 });
             }
             LanguageModelAssistantContent::Reasoning { .. } => {
-                return Err(BitrouterError::unsupported(
-                    ANTHROPIC_PROVIDER_NAME,
-                    "assistant reasoning prompt parts",
-                    Some(
-                        "Anthropic messages API does not expose a dedicated reasoning message part"
-                            .to_owned(),
-                    ),
-                ));
+                // Anthropic does support echoing back thinking blocks for
+                // tool-use continuation, but only when the original
+                // signature is preserved. Bitrouter doesn't carry the
+                // signature through `LanguageModelAssistantContent::Reasoning`,
+                // so silently strip rather than emit an invalid block.
+                // https://docs.claude.com/en/docs/build-with-claude/extended-thinking#preserving-thinking-blocks
             }
             LanguageModelAssistantContent::File { .. } => {
                 return Err(BitrouterError::unsupported(

--- a/bitrouter-providers/src/google/generate_content/api.rs
+++ b/bitrouter-providers/src/google/generate_content/api.rs
@@ -41,6 +41,7 @@ pub(super) use bitrouter_core::api::google::generate_content::types::GenerateCon
 
 pub(super) const GOOGLE_PROVIDER_NAME: &str = "google";
 pub(super) const STREAM_TEXT_ID: &str = "text";
+pub(super) const STREAM_REASONING_ID: &str = "reasoning";
 
 // ── Default max tokens ──────────────────────────────────────────────────────
 
@@ -433,6 +434,7 @@ fn convert_prompt(
                         inline_data: None,
                         function_call: None,
                         function_response: None,
+                        thought: None,
                     }]),
                 });
             }
@@ -476,6 +478,7 @@ fn convert_user_content(
                     inline_data: None,
                     function_call: None,
                     function_response: None,
+                    thought: None,
                 });
             }
             LanguageModelUserContent::File {
@@ -527,6 +530,7 @@ fn convert_file_input(data: &LanguageModelDataContent, media_type: &str) -> Resu
         }),
         function_call: None,
         function_response: None,
+        thought: None,
     })
 }
 
@@ -541,6 +545,7 @@ fn convert_assistant_content(content: &[LanguageModelAssistantContent]) -> Resul
                     inline_data: None,
                     function_call: None,
                     function_response: None,
+                    thought: None,
                 });
             }
             LanguageModelAssistantContent::ToolCall {
@@ -554,18 +559,13 @@ fn convert_assistant_content(content: &[LanguageModelAssistantContent]) -> Resul
                         args: Some(input.clone()),
                     }),
                     function_response: None,
+                    thought: None,
                 });
             }
             LanguageModelAssistantContent::Reasoning { .. } => {
-                return Err(BitrouterError::unsupported(
-                    GOOGLE_PROVIDER_NAME,
-                    "assistant reasoning prompt parts",
-                    Some(
-                        "Google Generative AI API does not expose a dedicated reasoning \
-                         message part"
-                            .to_owned(),
-                    ),
-                ));
+                // Gemini does not accept thought summaries back as input —
+                // they're stream-only output. Silently strip on multi-turn.
+                // https://ai.google.dev/gemini-api/docs/thinking#thought-summaries
             }
             LanguageModelAssistantContent::File { .. } => {
                 return Err(BitrouterError::unsupported(
@@ -603,6 +603,7 @@ fn convert_tool_results(content: &[LanguageModelToolResult]) -> Result<Vec<Googl
                         name: tool_name.clone(),
                         response: response_value,
                     }),
+                    thought: None,
                 });
             }
             LanguageModelToolResult::ToolApprovalResponse { .. } => {
@@ -814,6 +815,7 @@ impl GoogleSseParser {
 struct GoogleStreamState {
     metadata_emitted: bool,
     text_started: bool,
+    reasoning_started: bool,
     tool_started: HashMap<String, bool>,
     usage: Option<LanguageModelUsage>,
     finish_reason:
@@ -860,18 +862,44 @@ impl GoogleStreamState {
             {
                 for part in content_parts {
                     if let Some(text) = &part.text {
-                        if !self.text_started {
-                            parts.push(LanguageModelStreamPart::TextStart {
-                                id: STREAM_TEXT_ID.to_owned(),
+                        // Gemini 2.5+ flags thought summaries with
+                        // `thought: true` on a text part; route those to
+                        // reasoning events instead of visible text.
+                        // https://ai.google.dev/gemini-api/docs/thinking#thought-summaries
+                        if part.thought.unwrap_or(false) {
+                            if !self.reasoning_started {
+                                parts.push(LanguageModelStreamPart::ReasoningStart {
+                                    id: STREAM_REASONING_ID.to_owned(),
+                                    provider_metadata: None,
+                                });
+                                self.reasoning_started = true;
+                            }
+                            parts.push(LanguageModelStreamPart::ReasoningDelta {
+                                id: STREAM_REASONING_ID.to_owned(),
+                                delta: text.clone(),
                                 provider_metadata: None,
                             });
-                            self.text_started = true;
+                        } else {
+                            if !self.text_started {
+                                if self.reasoning_started {
+                                    parts.push(LanguageModelStreamPart::ReasoningEnd {
+                                        id: STREAM_REASONING_ID.to_owned(),
+                                        provider_metadata: None,
+                                    });
+                                    self.reasoning_started = false;
+                                }
+                                parts.push(LanguageModelStreamPart::TextStart {
+                                    id: STREAM_TEXT_ID.to_owned(),
+                                    provider_metadata: None,
+                                });
+                                self.text_started = true;
+                            }
+                            parts.push(LanguageModelStreamPart::TextDelta {
+                                id: STREAM_TEXT_ID.to_owned(),
+                                delta: text.clone(),
+                                provider_metadata: None,
+                            });
                         }
-                        parts.push(LanguageModelStreamPart::TextDelta {
-                            id: STREAM_TEXT_ID.to_owned(),
-                            delta: text.clone(),
-                            provider_metadata: None,
-                        });
                     }
                     if let Some(fc) = &part.function_call {
                         let tool_id = fc.name.clone();
@@ -931,6 +959,12 @@ impl GoogleStreamState {
         self.finished = true;
 
         let mut parts = Vec::new();
+        if self.reasoning_started {
+            parts.push(LanguageModelStreamPart::ReasoningEnd {
+                id: STREAM_REASONING_ID.to_owned(),
+                provider_metadata: None,
+            });
+        }
         if self.text_started {
             parts.push(LanguageModelStreamPart::TextEnd {
                 id: STREAM_TEXT_ID.to_owned(),
@@ -1295,6 +1329,87 @@ mod tests {
     }
 
     #[test]
+    fn parse_thought_summary_then_text_stream() {
+        // Regression test for issue #448: Gemini 2.5+ streams thought
+        // summaries as text parts flagged with `thought: true`. The
+        // parser must route those to Reasoning events, then close the
+        // reasoning block before the visible text block begins.
+        let mut parser = GoogleSseParser::new(false);
+
+        let parts = parser.push_bytes(&sse_event(
+            r#"{"candidates":[{"content":{"role":"model","parts":[{"text":"Pondering","thought":true}]},"index":0}],"modelVersion":"gemini-2.5-pro","usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":1,"totalTokenCount":2}}"#,
+        ));
+        assert!(
+            parts
+                .iter()
+                .any(|p| matches!(p, LanguageModelStreamPart::ReasoningStart { .. }))
+        );
+        assert!(parts.iter().any(|p| matches!(
+            p,
+            LanguageModelStreamPart::ReasoningDelta { delta, .. } if delta == "Pondering"
+        )));
+        assert!(
+            !parts
+                .iter()
+                .any(|p| matches!(p, LanguageModelStreamPart::TextStart { .. })),
+            "thought summaries must not start a visible text block"
+        );
+
+        // Same call now flips to visible text — reasoning must close
+        // before text opens.
+        let parts = parser.push_bytes(&sse_event(
+            r#"{"candidates":[{"content":{"role":"model","parts":[{"text":"Final answer"}]},"finishReason":"STOP","index":0}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":2,"totalTokenCount":3}}"#,
+        ));
+        let reasoning_end = parts
+            .iter()
+            .position(|p| matches!(p, LanguageModelStreamPart::ReasoningEnd { .. }))
+            .expect("ReasoningEnd before text");
+        let text_start = parts
+            .iter()
+            .position(|p| matches!(p, LanguageModelStreamPart::TextStart { .. }))
+            .expect("TextStart after reasoning");
+        assert!(reasoning_end < text_start);
+        assert!(parts.iter().any(|p| matches!(
+            p,
+            LanguageModelStreamPart::TextDelta { delta, .. } if delta == "Final answer"
+        )));
+
+        let parts = parser.finish();
+        assert!(
+            parts
+                .iter()
+                .any(|p| matches!(p, LanguageModelStreamPart::TextEnd { .. }))
+        );
+        assert!(
+            parts
+                .iter()
+                .any(|p| matches!(p, LanguageModelStreamPart::Finish { .. }))
+        );
+    }
+
+    #[test]
+    fn parse_thought_summary_only_closes_on_finish() {
+        // If the upstream emits only thought parts before closing, the
+        // ReasoningEnd must still be flushed on finish.
+        let mut parser = GoogleSseParser::new(false);
+
+        parser.push_bytes(&sse_event(
+            r#"{"candidates":[{"content":{"role":"model","parts":[{"text":"thinking","thought":true}]},"finishReason":"STOP","index":0}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":1,"totalTokenCount":2}}"#,
+        ));
+        let parts = parser.finish();
+        assert!(
+            parts
+                .iter()
+                .any(|p| matches!(p, LanguageModelStreamPart::ReasoningEnd { .. }))
+        );
+        assert!(
+            parts
+                .iter()
+                .any(|p| matches!(p, LanguageModelStreamPart::Finish { .. }))
+        );
+    }
+
+    #[test]
     fn parse_function_call_stream() {
         let mut parser = GoogleSseParser::new(false);
 
@@ -1654,6 +1769,7 @@ mod tests {
                     inline_data: None,
                     function_call: None,
                     function_response: None,
+                    thought: None,
                 }]),
             }],
             system_instruction: Some(GoogleContent {
@@ -1663,6 +1779,7 @@ mod tests {
                     inline_data: None,
                     function_call: None,
                     function_response: None,
+                    thought: None,
                 }]),
             }),
             tools: None,
@@ -1785,6 +1902,7 @@ mod tests {
             }),
             function_call: None,
             function_response: None,
+            thought: None,
         };
         let json = serde_json::to_value(&part).unwrap();
         assert_eq!(json["inlineData"]["mimeType"], "image/png");
@@ -1818,6 +1936,7 @@ mod tests {
                     inline_data: None,
                     function_call: None,
                     function_response: None,
+                    thought: None,
                 }]),
             }],
             system_instruction: None,

--- a/bitrouter-providers/src/openai/chat/api.rs
+++ b/bitrouter-providers/src/openai/chat/api.rs
@@ -43,6 +43,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 pub(super) const OPENAI_PROVIDER_NAME: &str = "openai";
 const STREAM_TEXT_ID: &str = "text";
+const STREAM_REASONING_ID: &str = "reasoning";
 
 // ── Helper functions (moved from types.rs) ──────────────────────────────────
 
@@ -472,11 +473,10 @@ fn convert_prompt(prompt: &[LanguageModelMessage]) -> Result<Vec<ChatMessage>> {
                             });
                         }
                         LanguageModelAssistantContent::Reasoning { .. } => {
-                            return Err(BitrouterError::unsupported(
-                                OPENAI_PROVIDER_NAME,
-                                "assistant reasoning prompt parts",
-                                Some("Chat completions does not expose a dedicated reasoning message part".to_owned()),
-                            ));
+                            // OpenAI Chat Completions does not have a dedicated
+                            // reasoning message part; silently strip thinking
+                            // blocks from prior turns.
+                            // https://platform.openai.com/docs/guides/reasoning
                         }
                         LanguageModelAssistantContent::File { .. } => {
                             return Err(BitrouterError::unsupported(
@@ -834,6 +834,7 @@ impl OpenAiSseParser {
 struct OpenAiStreamState {
     metadata_emitted: bool,
     text_started: bool,
+    reasoning_started: bool,
     tool_inputs: HashMap<u32, OpenAiToolInputState>,
     usage: Option<LanguageModelUsage>,
     finish_reason:
@@ -871,8 +872,31 @@ impl OpenAiStreamState {
                 continue;
             }
 
+            if let Some(reasoning) = choice.delta.reasoning_content {
+                if !self.reasoning_started {
+                    parts.push(LanguageModelStreamPart::ReasoningStart {
+                        id: STREAM_REASONING_ID.to_owned(),
+                        provider_metadata: None,
+                    });
+                    self.reasoning_started = true;
+                }
+                parts.push(LanguageModelStreamPart::ReasoningDelta {
+                    id: STREAM_REASONING_ID.to_owned(),
+                    delta: reasoning,
+                    provider_metadata: None,
+                });
+            }
+
             if let Some(content) = choice.delta.content {
                 if !self.text_started {
+                    // Close any open reasoning block before starting text.
+                    if self.reasoning_started {
+                        parts.push(LanguageModelStreamPart::ReasoningEnd {
+                            id: STREAM_REASONING_ID.to_owned(),
+                            provider_metadata: None,
+                        });
+                        self.reasoning_started = false;
+                    }
                     parts.push(LanguageModelStreamPart::TextStart {
                         id: STREAM_TEXT_ID.to_owned(),
                         provider_metadata: None,
@@ -959,6 +983,12 @@ impl OpenAiStreamState {
         self.finished = true;
 
         let mut parts = Vec::new();
+        if self.reasoning_started {
+            parts.push(LanguageModelStreamPart::ReasoningEnd {
+                id: STREAM_REASONING_ID.to_owned(),
+                provider_metadata: None,
+            });
+        }
         if self.text_started {
             parts.push(LanguageModelStreamPart::TextEnd {
                 id: STREAM_TEXT_ID.to_owned(),
@@ -1312,6 +1342,105 @@ mod tests {
                 .any(|p| matches!(p, LanguageModelStreamPart::Finish { .. }))
         );
         assert!(parser.is_finished());
+    }
+
+    #[test]
+    fn sse_parser_reasoning_then_text_stream() {
+        // Regression test for issue #448: OpenAI-compatible providers
+        // (DeepSeek, GLM, Aliyun) stream chain-of-thought via the
+        // `reasoning_content` delta field. The state machine must emit
+        // ReasoningStart/Delta then close that block before opening a Text
+        // block when visible content arrives.
+        let mut parser = OpenAiSseParser::new(false);
+
+        let chunk1 = json!({
+            "id": "c1", "created": 1, "model": "deepseek-r1",
+            "choices": [{"index": 0, "delta": {"reasoning_content": "Hmm"}, "finish_reason": null}]
+        });
+        let chunk2 = json!({
+            "id": "c1", "created": 1, "model": "deepseek-r1",
+            "choices": [{"index": 0, "delta": {"reasoning_content": " let me think"}, "finish_reason": null}]
+        });
+        let chunk3 = json!({
+            "id": "c1", "created": 1, "model": "deepseek-r1",
+            "choices": [{"index": 0, "delta": {"content": "Answer"}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 2, "total_tokens": 7}
+        });
+
+        let parts = parser.push_bytes(&sse_event(&chunk1.to_string()));
+        assert!(
+            parts
+                .iter()
+                .any(|p| matches!(p, LanguageModelStreamPart::ReasoningStart { .. }))
+        );
+        assert!(parts.iter().any(
+            |p| matches!(p, LanguageModelStreamPart::ReasoningDelta { delta, .. } if delta == "Hmm")
+        ));
+
+        let parts = parser.push_bytes(&sse_event(&chunk2.to_string()));
+        // Subsequent reasoning chunks must not re-emit ReasoningStart.
+        assert!(
+            !parts
+                .iter()
+                .any(|p| matches!(p, LanguageModelStreamPart::ReasoningStart { .. }))
+        );
+        assert!(parts.iter().any(
+            |p| matches!(p, LanguageModelStreamPart::ReasoningDelta { delta, .. } if delta == " let me think")
+        ));
+
+        let parts = parser.push_bytes(&sse_event(&chunk3.to_string()));
+        // Transitioning to visible text must close the reasoning block
+        // before opening text.
+        let reasoning_end_idx = parts
+            .iter()
+            .position(|p| matches!(p, LanguageModelStreamPart::ReasoningEnd { .. }))
+            .expect("ReasoningEnd should appear before text starts");
+        let text_start_idx = parts
+            .iter()
+            .position(|p| matches!(p, LanguageModelStreamPart::TextStart { .. }))
+            .expect("TextStart should appear");
+        assert!(reasoning_end_idx < text_start_idx);
+        assert!(parts.iter().any(
+            |p| matches!(p, LanguageModelStreamPart::TextDelta { delta, .. } if delta == "Answer")
+        ));
+
+        let done_parts = parser.push_bytes(&sse_event("[DONE]"));
+        assert!(
+            done_parts
+                .iter()
+                .any(|p| matches!(p, LanguageModelStreamPart::TextEnd { .. }))
+        );
+        assert!(
+            done_parts
+                .iter()
+                .any(|p| matches!(p, LanguageModelStreamPart::Finish { .. }))
+        );
+    }
+
+    #[test]
+    fn sse_parser_reasoning_only_closed_on_finish() {
+        // If a stream ends with only reasoning (no visible content), the
+        // ReasoningEnd must still be emitted at finish time.
+        let mut parser = OpenAiSseParser::new(false);
+
+        let chunk = json!({
+            "id": "c1", "created": 1, "model": "deepseek-r1",
+            "choices": [{"index": 0, "delta": {"reasoning_content": "thinking..."}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+        });
+        parser.push_bytes(&sse_event(&chunk.to_string()));
+
+        let done_parts = parser.push_bytes(&sse_event("[DONE]"));
+        assert!(
+            done_parts
+                .iter()
+                .any(|p| matches!(p, LanguageModelStreamPart::ReasoningEnd { .. }))
+        );
+        assert!(
+            done_parts
+                .iter()
+                .any(|p| matches!(p, LanguageModelStreamPart::Finish { .. }))
+        );
     }
 
     #[test]

--- a/bitrouter-providers/src/openai/chat/api.rs
+++ b/bitrouter-providers/src/openai/chat/api.rs
@@ -497,6 +497,17 @@ fn convert_prompt(prompt: &[LanguageModelMessage]) -> Result<Vec<ChatMessage>> {
 
                 let content_text = (!text_segments.is_empty())
                     .then(|| ChatMessageContent::Text(text_segments.join("\n")));
+                // Skip emitting empty assistant turns. Strict upstreams
+                // (e.g. Z.ai/GLM) reject `{role:"assistant"}` with neither
+                // `content` nor `tool_calls` populated, surfacing as
+                // "The prompt parameter was not received normally". This
+                // commonly happens when Codex CLI replays prior turns whose
+                // visible text was empty (real output lived in a separate
+                // `reasoning` item that we strip on this code path).
+                // https://platform.openai.com/docs/guides/text-generation
+                if content_text.is_none() && tool_calls.is_empty() {
+                    continue;
+                }
                 messages.push(ChatMessage {
                     role: "assistant".to_owned(),
                     content: content_text,
@@ -1219,6 +1230,73 @@ mod tests {
         };
         let err = message_to_language_model_content(message, None, json!({})).unwrap_err();
         assert!(format!("{err}").contains("neither content nor tool calls"));
+    }
+
+    #[test]
+    fn convert_prompt_drops_reasoning_only_assistant_turn() {
+        // Codex CLI replays prior assistant turns whose visible text was
+        // empty (real output lived in a separate `reasoning` item). After
+        // stripping Reasoning here, the assistant message has neither text
+        // nor tool_calls — emitting it would trip Z.ai/GLM's "prompt
+        // parameter was not received normally" error.
+        use bitrouter_core::models::language::prompt::{
+            LanguageModelAssistantContent, LanguageModelMessage, LanguageModelUserContent,
+        };
+        let prompt = vec![
+            LanguageModelMessage::User {
+                content: vec![LanguageModelUserContent::Text {
+                    text: "hi".to_owned(),
+                    provider_options: None,
+                }],
+                provider_options: None,
+            },
+            LanguageModelMessage::Assistant {
+                content: vec![LanguageModelAssistantContent::Reasoning {
+                    text: "internal monologue".to_owned(),
+                    provider_options: None,
+                }],
+                provider_options: None,
+            },
+            LanguageModelMessage::User {
+                content: vec![LanguageModelUserContent::Text {
+                    text: "do it".to_owned(),
+                    provider_options: None,
+                }],
+                provider_options: None,
+            },
+        ];
+        let chat = convert_prompt(&prompt).expect("convert_prompt should succeed");
+        // The reasoning-only assistant turn must be dropped.
+        assert_eq!(chat.len(), 2);
+        assert_eq!(chat[0].role, "user");
+        assert_eq!(chat[1].role, "user");
+    }
+
+    #[test]
+    fn convert_prompt_keeps_assistant_with_text() {
+        use bitrouter_core::models::language::prompt::{
+            LanguageModelAssistantContent, LanguageModelMessage,
+        };
+        let prompt = vec![LanguageModelMessage::Assistant {
+            content: vec![
+                LanguageModelAssistantContent::Reasoning {
+                    text: "thinking".to_owned(),
+                    provider_options: None,
+                },
+                LanguageModelAssistantContent::Text {
+                    text: "Hello".to_owned(),
+                    provider_options: None,
+                },
+            ],
+            provider_options: None,
+        }];
+        let chat = convert_prompt(&prompt).expect("convert");
+        assert_eq!(chat.len(), 1);
+        assert_eq!(chat[0].role, "assistant");
+        assert!(matches!(
+            chat[0].content.as_ref(),
+            Some(ChatMessageContent::Text(t)) if t == "Hello"
+        ));
     }
 
     #[test]

--- a/bitrouter-providers/src/openai/responses/api.rs
+++ b/bitrouter-providers/src/openai/responses/api.rs
@@ -36,6 +36,7 @@ use tokio_util::sync::CancellationToken;
 
 pub(crate) const OPENAI_PROVIDER_NAME: &str = "openai";
 const STREAM_TEXT_ID: &str = "text";
+const STREAM_REASONING_ID: &str = "reasoning";
 const MAX_RESPONSES_CALL_ID_LEN: usize = 64;
 
 // ── Free-function conversions (replace From / TryFrom impls) ───────────────
@@ -490,14 +491,11 @@ fn convert_prompt(prompt: &[LanguageModelMessage]) -> Result<Vec<ResponsesInputI
                             }));
                         }
                         LanguageModelAssistantContent::Reasoning { .. } => {
-                            return Err(BitrouterError::unsupported(
-                                OPENAI_PROVIDER_NAME,
-                                "assistant reasoning prompt parts",
-                                Some(
-                                    "Responses API does not expose a dedicated assistant reasoning input type"
-                                        .to_owned(),
-                                ),
-                            ));
+                            // The Responses API only accepts `output_text` /
+                            // function_call assistant items as input; reasoning
+                            // items from a prior turn are not echoed back.
+                            // Silently strip rather than failing the request.
+                            // https://platform.openai.com/docs/api-reference/responses/create
                         }
                         LanguageModelAssistantContent::File { .. } => {
                             return Err(BitrouterError::unsupported(
@@ -910,6 +908,7 @@ struct OpenAiToolInputState {
 #[derive(Default)]
 struct OpenAiResponsesStreamState {
     metadata_emitted: bool,
+    reasoning_started: bool,
     text_started: bool,
     text_id: Option<String>,
     tool_inputs: HashMap<String, OpenAiToolInputState>,
@@ -958,6 +957,18 @@ enum OpenAiResponsesStreamEvent {
         #[serde(default)]
         arguments: Option<String>,
     },
+    // https://platform.openai.com/docs/guides/reasoning#streaming
+    #[serde(rename = "response.reasoning_text.delta")]
+    ResponseReasoningTextDelta {
+        #[serde(default)]
+        item_id: Option<String>,
+        delta: String,
+    },
+    #[serde(rename = "response.reasoning_text.done")]
+    ResponseReasoningTextDone {
+        #[serde(default)]
+        item_id: Option<String>,
+    },
     #[serde(rename = "response.completed")]
     ResponseCompleted { response: ResponsesResponse },
     #[serde(rename = "response.incomplete")]
@@ -994,10 +1005,45 @@ impl OpenAiResponsesStreamState {
             OpenAiResponsesStreamEvent::ResponseOutputItemDone { item } => {
                 self.apply_output_item(item, true)
             }
+            OpenAiResponsesStreamEvent::ResponseReasoningTextDelta { delta, .. } => {
+                let mut parts = Vec::new();
+                if !self.reasoning_started {
+                    parts.push(LanguageModelStreamPart::ReasoningStart {
+                        id: STREAM_REASONING_ID.to_owned(),
+                        provider_metadata: None,
+                    });
+                    self.reasoning_started = true;
+                }
+                parts.push(LanguageModelStreamPart::ReasoningDelta {
+                    id: STREAM_REASONING_ID.to_owned(),
+                    delta,
+                    provider_metadata: None,
+                });
+                parts
+            }
+            OpenAiResponsesStreamEvent::ResponseReasoningTextDone { .. } => {
+                let mut parts = Vec::new();
+                if self.reasoning_started {
+                    parts.push(LanguageModelStreamPart::ReasoningEnd {
+                        id: STREAM_REASONING_ID.to_owned(),
+                        provider_metadata: None,
+                    });
+                    self.reasoning_started = false;
+                }
+                parts
+            }
             OpenAiResponsesStreamEvent::ResponseOutputTextDelta { item_id, delta } => {
                 let text_id = item_id.unwrap_or_else(|| STREAM_TEXT_ID.to_owned());
                 let mut parts = Vec::new();
                 if !self.text_started {
+                    // Close any open reasoning block before starting text.
+                    if self.reasoning_started {
+                        parts.push(LanguageModelStreamPart::ReasoningEnd {
+                            id: STREAM_REASONING_ID.to_owned(),
+                            provider_metadata: None,
+                        });
+                        self.reasoning_started = false;
+                    }
                     parts.push(LanguageModelStreamPart::TextStart {
                         id: text_id.clone(),
                         provider_metadata: None,
@@ -1304,6 +1350,12 @@ impl OpenAiResponsesStreamState {
         self.finished = true;
 
         let mut parts = Vec::new();
+        if self.reasoning_started {
+            parts.push(LanguageModelStreamPart::ReasoningEnd {
+                id: STREAM_REASONING_ID.to_owned(),
+                provider_metadata: None,
+            });
+        }
         if self.text_started {
             parts.push(LanguageModelStreamPart::TextEnd {
                 id: self
@@ -1920,7 +1972,7 @@ mod tests {
     }
 
     #[test]
-    fn sse_parser_ignores_unknown_responses_events() {
+    fn sse_parser_emits_reasoning_events() {
         let mut parser = OpenAiResponsesSseParser::new(false);
 
         let reasoning_delta = json!({
@@ -1928,6 +1980,11 @@ mod tests {
             "sequence_number": 1,
             "item_id": "rs_1",
             "delta": "thinking"
+        });
+        let reasoning_done = json!({
+            "type": "response.reasoning_text.done",
+            "sequence_number": 2,
+            "item_id": "rs_1"
         });
         let completed = json!({
             "type": "response.completed",
@@ -1941,10 +1998,23 @@ mod tests {
             }
         });
 
-        let unknown_parts = parser.push_bytes(&sse_event(&reasoning_delta.to_string()));
+        let delta_parts = parser.push_bytes(&sse_event(&reasoning_delta.to_string()));
         assert!(
-            unknown_parts.is_empty(),
-            "unknown Responses events should be ignored, got {unknown_parts:?}"
+            delta_parts
+                .iter()
+                .any(|part| matches!(part, LanguageModelStreamPart::ReasoningStart { .. }))
+        );
+        assert!(
+            delta_parts.iter().any(
+                |part| matches!(part, LanguageModelStreamPart::ReasoningDelta { delta, .. } if delta == "thinking")
+            )
+        );
+
+        let done_reasoning_parts = parser.push_bytes(&sse_event(&reasoning_done.to_string()));
+        assert!(
+            done_reasoning_parts
+                .iter()
+                .any(|part| matches!(part, LanguageModelStreamPart::ReasoningEnd { .. }))
         );
 
         let done_parts = parser.push_bytes(&sse_event(&completed.to_string()));
@@ -1952,7 +2022,7 @@ mod tests {
             done_parts
                 .iter()
                 .all(|part| !matches!(part, LanguageModelStreamPart::Error { .. })),
-            "unknown Responses events must not poison the stream: {done_parts:?}"
+            "Responses events must not poison the stream: {done_parts:?}"
         );
         assert!(
             done_parts

--- a/bitrouter-providers/src/openai/responses/api.rs
+++ b/bitrouter-providers/src/openai/responses/api.rs
@@ -209,6 +209,10 @@ pub(crate) fn build_responses_request(
     Ok(ResponsesRequest {
         model,
         input: ResponsesInput::Items(convert_prompt(&options.prompt)?),
+        // The provider request path doesn't lift system messages back into
+        // top-level `instructions` — they remain inline `developer` items
+        // inside `input`, which is also valid per the Responses spec.
+        instructions: None,
         stream: Some(stream),
         max_output_tokens: options.max_output_tokens,
         temperature: options.temperature,
@@ -531,11 +535,18 @@ fn convert_prompt(prompt: &[LanguageModelMessage]) -> Result<Vec<ResponsesInputI
                             ..
                         } => {
                             let call_id = call_ids.normalize(tool_call_id);
+                            // Plain-string form is the wire shape OpenAI's
+                            // Responses API accepts on input; the structured
+                            // {content_items: [...]} form is only used for
+                            // multimodal tool outputs which bitrouter does
+                            // not yet emit.
                             input.push(ResponsesInputItem::FunctionCallOutput(
                                 ResponsesInputFunctionCallOutput {
                                     item_type: "function_call_output".to_owned(),
                                     call_id,
-                                    output: stringify_tool_output(output)?,
+                                    output: serde_json::Value::String(stringify_tool_output(
+                                        output,
+                                    )?),
                                 },
                             ));
                         }


### PR DESCRIPTION
## Summary

Closes #448.

Thinking/reasoning content was silently dropped in **every** protocol path (OpenAI Chat, OpenAI Responses, Google, and Anthropic output-side converters), causing ~1 minute of apparent SSE silence when routing thinking-enabled upstreams (e.g. GLM-5.1 via Aliyun) through bitrouter's `v1/messages` endpoint.

The fix closes the gaps systematically in three areas:

- **Input** (provider SSE parsers): extract `reasoning_content` from OpenAI-compatible chunks, `response.reasoning_text.delta`/`.done` from Responses, and `thought: true` parts from Gemini 2.5+; emit `ReasoningStart/Delta/End` core stream parts. Reasoning blocks close cleanly when text starts and are flushed on finish.
- **Output** (`StreamConverter` for each protocol): map `ReasoningStart/Delta/End` to the protocol-specific carrier — `reasoning_content` (OpenAI Chat), `response.reasoning_text.delta`/`.done` (OpenAI Responses), `GooglePart { thought: true }` (Gemini), and Anthropic `thinking` content_block_start / `thinking_delta` / content_block_stop events. Thinking blocks auto-close on text/tool transitions and at finish.
- **Assistant prompt**: silently strip `LanguageModelAssistantContent::Reasoning` across all four providers instead of erroring, so multi-turn conversations with thinking models work.

External integration references (DeepSeek/OpenAI/Gemini/Anthropic doc URLs) are inlined as comments around each conversion path.

## Test plan

- [x] `cargo nextest run --all-features` — 899 tests pass (+16 new)
- [x] `cargo clippy --all-features` — clean
- [x] `cargo fmt -- --check` — clean
- [ ] Manual smoke test: `v1/messages` → bitrouter → OpenAI-compatible thinking provider; verify SSE thinking events arrive in real time
- [ ] Manual smoke test: `v1/chat/completions` with DeepSeek-R1 or GLM; verify `reasoning_content` deltas surface
- [ ] Manual smoke test: Gemini 2.5+ with thinking enabled; verify `thought: true` parts surface
- [ ] Manual smoke test: Anthropic extended thinking round-trip; verify `thinking_delta` arrives before `text_delta`

New unit tests cover both input (SSE state machine) and output (`StreamConverter`) for each of the four protocols, plus boundary conditions (text-after-reasoning closure, reasoning-only stream finish flush, multi-turn echo-back).

🤖 Generated with [Claude Code](https://claude.com/claude-code)