### PR TITLE
feat(sdk): add RouterOptions to opt out of built-in routes

### DIFF
--- a/crates/bitrouter-sdk/src/server.rs
+++ b/crates/bitrouter-sdk/src/server.rs
@@ -116,14 +116,34 @@ async fn shutdown_signal() {
 /// never be an unbounded allocation.
 const MAX_BODY_BYTES: usize = 16 * 1024 * 1024;
 
+/// Options controlling which routes the SDK mounts. Hosts that ship their
+/// own richer variant of a built-in route (e.g. bitrouter-cloud's enriched
+/// `/v1/models`) opt out of the SDK's plainer version here so
+/// [`axum::Router::merge`] does not panic on the duplicate path.
+#[derive(Default, Clone, Copy)]
+pub struct RouterOptions {
+    /// When `true`, omit `GET /v1/models` from the returned router.
+    pub omit_v1_models: bool,
+}
+
 /// Build the axum router for the given state.
 pub fn build_router(state: AppState) -> Router {
-    Router::new()
+    build_router_with_options(state, RouterOptions::default())
+}
+
+/// Like [`build_router`], but lets the caller opt out of specific routes
+/// before they are mounted (so a host can supply its own variant without
+/// tripping `Router::merge`'s duplicate-route panic).
+pub fn build_router_with_options(state: AppState, options: RouterOptions) -> Router {
+    let mut router = Router::new()
         .route("/v1/messages", post(anthropic_messages))
         .route("/v1/chat/completions", post(openai_chat))
         .route("/v1/responses", post(openai_responses))
-        .route("/v1beta/models/{model_action}", post(google_generate))
-        .route("/v1/models", get(list_models))
+        .route("/v1beta/models/{model_action}", post(google_generate));
+    if !options.omit_v1_models {
+        router = router.route("/v1/models", get(list_models));
+    }
+    router
         .route("/mcp/{server}", post(mcp_invoke))
         .route("/metrics", get(prometheus_metrics))
         .route("/health", get(health))


### PR DESCRIPTION
## Summary

Adds `build_router_with_options(state, RouterOptions)` to the `server` module, with an `omit_v1_models` flag, so a host that ships its own richer variant of a built-in route can suppress the SDK's plainer one.

`build_router` is preserved as a thin delegator calling `build_router_with_options` with `RouterOptions::default()` — **purely additive, no behaviour change for existing callers.**

## Motivation

`axum::Router::merge` panics on duplicate route paths. bitrouter-cloud ships an enriched `GET /v1/models` (catalog pricing + per-provider online counts) and needs to merge it with the SDK router, which always mounts its own plainer `/v1/models`. Without a seam to opt out, the host cannot compose its router with the SDK's. `RouterOptions { omit_v1_models }` provides that seam.

This unblocks the bitrouter-cloud v0→v1 migration (bitrouter-cloud PR #274), which currently consumes this change via a local path-dep.

## Test plan

- [x] `cargo build -p bitrouter-sdk --features server` — clean
- [x] `cargo clippy -p bitrouter-sdk --features server -- -D warnings` — clean
- [x] Existing callers of `build_router` (`apps/bitrouter`) unaffected — `build_router` behaviour is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)