### PR TITLE
feat(routing): multiple accounts per provider — failover + load-balance

### DIFF
--- a/apps/bitrouter/src/commands.rs
+++ b/apps/bitrouter/src/commands.rs
@@ -52,6 +52,11 @@ providers:
   openrouter: {}    # uses OPENROUTER_API_KEY
   # github-copilot needs `bitrouter login github-copilot` first:
   # github-copilot: {}
+  # A provider can hold multiple accounts — e.g. two subscriptions to
+  # the same upstream. `account_strategy` is `failover` (try the first,
+  # drop to the next on a retryable / out-of-credits error — default)
+  # or `balance` (spread load evenly across accounts):
+  # opencode-go: { account_strategy: failover, accounts: [{ api_key: "${OPENCODE_GO_KEY_A}", label: primary }, { api_key: "${OPENCODE_GO_KEY_B}", label: backup }] }
 
 # Upstream MCP (Model Context Protocol) servers — `bitrouter tools
 # list/status` reads this, and `POST /mcp/<name>` proxies JSON-RPC

--- a/apps/bitrouter/src/metering/tests.rs
+++ b/apps/bitrouter/src/metering/tests.rs
@@ -22,6 +22,7 @@ fn ctx(api_key: &str, prompt: u64, completion: u64) -> SettlementContext {
         target: None,
         model_id: "gpt-5".into(),
         provider_id: "openai".into(),
+        account_label: None,
         prompt_tokens: prompt,
         completion_tokens: completion,
         reasoning_tokens: 0,

--- a/crates/bitrouter-bedrock/src/lib.rs
+++ b/crates/bitrouter-bedrock/src/lib.rs
@@ -182,6 +182,7 @@ impl Executor for BedrockExecutor {
         Ok(ExecutionResult {
             provider_id: target.provider_name.clone(),
             model_id: target.service_id.clone(),
+            account_label: target.account_label.clone(),
             result: GenerateResult {
                 content,
                 usage,

--- a/crates/bitrouter-providers/src/apply.rs
+++ b/crates/bitrouter-providers/src/apply.rs
@@ -103,6 +103,13 @@ pub fn apply_builtin_defaults(config: &mut Config) {
         if provider.api_protocol.is_empty() {
             provider.api_protocol = protocol_mapping_to_pattern_map(&builtin.api_protocol);
         }
+        // A multi-account provider carries its credentials in `accounts`,
+        // not the top-level `api_key`. Skip both the env-var fill and the
+        // inactive guard for it — it is explicitly account-managed and
+        // already credentialed.
+        if !provider.accounts.is_empty() {
+            continue;
+        }
         if provider.api_key.is_empty()
             && let Some(env_var) = builtin.auth.env_var()
             && let Some(value) = bitrouter_sdk::config::env_lookup(env_var)

--- a/crates/bitrouter-providers/src/copilot/mod.rs
+++ b/crates/bitrouter-providers/src/copilot/mod.rs
@@ -214,6 +214,7 @@ mod tests {
             api_base: "https://api.githubcopilot.com".to_string(),
             api_key: String::new(),
             api_protocol: ApiProtocol::Anthropic,
+            account_label: None,
             api_key_override: None,
             api_base_override: None,
         }

--- a/crates/bitrouter-sdk/src/config/mod.rs
+++ b/crates/bitrouter-sdk/src/config/mod.rs
@@ -185,6 +185,67 @@ pub struct ProviderConfig {
     /// fields; explicit fields here win. Resolved by
     /// [`resolve_derivations`] after the config is parsed.
     pub derives: Option<String>,
+    /// Multiple credentials for this one provider — e.g. two
+    /// subscriptions to the same upstream. When non-empty, the routing
+    /// table expands the provider into one [`RoutingTarget`] per
+    /// account; [`account_strategy`](Self::account_strategy) decides
+    /// their order. Empty = a single-credential provider keyed off the
+    /// top-level [`api_key`](Self::api_key) (the common case).
+    pub accounts: Vec<ProviderAccount>,
+    /// How the per-account targets are ordered when `accounts` is set.
+    pub account_strategy: AccountStrategy,
+}
+
+/// One credential within a multi-account provider. An account varies
+/// only the credential (and optionally the base URL) — the protocol,
+/// model catalog, and rate limits are the provider's.
+#[derive(Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct ProviderAccount {
+    /// This account's API key (often a `${VAR}` reference).
+    pub api_key: String,
+    /// Optional per-account `api_base` override. Empty inherits the
+    /// provider's `api_base` — set it only for multi-region / multi-org
+    /// deployments where each account lives on a different host.
+    pub api_base: String,
+    /// Optional human label, surfaced in the request log so an operator
+    /// can see which account served a request. Defaults to
+    /// `account-<n>` (1-based) when empty.
+    pub label: String,
+}
+
+impl std::fmt::Debug for ProviderAccount {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Redact the key for the same reason `ProviderConfig` does.
+        f.debug_struct("ProviderAccount")
+            .field(
+                "api_key",
+                &if self.api_key.is_empty() {
+                    "<empty>"
+                } else {
+                    "<redacted>"
+                },
+            )
+            .field("api_base", &self.api_base)
+            .field("label", &self.label)
+            .finish()
+    }
+}
+
+/// How a multi-account provider's per-account targets are ordered.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AccountStrategy {
+    /// Accounts in declared order — the first is primary; routing drops
+    /// to the next on a retryable failure (5xx / 429 / timeout) or a
+    /// payment / credit-exhaustion error. The default.
+    #[default]
+    Failover,
+    /// Accounts ordered with a process-random rotation so the primary
+    /// (and therefore the load) spreads evenly across accounts. The
+    /// remaining accounts still act as failover targets for that
+    /// request.
+    Balance,
 }
 
 impl std::fmt::Debug for ProviderConfig {
@@ -206,6 +267,8 @@ impl std::fmt::Debug for ProviderConfig {
             .field("active", &self.active)
             .field("tags", &self.tags)
             .field("derives", &self.derives)
+            .field("accounts", &self.accounts)
+            .field("account_strategy", &self.account_strategy)
             .finish()
     }
 }
@@ -222,7 +285,27 @@ impl Default for ProviderConfig {
             active: true,
             tags: Vec::new(),
             derives: None,
+            accounts: Vec::new(),
+            account_strategy: AccountStrategy::default(),
         }
+    }
+}
+
+impl ProviderConfig {
+    /// The API key for provider-level operations that aren't tied to a
+    /// specific routed request — currently model discovery's `/models`
+    /// probe. Returns the top-level [`api_key`](Self::api_key), or the
+    /// first account's key when the provider is account-based and has
+    /// no top-level key.
+    pub fn primary_api_key(&self) -> &str {
+        if !self.api_key.is_empty() {
+            return &self.api_key;
+        }
+        self.accounts
+            .iter()
+            .map(|a| a.api_key.as_str())
+            .find(|k| !k.is_empty())
+            .unwrap_or("")
     }
 }
 
@@ -570,7 +653,7 @@ pub async fn discover_models(config: &mut Config) {
         let result = async {
             let resp = client
                 .get(&url)
-                .bearer_auth(&provider.api_key)
+                .bearer_auth(provider.primary_api_key())
                 .send()
                 .await
                 .ok()?;

--- a/crates/bitrouter-sdk/src/config/mod.rs
+++ b/crates/bitrouter-sdk/src/config/mod.rs
@@ -187,9 +187,9 @@ pub struct ProviderConfig {
     pub derives: Option<String>,
     /// Multiple credentials for this one provider — e.g. two
     /// subscriptions to the same upstream. When non-empty, the routing
-    /// table expands the provider into one [`RoutingTarget`] per
-    /// account; [`account_strategy`](Self::account_strategy) decides
-    /// their order. Empty = a single-credential provider keyed off the
+    /// table expands the provider into one routing target per account;
+    /// [`account_strategy`](Self::account_strategy) decides their
+    /// order. Empty = a single-credential provider keyed off the
     /// top-level [`api_key`](Self::api_key) (the common case).
     pub accounts: Vec<ProviderAccount>,
     /// How the per-account targets are ordered when `accounts` is set.

--- a/crates/bitrouter-sdk/src/config/routing_table.rs
+++ b/crates/bitrouter-sdk/src/config/routing_table.rs
@@ -86,20 +86,93 @@ impl ConfigRoutingTable {
     }
 }
 
-fn build_target(
+/// Build the routing target(s) for one `(provider, model)` pair.
+///
+/// A single-credential provider yields exactly one target. A
+/// multi-account provider (`accounts:` set) yields one target per
+/// account: `failover` keeps the declared order, `balance` applies a
+/// round-robin rotation so the primary advances by one each request
+/// and the load splits evenly. Either way the remaining accounts sit
+/// later in the chain that `execute_with_fallback` walks, so they act
+/// as failover targets for that request.
+fn build_targets(
     provider_id: &str,
     provider: &crate::config::ProviderConfig,
     model_id: &str,
-) -> RoutingTarget {
-    RoutingTarget {
-        provider_name: provider_id.to_string(),
-        service_id: model_id.to_string(),
-        api_base: provider.api_base.clone(),
-        api_key: provider.api_key.clone(),
-        api_protocol: provider.protocol_for(model_id),
-        api_key_override: None,
-        api_base_override: None,
+) -> Vec<RoutingTarget> {
+    let protocol = provider.protocol_for(model_id);
+    if provider.accounts.is_empty() {
+        return vec![RoutingTarget {
+            provider_name: provider_id.to_string(),
+            service_id: model_id.to_string(),
+            api_base: provider.api_base.clone(),
+            api_key: provider.api_key.clone(),
+            api_protocol: protocol,
+            account_label: None,
+            api_key_override: None,
+            api_base_override: None,
+        }];
     }
+
+    let n = provider.accounts.len();
+    let offset = match provider.account_strategy {
+        crate::config::AccountStrategy::Failover => 0,
+        crate::config::AccountStrategy::Balance => balance_offset(provider_id, n),
+    };
+    (0..n)
+        .map(|i| {
+            let idx = (i + offset) % n;
+            let account = &provider.accounts[idx];
+            let label = if account.label.is_empty() {
+                format!("account-{}", idx + 1)
+            } else {
+                account.label.clone()
+            };
+            let api_base = if account.api_base.is_empty() {
+                provider.api_base.clone()
+            } else {
+                account.api_base.clone()
+            };
+            RoutingTarget {
+                provider_name: provider_id.to_string(),
+                service_id: model_id.to_string(),
+                api_base,
+                api_key: account.api_key.clone(),
+                api_protocol: protocol.clone(),
+                account_label: Some(label),
+                api_key_override: None,
+                api_base_override: None,
+            }
+        })
+        .collect()
+}
+
+/// The rotation offset in `0..n` for a `balance` provider's next
+/// request — a round-robin counter, so the primary account advances by
+/// one each call and the load splits *exactly* evenly.
+///
+/// The counter is keyed per provider id (a `balance` provider with 2
+/// accounts and one with 3 must each cycle over their own `n`, not a
+/// shared sequence) and lives in a process-global map. A wall-clock
+/// seed was tried first but fails on platforms whose `SystemTime` has
+/// only microsecond granularity — `subsec_nanos() % 2` is then always
+/// `0`. The brief `Mutex` (one `HashMap` lookup + increment) is the
+/// one bit of state in this otherwise-pure resolution path.
+fn balance_offset(provider_id: &str, n: usize) -> usize {
+    use std::collections::HashMap;
+    use std::sync::{Mutex, OnceLock};
+    static COUNTERS: OnceLock<Mutex<HashMap<String, usize>>> = OnceLock::new();
+    if n <= 1 {
+        return 0;
+    }
+    let mut counters = COUNTERS
+        .get_or_init(|| Mutex::new(HashMap::new()))
+        .lock()
+        .expect("balance counter lock poisoned");
+    let counter = counters.entry(provider_id.to_string()).or_insert(0);
+    let offset = *counter % n;
+    *counter = counter.wrapping_add(1);
+    offset
 }
 
 /// Whether a provider carries every tag in `require_tags`.
@@ -126,7 +199,7 @@ pub fn resolve_route_chain(
         && let Some(provider) = config.providers.get(provider_id)
         && provider.active
     {
-        return Ok(vec![build_target(provider_id, provider, model_id)]);
+        return Ok(build_targets(provider_id, provider, model_id));
     }
 
     // ---- Strategy 2: explicit virtual model ----
@@ -136,7 +209,7 @@ pub fn resolve_route_chain(
             if let Some(provider) = config.providers.get(&endpoint.provider)
                 && provider.active
             {
-                chain.push(build_target(
+                chain.extend(build_targets(
                     &endpoint.provider,
                     provider,
                     &endpoint.service_id,
@@ -152,7 +225,9 @@ pub fn resolve_route_chain(
     }
 
     // ---- Strategy 3: auto-cascade across every provider declaring it ----
-    let mut chain: Vec<(String, RoutingTarget)> = Vec::new();
+    // Collect per-provider so the cascade sort is by provider id; each
+    // provider then contributes one-or-more (account-expanded) targets.
+    let mut chain: Vec<(String, Vec<RoutingTarget>)> = Vec::new();
     for (provider_id, provider) in &config.providers {
         if !provider.active {
             continue;
@@ -169,7 +244,7 @@ pub fn resolve_route_chain(
         if provider.models.iter().any(|m| m.id == clean) {
             chain.push((
                 provider_id.clone(),
-                build_target(provider_id, provider, &clean),
+                build_targets(provider_id, provider, &clean),
             ));
         }
     }
@@ -182,13 +257,14 @@ pub fn resolve_route_chain(
     }
 
     // Order the cascade. `Latency` / `Cost` have no metrics source yet, so
-    // they fall back to the alphabetical initial sort.
+    // they fall back to the alphabetical initial sort. Account-expanded
+    // targets within one provider keep their build order.
     match prefs.sort {
         SortOrder::Alphabetical | SortOrder::Latency | SortOrder::Cost => {
             chain.sort_by(|a, b| a.0.cmp(&b.0));
         }
     }
-    Ok(chain.into_iter().map(|(_, t)| t).collect())
+    Ok(chain.into_iter().flat_map(|(_, t)| t).collect())
 }
 
 /// List models for a config (the §5.7 aggregation logic, shared by both tables).
@@ -486,5 +562,190 @@ presets:
             .unwrap();
         assert_eq!(chain.len(), 1);
         assert_eq!(chain[0].provider_name, "paid");
+    }
+
+    // ===== multi-account provider =====
+
+    const TWO_ACCOUNTS: &str = r#"
+providers:
+  opencode-go:
+    api_base: https://opencode.ai/zen/go/v1
+    models: [{ id: glm-5.1 }]
+    accounts:
+      - { api_key: key-a, label: sub-a }
+      - { api_key: key-b, label: sub-b }
+"#;
+
+    #[tokio::test]
+    async fn multi_account_expands_into_one_target_per_account() {
+        // A provider:model route to a 2-account provider yields a
+        // 2-target chain — execute_with_fallback walks it as failover.
+        let t = table(TWO_ACCOUNTS);
+        let chain = t
+            .route_chain(
+                "opencode-go:glm-5.1",
+                &RoutingPrefs::default(),
+                &CallerContext::local(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(chain.len(), 2, "one target per account");
+        // failover (the default) keeps declared order.
+        assert_eq!(chain[0].api_key, "key-a");
+        assert_eq!(chain[0].account_label.as_deref(), Some("sub-a"));
+        assert_eq!(chain[1].api_key, "key-b");
+        assert_eq!(chain[1].account_label.as_deref(), Some("sub-b"));
+        // every target keeps the provider identity + service id.
+        for hop in &chain {
+            assert_eq!(hop.provider_name, "opencode-go");
+            assert_eq!(hop.service_id, "glm-5.1");
+            assert_eq!(hop.api_base, "https://opencode.ai/zen/go/v1");
+        }
+    }
+
+    #[tokio::test]
+    async fn single_credential_provider_still_yields_one_target() {
+        // Regression: a provider with no `accounts:` is unchanged — one
+        // target, `account_label` is None.
+        let t = table(PROVIDERS);
+        let chain = t
+            .route_chain(
+                "openai:gpt-5",
+                &RoutingPrefs::default(),
+                &CallerContext::local(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(chain.len(), 1);
+        assert_eq!(chain[0].api_key, "k-openai");
+        assert!(chain[0].account_label.is_none());
+    }
+
+    #[tokio::test]
+    async fn balance_strategy_keeps_every_account_in_the_chain() {
+        // `balance` rotates the primary; the chain still contains all
+        // accounts (the rest are that request's failover targets).
+        let yaml = r#"
+providers:
+  opencode-go:
+    api_base: https://opencode.ai/zen/go/v1
+    models: [{ id: glm-5.1 }]
+    account_strategy: balance
+    accounts:
+      - { api_key: key-a }
+      - { api_key: key-b }
+"#;
+        let t = table(yaml);
+        let chain = t
+            .route_chain(
+                "opencode-go:glm-5.1",
+                &RoutingPrefs::default(),
+                &CallerContext::local(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(chain.len(), 2);
+        let keys: std::collections::HashSet<&str> =
+            chain.iter().map(|t| t.api_key.as_str()).collect();
+        assert_eq!(
+            keys,
+            ["key-a", "key-b"].into_iter().collect(),
+            "both accounts present regardless of rotation"
+        );
+        // unlabelled accounts get a positional `account-<n>` label.
+        for hop in &chain {
+            assert!(
+                hop.account_label
+                    .as_deref()
+                    .is_some_and(|l| l.starts_with("account-")),
+                "default label: {:?}",
+                hop.account_label
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn balance_strategy_rotates_the_primary_round_robin() {
+        // The whole point of `balance` — consecutive requests must not
+        // all land on the same primary account. Use a provider id
+        // unique to this test so the round-robin counter starts clean.
+        let yaml = r#"
+providers:
+  bal-rr-provider:
+    api_base: https://example.invalid/v1
+    models: [{ id: m }]
+    account_strategy: balance
+    accounts:
+      - { api_key: key-a, label: a }
+      - { api_key: key-b, label: b }
+"#;
+        let t = table(yaml);
+        let mut primaries = Vec::new();
+        for _ in 0..4 {
+            let chain = t
+                .route_chain(
+                    "bal-rr-provider:m",
+                    &RoutingPrefs::default(),
+                    &CallerContext::local(),
+                )
+                .await
+                .unwrap();
+            primaries.push(chain[0].account_label.clone().unwrap());
+        }
+        // Round-robin over 2 accounts → strict a, b, a, b.
+        assert_eq!(primaries, vec!["a", "b", "a", "b"], "round-robin rotation");
+    }
+
+    #[tokio::test]
+    async fn account_api_base_override_wins_over_provider_base() {
+        // A per-account `api_base` covers multi-region / multi-org
+        // setups; an empty one inherits the provider base.
+        let yaml = r#"
+providers:
+  acme:
+    api_base: https://default.example/v1
+    models: [{ id: m1 }]
+    accounts:
+      - { api_key: key-a, api_base: "https://us.example/v1" }
+      - { api_key: key-b }
+"#;
+        let t = table(yaml);
+        let chain = t
+            .route_chain("acme:m1", &RoutingPrefs::default(), &CallerContext::local())
+            .await
+            .unwrap();
+        assert_eq!(chain[0].api_base, "https://us.example/v1");
+        assert_eq!(chain[1].api_base, "https://default.example/v1");
+    }
+
+    #[tokio::test]
+    async fn auto_cascade_expands_accounts_in_place() {
+        // `shared` is declared by a single-credential provider and a
+        // 2-account provider — the cascade is provider-ordered, and the
+        // multi-account provider contributes both of its accounts.
+        let yaml = r#"
+providers:
+  alpha:
+    api_base: https://alpha.example/v1
+    api_key: k-alpha
+    models: [{ id: shared }]
+  zeta:
+    api_base: https://zeta.example/v1
+    models: [{ id: shared }]
+    accounts:
+      - { api_key: z1 }
+      - { api_key: z2 }
+"#;
+        let t = table(yaml);
+        let chain = t
+            .route_chain("shared", &RoutingPrefs::default(), &CallerContext::local())
+            .await
+            .unwrap();
+        assert_eq!(chain.len(), 3, "alpha + zeta×2");
+        assert_eq!(chain[0].provider_name, "alpha");
+        assert_eq!(chain[1].provider_name, "zeta");
+        assert_eq!(chain[2].provider_name, "zeta");
+        assert_eq!(chain[1].api_key, "z1");
+        assert_eq!(chain[2].api_key, "z2");
     }
 }

--- a/crates/bitrouter-sdk/src/config/tests.rs
+++ b/crates/bitrouter-sdk/src/config/tests.rs
@@ -218,3 +218,61 @@ variants:
     assert_eq!(careful.routing.require_tags, vec!["paid"]);
     assert!(cfg.variants.contains_key("free"));
 }
+
+#[test]
+fn parses_multi_account_provider() {
+    let yaml = r#"
+providers:
+  opencode-go:
+    api_base: https://opencode.ai/zen/go/v1
+    account_strategy: balance
+    accounts:
+      - { api_key: key-a, label: sub-a }
+      - { api_key: key-b }
+"#;
+    let cfg = parse(yaml).unwrap();
+    let p = &cfg.providers["opencode-go"];
+    assert_eq!(p.accounts.len(), 2);
+    assert_eq!(p.account_strategy, AccountStrategy::Balance);
+    assert_eq!(p.accounts[0].api_key, "key-a");
+    assert_eq!(p.accounts[0].label, "sub-a");
+    assert!(p.accounts[1].label.is_empty());
+}
+
+#[test]
+fn account_strategy_defaults_to_failover() {
+    // A provider with `accounts:` and no explicit strategy.
+    let cfg = parse("providers:\n  p:\n    accounts:\n      - { api_key: k }\n").unwrap();
+    assert_eq!(
+        cfg.providers["p"].account_strategy,
+        AccountStrategy::Failover
+    );
+}
+
+#[test]
+fn primary_api_key_prefers_top_level_then_first_account() {
+    // Top-level key wins when set.
+    let mut p = ProviderConfig {
+        api_key: "top".to_string(),
+        ..ProviderConfig::default()
+    };
+    p.accounts = vec![ProviderAccount {
+        api_key: "acct".to_string(),
+        ..ProviderAccount::default()
+    }];
+    assert_eq!(p.primary_api_key(), "top");
+
+    // Falls back to the first non-empty account key when there's no
+    // top-level key — the account-managed case (used by model discovery).
+    let p2 = ProviderConfig {
+        accounts: vec![
+            ProviderAccount::default(),
+            ProviderAccount {
+                api_key: "second".to_string(),
+                ..ProviderAccount::default()
+            },
+        ],
+        ..ProviderConfig::default()
+    };
+    assert_eq!(p2.primary_api_key(), "second");
+}

--- a/crates/bitrouter-sdk/src/language_model/context.rs
+++ b/crates/bitrouter-sdk/src/language_model/context.rs
@@ -194,6 +194,7 @@ impl PipelineContext {
             target,
             model_id: exec.map(|e| e.model_id.clone()).unwrap_or_default(),
             provider_id: exec.map(|e| e.provider_id.clone()).unwrap_or_default(),
+            account_label: exec.and_then(|e| e.account_label.clone()),
             prompt_tokens: usage.prompt_tokens,
             completion_tokens: usage.completion_tokens,
             reasoning_tokens: usage.reasoning_tokens,

--- a/crates/bitrouter-sdk/src/language_model/executor.rs
+++ b/crates/bitrouter-sdk/src/language_model/executor.rs
@@ -93,6 +93,7 @@ impl Executor for MockExecutor {
             MockResponse::Generate(result) => Ok(ExecutionResult {
                 provider_id: target.provider_name.clone(),
                 model_id: target.service_id.clone(),
+                account_label: target.account_label.clone(),
                 result,
                 latency_ms: 1,
                 generation_time_ms: 1,
@@ -166,6 +167,39 @@ fn truncate_upstream_message(text: &str) -> String {
     } else {
         truncated
     }
+}
+
+/// Turn a non-2xx upstream response into the right [`BitrouterError`].
+///
+/// Most non-2xx maps to [`BitrouterError::Upstream`] carrying the
+/// status. The exception: credit / balance exhaustion. Some gateways
+/// signal it cleanly with `402`, but others (e.g. opencode) return a
+/// `401`/`403` with a `CreditsError` / "insufficient balance" body —
+/// which would otherwise be misread as an auth failure. Recognise that
+/// family and map it to [`BitrouterError::PaymentRequired`] so the
+/// fallback policy drops to the next account / provider instead of
+/// failing the request outright.
+fn classify_upstream_error(status: u16, body: &str) -> BitrouterError {
+    if matches!(status, 401..=403) && looks_like_credit_exhaustion(body) {
+        return BitrouterError::PaymentRequired(truncate_upstream_message(body));
+    }
+    BitrouterError::Upstream {
+        status,
+        message: truncate_upstream_message(body),
+    }
+}
+
+/// Heuristic: does this upstream error body describe a depleted
+/// credit / balance? Matches the stable phrase family rather than any
+/// one provider's exact wording — string matching is unavoidable here
+/// because the signal is not in the HTTP status.
+fn looks_like_credit_exhaustion(body: &str) -> bool {
+    let b = body.to_ascii_lowercase();
+    b.contains("creditserror")
+        || b.contains("insufficient balance")
+        || b.contains("insufficient credit")
+        || b.contains("insufficient funds")
+        || b.contains("out of credit")
 }
 
 /// The default upstream [`Executor`] — dispatches a canonical
@@ -296,10 +330,7 @@ impl Executor for HttpExecutor {
             })?;
 
         if !status.is_success() {
-            return Err(BitrouterError::Upstream {
-                status: status.as_u16(),
-                message: truncate_upstream_message(&text),
-            });
+            return Err(classify_upstream_error(status.as_u16(), &text));
         }
 
         let json: serde_json::Value =
@@ -313,6 +344,7 @@ impl Executor for HttpExecutor {
         Ok(ExecutionResult {
             provider_id: target.provider_name.clone(),
             model_id: target.service_id.clone(),
+            account_label: target.account_label.clone(),
             result,
             latency_ms: elapsed,
             generation_time_ms: elapsed,
@@ -356,10 +388,7 @@ impl Executor for HttpExecutor {
         let status = response.status();
         if !status.is_success() {
             let text = response.text().await.unwrap_or_default();
-            return Err(BitrouterError::Upstream {
-                status: status.as_u16(),
-                message: truncate_upstream_message(&text),
-            });
+            return Err(classify_upstream_error(status.as_u16(), &text));
         }
 
         // Parse the upstream SSE byte stream into canonical stream parts via
@@ -516,5 +545,55 @@ impl Executor for DispatchExecutor {
             .cloned()
             .unwrap_or_else(|| self.default.clone());
         executor.execute_stream(target, prompt).await
+    }
+}
+
+#[cfg(test)]
+mod error_classification_tests {
+    use super::*;
+
+    #[test]
+    fn credit_exhaustion_401_maps_to_payment_required() {
+        // opencode signals a drained balance with a 401 + CreditsError
+        // body — must map to PaymentRequired so failover drops to the
+        // next account rather than treating it as an auth failure.
+        let body =
+            r#"{"type":"error","error":{"type":"CreditsError","message":"Insufficient balance."}}"#;
+        match classify_upstream_error(401, body) {
+            BitrouterError::PaymentRequired(_) => {}
+            other => panic!("expected PaymentRequired, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn plain_401_stays_an_upstream_error() {
+        // A genuine auth failure (no credit signal) must NOT become
+        // PaymentRequired — it should fail the request, not silently
+        // fall through to the next account.
+        match classify_upstream_error(401, r#"{"error":"invalid api key"}"#) {
+            BitrouterError::Upstream { status, .. } => assert_eq!(status, 401),
+            other => panic!("expected Upstream(401), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn server_error_stays_an_upstream_error() {
+        match classify_upstream_error(503, "service unavailable") {
+            BitrouterError::Upstream { status, .. } => assert_eq!(status, 503),
+            other => panic!("expected Upstream(503), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn credit_phrase_family_is_recognised() {
+        assert!(looks_like_credit_exhaustion("Insufficient balance"));
+        assert!(looks_like_credit_exhaustion(
+            "INSUFFICIENT CREDIT remaining"
+        ));
+        assert!(looks_like_credit_exhaustion("you are out of credits"));
+        assert!(looks_like_credit_exhaustion(
+            r#"{"error":{"type":"CreditsError"}}"#
+        ));
+        assert!(!looks_like_credit_exhaustion("invalid request: bad model"));
     }
 }

--- a/crates/bitrouter-sdk/src/language_model/pipeline.rs
+++ b/crates/bitrouter-sdk/src/language_model/pipeline.rs
@@ -169,6 +169,7 @@ impl Pipeline {
             ctx.execution_result = Some(ExecutionResult {
                 provider_id: target.provider_name.clone(),
                 model_id: target.service_id.clone(),
+                account_label: target.account_label.clone(),
                 result: crate::language_model::types::GenerateResult {
                     content: Vec::new(),
                     usage: None,
@@ -498,12 +499,17 @@ fn log_request_received(ctx: &PipelineContext, head: Option<&RoutingTarget>, str
     let (provider, model) = head
         .map(|t| (t.provider_name.as_str(), t.service_id.as_str()))
         .unwrap_or(("-", "-"));
+    // The account of the *primary* target — for a multi-account
+    // provider this is the one routing will try first; failover may
+    // land on a different one (see the "request finished" line).
+    let account = head.and_then(|t| t.account_label.as_deref()).unwrap_or("-");
     tracing::info!(
         request_id = %ctx.request_id(),
         user_id = ctx.caller().user_id(),
         route = ctx.model(),
         provider,
         model,
+        account,
         stream,
         "request received"
     );
@@ -529,12 +535,17 @@ fn log_request_resolve_failed(ctx: &PipelineContext, error: &BitrouterError) {
 /// streamed flag — plus `status` (200 / inferred from error) so a
 /// log-collector can build dashboards without parsing the message.
 fn log_request_finished(settle: &SettlementContext) {
+    // The account that actually served the request — for a
+    // multi-account provider this reflects any failover hop, so it can
+    // differ from the "request received" line's primary account.
+    let account = settle.account_label.as_deref().unwrap_or("-");
     match &settle.error {
         None => tracing::info!(
             request_id = %settle.request_id,
             user_id = settle.caller.user_id(),
             provider = %settle.provider_id,
             model = %settle.model_id,
+            account,
             stream = settle.streamed,
             status = 200,
             latency_ms = settle.latency_ms,
@@ -547,6 +558,7 @@ fn log_request_finished(settle: &SettlementContext) {
             user_id = settle.caller.user_id(),
             provider = %settle.provider_id,
             model = %settle.model_id,
+            account,
             stream = settle.streamed,
             latency_ms = settle.latency_ms,
             error = %err,

--- a/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
@@ -749,6 +749,7 @@ fn anthropic_no_beta_header_is_emitted() {
         api_base: "http://example.invalid".into(),
         api_key: "k".into(),
         api_protocol: ApiProtocol::Anthropic,
+        account_label: None,
         api_key_override: None,
         api_base_override: None,
     };

--- a/crates/bitrouter-sdk/src/language_model/routing.rs
+++ b/crates/bitrouter-sdk/src/language_model/routing.rs
@@ -116,8 +116,9 @@ pub trait FallbackPolicy: Send + Sync {
     fn classify(&self, err: &BitrouterError, attempted: &RoutingTarget) -> FallbackDecision;
 }
 
-/// The default policy: 5xx / 408 / 429 / transport errors → try next; other
-/// 4xx → fail. Mirrors v0's `DefaultFallbackPolicy`.
+/// The default policy: 5xx / 408 / 429 / transport / payment-exhaustion
+/// errors → try next; other 4xx → fail. Mirrors v0's
+/// `DefaultFallbackPolicy`.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct DefaultFallbackPolicy;
 
@@ -130,6 +131,13 @@ impl FallbackPolicy for DefaultFallbackPolicy {
             }
             BitrouterError::UpstreamTimeout => FallbackDecision::TryNext,
             BitrouterError::RateLimited { .. } => FallbackDecision::TryNext,
+            // Payment / credit exhaustion → try the next target. For a
+            // multi-account provider this drops to the next account
+            // (the "fall back when a subscription runs out" path); for
+            // a plain cascade it tries the next provider, which may
+            // still have funds. If every target is drained the chain
+            // exhausts and the original error is returned.
+            BitrouterError::PaymentRequired(_) => FallbackDecision::TryNext,
             // Any other error is the request's own fault — do not retry; the
             // original error is preserved.
             other => FallbackDecision::Fail(other.clone()),

--- a/crates/bitrouter-sdk/src/language_model/settlement.rs
+++ b/crates/bitrouter-sdk/src/language_model/settlement.rs
@@ -30,6 +30,10 @@ pub struct SettlementContext {
     pub model_id: String,
     /// Resolved provider id.
     pub provider_id: String,
+    /// Which account of a multi-account provider served the request —
+    /// `None` for a single-credential provider. Reflects any failover
+    /// hop.
+    pub account_label: Option<String>,
     /// Prompt tokens consumed.
     pub prompt_tokens: u64,
     /// Completion tokens consumed.

--- a/crates/bitrouter-sdk/src/language_model/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/tests.rs
@@ -22,6 +22,7 @@ fn target(provider: &str) -> RoutingTarget {
         api_base: "https://example.invalid".to_string(),
         api_key: "k".to_string(),
         api_protocol: ApiProtocol::Openai,
+        account_label: None,
         api_key_override: None,
         api_base_override: None,
     }
@@ -339,6 +340,42 @@ async fn fallback_tries_next_on_5xx_then_succeeds() {
         resp.result.content,
         vec![Content::Text {
             text: "from b".into()
+        }]
+    );
+}
+
+#[tokio::test]
+async fn fallback_tries_next_on_payment_required_then_succeeds() {
+    // The account-failover path: the first target is out of credits
+    // (`PaymentRequired`), routing must drop to the next account, which
+    // serves the request. A single `routing_table` with two providers
+    // stands in for one provider's two accounts — the pipeline only
+    // sees a 2-target chain either way.
+    let pipeline = pipeline_with(
+        routing_table(&["account-a", "account-b"]),
+        Arc::new(MockExecutor::new(vec![
+            MockResponse::Error(BitrouterError::PaymentRequired(
+                "Insufficient balance.".into(),
+            )),
+            MockResponse::Generate(GenerateResult {
+                content: vec![Content::Text {
+                    text: "from account b".into(),
+                }],
+                usage: None,
+                finish_reason: Some(FinishReason::Stop),
+            }),
+        ])),
+        |_b| {},
+    );
+
+    let resp = pipeline
+        .execute(request())
+        .await
+        .expect("credit exhaustion on the first account falls back to the second");
+    assert_eq!(
+        resp.result.content,
+        vec![Content::Text {
+            text: "from account b".into()
         }]
     );
 }

--- a/crates/bitrouter-sdk/src/language_model/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/tests.rs
@@ -842,6 +842,7 @@ async fn executor_rejects_response_format_on_unsupported_outbound() {
         api_base: "http://example.invalid".into(),
         api_key: "k".into(),
         api_protocol: ApiProtocol::Custom("fake".into()),
+        account_label: None,
         api_key_override: None,
         api_base_override: None,
     };

--- a/crates/bitrouter-sdk/src/language_model/types.rs
+++ b/crates/bitrouter-sdk/src/language_model/types.rs
@@ -345,6 +345,10 @@ pub struct ExecutionResult {
     pub provider_id: String,
     /// The model/service id at that provider.
     pub model_id: String,
+    /// Which account of a multi-account provider served the request —
+    /// `None` for a single-credential provider. Reflects any failover
+    /// hop, so it can differ from the chain's primary account.
+    pub account_label: Option<String>,
     /// The generation result.
     pub result: GenerateResult,
     /// End-to-end latency in milliseconds.
@@ -370,6 +374,11 @@ pub struct RoutingTarget {
     pub api_key: String,
     /// The wire protocol this target speaks.
     pub api_protocol: ApiProtocol,
+    /// Which account of a multi-account provider this target came from
+    /// — `None` for a single-credential provider. Surfaced in the
+    /// request log so an operator can see which subscription served a
+    /// request; carries no routing behaviour itself.
+    pub account_label: Option<String>,
     /// Per-request key override. Set by a `RouteHook` that wants to
     /// substitute the caller's own provider key (e.g. BYOK) for this hop.
     /// The SDK itself is opinion-free about whether or how such a hook
@@ -387,6 +396,7 @@ impl std::fmt::Debug for RoutingTarget {
             .field("api_base", &self.api_base)
             .field("api_key", &redacted(&self.api_key))
             .field("api_protocol", &self.api_protocol)
+            .field("account_label", &self.account_label)
             .field(
                 "api_key_override",
                 &self.api_key_override.as_deref().map(redacted),

--- a/plugins/bitrouter-guardrails/src/tests.rs
+++ b/plugins/bitrouter-guardrails/src/tests.rs
@@ -72,6 +72,7 @@ fn target() -> RoutingTarget {
         api_base: "https://example.invalid".to_string(),
         api_key: "k".to_string(),
         api_protocol: ApiProtocol::Openai,
+        account_label: None,
         api_key_override: None,
         api_base_override: None,
     }


### PR DESCRIPTION
## Summary

Lets one provider hold several credentials — e.g. two subscriptions to the same upstream — and route across them the way bitrouter already routes across providers.

```yaml
providers:
  opencode-go:
    account_strategy: failover   # or: balance
    accounts:
      - { api_key: "${KEY_A}", label: primary }
      - { api_key: "${KEY_B}", label: backup }
```

- **failover** (default) — accounts in declared order; the first is primary, routing drops to the next on a retryable failure (5xx / 429 / timeout) or a payment / credit-exhaustion error.
- **balance** — a per-provider round-robin counter advances the primary by one each request, so load splits exactly evenly; the remaining accounts still act as that request's failover targets.

Backward compatible: a provider with the existing top-level `api_key` and no `accounts` is unchanged.

## How it works

- `ProviderConfig` gains `accounts: Vec<ProviderAccount>` + `account_strategy`. `ProviderAccount` is `{ api_key, api_base?, label? }` — `api_base` optional so it also covers multi-org / multi-region setups.
- `routing_table::build_targets` expands one `(provider, model)` pair into one `RoutingTarget` per account; the existing `execute_with_fallback` chain does the rest. Expansion happens in all three resolution strategies (direct / virtual-model / auto-cascade).
- Credit exhaustion: some gateways (opencode) signal a drained balance with a `401`/`403` + `CreditsError` body rather than a clean `402`. `executor::classify_upstream_error` recognises that phrase family and maps it to `BitrouterError::PaymentRequired`; `DefaultFallbackPolicy` now treats `PaymentRequired` as `TryNext`, so failover triggers on "out of credits", not just overload.
- `RoutingTarget` / `ExecutionResult` / `SettlementContext` carry an `account_label`; the `request received` / `request finished` logs print `account=…` so an operator sees which subscription served a request (and any failover hop).

## Test plan

- [x] `cargo fmt` / `clippy -D warnings` / 340 workspace tests pass
- [x] Unit: account expansion (single / failover / balance / per-account `api_base` / auto-cascade), round-robin rotation, credit-error classification, `PaymentRequired → TryNext` failover, config parsing
- [x] Live (daemon + real opencode key): **failover** — dead primary account → `request received account=dead-primary` then `request finished account=real-backup status=200`
- [x] Live: **balance** — four requests round-robin `sub-one, sub-two, sub-one, sub-two`

🤖 Generated with [Claude Code](https://claude.com/claude-code)