### PR TITLE
fix(daemon): re-apply built-in provider catalog on file reload

### DIFF
--- a/apps/bitrouter/src/lib.rs
+++ b/apps/bitrouter/src/lib.rs
@@ -21,6 +21,7 @@ pub mod error_report;
 pub mod metering;
 pub mod paths;
 pub mod policy;
+pub mod reload;
 pub mod style;
 pub mod tools;
 

--- a/apps/bitrouter/src/main.rs
+++ b/apps/bitrouter/src/main.rs
@@ -496,76 +496,6 @@ async fn resolve_client_socket_from(
     }
 }
 
-/// Whether the daemon is running against a `bitrouter.yaml` on disk
-/// (re-readable on reload) or a zero-config in-memory default
-/// (rebuilt by re-running [`bitrouter_providers::zero_config`]).
-enum ReloadSource {
-    /// File-backed; the routing table's own `reload` re-reads from
-    /// `path` and re-substitutes `${VAR}` references.
-    File,
-    /// In-memory zero-config; the reloader rebuilds the Config from
-    /// scratch and hands it to the routing table via
-    /// `replace_config`.
-    Default,
-}
-
-/// Fan out a daemon `Reload` (and SIGHUP) to every reloadable subsystem the
-/// running daemon owns. Failures from any single subsystem are accumulated and
-/// reported together so an unrelated subsystem (e.g. a missing policy dir)
-/// doesn't mask a fixable routing-table reload.
-struct AppReloader {
-    app: Arc<bitrouter_sdk::App>,
-    policy_store: Arc<bitrouter::policy::PolicyStore>,
-    /// Concrete handle on the routing table, used for zero-config
-    /// rebuilds where the pipeline's `&dyn RoutingTable` can't reach
-    /// `ConfigRoutingTable::replace_config`.
-    routing_table: Arc<bitrouter_sdk::config::ConfigRoutingTable>,
-    source: ReloadSource,
-}
-
-#[async_trait::async_trait]
-impl daemon::DaemonReloader for AppReloader {
-    async fn reload(&self) -> anyhow::Result<()> {
-        let mut errors: Vec<String> = Vec::new();
-        let routing_outcome = match self.source {
-            // File source: the routing table knows its own path and
-            // re-reads YAML there. `${VAR}` substitution flows through
-            // `env_lookup`, so any env override the CLI just installed
-            // takes effect.
-            ReloadSource::File => {
-                if let Some(pipeline) = self.app.language_model() {
-                    pipeline.routing_table().reload().await
-                } else {
-                    Ok(())
-                }
-            }
-            // Default source: no file to re-read. Rebuild a fresh
-            // zero-config `Config` (which goes through `env_lookup`
-            // too), then apply built-in catalog defaults so every
-            // newly-auto-enabled provider has its `api_base` /
-            // `api_protocol` / `api_key` filled — `replace_config`
-            // calls `discover_models`, which needs `api_base` to talk
-            // to `/models`.
-            ReloadSource::Default => {
-                let mut fresh = bitrouter_providers::zero_config();
-                bitrouter_providers::apply_builtin_defaults(&mut fresh);
-                self.routing_table.replace_config(fresh).await
-            }
-        };
-        if let Err(e) = routing_outcome {
-            errors.push(format!("routing table: {e}"));
-        }
-        if let Err(e) = self.policy_store.reload().await {
-            errors.push(format!("policy store: {e}"));
-        }
-        if errors.is_empty() {
-            Ok(())
-        } else {
-            Err(anyhow::anyhow!(errors.join("; ")))
-        }
-    }
-}
-
 async fn serve(source: &bitrouter::paths::ConfigSource) -> Result<()> {
     // Ensure the bitrouter home directory exists (zero-config first-run
     // creates `~/.bitrouter` on demand) and chdir into it. Every
@@ -600,17 +530,17 @@ async fn serve(source: &bitrouter::paths::ConfigSource) -> Result<()> {
     let assembled = bitrouter::build_app_with_path(&cfg, config_path_for_reload).await?;
     let app = Arc::new(assembled.app);
     let policy_store = assembled.policy_store;
-    let reload_source = if source.is_default() {
-        ReloadSource::Default
-    } else {
-        ReloadSource::File
+    let reload_source = match source {
+        bitrouter::paths::ConfigSource::File(path) => {
+            bitrouter::reload::ReloadSource::File(path.clone())
+        }
+        bitrouter::paths::ConfigSource::Default { .. } => bitrouter::reload::ReloadSource::Default,
     };
-    let reloader: Arc<dyn daemon::DaemonReloader> = Arc::new(AppReloader {
-        app: app.clone(),
-        policy_store: policy_store.clone(),
-        routing_table: assembled.routing_table,
-        source: reload_source,
-    });
+    let reloader: Arc<dyn daemon::DaemonReloader> = Arc::new(bitrouter::reload::AppReloader::new(
+        policy_store.clone(),
+        assembled.routing_table,
+        reload_source,
+    ));
 
     daemon::write_pid_file(&pid_path).await?;
     println!(

--- a/apps/bitrouter/src/reload.rs
+++ b/apps/bitrouter/src/reload.rs
@@ -1,0 +1,112 @@
+//! `AppReloader` — the daemon's config hot-reload fan-out.
+//!
+//! Kept in the lib (not `main.rs`) so the reload behaviour is testable
+//! without spawning the binary — the same reason `commands.rs` lives here.
+//!
+//! Both reload paths build a fresh `Config` **in the app layer** and swap
+//! it into the routing table via `ConfigRoutingTable::replace_config`.
+//! Building the config here — above `bitrouter-providers` — is what lets
+//! [`bitrouter_providers::apply_builtin_defaults`] fill the empty fields
+//! of a built-in provider (`openai: {}`). The SDK's own
+//! `RoutingTable::reload` sits *below* `bitrouter-providers` and so cannot
+//! apply the catalog; routing through it on reload would leave a built-in
+//! provider with an empty `api_base`, and an `auto_discover` provider
+//! would then silently drop every model.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use crate::daemon::DaemonReloader;
+use crate::policy::PolicyStore;
+
+/// Whether the daemon is running against a `bitrouter.yaml` on disk
+/// (re-readable on reload) or a zero-config in-memory default
+/// (rebuilt by re-running [`bitrouter_providers::zero_config`]).
+pub enum ReloadSource {
+    /// File-backed; the reloader re-reads the `bitrouter.yaml` at this
+    /// path (re-substituting `${VAR}` references), re-applies the
+    /// built-in provider catalog, and swaps the result into the
+    /// routing table.
+    File(PathBuf),
+    /// In-memory zero-config; the reloader rebuilds the Config from
+    /// scratch and hands it to the routing table via `replace_config`.
+    Default,
+}
+
+/// Fan out a daemon `Reload` (and SIGHUP) to every reloadable subsystem the
+/// running daemon owns. Failures from any single subsystem are accumulated and
+/// reported together so an unrelated subsystem (e.g. a missing policy dir)
+/// doesn't mask a fixable routing-table reload.
+pub struct AppReloader {
+    policy_store: Arc<PolicyStore>,
+    /// Concrete handle on the routing table. Both reload paths build a
+    /// fresh `Config` in the app layer — so `bitrouter_providers`'
+    /// built-in catalog can be applied above the SDK — and swap it in
+    /// via `ConfigRoutingTable::replace_config`.
+    routing_table: Arc<bitrouter_sdk::config::ConfigRoutingTable>,
+    source: ReloadSource,
+}
+
+impl AppReloader {
+    /// Build a reloader over the daemon's reloadable subsystems.
+    pub fn new(
+        policy_store: Arc<PolicyStore>,
+        routing_table: Arc<bitrouter_sdk::config::ConfigRoutingTable>,
+        source: ReloadSource,
+    ) -> Self {
+        Self {
+            policy_store,
+            routing_table,
+            source,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl DaemonReloader for AppReloader {
+    async fn reload(&self) -> anyhow::Result<()> {
+        let mut errors: Vec<String> = Vec::new();
+        let routing_outcome = match &self.source {
+            // File source: re-read the YAML (so `${VAR}` substitution
+            // picks up any env override the CLI just installed), then
+            // apply the built-in catalog. This is done in the app layer
+            // — not via the SDK's `RoutingTable::reload`, which sits
+            // below `bitrouter-providers` and so can't fill empty
+            // built-in fields — so a provider like `openai: {}` keeps
+            // its `api_base` / `api_protocol` / `api_key`. Without it an
+            // `auto_discover` provider would reload with an empty
+            // `api_base` and silently drop every model. `replace_config`
+            // then runs `discover_models` against the populated config.
+            ReloadSource::File(path) => match bitrouter_sdk::config::load(path).await {
+                Ok(mut fresh) => {
+                    bitrouter_providers::apply_builtin_defaults(&mut fresh);
+                    self.routing_table.replace_config(fresh).await
+                }
+                Err(e) => Err(e),
+            },
+            // Default source: no file to re-read. Rebuild a fresh
+            // zero-config `Config` (which goes through `env_lookup`
+            // too), then apply built-in catalog defaults so every
+            // newly-auto-enabled provider has its `api_base` /
+            // `api_protocol` / `api_key` filled — `replace_config`
+            // calls `discover_models`, which needs `api_base` to talk
+            // to `/models`.
+            ReloadSource::Default => {
+                let mut fresh = bitrouter_providers::zero_config();
+                bitrouter_providers::apply_builtin_defaults(&mut fresh);
+                self.routing_table.replace_config(fresh).await
+            }
+        };
+        if let Err(e) = routing_outcome {
+            errors.push(format!("routing table: {e}"));
+        }
+        if let Err(e) = self.policy_store.reload().await {
+            errors.push(format!("policy store: {e}"));
+        }
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(anyhow::anyhow!(errors.join("; ")))
+        }
+    }
+}

--- a/apps/bitrouter/tests/daemon.rs
+++ b/apps/bitrouter/tests/daemon.rs
@@ -209,6 +209,72 @@ providers:
     let _ = tokio::fs::remove_dir_all(&dir).await;
 }
 
+/// Regression: the production `AppReloader` must re-apply the built-in
+/// provider catalog on a file reload. `openai` here is declared with no
+/// `api_base` — it comes from the compiled-in catalog at assembly time.
+/// If the reload path swapped in a bare file re-read (skipping
+/// `apply_builtin_defaults`), the provider would come back with an empty
+/// `api_base`, and an `auto_discover` provider would then silently drop
+/// every model. The SDK's own `RoutingTable::reload` cannot fix this — it
+/// sits below `bitrouter-providers` — so the reloader rebuilds the config
+/// in the app layer.
+#[tokio::test]
+async fn reload_re_applies_builtin_provider_catalog() {
+    use bitrouter::daemon::DaemonReloader;
+    use bitrouter::reload::{AppReloader, ReloadSource};
+
+    let dir = tempdir("reload-builtin");
+    tokio::fs::create_dir_all(&dir).await.unwrap();
+    let cfg_path = dir.join("bitrouter.yaml");
+    // `openai` is a built-in: `api_base` is omitted and must be filled
+    // from the catalog. Explicit `models` keep discovery off the network.
+    let yaml = r#"
+server:
+  listen: "127.0.0.1:0"
+  skip_auth: true
+database:
+  url: "sqlite::memory:"
+inherit_defaults: true
+providers:
+  openai:
+    api_key: k1
+    models: [{ id: gpt-5 }]
+"#;
+    tokio::fs::write(&cfg_path, yaml).await.unwrap();
+
+    let cfg = config::load(&cfg_path).await.unwrap();
+    let assembled = build_app_with_path(&cfg, Some(&cfg_path)).await.unwrap();
+
+    // Sanity: assembly already filled the catalog `api_base`.
+    assert_eq!(
+        assembled.routing_table.snapshot_config().providers["openai"].api_base,
+        "https://api.openai.com/v1",
+    );
+
+    let reloader = AppReloader::new(
+        assembled.policy_store.clone(),
+        assembled.routing_table.clone(),
+        ReloadSource::File(cfg_path.clone()),
+    );
+    reloader.reload().await.expect("reload succeeds");
+
+    // The reloaded config must STILL carry the catalog `api_base` and
+    // `api_protocol` — the reload re-applies `apply_builtin_defaults`,
+    // not just a bare file re-read.
+    let after = assembled.routing_table.snapshot_config();
+    let openai = after.providers.get("openai").expect("openai still present");
+    assert_eq!(
+        openai.api_base, "https://api.openai.com/v1",
+        "built-in `api_base` must survive a file reload",
+    );
+    assert!(
+        !openai.api_protocol.is_empty(),
+        "built-in `api_protocol` must survive a file reload",
+    );
+
+    let _ = tokio::fs::remove_dir_all(&dir).await;
+}
+
 #[tokio::test]
 async fn route_for_unknown_model_returns_a_clean_error() {
     let dir = tempdir("noroute");


### PR DESCRIPTION
## Problem

Found while end-to-end testing #474. A file-backed daemon reload (`bitrouter reload` / SIGHUP) delegated to the SDK's `ConfigRoutingTable::reload`, which re-reads the YAML but **cannot** apply `bitrouter_providers::apply_builtin_defaults` — that crate sits *above* the SDK in the dependency graph (`providers → sdk`, never back).

So a built-in provider declared with an empty body (`openai: {}`, or just an `api_key`) came back from a reload with an empty `api_base` / `api_protocol`. For an `auto_discover` provider that meant `/models` discovery hit a relative URL, failed, and the provider **silently dropped every model**. A fresh `serve` worked; a reload broke it.

## Fix

Move the file-reload path up into the app layer, mirroring both the initial assembly path (`build_app_with_path`) and the existing zero-config `Default` reload branch:

> re-read the file → `apply_builtin_defaults` → `replace_config` (which runs `discover_models`)

- `ReloadSource::File` now carries the config `PathBuf`.
- `AppReloader` / `ReloadSource` move from `main.rs` into a new `bitrouter::reload` library module, so the production reloader is testable without spawning the binary — the same rationale that already keeps `commands.rs` in the lib. (Previously the only reload test used a fake `RoutingTableReloader`.) The now-unused `app` field is dropped.
- The SDK is untouched — no circular dependency introduced.

## Test

New regression test `reload_re_applies_builtin_provider_catalog`: a built-in provider declared without `api_base` must keep its catalog `api_base` / `api_protocol` across a file reload. Fails before this change, passes after.

Manual repro with an `auto_discover` provider confirms it:

```
status (fresh start)  → models  15 routable
reload                → config reloaded
status (after reload) → models  15 routable   # was 0 before the fix
```

## Checks

- `cargo nextest run -p bitrouter --all-features` → 139/139 passed
- `cargo clippy --all-features --tests` ✓
- `cargo fmt -- --check` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)