### PR TITLE
refactor(db): sea-orm migrations + all backends, no concrete driver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,6 +25,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "aliasable"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -656,11 +662,12 @@ dependencies = [
  "hex",
  "http 1.4.0",
  "rand 0.9.4",
+ "sea-orm",
+ "sea-orm-migration",
  "serde",
  "serde-saphyr",
  "serde_json",
  "sha2",
- "sqlx",
  "tokio",
  "tower",
  "tracing",
@@ -880,7 +887,7 @@ version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -1036,6 +1043,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1071,6 +1112,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1446,6 +1509,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "granit-parser"
 version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1518,6 +1587,12 @@ checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
  "hashbrown 0.15.5",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -1707,7 +1782,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -1845,6 +1920,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1875,6 +1956,17 @@ dependencies = [
  "hashbrown 0.17.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "inherent"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c727f80bfa4a6c6e2508d2f05b6f4bfce242030bd88ed15ae5331c5b5d30fba7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2274,6 +2366,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ouroboros"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0f050db9c44b97a94723127e6be766ac5c340c48f2c4bb3ffa11713744be59"
+dependencies = [
+ "aliasable",
+ "ouroboros_macro",
+ "static_assertions",
+]
+
+[[package]]
+name = "ouroboros_macro"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c7028bdd3d43083f6d8d4d5187680d0d3560d54df4cc9d752005268b41e64d0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2413,12 +2538,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+ "yansi",
 ]
 
 [[package]]
@@ -2699,7 +2859,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams 0.4.2",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -3029,6 +3189,147 @@ dependencies = [
 ]
 
 [[package]]
+name = "sea-bae"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f694a6ab48f14bc063cfadff30ab551d3c7e46d8f81836c51989d548f44a2a25"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "sea-orm"
+version = "1.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dc312fedd460a47ea563911761d254a84e7b51d8cc73ec92c929e78f33fa957"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "derive_more",
+ "futures-util",
+ "log",
+ "ouroboros",
+ "sea-orm-macros",
+ "sea-query",
+ "sea-query-binder",
+ "serde",
+ "sqlx",
+ "strum",
+ "thiserror",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "sea-orm-cli"
+version = "1.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da80ebcdb44571e86f03a2bdcb5532136a87397f366f38bbce64673fc5e6a450"
+dependencies = [
+ "chrono",
+ "glob",
+ "regex",
+ "sea-schema",
+ "sqlx",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+]
+
+[[package]]
+name = "sea-orm-macros"
+version = "1.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b9a3f90e336ec74803e8eb98c61bc98754c1adfba3b4f84d946237b752b1c88"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "sea-bae",
+ "syn",
+ "unicode-ident",
+]
+
+[[package]]
+name = "sea-orm-migration"
+version = "1.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07c577f2959277e936c1d08109acd1e08fc36a95ef29ec028190ba82cad8f96e"
+dependencies = [
+ "async-trait",
+ "sea-orm",
+ "sea-orm-cli",
+ "sea-schema",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "sea-query"
+version = "0.32.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a5d1c518eaf5eda38e5773f902b26ab6d5e9e9e2bb2349ca6c64cf96f80448c"
+dependencies = [
+ "inherent",
+ "ordered-float",
+ "sea-query-derive",
+]
+
+[[package]]
+name = "sea-query-binder"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0019f47430f7995af63deda77e238c17323359af241233ec768aba1faea7608"
+dependencies = [
+ "sea-query",
+ "sqlx",
+]
+
+[[package]]
+name = "sea-query-derive"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bae0cbad6ab996955664982739354128c58d16e126114fe88c2a493642502aab"
+dependencies = [
+ "darling",
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "thiserror",
+]
+
+[[package]]
+name = "sea-schema"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2239ff574c04858ca77485f112afea1a15e53135d3097d0c86509cef1def1338"
+dependencies = [
+ "futures",
+ "sea-query",
+ "sea-query-binder",
+ "sea-schema-derive",
+ "sqlx",
+]
+
+[[package]]
+name = "sea-schema-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "debdc8729c37fdbf88472f97fd470393089f997a909e535ff67c544d18cfccf0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3323,7 +3624,6 @@ checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "chrono",
  "crc",
  "crossbeam-queue",
  "either",
@@ -3339,6 +3639,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
+ "rustls 0.23.40",
  "serde",
  "serde_json",
  "sha2",
@@ -3348,6 +3649,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "url",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -3371,7 +3673,7 @@ checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
 dependencies = [
  "dotenvy",
  "either",
- "heck",
+ "heck 0.5.0",
  "hex",
  "once_cell",
  "proc-macro2",
@@ -3399,7 +3701,6 @@ dependencies = [
  "bitflags",
  "byteorder",
  "bytes",
- "chrono",
  "crc",
  "digest",
  "dotenvy",
@@ -3441,7 +3742,6 @@ dependencies = [
  "base64 0.22.1",
  "bitflags",
  "byteorder",
- "chrono",
  "crc",
  "dotenvy",
  "etcetera",
@@ -3476,7 +3776,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
 dependencies = [
  "atoi",
- "chrono",
  "flume",
  "futures-channel",
  "futures-core",
@@ -3514,6 +3813,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3529,6 +3834,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 
 [[package]]
 name = "subtle"
@@ -4222,6 +4533,15 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
@@ -4643,7 +4963,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "wit-parser",
 ]
 
@@ -4654,7 +4974,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "indexmap",
  "prettyplease",
  "syn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,11 +78,23 @@ rmcp = { version = "1.7", default-features = false, features = [
 # source of truth: <https://agentclientprotocol.com/protocol/schema> +
 # <https://agentclientprotocol.com/protocol/transports>.
 
-# database (used by apps/bitrouter's auth + metering modules)
-sqlx = { version = "0.8", default-features = false, features = [
-    "runtime-tokio",
+# database — sea-orm is the only database dependency in the workspace.
+# bitrouter depends on this high-level ORM abstraction, never on a concrete
+# driver: enabling `sqlx-sqlite` / `sqlx-postgres` / `sqlx-mysql` here lets
+# the `bitrouter` binary talk to every backend sea-orm supports from one
+# build. The schema is defined as `sea-orm-migration` Rust code, not SQL.
+sea-orm = { version = "1", default-features = false, features = [
     "macros",
-    "chrono",
+    "sqlx-sqlite",
+    "sqlx-postgres",
+    "sqlx-mysql",
+    "runtime-tokio-rustls",
+] }
+sea-orm-migration = { version = "1", default-features = false, features = [
+    "sqlx-sqlite",
+    "sqlx-postgres",
+    "sqlx-mysql",
+    "runtime-tokio-rustls",
 ] }
 
 # crypto / encoding

--- a/apps/bitrouter/Cargo.toml
+++ b/apps/bitrouter/Cargo.toml
@@ -27,7 +27,8 @@ base64.workspace = true
 rand.workspace = true
 hex.workspace = true
 serde-saphyr.workspace = true
-sqlx = { workspace = true, features = ["sqlite"] }
+sea-orm.workspace = true
+sea-orm-migration.workspace = true
 tokio = { workspace = true, features = ["full"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/apps/bitrouter/src/assemble.rs
+++ b/apps/bitrouter/src/assemble.rs
@@ -6,11 +6,8 @@
 
 use std::sync::Arc;
 
-use std::str::FromStr;
-
 use anyhow::{Context, Result};
-use sqlx::SqlitePool;
-use sqlx::sqlite::SqliteConnectOptions;
+use sea_orm::DatabaseConnection;
 
 use bitrouter_sdk::App;
 use bitrouter_sdk::acp::{AcpStdioExecutor, ConfigAcpRoutingTable};
@@ -27,13 +24,14 @@ use crate::auth::AuthHook;
 use crate::metering::{MeteringRecorder, MeteringStore, ModelPricing, PricingTable};
 use crate::policy::{PolicyHook, PolicyStore};
 
-/// A running application plus the database pool it was assembled over (the
-/// caller keeps the pool for management commands — key creation, etc.).
+/// A running application plus the database connection it was assembled
+/// over (the caller keeps the connection for management commands — key
+/// creation, etc.).
 pub struct Assembled {
     /// The fully wired application.
     pub app: App,
-    /// The shared database pool.
-    pub pool: SqlitePool,
+    /// The shared database connection.
+    pub db: DatabaseConnection,
     /// The policy store wired into the language_model pipeline. Held by the
     /// caller (the daemon) so `bitrouter reload` / SIGHUP can call
     /// [`PolicyStore::reload`] alongside the routing-table reload — reload
@@ -60,30 +58,24 @@ pub async fn build_app_with_path(
     config: &Config,
     config_path: Option<&std::path::Path>,
 ) -> Result<Assembled> {
-    // ---- database + migrations (each plugin owns its own tables) ----
-    // `SqlitePool::connect(url)` parses the DSN with sqlx's default
-    // open mode (read-write, *not* create), so a fresh
-    // `sqlite://./bitrouter.db` against a missing file errors with
-    // SQLITE_CANTOPEN. Parse the URL ourselves and force
-    // `create_if_missing(true)` so first-run works without forcing the
-    // user to write `?mode=rwc` into the DSN. The URL itself is still
-    // forwarded to sqlx verbatim — we only set a connection flag.
-    let connect_opts = SqliteConnectOptions::from_str(&config.database.url)
-        .with_context(|| format!("parsing database url {}", config.database.url))?
-        .create_if_missing(true);
-    let pool = SqlitePool::connect_with(connect_opts)
+    // ---- database + migrations ----
+    // `database.url` may name any backend sea-orm supports (sqlite /
+    // postgres / mysql); `crate::db::connect` handles the per-backend
+    // first-run conveniences (a SQLite file URL is created on demand).
+    // The schema is applied from `crate::db::migration` — Rust code, not
+    // SQL — so it lands identically on whichever backend is configured.
+    let db = crate::db::connect(&config.database.url)
         .await
         .with_context(|| format!("connecting to database {}", config.database.url))?;
-    crate::auth::migrate(&pool)
+    crate::db::run_migrations(&db)
         .await
-        .context("running auth migrations")?;
-    crate::metering::migrate(&pool)
-        .await
-        .context("running metering migrations")?;
-    // The SQLite database holds SHA-256 hashes of every virtual key, plus
-    // the metering audit trail. On Unix, tighten the file permissions to
-    // 0600 so a co-tenant on the host can't read it. The control socket
-    // already does the same in `daemon::run_control_socket`.
+        .context("running database migrations")?;
+    // A SQLite database file holds SHA-256 hashes of every virtual key,
+    // plus the metering audit trail. On Unix, tighten the file
+    // permissions to 0600 so a co-tenant on the host can't read it. The
+    // control socket already does the same in
+    // `daemon::run_control_socket`. Non-file backends (Postgres / MySQL)
+    // have no local file and govern access themselves.
     #[cfg(unix)]
     if let Some(path) = sqlite_file_path(&config.database.url) {
         use std::os::unix::fs::PermissionsExt;
@@ -129,7 +121,7 @@ pub async fn build_app_with_path(
 
     // ---- pricing, metering, policy, guardrails — all derived from config ----
     let pricing = Arc::new(build_pricing_table(config));
-    let metering_store = MeteringStore::new(pool.clone());
+    let metering_store = MeteringStore::new(db.clone());
     let metering_store_for_policy = metering_store.clone();
     let metering_store_for_recorder = metering_store.clone();
     let pricing_for_recorder = pricing.clone();
@@ -189,14 +181,14 @@ pub async fn build_app_with_path(
         .as_ref()
         .map(|_| Arc::new(AcpStdioExecutor::new()));
 
-    let pool_for_hooks = pool.clone();
+    let db_for_hooks = db.clone();
     let app = App::builder()
         .skip_auth(config.server.skip_auth)
         .metrics_renderer(metrics_renderer)
         .language_model(move |lm| {
             lm.routing_table(routing_table).executor(executor);
             // Stage 1, in order: auth → policy → guardrail (upstream).
-            lm.pre_request_hook(AuthHook::new(pool_for_hooks.clone()));
+            lm.pre_request_hook(AuthHook::new(db_for_hooks.clone()));
             lm.pre_request_hook(PolicyHook::new(
                 policy_store.clone(),
                 Some(metering_store_for_policy),
@@ -245,7 +237,7 @@ pub async fn build_app_with_path(
 
     Ok(Assembled {
         app,
-        pool,
+        db,
         policy_store: policy_store_for_reload,
         routing_table: routing_table_for_reload,
     })
@@ -370,16 +362,16 @@ impl bitrouter_sdk::language_model::ObserveHook for PrometheusObserve {
     }
 }
 
-/// Extract the file path from a sqlite URL. Returns `None` for `:memory:` or
-/// non-file URLs. Accepts the `sqlite://`, `sqlite:` and bare-path forms that
-/// `sqlx::SqlitePool::connect` accepts.
+/// Extract the file path from a SQLite URL. Returns `None` for `:memory:`
+/// and for any non-SQLite URL (Postgres / MySQL have no local file). Accepts
+/// the `sqlite://` and `sqlite:` forms.
 #[cfg(unix)]
 fn sqlite_file_path(url: &str) -> Option<std::path::PathBuf> {
+    // Only a SQLite URL names a local file — a Postgres / MySQL URL must
+    // never be mistaken for a path to chmod.
     let after_scheme = url
         .strip_prefix("sqlite://")
-        .or_else(|| url.strip_prefix("sqlite:"))
-        .unwrap_or(url);
-    // Strip a leading `//` (sqlite://path → /path; treat as filesystem path)
+        .or_else(|| url.strip_prefix("sqlite:"))?;
     let path = after_scheme.split('?').next().unwrap_or(after_scheme);
     if path.is_empty() || path == ":memory:" {
         return None;
@@ -408,5 +400,8 @@ mod sqlite_path_tests {
         );
         assert_eq!(sqlite_file_path(":memory:"), None);
         assert_eq!(sqlite_file_path("sqlite::memory:"), None);
+        // Non-SQLite URLs name no local file — never treated as a path.
+        assert_eq!(sqlite_file_path("postgres://u:p@host/bitrouter"), None);
+        assert_eq!(sqlite_file_path("mysql://u:p@host/bitrouter"), None);
     }
 }

--- a/apps/bitrouter/src/auth/db.rs
+++ b/apps/bitrouter/src/auth/db.rs
@@ -1,47 +1,19 @@
 //! Database access for the OSS auth module. This module owns the `users`
 //! and `api_keys` tables; the rest of the binary coordinates via the
 //! `Authenticated` event instead of reading `api_keys` directly.
+//!
+//! The tables themselves are created by the sea-orm migrations in
+//! `crate::db::migration`; this module only reads and writes rows.
 
 use chrono::{DateTime, Utc};
-use sqlx::{Row, SqlitePool};
+use sea_orm::sea_query::OnConflict;
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, DatabaseConnection, DbErr, EntityTrait, QueryFilter, Set,
+};
 
 use bitrouter_sdk::{BitrouterError, Result};
 
-/// The SQL that creates this module's tables. Run once at startup.
-pub const MIGRATION_SQL: &str = r#"
-CREATE TABLE IF NOT EXISTS users (
-    id          TEXT PRIMARY KEY,
-    created_at  TEXT NOT NULL
-);
-CREATE TABLE IF NOT EXISTS api_keys (
-    id                     TEXT PRIMARY KEY,
-    key_hash               TEXT NOT NULL UNIQUE,
-    user_id                TEXT NOT NULL,
-    spend_limit_micro_usd  INTEGER,
-    rpm_limit              INTEGER,
-    policy_id              TEXT,
-    expires_at             TEXT,
-    active                 INTEGER NOT NULL DEFAULT 1,
-    created_at             TEXT NOT NULL,
-    FOREIGN KEY (user_id) REFERENCES users(id)
-);
-CREATE INDEX IF NOT EXISTS idx_api_keys_hash ON api_keys(key_hash);
-"#;
-
-/// Create the auth tables on `pool`. Idempotent.
-pub async fn migrate(pool: &SqlitePool) -> Result<()> {
-    for stmt in MIGRATION_SQL.split(';') {
-        let stmt = stmt.trim();
-        if stmt.is_empty() {
-            continue;
-        }
-        sqlx::query(stmt)
-            .execute(pool)
-            .await
-            .map_err(|e| BitrouterError::internal(format!("auth migration: {e}")))?;
-    }
-    Ok(())
-}
+use crate::auth::entities::{api_keys, users};
 
 /// One row of the `api_keys` table, in typed form.
 #[derive(Debug, Clone)]
@@ -64,34 +36,34 @@ pub struct ApiKeyRecord {
     pub active: bool,
 }
 
-/// Look up an active api key by its SHA-256 hash. Only the **hash** is stored —
+/// Look up an api key by its SHA-256 hash. Only the **hash** is stored —
 /// the plaintext secret is never persisted.
-pub async fn find_key_by_hash(pool: &SqlitePool, key_hash: &str) -> Result<Option<ApiKeyRecord>> {
-    let row = sqlx::query(
-        "SELECT id, user_id, spend_limit_micro_usd, rpm_limit, \
-         policy_id, expires_at, active FROM api_keys WHERE key_hash = ?",
-    )
-    .bind(key_hash)
-    .fetch_optional(pool)
-    .await
-    .map_err(|e| BitrouterError::internal(format!("api_keys lookup: {e}")))?;
+pub async fn find_key_by_hash(
+    db: &DatabaseConnection,
+    key_hash: &str,
+) -> Result<Option<ApiKeyRecord>> {
+    let row = api_keys::Entity::find()
+        .filter(api_keys::Column::KeyHash.eq(key_hash))
+        .one(db)
+        .await
+        .map_err(|e| BitrouterError::internal(format!("api_keys lookup: {e}")))?;
 
     let Some(row) = row else {
         return Ok(None);
     };
-    let expires_at = row.get::<Option<String>, _>("expires_at").and_then(|s| {
-        DateTime::parse_from_rfc3339(&s)
+    let expires_at = row.expires_at.as_deref().and_then(|s| {
+        DateTime::parse_from_rfc3339(s)
             .ok()
             .map(|d| d.with_timezone(&Utc))
     });
     Ok(Some(ApiKeyRecord {
-        id: row.get("id"),
-        user_id: row.get("user_id"),
-        spend_limit_micro_usd: row.get("spend_limit_micro_usd"),
-        rpm_limit: row.get("rpm_limit"),
-        policy_id: row.get("policy_id"),
+        id: row.id,
+        user_id: row.user_id,
+        spend_limit_micro_usd: row.spend_limit_micro_usd,
+        rpm_limit: row.rpm_limit,
+        policy_id: row.policy_id,
         expires_at,
-        active: row.get::<i64, _>("active") != 0,
+        active: row.active != 0,
     }))
 }
 
@@ -109,19 +81,30 @@ pub fn is_reserved_user_id(user_id: &str) -> bool {
 
 /// Insert a user row (idempotent on conflict). Rejects [`is_reserved_user_id`]
 /// values — those names are owned by synthesised callers.
-pub async fn upsert_user(pool: &SqlitePool, user_id: &str) -> Result<()> {
+pub async fn upsert_user(db: &DatabaseConnection, user_id: &str) -> Result<()> {
     if is_reserved_user_id(user_id) {
         return Err(BitrouterError::bad_request(format!(
             "user id '{user_id}' is reserved for synthesised callers"
         )));
     }
-    sqlx::query("INSERT OR IGNORE INTO users (id, created_at) VALUES (?, ?)")
-        .bind(user_id)
-        .bind(Utc::now().to_rfc3339())
-        .execute(pool)
+    let row = users::ActiveModel {
+        id: Set(user_id.to_string()),
+        created_at: Set(Utc::now().to_rfc3339()),
+    };
+    // `do_nothing` makes this idempotent; on a conflict sea-orm reports
+    // `RecordNotInserted`, which here is the success path, not an error.
+    match users::Entity::insert(row)
+        .on_conflict(
+            OnConflict::column(users::Column::Id)
+                .do_nothing()
+                .to_owned(),
+        )
+        .exec(db)
         .await
-        .map_err(|e| BitrouterError::internal(format!("upsert user: {e}")))?;
-    Ok(())
+    {
+        Ok(_) | Err(DbErr::RecordNotInserted) => Ok(()),
+        Err(e) => Err(BitrouterError::internal(format!("upsert user: {e}"))),
+    }
 }
 
 /// Parameters for inserting a new api key.
@@ -143,22 +126,20 @@ pub struct NewApiKey {
 
 /// Insert a new api key row. The caller is responsible for having created the
 /// `users` row first (or call [`upsert_user`]).
-pub async fn insert_api_key(pool: &SqlitePool, key: &NewApiKey) -> Result<()> {
-    sqlx::query(
-        "INSERT INTO api_keys \
-         (id, key_hash, user_id, spend_limit_micro_usd, rpm_limit, \
-          policy_id, expires_at, active, created_at) \
-         VALUES (?, ?, ?, ?, ?, ?, NULL, 1, ?)",
-    )
-    .bind(&key.id)
-    .bind(&key.key_hash)
-    .bind(&key.user_id)
-    .bind(key.spend_limit_micro_usd)
-    .bind(key.rpm_limit)
-    .bind(&key.policy_id)
-    .bind(Utc::now().to_rfc3339())
-    .execute(pool)
-    .await
-    .map_err(|e| BitrouterError::internal(format!("insert api key: {e}")))?;
+pub async fn insert_api_key(db: &DatabaseConnection, key: &NewApiKey) -> Result<()> {
+    let row = api_keys::ActiveModel {
+        id: Set(key.id.clone()),
+        key_hash: Set(key.key_hash.clone()),
+        user_id: Set(key.user_id.clone()),
+        spend_limit_micro_usd: Set(key.spend_limit_micro_usd),
+        rpm_limit: Set(key.rpm_limit),
+        policy_id: Set(key.policy_id.clone()),
+        expires_at: Set(None),
+        active: Set(1),
+        created_at: Set(Utc::now().to_rfc3339()),
+    };
+    row.insert(db)
+        .await
+        .map_err(|e| BitrouterError::internal(format!("insert api key: {e}")))?;
     Ok(())
 }

--- a/apps/bitrouter/src/auth/entities/api_keys.rs
+++ b/apps/bitrouter/src/auth/entities/api_keys.rs
@@ -1,0 +1,34 @@
+//! The `api_keys` table.
+
+use sea_orm::entity::prelude::*;
+
+/// One row of the `api_keys` table. Only the SHA-256 **hash** of a virtual
+/// key is stored — never the plaintext secret.
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "api_keys")]
+pub struct Model {
+    /// The key id (e.g. `brvk_id_…`, distinct from the secret).
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: String,
+    /// Hex-encoded SHA-256 of the plaintext secret.
+    pub key_hash: String,
+    /// Owning user id.
+    pub user_id: String,
+    /// Monthly spend ceiling in micro-USD, if any.
+    pub spend_limit_micro_usd: Option<i64>,
+    /// Requests-per-minute ceiling, if any.
+    pub rpm_limit: Option<i64>,
+    /// The policy id this key is bound to, if any.
+    pub policy_id: Option<String>,
+    /// RFC3339 expiry timestamp, if any.
+    pub expires_at: Option<String>,
+    /// Whether the key is active (`1`) or revoked (`0`).
+    pub active: i32,
+    /// RFC3339 creation timestamp.
+    pub created_at: String,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/apps/bitrouter/src/auth/entities/mod.rs
+++ b/apps/bitrouter/src/auth/entities/mod.rs
@@ -1,0 +1,4 @@
+//! sea-orm entity definitions for the auth module's tables.
+
+pub mod api_keys;
+pub mod users;

--- a/apps/bitrouter/src/auth/entities/users.rs
+++ b/apps/bitrouter/src/auth/entities/users.rs
@@ -1,0 +1,19 @@
+//! The `users` table.
+
+use sea_orm::entity::prelude::*;
+
+/// One row of the `users` table.
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "users")]
+pub struct Model {
+    /// The user id.
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: String,
+    /// RFC3339 creation timestamp.
+    pub created_at: String,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/apps/bitrouter/src/auth/hook.rs
+++ b/apps/bitrouter/src/auth/hook.rs
@@ -27,7 +27,7 @@
 
 use async_trait::async_trait;
 use chrono::Utc;
-use sqlx::SqlitePool;
+use sea_orm::DatabaseConnection;
 
 use bitrouter_sdk::caller::CallerContext;
 use bitrouter_sdk::language_model::{DenyReason, HookDecision, PipelineContext, PreRequestHook};
@@ -49,14 +49,14 @@ pub fn plugin_id() -> PluginId {
 /// virtual key). Owns no routing or settlement behaviour — it only
 /// establishes identity.
 pub struct AuthHook {
-    pool: SqlitePool,
+    db: DatabaseConnection,
 }
 
 impl AuthHook {
-    /// Build an `AuthHook` over a sqlite pool. The pool must already have
-    /// this module's tables (`crate::auth::db::migrate`).
-    pub fn new(pool: SqlitePool) -> Self {
-        Self { pool }
+    /// Build an `AuthHook` over a database connection. The database must
+    /// already carry this module's tables (`crate::db::run_migrations`).
+    pub fn new(db: DatabaseConnection) -> Self {
+        Self { db }
     }
 
     /// Extract a presented API-key credential from the request headers.
@@ -114,7 +114,7 @@ impl PreRequestHook for AuthHook {
         }
 
         let hash = keys::hash_key(&credential);
-        let record = db::find_key_by_hash(&self.pool, &hash).await?;
+        let record = db::find_key_by_hash(&self.db, &hash).await?;
         let Some(record) = record else {
             return Ok(HookDecision::Deny(DenyReason::Unauthorized(
                 "unknown API key".to_string(),

--- a/apps/bitrouter/src/auth/mod.rs
+++ b/apps/bitrouter/src/auth/mod.rs
@@ -6,6 +6,7 @@
 //! against its own auth model.
 
 pub mod db;
+pub mod entities;
 pub mod events;
 pub mod hook;
 pub mod keys;
@@ -13,7 +14,7 @@ pub mod keys;
 #[cfg(test)]
 mod tests;
 
-pub use db::{ApiKeyRecord, NewApiKey, migrate};
+pub use db::{ApiKeyRecord, NewApiKey};
 pub use events::Authenticated;
 pub use hook::AuthHook;
 pub use keys::{GeneratedKey, KEY_PREFIX, generate, hash_key, looks_like_virtual_key};

--- a/apps/bitrouter/src/auth/tests.rs
+++ b/apps/bitrouter/src/auth/tests.rs
@@ -1,6 +1,9 @@
 //! Auth tests: the `skip_auth` truth table and the `brvk_` validation flow.
 
-use sqlx::SqlitePool;
+use sea_orm::sea_query::Expr;
+use sea_orm::{ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter};
+
+use crate::auth::entities::api_keys;
 
 use bitrouter_sdk::caller::CallerContext;
 use bitrouter_sdk::language_model::{
@@ -13,10 +16,10 @@ use crate::auth::events::Authenticated;
 use crate::auth::hook::AuthHook;
 use crate::auth::keys;
 
-async fn pool() -> SqlitePool {
-    let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
-    db::migrate(&pool).await.unwrap();
-    pool
+async fn pool() -> DatabaseConnection {
+    let db = crate::db::connect("sqlite::memory:").await.unwrap();
+    crate::db::run_migrations(&db).await.unwrap();
+    db
 }
 
 fn prompt() -> Prompt {
@@ -43,7 +46,7 @@ fn ctx_with(caller: CallerContext, bearer: Option<&str>) -> PipelineContext {
 }
 
 /// Insert a fresh active key, returning its plaintext secret + id.
-async fn insert_active_key(pool: &SqlitePool, user: &str) -> (String, String) {
+async fn insert_active_key(pool: &DatabaseConnection, user: &str) -> (String, String) {
     db::upsert_user(pool, user).await.unwrap();
     let key = keys::generate();
     let id = format!("key_{user}");
@@ -193,8 +196,10 @@ async fn inactive_key_is_denied() {
     .await
     .unwrap();
     // flip it inactive
-    sqlx::query("UPDATE api_keys SET active = 0 WHERE id = 'key_inactive'")
-        .execute(&pool)
+    api_keys::Entity::update_many()
+        .col_expr(api_keys::Column::Active, Expr::value(0))
+        .filter(api_keys::Column::Id.eq("key_inactive"))
+        .exec(&pool)
         .await
         .unwrap();
 

--- a/apps/bitrouter/src/commands.rs
+++ b/apps/bitrouter/src/commands.rs
@@ -3,7 +3,6 @@
 //! reuse it without dragging in the binary.
 
 use anyhow::{Context, Result};
-use sqlx::SqlitePool;
 
 use bitrouter_sdk::caller::CallerContext;
 use bitrouter_sdk::config::{Config, ConfigRoutingTable};
@@ -125,20 +124,20 @@ pub async fn key_sign(
     user_id: &str,
     policy_id: Option<&str>,
 ) -> Result<GeneratedKey> {
-    let pool = SqlitePool::connect(db_url)
+    let db = crate::db::connect(db_url)
         .await
         .with_context(|| format!("connecting to database {db_url}"))?;
-    auth_db::migrate(&pool)
+    crate::db::run_migrations(&db)
         .await
-        .context("running auth migrations")?;
-    auth_db::upsert_user(&pool, user_id)
+        .context("running database migrations")?;
+    auth_db::upsert_user(&db, user_id)
         .await
         .context("creating user row")?;
 
     let key = generate();
     let id = format!("brvk_id_{}", &key.hash[..16]);
     auth_db::insert_api_key(
-        &pool,
+        &db,
         &NewApiKey {
             id: id.clone(),
             key_hash: key.hash.clone(),

--- a/apps/bitrouter/src/db/migration/m20240101_000001_create_auth_tables.rs
+++ b/apps/bitrouter/src/db/migration/m20240101_000001_create_auth_tables.rs
@@ -1,0 +1,105 @@
+//! Create the auth module's `users` and `api_keys` tables.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(Users::Table)
+                    .if_not_exists()
+                    .col(ColumnDef::new(Users::Id).string().not_null().primary_key())
+                    .col(ColumnDef::new(Users::CreatedAt).string().not_null())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_table(
+                Table::create()
+                    .table(ApiKeys::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(ApiKeys::Id)
+                            .string()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(ApiKeys::KeyHash)
+                            .string()
+                            .not_null()
+                            .unique_key(),
+                    )
+                    .col(ColumnDef::new(ApiKeys::UserId).string().not_null())
+                    .col(ColumnDef::new(ApiKeys::SpendLimitMicroUsd).big_integer())
+                    .col(ColumnDef::new(ApiKeys::RpmLimit).big_integer())
+                    .col(ColumnDef::new(ApiKeys::PolicyId).string())
+                    .col(ColumnDef::new(ApiKeys::ExpiresAt).string())
+                    .col(
+                        ColumnDef::new(ApiKeys::Active)
+                            .integer()
+                            .not_null()
+                            .default(1),
+                    )
+                    .col(ColumnDef::new(ApiKeys::CreatedAt).string().not_null())
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("fk_api_keys_user")
+                            .from(ApiKeys::Table, ApiKeys::UserId)
+                            .to(Users::Table, Users::Id),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .if_not_exists()
+                    .name("idx_api_keys_hash")
+                    .table(ApiKeys::Table)
+                    .col(ApiKeys::KeyHash)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(ApiKeys::Table).to_owned())
+            .await?;
+        manager
+            .drop_table(Table::drop().table(Users::Table).to_owned())
+            .await?;
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+enum Users {
+    Table,
+    Id,
+    CreatedAt,
+}
+
+#[derive(DeriveIden)]
+enum ApiKeys {
+    Table,
+    Id,
+    KeyHash,
+    UserId,
+    SpendLimitMicroUsd,
+    RpmLimit,
+    PolicyId,
+    ExpiresAt,
+    Active,
+    CreatedAt,
+}

--- a/apps/bitrouter/src/db/migration/m20240101_000002_create_metering_tables.rs
+++ b/apps/bitrouter/src/db/migration/m20240101_000002_create_metering_tables.rs
@@ -1,0 +1,137 @@
+//! Create the metering module's `requests` table.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(Requests::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(Requests::RequestId)
+                            .string()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(Requests::UserId).string().not_null())
+                    .col(ColumnDef::new(Requests::ApiKeyId).string().not_null())
+                    .col(ColumnDef::new(Requests::ModelId).string().not_null())
+                    .col(ColumnDef::new(Requests::ProviderId).string().not_null())
+                    .col(
+                        ColumnDef::new(Requests::PromptTokens)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(Requests::CompletionTokens)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(Requests::ReasoningTokens)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(Requests::CacheReadTokens)
+                            .big_integer()
+                            .not_null()
+                            .default(0),
+                    )
+                    .col(
+                        ColumnDef::new(Requests::CacheWriteTokens)
+                            .big_integer()
+                            .not_null()
+                            .default(0),
+                    )
+                    .col(
+                        ColumnDef::new(Requests::EstimatedChargeMicroUsd)
+                            .big_integer()
+                            .not_null()
+                            .default(0),
+                    )
+                    .col(
+                        ColumnDef::new(Requests::Streamed)
+                            .integer()
+                            .not_null()
+                            .default(0),
+                    )
+                    .col(
+                        ColumnDef::new(Requests::LatencyMs)
+                            .big_integer()
+                            .not_null()
+                            .default(0),
+                    )
+                    .col(
+                        ColumnDef::new(Requests::GenerationTimeMs)
+                            .big_integer()
+                            .not_null()
+                            .default(0),
+                    )
+                    .col(ColumnDef::new(Requests::Error).string())
+                    .col(ColumnDef::new(Requests::CreatedAt).string().not_null())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .if_not_exists()
+                    .name("idx_requests_api_key_created")
+                    .table(Requests::Table)
+                    .col(Requests::ApiKeyId)
+                    .col(Requests::CreatedAt)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .if_not_exists()
+                    .name("idx_requests_user_created")
+                    .table(Requests::Table)
+                    .col(Requests::UserId)
+                    .col(Requests::CreatedAt)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(Requests::Table).to_owned())
+            .await?;
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+enum Requests {
+    Table,
+    RequestId,
+    UserId,
+    ApiKeyId,
+    ModelId,
+    ProviderId,
+    PromptTokens,
+    CompletionTokens,
+    ReasoningTokens,
+    CacheReadTokens,
+    CacheWriteTokens,
+    EstimatedChargeMicroUsd,
+    Streamed,
+    LatencyMs,
+    GenerationTimeMs,
+    Error,
+    CreatedAt,
+}

--- a/apps/bitrouter/src/db/migration/m20240101_000003_rename_legacy_charge_column.rs
+++ b/apps/bitrouter/src/db/migration/m20240101_000003_rename_legacy_charge_column.rs
@@ -1,0 +1,62 @@
+//! Rename the pre-OSS-refactor `requests.final_charge_micro_usd` column to
+//! the current `estimated_charge_micro_usd`.
+//!
+//! The pre-OSS-refactor schema named the column `final_charge_micro_usd`.
+//! The OSS metering module renamed it to `estimated_charge_micro_usd` for
+//! semantic clarity — we *measure*, cloud bills. A database created by the
+//! old code carries the legacy column, and an OSS recorder insert against
+//! it fails with `no such column: estimated_charge_micro_usd`.
+//!
+//! On a fresh database the previous migration already creates the column
+//! under its current name, so this migration inspects the live schema
+//! (portably, via `SchemaManager::has_column`) and renames in place only
+//! when the legacy column is the one actually present.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+const LEGACY: &str = "final_charge_micro_usd";
+const CURRENT: &str = "estimated_charge_micro_usd";
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let has_legacy = manager.has_column("requests", LEGACY).await?;
+        let has_current = manager.has_column("requests", CURRENT).await?;
+        if has_legacy && !has_current {
+            manager
+                .alter_table(
+                    Table::alter()
+                        .table(Requests::Table)
+                        .rename_column(Alias::new(LEGACY), Alias::new(CURRENT))
+                        .to_owned(),
+                )
+                .await?;
+            tracing::info!("metering: renamed legacy `requests.{LEGACY}` → `{CURRENT}`");
+        }
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let has_legacy = manager.has_column("requests", LEGACY).await?;
+        let has_current = manager.has_column("requests", CURRENT).await?;
+        if has_current && !has_legacy {
+            manager
+                .alter_table(
+                    Table::alter()
+                        .table(Requests::Table)
+                        .rename_column(Alias::new(CURRENT), Alias::new(LEGACY))
+                        .to_owned(),
+                )
+                .await?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+enum Requests {
+    Table,
+}

--- a/apps/bitrouter/src/db/migration/mod.rs
+++ b/apps/bitrouter/src/db/migration/mod.rs
@@ -1,0 +1,30 @@
+//! Schema migrations, as `sea-orm-migration` Rust code.
+//!
+//! Each migration is a `MigrationTrait` impl that builds tables and
+//! indexes through sea-orm's portable schema API — no hand-written SQL —
+//! so the identical schema applies on SQLite, Postgres and MySQL alike.
+//!
+//! Migration ordering is the order of the [`Migrator::migrations`] vec;
+//! applied migrations are recorded in the `seaql_migrations` table so a
+//! re-run is a no-op.
+
+pub mod m20240101_000001_create_auth_tables;
+pub mod m20240101_000002_create_metering_tables;
+pub mod m20240101_000003_rename_legacy_charge_column;
+
+use sea_orm_migration::{MigrationTrait, MigratorTrait};
+
+/// The bitrouter schema migrator — owns the ordered list of every
+/// migration the binary ships.
+pub struct Migrator;
+
+#[async_trait::async_trait]
+impl MigratorTrait for Migrator {
+    fn migrations() -> Vec<Box<dyn MigrationTrait>> {
+        vec![
+            Box::new(m20240101_000001_create_auth_tables::Migration),
+            Box::new(m20240101_000002_create_metering_tables::Migration),
+            Box::new(m20240101_000003_rename_legacy_charge_column::Migration),
+        ]
+    }
+}

--- a/apps/bitrouter/src/db/mod.rs
+++ b/apps/bitrouter/src/db/mod.rs
@@ -1,0 +1,113 @@
+//! Database layer: connection handling and schema migrations.
+//!
+//! bitrouter talks to its database exclusively through `sea-orm`, the
+//! high-level ORM abstraction — never a concrete driver. That buys two
+//! things:
+//!
+//! 1. **Every backend from one build.** `database.url` may be any URL
+//!    sea-orm understands — `sqlite://…`, `postgres://…`, `mysql://…`.
+//!    The default stays `sqlite://./bitrouter.db` for the local-first
+//!    story, but a multi-tenant deployment can point at Postgres without
+//!    a recompile.
+//! 2. **Schema as Rust, not SQL.** The schema lives in [`migration`] as
+//!    `sea-orm-migration` code, so the same table definitions apply
+//!    verbatim on whichever backend is configured.
+
+pub mod migration;
+
+use sea_orm::{ConnectOptions, Database, DatabaseConnection};
+use sea_orm_migration::MigratorTrait;
+
+use bitrouter_sdk::{BitrouterError, Result};
+
+/// Open a pooled connection to `url`. Accepts any backend sea-orm supports
+/// (`sqlite` / `postgres` / `mysql`).
+///
+/// Two backend-specific conveniences are applied so first-run "just works":
+///
+/// - A SQLite **file** URL gets `?mode=rwc` appended when it carries no
+///   explicit `mode=`, so a fresh `sqlite://./bitrouter.db` is created
+///   instead of failing with `SQLITE_CANTOPEN`.
+/// - A SQLite **in-memory** URL is pinned to a single pooled connection —
+///   otherwise each connection in the pool would see its own empty
+///   database.
+pub async fn connect(url: &str) -> Result<DatabaseConnection> {
+    let mut opts = ConnectOptions::new(normalize_url(url));
+    opts.sqlx_logging(false);
+    if is_sqlite_memory(url) {
+        opts.min_connections(1).max_connections(1);
+    }
+    Database::connect(opts)
+        .await
+        .map_err(|e| BitrouterError::internal(format!("connecting to database {url}: {e}")))
+}
+
+/// Apply every pending migration in [`migration::Migrator`]. Idempotent —
+/// already-applied migrations are skipped, tracked in `seaql_migrations`.
+pub async fn run_migrations(db: &DatabaseConnection) -> Result<()> {
+    migration::Migrator::up(db, None)
+        .await
+        .map_err(|e| BitrouterError::internal(format!("running database migrations: {e}")))?;
+    Ok(())
+}
+
+/// Whether `url` names an in-memory SQLite database.
+fn is_sqlite_memory(url: &str) -> bool {
+    url.starts_with("sqlite:") && url.contains(":memory:")
+}
+
+/// Append `?mode=rwc` to a SQLite file URL that carries no explicit `mode=`,
+/// so the database file is created on first run. Every other URL — including
+/// in-memory SQLite and all Postgres / MySQL URLs — is returned unchanged.
+fn normalize_url(url: &str) -> String {
+    let is_sqlite_file =
+        url.starts_with("sqlite:") && !url.contains(":memory:") && !url.contains("mode=");
+    if is_sqlite_file {
+        let sep = if url.contains('?') { '&' } else { '?' };
+        format!("{url}{sep}mode=rwc")
+    } else {
+        url.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sqlite_file_urls_get_mode_rwc() {
+        assert_eq!(
+            normalize_url("sqlite://./bitrouter.db"),
+            "sqlite://./bitrouter.db?mode=rwc"
+        );
+        assert_eq!(
+            normalize_url("sqlite://./bitrouter.db?cache=shared"),
+            "sqlite://./bitrouter.db?cache=shared&mode=rwc"
+        );
+    }
+
+    #[test]
+    fn explicit_mode_and_non_sqlite_urls_are_left_alone() {
+        // already has mode= → untouched
+        assert_eq!(
+            normalize_url("sqlite://./x.db?mode=ro"),
+            "sqlite://./x.db?mode=ro"
+        );
+        // in-memory → untouched
+        assert_eq!(normalize_url("sqlite::memory:"), "sqlite::memory:");
+        // postgres / mysql → untouched
+        assert_eq!(
+            normalize_url("postgres://u:p@host/db"),
+            "postgres://u:p@host/db"
+        );
+        assert_eq!(normalize_url("mysql://u:p@host/db"), "mysql://u:p@host/db");
+    }
+
+    #[test]
+    fn detects_in_memory_sqlite() {
+        assert!(is_sqlite_memory("sqlite::memory:"));
+        assert!(is_sqlite_memory("sqlite://:memory:"));
+        assert!(!is_sqlite_memory("sqlite://./bitrouter.db"));
+        assert!(!is_sqlite_memory("postgres://host/db"));
+    }
+}

--- a/apps/bitrouter/src/error_report.rs
+++ b/apps/bitrouter/src/error_report.rs
@@ -172,15 +172,16 @@ fn hint_for(root: &str) -> Option<String> {
                 .into(),
         );
     }
-    // Sqlite path didn't open. Match the specific phrasing from
+    // The database wouldn't open. Match the specific phrasing from
     // `BitrouterError::internal(format!("connecting to database {url}: …"))`
-    // in `apps/bitrouter/src/{auth,metering}/db.rs` — broad substring
-    // matching against bare "sqlite" would false-positive on unrelated
-    // migration / policy-store messages.
+    // in `apps/bitrouter/src/db/mod.rs` — broad substring matching against
+    // bare "sqlite" would false-positive on unrelated migration /
+    // policy-store messages.
     if root.contains("connecting to database") {
         return Some(
-            "Check the `database.url` value in bitrouter.yaml. For local use,\n\
-             `sqlite://./bitrouter.db` is the default; the file is created on first run."
+            "Check the `database.url` value in bitrouter.yaml. sqlite, postgres\n\
+             and mysql URLs are all supported; `sqlite://./bitrouter.db` is the\n\
+             default and the file is created on first run."
                 .into(),
         );
     }

--- a/apps/bitrouter/src/lib.rs
+++ b/apps/bitrouter/src/lib.rs
@@ -16,6 +16,7 @@ pub mod assemble;
 pub mod auth;
 pub mod commands;
 pub mod daemon;
+pub mod db;
 pub mod error_report;
 pub mod metering;
 pub mod paths;

--- a/apps/bitrouter/src/main.rs
+++ b/apps/bitrouter/src/main.rs
@@ -266,7 +266,8 @@ enum KeyAction {
         /// The owning user id.
         #[arg(short, long)]
         user: String,
-        /// Database URL.
+        /// Database URL — any backend sea-orm supports
+        /// (`sqlite://…`, `postgres://…`, `mysql://…`).
         #[arg(short, long, default_value = "sqlite://./bitrouter.db")]
         db: String,
         /// Optional policy id to bind to the key (the `policy_id` column).

--- a/apps/bitrouter/src/metering/db.rs
+++ b/apps/bitrouter/src/metering/db.rs
@@ -1,92 +1,15 @@
-//! Metering schema + the `RequestMetric` row.
+//! The `RequestMetric` row — the typed shape the recorder writes and the
+//! store persists into the `requests` table.
 //!
 //! v1 schema: a single `requests` table that records pipeline-observed
 //! usage + the estimated micro-USD computed from the pricing table. No
 //! charge state, no funding source — those are billing concepts, and
 //! this OSS module measures, not bills.
-
-use bitrouter_sdk::{BitrouterError, Result};
-use sqlx::{Row, SqlitePool};
-
-/// The SQL that creates this module's tables. Run once at startup.
-pub const MIGRATION_SQL: &str = r#"
-CREATE TABLE IF NOT EXISTS requests (
-    request_id                      TEXT PRIMARY KEY,
-    user_id                         TEXT NOT NULL,
-    api_key_id                      TEXT NOT NULL,
-    model_id                        TEXT NOT NULL,
-    provider_id                     TEXT NOT NULL,
-    prompt_tokens                   INTEGER NOT NULL,
-    completion_tokens               INTEGER NOT NULL,
-    reasoning_tokens                INTEGER NOT NULL,
-    cache_read_tokens               INTEGER NOT NULL DEFAULT 0,
-    cache_write_tokens              INTEGER NOT NULL DEFAULT 0,
-    estimated_charge_micro_usd      INTEGER NOT NULL DEFAULT 0,
-    streamed                        INTEGER NOT NULL DEFAULT 0,
-    latency_ms                      INTEGER NOT NULL DEFAULT 0,
-    generation_time_ms              INTEGER NOT NULL DEFAULT 0,
-    error                           TEXT,
-    created_at                      TEXT NOT NULL
-);
-CREATE INDEX IF NOT EXISTS idx_requests_api_key_created
-    ON requests(api_key_id, created_at);
-CREATE INDEX IF NOT EXISTS idx_requests_user_created
-    ON requests(user_id, created_at);
-"#;
-
-/// Create the metering tables on `pool`. Idempotent.
-///
-/// Also handles the schema rename from the pre-OSS-refactor column name
-/// `final_charge_micro_usd` to the current `estimated_charge_micro_usd`.
-/// A pre-refactor `.db` file would otherwise have the old column and
-/// every recorder insert would fail with `no such column:
-/// estimated_charge_micro_usd`. The rename is detected by inspecting
-/// `pragma_table_info(requests)` and applied with `ALTER TABLE … RENAME
-/// COLUMN`, which SQLite supports natively since 3.25.0.
-pub async fn migrate(pool: &SqlitePool) -> Result<()> {
-    for stmt in MIGRATION_SQL.split(';') {
-        let stmt = stmt.trim();
-        if stmt.is_empty() {
-            continue;
-        }
-        sqlx::query(stmt)
-            .execute(pool)
-            .await
-            .map_err(|e| BitrouterError::internal(format!("metering migration: {e}")))?;
-    }
-    rename_legacy_charge_column(pool).await?;
-    Ok(())
-}
-
-/// Pre-OSS-refactor schema named the column `final_charge_micro_usd`. The
-/// OSS metering module renamed it to `estimated_charge_micro_usd` for
-/// semantic clarity (we measure; cloud bills). This helper looks for the
-/// legacy column on existing databases and renames it in place.
-async fn rename_legacy_charge_column(pool: &SqlitePool) -> Result<()> {
-    let columns: Vec<String> = sqlx::query("PRAGMA table_info(requests)")
-        .fetch_all(pool)
-        .await
-        .map_err(|e| BitrouterError::internal(format!("metering migration probe: {e}")))?
-        .into_iter()
-        .map(|row| row.get::<String, _>("name"))
-        .collect();
-    let has_legacy = columns.iter().any(|c| c == "final_charge_micro_usd");
-    let has_current = columns.iter().any(|c| c == "estimated_charge_micro_usd");
-    if has_legacy && !has_current {
-        sqlx::query(
-            "ALTER TABLE requests RENAME COLUMN final_charge_micro_usd \
-             TO estimated_charge_micro_usd",
-        )
-        .execute(pool)
-        .await
-        .map_err(|e| BitrouterError::internal(format!("metering migration rename: {e}")))?;
-        tracing::info!(
-            "metering: renamed legacy `requests.final_charge_micro_usd` → \
-             `estimated_charge_micro_usd`"
-        );
-    }
-    Ok(())
-}
+//!
+//! The `requests` table is created by the sea-orm migrations in
+//! `crate::db::migration` (including the in-place rename of the
+//! pre-OSS-refactor `final_charge_micro_usd` column); this module only
+//! reads and writes rows.
 
 /// One settled request, as recorded by [`super::MeteringRecorder`].
 #[derive(Debug, Clone)]

--- a/apps/bitrouter/src/metering/entities/mod.rs
+++ b/apps/bitrouter/src/metering/entities/mod.rs
@@ -1,0 +1,3 @@
+//! sea-orm entity definitions for the metering module's tables.
+
+pub mod requests;

--- a/apps/bitrouter/src/metering/entities/requests.rs
+++ b/apps/bitrouter/src/metering/entities/requests.rs
@@ -1,0 +1,47 @@
+//! The `requests` table — one row per settled request.
+
+use sea_orm::entity::prelude::*;
+
+/// One row of the `requests` table.
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "requests")]
+pub struct Model {
+    /// Unique request id.
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub request_id: String,
+    /// Owning user id.
+    pub user_id: String,
+    /// API key id that made the request.
+    pub api_key_id: String,
+    /// Resolved model id.
+    pub model_id: String,
+    /// Resolved provider id.
+    pub provider_id: String,
+    /// Prompt tokens consumed.
+    pub prompt_tokens: i64,
+    /// Completion tokens consumed.
+    pub completion_tokens: i64,
+    /// Reasoning tokens consumed.
+    pub reasoning_tokens: i64,
+    /// Cache-read prompt tokens.
+    pub cache_read_tokens: i64,
+    /// Cache-write prompt tokens.
+    pub cache_write_tokens: i64,
+    /// Estimated charge in micro-USD computed from pricing × tokens.
+    pub estimated_charge_micro_usd: i64,
+    /// Whether the request was streamed (`1`) or not (`0`).
+    pub streamed: i32,
+    /// End-to-end latency in milliseconds.
+    pub latency_ms: i64,
+    /// Upstream generation time in milliseconds.
+    pub generation_time_ms: i64,
+    /// Error string if the request failed, else `None`.
+    pub error: Option<String>,
+    /// RFC3339 creation timestamp.
+    pub created_at: String,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/apps/bitrouter/src/metering/mod.rs
+++ b/apps/bitrouter/src/metering/mod.rs
@@ -23,6 +23,7 @@
 //! billing plugins via their own recorder.
 
 pub mod db;
+pub mod entities;
 pub mod pricing;
 pub mod recorder;
 pub mod store;
@@ -30,7 +31,7 @@ pub mod store;
 #[cfg(test)]
 mod tests;
 
-pub use db::{RequestMetric, migrate};
+pub use db::RequestMetric;
 pub use pricing::{ModelPricing, PricingTable, calculate_charge_micro_usd};
 pub use recorder::MeteringRecorder;
 pub use store::{MeteringStore, RateMetrics, TimeWindow, TokenUsage};

--- a/apps/bitrouter/src/metering/store.rs
+++ b/apps/bitrouter/src/metering/store.rs
@@ -1,14 +1,26 @@
-//! `MeteringStore` — SQLite read+write for the `requests` table.
+//! `MeteringStore` — read+write access to the `requests` table.
 //!
 //! Single writer ([`super::MeteringRecorder`]), multiple readers (the
 //! `policy` module's spend-cap enforcement; future analytics CLI).
+//!
+//! Every query goes through sea-orm, so the store works unchanged on
+//! whichever backend `database.url` selects (SQLite / Postgres / MySQL).
+//! The window rollups (`SUM` of charges / tokens) are folded in Rust
+//! rather than as a SQL aggregate: `SUM` returns a different value type
+//! per backend (`integer` / `numeric` / `decimal`), and folding the rows
+//! sidesteps that entirely. The metering windows are bounded (at most one
+//! month) so the row counts stay modest for a local-first deployment.
 
 use chrono::{DateTime, Datelike, Duration, TimeZone, Utc};
-use sqlx::{Row, SqlitePool};
+use sea_orm::sea_query::OnConflict;
+use sea_orm::{
+    ColumnTrait, DatabaseConnection, EntityTrait, PaginatorTrait, QueryFilter, QuerySelect, Set,
+};
 
 use bitrouter_sdk::{BitrouterError, Result};
 
 use crate::metering::db::RequestMetric;
+use crate::metering::entities::requests;
 
 /// A rolling time window for usage queries.
 #[derive(Debug, Clone, Copy)]
@@ -52,52 +64,43 @@ pub struct RateMetrics {
     pub tokens_per_minute: f64,
 }
 
-/// SQLite-backed metering store.
+/// sea-orm-backed metering store.
 #[derive(Clone)]
 pub struct MeteringStore {
-    pool: SqlitePool,
+    db: DatabaseConnection,
 }
 
 impl MeteringStore {
-    /// Build a store over a sqlite pool. The pool must already carry the
-    /// `requests` table (`crate::metering::db::migrate`).
-    pub fn new(pool: SqlitePool) -> Self {
-        Self { pool }
-    }
-
-    /// Shared access to the underlying pool (used by tests and by sibling
-    /// OSS business modules that want to share the same DB).
-    pub fn pool(&self) -> &SqlitePool {
-        &self.pool
+    /// Build a store over a database connection. The database must already
+    /// carry the `requests` table (`crate::db::run_migrations`).
+    pub fn new(db: DatabaseConnection) -> Self {
+        Self { db }
     }
 
     /// Total estimated spend (micro-USD) for `api_key_id` within `window`.
     pub async fn get_spend(&self, api_key_id: &str, window: TimeWindow) -> Result<u64> {
         let start = window_start(window).to_rfc3339();
-        let row = sqlx::query(
-            "SELECT COALESCE(SUM(estimated_charge_micro_usd), 0) AS total \
-             FROM requests WHERE api_key_id = ? AND created_at >= ?",
-        )
-        .bind(api_key_id)
-        .bind(&start)
-        .fetch_one(&self.pool)
-        .await
-        .map_err(|e| BitrouterError::internal(format!("get_spend: {e}")))?;
-        Ok(row.get::<i64, _>("total").max(0) as u64)
+        let charges: Vec<i64> = requests::Entity::find()
+            .select_only()
+            .column(requests::Column::EstimatedChargeMicroUsd)
+            .filter(requests::Column::ApiKeyId.eq(api_key_id))
+            .filter(requests::Column::CreatedAt.gte(start))
+            .into_tuple()
+            .all(&self.db)
+            .await
+            .map_err(|e| BitrouterError::internal(format!("get_spend: {e}")))?;
+        Ok(charges.into_iter().map(|c| c.max(0) as u64).sum())
     }
 
     /// Total request count for `api_key_id` within `window`.
     pub async fn get_request_count(&self, api_key_id: &str, window: TimeWindow) -> Result<u64> {
         let start = window_start(window).to_rfc3339();
-        let row = sqlx::query(
-            "SELECT COUNT(*) AS n FROM requests WHERE api_key_id = ? AND created_at >= ?",
-        )
-        .bind(api_key_id)
-        .bind(&start)
-        .fetch_one(&self.pool)
-        .await
-        .map_err(|e| BitrouterError::internal(format!("get_request_count: {e}")))?;
-        Ok(row.get::<i64, _>("n").max(0) as u64)
+        requests::Entity::find()
+            .filter(requests::Column::ApiKeyId.eq(api_key_id))
+            .filter(requests::Column::CreatedAt.gte(start))
+            .count(&self.db)
+            .await
+            .map_err(|e| BitrouterError::internal(format!("get_request_count: {e}")))
     }
 
     /// Token usage for `api_key_id` on `model` within `window`.
@@ -108,19 +111,19 @@ impl MeteringStore {
         window: TimeWindow,
     ) -> Result<TokenUsage> {
         let start = window_start(window).to_rfc3339();
-        let row = sqlx::query(
-            "SELECT COALESCE(SUM(prompt_tokens), 0) AS pt, \
-             COALESCE(SUM(completion_tokens), 0) AS ct \
-             FROM requests WHERE api_key_id = ? AND model_id = ? AND created_at >= ?",
-        )
-        .bind(api_key_id)
-        .bind(model)
-        .bind(&start)
-        .fetch_one(&self.pool)
-        .await
-        .map_err(|e| BitrouterError::internal(format!("get_token_usage: {e}")))?;
-        let prompt = row.get::<i64, _>("pt").max(0) as u64;
-        let completion = row.get::<i64, _>("ct").max(0) as u64;
+        let rows: Vec<(i64, i64)> = requests::Entity::find()
+            .select_only()
+            .column(requests::Column::PromptTokens)
+            .column(requests::Column::CompletionTokens)
+            .filter(requests::Column::ApiKeyId.eq(api_key_id))
+            .filter(requests::Column::ModelId.eq(model))
+            .filter(requests::Column::CreatedAt.gte(start))
+            .into_tuple()
+            .all(&self.db)
+            .await
+            .map_err(|e| BitrouterError::internal(format!("get_token_usage: {e}")))?;
+        let prompt: u64 = rows.iter().map(|(p, _)| (*p).max(0) as u64).sum();
+        let completion: u64 = rows.iter().map(|(_, c)| (*c).max(0) as u64).sum();
         Ok(TokenUsage {
             prompt_tokens: prompt,
             completion_tokens: completion,
@@ -131,70 +134,73 @@ impl MeteringStore {
     /// Current request/token rate for `api_key_id`.
     pub async fn get_rate(&self, api_key_id: &str) -> Result<RateMetrics> {
         let start = window_start(TimeWindow::LastMinute).to_rfc3339();
-        let row = sqlx::query(
-            "SELECT COUNT(*) AS n, \
-             COALESCE(SUM(prompt_tokens + completion_tokens), 0) AS tok \
-             FROM requests WHERE api_key_id = ? AND created_at >= ?",
-        )
-        .bind(api_key_id)
-        .bind(&start)
-        .fetch_one(&self.pool)
-        .await
-        .map_err(|e| BitrouterError::internal(format!("get_rate: {e}")))?;
+        let rows: Vec<(i64, i64)> = requests::Entity::find()
+            .select_only()
+            .column(requests::Column::PromptTokens)
+            .column(requests::Column::CompletionTokens)
+            .filter(requests::Column::ApiKeyId.eq(api_key_id))
+            .filter(requests::Column::CreatedAt.gte(start))
+            .into_tuple()
+            .all(&self.db)
+            .await
+            .map_err(|e| BitrouterError::internal(format!("get_rate: {e}")))?;
+        let tokens: u64 = rows
+            .iter()
+            .map(|(p, c)| (*p).max(0) as u64 + (*c).max(0) as u64)
+            .sum();
         Ok(RateMetrics {
-            requests_per_minute: row.get::<i64, _>("n").max(0) as f64,
-            tokens_per_minute: row.get::<i64, _>("tok").max(0) as f64,
+            requests_per_minute: rows.len() as f64,
+            tokens_per_minute: tokens as f64,
         })
     }
 
     /// Record one settled request. The single writer.
     pub async fn record_request(&self, record: RequestMetric) -> Result<()> {
+        let row = requests::ActiveModel {
+            request_id: Set(record.request_id),
+            user_id: Set(record.user_id),
+            api_key_id: Set(record.api_key_id),
+            model_id: Set(record.model_id),
+            provider_id: Set(record.provider_id),
+            prompt_tokens: Set(record.prompt_tokens as i64),
+            completion_tokens: Set(record.completion_tokens as i64),
+            reasoning_tokens: Set(record.reasoning_tokens as i64),
+            cache_read_tokens: Set(record.cache_read_tokens as i64),
+            cache_write_tokens: Set(record.cache_write_tokens as i64),
+            estimated_charge_micro_usd: Set(record.estimated_charge_micro_usd),
+            streamed: Set(record.streamed as i32),
+            latency_ms: Set(record.latency_ms as i64),
+            generation_time_ms: Set(record.generation_time_ms as i64),
+            error: Set(record.error),
+            created_at: Set(Utc::now().to_rfc3339()),
+        };
         // `ON CONFLICT(request_id) DO UPDATE` so a retried / streamed-then-
         // finalised write doesn't reset `created_at`; only mutable columns
         // refresh.
-        sqlx::query(
-            "INSERT INTO requests \
-             (request_id, user_id, api_key_id, model_id, provider_id, \
-              prompt_tokens, completion_tokens, reasoning_tokens, \
-              cache_read_tokens, cache_write_tokens, \
-              estimated_charge_micro_usd, streamed, \
-              latency_ms, generation_time_ms, error, created_at) \
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) \
-             ON CONFLICT(request_id) DO UPDATE SET \
-                user_id = excluded.user_id, \
-                api_key_id = excluded.api_key_id, \
-                model_id = excluded.model_id, \
-                provider_id = excluded.provider_id, \
-                prompt_tokens = excluded.prompt_tokens, \
-                completion_tokens = excluded.completion_tokens, \
-                reasoning_tokens = excluded.reasoning_tokens, \
-                cache_read_tokens = excluded.cache_read_tokens, \
-                cache_write_tokens = excluded.cache_write_tokens, \
-                estimated_charge_micro_usd = excluded.estimated_charge_micro_usd, \
-                streamed = excluded.streamed, \
-                latency_ms = excluded.latency_ms, \
-                generation_time_ms = excluded.generation_time_ms, \
-                error = excluded.error",
-        )
-        .bind(&record.request_id)
-        .bind(&record.user_id)
-        .bind(&record.api_key_id)
-        .bind(&record.model_id)
-        .bind(&record.provider_id)
-        .bind(record.prompt_tokens as i64)
-        .bind(record.completion_tokens as i64)
-        .bind(record.reasoning_tokens as i64)
-        .bind(record.cache_read_tokens as i64)
-        .bind(record.cache_write_tokens as i64)
-        .bind(record.estimated_charge_micro_usd)
-        .bind(record.streamed as i64)
-        .bind(record.latency_ms as i64)
-        .bind(record.generation_time_ms as i64)
-        .bind(&record.error)
-        .bind(Utc::now().to_rfc3339())
-        .execute(&self.pool)
-        .await
-        .map_err(|e| BitrouterError::internal(format!("record_request: {e}")))?;
+        requests::Entity::insert(row)
+            .on_conflict(
+                OnConflict::column(requests::Column::RequestId)
+                    .update_columns([
+                        requests::Column::UserId,
+                        requests::Column::ApiKeyId,
+                        requests::Column::ModelId,
+                        requests::Column::ProviderId,
+                        requests::Column::PromptTokens,
+                        requests::Column::CompletionTokens,
+                        requests::Column::ReasoningTokens,
+                        requests::Column::CacheReadTokens,
+                        requests::Column::CacheWriteTokens,
+                        requests::Column::EstimatedChargeMicroUsd,
+                        requests::Column::Streamed,
+                        requests::Column::LatencyMs,
+                        requests::Column::GenerationTimeMs,
+                        requests::Column::Error,
+                    ])
+                    .to_owned(),
+            )
+            .exec(&self.db)
+            .await
+            .map_err(|e| BitrouterError::internal(format!("record_request: {e}")))?;
         Ok(())
     }
 }

--- a/apps/bitrouter/src/metering/tests.rs
+++ b/apps/bitrouter/src/metering/tests.rs
@@ -1,18 +1,20 @@
-//! Metering integration tests against an in-memory SQLite pool.
+//! Metering integration tests against an in-memory SQLite database.
 
-use sqlx::SqlitePool;
 use std::sync::Arc;
+
+use sea_orm::{ConnectionTrait, DatabaseBackend, DatabaseConnection, Statement};
 
 use bitrouter_sdk::Result;
 use bitrouter_sdk::caller::CallerContext;
 use bitrouter_sdk::language_model::{SettlementContext, SettlementRecorder};
 
-use super::{MeteringRecorder, MeteringStore, ModelPricing, PricingTable, TimeWindow, migrate};
+use super::{MeteringRecorder, MeteringStore, ModelPricing, PricingTable, TimeWindow};
+use crate::db;
 
-async fn pool() -> SqlitePool {
-    let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
-    migrate(&pool).await.unwrap();
-    pool
+async fn pool() -> DatabaseConnection {
+    let db = db::connect("sqlite::memory:").await.unwrap();
+    db::run_migrations(&db).await.unwrap();
+    db
 }
 
 fn ctx(api_key: &str, prompt: u64, completion: u64) -> SettlementContext {
@@ -101,12 +103,15 @@ async fn spend_isolates_by_api_key() -> Result<()> {
 /// the new recorder writes work end-to-end.
 #[tokio::test]
 async fn migrate_renames_legacy_final_charge_column() -> Result<()> {
-    let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+    let pool = db::connect("sqlite::memory:").await.unwrap();
     // Stand up the pre-refactor schema (final_charge_micro_usd, no
     // cache_read/write columns — the renamer only handles the legacy
     // column; missing columns elsewhere would require a full v2
-    // migration which v1.0 doesn't ship).
-    sqlx::query(
+    // migration which v1.0 doesn't ship). Raw DDL is used here only to
+    // fabricate a *pre-migration* database; production schema is all
+    // sea-orm migration code.
+    pool.execute(Statement::from_string(
+        DatabaseBackend::Sqlite,
         "CREATE TABLE requests (\
             request_id                      TEXT PRIMARY KEY,\
             user_id                         TEXT NOT NULL,\
@@ -125,25 +130,24 @@ async fn migrate_renames_legacy_final_charge_column() -> Result<()> {
             error                           TEXT,\
             created_at                      TEXT NOT NULL\
          )",
-    )
-    .execute(&pool)
+    ))
     .await
     .unwrap();
 
     // Seed one row using the legacy column.
-    sqlx::query(
+    pool.execute(Statement::from_sql_and_values(
+        DatabaseBackend::Sqlite,
         "INSERT INTO requests VALUES (\
             'r-legacy', 'u', 'k', 'm', 'p', 1, 2, 0, 0, 0, 42, 0, 0, 0, NULL, ?\
          )",
-    )
-    .bind(chrono::Utc::now().to_rfc3339())
-    .execute(&pool)
+        [chrono::Utc::now().to_rfc3339().into()],
+    ))
     .await
     .unwrap();
 
-    // Run the new migration — it should detect the legacy column and
+    // Run the migrations — migration 3 should detect the legacy column and
     // rename it in place without losing the row.
-    migrate(&pool).await?;
+    db::run_migrations(&pool).await?;
 
     // Verify the row is reachable through the new column name.
     let store = MeteringStore::new(pool);

--- a/apps/bitrouter/src/policy/tests.rs
+++ b/apps/bitrouter/src/policy/tests.rs
@@ -2,18 +2,16 @@
 
 use std::sync::Arc;
 
+use crate::metering::{MeteringStore, RequestMetric};
+use crate::policy::hook::PolicyHook;
+use crate::policy::policy::Policy;
+use crate::policy::store::PolicyStore;
 use bitrouter_sdk::PluginId;
 use bitrouter_sdk::caller::CallerContext;
 use bitrouter_sdk::language_model::{
     GenerationParams, HookDecision, Message, PipelineContext, PipelineRequest, PreRequestHook,
     Prompt, Role, Tool,
 };
-use sqlx::SqlitePool;
-
-use crate::metering::{MeteringStore, RequestMetric, migrate as metering_migrate};
-use crate::policy::hook::PolicyHook;
-use crate::policy::policy::Policy;
-use crate::policy::store::PolicyStore;
 
 fn ctx(model: &str, policy_id: Option<&str>) -> PipelineContext {
     let prompt = Prompt {
@@ -67,9 +65,9 @@ fn ctx_with_tools(tools: &[&str], policy_id: Option<&str>) -> PipelineContext {
 }
 
 async fn fresh_metering() -> MeteringStore {
-    let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
-    metering_migrate(&pool).await.unwrap();
-    MeteringStore::new(pool)
+    let db = crate::db::connect("sqlite::memory:").await.unwrap();
+    crate::db::run_migrations(&db).await.unwrap();
+    MeteringStore::new(db)
 }
 
 #[tokio::test]

--- a/apps/bitrouter/tests/e2e.rs
+++ b/apps/bitrouter/tests/e2e.rs
@@ -14,10 +14,12 @@
 //! rather than in its own file.
 
 use axum_test::TestServer;
+use bitrouter::metering::entities::requests;
 use bitrouter_sdk::caller::CallerContext;
 use bitrouter_sdk::config;
 use bitrouter_sdk::language_model::{GenerationParams, Message, PipelineRequest, Prompt, Role};
 use bitrouter_sdk::server::{AppState, build_router};
+use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
 use serde_json::{Value, json};
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -112,14 +114,20 @@ async fn e2e_assembled_pipeline_routes_to_mock_provider() {
     assert_eq!(text, "hello from the mock upstream");
 
     // metering ran — a metering row exists with the full identity context.
-    let row: (i64, String) =
-        sqlx::query_as("SELECT estimated_charge_micro_usd, model_id FROM requests LIMIT 1")
-            .fetch_one(&assembled.pool)
-            .await
-            .expect("a metering row was written");
-    assert_eq!(row.1, "test-model", "metering row records the routed model");
+    let row = requests::Entity::find()
+        .one(&assembled.db)
+        .await
+        .expect("metering query runs")
+        .expect("a metering row was written");
+    assert_eq!(
+        row.model_id, "test-model",
+        "metering row records the routed model"
+    );
     // 11 prompt × 2 + 7 completion × 10 = 92 µ$
-    assert_eq!(row.0, 92, "estimated charge derived from pricing × tokens");
+    assert_eq!(
+        row.estimated_charge_micro_usd, 92,
+        "estimated charge derived from pricing × tokens"
+    );
 }
 
 #[tokio::test]
@@ -247,11 +255,11 @@ plugins:
 
     // Mint a `brvk_` key bound to `pol_cap`.
     let user = "spender";
-    auth_db::upsert_user(&assembled.pool, user).await.unwrap();
+    auth_db::upsert_user(&assembled.db, user).await.unwrap();
     let key = generate();
     let key_id = "spender-key".to_string();
     auth_db::insert_api_key(
-        &assembled.pool,
+        &assembled.db,
         &NewApiKey {
             id: key_id.clone(),
             key_hash: key.hash.clone(),
@@ -277,13 +285,16 @@ plugins:
     pipeline.execute(req1).await.expect("first request allowed");
 
     // Confirm the row landed with the expected estimated charge.
-    let row: (i64,) =
-        sqlx::query_as("SELECT estimated_charge_micro_usd FROM requests WHERE api_key_id = ?")
-            .bind(&key_id)
-            .fetch_one(&assembled.pool)
-            .await
-            .expect("metering wrote a row");
-    assert_eq!(row.0, 92, "first request bills 92µ$ (11×2 + 7×10)");
+    let row = requests::Entity::find()
+        .filter(requests::Column::ApiKeyId.eq(&key_id))
+        .one(&assembled.db)
+        .await
+        .expect("metering query runs")
+        .expect("metering wrote a row");
+    assert_eq!(
+        row.estimated_charge_micro_usd, 92,
+        "first request bills 92µ$ (11×2 + 7×10)"
+    );
 
     // Second request: 92µ$ already accrued ≥ 50µ$ cap → PolicyHook denies
     // at the `max_spend_micro_usd` check with 403.

--- a/apps/bitrouter/tests/full_stack.rs
+++ b/apps/bitrouter/tests/full_stack.rs
@@ -28,13 +28,15 @@ use wiremock::matchers::{method, path as wm_path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use bitrouter::auth::{NewApiKey, db as auth_db, generate};
+use bitrouter::metering::entities::requests;
+use sea_orm::{ColumnTrait, DatabaseConnection, EntityTrait, PaginatorTrait, QueryFilter};
 
 // ===== shared setup =====
 
 /// Everything one full-stack test needs after assembly.
 struct FullStack {
     server: TestServer,
-    pool: sqlx::SqlitePool,
+    db: DatabaseConnection,
     brvk_secret: String,
     upstream: MockServer,
     otlp_collector: MockServer,
@@ -137,11 +139,11 @@ plugins:
 
     // ── mint a brvk_ key bound to pol_main ──
     let user = "fullstack-user";
-    auth_db::upsert_user(&assembled.pool, user).await.unwrap();
+    auth_db::upsert_user(&assembled.db, user).await.unwrap();
     let key = generate();
     let key_id = "fullstack-key".to_string();
     auth_db::insert_api_key(
-        &assembled.pool,
+        &assembled.db,
         &NewApiKey {
             id: key_id,
             key_hash: key.hash.clone(),
@@ -166,7 +168,7 @@ plugins:
 
     FullStack {
         server,
-        pool: assembled.pool,
+        db: assembled.db,
         brvk_secret: key.secret,
         upstream,
         otlp_collector,
@@ -254,23 +256,28 @@ async fn e2e_full_stack_streaming_redacts_and_meters() {
 
     // The streaming pipeline finalises settlement asynchronously after
     // the last byte is sent; give the detached task a moment to land.
-    wait_for_metering_row(&fs.pool, "fullstack-key").await;
+    wait_for_metering_row(&fs.db, "fullstack-key").await;
 
     // ── MeteringRecorder ran: one row with streamed=1, identity intact ──
-    let row: (i64, String, i64) = sqlx::query_as(
-        "SELECT estimated_charge_micro_usd, model_id, streamed FROM requests \
-         WHERE api_key_id = 'fullstack-key' LIMIT 1",
-    )
-    .fetch_one(&fs.pool)
-    .await
-    .expect("metering wrote a row for the streamed request");
-    assert_eq!(row.1, "test-model", "metering row records the routed model");
-    assert_eq!(row.2, 1, "metering row marks the request as streamed");
+    let row = requests::Entity::find()
+        .filter(requests::Column::ApiKeyId.eq("fullstack-key"))
+        .one(&fs.db)
+        .await
+        .expect("metering query runs")
+        .expect("metering wrote a row for the streamed request");
+    assert_eq!(
+        row.model_id, "test-model",
+        "metering row records the routed model"
+    );
+    assert_eq!(
+        row.streamed, 1,
+        "metering row marks the request as streamed"
+    );
     // pricing 2µ$/prompt + 10µ$/completion × usage 11 + 7 = 92µ$.
     // Exact match so a regression that quietly halves the rate can't
     // sneak past with a > 0 check.
     assert_eq!(
-        row.0, 92,
+        row.estimated_charge_micro_usd, 92,
         "estimated_charge_micro_usd should be 2*11 + 10*7 = 92µ$",
     );
 
@@ -323,13 +330,13 @@ async fn e2e_full_stack_guardrail_blocks_at_pre_request() {
     );
 
     // No metering row.
-    let row_count: (i64,) =
-        sqlx::query_as("SELECT COUNT(*) FROM requests WHERE api_key_id = 'fullstack-key'")
-            .fetch_one(&fs.pool)
-            .await
-            .expect("count query runs");
+    let row_count = requests::Entity::find()
+        .filter(requests::Column::ApiKeyId.eq("fullstack-key"))
+        .count(&fs.db)
+        .await
+        .expect("count query runs");
     assert_eq!(
-        row_count.0, 0,
+        row_count, 0,
         "blocked request must not produce a metering row",
     );
 }
@@ -366,12 +373,12 @@ async fn e2e_full_stack_policy_denies_disallowed_tool_before_guardrails() {
     // No upstream call, no metering row.
     let upstream_requests = fs.upstream.received_requests().await.unwrap_or_default();
     assert!(upstream_requests.is_empty());
-    let row_count: (i64,) =
-        sqlx::query_as("SELECT COUNT(*) FROM requests WHERE api_key_id = 'fullstack-key'")
-            .fetch_one(&fs.pool)
-            .await
-            .expect("count query runs");
-    assert_eq!(row_count.0, 0);
+    let row_count = requests::Entity::find()
+        .filter(requests::Column::ApiKeyId.eq("fullstack-key"))
+        .count(&fs.db)
+        .await
+        .expect("count query runs");
+    assert_eq!(row_count, 0);
 }
 
 // ===== helpers =====
@@ -386,14 +393,14 @@ const POLL_INTERVAL_MS: u64 = 50;
 /// Streaming settlement is detached after the response finishes — poll
 /// for the metering row to appear so the test doesn't race the pipeline's
 /// background task.
-async fn wait_for_metering_row(pool: &sqlx::SqlitePool, api_key_id: &str) {
+async fn wait_for_metering_row(db: &DatabaseConnection, api_key_id: &str) {
     for _ in 0..(ASYNC_WAIT_BUDGET_MS / POLL_INTERVAL_MS) {
-        let row: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM requests WHERE api_key_id = ?")
-            .bind(api_key_id)
-            .fetch_one(pool)
+        let count = requests::Entity::find()
+            .filter(requests::Column::ApiKeyId.eq(api_key_id))
+            .count(db)
             .await
             .expect("count query runs");
-        if row.0 >= 1 {
+        if count >= 1 {
             return;
         }
         tokio::time::sleep(Duration::from_millis(POLL_INTERVAL_MS)).await;


### PR DESCRIPTION
## What

bitrouter now talks to its database exclusively through **sea-orm**, the high-level ORM abstraction. `sqlx` and the SQLite driver are no longer direct dependencies — they survive only as a transitive detail *inside* sea-orm.

## Migrations as Rust code, not SQL

New `apps/bitrouter/src/db/migration/` holds three `sea-orm-migration` `MigrationTrait` impls built with sea-orm's portable schema API:

- `m20240101_000001_create_auth_tables` — `users` + `api_keys` + index
- `m20240101_000002_create_metering_tables` — `requests` + two indexes
- `m20240101_000003_rename_legacy_charge_column` — the `final_charge_micro_usd → estimated_charge_micro_usd` rename, now portable via `SchemaManager::has_column` (replacing the SQLite-only `PRAGMA table_info` probe)

Applied migrations are tracked in `seaql_migrations`; re-runs are no-ops. The old raw `MIGRATION_SQL` strings and per-module `migrate()` functions are gone.

## All backends sea-orm supports, from one build

- Workspace dep `sqlx` → `sea-orm` + `sea-orm-migration` with `sqlx-sqlite` / `sqlx-postgres` / `sqlx-mysql` enabled.
- New `db::connect()` accepts any `sqlite://` / `postgres://` / `mysql://` URL; appends `?mode=rwc` only for SQLite files (first-run create) and pins in-memory SQLite to a single connection.
- `database.url` default stays `sqlite://./bitrouter.db`; the `key sign --db` help and error-report hint now mention all three backends.
- The 0600 chmod and `sqlite_file_path` are scoped to SQLite URLs only — a Postgres/MySQL URL is never mistaken for a local path.

## No concrete-driver dependency

- New sea-orm entities for `users`, `api_keys`, `requests`.
- `auth/db.rs` and `metering/store.rs` rewritten with sea-orm entity queries; `AuthHook` / `MeteringStore` / `Assembled` carry a `DatabaseConnection` instead of `SqlitePool`.
- Window rollups fold rows in Rust rather than as a SQL `SUM` aggregate, whose result type differs per backend (`integer` / `numeric` / `decimal`).
- Unit and integration tests (`e2e`, `full_stack`) converted off raw `sqlx` to sea-orm.

## Checks

- `cargo check --workspace --all-features` ✓
- `cargo nextest run -p bitrouter --all-features` → 138/138 passed ✓ (incl. the legacy column-rename regression test)
- `cargo clippy --all-features` ✓
- `cargo fmt -- --check` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)