### PR TITLE
feat(sdk): structured outputs (response_format) for all 4 protocols

### DIFF
--- a/apps/bitrouter/src/auth/tests.rs
+++ b/apps/bitrouter/src/auth/tests.rs
@@ -26,6 +26,7 @@ fn prompt() -> Prompt {
         messages: vec![Message::text(Role::User, "hi")],
         tools: Vec::new(),
         params: GenerationParams::default(),
+        response_format: None,
         stream: false,
     }
 }

--- a/apps/bitrouter/src/policy/tests.rs
+++ b/apps/bitrouter/src/policy/tests.rs
@@ -22,6 +22,7 @@ fn ctx(model: &str, policy_id: Option<&str>) -> PipelineContext {
         messages: vec![Message::text(Role::User, "hi")],
         tools: Vec::new(),
         params: GenerationParams::default(),
+        response_format: None,
         stream: false,
     };
     let req = PipelineRequest::new(model, CallerContext::new("k1", "u1"), prompt);
@@ -51,6 +52,7 @@ fn ctx_with_tools(tools: &[&str], policy_id: Option<&str>) -> PipelineContext {
             })
             .collect(),
         params: GenerationParams::default(),
+        response_format: None,
         stream: false,
     };
     let req = PipelineRequest::new("m", CallerContext::new("k1", "u1"), prompt);

--- a/apps/bitrouter/tests/e2e.rs
+++ b/apps/bitrouter/tests/e2e.rs
@@ -6,11 +6,19 @@
 //! (`wiremock`). This exercises the whole stack: inbound protocol parse →
 //! pipeline → routing → HttpExecutor → outbound protocol render → upstream →
 //! response parse → metering recorder.
+//!
+//! The `structured_outputs_matrix` block at the bottom of this file is a
+//! 4×4 (inbound × outbound) sweep for `response_format` (PR #472). It uses
+//! the same assembled-router + wiremock setup as the other tests but with
+//! a four-protocol upstream and a four-provider config, so it lives here
+//! rather than in its own file.
 
+use axum_test::TestServer;
 use bitrouter_sdk::caller::CallerContext;
 use bitrouter_sdk::config;
 use bitrouter_sdk::language_model::{GenerationParams, Message, PipelineRequest, Prompt, Role};
 use bitrouter_sdk::server::{AppState, build_router};
+use serde_json::{Value, json};
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -506,4 +514,496 @@ async fn e2e_mcp_route_invokes_the_pure_routing_pipeline() {
     assert_eq!(json["jsonrpc"], "2.0");
     assert_eq!(json["id"], 1);
     assert_eq!(json["error"]["code"], -32601);
+}
+
+// ============================================================================
+// structured outputs — the 4×4 inbound-protocol × outbound-protocol matrix
+// for `response_format` (PR #472).
+//
+// Same assembly model as the tests above (assembled router + wiremock
+// upstream + axum_test). The matrix supplies the same JSON schema in each
+// inbound protocol's native shape and asserts it lands at the right native
+// field on the wire to the upstream:
+//
+//   OpenAI Chat:      response_format.json_schema.schema
+//   OpenAI Responses: text.format.schema
+//   Anthropic:        output_config.format.schema
+//   Google:           generationConfig.responseSchema  (paired with
+//                     responseMimeType == "application/json")
+//
+// `name` / `strict` are dropped on the outbound to Anthropic and Google
+// because those native APIs don't carry them.
+//
+// Capability-gate coverage (a `Custom` outbound adapter without
+// `supports_response_format()` produces a 400) lives at the SDK level in
+// `crates/bitrouter-sdk/src/language_model/tests.rs ::
+// executor_rejects_response_format_on_unsupported_outbound`. We don't
+// duplicate it here because the gate fires inside `HttpExecutor` before
+// any HTTP-level transport detail (URL, auth) matters.
+// ============================================================================
+
+/// The schema attached to every matrix request. Small but recognisable so
+/// the per-outbound assertions can compare on `properties.city.type`.
+fn matrix_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": { "city": { "type": "string" } },
+        "required": ["city"],
+        "additionalProperties": false,
+    })
+}
+
+/// Model id → outbound `api_protocol`. Same upstream serves all four; the
+/// chosen model id picks the provider (and therefore the outbound protocol).
+const MODEL_VIA_OPENAI: &str = "model-via-openai";
+const MODEL_VIA_ANTHROPIC: &str = "model-via-anthropic";
+const MODEL_VIA_RESPONSES: &str = "model-via-responses";
+const MODEL_VIA_GOOGLE: &str = "model-via-google";
+
+/// Stand up one MockServer that speaks all four outbound wire formats on the
+/// path each provider's transport actually hits.
+async fn upstream_for_all_protocols() -> MockServer {
+    let server = MockServer::start().await;
+
+    // OpenAI Chat — POST /chat/completions
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "chatcmpl-1",
+            "object": "chat.completion",
+            "model": "test",
+            "choices": [{
+                "index": 0,
+                "message": { "role": "assistant", "content": "{\"city\":\"sf\"}" },
+                "finish_reason": "stop",
+            }],
+            "usage": { "prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2 },
+        })))
+        .mount(&server)
+        .await;
+
+    // OpenAI Responses — POST /responses
+    Mock::given(method("POST"))
+        .and(path("/responses"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "resp-1",
+            "object": "response",
+            "status": "completed",
+            "model": "test",
+            "output": [{
+                "type": "message",
+                "role": "assistant",
+                "content": [{ "type": "output_text", "text": "{\"city\":\"sf\"}" }],
+            }],
+            "usage": { "input_tokens": 1, "output_tokens": 1, "total_tokens": 2 },
+        })))
+        .mount(&server)
+        .await;
+
+    // Anthropic Messages — POST /messages
+    Mock::given(method("POST"))
+        .and(path("/messages"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "msg-1",
+            "type": "message",
+            "role": "assistant",
+            "model": "test",
+            "content": [{ "type": "text", "text": "{\"city\":\"sf\"}" }],
+            "stop_reason": "end_turn",
+            "usage": { "input_tokens": 1, "output_tokens": 1 },
+        })))
+        .mount(&server)
+        .await;
+
+    // Google — POST /models/{model}:generateContent (model id varies per
+    // test; match on path prefix + suffix).
+    Mock::given(method("POST"))
+        .and(wiremock::matchers::path_regex(
+            r"^/models/[^/]+:generateContent$",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "candidates": [{
+                "content": { "role": "model", "parts": [{ "text": "{\"city\":\"sf\"}" }] },
+                "finishReason": "STOP",
+            }],
+            "usageMetadata": {
+                "promptTokenCount": 1,
+                "candidatesTokenCount": 1,
+                "totalTokenCount": 2,
+            },
+        })))
+        .mount(&server)
+        .await;
+
+    server
+}
+
+/// Build a config with four providers, each speaking one outbound protocol
+/// and each routing one named model.
+fn config_for_matrix(upstream: &str) -> config::Config {
+    let yaml = format!(
+        r#"
+server:
+  listen: "127.0.0.1:0"
+  skip_auth: true
+database:
+  url: "sqlite::memory:"
+providers:
+  via_openai:
+    api_base: {upstream}
+    api_key: test-key
+    api_protocol:
+      - "*": openai
+    models:
+      - id: {MODEL_VIA_OPENAI}
+  via_anthropic:
+    api_base: {upstream}
+    api_key: test-key
+    api_protocol:
+      - "*": anthropic
+    models:
+      - id: {MODEL_VIA_ANTHROPIC}
+  via_responses:
+    api_base: {upstream}
+    api_key: test-key
+    api_protocol:
+      - "*": responses
+    models:
+      - id: {MODEL_VIA_RESPONSES}
+  via_google:
+    api_base: {upstream}
+    api_key: test-key
+    api_protocol:
+      - "*": google
+    models:
+      - id: {MODEL_VIA_GOOGLE}
+"#
+    );
+    config::parse_with(&yaml, |_| None).expect("config parses")
+}
+
+/// Assemble app + router + axum_test server with the matrix config.
+async fn matrix_server() -> (TestServer, MockServer) {
+    let upstream = upstream_for_all_protocols().await;
+    let cfg = config_for_matrix(&upstream.uri());
+    let assembled = bitrouter::build_app(&cfg).await.expect("app assembles");
+    let state = AppState {
+        language_model: assembled.app.language_model().unwrap().clone(),
+        mcp: assembled.app.mcp().cloned(),
+        skip_auth: assembled.app.skip_auth(),
+        metrics_renderer: assembled.app.metrics_renderer().cloned(),
+    };
+    (TestServer::new(build_router(state)), upstream)
+}
+
+// ----- inbound request builders (one per inbound protocol) -----
+
+fn inbound_openai_chat(model: &str) -> Value {
+    json!({
+        "model": model,
+        "messages": [{ "role": "user", "content": "weather?" }],
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "weather",
+                "strict": true,
+                "schema": matrix_schema(),
+            },
+        },
+    })
+}
+
+fn inbound_anthropic(model: &str) -> Value {
+    json!({
+        "model": model,
+        "max_tokens": 256,
+        "messages": [{ "role": "user", "content": "weather?" }],
+        "output_config": {
+            "format": { "type": "json_schema", "schema": matrix_schema() },
+        },
+    })
+}
+
+fn inbound_openai_responses(model: &str) -> Value {
+    json!({
+        "model": model,
+        "input": "weather?",
+        "text": {
+            "format": {
+                "type": "json_schema",
+                "name": "weather",
+                "strict": true,
+                "schema": matrix_schema(),
+            },
+        },
+    })
+}
+
+fn inbound_google() -> Value {
+    // Google carries the model in the URL, not the body.
+    json!({
+        "contents": [{ "role": "user", "parts": [{ "text": "weather?" }] }],
+        "generationConfig": {
+            "responseMimeType": "application/json",
+            "responseSchema": matrix_schema(),
+        },
+    })
+}
+
+#[derive(Clone, Copy)]
+enum Inbound {
+    OpenAiChat,
+    Anthropic,
+    OpenAiResponses,
+    Google,
+}
+
+#[derive(Clone, Copy)]
+enum Outbound {
+    OpenAiChat,
+    Anthropic,
+    OpenAiResponses,
+    Google,
+}
+
+impl Outbound {
+    fn model(self) -> &'static str {
+        match self {
+            Outbound::OpenAiChat => MODEL_VIA_OPENAI,
+            Outbound::Anthropic => MODEL_VIA_ANTHROPIC,
+            Outbound::OpenAiResponses => MODEL_VIA_RESPONSES,
+            Outbound::Google => MODEL_VIA_GOOGLE,
+        }
+    }
+
+    fn path_segment(self) -> &'static str {
+        match self {
+            Outbound::OpenAiChat => "/chat/completions",
+            Outbound::Anthropic => "/messages",
+            Outbound::OpenAiResponses => "/responses",
+            // Google's path contains the model id; matched via prefix below.
+            Outbound::Google => "/models/",
+        }
+    }
+}
+
+/// POST `body` to the inbound route matching `inbound`.
+async fn post_inbound(server: &TestServer, inbound: Inbound, model: &str, body: &Value) {
+    let response = match inbound {
+        Inbound::OpenAiChat => server.post("/v1/chat/completions").json(body).await,
+        Inbound::Anthropic => server.post("/v1/messages").json(body).await,
+        Inbound::OpenAiResponses => server.post("/v1/responses").json(body).await,
+        Inbound::Google => {
+            server
+                .post(&format!("/v1beta/models/{model}:generateContent"))
+                .json(body)
+                .await
+        }
+    };
+    response.assert_status_ok();
+}
+
+/// Pull the single upstream request that landed at the path expected for the
+/// outbound protocol. Panics with a useful message if zero or more than one
+/// matched — a wrong-path call would otherwise look like a successful test.
+async fn captured_outbound(upstream: &MockServer, outbound: Outbound) -> Value {
+    let received = upstream.received_requests().await.unwrap_or_default();
+    let suffix = match outbound {
+        Outbound::Google => ":generateContent",
+        _ => "",
+    };
+    let matches: Vec<_> = received
+        .iter()
+        .filter(|r| {
+            let p = r.url.path();
+            p.starts_with(outbound.path_segment()) && p.ends_with(suffix)
+        })
+        .collect();
+    assert_eq!(
+        matches.len(),
+        1,
+        "expected exactly one upstream request to outbound {:?} (path starts with {:?}); saw {} \
+         total requests, paths: {:?}",
+        outbound.path_segment(),
+        outbound.path_segment(),
+        received.len(),
+        received.iter().map(|r| r.url.path()).collect::<Vec<_>>(),
+    );
+    serde_json::from_slice(&matches[0].body).expect("upstream body is JSON")
+}
+
+/// Assert the upstream body carries the schema at the outbound protocol's
+/// native location. Encodes the per-protocol contract from PR #472.
+fn assert_native_schema(outbound: Outbound, body: &Value) {
+    let want = matrix_schema();
+    match outbound {
+        Outbound::OpenAiChat => {
+            assert_eq!(
+                body["response_format"]["type"], "json_schema",
+                "openai chat outbound must set response_format.type=json_schema; body: {body}",
+            );
+            assert_eq!(
+                body["response_format"]["json_schema"]["schema"], want,
+                "openai chat outbound must carry the schema under \
+                 response_format.json_schema.schema; body: {body}",
+            );
+            // OpenAI Chat requires `name`; the renderer must supply a default
+            // when the inbound (Anthropic, Google) didn't carry one. Either
+            // the caller-supplied name or the default `"response"` is fine.
+            assert!(
+                body["response_format"]["json_schema"]["name"].is_string(),
+                "openai chat outbound must always set a name; body: {body}",
+            );
+        }
+        Outbound::Anthropic => {
+            assert_eq!(
+                body["output_config"]["format"]["type"], "json_schema",
+                "anthropic outbound must set output_config.format.type=json_schema; body: {body}",
+            );
+            assert_eq!(
+                body["output_config"]["format"]["schema"], want,
+                "anthropic outbound must carry the schema under \
+                 output_config.format.schema; body: {body}",
+            );
+            // Anthropic's GA shape doesn't carry name/strict — the renderer
+            // must drop them, not forward them as unknown fields.
+            assert!(
+                body["output_config"]["format"].get("name").is_none(),
+                "anthropic outbound must NOT carry `name` (not in GA shape); body: {body}",
+            );
+            assert!(
+                body["output_config"]["format"].get("strict").is_none(),
+                "anthropic outbound must NOT carry `strict` (not in GA shape); body: {body}",
+            );
+            // The deprecated flat alias must never appear on the outbound.
+            assert!(
+                body.get("output_format").is_none(),
+                "anthropic outbound must not emit the deprecated `output_format` alias; \
+                 body: {body}",
+            );
+        }
+        Outbound::OpenAiResponses => {
+            assert_eq!(
+                body["text"]["format"]["type"], "json_schema",
+                "responses outbound must set text.format.type=json_schema; body: {body}",
+            );
+            assert_eq!(
+                body["text"]["format"]["schema"], want,
+                "responses outbound must carry the schema under text.format.schema; body: {body}",
+            );
+            assert!(
+                body["text"]["format"]["name"].is_string(),
+                "responses outbound must always set a name; body: {body}",
+            );
+        }
+        Outbound::Google => {
+            assert_eq!(
+                body["generationConfig"]["responseMimeType"], "application/json",
+                "google outbound must set generationConfig.responseMimeType=application/json; \
+                 body: {body}",
+            );
+            assert_eq!(
+                body["generationConfig"]["responseSchema"], want,
+                "google outbound must carry the schema under \
+                 generationConfig.responseSchema; body: {body}",
+            );
+        }
+    }
+}
+
+/// Drive one matrix cell end-to-end.
+async fn run_cell(inbound: Inbound, outbound: Outbound) {
+    let (server, upstream) = matrix_server().await;
+    let model = outbound.model();
+    let body = match inbound {
+        Inbound::OpenAiChat => inbound_openai_chat(model),
+        Inbound::Anthropic => inbound_anthropic(model),
+        Inbound::OpenAiResponses => inbound_openai_responses(model),
+        Inbound::Google => inbound_google(),
+    };
+    post_inbound(&server, inbound, model, &body).await;
+    let upstream_body = captured_outbound(&upstream, outbound).await;
+    assert_native_schema(outbound, &upstream_body);
+}
+
+// ----- 4×4 matrix -----
+
+#[tokio::test]
+async fn e2e_response_format_openai_chat_in_to_openai_chat_out() {
+    run_cell(Inbound::OpenAiChat, Outbound::OpenAiChat).await;
+}
+
+#[tokio::test]
+async fn e2e_response_format_openai_chat_in_to_anthropic_out() {
+    run_cell(Inbound::OpenAiChat, Outbound::Anthropic).await;
+}
+
+#[tokio::test]
+async fn e2e_response_format_openai_chat_in_to_responses_out() {
+    run_cell(Inbound::OpenAiChat, Outbound::OpenAiResponses).await;
+}
+
+#[tokio::test]
+async fn e2e_response_format_openai_chat_in_to_google_out() {
+    run_cell(Inbound::OpenAiChat, Outbound::Google).await;
+}
+
+#[tokio::test]
+async fn e2e_response_format_anthropic_in_to_openai_chat_out() {
+    run_cell(Inbound::Anthropic, Outbound::OpenAiChat).await;
+}
+
+#[tokio::test]
+async fn e2e_response_format_anthropic_in_to_anthropic_out() {
+    run_cell(Inbound::Anthropic, Outbound::Anthropic).await;
+}
+
+#[tokio::test]
+async fn e2e_response_format_anthropic_in_to_responses_out() {
+    run_cell(Inbound::Anthropic, Outbound::OpenAiResponses).await;
+}
+
+#[tokio::test]
+async fn e2e_response_format_anthropic_in_to_google_out() {
+    run_cell(Inbound::Anthropic, Outbound::Google).await;
+}
+
+#[tokio::test]
+async fn e2e_response_format_responses_in_to_openai_chat_out() {
+    run_cell(Inbound::OpenAiResponses, Outbound::OpenAiChat).await;
+}
+
+#[tokio::test]
+async fn e2e_response_format_responses_in_to_anthropic_out() {
+    run_cell(Inbound::OpenAiResponses, Outbound::Anthropic).await;
+}
+
+#[tokio::test]
+async fn e2e_response_format_responses_in_to_responses_out() {
+    run_cell(Inbound::OpenAiResponses, Outbound::OpenAiResponses).await;
+}
+
+#[tokio::test]
+async fn e2e_response_format_responses_in_to_google_out() {
+    run_cell(Inbound::OpenAiResponses, Outbound::Google).await;
+}
+
+#[tokio::test]
+async fn e2e_response_format_google_in_to_openai_chat_out() {
+    run_cell(Inbound::Google, Outbound::OpenAiChat).await;
+}
+
+#[tokio::test]
+async fn e2e_response_format_google_in_to_anthropic_out() {
+    run_cell(Inbound::Google, Outbound::Anthropic).await;
+}
+
+#[tokio::test]
+async fn e2e_response_format_google_in_to_responses_out() {
+    run_cell(Inbound::Google, Outbound::OpenAiResponses).await;
+}
+
+#[tokio::test]
+async fn e2e_response_format_google_in_to_google_out() {
+    run_cell(Inbound::Google, Outbound::Google).await;
 }

--- a/apps/bitrouter/tests/e2e.rs
+++ b/apps/bitrouter/tests/e2e.rs
@@ -68,6 +68,7 @@ fn chat_prompt() -> Prompt {
         messages: vec![Message::text(Role::User, "hello")],
         tools: Vec::new(),
         params: GenerationParams::default(),
+        response_format: None,
         stream: false,
     }
 }

--- a/crates/bitrouter-sdk/src/language_model/context.rs
+++ b/crates/bitrouter-sdk/src/language_model/context.rs
@@ -302,6 +302,7 @@ mod tests {
             }],
             tools: vec![],
             params: Default::default(),
+            response_format: None,
             stream: false,
         }
     }

--- a/crates/bitrouter-sdk/src/language_model/executor.rs
+++ b/crates/bitrouter-sdk/src/language_model/executor.rs
@@ -251,6 +251,25 @@ impl HttpExecutor {
             target.api_protocol, target.provider_name,
         ))
     }
+
+    /// Refuse to silently drop a caller-supplied `response_format` when the
+    /// resolved outbound protocol cannot honour it. Built-in adapters all
+    /// support it; only out-of-tree [`ApiProtocol::Custom`] targets that
+    /// haven't implemented translation hit this 400.
+    fn check_response_format(
+        prompt: &Prompt,
+        adapter: &Arc<dyn crate::language_model::protocol::OutboundAdapter>,
+        target: &RoutingTarget,
+    ) -> Result<()> {
+        if prompt.response_format.is_some() && !adapter.supports_response_format() {
+            return Err(BitrouterError::bad_request(format!(
+                "response_format requested but outbound protocol '{}' \
+                 (target provider '{}') does not support structured outputs",
+                target.api_protocol, target.provider_name,
+            )));
+        }
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -260,6 +279,8 @@ impl Executor for HttpExecutor {
             .dispatch
             .lookup(&target.api_protocol)
             .ok_or_else(|| Self::no_dispatch_error(target))?;
+
+        Self::check_response_format(prompt, adapter, target)?;
 
         let mut upstream_prompt = prompt.clone();
         upstream_prompt.model = target.service_id.clone();
@@ -328,6 +349,8 @@ impl Executor for HttpExecutor {
             .dispatch
             .lookup(&target.api_protocol)
             .ok_or_else(|| Self::no_dispatch_error(target))?;
+
+        Self::check_response_format(prompt, adapter, target)?;
 
         let mut upstream_prompt = prompt.clone();
         upstream_prompt.model = target.service_id.clone();

--- a/crates/bitrouter-sdk/src/language_model/protocol/anthropic.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/anthropic.rs
@@ -22,8 +22,8 @@ use crate::language_model::protocol::{
 };
 use crate::language_model::stream::SseFrame;
 use crate::language_model::types::{
-    ApiProtocol, Content, FinishReason, GenerateResult, GenerationParams, Message, Prompt, Role,
-    RoutingTarget, StreamPart, Usage,
+    ApiProtocol, Content, FinishReason, GenerateResult, GenerationParams, Message, Prompt,
+    ResponseFormat, Role, RoutingTarget, StreamPart, Usage,
 };
 
 /// The Anthropic Messages inbound + outbound protocol adapter.
@@ -284,6 +284,31 @@ impl InboundAdapter for AnthropicAdapter {
             })
             .collect();
 
+        // Anthropic's GA structured-outputs lives under
+        // `output_config.format`. Some clients still emit the deprecated flat
+        // `output_format` (vercel/ai#12298) — accept it as a graceful alias.
+        // Only the alias that actually matched is stripped from extras, so
+        // unknown siblings inside `output_config` survive opaquely if
+        // `output_format` was the source.
+        let mut extra = req.extra;
+        let response_format = if let Some(rf) = parse_output_config_format(&extra) {
+            if let Some(oc) = extra
+                .get_mut("output_config")
+                .and_then(|v| v.as_object_mut())
+            {
+                oc.remove("format");
+                if oc.is_empty() {
+                    extra.remove("output_config");
+                }
+            }
+            Some(rf)
+        } else if let Some(rf) = parse_legacy_output_format(&extra) {
+            extra.remove("output_format");
+            Some(rf)
+        } else {
+            None
+        };
+
         Ok(Prompt {
             model: req.model,
             system,
@@ -294,8 +319,9 @@ impl InboundAdapter for AnthropicAdapter {
                 top_p: req.top_p,
                 max_tokens: req.max_tokens,
                 reasoning_effort: None,
-                extra: req.extra,
+                extra,
             },
+            response_format,
             stream: req.stream,
         })
     }
@@ -380,6 +406,16 @@ impl OutboundAdapter for AnthropicAdapter {
         if let Some(p) = prompt.params.top_p {
             req.insert("top_p".into(), p.into());
         }
+        // Render the canonical response_format into Anthropic's GA shape
+        // (`output_config.format`). `name` and `strict` are intentionally
+        // dropped — Anthropic's schema-constrained sampling has no concept of
+        // either and they would be rejected as unknown fields.
+        if let Some(rf) = &prompt.response_format {
+            req.insert(
+                "output_config".into(),
+                serde_json::json!({ "format": render_anthropic_response_format(rf) }),
+            );
+        }
         // Splat anthropic-specific extras (tool_choice, stop_sequences, …) back
         // into the outbound request. Typed fields win over same-named extras.
         for (k, v) in &prompt.params.extra {
@@ -446,6 +482,46 @@ impl OutboundAdapter for AnthropicAdapter {
     fn stream_decoder(&self) -> Box<dyn StreamDecoder> {
         Box::new(AnthropicStreamDecoder::default())
     }
+
+    fn supports_response_format(&self) -> bool {
+        true
+    }
+}
+
+/// Lift Anthropic's GA `output_config.format: { type: "json_schema", schema }`
+/// into the canonical [`ResponseFormat`]. Anthropic's wire format carries no
+/// `name` / `strict` so both are `None`.
+fn parse_output_config_format(
+    extra: &std::collections::HashMap<String, serde_json::Value>,
+) -> Option<ResponseFormat> {
+    json_schema_from(extra.get("output_config")?.get("format")?)
+}
+
+/// Lift Anthropic's deprecated flat `output_format: { type: "json_schema", schema }`
+/// into the canonical [`ResponseFormat`]. Kept as a graceful alias for
+/// clients still emitting the pre-GA shape (vercel/ai#12298).
+fn parse_legacy_output_format(
+    extra: &std::collections::HashMap<String, serde_json::Value>,
+) -> Option<ResponseFormat> {
+    json_schema_from(extra.get("output_format")?)
+}
+
+fn json_schema_from(format: &serde_json::Value) -> Option<ResponseFormat> {
+    if format.get("type")?.as_str()? != "json_schema" {
+        return None;
+    }
+    Some(ResponseFormat::JsonSchema {
+        name: None,
+        strict: None,
+        schema: format.get("schema")?.clone(),
+    })
+}
+
+/// Render a canonical [`ResponseFormat`] into Anthropic's
+/// `{ type: "json_schema", schema }` body that sits under `output_config.format`.
+fn render_anthropic_response_format(rf: &ResponseFormat) -> serde_json::Value {
+    let ResponseFormat::JsonSchema { schema, .. } = rf;
+    serde_json::json!({ "type": "json_schema", "schema": schema })
 }
 
 #[async_trait]

--- a/crates/bitrouter-sdk/src/language_model/protocol/google.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/google.rs
@@ -19,8 +19,8 @@ use crate::language_model::protocol::{
 };
 use crate::language_model::stream::SseFrame;
 use crate::language_model::types::{
-    ApiProtocol, Content, FinishReason, GenerateResult, GenerationParams, Message, Prompt, Role,
-    RoutingTarget, StreamPart, Usage,
+    ApiProtocol, Content, FinishReason, GenerateResult, GenerationParams, Message, Prompt,
+    ResponseFormat, Role, RoutingTarget, StreamPart, Usage,
 };
 
 /// The Google Generative AI protocol adapter.
@@ -280,6 +280,16 @@ impl InboundAdapter for GoogleAdapter {
                 extra: g.extra,
             })
             .unwrap_or_default();
+        // Promote `generationConfig.responseSchema` (paired with
+        // `responseMimeType: "application/json"`) into the canonical slot
+        // so cross-protocol routing can translate it. When `responseMimeType`
+        // is some other value (e.g. `text/x.enum`) we leave both fields in
+        // extras as an opaque Google-native pass-through.
+        let response_format = parse_google_response_format(&params.extra);
+        if response_format.is_some() {
+            params.extra.remove("responseMimeType");
+            params.extra.remove("responseSchema");
+        }
         // Preserve top-level Google fields (`toolConfig`, `safetySettings`,
         // `cachedContent`, …) across the round-trip. They're namespaced so they
         // don't collide with `generationConfig`-level extras above and only the
@@ -297,6 +307,7 @@ impl InboundAdapter for GoogleAdapter {
             messages,
             tools,
             params,
+            response_format,
             stream: req.stream,
         })
     }
@@ -370,10 +381,17 @@ impl OutboundAdapter for GoogleAdapter {
         if let Some(mt) = prompt.params.max_tokens {
             gen_config.insert("maxOutputTokens".into(), mt.into());
         }
-        // Splat Google generation-config extras (stopSequences, topK, seed,
-        // responseMimeType / responseSchema, …) back into the outbound config.
-        // Typed fields above win over a same-named extra; the sentinel key
-        // carries top-level fields and is skipped here.
+        // Render the canonical response_format into Google's generationConfig.
+        // `name` and `strict` are intentionally dropped — Google's
+        // schema-constrained sampling has no concept of either.
+        if let Some(rf) = &prompt.response_format {
+            let ResponseFormat::JsonSchema { schema, .. } = rf;
+            gen_config.insert("responseMimeType".into(), "application/json".into());
+            gen_config.insert("responseSchema".into(), schema.clone());
+        }
+        // Splat Google generation-config extras (stopSequences, topK, seed, …)
+        // back into the outbound config. Typed fields above win over a same-named
+        // extra; the sentinel key carries top-level fields and is skipped here.
         for (k, v) in &prompt.params.extra {
             if k == GOOGLE_TOP_LEVEL_EXTRA_KEY {
                 continue;
@@ -424,6 +442,28 @@ impl OutboundAdapter for GoogleAdapter {
     fn stream_decoder(&self) -> Box<dyn StreamDecoder> {
         Box::new(GoogleStreamDecoder::default())
     }
+
+    fn supports_response_format(&self) -> bool {
+        true
+    }
+}
+
+/// Lift Google's structured-output fields out of `generationConfig` extras
+/// into the canonical [`ResponseFormat`]. Triggers only when
+/// `responseMimeType == "application/json"` *and* a `responseSchema` is set —
+/// other MIME modes (e.g. `text/x.enum`) have no schema to translate.
+fn parse_google_response_format(
+    extra: &std::collections::HashMap<String, serde_json::Value>,
+) -> Option<ResponseFormat> {
+    if extra.get("responseMimeType").and_then(|v| v.as_str()) != Some("application/json") {
+        return None;
+    }
+    let schema = extra.get("responseSchema")?.clone();
+    Some(ResponseFormat::JsonSchema {
+        name: None,
+        strict: None,
+        schema,
+    })
 }
 
 #[async_trait]

--- a/crates/bitrouter-sdk/src/language_model/protocol/mod.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/mod.rs
@@ -139,6 +139,15 @@ pub trait OutboundAdapter: Send + Sync {
     /// A fresh stateful decoder turning this protocol's SSE events into
     /// canonical [`StreamPart`]s.
     fn stream_decoder(&self) -> Box<dyn StreamDecoder>;
+
+    /// Whether this protocol can honour
+    /// [`Prompt::response_format`](crate::language_model::types::Prompt::response_format).
+    /// Default is `false` so out-of-tree custom adapters surface a clear 400
+    /// rather than silently dropping the schema. The four built-in adapters
+    /// override this to `true`.
+    fn supports_response_format(&self) -> bool {
+        false
+    }
 }
 
 /// Dispatch policy for one outbound provider — endpoint URL shape and

--- a/crates/bitrouter-sdk/src/language_model/protocol/openai_chat.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/openai_chat.rs
@@ -19,8 +19,8 @@ use crate::language_model::protocol::{
 };
 use crate::language_model::stream::SseFrame;
 use crate::language_model::types::{
-    ApiProtocol, Content, FinishReason, GenerateResult, GenerationParams, Message, Prompt, Role,
-    RoutingTarget, StreamPart, Usage,
+    ApiProtocol, Content, FinishReason, GenerateResult, GenerationParams, Message, Prompt,
+    ResponseFormat, Role, RoutingTarget, StreamPart, Usage,
 };
 
 /// The OpenAI Chat Completions inbound + outbound protocol adapter.
@@ -238,6 +238,16 @@ impl InboundAdapter for OpenAiChatAdapter {
             })
             .collect();
 
+        // Promote `response_format: { type: "json_schema", ... }` out of the
+        // extras splat into the canonical slot so cross-protocol routing can
+        // translate it. The legacy `{ type: "json_object" }` JSON mode is left
+        // in extras (it has no schema to translate and passes through opaquely).
+        let mut extra = req.extra;
+        let response_format = parse_chat_response_format(&extra);
+        if response_format.is_some() {
+            extra.remove("response_format");
+        }
+
         Ok(Prompt {
             model: req.model,
             system,
@@ -249,11 +259,15 @@ impl InboundAdapter for OpenAiChatAdapter {
                 max_tokens: req.max_tokens.or(req.max_completion_tokens),
                 reasoning_effort: req.reasoning_effort,
                 // Every OpenAI-Chat field we don't have a typed slot for —
-                // tool_choice, stop / stop_sequences, seed, response_format,
-                // n, presence/frequency_penalty, logit_bias, … — rides along
-                // in `extra` and is splatted back on render.
-                extra: req.extra,
+                // tool_choice, stop / stop_sequences, seed, n,
+                // presence/frequency_penalty, logit_bias, … — rides along
+                // in `extra` and is splatted back on render. Note:
+                // `response_format` with `type:"json_schema"` is promoted into
+                // `Prompt::response_format` above; other shapes (e.g.
+                // `type:"json_object"`) stay in extras.
+                extra,
             },
+            response_format,
             stream: req.stream,
         })
     }
@@ -388,9 +402,16 @@ impl OutboundAdapter for OpenAiChatAdapter {
         if let Some(re) = &prompt.params.reasoning_effort {
             req.insert("reasoning_effort".into(), re.clone().into());
         }
+        // Render the canonical response_format into OpenAI Chat's native shape.
+        // Inserted before the extras splat so it wins over any legacy
+        // `response_format` left in extras (typed slot wins, matching how
+        // other params are handled).
+        if let Some(rf) = &prompt.response_format {
+            req.insert("response_format".into(), render_chat_response_format(rf));
+        }
         // Splat the extras back into the outbound request — this is how
-        // `tool_choice`, `stop`, `seed`, `response_format`, etc. survive the
-        // round trip. Typed fields above win over any same-named extra.
+        // `tool_choice`, `stop`, `seed`, etc. survive the round trip. Typed
+        // fields above win over any same-named extra.
         for (k, v) in &prompt.params.extra {
             req.entry(k.clone()).or_insert_with(|| v.clone());
         }
@@ -515,6 +536,56 @@ impl OutboundAdapter for OpenAiChatAdapter {
     fn stream_decoder(&self) -> Box<dyn StreamDecoder> {
         Box::new(ChatStreamDecoder::default())
     }
+
+    fn supports_response_format(&self) -> bool {
+        true
+    }
+}
+
+/// Detect a `response_format: { type: "json_schema", json_schema: {...} }`
+/// blob in the inbound extras and lift it into the canonical [`ResponseFormat`].
+/// Returns `None` for any other shape (notably `{ type: "json_object" }`,
+/// which is the older JSON-mode and has no schema to translate).
+fn parse_chat_response_format(
+    extra: &HashMap<String, serde_json::Value>,
+) -> Option<ResponseFormat> {
+    let rf = extra.get("response_format")?;
+    if rf.get("type")?.as_str()? != "json_schema" {
+        return None;
+    }
+    let js = rf.get("json_schema")?;
+    let schema = js.get("schema")?.clone();
+    Some(ResponseFormat::JsonSchema {
+        name: js
+            .get("name")
+            .and_then(|n| n.as_str())
+            .map(|s| s.to_string()),
+        strict: js.get("strict").and_then(|s| s.as_bool()),
+        schema,
+    })
+}
+
+/// Render a canonical [`ResponseFormat`] into OpenAI Chat's native
+/// `{ type: "json_schema", json_schema: { name, strict, schema } }`. OpenAI
+/// requires `name`; supply a stable default when the caller didn't set one.
+fn render_chat_response_format(rf: &ResponseFormat) -> serde_json::Value {
+    let ResponseFormat::JsonSchema {
+        name,
+        strict,
+        schema,
+    } = rf;
+    let mut js = serde_json::Map::new();
+    js.insert(
+        "name".into(),
+        name.clone()
+            .unwrap_or_else(|| "response".to_string())
+            .into(),
+    );
+    if let Some(strict) = strict {
+        js.insert("strict".into(), (*strict).into());
+    }
+    js.insert("schema".into(), schema.clone());
+    serde_json::json!({ "type": "json_schema", "json_schema": serde_json::Value::Object(js) })
 }
 
 #[async_trait]

--- a/crates/bitrouter-sdk/src/language_model/protocol/openai_responses.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/openai_responses.rs
@@ -28,8 +28,8 @@ use crate::language_model::protocol::{
 };
 use crate::language_model::stream::SseFrame;
 use crate::language_model::types::{
-    ApiProtocol, Content, FinishReason, GenerateResult, GenerationParams, Message, Prompt, Role,
-    RoutingTarget, StreamPart, Usage,
+    ApiProtocol, Content, FinishReason, GenerateResult, GenerationParams, Message, Prompt,
+    ResponseFormat, Role, RoutingTarget, StreamPart, Usage,
 };
 
 /// The OpenAI Responses protocol adapter.
@@ -284,6 +284,20 @@ impl InboundAdapter for OpenAiResponsesAdapter {
             })
             .collect();
 
+        // Promote `text.format: { type: "json_schema", ... }` out of extras
+        // into the canonical slot. Other contents of `text` (e.g. `verbosity`)
+        // stay in extras and pass through opaquely.
+        let mut extra = req.extra;
+        let response_format = parse_responses_response_format(&extra);
+        if response_format.is_some()
+            && let Some(text) = extra.get_mut("text").and_then(|t| t.as_object_mut())
+        {
+            text.remove("format");
+            if text.is_empty() {
+                extra.remove("text");
+            }
+        }
+
         Ok(Prompt {
             model: req.model,
             system,
@@ -298,8 +312,9 @@ impl InboundAdapter for OpenAiResponsesAdapter {
                 // tool_choice, parallel_tool_calls, max_tool_calls, metadata,
                 // include[], previous_response_id, store, stream_options, … —
                 // into `extra` so render_request can put them back.
-                extra: req.extra,
+                extra,
             },
+            response_format,
             stream: req.stream,
         })
     }
@@ -393,6 +408,19 @@ impl OutboundAdapter for OpenAiResponsesAdapter {
         if let Some(re) = &prompt.params.reasoning_effort {
             req.insert("reasoning".into(), serde_json::json!({ "effort": re }));
         }
+        // Render the canonical response_format into Responses' `text.format`.
+        // Merge with any extras-supplied `text` blob so caller-supplied
+        // sibling keys (e.g. `verbosity`) survive.
+        if let Some(rf) = &prompt.response_format {
+            let mut text = prompt
+                .params
+                .extra
+                .get("text")
+                .and_then(|t| t.as_object().cloned())
+                .unwrap_or_default();
+            text.insert("format".into(), render_responses_response_format(rf));
+            req.insert("text".into(), serde_json::Value::Object(text));
+        }
         // Splat Responses-API extras (tool_choice, parallel_tool_calls,
         // metadata, include, …) back onto the outbound request. Typed fields
         // win.
@@ -474,6 +502,55 @@ impl OutboundAdapter for OpenAiResponsesAdapter {
     fn stream_decoder(&self) -> Box<dyn StreamDecoder> {
         Box::new(ResponsesStreamDecoder::default())
     }
+
+    fn supports_response_format(&self) -> bool {
+        true
+    }
+}
+
+/// Detect a `text.format: { type: "json_schema", ... }` blob in the inbound
+/// extras and lift it into the canonical [`ResponseFormat`]. Returns `None`
+/// for any other shape.
+fn parse_responses_response_format(
+    extra: &HashMap<String, serde_json::Value>,
+) -> Option<ResponseFormat> {
+    let format = extra.get("text")?.get("format")?;
+    if format.get("type")?.as_str()? != "json_schema" {
+        return None;
+    }
+    let schema = format.get("schema")?.clone();
+    Some(ResponseFormat::JsonSchema {
+        name: format
+            .get("name")
+            .and_then(|n| n.as_str())
+            .map(|s| s.to_string()),
+        strict: format.get("strict").and_then(|s| s.as_bool()),
+        schema,
+    })
+}
+
+/// Render a canonical [`ResponseFormat`] into Responses' native
+/// `{ type: "json_schema", name, strict, schema }` body that sits under
+/// `text.format`. OpenAI requires `name`; default it.
+fn render_responses_response_format(rf: &ResponseFormat) -> serde_json::Value {
+    let ResponseFormat::JsonSchema {
+        name,
+        strict,
+        schema,
+    } = rf;
+    let mut obj = serde_json::Map::new();
+    obj.insert("type".into(), "json_schema".into());
+    obj.insert(
+        "name".into(),
+        name.clone()
+            .unwrap_or_else(|| "response".to_string())
+            .into(),
+    );
+    if let Some(strict) = strict {
+        obj.insert("strict".into(), (*strict).into());
+    }
+    obj.insert("schema".into(), schema.clone());
+    serde_json::Value::Object(obj)
 }
 
 #[async_trait]

--- a/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
@@ -50,6 +50,7 @@ fn sample_prompt() -> Prompt {
             max_tokens: Some(256),
             ..Default::default()
         },
+        response_format: None,
         stream: false,
     }
 }
@@ -367,6 +368,395 @@ fn google_passes_through_uncommon_generation_config() {
             "Google generationConfig.{key} must survive parse/render"
         );
     }
+}
+
+// ===== structured outputs (response_format) =====
+
+/// A canonical prompt carrying a JSON-Schema response_format constraint.
+fn sample_prompt_with_schema() -> Prompt {
+    Prompt {
+        response_format: Some(ResponseFormat::JsonSchema {
+            name: Some("weather".to_string()),
+            strict: Some(true),
+            schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "location": {"type": "string"},
+                    "temperature": {"type": "number"}
+                },
+                "required": ["location", "temperature"],
+                "additionalProperties": false
+            }),
+        }),
+        ..sample_prompt()
+    }
+}
+
+#[test]
+fn openai_chat_inbound_promotes_json_schema_response_format() {
+    let adapter = adapter_for(ApiProtocol::Openai);
+    let body = serde_json::json!({
+        "model": "gpt-4o",
+        "messages": [{"role": "user", "content": "weather?"}],
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "weather",
+                "strict": true,
+                "schema": {"type": "object", "properties": {"x": {"type": "string"}}}
+            }
+        }
+    });
+    let prompt = adapter.parse_request(body).unwrap();
+    match prompt.response_format {
+        Some(ResponseFormat::JsonSchema {
+            name,
+            strict,
+            schema,
+        }) => {
+            assert_eq!(name.as_deref(), Some("weather"));
+            assert_eq!(strict, Some(true));
+            assert_eq!(schema["properties"]["x"]["type"], "string");
+        }
+        other => panic!("expected JsonSchema, got {other:?}"),
+    }
+    // Promoted out of extras to avoid double-rendering.
+    assert!(!prompt.params.extra.contains_key("response_format"));
+}
+
+#[test]
+fn openai_chat_inbound_leaves_json_object_in_extras() {
+    // The legacy `{type: "json_object"}` JSON mode has no schema to translate,
+    // so it must keep passing through opaquely.
+    let adapter = adapter_for(ApiProtocol::Openai);
+    let body = serde_json::json!({
+        "model": "gpt-4o",
+        "messages": [{"role": "user", "content": "hi"}],
+        "response_format": {"type": "json_object"}
+    });
+    let prompt = adapter.parse_request(body.clone()).unwrap();
+    assert!(prompt.response_format.is_none());
+    let rendered = adapter.render_request(&prompt).unwrap();
+    assert_eq!(rendered["response_format"], body["response_format"]);
+}
+
+#[test]
+fn openai_chat_outbound_renders_json_schema() {
+    let adapter = adapter_for(ApiProtocol::Openai);
+    let rendered = adapter
+        .render_request(&sample_prompt_with_schema())
+        .unwrap();
+    assert_eq!(rendered["response_format"]["type"], "json_schema");
+    assert_eq!(
+        rendered["response_format"]["json_schema"]["name"],
+        "weather"
+    );
+    assert_eq!(rendered["response_format"]["json_schema"]["strict"], true);
+    assert_eq!(
+        rendered["response_format"]["json_schema"]["schema"]["properties"]["location"]["type"],
+        "string"
+    );
+}
+
+#[test]
+fn openai_chat_outbound_supplies_default_name() {
+    // OpenAI Chat requires `name`; renderer fills it when absent (e.g. when
+    // the inbound was Anthropic/Google which carry no name).
+    let adapter = adapter_for(ApiProtocol::Openai);
+    let prompt = Prompt {
+        response_format: Some(ResponseFormat::JsonSchema {
+            name: None,
+            strict: None,
+            schema: serde_json::json!({"type": "object"}),
+        }),
+        ..sample_prompt()
+    };
+    let rendered = adapter.render_request(&prompt).unwrap();
+    assert_eq!(
+        rendered["response_format"]["json_schema"]["name"],
+        "response"
+    );
+    // strict is omitted (None) rather than serialised as null.
+    assert!(
+        rendered["response_format"]["json_schema"]
+            .get("strict")
+            .is_none()
+    );
+}
+
+#[test]
+fn anthropic_inbound_promotes_output_config_format() {
+    let adapter = adapter_for(ApiProtocol::Anthropic);
+    let body = serde_json::json!({
+        "model": "claude-opus-4-7",
+        "max_tokens": 1024,
+        "messages": [{"role": "user", "content": "weather?"}],
+        "output_config": {
+            "format": {
+                "type": "json_schema",
+                "schema": {"type": "object", "properties": {"x": {"type": "string"}}}
+            }
+        }
+    });
+    let prompt = adapter.parse_request(body).unwrap();
+    match prompt.response_format {
+        Some(ResponseFormat::JsonSchema { schema, .. }) => {
+            assert_eq!(schema["properties"]["x"]["type"], "string");
+        }
+        other => panic!("expected JsonSchema, got {other:?}"),
+    }
+    assert!(!prompt.params.extra.contains_key("output_config"));
+}
+
+#[test]
+fn anthropic_inbound_accepts_legacy_output_format_alias() {
+    // The deprecated flat `output_format` shape (pre-GA, still emitted by
+    // some clients — vercel/ai#12298) must still parse cleanly.
+    let adapter = adapter_for(ApiProtocol::Anthropic);
+    let body = serde_json::json!({
+        "model": "claude-opus-4-7",
+        "max_tokens": 1024,
+        "messages": [{"role": "user", "content": "weather?"}],
+        "output_format": {
+            "type": "json_schema",
+            "schema": {"type": "object"}
+        }
+    });
+    let prompt = adapter.parse_request(body).unwrap();
+    assert!(matches!(
+        prompt.response_format,
+        Some(ResponseFormat::JsonSchema { .. })
+    ));
+    assert!(!prompt.params.extra.contains_key("output_format"));
+}
+
+#[test]
+fn anthropic_inbound_legacy_alias_does_not_disturb_output_config_siblings() {
+    // If the legacy `output_format` alias is what matched, an unrelated
+    // `output_config` blob the client supplied must be left fully intact in
+    // extras so its siblings (`unknown_key` here) survive the round trip.
+    let adapter = adapter_for(ApiProtocol::Anthropic);
+    let body = serde_json::json!({
+        "model": "claude-opus-4-7",
+        "max_tokens": 1024,
+        "messages": [{"role": "user", "content": "weather?"}],
+        "output_config": {"unknown_key": "x"},
+        "output_format": {"type": "json_schema", "schema": {"type": "object"}}
+    });
+    let prompt = adapter.parse_request(body).unwrap();
+    assert!(matches!(
+        prompt.response_format,
+        Some(ResponseFormat::JsonSchema { .. })
+    ));
+    assert_eq!(prompt.params.extra["output_config"]["unknown_key"], "x");
+    assert!(!prompt.params.extra.contains_key("output_format"));
+}
+
+#[test]
+fn anthropic_outbound_renders_output_config_format() {
+    let adapter = adapter_for(ApiProtocol::Anthropic);
+    let rendered = adapter
+        .render_request(&sample_prompt_with_schema())
+        .unwrap();
+    assert_eq!(rendered["output_config"]["format"]["type"], "json_schema");
+    assert_eq!(
+        rendered["output_config"]["format"]["schema"]["properties"]["location"]["type"],
+        "string"
+    );
+    // Anthropic carries no `name` / `strict` — confirm they're dropped, not
+    // forwarded as unknown fields.
+    assert!(rendered["output_config"]["format"].get("name").is_none());
+    assert!(rendered["output_config"]["format"].get("strict").is_none());
+}
+
+#[test]
+fn google_inbound_promotes_response_schema() {
+    let adapter = adapter_for(ApiProtocol::Google);
+    let body = serde_json::json!({
+        "model": "gemini-2.5-pro",
+        "contents": [{"role": "user", "parts": [{"text": "weather?"}]}],
+        "generationConfig": {
+            "responseMimeType": "application/json",
+            "responseSchema": {"type": "object", "properties": {"x": {"type": "string"}}}
+        }
+    });
+    let prompt = adapter.parse_request(body).unwrap();
+    match prompt.response_format {
+        Some(ResponseFormat::JsonSchema { schema, .. }) => {
+            assert_eq!(schema["properties"]["x"]["type"], "string");
+        }
+        other => panic!("expected JsonSchema, got {other:?}"),
+    }
+    assert!(!prompt.params.extra.contains_key("responseSchema"));
+    assert!(!prompt.params.extra.contains_key("responseMimeType"));
+}
+
+#[test]
+fn google_inbound_leaves_enum_mime_in_extras() {
+    // `text/x.enum` has no JSON schema; must stay in extras for opaque
+    // Google-native pass-through.
+    let adapter = adapter_for(ApiProtocol::Google);
+    let body = serde_json::json!({
+        "model": "gemini-2.5-pro",
+        "contents": [{"role": "user", "parts": [{"text": "x"}]}],
+        "generationConfig": {
+            "responseMimeType": "text/x.enum"
+        }
+    });
+    let prompt = adapter.parse_request(body.clone()).unwrap();
+    assert!(prompt.response_format.is_none());
+    let rendered = adapter.render_request(&prompt).unwrap();
+    assert_eq!(
+        rendered["generationConfig"]["responseMimeType"],
+        "text/x.enum"
+    );
+}
+
+#[test]
+fn google_outbound_renders_response_schema() {
+    let adapter = adapter_for(ApiProtocol::Google);
+    let rendered = adapter
+        .render_request(&sample_prompt_with_schema())
+        .unwrap();
+    let gc = &rendered["generationConfig"];
+    assert_eq!(gc["responseMimeType"], "application/json");
+    assert_eq!(
+        gc["responseSchema"]["properties"]["location"]["type"],
+        "string"
+    );
+}
+
+#[test]
+fn responses_inbound_promotes_text_format() {
+    let adapter = adapter_for(ApiProtocol::Responses);
+    let body = serde_json::json!({
+        "model": "gpt-4o",
+        "input": "weather?",
+        "text": {
+            "format": {
+                "type": "json_schema",
+                "name": "weather",
+                "strict": true,
+                "schema": {"type": "object"}
+            },
+            "verbosity": "low"
+        }
+    });
+    let prompt = adapter.parse_request(body).unwrap();
+    assert!(matches!(
+        prompt.response_format,
+        Some(ResponseFormat::JsonSchema { .. })
+    ));
+    // Sibling keys under `text` survive opaquely (the `format` child was
+    // promoted, the rest of `text` stays in extras).
+    assert_eq!(prompt.params.extra["text"]["verbosity"], "low");
+    assert!(prompt.params.extra["text"].get("format").is_none());
+}
+
+#[test]
+fn responses_outbound_renders_text_format() {
+    let adapter = adapter_for(ApiProtocol::Responses);
+    let rendered = adapter
+        .render_request(&sample_prompt_with_schema())
+        .unwrap();
+    assert_eq!(rendered["text"]["format"]["type"], "json_schema");
+    assert_eq!(rendered["text"]["format"]["name"], "weather");
+    assert_eq!(rendered["text"]["format"]["strict"], true);
+}
+
+#[test]
+fn responses_outbound_merges_text_siblings() {
+    // When an inbound supplied a `text` object with `verbosity` (or any
+    // other future sibling), the outbound render must preserve it alongside
+    // the synthesised `format`.
+    let adapter = adapter_for(ApiProtocol::Responses);
+    let mut prompt = sample_prompt_with_schema();
+    prompt
+        .params
+        .extra
+        .insert("text".into(), serde_json::json!({ "verbosity": "low" }));
+    let rendered = adapter.render_request(&prompt).unwrap();
+    assert_eq!(rendered["text"]["verbosity"], "low");
+    assert_eq!(rendered["text"]["format"]["type"], "json_schema");
+}
+
+#[test]
+fn response_format_survives_cross_protocol_routing() {
+    // Set the canonical field once and assert every outbound adapter emits
+    // the right native shape — this is the cross-protocol guarantee.
+    let prompt = sample_prompt_with_schema();
+    let schema = match prompt.response_format.as_ref().unwrap() {
+        ResponseFormat::JsonSchema { schema, .. } => schema.clone(),
+    };
+
+    // OpenAI Chat
+    let chat = adapter_for(ApiProtocol::Openai)
+        .render_request(&prompt)
+        .unwrap();
+    assert_eq!(chat["response_format"]["json_schema"]["schema"], schema);
+
+    // Anthropic
+    let ant = adapter_for(ApiProtocol::Anthropic)
+        .render_request(&prompt)
+        .unwrap();
+    assert_eq!(ant["output_config"]["format"]["schema"], schema);
+
+    // Google
+    let g = adapter_for(ApiProtocol::Google)
+        .render_request(&prompt)
+        .unwrap();
+    assert_eq!(g["generationConfig"]["responseSchema"], schema);
+    assert_eq!(
+        g["generationConfig"]["responseMimeType"],
+        "application/json"
+    );
+
+    // OpenAI Responses
+    let r = adapter_for(ApiProtocol::Responses)
+        .render_request(&prompt)
+        .unwrap();
+    assert_eq!(r["text"]["format"]["schema"], schema);
+}
+
+#[test]
+fn builtin_adapters_advertise_response_format_support() {
+    for proto in all_protocols() {
+        let a = adapter_for(proto.clone());
+        assert!(
+            a.supports_response_format(),
+            "{proto:?} should advertise response_format support"
+        );
+    }
+}
+
+#[test]
+fn anthropic_no_beta_header_is_emitted() {
+    // The deprecated `anthropic-beta: structured-outputs-2025-11-13` header
+    // is no longer required by the Anthropic GA endpoint and is actively
+    // rejected by Vertex AI (vercel/ai#10981). The Anthropic transport must
+    // not introduce it as a side effect of structured outputs.
+    use crate::language_model::protocol::Transport;
+    use crate::language_model::types::RoutingTarget;
+    let transport = crate::language_model::protocol::anthropic::AnthropicTransport;
+    let client = reqwest::Client::new();
+    let req = client
+        .post("http://example.invalid/v1/messages")
+        .build()
+        .unwrap();
+    let target = RoutingTarget {
+        provider_name: "anthropic".into(),
+        service_id: "claude-opus-4-7".into(),
+        api_base: "http://example.invalid".into(),
+        api_key: "k".into(),
+        api_protocol: ApiProtocol::Anthropic,
+        api_key_override: None,
+        api_base_override: None,
+    };
+    let req = futures::executor::block_on(transport.authorise(req, &target)).unwrap();
+    assert!(
+        req.headers().get("anthropic-beta").is_none(),
+        "anthropic-beta header must not be set by the transport (deprecated and Vertex-incompatible)"
+    );
 }
 
 #[test]

--- a/crates/bitrouter-sdk/src/language_model/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/tests.rs
@@ -40,6 +40,7 @@ fn request() -> PipelineRequest {
         messages: vec![Message::text(Role::User, "hi")],
         tools: Vec::new(),
         params: GenerationParams::default(),
+        response_format: None,
         stream: false,
     };
     PipelineRequest::new("test-model", CallerContext::new("k1", "u1"), prompt)
@@ -745,4 +746,89 @@ async fn counting_pre_hook_runs_once() {
     );
     pipeline.execute(request()).await.expect("ok");
     assert_eq!(calls.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn executor_rejects_response_format_on_unsupported_outbound() {
+    // A custom outbound adapter that doesn't override `supports_response_format`
+    // (so it defaults to `false`) must cause the executor to return a 400
+    // rather than silently dropping the structured-output schema upstream.
+    use crate::language_model::executor::HttpExecutor;
+    use crate::language_model::protocol::{
+        OutboundAdapter, OutboundDispatch, StreamDecoder, Transport,
+    };
+    use crate::language_model::types::ResponseFormat;
+
+    struct FakeAdapter;
+    impl OutboundAdapter for FakeAdapter {
+        fn protocol(&self) -> ApiProtocol {
+            ApiProtocol::Custom("fake".into())
+        }
+        fn render_request(&self, _: &Prompt) -> Result<serde_json::Value> {
+            unreachable!("gate must fire before render_request")
+        }
+        fn parse_response(&self, _: serde_json::Value) -> Result<GenerateResult> {
+            unreachable!()
+        }
+        fn stream_decoder(&self) -> Box<dyn StreamDecoder> {
+            unreachable!()
+        }
+        // intentionally leaves `supports_response_format` at the default `false`
+    }
+
+    struct FakeTransport;
+    #[async_trait]
+    impl Transport for FakeTransport {
+        fn protocol(&self) -> ApiProtocol {
+            ApiProtocol::Custom("fake".into())
+        }
+        fn endpoint_url(&self, _: &RoutingTarget, _: bool) -> String {
+            "http://example.invalid".into()
+        }
+        async fn authorise(
+            &self,
+            r: reqwest::Request,
+            _: &RoutingTarget,
+        ) -> Result<reqwest::Request> {
+            Ok(r)
+        }
+    }
+
+    let mut dispatch = OutboundDispatch::empty();
+    dispatch.register(Arc::new(FakeAdapter), Arc::new(FakeTransport));
+    let executor =
+        HttpExecutor::with_dispatch(Default::default(), dispatch).expect("build executor");
+
+    let target = RoutingTarget {
+        provider_name: "fake".into(),
+        service_id: "m".into(),
+        api_base: "http://example.invalid".into(),
+        api_key: "k".into(),
+        api_protocol: ApiProtocol::Custom("fake".into()),
+        api_key_override: None,
+        api_base_override: None,
+    };
+    let prompt = Prompt {
+        model: "m".into(),
+        system: None,
+        messages: vec![Message::text(Role::User, "hi")],
+        tools: vec![],
+        params: GenerationParams::default(),
+        response_format: Some(ResponseFormat::JsonSchema {
+            name: None,
+            strict: None,
+            schema: serde_json::json!({"type": "object"}),
+        }),
+        stream: false,
+    };
+    let err = executor.execute(&target, &prompt).await.unwrap_err();
+    match err {
+        BitrouterError::BadRequest { message } => {
+            assert!(
+                message.contains("response_format"),
+                "error must mention response_format, got: {message}"
+            );
+        }
+        other => panic!("expected BadRequest, got {other:?}"),
+    }
 }

--- a/crates/bitrouter-sdk/src/language_model/types.rs
+++ b/crates/bitrouter-sdk/src/language_model/types.rs
@@ -161,6 +161,35 @@ pub struct Tool {
     pub parameters: serde_json::Value,
 }
 
+/// Constraint on the shape of the model's response.
+///
+/// Today the only variant is [`Self::JsonSchema`]; future variants (`json_object`,
+/// `text`, `regex`) can be added without breaking existing call sites.
+///
+/// Each inbound adapter promotes the provider-native field into this typed
+/// slot at `parse_request` time (e.g. OpenAI Chat's `response_format`,
+/// Anthropic's `output_config.format`, Google's `generationConfig.responseSchema`).
+/// Each outbound adapter renders it back into the upstream's native shape on
+/// `render_request`. Cross-protocol routing therefore works automatically:
+/// an OpenAI-Chat client asking for `json_schema` against an Anthropic upstream
+/// emits `output_config.format`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ResponseFormat {
+    /// Constrain output to a JSON Schema.
+    JsonSchema {
+        /// Schema name. Required by OpenAI Chat / Responses; ignored by
+        /// Anthropic and Google.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        name: Option<String>,
+        /// Strict-mode flag. OpenAI-only; Anthropic and Google are always strict.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        strict: Option<bool>,
+        /// The JSON Schema.
+        schema: serde_json::Value,
+    },
+}
+
 /// Sampling / generation parameters, carried verbatim where possible.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct GenerationParams {
@@ -199,6 +228,11 @@ pub struct Prompt {
     /// Generation parameters.
     #[serde(default)]
     pub params: GenerationParams,
+    /// Constraint on the model's response shape (e.g. a JSON Schema). Inbound
+    /// adapters promote the provider-native field into this slot; outbound
+    /// adapters render it back natively.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub response_format: Option<ResponseFormat>,
     /// Whether the caller requested a streaming response.
     pub stream: bool,
 }

--- a/plugins/bitrouter-guardrails/src/tests.rs
+++ b/plugins/bitrouter-guardrails/src/tests.rs
@@ -27,6 +27,7 @@ fn prompt(text: &str, stream: bool) -> Prompt {
         messages: vec![Message::text(Role::User, text)],
         tools: Vec::new(),
         params: GenerationParams::default(),
+        response_format: None,
         stream,
     }
 }

--- a/plugins/bitrouter-observe/src/prometheus.rs
+++ b/plugins/bitrouter-observe/src/prometheus.rs
@@ -128,6 +128,7 @@ mod tests {
             messages: vec![Message::text(Role::User, "hi")],
             tools: Vec::new(),
             params: GenerationParams::default(),
+            response_format: None,
             stream: false,
         };
         PipelineContext::new(PipelineRequest::new(


### PR DESCRIPTION
## Summary

Adds a canonical `Prompt::response_format: Option<ResponseFormat::JsonSchema { name, strict, schema }>` slot modeled on [OpenRouter's structured outputs API](https://openrouter.ai/docs/guides/features/structured-outputs). Each protocol adapter promotes its provider-native field into this slot on inbound parse and emits the native shape on outbound render, so cross-protocol routing (e.g. OpenAI-Chat client → Anthropic upstream) translates automatically.

### Per-protocol wire shapes

| Protocol | Inbound parses | Outbound emits |
|---|---|---|
| OpenAI Chat | `response_format: { type:"json_schema", json_schema:{name, strict, schema} }` | same |
| OpenAI Responses | `text.format: { type:"json_schema", name, strict, schema }` | same; sibling keys under `text` (e.g. `verbosity`) preserved |
| Anthropic | `output_config.format: { type:"json_schema", schema }` + legacy `output_format` alias | `output_config.format` only |
| Google Gemini | `generationConfig.{responseMimeType, responseSchema}` | same |

`name` / `strict` are dropped on outbound to Anthropic and Google because their native APIs don't carry them. OpenAI Chat / Responses require a `name`, so a stable `"response"` default is supplied when the caller did not set one.

### Capability gate

New `OutboundAdapter::supports_response_format() -> bool` (default `false`) gated in `HttpExecutor::{execute, execute_stream}`. Out-of-tree `ApiProtocol::Custom` adapters that haven't implemented translation now return a clear 400 instead of silently dropping the schema. All four built-in adapters override to `true`.

### Deliberately not done

- **No `anthropic-beta: structured-outputs-2025-11-13` header.** Deprecated on the GA endpoint and [actively rejected by Vertex AI](https://github.com/vercel/ai/issues/10981) — sending it defensively would break Vertex routing.
- **No synthetic-tool hack for Anthropic.** Anthropic's native API (launched Nov 2025) eliminated the need.
- **No new `StreamPart` variant.** Partial JSON streams via existing `TextDelta` on every provider.
- **No `ModelMetadata.structured_output` capability gate.** Trust the routing config; let the upstream error if the routed model is too old.
- **No response-healing / JSON repair.** Bitrouter is a proxy, not a validator.

### Footprint

15 files, +833/−20 lines. 18 new tests (168 total in `bitrouter-sdk`, all green). Clippy + fmt clean.

## Test plan

- [x] `cargo test --all-features --workspace` — all passing (168 in `bitrouter-sdk`, 103 in `bitrouter`, 44 in `bitrouter-providers`, full workspace green)
- [x] `cargo clippy --all-features --all-targets` — clean
- [x] `cargo fmt -- --check` — clean
- [x] Existing 4×4 conversion matrix test still passes
- [x] Existing `response_format: { type: "json_object" }` pass-through test still passes (legacy JSON mode untouched)
- [x] Schemars wire-type snapshot tests unchanged (`response_format` lives on `Prompt`, not on wire types)
- [x] New tests cover: per-protocol parse + render, cross-protocol matrix, custom-adapter rejection, Anthropic legacy alias, Anthropic transport beta-header absence

## Notes for reviewers

- The Anthropic legacy `output_format` alias is kept as a graceful inbound-only mitigation for clients affected by [vercel/ai#12298](https://github.com/vercel/ai/issues/12298) (some `@ai-sdk/anthropic` releases still emit the deprecated flat shape).
- An asymmetry in the OpenAI Responses adapter: `text.format` is promoted into the typed slot, but sibling keys under `text` (e.g. `verbosity`) remain in extras and are re-merged into `text` at render time. Test `responses_outbound_merges_text_siblings` locks this in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)