### PR TITLE
feat(sdk): derive JsonSchema on openai_responses + fix SSE decoder default-event bug

### DIFF
--- a/crates/bitrouter-sdk/src/language_model/protocol/openai_responses.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/openai_responses.rs
@@ -15,7 +15,11 @@
 //! - #434: function-call stream items map `item_id` back to `call_id`, and
 //!   argument deltas are not duplicated.
 
+use std::collections::HashMap;
+
 use async_trait::async_trait;
+use schemars::JsonSchema;
+use serde::Deserialize;
 
 use crate::error::{BitrouterError, Result};
 use crate::language_model::protocol::{
@@ -34,6 +38,70 @@ pub struct OpenAiResponsesAdapter;
 /// HTTP transport for OpenAI Responses: `POST {api_base}/responses` with
 /// `Authorization: Bearer <api_key>`.
 pub struct OpenAiResponsesTransport;
+
+// ===== wire request types =====
+
+/// OpenAI Responses request body
+/// (<https://platform.openai.com/docs/api-reference/responses/create>).
+///
+/// `pub` so downstream crates (notably `bitrouter-cloud`) can derive an
+/// OpenAPI schema from the canonical wire shape without redeclaring it.
+///
+/// `input` stays `serde_json::Value` on purpose — the Responses API accepts
+/// either a plain string or a heterogeneous item array (Codex multi-turn,
+/// #454-3), and the deeper walk happens in [`parse_input`]. Mirrors how
+/// Anthropic's `system` / `content` are typed.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ResponsesRequest {
+    #[serde(default)]
+    model: String,
+    input: serde_json::Value,
+    #[serde(default)]
+    instructions: Option<String>,
+    #[serde(default)]
+    tools: Vec<ResponsesTool>,
+    #[serde(default)]
+    temperature: Option<f64>,
+    #[serde(default)]
+    top_p: Option<f64>,
+    #[serde(default)]
+    max_output_tokens: Option<u32>,
+    #[serde(default)]
+    reasoning: Option<ResponsesReasoningConfig>,
+    #[serde(default)]
+    stream: bool,
+    /// Every other field — `tool_choice`, `parallel_tool_calls`,
+    /// `max_tool_calls`, `metadata`, `include[]`, `previous_response_id`,
+    /// `store`, `stream_options`, … — rides through here and is splatted
+    /// back on render. Skipped from the published schema so the documented
+    /// contract is the set of typed fields; pass-through behavior is
+    /// preserved at runtime.
+    #[serde(flatten)]
+    #[schemars(skip)]
+    extra: HashMap<String, serde_json::Value>,
+}
+
+/// One element of [`ResponsesRequest`]'s `tools` array — the Responses-flavoured
+/// flat tool definition (`{ type: "function", name, description, parameters }`).
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+pub struct ResponsesTool {
+    #[serde(default, rename = "type")]
+    kind: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    parameters: serde_json::Value,
+}
+
+/// `reasoning` knob on [`ResponsesRequest`] — only `effort` is read; other
+/// fields (`summary`, …) round-trip via no slot today (matching v0 behavior).
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+pub struct ResponsesReasoningConfig {
+    #[serde(default)]
+    effort: Option<String>,
+}
 
 fn parse_role(role: &str) -> Result<Role> {
     match role {
@@ -192,104 +260,47 @@ impl InboundAdapter for OpenAiResponsesAdapter {
     }
 
     fn parse_request(&self, body: serde_json::Value) -> Result<Prompt> {
-        // Parsed field-by-field (not via a strict struct) so unexpected
-        // Codex-style item shapes never cause a hard 400 (#454-3).
-        let model = body
-            .get("model")
-            .and_then(|m| m.as_str())
-            .unwrap_or_default()
-            .to_string();
-        let input = body.get("input").ok_or_else(|| {
-            describe_deser_error(
-                "ResponsesRequest",
-                &serde::de::Error::missing_field("input"),
-                &body,
-            )
-        })?;
-        let messages = parse_input(input)?;
-        let system = body
-            .get("instructions")
-            .and_then(|i| i.as_str())
-            .filter(|s| !s.is_empty())
-            .map(|s| s.to_string());
+        // The envelope deserializes strictly; `input` stays `Value` and is
+        // walked leniently by `parse_input` so unexpected Codex-style item
+        // shapes never cause a hard 400 (#454-3).
+        let req: ResponsesRequest = serde_json::from_value(body.clone())
+            .map_err(|e| describe_deser_error("ResponsesRequest", &e, &body))?;
 
-        let tools = body
-            .get("tools")
-            .and_then(|t| t.as_array())
-            .map(|arr| {
-                arr.iter()
-                    .filter(|t| {
-                        t.get("type").and_then(|ty| ty.as_str()) == Some("function")
-                            || t.get("name").is_some()
-                    })
-                    .map(|t| crate::language_model::types::Tool {
-                        name: t
-                            .get("name")
-                            .and_then(|n| n.as_str())
-                            .unwrap_or_default()
-                            .to_string(),
-                        description: t
-                            .get("description")
-                            .and_then(|d| d.as_str())
-                            .map(|s| s.to_string()),
-                        parameters: t
-                            .get("parameters")
-                            .cloned()
-                            .unwrap_or(serde_json::json!({})),
-                    })
-                    .collect()
-            })
-            .unwrap_or_default();
+        let messages = parse_input(&req.input)?;
+        let system = req.instructions.filter(|s| !s.is_empty());
 
-        // Collect every Responses-API field we don't have a typed slot for —
-        // tool_choice, parallel_tool_calls, max_tool_calls, metadata,
-        // include[], previous_response_id, store, stream_options, etc. — into
-        // `extra` so render_request can splat them back. The parser walks the
-        // body field-by-field (#454-3) so we explicitly subtract the known set.
-        const KNOWN: &[&str] = &[
-            "model",
-            "input",
-            "instructions",
-            "tools",
-            "temperature",
-            "top_p",
-            "max_output_tokens",
-            "reasoning",
-            "stream",
-        ];
-        let extra: std::collections::HashMap<String, serde_json::Value> = body
-            .as_object()
-            .map(|obj| {
-                obj.iter()
-                    .filter(|(k, _)| !KNOWN.contains(&k.as_str()))
-                    .map(|(k, v)| (k.clone(), v.clone()))
-                    .collect()
+        let tools = req
+            .tools
+            .into_iter()
+            .filter(|t| t.kind.as_deref() == Some("function") || t.name.is_some())
+            .map(|t| crate::language_model::types::Tool {
+                name: t.name.unwrap_or_default(),
+                description: t.description,
+                parameters: if t.parameters.is_null() {
+                    serde_json::json!({})
+                } else {
+                    t.parameters
+                },
             })
-            .unwrap_or_default();
+            .collect();
 
         Ok(Prompt {
-            model,
+            model: req.model,
             system,
             messages,
             tools,
             params: GenerationParams {
-                temperature: body.get("temperature").and_then(|t| t.as_f64()),
-                top_p: body.get("top_p").and_then(|t| t.as_f64()),
-                max_tokens: body
-                    .get("max_output_tokens")
-                    .and_then(|m| m.as_u64())
-                    .map(|m| m as u32),
-                reasoning_effort: body
-                    .get("reasoning")
-                    .and_then(|r| r.get("effort"))
-                    .and_then(|e| e.as_str())
-                    .map(|s| s.to_string()),
-                extra,
+                temperature: req.temperature,
+                top_p: req.top_p,
+                max_tokens: req.max_output_tokens,
+                reasoning_effort: req.reasoning.and_then(|r| r.effort),
+                // Splat every Responses-API field without a typed slot —
+                // tool_choice, parallel_tool_calls, max_tool_calls, metadata,
+                // include[], previous_response_id, store, stream_options, … —
+                // into `extra` so render_request can put them back.
+                extra: req.extra,
             },
-            stream: body
-                .get("stream")
-                .and_then(|s| s.as_bool())
-                .unwrap_or(false),
+            stream: req.stream,
         })
     }
 

--- a/crates/bitrouter-sdk/src/language_model/protocol/openai_responses.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/openai_responses.rs
@@ -679,12 +679,16 @@ impl StreamDecoder for ResponsesStreamDecoder {
             Ok(v) => v,
             Err(_) => return Ok(Vec::new()),
         };
-        // The event name lives in the `type` field (Responses puts it in both
-        // the SSE `event:` line and the JSON body).
-        let event_type = event
-            .event
-            .as_deref()
-            .or_else(|| json.get("type").and_then(|t| t.as_str()))
+        // The event name lives in the JSON body's `type` field; Responses also
+        // mirrors it onto the SSE `event:` line, but several upstreams (notably
+        // OpenRouter and stock OpenAI when fronted via gateways) emit only the
+        // `data:` line — the SSE spec then defaults `event` to "message",
+        // which would otherwise shadow the real event name. Always prefer the
+        // body `type` and fall back to the SSE header only when it's absent.
+        let event_type = json
+            .get("type")
+            .and_then(|t| t.as_str())
+            .or(event.event.as_deref())
             .unwrap_or_default();
 
         let mut parts = Vec::new();

--- a/crates/bitrouter-sdk/src/language_model/protocol/snapshots/openai_responses_request.json
+++ b/crates/bitrouter-sdk/src/language_model/protocol/snapshots/openai_responses_request.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ResponsesRequest",
+  "description": "OpenAI Responses request body\n(<https://platform.openai.com/docs/api-reference/responses/create>).\n\n`pub` so downstream crates (notably `bitrouter-cloud`) can derive an\nOpenAPI schema from the canonical wire shape without redeclaring it.\n\n`input` stays `serde_json::Value` on purpose — the Responses API accepts\neither a plain string or a heterogeneous item array (Codex multi-turn,\n#454-3), and the deeper walk happens in [`parse_input`]. Mirrors how\nAnthropic's `system` / `content` are typed.",
+  "type": "object",
+  "properties": {
+    "input": true,
+    "instructions": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "default": null
+    },
+    "max_output_tokens": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "uint32",
+      "default": null,
+      "minimum": 0
+    },
+    "model": {
+      "type": "string",
+      "default": ""
+    },
+    "reasoning": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ResponsesReasoningConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "stream": {
+      "type": "boolean",
+      "default": false
+    },
+    "temperature": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "format": "double",
+      "default": null
+    },
+    "tools": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/ResponsesTool"
+      }
+    },
+    "top_p": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "format": "double",
+      "default": null
+    }
+  },
+  "required": [
+    "input"
+  ],
+  "$defs": {
+    "ResponsesReasoningConfig": {
+      "description": "`reasoning` knob on [`ResponsesRequest`] — only `effort` is read; other\nfields (`summary`, …) round-trip via no slot today (matching v0 behavior).",
+      "type": "object",
+      "properties": {
+        "effort": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        }
+      }
+    },
+    "ResponsesTool": {
+      "description": "One element of [`ResponsesRequest`]'s `tools` array — the Responses-flavoured\nflat tool definition (`{ type: \"function\", name, description, parameters }`).",
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
+        "parameters": {
+          "default": null
+        },
+        "type": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        }
+      }
+    }
+  }
+}

--- a/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
@@ -1299,6 +1299,37 @@ fn responses_completed_preserves_id_status_and_usage() {
     assert_eq!(completed["response"]["usage"]["input_tokens"], 12);
 }
 
+/// Upstreams that omit the SSE `event:` line (OpenRouter, vanilla OpenAI
+/// fronted via some gateways) cause the SSE parser to default the event
+/// name to `"message"`. The Responses decoder must trust the body `type`
+/// field in that case instead of treating `"message"` as the event name —
+/// otherwise every delta/lifecycle frame is silently dropped as "unknown".
+#[test]
+fn responses_stream_decoder_prefers_body_type_over_default_message_event() {
+    let adapter = adapter_for(ApiProtocol::Responses);
+    let mut decoder = adapter.stream_decoder();
+
+    let event = SseEvent {
+        // SSE default event name when the upstream omits `event:`.
+        event: Some("message".to_string()),
+        data: serde_json::json!({
+            "type": "response.output_text.delta",
+            "delta": "pong",
+        })
+        .to_string(),
+    };
+    let parts = decoder
+        .decode(&event)
+        .expect("decoder must not error on default-named events");
+    assert!(
+        matches!(
+            parts.first(),
+            Some(StreamPart::TextDelta { text }) if text == "pong"
+        ),
+        "body `type` must win over the SSE default `message` event name; got {parts:?}"
+    );
+}
+
 /// #434 — Responses function-call stream items map `item_id` back to the
 /// canonical `call_id`, and the `.done` event does not duplicate the arguments.
 #[test]

--- a/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
@@ -1472,6 +1472,11 @@ fn google_generate_content_request_schema_is_stable() {
     assert_schema_snapshot::<google::GenerateContentRequest>("google_generate_content_request");
 }
 
+#[test]
+fn openai_responses_request_schema_is_stable() {
+    assert_schema_snapshot::<openai_responses::ResponsesRequest>("openai_responses_request");
+}
+
 /// `#[schemars(skip)]` on the `extra` `HashMap` must hide it from the published
 /// contract — the schema for the request should never expose
 /// `additionalProperties` of arbitrary JSON values. The exact wording belongs
@@ -1506,5 +1511,11 @@ fn extra_passthrough_field_is_not_in_schema() {
             .and_then(|p| p.get("extra"))
             .is_none(),
         "Google GoogleGenerationConfig schema must not expose `extra`",
+    );
+    let s =
+        serde_json::to_value(schemars::schema_for!(openai_responses::ResponsesRequest)).unwrap();
+    assert!(
+        s.get("properties").and_then(|p| p.get("extra")).is_none(),
+        "OpenAI ResponsesRequest schema must not expose `extra` (pass-through field)",
     );
 }


### PR DESCRIPTION
Stacks on #469. Picks up the **OpenAI Responses** gap that #469 explicitly deferred, and along the way fixes a pre-existing streaming bug surfaced by end-to-end testing.

## Commit 1 — `feat(sdk): derive JsonSchema on openai_responses wire types`

#469 carved Responses out of scope because its \`parse_request\` walked \`serde_json::Value\` field-by-field to preserve Codex-style \`input\` leniency (#454-3). The PR text gave two options (doc-only types, or a strict-typed rewrite) and rejected both.

This change takes a third path the sibling adapters already use: **shallow Deserialize**. The envelope deserializes strictly into typed \`ResponsesRequest\` / \`ResponsesTool\` / \`ResponsesReasoningConfig\`, but the polymorphic \`input\` field stays \`serde_json::Value\` and the existing \`parse_input\` lenient walk runs over it unchanged — exactly the same pattern as \`AnthropicMessage.content\`, \`MessagesRequest.system\`, \`ChatMessage.content\`. \`#[serde(flatten)] #[schemars(skip)] extra\` replaces the manual KNOWN-list subtraction.

\`parse_request\` shrinks from ~100 lines to ~30. No behavior change for #454-3 (verified by the existing regression test).

Snapshot test (\`openai_responses_request_schema_is_stable\`) added; \`extra_passthrough_field_is_not_in_schema\` extended.

## Commit 2 — \`fix(sdk): Responses decoder must trust body \\\`type\\\` over SSE default\`

Discovered while running an openclaw → bitrouter → OpenRouter end-to-end. **OpenRouter (and vanilla OpenAI fronted via gateways) emit Responses SSE frames without an \`event:\` line** — per SSE spec the parser then defaults the event name to \`\"message\"\`. The decoder was reading \`event.event\` first, so every real event silently fell through the unknown-event arm and the whole stream returned 200 OK with an empty body.

One-line fix: prefer the JSON body's \`type\` field, fall back to the SSE header only if absent. Our own emitter sets both with the same value, so internal round-trips are unaffected. Dedicated regression test added.

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --workspace --all-targets --all-features -- -D warnings\`
- [x] \`cargo test -p bitrouter-sdk --all-features\` — **150 tests pass** (was 148 on this branch's parent; +1 schema snapshot, +1 SSE regression)
- [x] **Real-environment validation**: openclaw \`capability model run --model bitrouter/openrouter-responses:openai/gpt-4o-mini\` round-trips through a local v1 daemon to OpenRouter's \`/api/v1/responses\` and back, with streaming enabled by default. Pre-fix: 200 OK empty body. Post-fix: full lifecycle envelope (\`response.created\` → … → \`response.completed\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)