### PR TITLE
chore(observe): streamline per-request log output

### DIFF
--- a/bitrouter-accounts/src/service/account.rs
+++ b/bitrouter-accounts/src/service/account.rs
@@ -81,7 +81,7 @@ impl<'db> AccountService<'db> {
     ) -> Result<Option<account::Model>, DbErr> {
         // Check current active pubkey.
         if let Some(account) = self.find_by_pubkey(pubkey).await? {
-            tracing::info!(account_id = %account.id, "account resolved by pubkey");
+            tracing::debug!(account_id = %account.id, "account resolved by pubkey");
             return Ok(Some(account));
         }
 

--- a/bitrouter-api/src/router/anthropic/messages/filters.rs
+++ b/bitrouter-api/src/router/anthropic/messages/filters.rs
@@ -301,33 +301,44 @@ where
     if let Some(ref allowed) = caller.models
         && !is_model_allowed(&incoming_model, allowed)
     {
-        return Err(warp::reject::custom(BitrouterRejection(
-            BitrouterError::AccessDenied {
-                message: format!("model '{}' is not in your allowlist", incoming_model),
-            },
-        )));
+        let err = BitrouterError::AccessDenied {
+            message: format!("model '{}' is not in your allowlist", incoming_model),
+        };
+        crate::router::log_request_resolve_failed(&caller, &incoming_model, &err);
+        return Err(warp::reject::custom(BitrouterRejection(err)));
     }
 
     let mut target = table
         .route(&incoming_model, &route_ctx)
         .await
-        .map_err(|e| warp::reject::custom(BitrouterRejection(e)))?;
+        .map_err(|e| {
+            crate::router::log_request_resolve_failed(&caller, &incoming_model, &e);
+            warp::reject::custom(BitrouterRejection(e))
+        })?;
 
     if let Some(ref overlay) = target_overlay {
-        overlay
-            .apply(&mut target, &caller)
-            .await
-            .map_err(|e| warp::reject::custom(BitrouterRejection(e)))?;
+        overlay.apply(&mut target, &caller).await.map_err(|e| {
+            crate::router::log_request_resolve_failed(&caller, &incoming_model, &e);
+            warp::reject::custom(BitrouterRejection(e))
+        })?;
     }
 
     let byok_used = target.api_key_override.is_some();
     let provider_name = target.provider_name.clone();
     let target_model_id = target.service_id.clone();
 
-    let model = router
-        .route_model(target.clone())
-        .await
-        .map_err(|e| warp::reject::custom(BitrouterRejection(e)))?;
+    let model = router.route_model(target.clone()).await.map_err(|e| {
+        crate::router::log_request_resolve_failed(&caller, &incoming_model, &e);
+        warp::reject::custom(BitrouterRejection(e))
+    })?;
+
+    crate::router::log_request_received(
+        &caller,
+        &incoming_model,
+        &provider_name,
+        &target_model_id,
+        is_stream,
+    );
 
     let model_id = model.model_id().to_owned();
     let options = convert::to_call_options(request);
@@ -557,25 +568,36 @@ where
     if let Some(ref allowed) = caller.models
         && !is_model_allowed(&incoming_model, allowed)
     {
-        return Err(warp::reject::custom(BitrouterRejection(
-            BitrouterError::AccessDenied {
-                message: format!("model '{}' is not in your allowlist", incoming_model),
-            },
-        )));
+        let err = BitrouterError::AccessDenied {
+            message: format!("model '{}' is not in your allowlist", incoming_model),
+        };
+        crate::router::log_request_resolve_failed(&caller, &incoming_model, &err);
+        return Err(warp::reject::custom(BitrouterRejection(err)));
     }
 
     let target = table
         .route(&incoming_model, &route_ctx)
         .await
-        .map_err(|e| warp::reject::custom(BitrouterRejection(e)))?;
+        .map_err(|e| {
+            crate::router::log_request_resolve_failed(&caller, &incoming_model, &e);
+            warp::reject::custom(BitrouterRejection(e))
+        })?;
 
     let provider_name = target.provider_name.clone();
     let target_model_id = target.service_id.clone();
 
-    let model = router
-        .route_model(target.clone())
-        .await
-        .map_err(|e| warp::reject::custom(BitrouterRejection(e)))?;
+    let model = router.route_model(target.clone()).await.map_err(|e| {
+        crate::router::log_request_resolve_failed(&caller, &incoming_model, &e);
+        warp::reject::custom(BitrouterRejection(e))
+    })?;
+
+    crate::router::log_request_received(
+        &caller,
+        &incoming_model,
+        &provider_name,
+        &target_model_id,
+        is_stream,
+    );
 
     let model_id = model.model_id().to_owned();
     let options = convert::to_call_options(request);

--- a/bitrouter-api/src/router/google/generate_content/filters.rs
+++ b/bitrouter-api/src/router/google/generate_content/filters.rs
@@ -235,26 +235,37 @@ where
     if let Some(ref allowed) = caller.models
         && !is_model_allowed(&incoming_model, allowed)
     {
-        return Err(warp::reject::custom(BitrouterRejection(
-            BitrouterError::AccessDenied {
-                message: format!("model '{}' is not in your allowlist", incoming_model),
-            },
-        )));
+        let err = BitrouterError::AccessDenied {
+            message: format!("model '{}' is not in your allowlist", incoming_model),
+        };
+        crate::router::log_request_resolve_failed(&caller, &incoming_model, &err);
+        return Err(warp::reject::custom(BitrouterRejection(err)));
     }
 
     let target = table
         .route(&incoming_model, &route_ctx)
         .await
-        .map_err(|e| warp::reject::custom(BitrouterRejection(e)))?;
+        .map_err(|e| {
+            crate::router::log_request_resolve_failed(&caller, &incoming_model, &e);
+            warp::reject::custom(BitrouterRejection(e))
+        })?;
 
     let byok_used = target.api_key_override.is_some();
     let provider_name = target.provider_name.clone();
     let target_model_id = target.service_id.clone();
 
-    let model = router
-        .route_model(target.clone())
-        .await
-        .map_err(|e| warp::reject::custom(BitrouterRejection(e)))?;
+    let model = router.route_model(target.clone()).await.map_err(|e| {
+        crate::router::log_request_resolve_failed(&caller, &incoming_model, &e);
+        warp::reject::custom(BitrouterRejection(e))
+    })?;
+
+    crate::router::log_request_received(
+        &caller,
+        &incoming_model,
+        &provider_name,
+        &target_model_id,
+        is_stream,
+    );
 
     let model_id = model.model_id().to_owned();
     let options = convert::to_call_options(request);
@@ -455,25 +466,36 @@ where
     if let Some(ref allowed) = caller.models
         && !is_model_allowed(&incoming_model, allowed)
     {
-        return Err(warp::reject::custom(BitrouterRejection(
-            BitrouterError::AccessDenied {
-                message: format!("model '{}' is not in your allowlist", incoming_model),
-            },
-        )));
+        let err = BitrouterError::AccessDenied {
+            message: format!("model '{}' is not in your allowlist", incoming_model),
+        };
+        crate::router::log_request_resolve_failed(&caller, &incoming_model, &err);
+        return Err(warp::reject::custom(BitrouterRejection(err)));
     }
 
     let target = table
         .route(&incoming_model, &route_ctx)
         .await
-        .map_err(|e| warp::reject::custom(BitrouterRejection(e)))?;
+        .map_err(|e| {
+            crate::router::log_request_resolve_failed(&caller, &incoming_model, &e);
+            warp::reject::custom(BitrouterRejection(e))
+        })?;
 
     let provider_name = target.provider_name.clone();
     let target_model_id = target.service_id.clone();
 
-    let model = router
-        .route_model(target.clone())
-        .await
-        .map_err(|e| warp::reject::custom(BitrouterRejection(e)))?;
+    let model = router.route_model(target.clone()).await.map_err(|e| {
+        crate::router::log_request_resolve_failed(&caller, &incoming_model, &e);
+        warp::reject::custom(BitrouterRejection(e))
+    })?;
+
+    crate::router::log_request_received(
+        &caller,
+        &incoming_model,
+        &provider_name,
+        &target_model_id,
+        is_stream,
+    );
 
     let model_id = model.model_id().to_owned();
     let options = convert::to_call_options(request);

--- a/bitrouter-api/src/router/mod.rs
+++ b/bitrouter-api/src/router/mod.rs
@@ -40,6 +40,47 @@ mod observe_ctx {
 
 pub(crate) use observe_ctx::StreamObserveContext;
 
+mod request_log {
+    use bitrouter_core::errors::BitrouterError;
+    use bitrouter_core::observe::CallerContext;
+
+    /// Emit the canonical "request received" INFO log after model name
+    /// resolution has succeeded. Companion to the "request finished" log
+    /// emitted by `ModelSpendObserver`.
+    pub(crate) fn received(
+        caller: &CallerContext,
+        route: &str,
+        provider: &str,
+        model: &str,
+        stream: bool,
+    ) {
+        tracing::info!(
+            account_id = caller.account_id.as_deref().unwrap_or("-"),
+            route,
+            provider,
+            model,
+            stream,
+            "request received",
+        );
+    }
+
+    /// Emit the "request received" log when model name resolution fails.
+    /// The request never reaches the observer, so this is the only log line
+    /// the operator will see for these requests.
+    pub(crate) fn resolve_failed(caller: &CallerContext, route: &str, error: &BitrouterError) {
+        tracing::info!(
+            account_id = caller.account_id.as_deref().unwrap_or("-"),
+            route,
+            error = %error,
+            "request received (model resolution failed)",
+        );
+    }
+}
+
+pub(crate) use request_log::{
+    received as log_request_received, resolve_failed as log_request_resolve_failed,
+};
+
 mod stream_observation {
     use bitrouter_core::{
         errors::BitrouterError,

--- a/bitrouter-api/src/router/openai/chat/filters.rs
+++ b/bitrouter-api/src/router/openai/chat/filters.rs
@@ -293,33 +293,44 @@ where
     if let Some(ref allowed) = caller.models
         && !is_model_allowed(&incoming_model, allowed)
     {
-        return Err(warp::reject::custom(BitrouterRejection(
-            BitrouterError::AccessDenied {
-                message: format!("model '{}' is not in your allowlist", incoming_model),
-            },
-        )));
+        let err = BitrouterError::AccessDenied {
+            message: format!("model '{}' is not in your allowlist", incoming_model),
+        };
+        crate::router::log_request_resolve_failed(&caller, &incoming_model, &err);
+        return Err(warp::reject::custom(BitrouterRejection(err)));
     }
 
     let mut target = table
         .route(&incoming_model, &route_ctx)
         .await
-        .map_err(|e| warp::reject::custom(BitrouterRejection(e)))?;
+        .map_err(|e| {
+            crate::router::log_request_resolve_failed(&caller, &incoming_model, &e);
+            warp::reject::custom(BitrouterRejection(e))
+        })?;
 
     if let Some(ref overlay) = target_overlay {
-        overlay
-            .apply(&mut target, &caller)
-            .await
-            .map_err(|e| warp::reject::custom(BitrouterRejection(e)))?;
+        overlay.apply(&mut target, &caller).await.map_err(|e| {
+            crate::router::log_request_resolve_failed(&caller, &incoming_model, &e);
+            warp::reject::custom(BitrouterRejection(e))
+        })?;
     }
 
     let byok_used = target.api_key_override.is_some();
     let provider_name = target.provider_name.clone();
     let target_model_id = target.service_id.clone();
 
-    let model = router
-        .route_model(target.clone())
-        .await
-        .map_err(|e| warp::reject::custom(BitrouterRejection(e)))?;
+    let model = router.route_model(target.clone()).await.map_err(|e| {
+        crate::router::log_request_resolve_failed(&caller, &incoming_model, &e);
+        warp::reject::custom(BitrouterRejection(e))
+    })?;
+
+    crate::router::log_request_received(
+        &caller,
+        &incoming_model,
+        &provider_name,
+        &target_model_id,
+        is_stream,
+    );
 
     let model_id = model.model_id().to_owned();
     let options = convert::to_call_options(request);
@@ -623,17 +634,29 @@ where
     if let Some(ref allowed) = caller.models
         && !is_model_allowed(&incoming_model, allowed)
     {
-        return Err(warp::reject::custom(BitrouterRejection(
-            BitrouterError::AccessDenied {
-                message: format!("model '{}' is not in your allowlist", incoming_model),
-            },
-        )));
+        let err = BitrouterError::AccessDenied {
+            message: format!("model '{}' is not in your allowlist", incoming_model),
+        };
+        crate::router::log_request_resolve_failed(&caller, &incoming_model, &err);
+        return Err(warp::reject::custom(BitrouterRejection(err)));
     }
 
     let chain = table
         .route_chain(&incoming_model, &route_ctx)
         .await
-        .map_err(|e| warp::reject::custom(BitrouterRejection(e)))?;
+        .map_err(|e| {
+            crate::router::log_request_resolve_failed(&caller, &incoming_model, &e);
+            warp::reject::custom(BitrouterRejection(e))
+        })?;
+    if let Some(first) = chain.first() {
+        crate::router::log_request_received(
+            &caller,
+            &incoming_model,
+            &first.provider_name,
+            &first.service_id,
+            is_stream,
+        );
+    }
     let options = convert::to_call_options(request);
     let start = Instant::now();
     let request_id = uuid::Uuid::new_v4().to_string();

--- a/bitrouter-api/src/router/openai/responses/filters.rs
+++ b/bitrouter-api/src/router/openai/responses/filters.rs
@@ -299,33 +299,44 @@ where
     if let Some(ref allowed) = caller.models
         && !is_model_allowed(&incoming_model, allowed)
     {
-        return Err(warp::reject::custom(BitrouterRejection(
-            BitrouterError::AccessDenied {
-                message: format!("model '{}' is not in your allowlist", incoming_model),
-            },
-        )));
+        let err = BitrouterError::AccessDenied {
+            message: format!("model '{}' is not in your allowlist", incoming_model),
+        };
+        crate::router::log_request_resolve_failed(&caller, &incoming_model, &err);
+        return Err(warp::reject::custom(BitrouterRejection(err)));
     }
 
     let mut target = table
         .route(&incoming_model, &route_ctx)
         .await
-        .map_err(|e| warp::reject::custom(BitrouterRejection(e)))?;
+        .map_err(|e| {
+            crate::router::log_request_resolve_failed(&caller, &incoming_model, &e);
+            warp::reject::custom(BitrouterRejection(e))
+        })?;
 
     if let Some(ref overlay) = target_overlay {
-        overlay
-            .apply(&mut target, &caller)
-            .await
-            .map_err(|e| warp::reject::custom(BitrouterRejection(e)))?;
+        overlay.apply(&mut target, &caller).await.map_err(|e| {
+            crate::router::log_request_resolve_failed(&caller, &incoming_model, &e);
+            warp::reject::custom(BitrouterRejection(e))
+        })?;
     }
 
     let byok_used = target.api_key_override.is_some();
     let provider_name = target.provider_name.clone();
     let target_model_id = target.service_id.clone();
 
-    let model = router
-        .route_model(target.clone())
-        .await
-        .map_err(|e| warp::reject::custom(BitrouterRejection(e)))?;
+    let model = router.route_model(target.clone()).await.map_err(|e| {
+        crate::router::log_request_resolve_failed(&caller, &incoming_model, &e);
+        warp::reject::custom(BitrouterRejection(e))
+    })?;
+
+    crate::router::log_request_received(
+        &caller,
+        &incoming_model,
+        &provider_name,
+        &target_model_id,
+        is_stream,
+    );
 
     let model_id = model.model_id().to_owned();
     let options = convert::to_call_options(request);
@@ -561,25 +572,36 @@ where
     if let Some(ref allowed) = caller.models
         && !is_model_allowed(&incoming_model, allowed)
     {
-        return Err(warp::reject::custom(BitrouterRejection(
-            BitrouterError::AccessDenied {
-                message: format!("model '{}' is not in your allowlist", incoming_model),
-            },
-        )));
+        let err = BitrouterError::AccessDenied {
+            message: format!("model '{}' is not in your allowlist", incoming_model),
+        };
+        crate::router::log_request_resolve_failed(&caller, &incoming_model, &err);
+        return Err(warp::reject::custom(BitrouterRejection(err)));
     }
 
     let target = table
         .route(&incoming_model, &route_ctx)
         .await
-        .map_err(|e| warp::reject::custom(BitrouterRejection(e)))?;
+        .map_err(|e| {
+            crate::router::log_request_resolve_failed(&caller, &incoming_model, &e);
+            warp::reject::custom(BitrouterRejection(e))
+        })?;
 
     let provider_name = target.provider_name.clone();
     let target_model_id = target.service_id.clone();
 
-    let model = router
-        .route_model(target.clone())
-        .await
-        .map_err(|e| warp::reject::custom(BitrouterRejection(e)))?;
+    let model = router.route_model(target.clone()).await.map_err(|e| {
+        crate::router::log_request_resolve_failed(&caller, &incoming_model, &e);
+        warp::reject::custom(BitrouterRejection(e))
+    })?;
+
+    crate::router::log_request_received(
+        &caller,
+        &incoming_model,
+        &provider_name,
+        &target_model_id,
+        is_stream,
+    );
 
     let model_id = model.model_id().to_owned();
     let options = convert::to_call_options(request);

--- a/bitrouter-observe/src/model_observer.rs
+++ b/bitrouter-observe/src/model_observer.rs
@@ -44,6 +44,22 @@ impl ObserveCallback for ModelSpendObserver {
         Box::pin(async move {
             let pricing = (self.pricing_lookup)(&event.ctx.provider, &event.ctx.model);
             let cost = calculate_cost(&event.usage, &pricing);
+            let input_tokens = event.usage.input_tokens.total.unwrap_or(0);
+            let output_tokens = event.usage.output_tokens.total.unwrap_or(0);
+
+            tracing::info!(
+                account_id = event.ctx.caller.account_id.as_deref().unwrap_or("-"),
+                route = %event.ctx.route,
+                provider = %event.ctx.provider,
+                model = %event.ctx.model,
+                stream = event.streamed,
+                status = 200,
+                latency_ms = event.ctx.latency_ms,
+                input_tokens,
+                output_tokens,
+                cost_usd = cost,
+                "request finished",
+            );
 
             let log = SpendLog {
                 id: Uuid::new_v4(),
@@ -53,8 +69,8 @@ impl ObserveCallback for ModelSpendObserver {
                 session_id: None,
                 service_name: event.ctx.route,
                 operation: format!("{}:{}", event.ctx.provider, event.ctx.model),
-                input_tokens: event.usage.input_tokens.total.unwrap_or(0),
-                output_tokens: event.usage.output_tokens.total.unwrap_or(0),
+                input_tokens,
+                output_tokens,
                 cost,
                 latency_ms: event.ctx.latency_ms,
                 success: true,
@@ -72,6 +88,19 @@ impl ObserveCallback for ModelSpendObserver {
     ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
         Box::pin(async move {
             let error_info = error_variant_name(&event.error);
+            let status = error_http_status(&event.error);
+
+            tracing::info!(
+                account_id = event.ctx.caller.account_id.as_deref().unwrap_or("-"),
+                route = %event.ctx.route,
+                provider = %event.ctx.provider,
+                model = %event.ctx.model,
+                status,
+                latency_ms = event.ctx.latency_ms,
+                error_kind = %error_info,
+                error = %event.error,
+                "request finished",
+            );
 
             let log = SpendLog {
                 id: Uuid::new_v4(),
@@ -108,6 +137,25 @@ fn error_variant_name(error: &bitrouter_core::errors::BitrouterError) -> String 
         BitrouterError::Provider { .. } => "Provider".into(),
         BitrouterError::StreamProtocol { .. } => "StreamProtocol".into(),
         BitrouterError::AccessDenied { .. } => "AccessDenied".into(),
+    }
+}
+
+/// HTTP status code that a [`BitrouterError`] maps to in the response layer.
+///
+/// Mirrors the mapping in `bitrouter-api`'s rejection handler so that the
+/// finish log reports the same status the client will see.
+fn error_http_status(error: &bitrouter_core::errors::BitrouterError) -> u16 {
+    use bitrouter_core::errors::BitrouterError;
+    match error {
+        BitrouterError::InvalidRequest { .. }
+        | BitrouterError::UnsupportedFeature { .. }
+        | BitrouterError::Cancelled { .. } => 400,
+        BitrouterError::AccessDenied { .. } => 403,
+        BitrouterError::Provider { context, .. } => context.status_code.unwrap_or(502),
+        BitrouterError::Transport { .. }
+        | BitrouterError::ResponseDecode { .. }
+        | BitrouterError::InvalidResponse { .. }
+        | BitrouterError::StreamProtocol { .. } => 502,
     }
 }
 

--- a/bitrouter-observe/src/spend/sea_orm_store.rs
+++ b/bitrouter-observe/src/spend/sea_orm_store.rs
@@ -51,12 +51,6 @@ impl SpendStore for SeaOrmSpendStore {
                 i64::MAX
             });
 
-            let service_type_str = log.service_type.to_string();
-            let service_name_str = log.service_name.clone();
-            let success = log.success;
-            let latency_ms_log = latency_ms;
-            let error_info_log = log.error_info.clone();
-
             let active = spend_log::ActiveModel {
                 id: Set(log.id),
                 service_type: Set(log.service_type.to_string()),
@@ -76,15 +70,6 @@ impl SpendStore for SeaOrmSpendStore {
 
             if let Err(e) = active.insert(&self.db).await {
                 tracing::warn!(error = %e, "failed to write spend log");
-            } else {
-                tracing::info!(
-                    service_type = %service_type_str,
-                    service_name = %service_name_str,
-                    success = success,
-                    latency_ms = latency_ms_log,
-                    error_info = error_info_log.as_deref().unwrap_or(""),
-                    "spend log recorded",
-                );
             }
         })
     }

--- a/bitrouter/src/runtime/server.rs
+++ b/bitrouter/src/runtime/server.rs
@@ -704,11 +704,7 @@ where
         let acct = bitrouter_accounts::filters::account_routes(db_conn.clone(), mgmt_auth.clone());
         let sess = bitrouter_accounts::filters::session_routes(db_conn, mgmt_auth);
 
-        let all = all_routes
-            .or(acct)
-            .or(sess)
-            .recover(handle_auth_rejection)
-            .with(warp::trace::request());
+        let all = all_routes.or(acct).or(sess).recover(handle_auth_rejection);
 
         // Pre-check that the address is available (warp's bind panics on failure).
         check_addr_available(addr)?;


### PR DESCRIPTION
## Summary

Server-side logs are noisy today: each request emits a `warp::filters::trace` start/finish pair, the auth filter resolves the account three times (logging each), and the spend store writes its own "spend log recorded" INFO line. That's six-plus lines per request before anything happens.

This PR replaces all of that with two INFO lines per request:

- **`request received`** — emitted from each protocol handler after model name resolution succeeds. Fields: `account_id`, `route` (the requested model id), `provider`, `model` (the resolved provider model), `stream`. If model resolution fails (allowlist, routing table, model factory), a single `request received (model resolution failed)` line carries the error instead — so failed-to-resolve requests still produce exactly one arrival log.
- **`request finished`** — emitted from `ModelSpendObserver` for both success and failure. Fields: `account_id`, `route`, `provider`, `model`, `status` (HTTP status mirroring `handle_bitrouter_rejection`'s mapping), `latency_ms`. Success adds `stream`, `input_tokens`, `output_tokens`, `cost_usd`; failure adds `error_kind` and the rendered error.

Library-emitted error lines (warp connection errors, MPP deduction warnings, spend-store write failures, etc.) are untouched.

## Changes

- Drop `.with(warp::trace::request())` from the warp filter stack.
- Demote `account resolved by pubkey` (`bitrouter-accounts`) and `spend log recorded` (`bitrouter-observe`) from INFO to lower-noise levels (debug-or-gone).
- Add `log_request_received` / `log_request_resolve_failed` helpers in `bitrouter-api::router` and call them in the four `_with_observe` and three `_with_gate` (MPP) handlers.
- Add the `request finished` INFO log in `ModelSpendObserver::on_request_success` / `on_request_failure`.

## Test plan

- [x] `cargo build --all-features`
- [x] `cargo clippy --all-features`
- [x] `cargo fmt -- --check`
- [x] `cargo nextest run --all-features` (914 / 914 passing)
- [x] `cargo test --all-features --doc`
- [ ] Smoke-test live: hit `/v1/chat/completions`, `/v1/messages`, `/v1/responses`, `/v1beta/models/:model:generateContent` and confirm exactly two INFO lines per request (one arrival, one finish), and that a bad model id produces a single `request received (model resolution failed)` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)