### PR TITLE
fix(billing): audit P0 contract changes — pricing Option, BillingMode, DebitOutcome

### DIFF
--- a/bitrouter-api/src/fallback.rs
+++ b/bitrouter-api/src/fallback.rs
@@ -51,7 +51,10 @@ pub fn default_fallback_policy() -> std::sync::Arc<dyn FallbackPolicy> {
 
 #[cfg(test)]
 mod tests {
-    use bitrouter_core::{errors::ProviderErrorContext, routers::routing_table::ApiProtocol};
+    use bitrouter_core::{
+        errors::ProviderErrorContext,
+        routers::routing_table::{ApiProtocol, BillingMode},
+    };
 
     use super::*;
 
@@ -63,6 +66,7 @@ mod tests {
             api_key_override: None,
             api_base_override: None,
             preset: None,
+            billing_mode: BillingMode::default(),
         }
     }
 

--- a/bitrouter-api/src/mpp/metered_sse.rs
+++ b/bitrouter-api/src/mpp/metered_sse.rs
@@ -60,7 +60,7 @@ impl MeteredSseContext {
                 )
                 .await
             {
-                Ok(()) => return true,
+                Ok(_outcome) => return true,
                 Err(_) => {
                     // Emit need-voucher event.
                     if let Some((settled, authorized, deposit)) = self

--- a/bitrouter-api/src/mpp/mod.rs
+++ b/bitrouter-api/src/mpp/mod.rs
@@ -21,6 +21,6 @@ pub use filter::{
     mpp_payment_filter, verify_mpp_payment,
 };
 pub use gate_context::{GateContext, PaymentGateOverlayOptions};
-pub use payment_gate::PaymentGate;
+pub use payment_gate::{DebitOutcome, PaymentGate};
 pub use pricing::{PricingLookup, calculate_usage_cost, cost_to_micro_units};
 pub use state::MppState;

--- a/bitrouter-api/src/mpp/payment_gate.rs
+++ b/bitrouter-api/src/mpp/payment_gate.rs
@@ -7,6 +7,28 @@ use super::filter::MppPaymentContext;
 /// Pinned boxed future used as the return type for [`PaymentGate`] methods.
 type GateFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
+/// Outcome of a successful `deduct` call.
+///
+/// Distinguishes "money moved" from "debt recorded for later" so the
+/// chat/completions filters don't have to encode that policy themselves.
+/// Callers MUST treat `Deferred` as success — the response goes back to
+/// the client unchanged; recovery happens on the user's next gate
+/// `verify_payment`, which is expected to refuse the caller until the
+/// debt is cleared.
+///
+/// `Err(_)` from `deduct` is reserved for cases where the gate could
+/// neither settle nor record the debt (e.g., DB outage). Today the
+/// filters log-and-ship in that case; a future change may surface it.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum DebitOutcome {
+    /// The full amount was deducted synchronously.
+    Settled,
+    /// The amount could not be deducted (typically: insufficient
+    /// balance) and was recorded as pending debt instead. The next
+    /// `verify_payment` for this caller will reject until cleared.
+    Deferred,
+}
+
 /// Trait abstracting payment verification and settlement for MPP handlers.
 ///
 /// Allows downstream crates to provide custom payment logic (e.g. charge-based
@@ -38,13 +60,18 @@ pub trait PaymentGate: Send + Sync {
     /// request that triggered this deduction. It is `None` for streaming
     /// per-tick deductions where receipts are not tracked at the request
     /// level. Implementations that don't track receipts may ignore it.
+    ///
+    /// Returns [`DebitOutcome::Settled`] on a synchronous deduction,
+    /// or [`DebitOutcome::Deferred`] when the gate could not deduct
+    /// right now but has recorded the debt for later collection. See
+    /// [`DebitOutcome`] for the contract callers must honour.
     fn deduct<'a>(
         &'a self,
         backend_key: &'a str,
         channel_id: &'a str,
         amount: u128,
         request_id: Option<&'a str>,
-    ) -> GateFuture<'a, Result<(), mpp::server::VerificationError>>;
+    ) -> GateFuture<'a, Result<DebitOutcome, mpp::server::VerificationError>>;
 
     /// Wait for the next channel update on the given backend.
     ///
@@ -93,7 +120,7 @@ impl PaymentGate for Arc<dyn PaymentGate> {
         channel_id: &'a str,
         amount: u128,
         request_id: Option<&'a str>,
-    ) -> GateFuture<'a, Result<(), mpp::server::VerificationError>> {
+    ) -> GateFuture<'a, Result<DebitOutcome, mpp::server::VerificationError>> {
         (**self).deduct(backend_key, channel_id, amount, request_id)
     }
 

--- a/bitrouter-api/src/mpp/pricing.rs
+++ b/bitrouter-api/src/mpp/pricing.rs
@@ -30,8 +30,10 @@ impl<T: PricingLookup> PricingLookup for bitrouter_core::routers::dynamic::Dynam
 
 /// Calculates the cost in USD from token usage and per-million-token pricing.
 ///
-/// Delegates to [`bitrouter_core::pricing::calculate_cost`].
-pub fn calculate_usage_cost(usage: &LanguageModelUsage, pricing: &ModelPricing) -> f64 {
+/// Delegates to [`bitrouter_core::pricing::calculate_cost`]. Returns `None`
+/// when any token bucket with a nonzero count has no matching rate — callers
+/// must NOT silently treat `None` as zero (that would undercharge).
+pub fn calculate_usage_cost(usage: &LanguageModelUsage, pricing: &ModelPricing) -> Option<f64> {
     bitrouter_core::pricing::calculate_cost(usage, pricing)
 }
 

--- a/bitrouter-api/src/mpp/state.rs
+++ b/bitrouter-api/src/mpp/state.rs
@@ -640,13 +640,25 @@ impl super::payment_gate::PaymentGate for MppState {
         request_id: Option<&'a str>,
     ) -> std::pin::Pin<
         Box<
-            dyn std::future::Future<Output = Result<(), mpp::server::VerificationError>>
-                + Send
+            dyn std::future::Future<
+                    Output = Result<
+                        super::payment_gate::DebitOutcome,
+                        mpp::server::VerificationError,
+                    >,
+                > + Send
                 + 'a,
         >,
     > {
         let _ = request_id;
-        Box::pin(self.deduct(backend_key, channel_id, amount))
+        // MPP channels can't defer — a channel either has funds or it
+        // doesn't. Translate the inner deduct into a Settled outcome
+        // on success; on insufficient funds the inner method returns
+        // Err, which propagates up unchanged.
+        Box::pin(async move {
+            self.deduct(backend_key, channel_id, amount)
+                .await
+                .map(|()| super::payment_gate::DebitOutcome::Settled)
+        })
     }
 
     fn wait_for_update<'a>(

--- a/bitrouter-api/src/router/admin.rs
+++ b/bitrouter-api/src/router/admin.rs
@@ -201,7 +201,7 @@ mod tests {
     use bitrouter_core::routers::content::RouteContext;
     use bitrouter_core::routers::dynamic::DynamicRoutingTable;
     use bitrouter_core::routers::routing_table::{
-        ApiProtocol, RouteEntry, RoutingTable, RoutingTarget,
+        ApiProtocol, BillingMode, RouteEntry, RoutingTable, RoutingTarget,
     };
 
     use super::admin_routes_filter;
@@ -218,6 +218,7 @@ mod tests {
                     api_key_override: None,
                     api_base_override: None,
                     preset: None,
+                    billing_mode: BillingMode::default(),
                 })
             } else {
                 Err(BitrouterError::invalid_request(

--- a/bitrouter-api/src/router/anthropic/messages/filters.rs
+++ b/bitrouter-api/src/router/anthropic/messages/filters.rs
@@ -570,8 +570,23 @@ where
                         )));
                     };
                     let pricing = table.model_pricing(&provider_name, &target_model_id);
-                    let cost_usd = crate::mpp::calculate_usage_cost(&result.usage, &pricing);
-                    let micro_units = crate::mpp::cost_to_micro_units(cost_usd);
+                    let micro_units = match crate::mpp::calculate_usage_cost(
+                        &result.usage,
+                        &pricing,
+                    ) {
+                        Some(cost) => crate::mpp::cost_to_micro_units(cost),
+                        None => {
+                            tracing::warn!(
+                                provider = %provider_name,
+                                model = %target_model_id,
+                                request_id = %iter_request_id,
+                                "pricing_unavailable: upstream returned usage but \
+                                 pricing for this provider/model is incomplete; \
+                                 skipping deduction (response not billed)"
+                            );
+                            0
+                        }
+                    };
 
                     if !byok_used
                         && micro_units > 0

--- a/bitrouter-api/src/router/anthropic/messages/filters.rs
+++ b/bitrouter-api/src/router/anthropic/messages/filters.rs
@@ -15,7 +15,10 @@ use bitrouter_core::{
     observe::{
         CallerContext, ObserveCallback, RequestContext, RequestFailureEvent, RequestSuccessEvent,
     },
-    routers::{router::LanguageModelRouter, routing_table::RoutingTable},
+    routers::{
+        router::LanguageModelRouter,
+        routing_table::{BillingMode, RoutingTable},
+    },
 };
 use warp::Filter;
 
@@ -352,7 +355,7 @@ where
     let chain_len = chain.len();
     for (idx, target) in chain.into_iter().enumerate() {
         let is_last = idx + 1 == chain_len;
-        let byok_used = target.api_key_override.is_some();
+        let byok_used = matches!(target.billing_mode, BillingMode::Byok);
         let provider_name = target.provider_name.clone();
         let target_model_id = target.service_id.clone();
         let iter_caller = caller.clone();
@@ -570,23 +573,21 @@ where
                         )));
                     };
                     let pricing = table.model_pricing(&provider_name, &target_model_id);
-                    let micro_units = match crate::mpp::calculate_usage_cost(
-                        &result.usage,
-                        &pricing,
-                    ) {
-                        Some(cost) => crate::mpp::cost_to_micro_units(cost),
-                        None => {
-                            tracing::warn!(
-                                provider = %provider_name,
-                                model = %target_model_id,
-                                request_id = %iter_request_id,
-                                "pricing_unavailable: upstream returned usage but \
-                                 pricing for this provider/model is incomplete; \
-                                 skipping deduction (response not billed)"
-                            );
-                            0
-                        }
-                    };
+                    let micro_units =
+                        match crate::mpp::calculate_usage_cost(&result.usage, &pricing) {
+                            Some(cost) => crate::mpp::cost_to_micro_units(cost),
+                            None => {
+                                tracing::warn!(
+                                    provider = %provider_name,
+                                    model = %target_model_id,
+                                    request_id = %iter_request_id,
+                                    "pricing_unavailable: upstream returned usage but \
+                                     pricing for this provider/model is incomplete; \
+                                     skipping deduction (response not billed)"
+                                );
+                                0
+                            }
+                        };
 
                     if !byok_used
                         && micro_units > 0

--- a/bitrouter-api/src/router/anthropic/messages/filters.rs
+++ b/bitrouter-api/src/router/anthropic/messages/filters.rs
@@ -15,11 +15,13 @@ use bitrouter_core::{
     observe::{
         CallerContext, ObserveCallback, RequestContext, RequestFailureEvent, RequestSuccessEvent,
     },
-    routers::{
-        router::LanguageModelRouter,
-        routing_table::{BillingMode, RoutingTable},
-    },
+    routers::{router::LanguageModelRouter, routing_table::RoutingTable},
 };
+// BillingMode is only read by the payment-gated filter branches; gate
+// the import or the no-features build sees an unused-imports warning
+// (which CI treats as a hard error via -D warnings).
+#[cfg(any(feature = "payments-tempo", feature = "payments-solana"))]
+use bitrouter_core::routers::routing_table::BillingMode;
 use warp::Filter;
 
 use crate::error::BitrouterRejection;

--- a/bitrouter-api/src/router/anthropic/messages/tests.rs
+++ b/bitrouter-api/src/router/anthropic/messages/tests.rs
@@ -16,7 +16,7 @@ use bitrouter_core::{
     routers::{
         content::RouteContext,
         router::LanguageModelRouter,
-        routing_table::{ApiProtocol, RoutingTable, RoutingTarget},
+        routing_table::{ApiProtocol, BillingMode, RoutingTable, RoutingTarget},
     },
 };
 use regex::Regex;
@@ -39,6 +39,7 @@ impl RoutingTable for MockTable {
             api_key_override: None,
             api_base_override: None,
             preset: None,
+            billing_mode: BillingMode::default(),
         })
     }
 }

--- a/bitrouter-api/src/router/google/generate_content/filters.rs
+++ b/bitrouter-api/src/router/google/generate_content/filters.rs
@@ -11,7 +11,10 @@ use bitrouter_core::{
     observe::{
         CallerContext, ObserveCallback, RequestContext, RequestFailureEvent, RequestSuccessEvent,
     },
-    routers::{router::LanguageModelRouter, routing_table::RoutingTable},
+    routers::{
+        router::LanguageModelRouter,
+        routing_table::{BillingMode, RoutingTable},
+    },
 };
 use warp::Filter;
 
@@ -254,7 +257,7 @@ where
             warp::reject::custom(BitrouterRejection(e))
         })?;
 
-    let byok_used = target.api_key_override.is_some();
+    let byok_used = matches!(target.billing_mode, BillingMode::Byok);
     let provider_name = target.provider_name.clone();
     let target_model_id = target.service_id.clone();
 
@@ -383,10 +386,7 @@ where
         match gen_result {
             Ok(result) => {
                 let pricing = table.model_pricing(&provider_name, &target_model_id);
-                let micro_units = match crate::mpp::calculate_usage_cost(
-                    &result.usage,
-                    &pricing,
-                ) {
+                let micro_units = match crate::mpp::calculate_usage_cost(&result.usage, &pricing) {
                     Some(cost) => crate::mpp::cost_to_micro_units(cost),
                     None => {
                         tracing::warn!(

--- a/bitrouter-api/src/router/google/generate_content/filters.rs
+++ b/bitrouter-api/src/router/google/generate_content/filters.rs
@@ -383,8 +383,23 @@ where
         match gen_result {
             Ok(result) => {
                 let pricing = table.model_pricing(&provider_name, &target_model_id);
-                let cost_usd = crate::mpp::calculate_usage_cost(&result.usage, &pricing);
-                let micro_units = crate::mpp::cost_to_micro_units(cost_usd);
+                let micro_units = match crate::mpp::calculate_usage_cost(
+                    &result.usage,
+                    &pricing,
+                ) {
+                    Some(cost) => crate::mpp::cost_to_micro_units(cost),
+                    None => {
+                        tracing::warn!(
+                            provider = %provider_name,
+                            model = %target_model_id,
+                            request_id = %request_id,
+                            "pricing_unavailable: upstream returned usage but \
+                             pricing for this provider/model is incomplete; \
+                             skipping deduction (response not billed)"
+                        );
+                        0
+                    }
+                };
 
                 if !byok_used
                     && micro_units > 0

--- a/bitrouter-api/src/router/google/generate_content/filters.rs
+++ b/bitrouter-api/src/router/google/generate_content/filters.rs
@@ -11,11 +11,13 @@ use bitrouter_core::{
     observe::{
         CallerContext, ObserveCallback, RequestContext, RequestFailureEvent, RequestSuccessEvent,
     },
-    routers::{
-        router::LanguageModelRouter,
-        routing_table::{BillingMode, RoutingTable},
-    },
+    routers::{router::LanguageModelRouter, routing_table::RoutingTable},
 };
+// BillingMode is only read by the payment-gated filter branches; gate
+// the import or the no-features build sees an unused-imports warning
+// (which CI treats as a hard error via -D warnings).
+#[cfg(any(feature = "payments-tempo", feature = "payments-solana"))]
+use bitrouter_core::routers::routing_table::BillingMode;
 use warp::Filter;
 
 use crate::error::BitrouterRejection;

--- a/bitrouter-api/src/router/google/generate_content/tests.rs
+++ b/bitrouter-api/src/router/google/generate_content/tests.rs
@@ -16,7 +16,7 @@ use bitrouter_core::{
     routers::{
         content::RouteContext,
         router::LanguageModelRouter,
-        routing_table::{ApiProtocol, RoutingTable, RoutingTarget},
+        routing_table::{ApiProtocol, BillingMode, RoutingTable, RoutingTarget},
     },
 };
 use regex::Regex;
@@ -39,6 +39,7 @@ impl RoutingTable for MockTable {
             api_key_override: None,
             api_base_override: None,
             preset: None,
+            billing_mode: BillingMode::default(),
         })
     }
 }

--- a/bitrouter-api/src/router/mod.rs
+++ b/bitrouter-api/src/router/mod.rs
@@ -90,9 +90,22 @@ mod stream_observation {
         },
     };
 
+    /// Bytes-per-token estimate used when the client disconnects before the
+    /// upstream's authoritative Finish event lands. 4 is the canonical
+    /// English-text heuristic (≈4 bytes per BPE token); biased low for
+    /// non-Latin scripts and high for code/whitespace-heavy output. This
+    /// matters only for partial-disconnect billing, where any estimate is
+    /// better than the previous behaviour of charging zero.
+    const ESTIMATE_BYTES_PER_TOKEN: usize = 4;
+
     pub(crate) struct StreamObservation {
         usage: Option<LanguageModelUsage>,
         saw_output: bool,
+        /// Sum of `delta.len()` bytes seen across TextDelta /
+        /// ReasoningDelta / ToolInputDelta. Used to estimate output
+        /// tokens when the stream is interrupted before Finish lands —
+        /// see `outcome`'s disconnect branch.
+        output_bytes: usize,
         error: Option<BitrouterError>,
     }
 
@@ -101,6 +114,7 @@ mod stream_observation {
             Self {
                 usage: None,
                 saw_output: false,
+                output_bytes: 0,
                 error: None,
             }
         }
@@ -117,11 +131,14 @@ mod stream_observation {
                         Some(error.clone()),
                     ));
                 }
-                LanguageModelStreamPart::TextDelta { .. }
-                | LanguageModelStreamPart::ReasoningDelta { .. }
-                | LanguageModelStreamPart::ToolCall { .. }
+                LanguageModelStreamPart::TextDelta { delta, .. }
+                | LanguageModelStreamPart::ReasoningDelta { delta, .. }
+                | LanguageModelStreamPart::ToolInputDelta { delta, .. } => {
+                    self.saw_output = true;
+                    self.output_bytes = self.output_bytes.saturating_add(delta.len());
+                }
+                LanguageModelStreamPart::ToolCall { .. }
                 | LanguageModelStreamPart::ToolInputStart { .. }
-                | LanguageModelStreamPart::ToolInputDelta { .. }
                 | LanguageModelStreamPart::ToolInputEnd { .. }
                 | LanguageModelStreamPart::File { .. }
                 | LanguageModelStreamPart::ToolApprovalRequest { .. }
@@ -138,17 +155,28 @@ mod stream_observation {
             self,
             client_disconnected: bool,
         ) -> std::result::Result<LanguageModelUsage, BitrouterError> {
+            // Authoritative usage from a Finish event always wins —
+            // even when the client disconnected immediately after EOS,
+            // the upstream already computed and shipped us the tokens.
+            if let Some(usage) = self.usage {
+                return Ok(usage);
+            }
+            // Mid-stream disconnect with no Finish: bill what we can
+            // estimate from delta bytes seen so the request isn't free
+            // for an attacker who drains the response and then hangs
+            // up. Input tokens are unknown at this layer; the missing
+            // input cost is a known gap (would need the prompt token
+            // count plumbed in from the request path).
             if client_disconnected {
-                return Err(BitrouterError::cancelled(
-                    None,
-                    "client disconnected during stream",
-                ));
+                // Saturate at u32::MAX rather than wrap, in the
+                // pathological case where output_bytes would overflow.
+                let estimated_output =
+                    u32::try_from(self.output_bytes.div_ceil(ESTIMATE_BYTES_PER_TOKEN))
+                        .unwrap_or(u32::MAX);
+                return Ok(synthesize_usage_for_partial(estimated_output));
             }
             if let Some(error) = self.error {
                 return Err(error);
-            }
-            if let Some(usage) = self.usage {
-                return Ok(usage);
             }
             if self.saw_output {
                 return Ok(empty_usage());
@@ -177,6 +205,101 @@ mod stream_observation {
             raw: None,
         }
     }
+
+    fn synthesize_usage_for_partial(output_tokens: u32) -> LanguageModelUsage {
+        LanguageModelUsage {
+            input_tokens: LanguageModelInputTokens {
+                total: None,
+                no_cache: None,
+                cache_read: None,
+                cache_write: None,
+            },
+            output_tokens: LanguageModelOutputTokens {
+                total: Some(output_tokens),
+                text: Some(output_tokens),
+                reasoning: None,
+            },
+            raw: None,
+        }
+    }
 }
 
 pub(crate) use stream_observation::StreamObservation;
+
+#[cfg(test)]
+mod stream_observation_tests {
+    use bitrouter_core::models::language::{
+        finish_reason::LanguageModelFinishReason,
+        stream_part::LanguageModelStreamPart,
+        usage::{LanguageModelInputTokens, LanguageModelOutputTokens, LanguageModelUsage},
+    };
+
+    use super::StreamObservation;
+
+    fn finish_usage() -> LanguageModelUsage {
+        LanguageModelUsage {
+            input_tokens: LanguageModelInputTokens {
+                total: Some(123),
+                no_cache: Some(123),
+                cache_read: None,
+                cache_write: None,
+            },
+            output_tokens: LanguageModelOutputTokens {
+                total: Some(456),
+                text: Some(456),
+                reasoning: None,
+            },
+            raw: None,
+        }
+    }
+
+    #[test]
+    fn finish_before_disconnect_returns_authoritative_usage() {
+        // Even when the client disconnects, a Finish event that landed
+        // first is the source of truth — bill the full upstream-reported
+        // usage rather than a delta-byte estimate.
+        let mut obs = StreamObservation::new();
+        obs.record_part(&LanguageModelStreamPart::TextDelta {
+            id: "0".into(),
+            delta: "hi".into(),
+            provider_metadata: None,
+        });
+        obs.record_part(&LanguageModelStreamPart::Finish {
+            usage: finish_usage(),
+            finish_reason: LanguageModelFinishReason::Stop,
+            provider_metadata: None,
+        });
+        let usage = obs.outcome(true).expect("finish wins over disconnect");
+        assert_eq!(usage.output_tokens.total, Some(456));
+        assert_eq!(usage.input_tokens.total, Some(123));
+    }
+
+    #[test]
+    fn disconnect_without_finish_estimates_output_from_delta_bytes() {
+        // Audit B8: a client that drains output then disconnects before
+        // EOS used to be free. Now: estimate output tokens from streamed
+        // bytes (4 b/tok heuristic) so the request bills something.
+        let mut obs = StreamObservation::new();
+        // 16 bytes ⇒ 4 estimated tokens (16/4 ceil).
+        obs.record_part(&LanguageModelStreamPart::TextDelta {
+            id: "0".into(),
+            delta: "1234567890123456".into(),
+            provider_metadata: None,
+        });
+        let usage = obs.outcome(true).expect("disconnect with output");
+        assert_eq!(usage.output_tokens.text, Some(4));
+        assert_eq!(usage.output_tokens.total, Some(4));
+        // Input billing on disconnect is a known gap (prompt not plumbed
+        // through StreamObservation); the field stays None.
+        assert_eq!(usage.input_tokens.total, None);
+    }
+
+    #[test]
+    fn disconnect_with_no_output_estimates_zero() {
+        // Disconnect before any delta = nothing to bill. The synthesized
+        // usage is all-zero, which calculate_cost handles as Some(0.0).
+        let obs = StreamObservation::new();
+        let usage = obs.outcome(true).expect("disconnect with no output");
+        assert_eq!(usage.output_tokens.total, Some(0));
+    }
+}

--- a/bitrouter-api/src/router/openai/chat/filters.rs
+++ b/bitrouter-api/src/router/openai/chat/filters.rs
@@ -470,8 +470,23 @@ where
                         )));
                     };
                     let pricing = table.model_pricing(&provider_name, &target_model_id);
-                    let cost_usd = crate::mpp::calculate_usage_cost(&result.usage, &pricing);
-                    let micro_units = crate::mpp::cost_to_micro_units(cost_usd);
+                    let micro_units = match crate::mpp::calculate_usage_cost(
+                        &result.usage,
+                        &pricing,
+                    ) {
+                        Some(cost) => crate::mpp::cost_to_micro_units(cost),
+                        None => {
+                            tracing::warn!(
+                                provider = %provider_name,
+                                model = %target_model_id,
+                                request_id = %iter_request_id,
+                                "pricing_unavailable: upstream returned usage but \
+                                 pricing for this provider/model is incomplete; \
+                                 skipping deduction (response not billed)"
+                            );
+                            0
+                        }
+                    };
 
                     if !byok_used
                         && micro_units > 0

--- a/bitrouter-api/src/router/openai/chat/filters.rs
+++ b/bitrouter-api/src/router/openai/chat/filters.rs
@@ -15,7 +15,10 @@ use bitrouter_core::{
     observe::{
         CallerContext, ObserveCallback, RequestContext, RequestFailureEvent, RequestSuccessEvent,
     },
-    routers::{router::LanguageModelRouter, routing_table::RoutingTable},
+    routers::{
+        router::LanguageModelRouter,
+        routing_table::{BillingMode, RoutingTable},
+    },
 };
 
 use crate::fallback::{FallbackDecision, FallbackPolicy, default_fallback_policy};
@@ -334,7 +337,7 @@ where
     let mut last_err: Option<BitrouterError> = None;
     for (idx, target) in chain.into_iter().enumerate() {
         let is_last = idx + 1 == chain_len;
-        let byok_used = target.api_key_override.is_some();
+        let byok_used = matches!(target.billing_mode, BillingMode::Byok);
         let provider_name = target.provider_name.clone();
         let target_model_id = target.service_id.clone();
         let iter_caller = caller.clone();
@@ -470,23 +473,21 @@ where
                         )));
                     };
                     let pricing = table.model_pricing(&provider_name, &target_model_id);
-                    let micro_units = match crate::mpp::calculate_usage_cost(
-                        &result.usage,
-                        &pricing,
-                    ) {
-                        Some(cost) => crate::mpp::cost_to_micro_units(cost),
-                        None => {
-                            tracing::warn!(
-                                provider = %provider_name,
-                                model = %target_model_id,
-                                request_id = %iter_request_id,
-                                "pricing_unavailable: upstream returned usage but \
-                                 pricing for this provider/model is incomplete; \
-                                 skipping deduction (response not billed)"
-                            );
-                            0
-                        }
-                    };
+                    let micro_units =
+                        match crate::mpp::calculate_usage_cost(&result.usage, &pricing) {
+                            Some(cost) => crate::mpp::cost_to_micro_units(cost),
+                            None => {
+                                tracing::warn!(
+                                    provider = %provider_name,
+                                    model = %target_model_id,
+                                    request_id = %iter_request_id,
+                                    "pricing_unavailable: upstream returned usage but \
+                                     pricing for this provider/model is incomplete; \
+                                     skipping deduction (response not billed)"
+                                );
+                                0
+                            }
+                        };
 
                     if !byok_used
                         && micro_units > 0

--- a/bitrouter-api/src/router/openai/chat/filters.rs
+++ b/bitrouter-api/src/router/openai/chat/filters.rs
@@ -15,11 +15,13 @@ use bitrouter_core::{
     observe::{
         CallerContext, ObserveCallback, RequestContext, RequestFailureEvent, RequestSuccessEvent,
     },
-    routers::{
-        router::LanguageModelRouter,
-        routing_table::{BillingMode, RoutingTable},
-    },
+    routers::{router::LanguageModelRouter, routing_table::RoutingTable},
 };
+// BillingMode is only read by the payment-gated filter branches; gate
+// the import or the no-features build sees an unused-imports warning
+// (which CI treats as a hard error via -D warnings).
+#[cfg(any(feature = "payments-tempo", feature = "payments-solana"))]
+use bitrouter_core::routers::routing_table::BillingMode;
 
 use crate::fallback::{FallbackDecision, FallbackPolicy, default_fallback_policy};
 use crate::router::context::openai_chat;

--- a/bitrouter-api/src/router/openai/chat/tests.rs
+++ b/bitrouter-api/src/router/openai/chat/tests.rs
@@ -16,7 +16,7 @@ use bitrouter_core::{
     routers::{
         content::RouteContext,
         router::LanguageModelRouter,
-        routing_table::{ApiProtocol, RoutingTable, RoutingTarget},
+        routing_table::{ApiProtocol, BillingMode, RoutingTable, RoutingTarget},
     },
 };
 use regex::Regex;
@@ -56,6 +56,7 @@ impl RoutingTable for MockTable {
             api_key_override: None,
             api_base_override: None,
             preset: None,
+            billing_mode: BillingMode::default(),
         })
     }
 }
@@ -86,6 +87,7 @@ fn target(provider: &str, service_id: &str) -> RoutingTarget {
         api_key_override: None,
         api_base_override: None,
         preset: None,
+        billing_mode: BillingMode::default(),
     }
 }
 

--- a/bitrouter-api/src/router/openai/responses/filters.rs
+++ b/bitrouter-api/src/router/openai/responses/filters.rs
@@ -15,7 +15,10 @@ use bitrouter_core::{
     observe::{
         CallerContext, ObserveCallback, RequestContext, RequestFailureEvent, RequestSuccessEvent,
     },
-    routers::{router::LanguageModelRouter, routing_table::RoutingTable},
+    routers::{
+        router::LanguageModelRouter,
+        routing_table::{BillingMode, RoutingTable},
+    },
 };
 use warp::Filter;
 
@@ -359,7 +362,7 @@ where
         bitrouter_core::api::openai::responses::preset::apply(&mut request, &preset);
     }
 
-    let byok_used = target.api_key_override.is_some();
+    let byok_used = matches!(target.billing_mode, BillingMode::Byok);
     let provider_name = target.provider_name.clone();
     let target_model_id = target.service_id.clone();
 
@@ -523,10 +526,7 @@ where
         match gen_result {
             Ok(result) => {
                 let pricing = table.model_pricing(&provider_name, &target_model_id);
-                let micro_units = match crate::mpp::calculate_usage_cost(
-                    &result.usage,
-                    &pricing,
-                ) {
+                let micro_units = match crate::mpp::calculate_usage_cost(&result.usage, &pricing) {
                     Some(cost) => crate::mpp::cost_to_micro_units(cost),
                     None => {
                         tracing::warn!(

--- a/bitrouter-api/src/router/openai/responses/filters.rs
+++ b/bitrouter-api/src/router/openai/responses/filters.rs
@@ -523,8 +523,23 @@ where
         match gen_result {
             Ok(result) => {
                 let pricing = table.model_pricing(&provider_name, &target_model_id);
-                let cost_usd = crate::mpp::calculate_usage_cost(&result.usage, &pricing);
-                let micro_units = crate::mpp::cost_to_micro_units(cost_usd);
+                let micro_units = match crate::mpp::calculate_usage_cost(
+                    &result.usage,
+                    &pricing,
+                ) {
+                    Some(cost) => crate::mpp::cost_to_micro_units(cost),
+                    None => {
+                        tracing::warn!(
+                            provider = %provider_name,
+                            model = %target_model_id,
+                            request_id = %request_id,
+                            "pricing_unavailable: upstream returned usage but \
+                             pricing for this provider/model is incomplete; \
+                             skipping deduction (response not billed)"
+                        );
+                        0
+                    }
+                };
 
                 if !byok_used
                     && micro_units > 0

--- a/bitrouter-api/src/router/openai/responses/filters.rs
+++ b/bitrouter-api/src/router/openai/responses/filters.rs
@@ -15,11 +15,13 @@ use bitrouter_core::{
     observe::{
         CallerContext, ObserveCallback, RequestContext, RequestFailureEvent, RequestSuccessEvent,
     },
-    routers::{
-        router::LanguageModelRouter,
-        routing_table::{BillingMode, RoutingTable},
-    },
+    routers::{router::LanguageModelRouter, routing_table::RoutingTable},
 };
+// BillingMode is only read by the payment-gated filter branches; gate
+// the import or the no-features build sees an unused-imports warning
+// (which CI treats as a hard error via -D warnings).
+#[cfg(any(feature = "payments-tempo", feature = "payments-solana"))]
+use bitrouter_core::routers::routing_table::BillingMode;
 use warp::Filter;
 
 use crate::error::BitrouterRejection;

--- a/bitrouter-api/src/router/openai/responses/tests.rs
+++ b/bitrouter-api/src/router/openai/responses/tests.rs
@@ -16,7 +16,7 @@ use bitrouter_core::{
     routers::{
         content::RouteContext,
         router::LanguageModelRouter,
-        routing_table::{ApiProtocol, RoutingTable, RoutingTarget},
+        routing_table::{ApiProtocol, BillingMode, RoutingTable, RoutingTarget},
     },
 };
 use regex::Regex;
@@ -39,6 +39,7 @@ impl RoutingTable for MockTable {
             api_key_override: None,
             api_base_override: None,
             preset: None,
+            billing_mode: BillingMode::default(),
         })
     }
 }

--- a/bitrouter-config/src/routing.rs
+++ b/bitrouter-config/src/routing.rs
@@ -9,7 +9,8 @@ use bitrouter_core::{
         ModelRegistry, ToolEntry, ToolRegistry,
     },
     routers::routing_table::{
-        ApiProtocol, ModelPricing, RouteEntry, RoutingTable, RoutingTarget, strip_ansi_escapes,
+        ApiProtocol, BillingMode, ModelPricing, RouteEntry, RoutingTable, RoutingTarget,
+        strip_ansi_escapes,
     },
     tools::definition::ToolDefinition,
 };
@@ -400,6 +401,7 @@ impl RoutingTable for ConfigRoutingTable {
             api_key_override: resolved.api_key_override,
             api_base_override: resolved.api_base_override,
             preset: pr.preset,
+            billing_mode: BillingMode::default(),
         })
     }
 
@@ -733,6 +735,7 @@ impl RoutingTable for ConfigToolRoutingTable {
             api_key_override: resolved.api_key_override,
             api_base_override: resolved.api_base_override,
             preset: None,
+            billing_mode: BillingMode::default(),
         })
     }
 
@@ -1134,6 +1137,8 @@ mod tests {
                     output_tokens: OutputTokenPricing {
                         text: Some(10.00),
                         reasoning: Some(10.00),
+                        image: None,
+                        audio: None,
                     },
                 },
                 ..Default::default()
@@ -1186,6 +1191,8 @@ mod tests {
                     output_tokens: OutputTokenPricing {
                         text: Some(10.00),
                         reasoning: Some(10.00),
+                        image: None,
+                        audio: None,
                     },
                 },
                 ..Default::default()
@@ -1227,6 +1234,8 @@ mod tests {
                     output_tokens: OutputTokenPricing {
                         text: Some(3.50),
                         reasoning: None,
+                        image: None,
+                        audio: None,
                     },
                 },
                 ..Default::default()
@@ -1328,6 +1337,8 @@ mod tests {
                     output_tokens: OutputTokenPricing {
                         text: Some(15.00),
                         reasoning: None,
+                        image: None,
+                        audio: None,
                     },
                 },
                 name: Some("GPT-4o".into()),
@@ -1365,6 +1376,8 @@ mod tests {
                     output_tokens: OutputTokenPricing {
                         text: Some(199.00),
                         reasoning: None,
+                        image: None,
+                        audio: None,
                     },
                 },
                 name: Some("Provider Override".into()),
@@ -1394,6 +1407,8 @@ mod tests {
                     output_tokens: OutputTokenPricing {
                         text: Some(10.00),
                         reasoning: None,
+                        image: None,
+                        audio: None,
                     },
                 },
                 ..Default::default()

--- a/bitrouter-core/src/pricing.rs
+++ b/bitrouter-core/src/pricing.rs
@@ -40,51 +40,68 @@ const PER_MILLION: f64 = 1_000_000.0;
 
 /// Calculates the USD cost of a model request from token usage and pricing.
 ///
+/// Returns `None` when any token bucket with a nonzero count has no
+/// matching rate. Treating missing rates as zero would silently undercharge
+/// (a provider that omitted output pricing would bill all output tokens at
+/// $0); callers must decide what to do with `None` — typically: log
+/// `pricing_unavailable`, skip the debit, and surface a receipt with no
+/// charge. Returns `Some(0.0)` when usage is empty or every nonzero bucket
+/// has a rate of zero.
+///
 /// For input tokens: if granular buckets (`no_cache`, `cache_read`,
 /// `cache_write`) are available they are used with their respective rates.
 /// Otherwise falls back to `total * input_no_cache`.
 ///
 /// For output tokens: if granular buckets (`text`, `reasoning`) are available
 /// they are used. Otherwise falls back to `total * output_text`.
-pub fn calculate_cost(usage: &LanguageModelUsage, pricing: &ModelPricing) -> f64 {
-    let input_cost = {
-        let has_granular = usage.input_tokens.no_cache.is_some()
-            || usage.input_tokens.cache_read.is_some()
-            || usage.input_tokens.cache_write.is_some();
+pub fn calculate_cost(usage: &LanguageModelUsage, pricing: &ModelPricing) -> Option<f64> {
+    let input_cost = calculate_input_cost(usage, pricing)?;
+    let output_cost = calculate_output_cost(usage, pricing)?;
+    Some(input_cost + output_cost)
+}
 
-        if has_granular {
-            let no_cache = usage.input_tokens.no_cache.unwrap_or(0) as f64;
-            let cache_read = usage.input_tokens.cache_read.unwrap_or(0) as f64;
-            let cache_write = usage.input_tokens.cache_write.unwrap_or(0) as f64;
-            (no_cache * pricing.input_tokens.no_cache.unwrap_or(0.0)
-                + cache_read * pricing.input_tokens.cache_read.unwrap_or(0.0)
-                + cache_write * pricing.input_tokens.cache_write.unwrap_or(0.0))
-                / PER_MILLION
-        } else if let Some(total) = usage.input_tokens.total {
-            total as f64 * pricing.input_tokens.no_cache.unwrap_or(0.0) / PER_MILLION
-        } else {
-            0.0
+fn calculate_input_cost(usage: &LanguageModelUsage, pricing: &ModelPricing) -> Option<f64> {
+    let has_granular = usage.input_tokens.no_cache.is_some()
+        || usage.input_tokens.cache_read.is_some()
+        || usage.input_tokens.cache_write.is_some();
+
+    if has_granular {
+        let mut cost = 0.0;
+        if let Some(tokens) = usage.input_tokens.no_cache.filter(|&t| t > 0) {
+            cost += tokens as f64 * pricing.input_tokens.no_cache? / PER_MILLION;
         }
-    };
-
-    let output_cost = {
-        let has_granular =
-            usage.output_tokens.text.is_some() || usage.output_tokens.reasoning.is_some();
-
-        if has_granular {
-            let text = usage.output_tokens.text.unwrap_or(0) as f64;
-            let reasoning = usage.output_tokens.reasoning.unwrap_or(0) as f64;
-            (text * pricing.output_tokens.text.unwrap_or(0.0)
-                + reasoning * pricing.output_tokens.reasoning.unwrap_or(0.0))
-                / PER_MILLION
-        } else if let Some(total) = usage.output_tokens.total {
-            total as f64 * pricing.output_tokens.text.unwrap_or(0.0) / PER_MILLION
-        } else {
-            0.0
+        if let Some(tokens) = usage.input_tokens.cache_read.filter(|&t| t > 0) {
+            cost += tokens as f64 * pricing.input_tokens.cache_read? / PER_MILLION;
         }
-    };
+        if let Some(tokens) = usage.input_tokens.cache_write.filter(|&t| t > 0) {
+            cost += tokens as f64 * pricing.input_tokens.cache_write? / PER_MILLION;
+        }
+        Some(cost)
+    } else if let Some(total) = usage.input_tokens.total.filter(|&t| t > 0) {
+        Some(total as f64 * pricing.input_tokens.no_cache? / PER_MILLION)
+    } else {
+        Some(0.0)
+    }
+}
 
-    input_cost + output_cost
+fn calculate_output_cost(usage: &LanguageModelUsage, pricing: &ModelPricing) -> Option<f64> {
+    let has_granular =
+        usage.output_tokens.text.is_some() || usage.output_tokens.reasoning.is_some();
+
+    if has_granular {
+        let mut cost = 0.0;
+        if let Some(tokens) = usage.output_tokens.text.filter(|&t| t > 0) {
+            cost += tokens as f64 * pricing.output_tokens.text? / PER_MILLION;
+        }
+        if let Some(tokens) = usage.output_tokens.reasoning.filter(|&t| t > 0) {
+            cost += tokens as f64 * pricing.output_tokens.reasoning? / PER_MILLION;
+        }
+        Some(cost)
+    } else if let Some(total) = usage.output_tokens.total.filter(|&t| t > 0) {
+        Some(total as f64 * pricing.output_tokens.text? / PER_MILLION)
+    } else {
+        Some(0.0)
+    }
 }
 
 #[cfg(test)]
@@ -127,7 +144,7 @@ mod tests {
             raw: None,
         };
 
-        let cost = calculate_cost(&usage, &test_pricing());
+        let cost = calculate_cost(&usage, &test_pricing()).expect("complete pricing");
         // input: (1000*2.50 + 1500*1.25 + 500*3.75) / 1_000_000 = 0.00625
         // output: (400*10.0 + 200*15.0) / 1_000_000 = 0.007
         let expected = 0.00625 + 0.007;
@@ -151,7 +168,7 @@ mod tests {
             raw: None,
         };
 
-        let cost = calculate_cost(&usage, &test_pricing());
+        let cost = calculate_cost(&usage, &test_pricing()).expect("complete pricing");
         // input: 2000 * 2.50 / 1_000_000 = 0.005
         // output: 500 * 10.0 / 1_000_000 = 0.005
         let expected = 0.005 + 0.005;
@@ -175,12 +192,13 @@ mod tests {
             raw: None,
         };
 
-        let cost = calculate_cost(&usage, &test_pricing());
+        // Pricing irrelevant when no tokens — must still report a value, not None.
+        let cost = calculate_cost(&usage, &ModelPricing::default()).expect("zero usage");
         assert!((cost - 0.0).abs() < f64::EPSILON);
     }
 
     #[test]
-    fn zero_pricing_yields_zero_cost() {
+    fn missing_pricing_for_nonzero_tokens_yields_none() {
         let usage = LanguageModelUsage {
             input_tokens: LanguageModelInputTokens {
                 total: Some(10000),
@@ -196,8 +214,57 @@ mod tests {
             raw: None,
         };
 
-        let cost = calculate_cost(&usage, &ModelPricing::default());
-        assert!((cost - 0.0).abs() < f64::EPSILON);
+        // Default ModelPricing has every rate = None. With nonzero tokens
+        // we cannot bill — return None so callers don't silently undercharge.
+        assert!(calculate_cost(&usage, &ModelPricing::default()).is_none());
+    }
+
+    #[test]
+    fn partial_output_pricing_yields_none() {
+        // Common production shape: input pricing complete, output pricing
+        // empty (the placeholder-entry footgun the audit caught).
+        let mut pricing = ModelPricing::default();
+        pricing.input_tokens.no_cache = Some(2.5);
+        let usage = LanguageModelUsage {
+            input_tokens: LanguageModelInputTokens {
+                total: Some(1000),
+                no_cache: Some(1000),
+                cache_read: None,
+                cache_write: None,
+            },
+            output_tokens: LanguageModelOutputTokens {
+                total: Some(500),
+                text: Some(500),
+                reasoning: None,
+            },
+            raw: None,
+        };
+        assert!(calculate_cost(&usage, &pricing).is_none());
+    }
+
+    #[test]
+    fn missing_rate_for_unused_bucket_is_ok() {
+        // cache_read tokens are 0, so a missing cache_read rate is fine.
+        let mut pricing = ModelPricing::default();
+        pricing.input_tokens.no_cache = Some(2.0);
+        pricing.output_tokens.text = Some(10.0);
+        let usage = LanguageModelUsage {
+            input_tokens: LanguageModelInputTokens {
+                total: Some(1000),
+                no_cache: Some(1000),
+                cache_read: Some(0),
+                cache_write: None,
+            },
+            output_tokens: LanguageModelOutputTokens {
+                total: Some(500),
+                text: Some(500),
+                reasoning: None,
+            },
+            raw: None,
+        };
+        let cost = calculate_cost(&usage, &pricing).expect("unused bucket should not block");
+        // input: 1000 * 2.0 / 1M = 0.002; output: 500 * 10.0 / 1M = 0.005
+        assert!((cost - 0.007).abs() < 1e-10);
     }
 
     // ── FlatPricing tests ──────────────────────────────────────────────

--- a/bitrouter-core/src/pricing.rs
+++ b/bitrouter-core/src/pricing.rs
@@ -123,6 +123,8 @@ mod tests {
             output_tokens: OutputTokenPricing {
                 text: Some(10.00),
                 reasoning: Some(15.00),
+                image: None,
+                audio: None,
             },
         }
     }

--- a/bitrouter-core/src/routers/dynamic.rs
+++ b/bitrouter-core/src/routers/dynamic.rs
@@ -20,7 +20,7 @@ use super::admin::{
 use super::registry::{ModelEntry, ModelRegistry, ToolEntry, ToolRegistry};
 use super::reload::ReloadableRoutingTable;
 use super::routing_table::{
-    ApiProtocol, RouteEntry, RoutingTable, RoutingTarget, strip_ansi_escapes,
+    ApiProtocol, BillingMode, RouteEntry, RoutingTable, RoutingTarget, strip_ansi_escapes,
 };
 use crate::routers::content::RouteContext;
 
@@ -91,6 +91,7 @@ impl<T> DynamicRoutingTable<T> {
             api_key_override: None,
             api_base_override: None,
             preset: None,
+            billing_mode: BillingMode::default(),
         })
     }
 }
@@ -252,6 +253,7 @@ mod tests {
                     api_key_override: None,
                     api_base_override: None,
                     preset: None,
+                    billing_mode: BillingMode::default(),
                 })
             } else {
                 Err(BitrouterError::invalid_request(
@@ -457,6 +459,7 @@ mod tests {
                             api_key_override: None,
                             api_base_override: None,
                             preset: None,
+                            billing_mode: BillingMode::default(),
                         })
                     } else {
                         Ok(RoutingTarget {
@@ -466,6 +469,7 @@ mod tests {
                             api_key_override: None,
                             api_base_override: None,
                             preset: None,
+                            billing_mode: BillingMode::default(),
                         })
                     }
                 } else {
@@ -524,6 +528,7 @@ mod tests {
                             api_key_override: None,
                             api_base_override: None,
                             preset: None,
+                            billing_mode: BillingMode::default(),
                         })
                     } else {
                         Ok(RoutingTarget {
@@ -533,6 +538,7 @@ mod tests {
                             api_key_override: None,
                             api_base_override: None,
                             preset: None,
+                            billing_mode: BillingMode::default(),
                         })
                     }
                 } else {

--- a/bitrouter-core/src/routers/router.rs
+++ b/bitrouter-core/src/routers/router.rs
@@ -198,7 +198,7 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
-    use crate::routers::routing_table::ApiProtocol;
+    use crate::routers::routing_table::{ApiProtocol, BillingMode};
 
     struct StaticKeyOverlay {
         key: String,
@@ -227,6 +227,7 @@ mod tests {
             api_key_override: None,
             api_base_override: None,
             preset: None,
+            billing_mode: BillingMode::default(),
         };
         let caller = CallerContext::default();
 
@@ -263,6 +264,7 @@ mod tests {
             api_key_override: None,
             api_base_override: None,
             preset: None,
+            billing_mode: BillingMode::default(),
         }
     }
 
@@ -311,6 +313,7 @@ mod tests {
                 api_key_override: None,
                 api_base_override: None,
                 preset: None,
+                billing_mode: BillingMode::default(),
             },
             RoutingTarget {
                 provider_name: "anthropic".to_owned(),
@@ -319,6 +322,7 @@ mod tests {
                 api_key_override: None,
                 api_base_override: None,
                 preset: None,
+                billing_mode: BillingMode::default(),
             },
         ];
         let caller = CallerContext::default();

--- a/bitrouter-core/src/routers/routing_table.rs
+++ b/bitrouter-core/src/routers/routing_table.rs
@@ -82,6 +82,28 @@ impl AppliedPreset {
     }
 }
 
+/// Who pays for a routed request.
+///
+/// Filters check `billing_mode` (not `api_key_override.is_some()`) to
+/// decide whether to deduct from the platform's payment gate after the
+/// upstream call. Inferring this from "the target has an api_key_override"
+/// breaks under the cloud's RegistryRoutingTable, which fills in the
+/// platform key on every target — including cloud-billed ones — and
+/// would have silently treated every request as BYOK.
+///
+/// Defaults to `Cloud` so a forgotten field still bills (safer to
+/// over-charge than to silently leak).
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
+pub enum BillingMode {
+    /// Platform-paid: cloud-routed via a managed upstream credential;
+    /// the payment gate deducts against the user's credit balance.
+    #[default]
+    Cloud,
+    /// User-paid: caller supplied their own upstream credential (BYOK).
+    /// Skip the gate's deduction entirely.
+    Byok,
+}
+
 /// The resolved target for a routed request (model or tool).
 #[derive(Debug, Clone)]
 pub struct RoutingTarget {
@@ -97,6 +119,8 @@ pub struct RoutingTarget {
     /// over the provider's default `api_key`. Populated by per-endpoint
     /// configuration (see `Endpoint.api_key`) or by a [`TargetOverlay`] that
     /// runs after routing.
+    ///
+    /// Does NOT determine billing — see [`BillingMode`] / `billing_mode`.
     pub api_key_override: Option<String>,
     /// Per-target API base URL override.
     ///
@@ -108,6 +132,9 @@ pub struct RoutingTarget {
     /// string. When set, filter handlers shallow-merge these defaults onto
     /// the inbound request before dispatch.
     pub preset: Option<AppliedPreset>,
+    /// Who pays for this request. Read by the chat/completions filters
+    /// to decide whether to invoke the payment gate.
+    pub billing_mode: BillingMode,
 }
 
 /// A single entry in the route listing, describing a configured route.

--- a/bitrouter-core/src/routers/routing_table.rs
+++ b/bitrouter-core/src/routers/routing_table.rs
@@ -150,11 +150,22 @@ pub struct OutputTokenPricing {
     /// Cost per million reasoning output tokens.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reasoning: Option<f64>,
+    /// Cost per million image output tokens. Reserved — not yet wired into
+    /// `calculate_cost`; multimodal output billing will land alongside the
+    /// matching usage bucket in `LanguageModelOutputTokens`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image: Option<f64>,
+    /// Cost per million audio output tokens. Reserved — see `image`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub audio: Option<f64>,
 }
 
 impl OutputTokenPricing {
     fn is_empty(&self) -> bool {
-        self.text.is_none() && self.reasoning.is_none()
+        self.text.is_none()
+            && self.reasoning.is_none()
+            && self.image.is_none()
+            && self.audio.is_none()
     }
 }
 
@@ -171,6 +182,15 @@ impl ModelPricing {
     /// Returns `true` when no pricing data is set.
     pub fn is_empty(&self) -> bool {
         self.input_tokens.is_empty() && self.output_tokens.is_empty()
+    }
+
+    /// Returns `true` when at minimum `input_tokens.no_cache` and
+    /// `output_tokens.text` are present. This is the "safe to bill"
+    /// predicate used by the cheapest-provider picker and the recommender
+    /// to skip provider entries with placeholder pricing; per-bucket
+    /// granular checks happen inside `calculate_cost`.
+    pub fn is_complete(&self) -> bool {
+        self.input_tokens.no_cache.is_some() && self.output_tokens.text.is_some()
     }
 }
 

--- a/bitrouter-observe/src/model_observer.rs
+++ b/bitrouter-observe/src/model_observer.rs
@@ -197,6 +197,8 @@ mod tests {
             output_tokens: OutputTokenPricing {
                 text: Some(10.00),
                 reasoning: None,
+                image: None,
+                audio: None,
             },
         }
     }

--- a/bitrouter-observe/src/model_observer.rs
+++ b/bitrouter-observe/src/model_observer.rs
@@ -43,7 +43,16 @@ impl ObserveCallback for ModelSpendObserver {
     ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
         Box::pin(async move {
             let pricing = (self.pricing_lookup)(&event.ctx.provider, &event.ctx.model);
-            let cost = calculate_cost(&event.usage, &pricing);
+            let cost = calculate_cost(&event.usage, &pricing).unwrap_or_else(|| {
+                tracing::warn!(
+                    provider = %event.ctx.provider,
+                    model = %event.ctx.model,
+                    "pricing_unavailable: spend log will record cost=0 \
+                     (incomplete pricing rates); fix the catalog entry to \
+                     restore correct accounting"
+                );
+                0.0
+            });
             let input_tokens = event.usage.input_tokens.total.unwrap_or(0);
             let output_tokens = event.usage.output_tokens.total.unwrap_or(0);
 

--- a/bitrouter/src/runtime/mcp_client.rs
+++ b/bitrouter/src/runtime/mcp_client.rs
@@ -88,7 +88,9 @@ use bitrouter_core::routers::content::RouteContext;
 #[cfg(feature = "mcp")]
 use bitrouter_core::routers::router::LanguageModelRouter;
 #[cfg(feature = "mcp")]
-use bitrouter_core::routers::routing_table::{RouteEntry, RoutingTable, RoutingTarget};
+use bitrouter_core::routers::routing_table::{
+    BillingMode, RouteEntry, RoutingTable, RoutingTarget,
+};
 #[cfg(feature = "mcp")]
 use bitrouter_providers::mcp::client::bridge::SingleServerBridge;
 #[cfg(feature = "mcp")]
@@ -461,6 +463,7 @@ fn match_hint(hint: &str, routes: &[RouteEntry]) -> Option<RoutingTarget> {
                 api_key_override: None,
                 api_base_override: None,
                 preset: None,
+                billing_mode: BillingMode::default(),
             });
         }
     }

--- a/bitrouter/src/runtime/router.rs
+++ b/bitrouter/src/runtime/router.rs
@@ -6,7 +6,10 @@ use bitrouter_config::{ApiProtocol, ProviderConfig};
 use bitrouter_core::{
     errors::{BitrouterError, Result},
     models::language::language_model::DynLanguageModel,
-    routers::{router::LanguageModelRouter, routing_table::RoutingTarget},
+    routers::{
+        router::LanguageModelRouter,
+        routing_table::{BillingMode, RoutingTarget},
+    },
     tools::provider::DynToolProvider,
 };
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
@@ -763,6 +766,7 @@ mod tests {
             api_key_override: None,
             api_base_override: None,
             preset: None,
+            billing_mode: BillingMode::default(),
         };
 
         let provider = router.route_tool(target).await;
@@ -787,6 +791,7 @@ mod tests {
             api_key_override: None,
             api_base_override: None,
             preset: None,
+            billing_mode: BillingMode::default(),
         };
         assert!(router.route_tool(target).await.is_err());
     }

--- a/bitrouter/src/runtime/router.rs
+++ b/bitrouter/src/runtime/router.rs
@@ -3,13 +3,12 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use bitrouter_config::{ApiProtocol, ProviderConfig};
+#[cfg(test)]
+use bitrouter_core::routers::routing_table::BillingMode;
 use bitrouter_core::{
     errors::{BitrouterError, Result},
     models::language::language_model::DynLanguageModel,
-    routers::{
-        router::LanguageModelRouter,
-        routing_table::{BillingMode, RoutingTarget},
-    },
+    routers::{router::LanguageModelRouter, routing_table::RoutingTarget},
     tools::provider::DynToolProvider,
 };
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};


### PR DESCRIPTION
Six commits supporting a follow-up bitrouter-cloud audit-fix PR. All semver-affecting changes are in this PR so cloud's dep bump can land cleanly after the next release.

## What's in here

- **`fix(pricing): return Option when a required rate is missing`** (`dedf41c`)
  `bitrouter_core::pricing::calculate_cost` and the `bitrouter_api::mpp::calculate_usage_cost` wrapper now return `Option<f64>`. The previous `unwrap_or(0.0)` short-circuit silently undercharged whenever a token bucket had nonzero usage but no rate (a provider with input pricing and `output_tokens: {}` placeholder, for instance, billed every output token at \$0). The four `/v1/chat/completions`-shaped filter sites log `pricing_unavailable` and skip the deduct when `None` comes back — the recommender's skip-incomplete change on the cloud side is what should keep that from happening in practice.

- **`feat(pricing): add ModelPricing::is_complete and reserved output buckets`** (`95b64cf`)
  `ModelPricing::is_complete()` is the "safe to bill" predicate the cheapest-picker / recommender call to refuse placeholder entries. Adds reserved `OutputTokenPricing.image` / `.audio` fields (serde-round-tripped) so multimodal billing has a place to land without another breaking change.

- **`feat(billing): explicit BillingMode on RoutingTarget`** (`1b68281`)
  The filters previously inferred "is this a BYOK request?" from `target.api_key_override.is_some()`. Cloud-routed targets always carry a platform key, so that inference treated *every* cloud request as BYOK and the deduct gate was unconditionally skipped. New `BillingMode { Cloud, Byok }` field on `RoutingTarget`; defaults to `Cloud` so a forgotten field bills (safer than silently leaking). All four filters now read this field. All in-tree `RoutingTarget` constructors get an explicit `billing_mode: BillingMode::default()`.

- **`feat(billing): deduct returns DebitOutcome (Settled | Deferred)`** (`65efb60`)
  Extends the `PaymentGate::deduct` contract. `Deferred` lets a gate signal "couldn't draw right now but recorded the debt for later collection" — callers MUST treat it as success, the response goes back unchanged. The credits-backed cloud gate uses this to insert a `pending_debits` row instead of failing the response. `MppState`'s impl maps its existing success path to `Settled` (channels can't defer).

- **`feat(mpp): export DebitOutcome from the public mpp module`** (`01ee02c`)
  One-liner to make the new enum reachable from downstream cloud crates.

- **`fix(stream): bill estimated output on mid-stream client disconnect`** (`720bd77`)
  `StreamObservation::outcome` used to return `Err` whenever the client disconnected mid-stream, routing to `on_request_failure` with no billing — an attacker who drained a long generation and hung up before the Finish event paid nothing. Now: when Finish landed first, settle with its authoritative usage even if disconnect happened after; when disconnect beats Finish, return a synthesized usage with output tokens estimated from `delta.len() / 4` so the request bills something. Input billing on disconnect is a known gap (prompt not plumbed through `StreamObservation`).

## Compat notes

Three of these are technically API-breaking and want a minor bump:
- `RoutingTarget` gains a `billing_mode` field — any downstream literal constructor needs to add it. Cushioned by `BillingMode::default()` returning `Cloud`.
- `calculate_cost` / `calculate_usage_cost` now return `Option<f64>` — callers must handle `None`. Only known consumer is `bitrouter-cloud`.
- `PaymentGate::deduct` returns `Result<DebitOutcome, _>` — trait impls update.

`bitrouter-observe::ModelSpendObserver` is updated in-tree to keep working with the new `Option` return (logs `pricing_unavailable`, writes `cost=0` to the spend log rather than crashing).

## Test plan

- [x] `cargo nextest run` — 968/968 pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] New unit tests in `bitrouter-core::pricing::tests` (Option / partial pricing / unused-bucket cases)
- [x] New unit tests in `bitrouter-api::router::stream_observation_tests` (disconnect after Finish, disconnect with deltas, disconnect with no output)
- [ ] Integration / staging snapshot — paired with the bitrouter-cloud follow-up PR before either lands in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)