### PR TITLE
docs: rewrite README for v1.0 + add CLI reference

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -195,9 +195,14 @@ Mints a scoped `brvk_` virtual key for a user. The plaintext secret is printed o
 
 ```
 bitrouter login github-copilot
+bitrouter login anthropic            # Claude Pro/Max subscription PKCE flow
+bitrouter login openai-codex         # ChatGPT subscription PKCE flow
+bitrouter login github-copilot       # GitHub device-code flow
 ```
 
-Runs the provider's OAuth Device Authorization Grant and stores the token in `$XDG_DATA_HOME/bitrouter/oauth-tokens.json`.
+Runs the provider's OAuth flow (PKCE in a browser or device-code, depending on provider) and stores the token in `$XDG_DATA_HOME/bitrouter/oauth-tokens.json`. The slot is keyed by `(provider_id, label)` — pass `--label <name>` to keep multiple accounts of the same provider side by side. Other providers fall back to a pasted API key.
+
+For cloud sign-in (signing into your BitRouter Cloud account, not an upstream LLM provider), see [`bitrouter auth login`](#bitrouter-auth-login--logout--whoami) below.
 
 ### `bitrouter logout <provider>`
 
@@ -205,7 +210,25 @@ Runs the provider's OAuth Device Authorization Grant and stores the token in `$X
 bitrouter logout github-copilot
 ```
 
-Removes the stored OAuth token for the provider.
+Removes every stored credential for the provider (subscription OAuth tokens and pasted API keys alike).
+
+### `bitrouter auth login` / `logout` / `whoami`
+
+Cloud sign-in, distinct from the per-provider `bitrouter login` flow above. Signs the CLI into your BitRouter Cloud account via the RFC 8628 OAuth Device Authorization Grant; the resulting bearer authenticates inbound calls to the cloud `/v1/*` surface (inference, key management, BYOK, policy, billing) and is auto-refreshed on use.
+
+```
+bitrouter auth login [--oauth-as <URL>] [--client-id <ID>] [--scope <SCOPE>]
+bitrouter auth logout [--oauth-as <URL>] [--client-id <ID>]
+bitrouter auth whoami
+```
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--oauth-as` | `https://api.bitrouter.ai` (env: `BITROUTER_OAUTH_AS`) | Authorization server base URL — override only for a self-hosted deployment |
+| `--client-id` | `bitrouter-cli` (env: `BITROUTER_OAUTH_CLIENT_ID`) | Public OAuth client id |
+| `--scope` | broad developer set (env: `BITROUTER_OAUTH_SCOPE`) | Space-delimited scopes to request. Default includes `inference:invoke`, `usage:read`, `keys:read`/`write`, `billing:read`, `policy:read`/`write`, `byok:read`/`write`, `account:read`. Sensitive scopes (`billing:write`, `clients:read`/`write`, `account:write`) are opt-in. |
+
+Credentials are persisted at `<data-dir>/account-credentials.json` (mode `0600` on Unix). `whoami` answers from the local file with no network call.
 
 ---
 
@@ -222,3 +245,115 @@ Writes a starter policy file to the policy directory. Bind it to a key with:
 ```
 bitrouter key sign --user <id> --policy strict
 ```
+
+---
+
+## Cloud account management
+
+`bitrouter cloud …` drives the BitRouter Cloud `/v1/*` management surface (keys, usage, billing, policies, BYOK, OAuth clients) using the credential persisted by [`bitrouter auth login`](#bitrouter-auth-login--logout--whoami). Sign in first, then call any subcommand.
+
+Every leaf accepts `--json` to print the raw response body instead of the human-readable summary. On a 403 whose description is `missing required scope: <s>`, the CLI prints a copy-pasteable re-login hint that appends the missing scope to your current set.
+
+### `bitrouter cloud whoami`
+
+```
+bitrouter cloud whoami
+```
+
+Prints the cloud identity stored on this machine alongside the `/v1/*` base URL the CLI will target. Reads the local credentials file only — no network call.
+
+### `bitrouter cloud keys`
+
+Manage `brk_` API keys on your account.
+
+```
+bitrouter cloud keys list [--json]
+bitrouter cloud keys mint --name <NAME> --scope <SCOPE> [--scope <SCOPE> …] [--expires-at <RFC3339>] [--json]
+bitrouter cloud keys revoke <ID> [--json]
+```
+
+Requested scopes on `mint` must be a subset of your effective scopes (RFC 6749 §3.3 — no upscaling). The plaintext token is shown once in the `mint` response and is not recoverable after.
+
+### `bitrouter cloud usage` / `bitrouter cloud requests`
+
+Read aggregate spend / token counts and page through recent inference requests.
+
+```
+bitrouter cloud usage    [--from <RFC3339>] [--to <RFC3339>] [--json]
+bitrouter cloud requests [--limit <N>] [--offset <N>] [--json]
+```
+
+`usage` defaults to a 30-day rolling window. `requests` clamps the page size to `[1, 100]` and defaults to 25.
+
+### `bitrouter cloud billing`
+
+```
+bitrouter cloud billing balance [--json]
+bitrouter cloud billing checkout --amount-cents <N> [--json]
+```
+
+`checkout` starts a Stripe credit-purchase session and prints the hosted URL. Requires the `billing:write` scope, which is opt-in — pass `--scope` to `bitrouter auth login` to request it.
+
+### `bitrouter cloud policy`
+
+Generic CRUD over the typed policy registry (kinds: `budget`, `rate_limit`, `guardrail`, `preset`).
+
+```
+bitrouter cloud policy list [--kind <KIND>] [--json]
+bitrouter cloud policy get <ID> [--json]
+bitrouter cloud policy create --name <NAME> --kind <KIND> --spec <FILE|-> [--json]
+bitrouter cloud policy update <ID> [--name <NAME>] [--spec <FILE|->] [--json]
+bitrouter cloud policy delete <ID> [--json]
+bitrouter cloud policy bind <ID> --principal-type <TYPE> --principal-id <ID> [--json]
+bitrouter cloud policy unbind <ID> <BINDING_ID> [--json]
+bitrouter cloud policy enable <ID> [--json]
+bitrouter cloud policy disable <ID> [--json]
+bitrouter cloud policy bindings <ID> [--json]
+bitrouter cloud policy effective --principal-type <TYPE> --principal-id <ID> [--json]
+bitrouter cloud policy for-principal <TYPE> <ID> [--json]
+```
+
+`--spec` reads the flat inner spec body as JSON from a file path or `-` for stdin. Principal types: `account`, `api_key`, `oauth_token`, `oauth_client`. `disable` parks a policy without deleting it — the engine skips disabled rows at request time.
+
+### `bitrouter cloud budget` / `bitrouter cloud preset`
+
+Typed wrappers over the budget-kind and preset-kind policy rows — same storage, flat wire shape (no `kind`/`spec` envelope).
+
+```
+bitrouter cloud budget list [--json]
+bitrouter cloud budget get <ID> [--json]
+bitrouter cloud budget create --name <NAME> --window <day|month|total> --limit-micro-usd <N> [--json]
+bitrouter cloud budget update <ID> [--name <NAME>] [--window <W>] [--limit-micro-usd <N>] [--json]
+bitrouter cloud budget delete <ID> [--json]
+
+bitrouter cloud preset list [--json]
+bitrouter cloud preset get <ID> [--json]
+bitrouter cloud preset create --name <NAME> [--guardrail <FILE|->] [--budget <FILE|->] [--rate-limit <FILE|->] [--json]
+bitrouter cloud preset update <ID> [--name <NAME>] [--guardrail <FILE|->] [--budget <FILE|->] [--rate-limit <FILE|->] [--clear-guardrail] [--clear-budget] [--clear-rate-limit] [--json]
+bitrouter cloud preset delete <ID> [--json]
+```
+
+Budget `--limit-micro-usd` must be strictly positive (the engine treats `<= 0` as "no policy" and the API refuses it up-front). Preset clauses are independently optional; use `--clear-*` flags to drop a clause from an existing preset.
+
+### `bitrouter cloud byok`
+
+Manage bring-your-own-key provider keys. The cloud only stores already-sealed ciphertext — seal against the cloud's current X25519 public key (separate fetch) before calling.
+
+```
+bitrouter cloud byok list [--json]
+bitrouter cloud byok set    --provider <ID> --ciphertext-b64 <B64> --kek-id <ID> --key-prefix <PREFIX> [--api-base <URL>] [--json]
+bitrouter cloud byok delete <PROVIDER> [--json]
+```
+
+### `bitrouter cloud oauth-client`
+
+Manage OAuth client registrations on your account. Requires `clients:read` / `clients:write`, both opt-in — request them via `bitrouter auth login --scope "<existing> clients:read clients:write"`.
+
+```
+bitrouter cloud oauth-client list [--json]
+bitrouter cloud oauth-client register --name <NAME> --type <confidential|public> --grant <GRANT> [--grant <GRANT> …] [--scope <SCOPE> …] [--redirect-uri <URI> …] [--json]
+bitrouter cloud oauth-client update <CLIENT_ID> [--name <NAME>] [--grant <GRANT> …] [--scope <SCOPE> …] [--redirect-uri <URI> …] [--json]
+bitrouter cloud oauth-client delete <CLIENT_ID> [--json]
+```
+
+Grant types: `authorization_code`, `refresh_token`, `urn:ietf:params:oauth:grant-type:device_code`. For confidential clients, the freshly minted `client_secret` is returned exactly once in the `register` response.

--- a/CLI.md
+++ b/CLI.md
@@ -25,7 +25,7 @@ Run the HTTP server and control socket **in the foreground**.
 bitrouter serve [-c <path>]
 ```
 
-Starts the proxy on the configured listen address (default `127.0.0.1:8787`) and opens a Unix domain control socket. Logs to stdout.
+Starts the proxy on the configured listen address (default `127.0.0.1:4356`) and opens a Unix domain control socket. Logs to stdout.
 
 ### `bitrouter start`
 
@@ -35,7 +35,7 @@ Spawn `serve` as a **detached background daemon**.
 bitrouter start [-c <path>] [--log <path>]
 ```
 
-Logs default to `~/.bitrouter/bitrouter.log`. Refuses to start if a daemon is already running.
+Logs default to `bitrouter.log` next to the config file (e.g. `~/.bitrouter/bitrouter.log` when the config resolved to `~/.bitrouter/bitrouter.yaml`). Refuses to start if a daemon is already running.
 
 ### `bitrouter stop`
 
@@ -194,13 +194,12 @@ Mints a scoped `brvk_` virtual key for a user. The plaintext secret is printed o
 ### `bitrouter login <provider>`
 
 ```
-bitrouter login github-copilot
 bitrouter login anthropic            # Claude Pro/Max subscription PKCE flow
 bitrouter login openai-codex         # ChatGPT subscription PKCE flow
 bitrouter login github-copilot       # GitHub device-code flow
 ```
 
-Runs the provider's OAuth flow (PKCE in a browser or device-code, depending on provider) and stores the token in `$XDG_DATA_HOME/bitrouter/oauth-tokens.json`. The slot is keyed by `(provider_id, label)` — pass `--label <name>` to keep multiple accounts of the same provider side by side. Other providers fall back to a pasted API key.
+Runs the provider's OAuth flow (PKCE in a browser or device-code, depending on provider) and stores the token in `$XDG_DATA_HOME/bitrouter/oauth-tokens.json`. The slot is keyed by `(provider_id, label)` — pass `--label <name>` (defaults to `default`) to keep multiple accounts of the same provider side by side. Other providers fall back to a pasted API key.
 
 For cloud sign-in (signing into your BitRouter Cloud account, not an upstream LLM provider), see [`bitrouter auth login`](#bitrouter-auth-login--logout--whoami) below.
 

--- a/CLI.md
+++ b/CLI.md
@@ -1,0 +1,224 @@
+# BitRouter CLI Reference
+
+`bitrouter <subcommand> [flags]`
+
+## Config resolution
+
+All subcommands accept an optional `-c / --config <path>` flag. When omitted the binary walks this order:
+
+1. `./bitrouter.yaml` in the current directory
+2. `$BITROUTER_HOME/bitrouter.yaml` — if the env var is set, the file must exist
+3. `~/.bitrouter/bitrouter.yaml` — used if present
+4. **Zero-config** — in-memory defaults; auto-enables any provider whose API key is set in the environment
+
+Daemon-control subcommands (`stop`, `reload`, `status`) also accept `--socket <path>` to override the control socket path derived from the config.
+
+---
+
+## Daemon lifecycle
+
+### `bitrouter serve`
+
+Run the HTTP server and control socket **in the foreground**.
+
+```
+bitrouter serve [-c <path>]
+```
+
+Starts the proxy on the configured listen address (default `127.0.0.1:8787`) and opens a Unix domain control socket. Logs to stdout.
+
+### `bitrouter start`
+
+Spawn `serve` as a **detached background daemon**.
+
+```
+bitrouter start [-c <path>] [--log <path>]
+```
+
+Logs default to `~/.bitrouter/bitrouter.log`. Refuses to start if a daemon is already running.
+
+### `bitrouter stop`
+
+```
+bitrouter stop [-c <path>] [--socket <path>]
+```
+
+### `bitrouter restart`
+
+```
+bitrouter restart [-c <path>] [--socket <path>] [--log <path>]
+```
+
+Stops the running daemon (waiting up to 30s for in-flight requests to drain), then starts a fresh one.
+
+### `bitrouter reload`
+
+```
+bitrouter reload [-c <path>] [--socket <path>]
+```
+
+Hot-reloads the running daemon's config and routing table without dropping connections. Also triggered by `SIGHUP`.
+
+Any provider API keys present in the current environment are forwarded to the daemon so `export OPENAI_API_KEY=…; bitrouter reload` takes effect immediately.
+
+### `bitrouter status`
+
+```
+bitrouter status [-c <path>] [--socket <path>]
+```
+
+Prints pid, listen address, number of routable models, and control socket path. Exits cleanly with "stopped" when no daemon is reachable.
+
+---
+
+## Config
+
+### `bitrouter init`
+
+```
+bitrouter init [-c <path>]           # default: ./bitrouter.yaml
+```
+
+Writes a commented starter `bitrouter.yaml` with `skip_auth: true`. Edit it to configure providers, routing, guardrails, MCP servers, and agents.
+
+---
+
+## Routing / introspection
+
+### `bitrouter route <model>`
+
+```
+bitrouter route gpt-4o [-c <path>] [--socket <path>]
+```
+
+Resolves a model name through the routing table and prints the full fallback chain (provider → upstream service id → protocol). Queries the running daemon if reachable; falls back to a local config parse.
+
+### `bitrouter models`
+
+```
+bitrouter models [-c <path>] [-p <provider-id>]
+```
+
+Lists all routable models. Filter by provider with `--provider`.
+
+### `bitrouter providers list`
+
+```
+bitrouter providers list [-c <path>]
+```
+
+Prints each configured provider's id, model count, active state, and API base URL.
+
+---
+
+## MCP tool introspection
+
+### `bitrouter tools list`
+
+```
+bitrouter tools list [-c <path>]
+```
+
+Connects to every `mcp_servers` entry in the config and lists advertised tools with descriptions.
+
+### `bitrouter tools status`
+
+```
+bitrouter tools status [-c <path>]
+```
+
+Health-checks each configured MCP server with a `tools/list` round-trip. Prints status, latency, and transport.
+
+### `bitrouter tools discover <server>`
+
+```
+bitrouter tools discover my-server [-c <path>]
+```
+
+Connects to one MCP server and prints a YAML stub suitable for pasting into the `mcp_servers:` block of `bitrouter.yaml`.
+
+---
+
+## ACP agent management
+
+### `bitrouter agents list`
+
+```
+bitrouter agents list [-c <path>]
+```
+
+Shows the built-in agent catalog alongside which agents are configured in the loaded config.
+
+### `bitrouter agents check`
+
+```
+bitrouter agents check [-c <path>]
+```
+
+Spawns each configured agent and verifies it responds to `initialize`. Prints latency or error per agent.
+
+### `bitrouter agents install <id>`
+
+```
+bitrouter agents install claude-code
+```
+
+Prints a YAML stub for the named catalog agent. Paste the output under `agents:` in `bitrouter.yaml`.
+
+### `bitrouter agent-proxy <id>`
+
+```
+bitrouter agent-proxy claude-code [-c <path>]
+```
+
+Stdio bridge between an ACP-aware editor and a configured upstream agent. The editor spawns this as a child process; `agent-proxy` routes JSON-RPC over the `acp` pipeline and relays notifications back.
+
+---
+
+## Auth and keys
+
+### `bitrouter key sign`
+
+```
+bitrouter key sign --user <id> [--db <url>] [--policy <policy-id>]
+```
+
+Mints a scoped `brvk_` virtual key for a user. The plaintext secret is printed once — only its SHA-256 hash is stored.
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--user` | *(required)* | Owning user id |
+| `--db` | `sqlite://./bitrouter.db` | Database URL — `sqlite://`, `postgres://`, or `mysql://` |
+| `--policy` | *(none)* | Policy id to bind to the key |
+
+### `bitrouter login <provider>`
+
+```
+bitrouter login github-copilot
+```
+
+Runs the provider's OAuth Device Authorization Grant and stores the token in `$XDG_DATA_HOME/bitrouter/oauth-tokens.json`.
+
+### `bitrouter logout <provider>`
+
+```
+bitrouter logout github-copilot
+```
+
+Removes the stored OAuth token for the provider.
+
+---
+
+## Policy
+
+### `bitrouter policy create <id>`
+
+```
+bitrouter policy create strict [--dir ./policies]
+```
+
+Writes a starter policy file to the policy directory. Bind it to a key with:
+
+```
+bitrouter key sign --user <id> --policy strict
+```

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## Overview
 
-AI agent runtimes need to route to different LLM providers without reconfiguration. BitRouter is a local Rust proxy that gives your agent a single endpoint at `http://localhost:8787` — configure your providers once, then route freely. Any client protocol (OpenAI, Anthropic, Google) can transparently target any upstream, with ~10ms overhead and no cloud dependency required.
+AI agent runtimes need to route to different LLM providers without reconfiguration. BitRouter is a local Rust proxy that gives your agent a single endpoint at `http://localhost:4356` — configure your providers once, then route freely. Any client protocol (OpenAI, Anthropic, Google) can transparently target any upstream, with ~10ms overhead and no cloud dependency required.
 
 ## Install
 
@@ -44,29 +44,36 @@ Set your provider API keys and start:
 ```bash
 export OPENAI_API_KEY=sk-...    # ANTHROPIC_API_KEY / GOOGLE_API_KEY also work
 bitrouter start
-# Proxy running at http://localhost:8787
+# Proxy running at http://localhost:4356
 ```
 
-BitRouter auto-detects any key set in the environment — no config file needed. Point your agent runtime at `http://localhost:8787` and any provider whose key is present is immediately available.
+BitRouter auto-detects any key set in the environment — no config file needed. Point your agent runtime at `http://localhost:4356` and any provider whose key is present is immediately available.
 
 For advanced routing rules, guardrails, or multi-account failover, scaffold a config file:
 
 ```bash
-bitrouter init          # writes ~/.bitrouter/bitrouter.yaml
+bitrouter init          # writes ./bitrouter.yaml (override with `-c <path>`)
 bitrouter start
 ```
 
 ### Cloud
 
-To use BitRouter Cloud (managed routing without local API keys), sign up at [cloud.bitrouter.ai](https://cloud.bitrouter.ai) and follow the cloud setup guide.
+Sign in to your BitRouter Cloud account from the terminal — one OAuth account covers every model the gateway offers, no upstream provider keys required:
+
+```bash
+bitrouter auth login    # RFC 8628 device flow against api.bitrouter.ai
+bitrouter start         # `bitrouter` provider auto-enables once signed in
+```
+
+Manage keys, usage, billing, policies, and BYOK from the same CLI — see `bitrouter cloud --help` or [`CLI.md`](CLI.md#cloud-account-management).
 
 ## Features
 
-- **Multi-provider routing** — unified access to OpenAI, Anthropic, Google, OpenRouter, OpenCode, and Amazon Bedrock; configure multiple accounts per provider with failover or round-robin load-balancing ([`sdk`](crates/bitrouter-sdk/) · [`providers`](crates/bitrouter-providers/))
+- **Multi-provider routing** — unified access to OpenAI, Anthropic, Google, OpenRouter, OpenCode Zen / Go, BitRouter Cloud, GitHub Copilot, ChatGPT Codex, and Amazon Bedrock; configure multiple accounts per provider with failover or round-robin load-balancing ([`sdk`](crates/bitrouter-sdk/) · [`providers`](crates/bitrouter-providers/))
 - **Cross-protocol routing** — any client protocol (OpenAI Chat, OpenAI Responses, Anthropic Messages, Google Gemini) against any upstream; BitRouter translates transparently ([`sdk`](crates/bitrouter-sdk/))
 - **Zero-config** — auto-detects providers from environment variables; no config file needed to get started ([`providers`](crates/bitrouter-providers/))
 - **MCP gateway** — proxy for MCP servers; agents discover and call tools across hosts ([`sdk`](crates/bitrouter-sdk/))
-- **ACP integration** — manage coding agent sessions (Claude Code, OpenCode, OpenClaw) via the CLI ([`sdk`](crates/bitrouter-sdk/))
+- **ACP integration** — manage coding agent sessions (Claude Code, OpenAI Codex, Gemini CLI) via the CLI ([`sdk`](crates/bitrouter-sdk/))
 - **Agent guardrails** — inspect, redact, or block risky content at the proxy layer ([`guardrails`](plugins/bitrouter-guardrails/))
 - **Observability** — per-request spend tracking, Prometheus metrics, and OTLP export ([`observe`](plugins/bitrouter-observe/))
 - **Virtual keys** — mint scoped `brvk_` API keys with `bitrouter key sign`, persisted to SQLite, PostgreSQL, or MySQL
@@ -74,19 +81,22 @@ To use BitRouter Cloud (managed routing without local API keys), sign up at [clo
 
 ## Supported Providers
 
-| Provider       | Status | Notes                                                     |
-| -------------- | ------ | --------------------------------------------------------- |
-| OpenAI         | ✅     | Chat Completions + Responses API                          |
-| Anthropic      | ✅     | Messages API                                              |
-| Google         | ✅     | Generative AI API                                         |
-| Amazon Bedrock | ✅     | Via AWS SDK (opt-in)                                      |
-| OpenRouter     | ✅     | Chat Completions + Responses API                          |
-| OpenCode Zen   | ✅     | Curated models across OpenAI, Anthropic, Google protocols |
-| OpenCode Go    | ✅     | Low-cost subscription for open coding models              |
+| Provider        | Status | Notes                                                          |
+| --------------- | ------ | -------------------------------------------------------------- |
+| OpenAI          | ✅     | Chat Completions + Responses API                               |
+| Anthropic       | ✅     | Messages API + Claude Pro/Max subscription (PKCE)              |
+| Google          | ✅     | Generative AI API                                              |
+| Amazon Bedrock  | ✅     | Via AWS SDK (opt-in)                                           |
+| OpenRouter      | ✅     | Chat Completions + Responses API                               |
+| OpenCode Zen    | ✅     | Curated models across OpenAI, Anthropic, Google protocols      |
+| OpenCode Go     | ✅     | Low-cost subscription for open coding models                   |
+| BitRouter Cloud | ✅     | OAuth sign-in (`bitrouter auth login`); cloud-managed routing  |
+| GitHub Copilot  | ✅     | GitHub OAuth device flow (`bitrouter login github-copilot`)    |
+| ChatGPT Codex   | ✅     | ChatGPT subscription PKCE (`bitrouter login openai-codex`)     |
 
 Want to see another provider? [Open an issue](https://github.com/bitrouter/bitrouter/issues) or submit a PR. If you're a provider interested in first-party integration, reach out on [Discord](https://discord.gg/G3zVrZDa5C).
 
-Any agent runtime that supports a custom OpenAI or Anthropic base URL works with BitRouter out of the box — point it at `http://localhost:8787`. **Building an agent runtime?** We partner with teams on native integrations — email [contact@bitrouter.ai](mailto:contact@bitrouter.ai) or [book a meeting with the founder](https://cal.com/kelsenliu/founder-meeting).
+Any agent runtime that supports a custom OpenAI or Anthropic base URL works with BitRouter out of the box — point it at `http://localhost:4356`. **Building an agent runtime?** We partner with teams on native integrations — email [contact@bitrouter.ai](mailto:contact@bitrouter.ai) or [book a meeting with the founder](https://cal.com/kelsenliu/founder-meeting).
 
 ## Comparison
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,9 @@ bitrouter agents list / check / install        # ACP agent management
 bitrouter key sign --user <id>                 # mint a scoped brvk_ API key
 bitrouter policy create <id>                   # scaffold a routing policy
 bitrouter init                                 # scaffold bitrouter.yaml
-bitrouter login <provider>                     # OAuth login (e.g. github-copilot)
+bitrouter login <provider>                     # upstream-provider OAuth (anthropic, openai-codex, github-copilot, …)
+bitrouter auth login / logout / whoami         # BitRouter Cloud sign-in (RFC 8628 device flow)
+bitrouter cloud keys / usage / billing / …     # manage keys, usage, billing, policies, BYOK against BitRouter Cloud
 ```
 
 See [`CLI.md`](CLI.md) for flags, config resolution, and examples.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# BitRouter - Open Intelligence Router for LLM Agents
+# BitRouter
 
-> The agentic proxy for modern agent runtimes. Smart, safe, agent-controlled routing across LLMs, tools, and agents.
+> The local proxy built for AI agent runtimes — one endpoint to reach any LLM provider, with automatic cross-protocol translation and failover.
 
 [![Build status](https://github.com/bitrouter/bitrouter/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/bitrouter/bitrouter/actions)
 [![Crates.io](https://img.shields.io/crates/v/bitrouter)](https://crates.io/crates/bitrouter)
@@ -11,128 +11,136 @@
 
 ## Overview
 
-As LLM agents grow more autonomous, humans can no longer hand-pick the best model, tool, or sub-agent for every runtime decision. BitRouter is a proxy layer purpose-built for LLM agents (OpenClaw, OpenCode, etc.) to discover and route to LLMs, tools, and other agents autonomously — with agent-native control, guardrails, and observability via CLI + TUI, backed by a high-performance Rust proxy that optimizes for performance, cost, and safety during runtime.
+AI agent runtimes need to route to different LLM providers without reconfiguration. BitRouter is a local Rust proxy that gives your agent a single endpoint at `http://localhost:8787` — configure your providers once, then route freely. Any client protocol (OpenAI, Anthropic, Google) can transparently target any upstream, with ~10ms overhead and no cloud dependency required.
 
-## Features
+## Install
 
-- **Multi-provider routing** — unified access to OpenAI, Anthropic, Google, and custom providers with cost/performance-aware routing ([`core`](bitrouter-core/) · [`providers`](bitrouter-providers/) · [`config`](bitrouter-config/))
-- **Tools as a service** — discover, aggregate, and route tool calls across MCP servers and REST APIs with the same config-driven routing used for models ([`core`](bitrouter-core/) · [`providers`](bitrouter-providers/) · [`config`](bitrouter-config/))
-- **Streaming & non-streaming** — first-class support for both modes across all providers
-- **Agent firewall** — inspect, warn, redact, or block risky content at the proxy layer ([`guardrails`](bitrouter-guardrails/))
-- **MCP gateway** — proxy for MCP servers, agents discover and call tools across hosts ([`providers`](bitrouter-providers/) · [`api`](bitrouter-api/))
-- **Skills registry** — track and expose agent skills following the [agentskills.io](https://agentskills.io) standard ([`providers`](bitrouter-providers/))
-- **Agentic payment** — 402/MPP payment handling for LLMs, tools, and APIs ([`api`](bitrouter-api/) · [`accounts`](bitrouter-accounts/))
-- **Observability** — per-request spend tracking, metrics, and cost calculation ([`observe`](bitrouter-observe/))
-- **CLI + TUI** — monitor and control agent sessions in real time, with live ACP (Agent Client Protocol) integration for managing coding agents ([`cli`](bitrouter/) · [`tui`](bitrouter-tui/))
+```bash
+# macOS / Linux
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/bitrouter/bitrouter/releases/latest/download/bitrouter-installer.sh | sh
 
-## Documentation
+# Homebrew
+brew install bitrouter/tap/bitrouter
 
-- [`DEVELOPMENT.md`](DEVELOPMENT.md) — workspace architecture and server composition details
-- [`CONTRIBUTING.md`](CONTRIBUTING.md) — contribution workflow, issue reporting, and provider updates
-- [`CLAUDE.md`](CLAUDE.md) — guidance for AI coding agents working in this repository
+# npm
+npm install -g bitrouter
+```
 
-## Quick Start
-
-### Install
+<details>
+<summary>From source (Cargo)</summary>
 
 ```bash
 cargo install bitrouter
 ```
 
-### Default (setup wizard)
+</details>
+
+## Quick Start
+
+### Local (BYOK)
+
+Set your provider API keys and start:
 
 ```bash
-bitrouter
+export OPENAI_API_KEY=sk-...    # ANTHROPIC_API_KEY / GOOGLE_API_KEY also work
+bitrouter start
+# Proxy running at http://localhost:8787
 ```
 
-On first launch, BitRouter runs an interactive setup wizard with two modes:
+BitRouter auto-detects any key set in the environment — no config file needed. Point your agent runtime at `http://localhost:8787` and any provider whose key is present is immediately available.
 
-- **Cloud** — connect to BitRouter Cloud with x402/Solana wallet payments
-- **BYOK** — bring your own API keys for OpenAI, Anthropic, Google, or custom providers
-
-After setup, the TUI and API server start at `http://localhost:8787`.
-
-You can re-run the wizard at any time with `bitrouter reset`.
-
-### BYOK (bring your own keys)
-
-If you already have provider API keys in your environment, BitRouter auto-detects them — no config file needed:
+For advanced routing rules, guardrails, or multi-account failover, scaffold a config file:
 
 ```bash
-export OPENAI_API_KEY=sk-...
-bitrouter
-# Routes to "openai:gpt-4o" at http://localhost:8787
+bitrouter init          # writes ~/.bitrouter/bitrouter.yaml
+bitrouter start
 ```
 
-For a foreground server without the TUI, use `bitrouter serve`.
+### Cloud
 
-### Agent Skills
+To use BitRouter Cloud (managed routing without local API keys), sign up at [cloud.bitrouter.ai](https://cloud.bitrouter.ai) and follow the cloud setup guide.
 
-Install [Agent Skills](https://github.com/bitrouter/agent-skills) to give your AI agent the knowledge to register on the BitRouter network, configure services, and start serving requests:
+## Features
 
-```bash
-# Any agent (Claude Code, Copilot, Cursor, Codex, etc.)
-npx skills add BitRouterAI/agent-skills
-```
+- **Multi-provider routing** — unified access to OpenAI, Anthropic, Google, OpenRouter, OpenCode, and Amazon Bedrock; configure multiple accounts per provider with failover or round-robin load-balancing ([`sdk`](crates/bitrouter-sdk/) · [`providers`](crates/bitrouter-providers/))
+- **Cross-protocol routing** — any client protocol (OpenAI Chat, OpenAI Responses, Anthropic Messages, Google Gemini) against any upstream; BitRouter translates transparently ([`sdk`](crates/bitrouter-sdk/))
+- **Zero-config** — auto-detects providers from environment variables; no config file needed to get started ([`providers`](crates/bitrouter-providers/))
+- **MCP gateway** — proxy for MCP servers; agents discover and call tools across hosts ([`sdk`](crates/bitrouter-sdk/))
+- **ACP integration** — manage coding agent sessions (Claude Code, OpenCode, OpenClaw) via the CLI ([`sdk`](crates/bitrouter-sdk/))
+- **Agent guardrails** — inspect, redact, or block risky content at the proxy layer ([`guardrails`](plugins/bitrouter-guardrails/))
+- **Observability** — per-request spend tracking, Prometheus metrics, and OTLP export ([`observe`](plugins/bitrouter-observe/))
+- **Virtual keys** — mint scoped `brvk_` API keys with `bitrouter key sign`, persisted to SQLite, PostgreSQL, or MySQL
+- **Custom providers** — add any OpenAI-compatible or Anthropic-compatible upstream via config
 
 ## Supported Providers
 
-| Provider   | Status | Notes                            |
-| ---------- | ------ | -------------------------------- |
-| OpenAI     | ✅     | Chat Completions + Responses API |
-| Anthropic  | ✅     | Messages API                     |
-| Google     | ✅     | Generative AI API                |
-| OpenRouter | ✅     | Chat Completions + Responses API |
-| OpenCode Zen | ✅  | Curated models across OpenAI, Anthropic, Google protocols |
-| OpenCode Go  | ✅  | Low-cost subscription for open coding models |
+| Provider       | Status | Notes                                                     |
+| -------------- | ------ | --------------------------------------------------------- |
+| OpenAI         | ✅     | Chat Completions + Responses API                          |
+| Anthropic      | ✅     | Messages API                                              |
+| Google         | ✅     | Generative AI API                                         |
+| Amazon Bedrock | ✅     | Via AWS SDK (opt-in)                                      |
+| OpenRouter     | ✅     | Chat Completions + Responses API                          |
+| OpenCode Zen   | ✅     | Curated models across OpenAI, Anthropic, Google protocols |
+| OpenCode Go    | ✅     | Low-cost subscription for open coding models              |
 
-Want to see another provider supported? [Open an issue](https://github.com/bitrouter/bitrouter/issues) or submit a PR — contributions are welcome. If you're a provider interested in first-party integration, reach out on [Discord](https://discord.gg/G3zVrZDa5C).
+Want to see another provider? [Open an issue](https://github.com/bitrouter/bitrouter/issues) or submit a PR. If you're a provider interested in first-party integration, reach out on [Discord](https://discord.gg/G3zVrZDa5C).
 
-## Supported Agent Runtimes
-
-BitRouter works as a drop-in proxy for agent runtimes that support custom API base URLs. Point your runtime at `http://localhost:8787` and route to any configured provider.
-
-| Runtime                                                  | Integration                                                      |
-| -------------------------------------------------------- | ---------------------------------------------------------------- |
-| [OpenClaw](https://github.com/openclaw/openclaw)         | [Native plugin](https://github.com/bitrouter/bitrouter-openclaw) |
-| [Claude Code](https://github.com/anthropics/claude-code) | CLI + Skills                                                     |
-| [ZeroClaw](https://github.com/zeroclaw-labs/zeroclaw)    | CLI + Skills                                                     |
-| [Codex CLI](https://github.com/openai/codex)             | CLI + Skills                                                     |
-| [OpenCode](https://github.com/opencode-ai/opencode)      | CLI + Skills                                                     |
-| [Kilo Code](https://github.com/Kilo-Org/kilocode)        | CLI + Skills                                                     |
-
-Any agent runtime that can target a custom OpenAI or Anthropic base URL works with BitRouter out of the box. **Building an agent runtime or framework?** We partner with teams to build native BitRouter integrations — reach out on [Discord](https://discord.gg/G3zVrZDa5C) or [open an issue](https://github.com/bitrouter/bitrouter/issues).
+Any agent runtime that supports a custom OpenAI or Anthropic base URL works with BitRouter out of the box — point it at `http://localhost:8787`. **Building an agent runtime?** We partner with teams on native integrations — email [contact@bitrouter.ai](mailto:contact@bitrouter.ai) or [book a meeting with the founder](https://cal.com/kelsenliu/founder-meeting).
 
 ## Comparison
 
-| | **BitRouter** | **OpenRouter** | **LiteLLM** |
-| --- | --- | --- | --- |
-| **Architecture** | Local-first proxy + optional cloud | Cloud-only SaaS | Local proxy (Python) |
-| **Language** | Rust | Closed-source | Python |
-| **Self-hosted** | Yes | No | Yes |
-| **Agent-native** | Yes — built for autonomous agent runtimes | No — human-facing API gateway | Partial — SDK-oriented |
-| **Agent protocols** | MCP + Skills + ACP | No | MCP |
-| **Agent firewall** | Built-in guardrails (inspect, redact, block) | Yes | Yes |
-| **Cross-protocol routing** | Yes (e.g. OpenAI format → Anthropic provider) | Provider-specific | Yes (unified interface) |
-| **Agentic payments** | Stablecoin (402/MPP) + Fiat| Credit-based billing | No |
-| **Observability** | CLI + TUI + per-request cost tracking | Web dashboard | Logging + callbacks + WebUI |
-| **Extensibility** | Trait-based SDK — import and compose crates | API only | Python middleware |
-| **Performance** | ~10ms | ~30ms (cloud) | ~500ms |
-| **License** | Apache 2.0 | Proprietary | Apache 2.0 |
+|                           | **BitRouter**                               | **OpenRouter**            | **LiteLLM**                    |
+| ------------------------- | ------------------------------------------- | ------------------------- | ------------------------------ |
+| **Architecture**          | Local-first proxy + optional cloud          | Cloud-only SaaS           | Local proxy (Python)           |
+| **Language**              | Rust                                        | Closed-source             | Python                         |
+| **Self-hosted**           | Yes                                         | No                        | Yes                            |
+| **Agent-native**          | Yes — built for autonomous agent runtimes   | No — human-facing gateway | Partial — SDK-oriented         |
+| **Agent protocols**       | MCP + ACP                                   | No                        | MCP                            |
+| **Agent guardrails**      | Built-in (inspect, redact, block)           | Yes                       | Yes                            |
+| **Cross-protocol routing**| Yes (e.g. OpenAI format → Anthropic upstream)| Provider-specific        | Yes (unified interface)        |
+| **Observability**         | CLI + per-request cost tracking + Prometheus| Web dashboard             | Logging + callbacks + WebUI    |
+| **Extensibility**         | Trait-based SDK — import and compose crates | API only                  | Python middleware               |
+| **Performance**           | ~10ms                                       | ~30ms (cloud)             | ~500ms                         |
+| **License**               | Apache 2.0                                  | Proprietary               | Apache 2.0                     |
 
-**TL;DR** — OpenRouter is a cloud API marketplace for humans picking models. LiteLLM is a Python proxy for unifying provider SDKs. BitRouter is a Rust-native proxy purpose-built for autonomous agents — with unified model and tool routing, agent protocols (MCP, Skills), guardrails, and agentic payments out of the box.
+**TL;DR** — OpenRouter is a cloud API marketplace for humans picking models. LiteLLM is a Python proxy for unifying provider SDKs. BitRouter is a Rust-native proxy purpose-built for autonomous agents — with cross-protocol routing, MCP and ACP support, and guardrails out of the box.
+
+## CLI
+
+```bash
+bitrouter start / stop / restart / reload      # daemon lifecycle
+bitrouter status                               # pid, listen address, active models
+bitrouter route <model>                        # trace how a model name resolves
+bitrouter models [--provider <id>]            # list routable models
+bitrouter providers list                       # list configured providers
+bitrouter tools list / status / discover       # MCP server introspection
+bitrouter agents list / check / install        # ACP agent management
+bitrouter key sign --user <id>                 # mint a scoped brvk_ API key
+bitrouter policy create <id>                   # scaffold a routing policy
+bitrouter init                                 # scaffold bitrouter.yaml
+bitrouter login <provider>                     # OAuth login (e.g. github-copilot)
+```
+
+See [`CLI.md`](CLI.md) for flags, config resolution, and examples.
+
+## Documentation
+
+- [`CLI.md`](CLI.md) — full CLI reference with flags and examples
+- [`DEVELOPMENT.md`](DEVELOPMENT.md) — workspace architecture and SDK internals
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — contribution workflow, issue reporting, and provider updates
+- [`CLAUDE.md`](CLAUDE.md) — guidance for AI coding agents working in this repository
 
 ## Roadmap
 
 - [x] Core routing engine and provider abstractions
-- [x] OpenAI, Anthropic, and Google adapters
-- [x] Interactive setup wizard (`bitrouter init`) with auto-detection
+- [x] OpenAI, Anthropic, Google, and Amazon Bedrock adapters
+- [x] Zero-config auto-detection from environment variables
 - [x] Custom provider support (OpenAI-compatible / Anthropic-compatible)
 - [x] Cross-protocol routing (e.g. OpenAI format → Anthropic provider)
-- [x] MCP & Skills protocol support
-- [x] Tools as a service — config-driven tool routing across MCP and REST providers
-- [x] ACP (Agent Client Protocol) integration — manage coding agents (Claude Code, OpenCode, OpenClaw) via the TUI
-- [ ] TUI observability dashboard
+- [x] MCP gateway and ACP agent integration
+- [x] Multiple accounts per provider — failover + load-balancing
+- [x] Virtual key management (`bitrouter key`) backed by SQLite / PostgreSQL / MySQL
 - [ ] Telemetry and usage analytics
 - [ ] Provider & model routing policy customization
 


### PR DESCRIPTION
## Summary

- **README rewrite** — agent-native tagline and overview, npm/brew/curl install as primary paths, Quick Start split into Local (BYOK) vs Cloud, removed stale v0 content (TUI, Skills registry, agentic payments, fake setup wizard, agent runtimes table, wrong crate names), added accurate features (multi-account failover, virtual keys, Amazon Bedrock, correct crate links), fixed comparison table
- **CLI section in README** — lightweight 11-command summary linking to the new reference doc
- **CLI.md** (new) — full CLI reference covering all subcommands with flags, defaults, config resolution rules, and examples; derived directly from `apps/bitrouter/src/main.rs`

## What was removed

| Removed | Reason |
| --- | --- |
| TUI / `bitrouter-tui` references | Deprecated, not in v1.0 |
| Skills registry / agentskills.io | Not implemented in v1.0 |
| Agentic payments (402/MPP) | Not in v1.0 scope |
| Setup wizard / `bitrouter reset` | Doesn't exist |
| Agent runtimes table | Drifts quickly; replaced with one sentence |
| Wrong crate names (`bitrouter-core`, `-api`, `-accounts`, `-config`, `-tui`) | Don't exist in workspace |

🤖 Generated with [Claude Code](https://claude.com/claude-code)