### PR TITLE
feat: wire reasoning effort through presets and provider adapters

### DIFF
--- a/bitrouter-config/src/config.rs
+++ b/bitrouter-config/src/config.rs
@@ -7,6 +7,7 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 
+use bitrouter_core::models::language::call_options::ReasoningEffort;
 use bitrouter_core::routers::routing_table::ApiProtocol;
 
 use crate::env::{load_env, substitute_in_value};
@@ -891,10 +892,9 @@ pub struct Endpoint {
 /// the preset's fields fill in anything the request leaves unset — fields
 /// already present on the request always win (shallow merge).
 ///
-/// Reasoning effort and tool-policy (parallel_tool_calls, tool_choice) are
-/// intentionally omitted from v0. They will be added when wired through to
-/// provider adapters in a follow-up PR — adding inert fields now would be
-/// dead config surface.
+/// Tool-policy fields (parallel_tool_calls, tool_choice) are intentionally
+/// omitted — they will land when wired through to provider adapters; adding
+/// inert fields now would be dead config surface.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct PresetConfig {
     /// Concrete model name this preset routes to (e.g. `gpt-5`).
@@ -946,6 +946,12 @@ pub struct GenerationParams {
     pub presence_penalty: Option<f32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stop: Option<Vec<String>>,
+    /// Normalized reasoning effort. Provider adapters translate this to the
+    /// upstream's native shape — OpenAI takes the enum string directly,
+    /// Anthropic maps to a `thinking.budget_tokens` integer, Google to
+    /// `thinkingConfig.thinkingBudget`. See [`ReasoningEffort`] for the table.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning_effort: Option<ReasoningEffort>,
 }
 
 impl GenerationParams {
@@ -957,6 +963,7 @@ impl GenerationParams {
             && self.frequency_penalty.is_none()
             && self.presence_penalty.is_none()
             && self.stop.is_none()
+            && self.reasoning_effort.is_none()
     }
 }
 

--- a/bitrouter-config/src/presets.rs
+++ b/bitrouter-config/src/presets.rs
@@ -180,6 +180,7 @@ pub fn resolve(
             stop_sequences: params.stop.clone(),
             presence_penalty: params.presence_penalty,
             frequency_penalty: params.frequency_penalty,
+            reasoning_effort: params.reasoning_effort,
         };
         if bundle.is_empty() {
             None
@@ -413,6 +414,28 @@ mod tests {
         let p = r.preset.expect("preset bundle");
         assert_eq!(p.temperature, Some(0.2));
         assert_eq!(p.system.as_deref(), Some("Reason carefully."));
+    }
+
+    #[test]
+    fn resolve_propagates_reasoning_effort_into_bundle() {
+        use bitrouter_core::models::language::call_options::ReasoningEffort;
+
+        let mut presets = HashMap::new();
+        presets.insert(
+            "deep".to_owned(),
+            PresetConfig {
+                model: Some("gpt-5".to_owned()),
+                params: crate::config::GenerationParams {
+                    reasoning_effort: Some(ReasoningEffort::High),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        );
+        let variants = HashMap::new();
+        let r = resolve("@deep", &presets, &variants).unwrap();
+        let bundle = r.preset.expect("preset bundle");
+        assert_eq!(bundle.reasoning_effort, Some(ReasoningEffort::High));
     }
 
     #[test]

--- a/bitrouter-config/templates/full.yaml
+++ b/bitrouter-config/templates/full.yaml
@@ -216,6 +216,11 @@ models:
 #     system_prompt: "Reason carefully. Cite sources when relevant."
 #     params:
 #       temperature: 0.2
+#       # Normalized reasoning effort: minimal | low | medium | high.
+#       # OpenAI receives the string directly; Anthropic maps to a
+#       # `thinking.budget_tokens` integer (minimal disables thinking);
+#       # Google maps to `thinkingConfig.thinkingBudget`.
+#       reasoning_effort: high
 #     routing:
 #       require_tags: [paid]
 #

--- a/bitrouter-core/src/api/anthropic/messages/convert.rs
+++ b/bitrouter-core/src/api/anthropic/messages/convert.rs
@@ -120,12 +120,19 @@ pub fn to_call_options(request: MessagesRequest) -> LanguageModelCallOptions {
 /// `Disabled` → `Minimal`; `Enabled` buckets on `budget_tokens`; `Adaptive`
 /// is passthrough (`None`) so downstream protocol-translation hands the
 /// "let the model decide" intent back without forcing a bucket.
+///
+/// Bucket boundaries are the midpoints between consecutive outbound emit
+/// values (`Low → 1024`, `Medium → 4096`, `High → 16384`). Picking
+/// midpoints means a same-protocol round-trip rounds each input to the
+/// *nearest* canonical budget rather than silently halving it: e.g.
+/// inbound `budget_tokens: 2000` buckets to `Low` (closer to 1024
+/// than to 4096) instead of being mis-bucketed by an off-midpoint cutoff.
 fn map_thinking_to_effort(thinking: &AnthropicThinking) -> Option<ReasoningEffort> {
     match thinking {
         AnthropicThinking::Disabled => Some(ReasoningEffort::Minimal),
         AnthropicThinking::Enabled { budget_tokens, .. } => Some(match *budget_tokens {
-            0..=2047 => ReasoningEffort::Low,
-            2048..=8191 => ReasoningEffort::Medium,
+            0..=2559 => ReasoningEffort::Low,
+            2560..=10239 => ReasoningEffort::Medium,
             _ => ReasoningEffort::High,
         }),
         AnthropicThinking::Adaptive { .. } => None,
@@ -623,6 +630,37 @@ mod tests {
 
         let opts = to_call_options(request);
         assert_eq!(opts.reasoning_effort, Some(ReasoningEffort::Medium));
+    }
+
+    #[test]
+    fn to_call_options_thinking_budget_buckets_at_midpoints() {
+        // Bucket boundaries are midpoints of the outbound emit table
+        // (1024, 4096, 16384). Exercises the boundary values directly so
+        // future tuning of the table doesn't silently shift the rounding.
+        let cases = [
+            (1024_u32, ReasoningEffort::Low),
+            (2559, ReasoningEffort::Low),
+            (2560, ReasoningEffort::Medium),
+            (4096, ReasoningEffort::Medium),
+            (10239, ReasoningEffort::Medium),
+            (10240, ReasoningEffort::High),
+            (16384, ReasoningEffort::High),
+        ];
+        for (budget, expected) in cases {
+            let request: MessagesRequest = serde_json::from_value(serde_json::json!({
+                "model": "claude-sonnet-4-5",
+                "max_tokens": 32768,
+                "messages": [{"role": "user", "content": "hi"}],
+                "thinking": {"type": "enabled", "budget_tokens": budget},
+            }))
+            .expect("messages request parses");
+            let opts = to_call_options(request);
+            assert_eq!(
+                opts.reasoning_effort,
+                Some(expected),
+                "budget_tokens={budget} should bucket to {expected:?}"
+            );
+        }
     }
 
     #[test]

--- a/bitrouter-core/src/api/anthropic/messages/convert.rs
+++ b/bitrouter-core/src/api/anthropic/messages/convert.rs
@@ -4,7 +4,7 @@ use std::collections::{HashMap, HashSet};
 
 use crate::models::{
     language::{
-        call_options::LanguageModelCallOptions,
+        call_options::{LanguageModelCallOptions, ReasoningEffort},
         content::LanguageModelContent,
         finish_reason::LanguageModelFinishReason,
         generate_result::LanguageModelGenerateResult,
@@ -20,9 +20,9 @@ use crate::models::{
 };
 
 use super::types::{
-    AnthropicContentBlock, AnthropicMessageContent, AnthropicToolChoice, MessagesMessageDelta,
-    MessagesRequest, MessagesResponse, MessagesStreamDelta, MessagesStreamEvent,
-    MessagesStreamMessage, MessagesUsage,
+    AnthropicContentBlock, AnthropicMessageContent, AnthropicThinking, AnthropicToolChoice,
+    MessagesMessageDelta, MessagesRequest, MessagesResponse, MessagesStreamDelta,
+    MessagesStreamEvent, MessagesStreamMessage, MessagesUsage,
 };
 use crate::api::util::generate_id;
 
@@ -91,6 +91,8 @@ pub fn to_call_options(request: MessagesRequest) -> LanguageModelCallOptions {
 
     let tool_choice = request.tool_choice.as_ref().and_then(convert_tool_choice);
 
+    let reasoning_effort = request.thinking.as_ref().and_then(map_thinking_to_effort);
+
     LanguageModelCallOptions {
         prompt,
         stream: request.stream,
@@ -108,7 +110,25 @@ pub fn to_call_options(request: MessagesRequest) -> LanguageModelCallOptions {
         include_raw_chunks: None,
         abort_signal: None,
         headers: None,
+        reasoning_effort,
         provider_options: None,
+    }
+}
+
+/// Buckets an Anthropic `thinking` configuration into the normalized enum.
+///
+/// `Disabled` → `Minimal`; `Enabled` buckets on `budget_tokens`; `Adaptive`
+/// is passthrough (`None`) so downstream protocol-translation hands the
+/// "let the model decide" intent back without forcing a bucket.
+fn map_thinking_to_effort(thinking: &AnthropicThinking) -> Option<ReasoningEffort> {
+    match thinking {
+        AnthropicThinking::Disabled => Some(ReasoningEffort::Minimal),
+        AnthropicThinking::Enabled { budget_tokens, .. } => Some(match *budget_tokens {
+            0..=2047 => ReasoningEffort::Low,
+            2048..=8191 => ReasoningEffort::Medium,
+            _ => ReasoningEffort::High,
+        }),
+        AnthropicThinking::Adaptive { .. } => None,
     }
 }
 
@@ -588,6 +608,36 @@ fn empty_stream_usage() -> MessagesUsage {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn to_call_options_buckets_anthropic_thinking_budget() {
+        // Construct via JSON so the test exercises the wire-format
+        // deserialization path users actually hit.
+        let request: MessagesRequest = serde_json::from_value(serde_json::json!({
+            "model": "claude-sonnet-4-5",
+            "max_tokens": 16384,
+            "messages": [{"role": "user", "content": "hi"}],
+            "thinking": {"type": "enabled", "budget_tokens": 5000},
+        }))
+        .expect("messages request parses");
+
+        let opts = to_call_options(request);
+        assert_eq!(opts.reasoning_effort, Some(ReasoningEffort::Medium));
+    }
+
+    #[test]
+    fn to_call_options_disabled_thinking_maps_to_minimal() {
+        let request: MessagesRequest = serde_json::from_value(serde_json::json!({
+            "model": "claude-sonnet-4-5",
+            "max_tokens": 4096,
+            "messages": [{"role": "user", "content": "hi"}],
+            "thinking": {"type": "disabled"},
+        }))
+        .expect("messages request parses");
+
+        let opts = to_call_options(request);
+        assert_eq!(opts.reasoning_effort, Some(ReasoningEffort::Minimal));
+    }
 
     #[test]
     fn stream_converter_starts_tool_block_for_delta_without_start() {

--- a/bitrouter-core/src/api/anthropic/messages/preset.rs
+++ b/bitrouter-core/src/api/anthropic/messages/preset.rs
@@ -8,7 +8,7 @@
 
 use crate::routers::routing_table::AppliedPreset;
 
-use super::types::{MessagesRequest, SystemPrompt};
+use super::types::{AnthropicThinking, MessagesRequest, SystemPrompt};
 
 /// Shallow-merges `preset` defaults onto `request`.
 pub fn apply(request: &mut MessagesRequest, preset: &AppliedPreset) {
@@ -28,6 +28,15 @@ pub fn apply(request: &mut MessagesRequest, preset: &AppliedPreset) {
     if request.stop_sequences.is_none() {
         request.stop_sequences = preset.stop_sequences.clone();
     }
+    // Anthropic thinking: only inject when the request omits it. Budget is
+    // clamped here against `max_tokens` to satisfy Anthropic's constraint
+    // (`budget_tokens < max_tokens`); a 256-token margin leaves room for the
+    // visible response.
+    if request.thinking.is_none()
+        && let Some(effort) = preset.reasoning_effort
+    {
+        request.thinking = Some(effort_to_thinking(effort, request.max_tokens));
+    }
 
     // System prompt: only set when request has none.
     if request.system.is_none()
@@ -37,10 +46,31 @@ pub fn apply(request: &mut MessagesRequest, preset: &AppliedPreset) {
     }
 }
 
+/// Maps a normalized effort onto Anthropic's `thinking` configuration.
+///
+/// Returns `Disabled` for [`ReasoningEffort::Minimal`]; otherwise enables
+/// thinking with the per-effort budget, clamped so `budget_tokens` stays
+/// strictly below `max_tokens` (Anthropic constraint — thinking and visible
+/// output share the same output pool) with a 256-token margin.
+pub fn effort_to_thinking(
+    effort: crate::models::language::call_options::ReasoningEffort,
+    max_tokens: u32,
+) -> AnthropicThinking {
+    let Some(budget) = effort.anthropic_budget_tokens() else {
+        return AnthropicThinking::Disabled;
+    };
+    let cap = max_tokens.saturating_sub(256).max(1024);
+    AnthropicThinking::Enabled {
+        budget_tokens: budget.min(cap),
+        display: None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::api::anthropic::messages::types::AnthropicMessage;
+    use crate::models::language::call_options::ReasoningEffort;
 
     fn empty_request() -> MessagesRequest {
         MessagesRequest {
@@ -49,7 +79,7 @@ mod tests {
                 role: "user".into(),
                 content: None,
             }],
-            max_tokens: 1024,
+            max_tokens: 8192,
             system: None,
             temperature: None,
             top_p: None,
@@ -59,6 +89,7 @@ mod tests {
             tools: None,
             tool_choice: None,
             metadata: None,
+            thinking: None,
         }
     }
 
@@ -97,6 +128,63 @@ mod tests {
             Some(SystemPrompt::Text(t)) => assert_eq!(t, "Reason carefully."),
             _ => panic!("expected text system prompt"),
         }
+    }
+
+    #[test]
+    fn preset_reasoning_effort_emits_thinking_when_request_unset() {
+        let mut req = empty_request();
+        let preset = AppliedPreset {
+            reasoning_effort: Some(ReasoningEffort::Medium),
+            ..Default::default()
+        };
+        apply(&mut req, &preset);
+        match req.thinking {
+            Some(AnthropicThinking::Enabled { budget_tokens, .. }) => {
+                assert_eq!(budget_tokens, 4096);
+            }
+            _ => panic!("expected enabled thinking"),
+        }
+    }
+
+    #[test]
+    fn preset_minimal_effort_disables_thinking() {
+        let mut req = empty_request();
+        let preset = AppliedPreset {
+            reasoning_effort: Some(ReasoningEffort::Minimal),
+            ..Default::default()
+        };
+        apply(&mut req, &preset);
+        assert!(matches!(req.thinking, Some(AnthropicThinking::Disabled)));
+    }
+
+    #[test]
+    fn preset_high_effort_clamps_budget_below_max_tokens() {
+        let mut req = empty_request();
+        req.max_tokens = 4096; // High preset budget (16384) must be clamped.
+        let preset = AppliedPreset {
+            reasoning_effort: Some(ReasoningEffort::High),
+            ..Default::default()
+        };
+        apply(&mut req, &preset);
+        match req.thinking {
+            Some(AnthropicThinking::Enabled { budget_tokens, .. }) => {
+                assert!(budget_tokens < req.max_tokens);
+                assert!(budget_tokens >= 1024);
+            }
+            _ => panic!("expected enabled thinking"),
+        }
+    }
+
+    #[test]
+    fn request_thinking_wins() {
+        let mut req = empty_request();
+        req.thinking = Some(AnthropicThinking::Disabled);
+        let preset = AppliedPreset {
+            reasoning_effort: Some(ReasoningEffort::High),
+            ..Default::default()
+        };
+        apply(&mut req, &preset);
+        assert!(matches!(req.thinking, Some(AnthropicThinking::Disabled)));
     }
 
     #[test]

--- a/bitrouter-core/src/api/anthropic/messages/preset.rs
+++ b/bitrouter-core/src/api/anthropic/messages/preset.rs
@@ -48,10 +48,12 @@ pub fn apply(request: &mut MessagesRequest, preset: &AppliedPreset) {
 
 /// Maps a normalized effort onto Anthropic's `thinking` configuration.
 ///
-/// Returns `Disabled` for [`ReasoningEffort::Minimal`]; otherwise enables
-/// thinking with the per-effort budget, clamped so `budget_tokens` stays
-/// strictly below `max_tokens` (Anthropic constraint — thinking and visible
-/// output share the same output pool) with a 256-token margin.
+/// Returns `Disabled` for [`ReasoningEffort::Minimal`], and also when the
+/// caller's `max_tokens` is too small to fit Anthropic's hard minimum of 1024
+/// thinking tokens plus a 256-token visible-output margin. Anthropic requires
+/// `1024 <= budget_tokens < max_tokens`; if that window collapses we honor
+/// `max_tokens` and silently drop thinking rather than emit a request the
+/// upstream will reject.
 pub fn effort_to_thinking(
     effort: crate::models::language::call_options::ReasoningEffort,
     max_tokens: u32,
@@ -59,9 +61,14 @@ pub fn effort_to_thinking(
     let Some(budget) = effort.anthropic_budget_tokens() else {
         return AnthropicThinking::Disabled;
     };
-    let cap = max_tokens.saturating_sub(256).max(1024);
+    const MIN_BUDGET: u32 = 1024;
+    const VISIBLE_MARGIN: u32 = 256;
+    let usable = max_tokens.saturating_sub(VISIBLE_MARGIN);
+    if usable < MIN_BUDGET {
+        return AnthropicThinking::Disabled;
+    }
     AnthropicThinking::Enabled {
-        budget_tokens: budget.min(cap),
+        budget_tokens: budget.min(usable),
         display: None,
     }
 }
@@ -172,6 +179,47 @@ mod tests {
                 assert!(budget_tokens >= 1024);
             }
             _ => panic!("expected enabled thinking"),
+        }
+    }
+
+    #[test]
+    fn preset_high_effort_disables_thinking_when_max_tokens_too_small() {
+        // Anthropic requires 1024 <= budget_tokens < max_tokens. With a
+        // 256-token visible-output margin the floor is max_tokens >= 1280.
+        // Below that, the only valid choice is to disable thinking entirely
+        // — emitting any Enabled config would violate Anthropic's contract.
+        for max_tokens in [0_u32, 1024, 1279] {
+            let mut req = empty_request();
+            req.max_tokens = max_tokens;
+            let preset = AppliedPreset {
+                reasoning_effort: Some(ReasoningEffort::High),
+                ..Default::default()
+            };
+            apply(&mut req, &preset);
+            assert!(
+                matches!(req.thinking, Some(AnthropicThinking::Disabled)),
+                "max_tokens={max_tokens} should disable thinking, got {:?}",
+                req.thinking
+            );
+        }
+    }
+
+    #[test]
+    fn preset_effort_enables_at_min_budget_when_max_tokens_just_fits() {
+        // 1280 = 1024 (Anthropic min) + 256 (visible margin) — the boundary.
+        let mut req = empty_request();
+        req.max_tokens = 1280;
+        let preset = AppliedPreset {
+            reasoning_effort: Some(ReasoningEffort::High),
+            ..Default::default()
+        };
+        apply(&mut req, &preset);
+        match req.thinking {
+            Some(AnthropicThinking::Enabled { budget_tokens, .. }) => {
+                assert_eq!(budget_tokens, 1024);
+                assert!(budget_tokens < req.max_tokens);
+            }
+            other => panic!("expected enabled thinking at boundary, got {other:?}"),
         }
     }
 

--- a/bitrouter-core/src/api/anthropic/messages/types.rs
+++ b/bitrouter-core/src/api/anthropic/messages/types.rs
@@ -57,6 +57,29 @@ pub struct MessagesRequest {
     pub tool_choice: Option<AnthropicToolChoice>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub metadata: Option<AnthropicMetadata>,
+    /// Extended-thinking configuration.
+    /// <https://docs.claude.com/en/docs/build-with-claude/extended-thinking>
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thinking: Option<AnthropicThinking>,
+}
+
+/// Anthropic extended-thinking configuration.
+///
+/// `budget_tokens` must be at least 1024 and strictly less than
+/// `max_tokens` (they share the same output pool).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum AnthropicThinking {
+    Enabled {
+        budget_tokens: u32,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        display: Option<String>,
+    },
+    Disabled,
+    Adaptive {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        display: Option<String>,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/bitrouter-core/src/api/google/generate_content/convert.rs
+++ b/bitrouter-core/src/api/google/generate_content/convert.rs
@@ -146,6 +146,10 @@ pub fn to_call_options(request: GenerateContentRequest) -> LanguageModelCallOpti
 /// Prefers `thinking_level` (Gemini 3+) when set, falling back to bucketing
 /// `thinking_budget` (Gemini 2.5). The dynamic-thinking sentinel `-1` is
 /// treated as passthrough — the caller asked the model to decide.
+///
+/// Bucket boundaries are the midpoints between consecutive outbound emit
+/// values (`Low → 1024`, `Medium → 4096`, `High → 16384`) so a same-protocol
+/// round-trip rounds to the nearest canonical budget.
 fn map_thinking_config(cfg: &GoogleThinkingConfig) -> Option<ReasoningEffort> {
     if let Some(level) = cfg.thinking_level.as_deref()
         && let Some(effort) = ReasoningEffort::from_str_opt(level)
@@ -155,8 +159,8 @@ fn map_thinking_config(cfg: &GoogleThinkingConfig) -> Option<ReasoningEffort> {
     match cfg.thinking_budget? {
         -1 => None,
         0 => Some(ReasoningEffort::Minimal),
-        1..=2047 => Some(ReasoningEffort::Low),
-        2048..=8191 => Some(ReasoningEffort::Medium),
+        1..=2559 => Some(ReasoningEffort::Low),
+        2560..=10239 => Some(ReasoningEffort::Medium),
         _ => Some(ReasoningEffort::High),
     }
 }
@@ -511,6 +515,35 @@ mod tests {
 
         let opts = to_call_options(request);
         assert_eq!(opts.reasoning_effort, Some(ReasoningEffort::Medium));
+    }
+
+    #[test]
+    fn to_call_options_thinking_budget_buckets_at_midpoints() {
+        // Mirrors the Anthropic boundary test — bucket cutoffs are the
+        // midpoints between outbound emit values (1024, 4096, 16384).
+        let cases = [
+            (0_i32, ReasoningEffort::Minimal),
+            (1024, ReasoningEffort::Low),
+            (2559, ReasoningEffort::Low),
+            (2560, ReasoningEffort::Medium),
+            (4096, ReasoningEffort::Medium),
+            (10239, ReasoningEffort::Medium),
+            (10240, ReasoningEffort::High),
+            (32768, ReasoningEffort::High),
+        ];
+        for (budget, expected) in cases {
+            let request: GenerateContentRequest = serde_json::from_value(serde_json::json!({
+                "contents": [{"role": "user", "parts": [{"text": "hi"}]}],
+                "generationConfig": {"thinkingConfig": {"thinkingBudget": budget}}
+            }))
+            .expect("generate_content request parses");
+            let opts = to_call_options(request);
+            assert_eq!(
+                opts.reasoning_effort,
+                Some(expected),
+                "thinkingBudget={budget} should bucket to {expected:?}"
+            );
+        }
     }
 
     #[test]

--- a/bitrouter-core/src/api/google/generate_content/convert.rs
+++ b/bitrouter-core/src/api/google/generate_content/convert.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use crate::models::{
     language::{
-        call_options::LanguageModelCallOptions,
+        call_options::{LanguageModelCallOptions, ReasoningEffort},
         content::LanguageModelContent,
         finish_reason::LanguageModelFinishReason,
         generate_result::LanguageModelGenerateResult,
@@ -21,7 +21,8 @@ use crate::models::{
 
 use super::types::{
     GenerateContentCandidate, GenerateContentRequest, GenerateContentResponse,
-    GenerateContentUsageMetadata, GoogleContent, GoogleFunctionCall, GooglePart, GoogleToolConfig,
+    GenerateContentUsageMetadata, GoogleContent, GoogleFunctionCall, GooglePart,
+    GoogleThinkingConfig, GoogleToolConfig,
 };
 use crate::api::util::generate_id;
 
@@ -100,17 +101,22 @@ pub fn to_call_options(request: GenerateContentRequest) -> LanguageModelCallOpti
 
     let tool_choice = request.tool_config.and_then(convert_tool_config);
 
-    let (max_output_tokens, temperature, top_p, top_k, stop_sequences) =
+    let (max_output_tokens, temperature, top_p, top_k, stop_sequences, reasoning_effort) =
         if let Some(config) = request.generation_config {
+            let effort = config
+                .thinking_config
+                .as_ref()
+                .and_then(map_thinking_config);
             (
                 config.max_output_tokens,
                 config.temperature,
                 config.top_p,
                 config.top_k,
                 config.stop_sequences,
+                effort,
             )
         } else {
-            (None, None, None, None, None)
+            (None, None, None, None, None, None)
         };
 
     LanguageModelCallOptions {
@@ -130,7 +136,28 @@ pub fn to_call_options(request: GenerateContentRequest) -> LanguageModelCallOpti
         include_raw_chunks: None,
         abort_signal: None,
         headers: None,
+        reasoning_effort,
         provider_options: None,
+    }
+}
+
+/// Buckets a Google `thinkingConfig` into the normalized enum.
+///
+/// Prefers `thinking_level` (Gemini 3+) when set, falling back to bucketing
+/// `thinking_budget` (Gemini 2.5). The dynamic-thinking sentinel `-1` is
+/// treated as passthrough — the caller asked the model to decide.
+fn map_thinking_config(cfg: &GoogleThinkingConfig) -> Option<ReasoningEffort> {
+    if let Some(level) = cfg.thinking_level.as_deref()
+        && let Some(effort) = ReasoningEffort::from_str_opt(level)
+    {
+        return Some(effort);
+    }
+    match cfg.thinking_budget? {
+        -1 => None,
+        0 => Some(ReasoningEffort::Minimal),
+        1..=2047 => Some(ReasoningEffort::Low),
+        2048..=8191 => Some(ReasoningEffort::Medium),
+        _ => Some(ReasoningEffort::High),
     }
 }
 
@@ -471,6 +498,51 @@ fn map_finish_reason(reason: &LanguageModelFinishReason) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn to_call_options_buckets_google_thinking_budget() {
+        let request: GenerateContentRequest = serde_json::from_value(serde_json::json!({
+            "contents": [{"role": "user", "parts": [{"text": "hi"}]}],
+            "generationConfig": {
+                "thinkingConfig": {"thinkingBudget": 5000}
+            }
+        }))
+        .expect("generate_content request parses");
+
+        let opts = to_call_options(request);
+        assert_eq!(opts.reasoning_effort, Some(ReasoningEffort::Medium));
+    }
+
+    #[test]
+    fn to_call_options_dynamic_thinking_budget_passes_through() {
+        // `-1` means "let the model decide" — we don't bucket, we pass
+        // through as no normalized effort so cross-protocol routing
+        // doesn't force a level on the caller's behalf.
+        let request: GenerateContentRequest = serde_json::from_value(serde_json::json!({
+            "contents": [{"role": "user", "parts": [{"text": "hi"}]}],
+            "generationConfig": {
+                "thinkingConfig": {"thinkingBudget": -1}
+            }
+        }))
+        .expect("generate_content request parses");
+
+        let opts = to_call_options(request);
+        assert!(opts.reasoning_effort.is_none());
+    }
+
+    #[test]
+    fn to_call_options_thinking_level_takes_precedence() {
+        let request: GenerateContentRequest = serde_json::from_value(serde_json::json!({
+            "contents": [{"role": "user", "parts": [{"text": "hi"}]}],
+            "generationConfig": {
+                "thinkingConfig": {"thinkingLevel": "high", "thinkingBudget": 0}
+            }
+        }))
+        .expect("generate_content request parses");
+
+        let opts = to_call_options(request);
+        assert_eq!(opts.reasoning_effort, Some(ReasoningEffort::High));
+    }
 
     #[test]
     fn stream_converter_reasoning_delta_emits_thought_part() {

--- a/bitrouter-core/src/api/google/generate_content/preset.rs
+++ b/bitrouter-core/src/api/google/generate_content/preset.rs
@@ -6,7 +6,9 @@
 
 use crate::routers::routing_table::AppliedPreset;
 
-use super::types::{GenerateContentRequest, GoogleContent, GoogleGenerationConfig, GooglePart};
+use super::types::{
+    GenerateContentRequest, GoogleContent, GoogleGenerationConfig, GooglePart, GoogleThinkingConfig,
+};
 
 /// Shallow-merges `preset` defaults onto `request`.
 pub fn apply(request: &mut GenerateContentRequest, preset: &AppliedPreset) {
@@ -22,7 +24,8 @@ pub fn apply(request: &mut GenerateContentRequest, preset: &AppliedPreset) {
         || preset.max_tokens.is_some()
         || preset.stop_sequences.is_some()
         || preset.presence_penalty.is_some()
-        || preset.frequency_penalty.is_some();
+        || preset.frequency_penalty.is_some()
+        || preset.reasoning_effort.is_some();
     if needs_gen_config {
         let cfg = request
             .generation_config
@@ -48,6 +51,19 @@ pub fn apply(request: &mut GenerateContentRequest, preset: &AppliedPreset) {
         if cfg.frequency_penalty.is_none() {
             cfg.frequency_penalty = preset.frequency_penalty;
         }
+        // Inject thinking only when the request omits the entire object.
+        // A request that supplied `thinkingConfig: {}` (no fields) is
+        // treated as explicit opt-out of preset thinking, matching the
+        // "request wins" semantics other fields use.
+        if cfg.thinking_config.is_none()
+            && let Some(effort) = preset.reasoning_effort
+        {
+            cfg.thinking_config = Some(GoogleThinkingConfig {
+                thinking_budget: Some(effort.google_thinking_budget()),
+                thinking_level: None,
+                include_thoughts: None,
+            });
+        }
     }
 
     // System: only when request has no system_instruction.
@@ -70,6 +86,7 @@ pub fn apply(request: &mut GenerateContentRequest, preset: &AppliedPreset) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::models::language::call_options::ReasoningEffort;
 
     fn empty_request() -> GenerateContentRequest {
         GenerateContentRequest {
@@ -109,6 +126,40 @@ mod tests {
         apply(&mut req, &preset);
         let cfg = req.generation_config.unwrap();
         assert_eq!(cfg.temperature, Some(0.9));
+    }
+
+    #[test]
+    fn preset_reasoning_effort_writes_thinking_budget() {
+        let mut req = empty_request();
+        let preset = AppliedPreset {
+            reasoning_effort: Some(ReasoningEffort::High),
+            ..Default::default()
+        };
+        apply(&mut req, &preset);
+        let cfg = req.generation_config.expect("generation_config");
+        let thinking = cfg.thinking_config.expect("thinking_config");
+        assert_eq!(thinking.thinking_budget, Some(16384));
+    }
+
+    #[test]
+    fn request_thinking_config_wins() {
+        let mut req = empty_request();
+        req.generation_config = Some(GoogleGenerationConfig {
+            thinking_config: Some(GoogleThinkingConfig {
+                thinking_budget: Some(0),
+                thinking_level: None,
+                include_thoughts: None,
+            }),
+            ..Default::default()
+        });
+        let preset = AppliedPreset {
+            reasoning_effort: Some(ReasoningEffort::High),
+            ..Default::default()
+        };
+        apply(&mut req, &preset);
+        let cfg = req.generation_config.unwrap();
+        let thinking = cfg.thinking_config.unwrap();
+        assert_eq!(thinking.thinking_budget, Some(0));
     }
 
     #[test]

--- a/bitrouter-core/src/api/google/generate_content/types.rs
+++ b/bitrouter-core/src/api/google/generate_content/types.rs
@@ -128,6 +128,25 @@ pub struct GoogleGenerationConfig {
     pub response_mime_type: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub response_schema: Option<serde_json::Value>,
+    /// Thinking configuration for Gemini 2.5+ models.
+    /// <https://ai.google.dev/gemini-api/docs/thinking>
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thinking_config: Option<GoogleThinkingConfig>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GoogleThinkingConfig {
+    /// Token budget for thinking. `-1` enables dynamic thinking; `0` disables
+    /// thinking (allowed on 2.5 Flash, rejected on 2.5 Pro which requires ≥128).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thinking_budget: Option<i32>,
+    /// Discrete thinking level (Gemini 3+ models only).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thinking_level: Option<String>,
+    /// Whether to emit thought summaries in the response.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub include_thoughts: Option<bool>,
 }
 
 // ── Response ────────────────────────────────────────────────────────────────

--- a/bitrouter-core/src/api/openai/chat/convert.rs
+++ b/bitrouter-core/src/api/openai/chat/convert.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use crate::models::{
     language::{
-        call_options::LanguageModelCallOptions,
+        call_options::{LanguageModelCallOptions, ReasoningEffort},
         content::LanguageModelContent,
         finish_reason::LanguageModelFinishReason,
         generate_result::LanguageModelGenerateResult,
@@ -58,6 +58,11 @@ pub fn to_call_options(request: ChatCompletionRequest) -> LanguageModelCallOptio
 
     let tool_choice = request.tool_choice.as_ref().and_then(convert_tool_choice);
 
+    let reasoning_effort = request
+        .reasoning_effort
+        .as_deref()
+        .and_then(ReasoningEffort::from_str_opt);
+
     LanguageModelCallOptions {
         prompt,
         stream: request.stream,
@@ -75,6 +80,7 @@ pub fn to_call_options(request: ChatCompletionRequest) -> LanguageModelCallOptio
         include_raw_chunks: None,
         abort_signal: None,
         headers: None,
+        reasoning_effort,
         provider_options: None,
     }
 }
@@ -456,6 +462,33 @@ mod tests {
     };
 
     // ── Request Deserialization ─────────────────────────────────────────
+
+    #[test]
+    fn to_call_options_parses_reasoning_effort_string() {
+        let json = r#"{
+            "model": "gpt-5",
+            "messages": [{"role": "user", "content": "hi"}],
+            "reasoning_effort": "high"
+        }"#;
+        let req: ChatCompletionRequest = serde_json::from_str(json).expect("parse failed");
+        let opts = to_call_options(req);
+        assert_eq!(opts.reasoning_effort, Some(ReasoningEffort::High));
+    }
+
+    #[test]
+    fn to_call_options_unknown_reasoning_effort_drops_to_none() {
+        // `xhigh` is OpenAI-specific (codex-max+); BitRouter's normalized
+        // enum doesn't carry it, so unknown values must drop cleanly
+        // rather than panicking or refusing the request.
+        let json = r#"{
+            "model": "gpt-5.1-codex-max",
+            "messages": [{"role": "user", "content": "hi"}],
+            "reasoning_effort": "xhigh"
+        }"#;
+        let req: ChatCompletionRequest = serde_json::from_str(json).expect("parse failed");
+        let opts = to_call_options(req);
+        assert!(opts.reasoning_effort.is_none());
+    }
 
     #[test]
     fn deserialize_simple_text_message_request() {

--- a/bitrouter-core/src/api/openai/chat/preset.rs
+++ b/bitrouter-core/src/api/openai/chat/preset.rs
@@ -36,6 +36,11 @@ pub fn apply(request: &mut ChatCompletionRequest, preset: &AppliedPreset) {
     if request.frequency_penalty.is_none() {
         request.frequency_penalty = preset.frequency_penalty;
     }
+    if request.reasoning_effort.is_none()
+        && let Some(effort) = preset.reasoning_effort
+    {
+        request.reasoning_effort = Some(effort.as_openai_str().to_owned());
+    }
 
     // System prompt: only inject when the request has no system message of its own.
     if let Some(system) = &preset.system
@@ -57,6 +62,7 @@ pub fn apply(request: &mut ChatCompletionRequest, preset: &AppliedPreset) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::models::language::call_options::ReasoningEffort;
 
     fn empty_request() -> ChatCompletionRequest {
         ChatCompletionRequest {
@@ -82,6 +88,7 @@ mod tests {
             tool_choice: None,
             parallel_tool_calls: None,
             response_format: None,
+            reasoning_effort: None,
         }
     }
 
@@ -118,6 +125,29 @@ mod tests {
         apply(&mut req, &preset);
         assert_eq!(req.messages.len(), 2);
         assert_eq!(req.messages[0].role, "system");
+    }
+
+    #[test]
+    fn preset_reasoning_effort_fills_when_request_unset() {
+        let mut req = empty_request();
+        let preset = AppliedPreset {
+            reasoning_effort: Some(ReasoningEffort::High),
+            ..Default::default()
+        };
+        apply(&mut req, &preset);
+        assert_eq!(req.reasoning_effort.as_deref(), Some("high"));
+    }
+
+    #[test]
+    fn request_reasoning_effort_wins() {
+        let mut req = empty_request();
+        req.reasoning_effort = Some("xhigh".into());
+        let preset = AppliedPreset {
+            reasoning_effort: Some(ReasoningEffort::Low),
+            ..Default::default()
+        };
+        apply(&mut req, &preset);
+        assert_eq!(req.reasoning_effort.as_deref(), Some("xhigh"));
     }
 
     #[test]

--- a/bitrouter-core/src/api/openai/chat/types.rs
+++ b/bitrouter-core/src/api/openai/chat/types.rs
@@ -36,6 +36,14 @@ pub struct ChatCompletionRequest {
     pub parallel_tool_calls: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub response_format: Option<ChatResponseFormat>,
+    /// Reasoning effort for `o`- and `gpt-5`-series models.
+    /// <https://platform.openai.com/docs/guides/reasoning>
+    ///
+    /// Carried as a free-form string so requests targeting models that accept
+    /// values beyond BitRouter's normalized enum (e.g. `xhigh`, `none`) can
+    /// round-trip when both inbound and outbound protocol is OpenAI Chat.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning_effort: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/bitrouter-core/src/api/openai/responses/convert.rs
+++ b/bitrouter-core/src/api/openai/responses/convert.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use crate::models::{
     language::{
-        call_options::LanguageModelCallOptions,
+        call_options::{LanguageModelCallOptions, ReasoningEffort},
         content::LanguageModelContent,
         data_content::LanguageModelDataContent,
         generate_result::LanguageModelGenerateResult,
@@ -79,6 +79,12 @@ pub fn to_call_options(request: ResponsesRequest) -> LanguageModelCallOptions {
             .collect()
     });
 
+    let reasoning_effort = request
+        .reasoning
+        .as_ref()
+        .and_then(|r| r.effort.as_deref())
+        .and_then(ReasoningEffort::from_str_opt);
+
     LanguageModelCallOptions {
         prompt,
         stream: request.stream,
@@ -96,6 +102,7 @@ pub fn to_call_options(request: ResponsesRequest) -> LanguageModelCallOptions {
         include_raw_chunks: None,
         abort_signal: None,
         headers: None,
+        reasoning_effort,
         provider_options: None,
     }
 }
@@ -1493,6 +1500,7 @@ mod tests {
             tool_choice: None,
             parallel_tool_calls: None,
             text: None,
+            reasoning: None,
         };
 
         let val = serde_json::to_value(&req).expect("serialize failed");

--- a/bitrouter-core/src/api/openai/responses/preset.rs
+++ b/bitrouter-core/src/api/openai/responses/preset.rs
@@ -5,7 +5,7 @@
 
 use crate::routers::routing_table::AppliedPreset;
 
-use super::types::ResponsesRequest;
+use super::types::{ResponsesReasoning, ResponsesRequest};
 
 /// Shallow-merges `preset` defaults onto `request`.
 ///
@@ -26,6 +26,18 @@ pub fn apply(request: &mut ResponsesRequest, preset: &AppliedPreset) {
     if request.max_output_tokens.is_none() {
         request.max_output_tokens = preset.max_tokens;
     }
+    // Responses API nests effort under a `reasoning` object. Inject the
+    // whole object when the request omits it; if the request has its own
+    // `reasoning` (even with effort unset), leave it alone — the request
+    // already opted into reasoning configuration explicitly.
+    if request.reasoning.is_none()
+        && let Some(effort) = preset.reasoning_effort
+    {
+        request.reasoning = Some(ResponsesReasoning {
+            effort: Some(effort.as_openai_str().to_owned()),
+            summary: None,
+        });
+    }
 
     if request.instructions.is_none()
         && let Some(system) = &preset.system
@@ -38,6 +50,7 @@ pub fn apply(request: &mut ResponsesRequest, preset: &AppliedPreset) {
 mod tests {
     use super::*;
     use crate::api::openai::responses::types::ResponsesInput;
+    use crate::models::language::call_options::ReasoningEffort;
 
     fn empty_request() -> ResponsesRequest {
         ResponsesRequest {
@@ -52,6 +65,7 @@ mod tests {
             tool_choice: None,
             parallel_tool_calls: None,
             text: None,
+            reasoning: None,
         }
     }
 
@@ -75,6 +89,34 @@ mod tests {
         };
         apply(&mut req, &preset);
         assert_eq!(req.instructions.as_deref(), Some("Reason carefully."));
+    }
+
+    #[test]
+    fn preset_reasoning_effort_wraps_in_object_when_request_unset() {
+        let mut req = empty_request();
+        let preset = AppliedPreset {
+            reasoning_effort: Some(ReasoningEffort::High),
+            ..Default::default()
+        };
+        apply(&mut req, &preset);
+        let r = req.reasoning.expect("reasoning object created");
+        assert_eq!(r.effort.as_deref(), Some("high"));
+    }
+
+    #[test]
+    fn request_reasoning_object_wins() {
+        let mut req = empty_request();
+        req.reasoning = Some(ResponsesReasoning {
+            effort: Some("minimal".into()),
+            summary: None,
+        });
+        let preset = AppliedPreset {
+            reasoning_effort: Some(ReasoningEffort::High),
+            ..Default::default()
+        };
+        apply(&mut req, &preset);
+        let r = req.reasoning.expect("reasoning preserved");
+        assert_eq!(r.effort.as_deref(), Some("minimal"));
     }
 
     #[test]

--- a/bitrouter-core/src/api/openai/responses/types.rs
+++ b/bitrouter-core/src/api/openai/responses/types.rs
@@ -35,6 +35,22 @@ pub struct ResponsesRequest {
     pub parallel_tool_calls: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub text: Option<ResponsesTextConfig>,
+    /// Reasoning configuration for `o`- and `gpt-5`-series models on the
+    /// Responses API. The Responses API nests `effort` under a `reasoning`
+    /// object (Chat Completions uses a flat top-level field).
+    /// <https://platform.openai.com/docs/api-reference/responses/create>
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning: Option<ResponsesReasoning>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ResponsesReasoning {
+    /// Free-form string for forward-compatibility with `xhigh` / `none`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effort: Option<String>,
+    /// Reasoning summary visibility (`auto` | `concise` | `detailed`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/bitrouter-core/src/models/language/call_options.rs
+++ b/bitrouter-core/src/models/language/call_options.rs
@@ -1,6 +1,7 @@
 //! Options for calling a language model, including prompt, generation parameters, tools, and provider-specific options
 
 use http::HeaderMap;
+use serde::{Deserialize, Serialize};
 use tokio_util::sync::CancellationToken;
 
 use crate::models::shared::{provider::ProviderOptions, types::JsonSchema};
@@ -8,6 +9,79 @@ use crate::models::shared::{provider::ProviderOptions, types::JsonSchema};
 use super::{
     prompt::LanguageModelPrompt, tool::LanguageModelTool, tool_choice::LanguageModelToolChoice,
 };
+
+/// Normalized reasoning effort across providers.
+///
+/// Providers expose reasoning configuration in fundamentally different shapes:
+/// OpenAI uses an enum (`minimal`/`low`/`medium`/`high`), Anthropic uses an
+/// explicit `budget_tokens` integer, and Google uses a `thinkingBudget` (or
+/// `thinkingLevel` on Gemini 3). BitRouter normalizes through this enum and
+/// lets each provider adapter map it back to the native shape. Mappings are
+/// intentionally lossy at the bucket boundaries — see the per-protocol
+/// `preset.rs` and provider `build_*_request` for the table.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ReasoningEffort {
+    Minimal,
+    Low,
+    Medium,
+    High,
+}
+
+impl ReasoningEffort {
+    /// Parses a string value, returning `None` for unknown variants.
+    ///
+    /// Comparison is ASCII case-insensitive. Used by inbound parsers to lift
+    /// per-protocol string fields (OpenAI `reasoning_effort`, Google
+    /// `thinkingLevel`) into the normalized enum.
+    pub fn from_str_opt(s: &str) -> Option<Self> {
+        match s.to_ascii_lowercase().as_str() {
+            "minimal" => Some(Self::Minimal),
+            "low" => Some(Self::Low),
+            "medium" => Some(Self::Medium),
+            "high" => Some(Self::High),
+            _ => None,
+        }
+    }
+
+    /// String form accepted by OpenAI's `reasoning_effort` field
+    /// (Chat Completions) and `reasoning.effort` (Responses).
+    pub fn as_openai_str(self) -> &'static str {
+        match self {
+            Self::Minimal => "minimal",
+            Self::Low => "low",
+            Self::Medium => "medium",
+            Self::High => "high",
+        }
+    }
+
+    /// Token budget for Anthropic's `thinking.budget_tokens` field. `None`
+    /// means "disable thinking" (mapped to `{type: "disabled"}` upstream).
+    ///
+    /// Returned values respect Anthropic's documented minimum of 1024. The
+    /// outbound provider must additionally clamp the budget to be strictly
+    /// less than the request's `max_tokens`.
+    pub fn anthropic_budget_tokens(self) -> Option<u32> {
+        match self {
+            Self::Minimal => None,
+            Self::Low => Some(1024),
+            Self::Medium => Some(4096),
+            Self::High => Some(16384),
+        }
+    }
+
+    /// Token budget for Google's `thinkingConfig.thinkingBudget` field
+    /// (Gemini 2.5). `0` disables thinking on Flash models; Pro models
+    /// require a minimum of 128 and will reject 0.
+    pub fn google_thinking_budget(self) -> i32 {
+        match self {
+            Self::Minimal => 0,
+            Self::Low => 1024,
+            Self::Medium => 4096,
+            Self::High => 16384,
+        }
+    }
+}
 
 /// Options for calling a language model
 #[derive(Debug, Clone)]
@@ -44,6 +118,11 @@ pub struct LanguageModelCallOptions {
     pub abort_signal: Option<CancellationToken>,
     /// Custom headers to include in the request
     pub headers: Option<HeaderMap>,
+
+    /// Normalized reasoning effort. Each provider adapter maps this to the
+    /// native shape (OpenAI `reasoning_effort` string, Anthropic `thinking`
+    /// object, Google `thinkingConfig`).
+    pub reasoning_effort: Option<ReasoningEffort>,
 
     /// Provider-specific options that can be used to pass additional information to the provider or control provider-specific behavior
     pub provider_options: Option<ProviderOptions>,

--- a/bitrouter-core/src/routers/routing_table.rs
+++ b/bitrouter-core/src/routers/routing_table.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use serde::{Deserialize, Serialize};
 
 use crate::errors::Result;
+use crate::models::language::call_options::ReasoningEffort;
 use crate::routers::content::RouteContext;
 
 // ── API protocol ──────────────────────────────────────────────────
@@ -63,6 +64,7 @@ pub struct AppliedPreset {
     pub stop_sequences: Option<Vec<String>>,
     pub presence_penalty: Option<f32>,
     pub frequency_penalty: Option<f32>,
+    pub reasoning_effort: Option<ReasoningEffort>,
 }
 
 impl AppliedPreset {
@@ -76,6 +78,7 @@ impl AppliedPreset {
             && self.stop_sequences.is_none()
             && self.presence_penalty.is_none()
             && self.frequency_penalty.is_none()
+            && self.reasoning_effort.is_none()
     }
 }
 

--- a/bitrouter-guardrails/src/engine.rs
+++ b/bitrouter-guardrails/src/engine.rs
@@ -1012,6 +1012,7 @@ mod tests {
             include_raw_chunks: None,
             abort_signal: None,
             headers: None,
+            reasoning_effort: None,
             provider_options: None,
         }
     }

--- a/bitrouter-providers/src/anthropic/messages/api.rs
+++ b/bitrouter-providers/src/anthropic/messages/api.rs
@@ -249,11 +249,15 @@ pub(super) fn build_messages_request(
         .transpose()?;
 
     let (system, messages) = convert_prompt(&options.prompt)?;
+    let max_tokens = options.max_output_tokens.unwrap_or(DEFAULT_MAX_TOKENS);
+    let thinking = options.reasoning_effort.map(|e| {
+        bitrouter_core::api::anthropic::messages::preset::effort_to_thinking(e, max_tokens)
+    });
 
     Ok(MessagesRequest {
         model,
         messages,
-        max_tokens: options.max_output_tokens.unwrap_or(DEFAULT_MAX_TOKENS),
+        max_tokens,
         system: system.map(bitrouter_core::api::anthropic::messages::types::SystemPrompt::Text),
         stream: Some(stream),
         temperature: options.temperature,
@@ -266,6 +270,7 @@ pub(super) fn build_messages_request(
             .as_ref()
             .map(tool_choice_from_language_model),
         metadata: None,
+        thinking,
     })
 }
 
@@ -1467,6 +1472,88 @@ mod tests {
                 .iter()
                 .any(|p| matches!(p, LanguageModelStreamPart::ToolInputEnd { .. }))
         );
+    }
+
+    #[test]
+    fn build_messages_request_maps_effort_to_thinking_budget() {
+        use bitrouter_core::api::anthropic::messages::types::AnthropicThinking;
+        use bitrouter_core::models::language::call_options::ReasoningEffort;
+
+        let options = LanguageModelCallOptions {
+            prompt: vec![LanguageModelMessage::User {
+                content: vec![LanguageModelUserContent::Text {
+                    text: "hello".to_owned(),
+                    provider_options: None,
+                }],
+                provider_options: None,
+            }],
+            stream: None,
+            max_output_tokens: Some(32_000),
+            temperature: None,
+            top_p: None,
+            top_k: None,
+            stop_sequences: None,
+            presence_penalty: None,
+            frequency_penalty: None,
+            response_format: None,
+            seed: None,
+            tools: None,
+            tool_choice: None,
+            include_raw_chunks: None,
+            abort_signal: None,
+            headers: None,
+            reasoning_effort: Some(ReasoningEffort::Medium),
+            provider_options: None,
+        };
+
+        let request = build_messages_request("claude-sonnet-4-5", &options, false)
+            .expect("request should build");
+        match request.thinking {
+            Some(AnthropicThinking::Enabled { budget_tokens, .. }) => {
+                assert_eq!(budget_tokens, 4096);
+            }
+            other => panic!("expected enabled thinking, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn build_messages_request_minimal_effort_disables_thinking() {
+        use bitrouter_core::api::anthropic::messages::types::AnthropicThinking;
+        use bitrouter_core::models::language::call_options::ReasoningEffort;
+
+        let options = LanguageModelCallOptions {
+            prompt: vec![LanguageModelMessage::User {
+                content: vec![LanguageModelUserContent::Text {
+                    text: "hello".to_owned(),
+                    provider_options: None,
+                }],
+                provider_options: None,
+            }],
+            stream: None,
+            max_output_tokens: Some(8192),
+            temperature: None,
+            top_p: None,
+            top_k: None,
+            stop_sequences: None,
+            presence_penalty: None,
+            frequency_penalty: None,
+            response_format: None,
+            seed: None,
+            tools: None,
+            tool_choice: None,
+            include_raw_chunks: None,
+            abort_signal: None,
+            headers: None,
+            reasoning_effort: Some(ReasoningEffort::Minimal),
+            provider_options: None,
+        };
+
+        let request = build_messages_request("claude-sonnet-4-5", &options, false)
+            .expect("request should build");
+        assert!(matches!(
+            request.thinking,
+            Some(AnthropicThinking::Disabled)
+        ));
     }
 
     #[test]

--- a/bitrouter-providers/src/google/generate_content/api.rs
+++ b/bitrouter-providers/src/google/generate_content/api.rs
@@ -6,7 +6,7 @@ use bitrouter_core::{
         GenerateContentCandidate, GenerateContentResponse, GenerateContentUsageMetadata,
         GoogleContent, GoogleErrorEnvelope, GoogleFunctionCall, GoogleFunctionCallingConfig,
         GoogleFunctionDeclaration, GoogleFunctionResponse, GoogleGenerationConfig,
-        GoogleInlineData, GooglePart, GoogleTool, GoogleToolConfig,
+        GoogleInlineData, GooglePart, GoogleThinkingConfig, GoogleTool, GoogleToolConfig,
     },
     errors::{BitrouterError, ProviderErrorContext, Result},
     models::{
@@ -250,7 +250,8 @@ pub(super) fn build_generate_content_request(
         || options.presence_penalty.is_some()
         || options.frequency_penalty.is_some()
         || options.seed.is_some()
-        || options.response_format.is_some();
+        || options.response_format.is_some()
+        || options.reasoning_effort.is_some();
 
     let generation_config = if has_generation_config {
         Some(GoogleGenerationConfig {
@@ -267,6 +268,11 @@ pub(super) fn build_generate_content_request(
                 .as_ref()
                 .map(|_| "application/json".to_owned()),
             response_schema: None,
+            thinking_config: options.reasoning_effort.map(|e| GoogleThinkingConfig {
+                thinking_budget: Some(e.google_thinking_budget()),
+                thinking_level: None,
+                include_thoughts: None,
+            }),
         })
     } else {
         None
@@ -1795,6 +1801,7 @@ mod tests {
                 seed: None,
                 response_mime_type: None,
                 response_schema: None,
+                thinking_config: None,
             }),
             stream: None,
         };
@@ -1808,6 +1815,46 @@ mod tests {
         assert!(json["generationConfig"]["temperature"].as_f64().unwrap() - 0.7 < 0.01);
         assert_eq!(json["generationConfig"]["maxOutputTokens"], 1024);
         assert!(json.get("tools").is_none());
+    }
+
+    #[test]
+    fn build_generate_content_request_writes_thinking_budget() {
+        use bitrouter_core::models::language::{
+            call_options::ReasoningEffort,
+            prompt::{LanguageModelMessage, LanguageModelUserContent},
+        };
+
+        let options = LanguageModelCallOptions {
+            prompt: vec![LanguageModelMessage::User {
+                content: vec![LanguageModelUserContent::Text {
+                    text: "hi".to_owned(),
+                    provider_options: None,
+                }],
+                provider_options: None,
+            }],
+            stream: None,
+            max_output_tokens: None,
+            temperature: None,
+            top_p: None,
+            top_k: None,
+            stop_sequences: None,
+            presence_penalty: None,
+            frequency_penalty: None,
+            response_format: None,
+            seed: None,
+            tools: None,
+            tool_choice: None,
+            include_raw_chunks: None,
+            abort_signal: None,
+            headers: None,
+            reasoning_effort: Some(ReasoningEffort::High),
+            provider_options: None,
+        };
+
+        let request = build_generate_content_request("gemini-2.5-pro", &options).expect("build ok");
+        let cfg = request.generation_config.expect("generation_config");
+        let thinking = cfg.thinking_config.expect("thinking_config");
+        assert_eq!(thinking.thinking_budget, Some(16384));
     }
 
     #[test]

--- a/bitrouter-providers/src/openai/chat/api.rs
+++ b/bitrouter-providers/src/openai/chat/api.rs
@@ -320,6 +320,9 @@ pub(super) fn build_chat_request(
             .as_ref()
             .map(tool_choice_from_language_model),
         parallel_tool_calls: has_tools.then_some(false),
+        reasoning_effort: options
+            .reasoning_effort
+            .map(|e| e.as_openai_str().to_owned()),
     })
 }
 
@@ -1325,6 +1328,45 @@ mod tests {
     }
 
     #[test]
+    fn build_chat_request_passes_reasoning_effort_through() {
+        use bitrouter_core::models::language::call_options::ReasoningEffort;
+
+        let request = build_chat_request(
+            "gpt-5",
+            &LanguageModelCallOptions {
+                prompt: vec![LanguageModelMessage::User {
+                    content: vec![LanguageModelUserContent::Text {
+                        text: "ping".to_owned(),
+                        provider_options: None,
+                    }],
+                    provider_options: None,
+                }],
+                stream: None,
+                max_output_tokens: None,
+                temperature: None,
+                top_p: None,
+                top_k: None,
+                stop_sequences: None,
+                presence_penalty: None,
+                frequency_penalty: None,
+                response_format: None,
+                seed: None,
+                tools: None,
+                tool_choice: None,
+                include_raw_chunks: None,
+                abort_signal: None,
+                headers: None,
+                reasoning_effort: Some(ReasoningEffort::High),
+                provider_options: None,
+            },
+            false,
+        )
+        .expect("request should build");
+
+        assert_eq!(request.reasoning_effort.as_deref(), Some("high"));
+    }
+
+    #[test]
     fn builds_image_prompt_request() {
         let request = build_chat_request(
             "gpt-4o-mini",
@@ -1361,6 +1403,7 @@ mod tests {
                 include_raw_chunks: None,
                 abort_signal: None,
                 headers: None,
+                reasoning_effort: None,
                 provider_options: None,
             },
             false,

--- a/bitrouter-providers/src/openai/responses/api.rs
+++ b/bitrouter-providers/src/openai/responses/api.rs
@@ -227,6 +227,12 @@ pub(crate) fn build_responses_request(
             .response_format
             .as_ref()
             .map(text_config_from_response_format),
+        reasoning: options.reasoning_effort.map(|e| {
+            bitrouter_core::api::openai::responses::types::ResponsesReasoning {
+                effort: Some(e.as_openai_str().to_owned()),
+                summary: None,
+            }
+        }),
     })
 }
 
@@ -1645,6 +1651,47 @@ mod tests {
     };
 
     #[test]
+    fn build_responses_request_nests_effort_under_reasoning_object() {
+        use bitrouter_core::models::language::call_options::ReasoningEffort;
+
+        let request = build_responses_request(
+            "gpt-5",
+            &LanguageModelCallOptions {
+                prompt: vec![LanguageModelMessage::User {
+                    content: vec![LanguageModelUserContent::Text {
+                        text: "ping".to_owned(),
+                        provider_options: None,
+                    }],
+                    provider_options: None,
+                }],
+                stream: None,
+                max_output_tokens: None,
+                temperature: None,
+                top_p: None,
+                top_k: None,
+                stop_sequences: None,
+                presence_penalty: None,
+                frequency_penalty: None,
+                response_format: None,
+                seed: None,
+                tools: None,
+                tool_choice: None,
+                include_raw_chunks: None,
+                abort_signal: None,
+                headers: None,
+                reasoning_effort: Some(ReasoningEffort::Low),
+                provider_options: None,
+            },
+            false,
+        )
+        .expect("request should build");
+
+        let reasoning = request.reasoning.expect("reasoning object present");
+        assert_eq!(reasoning.effort.as_deref(), Some("low"));
+        assert!(reasoning.summary.is_none());
+    }
+
+    #[test]
     fn builds_image_prompt_request() {
         let request = build_responses_request(
             "gpt-4.1-mini",
@@ -1681,6 +1728,7 @@ mod tests {
                 include_raw_chunks: None,
                 abort_signal: None,
                 headers: None,
+                reasoning_effort: None,
                 provider_options: None,
             },
             false,
@@ -1722,6 +1770,7 @@ mod tests {
                 include_raw_chunks: None,
                 abort_signal: None,
                 headers: None,
+                reasoning_effort: None,
                 provider_options: None,
             },
             false,
@@ -1791,6 +1840,7 @@ mod tests {
                 include_raw_chunks: None,
                 abort_signal: None,
                 headers: None,
+                reasoning_effort: None,
                 provider_options: None,
             },
             false,
@@ -1855,6 +1905,7 @@ mod tests {
                 include_raw_chunks: None,
                 abort_signal: None,
                 headers: None,
+                reasoning_effort: None,
                 provider_options: None,
             },
             false,

--- a/bitrouter/src/runtime/app.rs
+++ b/bitrouter/src/runtime/app.rs
@@ -99,10 +99,12 @@ impl
     pub fn load(paths: RuntimePaths) -> Result<Self> {
         let env_file = paths.env_file.exists().then_some(paths.env_file.as_path());
         let config = BitrouterConfig::load_from_file(&paths.config_file, env_file)?;
-        let config_table = bitrouter_config::ConfigRoutingTable::with_routing(
+        let config_table = bitrouter_config::ConfigRoutingTable::with_full_config(
             config.providers.clone(),
             config.models.clone(),
             &config.routing,
+            config.presets.clone(),
+            config.variants.clone(),
         );
         let routing_table =
             bitrouter_core::routers::dynamic::DynamicRoutingTable::new(config_table);
@@ -121,10 +123,12 @@ impl
     pub fn scaffold(paths: RuntimePaths) -> Self {
         let env_file = paths.env_file.exists().then_some(paths.env_file.as_path());
         let config = BitrouterConfig::load_from_str("{}", env_file).unwrap_or_default();
-        let config_table = bitrouter_config::ConfigRoutingTable::with_routing(
+        let config_table = bitrouter_config::ConfigRoutingTable::with_full_config(
             config.providers.clone(),
             config.models.clone(),
             &config.routing,
+            config.presets.clone(),
+            config.variants.clone(),
         );
         let routing_table =
             bitrouter_core::routers::dynamic::DynamicRoutingTable::new(config_table);
@@ -192,10 +196,12 @@ impl
                 .map_err(|e| e.to_string())?;
 
             // Reload model routing table.
-            let new_table = bitrouter_config::ConfigRoutingTable::with_routing(
+            let new_table = bitrouter_config::ConfigRoutingTable::with_full_config(
                 config.providers.clone(),
                 config.models.clone(),
                 &config.routing,
+                config.presets.clone(),
+                config.variants.clone(),
             );
             reload_table.reload(new_table).map_err(|e| e.to_string())?;
 

--- a/bitrouter/src/runtime/mcp_client.rs
+++ b/bitrouter/src/runtime/mcp_client.rs
@@ -388,6 +388,7 @@ where
                 include_raw_chunks: None,
                 abort_signal: None,
                 headers: None,
+                reasoning_effort: None,
                 provider_options: None,
             };
 


### PR DESCRIPTION
Follow-up to #457 — closes the first deferred item.

## Summary

Wires the **reasoning effort** preset knob end-to-end across all four protocols. A new normalized `ReasoningEffort` enum (`minimal | low | medium | high`) lives on the central `LanguageModelCallOptions`; each protocol adapter maps it to / from the upstream's native shape.

```yaml
presets:
  careful:
    model: gpt-5
    params:
      reasoning_effort: high
```

## Why an enum (and not token budgets)

Providers disagree on the abstraction:

| Provider | Native shape |
|---|---|
| OpenAI Chat | top-level `reasoning_effort: "minimal"\|"low"\|"medium"\|"high"\|...` |
| OpenAI Responses | nested `reasoning: { effort, summary }` |
| Anthropic | `thinking: { type, budget_tokens, display }` — explicit integer |
| Google 2.5 | `thinkingConfig.thinkingBudget: int` (`-1` dynamic, `0` off) |
| Google 3.x | `thinkingConfig.thinkingLevel: string` enum |

There is no clean union. We picked the OpenAI-style enum as the BitRouter normal form because it composes cleanly into presets, and added a small mapping table for the other providers. Lossless when the inbound and outbound protocol agree on the enum; lossy at the bucket boundary across providers — that's documented and tested.

A `max_reasoning_tokens` escape hatch is deferred until a user asks for precise Anthropic control — adding it now without demand would be dead config surface (CLAUDE.md #4).

## Mapping table

| Effort | OpenAI | Anthropic | Google |
|---|---|---|---|
| minimal | `"minimal"` | `{type: "disabled"}` | `thinkingBudget: 0` |
| low | `"low"` | `{type: "enabled", budget_tokens: 1024}` | `thinkingBudget: 1024` |
| medium | `"medium"` | `{type: "enabled", budget_tokens: 4096}` | `thinkingBudget: 4096` |
| high | `"high"` | `{type: "enabled", budget_tokens: 16384}` | `thinkingBudget: 16384` |

Anthropic constraint (`1024 <= budget_tokens < max_tokens`) is enforced by clamping at the outbound builder: budget is capped to `max_tokens - 256`. If `max_tokens` is small enough that the 1024-token minimum no longer fits with the 256-token visible-output margin, thinking is disabled entirely rather than emit an invariant-violating request.

Inbound bucket boundaries on Anthropic and Google are the midpoints between consecutive outbound emit values (cutoffs at 2560 and 10240), so a same-protocol round-trip rounds each input to the nearest canonical budget instead of always rounding down.

## Wire-up

- **Core (8 files)**
  - `ReasoningEffort` enum on `LanguageModelCallOptions` with provider mapping helpers (`as_openai_str`, `anthropic_budget_tokens`, `google_thinking_budget`, `from_str_opt`).
  - Field on `AppliedPreset` and `GenerationParams` (under `params:` in YAML for consistency).
  - 4 × `to_call_options` parse inbound effort. OpenAI passes the enum through; Anthropic buckets `budget_tokens` (and disabled → `Minimal`); Google honors `thinkingLevel` first, otherwise buckets `thinkingBudget` (treats `-1` as passthrough so "let the model decide" survives cross-protocol routing).
  - 4 × `preset.rs::apply` shallow-merge effort onto the protocol's native field when the request omits it (request always wins).
- **Providers (4 files)** — `build_*_request` writes `options.reasoning_effort` to the upstream's native shape; Anthropic clamps budget below `max_tokens` or disables thinking when no valid window exists.
- **Runtime fix** — `AppRuntime::load`, `::scaffold`, and the SIGHUP reload path were calling `ConfigRoutingTable::with_routing(...)`, which silently dropped the YAML's `presets:` and `variants:` (passed empty maps to `with_full_config`). Switched all three sites to `with_full_config` so YAML-declared presets actually reach the routing table. This is a pre-existing gap from #449 caught while live-testing reasoning-effort end-to-end through a Python echo upstream — without this fix the entire preset feature returns `unknown preset` at runtime.

## What's *not* in here

Deferred items from #457 that still belong elsewhere:
- `parallel_tool_calls` — same call_options-and-4-adapters surface, but unrelated to reasoning. Separate PR.
- `:throughput` / `:latency` variants — still blocked on observability backbone.
- Per-caller / DB-backed presets — schema-compatible additive change.
- `max_reasoning_tokens` escape hatch — gated on Anthropic-budget demand.

**Lossy-normalization follow-ups** — tracked in #459. Specifically: caller-explicit values outside our 4-enum (OpenAI `xhigh` / `none`, Anthropic `adaptive`, Google `-1` / `0`) are silently demoted; same-protocol numeric round-trips on Anthropic/Google flatten through 3 buckets; no observability on what BitRouter actually sent upstream. v1 ships the 4-bucket enum deliberately because it composes cleanly with presets and is correct for the common path; the wider type expansion is non-trivial and would have buried this feature. See #459 for the proposed `ReasoningHint` direction.

## Tests

26 new tests:
- **Convert (inbound)**: OpenAI Chat parses effort + drops unknown values; Anthropic buckets budget + disabled→minimal + boundary table; Google buckets budget + dynamic→None + level-takes-precedence + boundary table.
- **Preset apply**: each of the 4 protocols asserts "preset fills when request unset" and "request wins"; Anthropic adds "minimal disables thinking", "high effort clamps below max_tokens", "disables thinking when max_tokens too small", and "enables at min budget when max_tokens just fits".
- **Provider builders**: OpenAI Chat passes-through; Responses nests under `reasoning`; Anthropic emits budget for non-minimal and `Disabled` for minimal; Google writes `thinkingBudget`.
- **Preset resolver**: `GenerationParams.reasoning_effort` propagates into the `AppliedPreset` bundle.

## Test plan

- [x] `cargo test --workspace --all-features` passes when `OPENAI_BASE_URL` is unset (the one pre-existing failure, `config::tests::load_with_custom_derived_provider`, is the env-var leakage flagged in #457's description, not caused by this PR).
- [x] `cargo clippy --workspace --all-features --all-targets` clean.
- [x] `cargo fmt -- --check` clean.
- [x] **Live end-to-end** through a local Python echo upstream — 11 cases across all 4 outbound protocols verified: preset → upstream wire format (`reasoning_effort: "high"` / `"minimal"` / `"low"` request-wins on Chat; `thinking: {type: enabled, budget_tokens: 16384/0/clamped}` on Anthropic; `thinkingConfig: {thinkingBudget: 16384/0}` on Google), plus inbound parser cases for `/v1/responses` reasoning.effort, `/v1/messages` thinking.budget_tokens, and `/v1beta/.../generateContent` thinkingBudget / thinkingLevel. Anthropic budget clamping verified at `max_tokens=4096` (clamped to 3840) and the disabled-when-too-small boundary at `max_tokens<1280`.
