### PR TITLE
feat(mcp): aggregation + caching + SSE + sampling-deny

### DIFF
--- a/apps/bitrouter/src/assemble.rs
+++ b/apps/bitrouter/src/assemble.rs
@@ -224,11 +224,22 @@ pub async fn build_app_with_path(
         // matches the aggregate's last path segment. Trim trailing slashes
         // first — a route written as `/mcp/` in YAML must still trigger the
         // check.
+        //
+        // This is a shallow heuristic: the only collision shape it catches is
+        // `{aggregate_route}/{server}` overlapping with `/mcp/{server}` when
+        // the aggregate route's tail equals a server name. Stranger
+        // collisions (e.g. an aggregate route that re-introduces `/mcp` as a
+        // non-tail segment) fall through and are caught later by axum's
+        // route-registration panic at mount time. Surfacing this case early
+        // gives the operator a config-shaped error rather than a startup
+        // panic for the most common misconfiguration.
         let agg_last = route.trim_end_matches('/').rsplit('/').next().unwrap_or("");
         if !agg_last.is_empty() && config.mcp_servers.keys().any(|k| k.as_str() == agg_last) {
             anyhow::bail!(
-                "mcp_servers entry '{agg_last}' collides with the aggregate route '{route}' — \
-                 rename the server or move the aggregate route"
+                "mcp_servers entry '{agg_last}' would be shadowed by the per-server mount at \
+                 '{route}/{agg_last}' (derived from the aggregate route '{route}'). Rename the \
+                 server or move the aggregate route. Note: this check only catches the \
+                 last-segment overlap; axum mounts may still reject other shapes at startup."
             );
         }
     }

--- a/apps/bitrouter/src/assemble.rs
+++ b/apps/bitrouter/src/assemble.rs
@@ -16,8 +16,8 @@ use bitrouter_sdk::language_model::protocol::OutboundDispatch;
 use bitrouter_sdk::language_model::{AuthAppliers, HttpExecutor, HttpTimeouts};
 use bitrouter_sdk::mcp::aggregating_executor::AggregatingExecutor;
 use bitrouter_sdk::mcp::caching_executor::{CacheTtls, CachingExecutor};
-use bitrouter_sdk::mcp::config_routing::McpServerAggregateConfig;
-use bitrouter_sdk::mcp::{ConfigMcpRoutingTable, RmcpExecutor};
+use bitrouter_sdk::mcp::config_routing::{ConfigMcpRoutingTable, McpServerAggregateConfig};
+use bitrouter_sdk::mcp::rmcp_executor::RmcpExecutor;
 
 use bitrouter_guardrails::{Action, GuardrailPreHook, GuardrailRule, GuardrailStreamHook, RuleSet};
 use bitrouter_observe::OTEL_ENABLED;

--- a/apps/bitrouter/src/assemble.rs
+++ b/apps/bitrouter/src/assemble.rs
@@ -14,6 +14,9 @@ use bitrouter_sdk::acp::{AcpStdioExecutor, ConfigAcpRoutingTable};
 use bitrouter_sdk::config::{Config, ConfigRoutingTable};
 use bitrouter_sdk::language_model::protocol::OutboundDispatch;
 use bitrouter_sdk::language_model::{AuthAppliers, HttpExecutor, HttpTimeouts};
+use bitrouter_sdk::mcp::aggregating_executor::AggregatingExecutor;
+use bitrouter_sdk::mcp::caching_executor::{CacheTtls, CachingExecutor};
+use bitrouter_sdk::mcp::config_routing::McpServerAggregateConfig;
 use bitrouter_sdk::mcp::{ConfigMcpRoutingTable, RmcpExecutor};
 
 use bitrouter_guardrails::{Action, GuardrailPreHook, GuardrailRule, GuardrailStreamHook, RuleSet};
@@ -211,21 +214,60 @@ pub async fn build_app_with_path(
     // declares at least one upstream MCP server. The pipeline is independent
     // of the language_model pipeline (different hook traits, different
     // routing table) and carries no settlement.
+    let mcp_aggregate_route = if config.mcp.aggregate.enabled {
+        Some(config.mcp.aggregate.route.clone())
+    } else {
+        None
+    };
+    if let Some(route) = mcp_aggregate_route.as_deref() {
+        // URL collision: a per-server route would be shadowed if its name
+        // matches the aggregate's last path segment. Trim trailing slashes
+        // first — a route written as `/mcp/` in YAML must still trigger the
+        // check.
+        let agg_last = route.trim_end_matches('/').rsplit('/').next().unwrap_or("");
+        if !agg_last.is_empty() && config.mcp_servers.keys().any(|k| k.as_str() == agg_last) {
+            anyhow::bail!(
+                "mcp_servers entry '{agg_last}' collides with the aggregate route '{route}' — \
+                 rename the server or move the aggregate route"
+            );
+        }
+    }
+
     let mcp_routing = if config.mcp_servers.is_empty() {
         None
     } else {
         Some(Arc::new(
-            ConfigMcpRoutingTable::from_configs(
-                config
-                    .mcp_servers
-                    .iter()
-                    .map(|(k, v)| (k.clone(), v.clone())),
-            )
+            ConfigMcpRoutingTable::from_configs(config.mcp_servers.iter().map(|(k, v)| {
+                let agg = McpServerAggregateConfig {
+                    aggregate: v.aggregate,
+                    tool_prefix: v.tool_prefix.clone().unwrap_or_else(|| format!("{k}__")),
+                };
+                (k.clone(), v.clone(), agg)
+            }))
             .context("building the MCP routing table from config.mcp_servers")?,
         ))
     };
-    let mcp_executor: Option<Arc<RmcpExecutor>> =
-        mcp_routing.as_ref().map(|_| Arc::new(RmcpExecutor::new()));
+    // The MCP executor stack — composed innermost-out so a single
+    // `/mcp tools/list` with cold caches dials N servers once, after which
+    // it's all cache hits:
+    //   AggregatingExecutor → CachingExecutor → RmcpExecutor
+    // Caches sit at the leaves so a single-server `notifications/*` only
+    // invalidates that server's slice.
+    let mcp_executor = mcp_routing.as_ref().map(|_| {
+        let rmcp: Arc<RmcpExecutor> = Arc::new(RmcpExecutor::new());
+        let inner_for_cache: Arc<RmcpExecutor> = rmcp.clone();
+        if config.mcp.cache.enabled {
+            let ttls: CacheTtls = (&config.mcp.cache).into();
+            let cached: Arc<CachingExecutor<RmcpExecutor>> = Arc::new(
+                CachingExecutor::new(inner_for_cache, ttls)
+                    .with_invalidation(rmcp.invalidation_receiver()),
+            );
+            Arc::new(AggregatingExecutor::new(cached)) as Arc<dyn bitrouter_sdk::mcp::Executor>
+        } else {
+            Arc::new(AggregatingExecutor::new(inner_for_cache))
+                as Arc<dyn bitrouter_sdk::mcp::Executor>
+        }
+    });
 
     // Optional ACP pure-routing pipeline — wired only when the config
     // declares at least one upstream agent. Mirrors the MCP wiring above;
@@ -280,9 +322,16 @@ pub async fn build_app_with_path(
     // so the language_model configuration above stays the same shape it has
     // had since v0.
     let app = match (mcp_routing, mcp_executor) {
-        (Some(table), Some(exec)) => app.mcp(move |m| {
-            m.routing_table(table).executor(exec);
-        }),
+        (Some(table), Some(exec)) => {
+            let app = app.mcp(move |m| {
+                m.routing_table(table).executor(exec);
+            });
+            if let Some(route) = mcp_aggregate_route {
+                app.mcp_aggregate_route(route)
+            } else {
+                app
+            }
+        }
         _ => app,
     };
     // ACP pipeline — separate match because it's an independent optional

--- a/apps/bitrouter/src/tools.rs
+++ b/apps/bitrouter/src/tools.rs
@@ -15,7 +15,9 @@ use std::time::{Duration, Instant};
 
 use bitrouter_sdk::caller::CallerContext;
 use bitrouter_sdk::config::Config;
-use bitrouter_sdk::mcp::{Executor, McpRequest, McpTarget, McpTransport, RmcpExecutor};
+use bitrouter_sdk::mcp::rmcp_executor::RmcpExecutor;
+use bitrouter_sdk::mcp::transport::McpTransport;
+use bitrouter_sdk::mcp::{Executor, McpRequest, McpTarget};
 
 /// One row in `bitrouter tools list`.
 #[derive(Debug, Clone)]
@@ -224,7 +226,7 @@ fn render_discovery(server: &str, transport: &McpTransport, tools: &[ToolSummary
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bitrouter_sdk::mcp::McpServerConfig;
+    use bitrouter_sdk::mcp::transport::McpServerConfig;
     use std::collections::HashMap;
 
     fn cfg_with(server_id: &str, server_cfg: McpServerConfig) -> Config {

--- a/apps/bitrouter/src/tools.rs
+++ b/apps/bitrouter/src/tools.rs
@@ -58,11 +58,11 @@ pub async fn list(config: &Config) -> Vec<ServerTools> {
     let mut servers: Vec<_> = config.mcp_servers.iter().collect();
     servers.sort_by(|a, b| a.0.cmp(b.0));
     for (name, server_cfg) in servers {
-        let target = McpTarget {
+        let target = McpTarget::Direct {
             server_name: name.clone(),
             transport: server_cfg.transport.clone(),
         };
-        let req = McpRequest::new(
+        let req = McpRequest::direct(
             name,
             "tools/list",
             serde_json::json!({}),
@@ -89,11 +89,11 @@ pub async fn status(config: &Config) -> Vec<ServerStatus> {
     let mut servers: Vec<_> = config.mcp_servers.iter().collect();
     servers.sort_by(|a, b| a.0.cmp(b.0));
     for (name, server_cfg) in servers {
-        let target = McpTarget {
+        let target = McpTarget::Direct {
             server_name: name.clone(),
             transport: server_cfg.transport.clone(),
         };
-        let req = McpRequest::new(
+        let req = McpRequest::direct(
             name,
             "tools/list",
             serde_json::json!({}),
@@ -122,11 +122,11 @@ pub async fn discover(config: &Config, server: &str) -> Result<String, String> {
         .get(server)
         .ok_or_else(|| format!("no mcp server configured for '{server}'"))?;
     let executor = RmcpExecutor::new();
-    let target = McpTarget {
+    let target = McpTarget::Direct {
         server_name: server.to_string(),
         transport: server_cfg.transport.clone(),
     };
-    let req = McpRequest::new(
+    let req = McpRequest::direct(
         server,
         "tools/list",
         serde_json::json!({}),
@@ -234,14 +234,14 @@ mod tests {
     }
 
     fn stdio_target(server: &str, cmd: &str) -> McpServerConfig {
-        McpServerConfig {
-            name: server.to_string(),
-            transport: McpTransport::Stdio {
+        McpServerConfig::with_defaults(
+            server,
+            McpTransport::Stdio {
                 command: cmd.into(),
                 args: vec![],
                 env: HashMap::new(),
             },
-        }
+        )
     }
 
     #[tokio::test]

--- a/apps/bitrouter/tests/e2e.rs
+++ b/apps/bitrouter/tests/e2e.rs
@@ -328,8 +328,9 @@ plugins:
 async fn e2e_mcp_route_invokes_the_pure_routing_pipeline() {
     use async_trait::async_trait;
     use bitrouter_sdk::App;
+    use bitrouter_sdk::mcp::transport::McpTransport;
     use bitrouter_sdk::mcp::{
-        Executor, McpRequest, McpResponse, McpTarget, McpTransport, RoutingTable, ServerSelector,
+        Executor, McpRequest, McpResponse, McpTarget, RoutingTable, ServerSelector,
     };
     use http::Request;
     use std::sync::Arc;
@@ -542,9 +543,9 @@ async fn e2e_mcp_route_invokes_the_pure_routing_pipeline() {
 async fn e2e_mcp_aggregate_and_sse_endpoints() {
     use async_trait::async_trait;
     use bitrouter_sdk::App;
+    use bitrouter_sdk::mcp::transport::McpTransport;
     use bitrouter_sdk::mcp::{
-        AggregateMember, Executor, McpRequest, McpResponse, McpTarget, McpTransport, RoutingTable,
-        ServerSelector,
+        AggregateMember, Executor, McpRequest, McpResponse, McpTarget, RoutingTable, ServerSelector,
     };
     use bitrouter_sdk::server::{RouterOptions, build_router_with_options};
     use http::Request;

--- a/apps/bitrouter/tests/e2e.rs
+++ b/apps/bitrouter/tests/e2e.rs
@@ -329,7 +329,7 @@ async fn e2e_mcp_route_invokes_the_pure_routing_pipeline() {
     use async_trait::async_trait;
     use bitrouter_sdk::App;
     use bitrouter_sdk::mcp::{
-        Executor, McpRequest, McpResponse, McpTarget, McpTransport, RoutingTable,
+        Executor, McpRequest, McpResponse, McpTarget, McpTransport, RoutingTable, ServerSelector,
     };
     use http::Request;
     use std::sync::Arc;
@@ -342,22 +342,22 @@ async fn e2e_mcp_route_invokes_the_pure_routing_pipeline() {
     impl RoutingTable for StaticTable {
         async fn resolve(
             &self,
-            server: &str,
+            selector: &ServerSelector,
             _caller: &bitrouter_sdk::caller::CallerContext,
         ) -> bitrouter_sdk::Result<McpTarget> {
-            if server == "known" {
-                Ok(McpTarget {
-                    server_name: server.to_string(),
+            match selector {
+                ServerSelector::Direct(name) if name == "known" => Ok(McpTarget::Direct {
+                    server_name: name.clone(),
                     transport: McpTransport::Stdio {
                         command: "/bin/true".into(),
                         args: vec![],
                         env: Default::default(),
                     },
-                })
-            } else {
-                Err(bitrouter_sdk::BitrouterError::NotFound(format!(
-                    "unknown mcp server '{server}'"
-                )))
+                }),
+                ServerSelector::Direct(name) => Err(bitrouter_sdk::BitrouterError::NotFound(
+                    format!("unknown mcp server '{name}'"),
+                )),
+                ServerSelector::Aggregate => Ok(McpTarget::Aggregate { members: vec![] }),
             }
         }
     }
@@ -369,11 +369,15 @@ async fn e2e_mcp_route_invokes_the_pure_routing_pipeline() {
             target: &McpTarget,
             request: &McpRequest,
         ) -> bitrouter_sdk::Result<McpResponse> {
+            let server = match target {
+                McpTarget::Direct { server_name, .. } => server_name.clone(),
+                McpTarget::Aggregate { .. } => "<aggregate>".to_string(),
+            };
             Ok(McpResponse {
                 request_id: request.request_id.clone(),
                 result: serde_json::json!({
                     "method": request.method,
-                    "server": target.server_name,
+                    "server": server,
                     "params_seen": request.params,
                 }),
             })
@@ -532,6 +536,210 @@ async fn e2e_mcp_route_invokes_the_pure_routing_pipeline() {
     assert_eq!(json["jsonrpc"], "2.0");
     assert_eq!(json["id"], 1);
     assert_eq!(json["error"]["code"], -32601);
+}
+
+#[tokio::test]
+async fn e2e_mcp_aggregate_and_sse_endpoints() {
+    use async_trait::async_trait;
+    use bitrouter_sdk::App;
+    use bitrouter_sdk::mcp::{
+        AggregateMember, Executor, McpRequest, McpResponse, McpTarget, McpTransport, RoutingTable,
+        ServerSelector,
+    };
+    use bitrouter_sdk::server::{RouterOptions, build_router_with_options};
+    use http::Request;
+    use std::sync::Arc;
+    use tower::ServiceExt;
+
+    // Two-member aggregate table. The executor branches on Direct vs
+    // Aggregate so we test the SDK's AggregatingExecutor through its real
+    // wiring rather than reimplementing fan-out in the fixture.
+    struct TwoServerTable;
+    #[async_trait]
+    impl RoutingTable for TwoServerTable {
+        async fn resolve(
+            &self,
+            selector: &ServerSelector,
+            _caller: &bitrouter_sdk::caller::CallerContext,
+        ) -> bitrouter_sdk::Result<McpTarget> {
+            let stub = McpTransport::Stdio {
+                command: "/bin/true".into(),
+                args: vec![],
+                env: Default::default(),
+            };
+            match selector {
+                ServerSelector::Direct(name) => Ok(McpTarget::Direct {
+                    server_name: name.clone(),
+                    transport: stub,
+                }),
+                ServerSelector::Aggregate => Ok(McpTarget::Aggregate {
+                    members: vec![
+                        AggregateMember {
+                            server_name: "a".into(),
+                            tool_prefix: "a__".into(),
+                            transport: stub.clone(),
+                        },
+                        AggregateMember {
+                            server_name: "b".into(),
+                            tool_prefix: "b__".into(),
+                            transport: stub,
+                        },
+                    ],
+                }),
+            }
+        }
+    }
+
+    struct StaticToolsExecutor;
+    #[async_trait]
+    impl Executor for StaticToolsExecutor {
+        async fn execute(
+            &self,
+            target: &McpTarget,
+            request: &McpRequest,
+        ) -> bitrouter_sdk::Result<McpResponse> {
+            let server = match target {
+                McpTarget::Direct { server_name, .. } => server_name.clone(),
+                McpTarget::Aggregate { .. } => unreachable!("AggregatingExecutor must intercept"),
+            };
+            let tools = serde_json::json!([
+                { "name": "search", "description": format!("from {server}") },
+            ]);
+            Ok(McpResponse {
+                request_id: request.request_id.clone(),
+                result: serde_json::json!({ "tools": tools }),
+            })
+        }
+    }
+
+    struct UnusedLmExecutor;
+    #[async_trait]
+    impl bitrouter_sdk::language_model::Executor for UnusedLmExecutor {
+        async fn execute(
+            &self,
+            _target: &bitrouter_sdk::language_model::RoutingTarget,
+            _prompt: &bitrouter_sdk::language_model::Prompt,
+        ) -> bitrouter_sdk::Result<bitrouter_sdk::language_model::ExecutionResult> {
+            Err(bitrouter_sdk::BitrouterError::internal("unused"))
+        }
+        async fn execute_stream(
+            &self,
+            _target: &bitrouter_sdk::language_model::RoutingTarget,
+            _prompt: &bitrouter_sdk::language_model::Prompt,
+        ) -> bitrouter_sdk::Result<bitrouter_sdk::language_model::StreamPartStream> {
+            Err(bitrouter_sdk::BitrouterError::internal("unused"))
+        }
+    }
+
+    let app = App::builder()
+        .language_model(|lm| {
+            lm.routing_table(Arc::new(
+                bitrouter_sdk::language_model::StaticRoutingTable::new(),
+            ))
+            .executor(Arc::new(UnusedLmExecutor));
+        })
+        .mcp(|m| {
+            // The pipeline-level executor is the real AggregatingExecutor,
+            // wrapping our canned StaticToolsExecutor at the leaves.
+            let inner: Arc<StaticToolsExecutor> = Arc::new(StaticToolsExecutor);
+            let agg = bitrouter_sdk::mcp::aggregating_executor::AggregatingExecutor::new(inner);
+            m.routing_table(Arc::new(TwoServerTable))
+                .executor(Arc::new(agg));
+        })
+        .mcp_aggregate_route("/mcp")
+        .skip_auth(true)
+        .build()
+        .expect("app builds");
+
+    let state = AppState {
+        language_model: app.language_model().unwrap().clone(),
+        mcp: app.mcp().cloned(),
+        skip_auth: true,
+        metrics_renderer: None,
+    };
+    let options = RouterOptions {
+        omit_v1_models: false,
+        mcp_aggregate_route: app.mcp_aggregate_route().map(String::from),
+    };
+    let router = build_router_with_options(state, options);
+
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/list",
+        "params": {}
+    });
+
+    // (1) POST /mcp returns merged tools/list with `{prefix}{name}`.
+    let request = Request::builder()
+        .method("POST")
+        .uri("/mcp")
+        .header("content-type", "application/json")
+        .body(axum::body::Body::from(body.to_string()))
+        .unwrap();
+    let response = router.clone().oneshot(request).await.unwrap();
+    assert_eq!(response.status(), 200);
+    let bytes = axum::body::to_bytes(response.into_body(), 1 << 16)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    let names: Vec<String> = json["result"]["tools"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|t| t["name"].as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(names, vec!["a__search", "b__search"]);
+
+    // (2) Accept: text/event-stream on the aggregate route returns SSE.
+    let request = Request::builder()
+        .method("POST")
+        .uri("/mcp")
+        .header("content-type", "application/json")
+        .header("accept", "text/event-stream")
+        .body(axum::body::Body::from(body.to_string()))
+        .unwrap();
+    let response = router.clone().oneshot(request).await.unwrap();
+    assert_eq!(response.status(), 200);
+    let content_type = response
+        .headers()
+        .get(http::header::CONTENT_TYPE)
+        .expect("SSE response must carry Content-Type")
+        .to_str()
+        .unwrap();
+    assert!(
+        content_type.starts_with("text/event-stream"),
+        "expected SSE Content-Type, got: {content_type}"
+    );
+    let bytes = axum::body::to_bytes(response.into_body(), 1 << 16)
+        .await
+        .unwrap();
+    let body_str = String::from_utf8(bytes.to_vec()).unwrap();
+    // SSE body contains at least one `data:` line carrying the JSON-RPC result.
+    let data_line = body_str
+        .lines()
+        .find(|l| l.starts_with("data: "))
+        .expect("SSE stream must include a data event");
+    let payload: serde_json::Value =
+        serde_json::from_str(data_line.trim_start_matches("data: ")).unwrap();
+    assert_eq!(payload["jsonrpc"], "2.0");
+    assert_eq!(payload["id"], 1);
+    assert_eq!(payload["result"]["tools"][0]["name"], "a__search");
+
+    // (3) JSON path on the per-server route still works after refactor.
+    let request = Request::builder()
+        .method("POST")
+        .uri("/mcp/a")
+        .header("content-type", "application/json")
+        .body(axum::body::Body::from(body.to_string()))
+        .unwrap();
+    let response = router.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), 200);
+    let bytes = axum::body::to_bytes(response.into_body(), 1 << 16)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(json["result"]["tools"][0]["name"], "search");
 }
 
 // ============================================================================

--- a/crates/bitrouter-sdk/src/app.rs
+++ b/crates/bitrouter-sdk/src/app.rs
@@ -69,6 +69,7 @@ pub struct App {
     metrics_renderer: Option<Arc<dyn MetricsRenderer>>,
     migrations: Vec<MigrationItem>,
     skip_auth: bool,
+    mcp_aggregate_route: Option<String>,
 }
 
 impl App {
@@ -111,6 +112,13 @@ impl App {
     pub fn metrics_renderer(&self) -> Option<&Arc<dyn MetricsRenderer>> {
         self.metrics_renderer.as_ref()
     }
+
+    /// HTTP path for the MCP aggregate route, when configured (`POST <path>`
+    /// fans out across every `aggregate: true` MCP server). `None` means
+    /// only per-server routes (`POST /mcp/{server}`) are mounted.
+    pub fn mcp_aggregate_route(&self) -> Option<&str> {
+        self.mcp_aggregate_route.as_deref()
+    }
 }
 
 /// Configures an [`App`]. Each protocol is configured through its own
@@ -123,6 +131,7 @@ pub struct AppBuilder {
     metrics_renderer: Option<Arc<dyn MetricsRenderer>>,
     migrations: Vec<MigrationItem>,
     skip_auth: bool,
+    mcp_aggregate_route: Option<String>,
 }
 
 impl AppBuilder {
@@ -135,7 +144,17 @@ impl AppBuilder {
             metrics_renderer: None,
             migrations: Vec::new(),
             skip_auth: false,
+            mcp_aggregate_route: None,
         }
+    }
+
+    /// Path for the MCP aggregate fan-out endpoint (e.g. `/mcp`). When set,
+    /// `App::serve` mounts a `POST <path>` handler that fans out across every
+    /// `aggregate: true` MCP server. Has no effect unless the MCP pipeline is
+    /// also configured.
+    pub fn mcp_aggregate_route(mut self, path: impl Into<String>) -> Self {
+        self.mcp_aggregate_route = Some(path.into());
+        self
     }
 
     /// Set the SDK-level `skip_auth` flag (code default `false`). When `true`,
@@ -227,6 +246,16 @@ impl AppBuilder {
 
         self.migrations.sort_by_key(|m| m.version);
 
+        // The aggregate route only makes sense alongside an MCP pipeline —
+        // drop it silently if no MCP pipeline was configured (keeps
+        // `mcp_aggregate_route(...)` from accidentally mounting a 404-only
+        // handler in apps that don't use MCP).
+        let mcp_aggregate_route = if mcp.is_some() {
+            self.mcp_aggregate_route
+        } else {
+            None
+        };
+
         Ok(App {
             language_model,
             mcp,
@@ -234,6 +263,7 @@ impl AppBuilder {
             metrics_renderer: self.metrics_renderer,
             migrations: self.migrations,
             skip_auth: self.skip_auth,
+            mcp_aggregate_route,
         })
     }
 }

--- a/crates/bitrouter-sdk/src/config/mod.rs
+++ b/crates/bitrouter-sdk/src/config/mod.rs
@@ -64,7 +64,7 @@ pub struct Config {
     /// Upstream MCP servers, keyed by server id. The id is what appears in
     /// `POST /mcp/{id}` and what the `mcp` pipeline's routing table looks up.
     /// Empty by default — when empty, the binary does not mount the MCP route.
-    pub mcp_servers: HashMap<String, crate::mcp::McpServerConfig>,
+    pub mcp_servers: HashMap<String, crate::mcp::transport::McpServerConfig>,
     /// Upstream ACP agents, keyed by agent id. Looked up by the `acp`
     /// pipeline's routing table; the `bitrouter agent-proxy <id>` CLI
     /// dispatches against this. Empty by default.

--- a/crates/bitrouter-sdk/src/config/mod.rs
+++ b/crates/bitrouter-sdk/src/config/mod.rs
@@ -58,6 +58,9 @@ pub struct Config {
     pub variants: HashMap<String, VariantConfig>,
     /// Plugin config, keyed by plugin / bundle id.
     pub plugins: HashMap<String, serde_json::Value>,
+    /// Top-level MCP gateway settings (aggregation, caching). All fields
+    /// default — `mcp:` is optional in `bitrouter.yaml`.
+    pub mcp: McpConfig,
     /// Upstream MCP servers, keyed by server id. The id is what appears in
     /// `POST /mcp/{id}` and what the `mcp` pipeline's routing table looks up.
     /// Empty by default — when empty, the binary does not mount the MCP route.
@@ -80,9 +83,74 @@ impl Default for Config {
             presets: HashMap::new(),
             variants: HashMap::new(),
             plugins: HashMap::new(),
+            mcp: McpConfig::default(),
             mcp_servers: HashMap::new(),
             agents: HashMap::new(),
             inherit_defaults: true,
+        }
+    }
+}
+
+/// Top-level MCP gateway settings.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct McpConfig {
+    /// Aggregation (fan-out) endpoint settings.
+    pub aggregate: McpAggregateConfig,
+    /// List-call cache settings.
+    pub cache: McpCacheConfig,
+}
+
+/// `mcp.aggregate` — the virtual aggregate endpoint.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct McpAggregateConfig {
+    /// When `true` (the default), mount the aggregate route. When `false`,
+    /// only per-server routes (`/mcp/{server}`) are mounted.
+    pub enabled: bool,
+    /// HTTP path for the aggregate endpoint. Default `/mcp`.
+    pub route: String,
+}
+
+impl Default for McpAggregateConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            route: "/mcp".to_string(),
+        }
+    }
+}
+
+/// `mcp.cache` — the TTL cache wrapping cheap list calls.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct McpCacheConfig {
+    /// When `false`, the cache layer is not installed.
+    pub enabled: bool,
+    /// TTL for `tools/list`. `0` disables for this method.
+    pub tools_list_ttl_secs: u64,
+    /// TTL for `resources/list`. `0` disables for this method.
+    pub resources_list_ttl_secs: u64,
+    /// TTL for `resources/templates/list`. `0` disables for this method.
+    pub resources_templates_list_ttl_secs: u64,
+    /// TTL for `prompts/list`. `0` disables for this method.
+    pub prompts_list_ttl_secs: u64,
+    /// LRU safety bound — max entries per server.
+    pub max_entries_per_server: usize,
+}
+
+impl Default for McpCacheConfig {
+    fn default() -> Self {
+        // Defaults below are kept in lockstep with `mcp::CacheTtls::default()`.
+        // `mcp_cache_config_defaults_match_cache_ttls` (caching_executor tests)
+        // fails the build if these drift apart.
+        Self {
+            enabled: true,
+            tools_list_ttl_secs: 60,
+            resources_list_ttl_secs: 60,
+            resources_templates_list_ttl_secs: 300,
+            prompts_list_ttl_secs: 300,
+            max_entries_per_server: 64,
         }
     }
 }

--- a/crates/bitrouter-sdk/src/mcp/aggregating_executor.rs
+++ b/crates/bitrouter-sdk/src/mcp/aggregating_executor.rs
@@ -22,8 +22,9 @@
 //!
 //! Failure semantics for fan-out: **partial-success** by default. Servers that
 //! responded contribute their results; servers that failed are listed under
-//! `result._errors = [{server, error}]`. The `_` prefix marks the field as
-//! gateway-injected (not part of the MCP spec for the underlying method).
+//! `result._bitrouterErrors = [{server, error}]`. The `_bitrouter` prefix
+//! namespaces gateway-injected fields so they cannot collide with anything the
+//! upstream method's result schema may carry now or later.
 
 use std::sync::Arc;
 
@@ -77,12 +78,22 @@ impl<E: Executor> AggregatingExecutor<E> {
         list_key: &str,
         prefix_field: Option<&str>,
     ) -> Result<McpResponse> {
-        let mut items: Vec<serde_json::Value> = Vec::new();
-        let mut errors: Vec<serde_json::Value> = Vec::new();
-        for member in members {
+        // Fan out concurrently — cold-cache latency is Σ→max(per-server). Errors
+        // are collected as data (partial-success semantics), so there is no
+        // short-circuit and `join_all` is correct here. Order of members is
+        // preserved in the merged result because `join_all` returns results in
+        // input order regardless of completion order.
+        let calls = members.iter().map(|member| {
             let sub_req = Self::direct_request(request, member);
             let target = Self::direct_target(member);
-            match self.inner.execute(&target, &sub_req).await {
+            async move { (member, self.inner.execute(&target, &sub_req).await) }
+        });
+        let outcomes = futures::future::join_all(calls).await;
+
+        let mut items: Vec<serde_json::Value> = Vec::new();
+        let mut errors: Vec<serde_json::Value> = Vec::new();
+        for (member, outcome) in outcomes {
+            match outcome {
                 Ok(resp) => match resp.result.get(list_key).and_then(|v| v.as_array()) {
                     Some(arr) => {
                         for entry in arr {
@@ -112,7 +123,7 @@ impl<E: Executor> AggregatingExecutor<E> {
         }
         let mut result = serde_json::json!({ list_key: items });
         if !errors.is_empty() {
-            result["_errors"] = serde_json::Value::Array(errors);
+            result["_bitrouterErrors"] = serde_json::Value::Array(errors);
         }
         Ok(McpResponse {
             request_id: request.request_id.clone(),
@@ -380,7 +391,7 @@ mod tests {
             .map(|t| t["name"].as_str().unwrap().to_string())
             .collect();
         assert_eq!(names, vec!["a__search", "a__fetch", "b__noop"]);
-        assert!(resp.result.get("_errors").is_none());
+        assert!(resp.result.get("_bitrouterErrors").is_none());
     }
 
     #[tokio::test]
@@ -403,7 +414,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.result["tools"][0]["name"], "a__ok");
-        let errors = resp.result["_errors"].as_array().unwrap();
+        let errors = resp.result["_bitrouterErrors"].as_array().unwrap();
         assert_eq!(errors.len(), 1);
         assert_eq!(errors[0]["server"], "b");
     }

--- a/crates/bitrouter-sdk/src/mcp/aggregating_executor.rs
+++ b/crates/bitrouter-sdk/src/mcp/aggregating_executor.rs
@@ -1,0 +1,555 @@
+//! Aggregating [`Executor`] — fan-out across many upstream MCP servers behind
+//! one virtual `POST /mcp` endpoint.
+//!
+//! Wraps an inner [`Executor`] that only knows how to handle
+//! [`McpTarget::Direct`]; this layer is responsible for resolving
+//! [`McpTarget::Aggregate`] into N direct calls, merging their results, and
+//! applying the per-server `tool_prefix` rewrites the MCP-gateway ecosystem
+//! has converged on (MetaMCP, mcphub, Pluggedin, Docker MCP Gateway,
+//! Cloudflare portals).
+//!
+//! Per-method behaviour (see issue #483 for the dispatch table):
+//!
+//! | Inbound | Behaviour |
+//! |---|---|
+//! | `tools/list` | fan-out → concat tools, prepend `tool_prefix` to each name |
+//! | `resources/list` | fan-out → concat (no prefix, URIs are globally addressable) |
+//! | `resources/templates/list` | fan-out → concat |
+//! | `prompts/list` | fan-out → concat, prepend `tool_prefix` to each name |
+//! | `tools/call` | strip prefix from `params.name`, dispatch to owning member |
+//! | `resources/read` | try each member, first success wins |
+//! | `prompts/get` | strip prefix from `params.name`, dispatch to owning member |
+//!
+//! Failure semantics for fan-out: **partial-success** by default. Servers that
+//! responded contribute their results; servers that failed are listed under
+//! `result._errors = [{server, error}]`. The `_` prefix marks the field as
+//! gateway-injected (not part of the MCP spec for the underlying method).
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use futures::stream::{self, BoxStream, StreamExt};
+
+use super::{
+    AggregateMember, Executor, McpRequest, McpResponse, McpStreamPart, McpTarget, ServerSelector,
+};
+use crate::error::{BitrouterError, Result};
+
+/// Fan-out wrapper over an inner [`Executor`]. Passes [`McpTarget::Direct`]
+/// straight through to the inner; handles [`McpTarget::Aggregate`] by issuing
+/// per-member direct calls and merging the results.
+pub struct AggregatingExecutor<E: Executor> {
+    inner: Arc<E>,
+}
+
+impl<E: Executor> AggregatingExecutor<E> {
+    /// Wrap an inner executor.
+    pub fn new(inner: Arc<E>) -> Self {
+        Self { inner }
+    }
+
+    /// Build a per-member direct request from the aggregate request. Used by
+    /// fan-out and prefix-routed methods.
+    fn direct_request(request: &McpRequest, member: &AggregateMember) -> McpRequest {
+        // The aggregate's `request_id` is the inbound id from the JSON-RPC
+        // client. Per-member sub-calls reuse it so settled/observe hooks can
+        // correlate the whole fan-out as one logical request.
+        McpRequest {
+            request_id: request.request_id.clone(),
+            selector: ServerSelector::Direct(member.server_name.clone()),
+            method: request.method.clone(),
+            params: request.params.clone(),
+            caller: request.caller.clone(),
+        }
+    }
+
+    fn direct_target(member: &AggregateMember) -> McpTarget {
+        McpTarget::Direct {
+            server_name: member.server_name.clone(),
+            transport: member.transport.clone(),
+        }
+    }
+
+    async fn fanout_list(
+        &self,
+        members: &[AggregateMember],
+        request: &McpRequest,
+        list_key: &str,
+        prefix_field: Option<&str>,
+    ) -> Result<McpResponse> {
+        let mut items: Vec<serde_json::Value> = Vec::new();
+        let mut errors: Vec<serde_json::Value> = Vec::new();
+        for member in members {
+            let sub_req = Self::direct_request(request, member);
+            let target = Self::direct_target(member);
+            match self.inner.execute(&target, &sub_req).await {
+                Ok(resp) => match resp.result.get(list_key).and_then(|v| v.as_array()) {
+                    Some(arr) => {
+                        for entry in arr {
+                            let mut entry = entry.clone();
+                            if let Some(field) = prefix_field
+                                && let Some(obj) = entry.as_object_mut()
+                                && let Some(name) = obj.get_mut(field).and_then(|v| v.as_str())
+                            {
+                                let prefixed = format!("{}{name}", member.tool_prefix);
+                                obj.insert(field.to_string(), prefixed.into());
+                            }
+                            items.push(entry);
+                        }
+                    }
+                    None => errors.push(serde_json::json!({
+                        "server": member.server_name,
+                        "error": format!(
+                            "upstream response missing or non-array '{list_key}'",
+                        ),
+                    })),
+                },
+                Err(e) => errors.push(serde_json::json!({
+                    "server": member.server_name,
+                    "error": e.to_string(),
+                })),
+            }
+        }
+        let mut result = serde_json::json!({ list_key: items });
+        if !errors.is_empty() {
+            result["_errors"] = serde_json::Value::Array(errors);
+        }
+        Ok(McpResponse {
+            request_id: request.request_id.clone(),
+            result,
+        })
+    }
+
+    /// Resolve a prefix-routed request (`tools/call` / `prompts/get`) into the
+    /// per-member direct request and target. Returns the rewritten `name`
+    /// stripped of its prefix.
+    ///
+    /// Longest-prefix wins so `a__` does not steal calls intended for `ab__`
+    /// when both servers are registered.
+    fn resolve_prefixed(
+        members: &[AggregateMember],
+        request: &McpRequest,
+    ) -> Result<(McpRequest, McpTarget)> {
+        let name = request
+            .params
+            .get("name")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| {
+                BitrouterError::bad_request(format!(
+                    "mcp aggregate {}: params.name is required",
+                    request.method
+                ))
+            })?;
+        let (member, stripped) = members
+            .iter()
+            .filter_map(|m| name.strip_prefix(&m.tool_prefix).map(|s| (m, s)))
+            .max_by_key(|(m, _)| m.tool_prefix.len())
+            .ok_or_else(|| {
+                BitrouterError::NotFound(format!(
+                    "mcp aggregate {}: no member prefix matches '{name}'",
+                    request.method
+                ))
+            })?;
+        let mut sub_req = Self::direct_request(request, member);
+        if let Some(obj) = sub_req.params.as_object_mut() {
+            obj.insert("name".to_string(), stripped.to_string().into());
+        }
+        Ok((sub_req, Self::direct_target(member)))
+    }
+
+    /// Strip the `tool_prefix` from `params.name` and dispatch to the owning
+    /// member. Used by `tools/call` and `prompts/get`.
+    async fn prefixed_dispatch(
+        &self,
+        members: &[AggregateMember],
+        request: &McpRequest,
+    ) -> Result<McpResponse> {
+        let (sub_req, target) = Self::resolve_prefixed(members, request)?;
+        self.inner.execute(&target, &sub_req).await
+    }
+
+    /// `resources/read` — try each member; first success wins. Errors are
+    /// accumulated and returned only if every member fails.
+    async fn try_each(
+        &self,
+        members: &[AggregateMember],
+        request: &McpRequest,
+    ) -> Result<McpResponse> {
+        let mut errors = Vec::new();
+        for member in members {
+            let sub_req = Self::direct_request(request, member);
+            let target = Self::direct_target(member);
+            match self.inner.execute(&target, &sub_req).await {
+                Ok(resp) => return Ok(resp),
+                Err(e) => errors.push(format!("{}: {}", member.server_name, e)),
+            }
+        }
+        Err(BitrouterError::NotFound(format!(
+            "mcp aggregate {}: no member served the request ({})",
+            request.method,
+            errors.join("; ")
+        )))
+    }
+
+    async fn dispatch_aggregate(
+        &self,
+        members: &[AggregateMember],
+        request: &McpRequest,
+    ) -> Result<McpResponse> {
+        if members.is_empty() {
+            // Empty aggregate (e.g. every server set `aggregate: false`) —
+            // return an empty list shape so list calls keep parsing on the
+            // client. Non-list methods surface as "method not found".
+            return match request.method.as_str() {
+                "tools/list" => Ok(McpResponse {
+                    request_id: request.request_id.clone(),
+                    result: serde_json::json!({ "tools": [] }),
+                }),
+                "resources/list" => Ok(McpResponse {
+                    request_id: request.request_id.clone(),
+                    result: serde_json::json!({ "resources": [] }),
+                }),
+                "resources/templates/list" => Ok(McpResponse {
+                    request_id: request.request_id.clone(),
+                    result: serde_json::json!({ "resourceTemplates": [] }),
+                }),
+                "prompts/list" => Ok(McpResponse {
+                    request_id: request.request_id.clone(),
+                    result: serde_json::json!({ "prompts": [] }),
+                }),
+                other => Err(BitrouterError::NotFound(format!(
+                    "mcp aggregate {other}: no member servers configured"
+                ))),
+            };
+        }
+        match request.method.as_str() {
+            "tools/list" => {
+                self.fanout_list(members, request, "tools", Some("name"))
+                    .await
+            }
+            "resources/list" => self.fanout_list(members, request, "resources", None).await,
+            "resources/templates/list" => {
+                self.fanout_list(members, request, "resourceTemplates", None)
+                    .await
+            }
+            "prompts/list" => {
+                self.fanout_list(members, request, "prompts", Some("name"))
+                    .await
+            }
+            "tools/call" | "prompts/get" => self.prefixed_dispatch(members, request).await,
+            "resources/read" => self.try_each(members, request).await,
+            other => Err(BitrouterError::NotFound(format!(
+                "mcp aggregate {other}: not supported on the aggregate endpoint"
+            ))),
+        }
+    }
+}
+
+#[async_trait]
+impl<E: Executor + 'static> Executor for AggregatingExecutor<E> {
+    async fn execute(&self, target: &McpTarget, request: &McpRequest) -> Result<McpResponse> {
+        match target {
+            McpTarget::Direct { .. } => self.inner.execute(target, request).await,
+            McpTarget::Aggregate { members } => self.dispatch_aggregate(members, request).await,
+        }
+    }
+
+    async fn execute_streaming(
+        &self,
+        target: &McpTarget,
+        request: &McpRequest,
+    ) -> Result<BoxStream<'static, Result<McpStreamPart>>> {
+        match target {
+            McpTarget::Direct { .. } => self.inner.execute_streaming(target, request).await,
+            McpTarget::Aggregate { members } => {
+                // `tools/call` (and `prompts/get`) is the only aggregate-mode
+                // method that meaningfully streams — it routes to a single
+                // member by prefix, so the inner stream passes through.
+                if matches!(request.method.as_str(), "tools/call" | "prompts/get") {
+                    let (sub_req, target) = Self::resolve_prefixed(members, request)?;
+                    return self.inner.execute_streaming(&target, &sub_req).await;
+                }
+                // For fan-out methods (list-shaped, `resources/read`), there
+                // is no meaningful intermediate stream — buffer the merged
+                // response and emit a single `Final`.
+                let response = self.dispatch_aggregate(members, request).await?;
+                Ok(stream::once(async move { Ok(McpStreamPart::Final(response)) }).boxed())
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::caller::CallerContext;
+    use crate::mcp::McpTransport;
+    use async_trait::async_trait;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    struct CannedExecutor {
+        responses: Mutex<HashMap<String, Result<serde_json::Value>>>,
+    }
+
+    impl CannedExecutor {
+        fn new() -> Self {
+            Self {
+                responses: Mutex::new(HashMap::new()),
+            }
+        }
+        fn with(self, server: &str, value: serde_json::Value) -> Self {
+            self.responses
+                .lock()
+                .unwrap()
+                .insert(server.to_string(), Ok(value));
+            self
+        }
+        fn with_err(self, server: &str, err: BitrouterError) -> Self {
+            self.responses
+                .lock()
+                .unwrap()
+                .insert(server.to_string(), Err(err));
+            self
+        }
+    }
+
+    #[async_trait]
+    impl Executor for CannedExecutor {
+        async fn execute(&self, target: &McpTarget, request: &McpRequest) -> Result<McpResponse> {
+            let name = match target {
+                McpTarget::Direct { server_name, .. } => server_name.clone(),
+                McpTarget::Aggregate { .. } => panic!("inner saw aggregate"),
+            };
+            let mut map = self.responses.lock().unwrap();
+            // Allow per-server multi-method canned responses by keying on
+            // "{server}:{method}" when the test prepared one, falling back to
+            // the bare server key.
+            let composite = format!("{name}:{}", request.method);
+            let entry = map
+                .remove(&composite)
+                .or_else(|| map.remove(&name))
+                .unwrap_or_else(|| {
+                    Err(BitrouterError::internal(format!(
+                        "no canned response for '{name}' / '{composite}'"
+                    )))
+                });
+            entry.map(|result| McpResponse {
+                request_id: request.request_id.clone(),
+                result,
+            })
+        }
+    }
+
+    fn member(name: &str) -> AggregateMember {
+        AggregateMember {
+            server_name: name.into(),
+            tool_prefix: format!("{name}__"),
+            transport: McpTransport::Stdio {
+                command: "/bin/true".into(),
+                args: vec![],
+                env: Default::default(),
+            },
+        }
+    }
+
+    fn agg_req(method: &str, params: serde_json::Value) -> McpRequest {
+        McpRequest::aggregate(method, params, CallerContext::new("k", "u"))
+    }
+
+    #[tokio::test]
+    async fn tools_list_fanout_prefixes_names_and_concats() {
+        let inner = CannedExecutor::new()
+            .with(
+                "a",
+                serde_json::json!({"tools": [{"name": "search"}, {"name": "fetch"}]}),
+            )
+            .with("b", serde_json::json!({"tools": [{"name": "noop"}]}));
+        let exec = AggregatingExecutor::new(Arc::new(inner));
+        let target = McpTarget::Aggregate {
+            members: vec![member("a"), member("b")],
+        };
+        let resp = exec
+            .execute(&target, &agg_req("tools/list", serde_json::json!({})))
+            .await
+            .unwrap();
+        let names: Vec<String> = resp.result["tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|t| t["name"].as_str().unwrap().to_string())
+            .collect();
+        assert_eq!(names, vec!["a__search", "a__fetch", "b__noop"]);
+        assert!(resp.result.get("_errors").is_none());
+    }
+
+    #[tokio::test]
+    async fn tools_list_partial_failure_surfaces_under_errors() {
+        let inner = CannedExecutor::new()
+            .with("a", serde_json::json!({"tools": [{"name": "ok"}]}))
+            .with_err(
+                "b",
+                BitrouterError::Upstream {
+                    status: 502,
+                    message: "boom".into(),
+                },
+            );
+        let exec = AggregatingExecutor::new(Arc::new(inner));
+        let target = McpTarget::Aggregate {
+            members: vec![member("a"), member("b")],
+        };
+        let resp = exec
+            .execute(&target, &agg_req("tools/list", serde_json::json!({})))
+            .await
+            .unwrap();
+        assert_eq!(resp.result["tools"][0]["name"], "a__ok");
+        let errors = resp.result["_errors"].as_array().unwrap();
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0]["server"], "b");
+    }
+
+    #[tokio::test]
+    async fn tools_call_strips_prefix_and_dispatches_to_member() {
+        let inner = CannedExecutor::new().with("a", serde_json::json!({"ok": true}));
+        let exec = AggregatingExecutor::new(Arc::new(inner));
+        let target = McpTarget::Aggregate {
+            members: vec![member("a"), member("b")],
+        };
+        let resp = exec
+            .execute(
+                &target,
+                &agg_req(
+                    "tools/call",
+                    serde_json::json!({ "name": "a__search", "arguments": {} }),
+                ),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.result["ok"], true);
+    }
+
+    #[tokio::test]
+    async fn tools_call_uses_longest_matching_prefix() {
+        // Two servers — "a" with prefix "a__" and "ab" with prefix "ab__". A
+        // call to "ab__tool" must route to "ab" (longer prefix) even though
+        // "a__" is also a valid `strip_prefix` candidate. Without
+        // longest-prefix-wins this would silently misroute to "a" with the
+        // stripped name "b__tool".
+        let inner = CannedExecutor::new()
+            .with("ab", serde_json::json!({"server": "ab"}))
+            .with("a", serde_json::json!({"server": "a"}));
+        let exec = AggregatingExecutor::new(Arc::new(inner));
+        let mut m_a = member("a");
+        m_a.tool_prefix = "a__".into();
+        let mut m_ab = member("ab");
+        m_ab.tool_prefix = "ab__".into();
+        let target = McpTarget::Aggregate {
+            members: vec![m_a, m_ab],
+        };
+        let resp = exec
+            .execute(
+                &target,
+                &agg_req(
+                    "tools/call",
+                    serde_json::json!({ "name": "ab__tool", "arguments": {} }),
+                ),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.result["server"], "ab");
+    }
+
+    #[tokio::test]
+    async fn tools_call_unknown_prefix_is_404() {
+        let inner = CannedExecutor::new();
+        let exec = AggregatingExecutor::new(Arc::new(inner));
+        let target = McpTarget::Aggregate {
+            members: vec![member("a")],
+        };
+        let err = exec
+            .execute(
+                &target,
+                &agg_req("tools/call", serde_json::json!({ "name": "ghost__search" })),
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(err.status(), 404);
+    }
+
+    #[tokio::test]
+    async fn resources_read_returns_first_success() {
+        let inner = CannedExecutor::new()
+            .with_err("a", BitrouterError::NotFound("missing".into()))
+            .with("b", serde_json::json!({"contents": ["data"]}));
+        let exec = AggregatingExecutor::new(Arc::new(inner));
+        let target = McpTarget::Aggregate {
+            members: vec![member("a"), member("b")],
+        };
+        let resp = exec
+            .execute(
+                &target,
+                &agg_req("resources/read", serde_json::json!({ "uri": "x://y" })),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.result["contents"][0], "data");
+    }
+
+    #[tokio::test]
+    async fn resources_read_all_failures_is_404() {
+        let inner = CannedExecutor::new()
+            .with_err("a", BitrouterError::NotFound("missing a".into()))
+            .with_err("b", BitrouterError::NotFound("missing b".into()));
+        let exec = AggregatingExecutor::new(Arc::new(inner));
+        let target = McpTarget::Aggregate {
+            members: vec![member("a"), member("b")],
+        };
+        let err = exec
+            .execute(
+                &target,
+                &agg_req("resources/read", serde_json::json!({ "uri": "x://y" })),
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(err.status(), 404);
+    }
+
+    #[tokio::test]
+    async fn empty_aggregate_returns_empty_list_for_list_methods() {
+        let inner = CannedExecutor::new();
+        let exec = AggregatingExecutor::new(Arc::new(inner));
+        let target = McpTarget::Aggregate { members: vec![] };
+        let resp = exec
+            .execute(&target, &agg_req("tools/list", serde_json::json!({})))
+            .await
+            .unwrap();
+        assert_eq!(resp.result["tools"].as_array().unwrap().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn direct_target_passes_through_to_inner() {
+        let inner = CannedExecutor::new().with("only", serde_json::json!({"pass": true}));
+        let exec = AggregatingExecutor::new(Arc::new(inner));
+        let target = McpTarget::Direct {
+            server_name: "only".into(),
+            transport: McpTransport::Stdio {
+                command: "/bin/true".into(),
+                args: vec![],
+                env: Default::default(),
+            },
+        };
+        let resp = exec
+            .execute(
+                &target,
+                &McpRequest::direct(
+                    "only",
+                    "tools/list",
+                    serde_json::json!({}),
+                    CallerContext::new("k", "u"),
+                ),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.result["pass"], true);
+    }
+}

--- a/crates/bitrouter-sdk/src/mcp/aggregating_executor.rs
+++ b/crates/bitrouter-sdk/src/mcp/aggregating_executor.rs
@@ -294,7 +294,7 @@ impl<E: Executor + 'static> Executor for AggregatingExecutor<E> {
 mod tests {
     use super::*;
     use crate::caller::CallerContext;
-    use crate::mcp::McpTransport;
+    use crate::mcp::transport::McpTransport;
     use async_trait::async_trait;
     use std::collections::HashMap;
     use std::sync::Mutex;

--- a/crates/bitrouter-sdk/src/mcp/caching_executor.rs
+++ b/crates/bitrouter-sdk/src/mcp/caching_executor.rs
@@ -1,19 +1,20 @@
-//! TTL-cached [`Executor`](super::Executor) — wraps another executor with a
-//! per-server cache for cheap list calls (`tools/list`, `resources/list`,
+//! TTL-cached [`Executor`] — wraps another executor with a per-server cache
+//! for cheap list calls (`tools/list`, `resources/list`,
 //! `resources/templates/list`, `prompts/list`).
 //!
 //! Non-list methods (`tools/call`, `resources/read`, `prompts/get`) and
 //! aggregate targets pass straight through.
 //!
 //! Cache entries expire on TTL. When the inner executor is hooked up to a
-//! `notifications/*_list_changed` source via [`with_invalidation`], affected
-//! entries are also evicted on demand. The TTL on each entry honours the MCP
-//! spec's `ttlMs` cache-control hint when present in the upstream `_meta`.
+//! `notifications/*_list_changed` source via
+//! [`CachingExecutor::with_invalidation`], affected entries are also evicted
+//! on demand. The TTL on each entry honours the MCP spec's `ttlMs`
+//! cache-control hint when present in the upstream `_meta`.
 //!
 //! Caching applies per [`McpTarget::Direct`] member; when used inside an
-//! [`super::AggregatingExecutor`], the cache key includes the per-member
-//! server name so a cold aggregate fan-out warms each leaf cache
-//! independently.
+//! [`super::aggregating_executor::AggregatingExecutor`], the cache key
+//! includes the per-member server name so a cold aggregate fan-out warms
+//! each leaf cache independently.
 
 use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex};

--- a/crates/bitrouter-sdk/src/mcp/caching_executor.rs
+++ b/crates/bitrouter-sdk/src/mcp/caching_executor.rs
@@ -190,8 +190,8 @@ impl<E: Executor + 'static> CachingExecutor<E> {
     }
 
     /// Subscribe the cache to an [`InvalidationEvent`] stream — typically
-    /// [`super::RmcpExecutor::invalidation_receiver`]. Returns `self` so the
-    /// builder reads naturally.
+    /// [`super::rmcp_executor::RmcpExecutor::invalidation_receiver`]. Returns
+    /// `self` so the builder reads naturally.
     pub fn with_invalidation(mut self, mut rx: broadcast::Receiver<InvalidationEvent>) -> Self {
         let caches = self.caches.clone();
         let handle = tokio::spawn(async move {
@@ -448,7 +448,7 @@ impl<E: Executor + 'static> Executor for CachingExecutor<E> {
 mod tests {
     use super::*;
     use crate::caller::CallerContext;
-    use crate::mcp::McpTransport;
+    use crate::mcp::transport::McpTransport;
     use async_trait::async_trait;
     use std::collections::HashMap;
     use std::sync::atomic::{AtomicUsize, Ordering};

--- a/crates/bitrouter-sdk/src/mcp/caching_executor.rs
+++ b/crates/bitrouter-sdk/src/mcp/caching_executor.rs
@@ -171,6 +171,11 @@ pub struct CachingExecutor<E: Executor> {
     inner: Arc<E>,
     ttls: CacheTtls,
     caches: Arc<Mutex<HashMap<String, ServerCache>>>,
+    /// `Some` once [`with_invalidation`] has spawned the receiver loop. Held so
+    /// `Drop` can `abort()` it — otherwise the task would outlive the
+    /// executor whenever the broadcast sender (typically on the inner
+    /// `RmcpExecutor`) lives longer than this wrapper.
+    invalidation_task: Option<tokio::task::JoinHandle<()>>,
 }
 
 impl<E: Executor + 'static> CachingExecutor<E> {
@@ -180,15 +185,16 @@ impl<E: Executor + 'static> CachingExecutor<E> {
             inner,
             ttls,
             caches: Arc::new(Mutex::new(HashMap::new())),
+            invalidation_task: None,
         }
     }
 
     /// Subscribe the cache to an [`InvalidationEvent`] stream — typically
     /// [`super::RmcpExecutor::invalidation_receiver`]. Returns `self` so the
     /// builder reads naturally.
-    pub fn with_invalidation(self, mut rx: broadcast::Receiver<InvalidationEvent>) -> Self {
+    pub fn with_invalidation(mut self, mut rx: broadcast::Receiver<InvalidationEvent>) -> Self {
         let caches = self.caches.clone();
-        tokio::spawn(async move {
+        let handle = tokio::spawn(async move {
             loop {
                 match rx.recv().await {
                     Ok(event) => apply_invalidation(&caches, &event),
@@ -206,6 +212,7 @@ impl<E: Executor + 'static> CachingExecutor<E> {
                 }
             }
         });
+        self.invalidation_task = Some(handle);
         self
     }
 
@@ -230,6 +237,14 @@ impl<E: Executor + 'static> CachingExecutor<E> {
                 ttl,
             },
         );
+    }
+}
+
+impl<E: Executor> Drop for CachingExecutor<E> {
+    fn drop(&mut self) {
+        if let Some(handle) = self.invalidation_task.take() {
+            handle.abort();
+        }
     }
 }
 
@@ -277,11 +292,55 @@ fn extract_ttl_hint(result: &serde_json::Value) -> Option<Duration> {
 
 fn params_hash(params: &serde_json::Value) -> u64 {
     use std::collections::hash_map::DefaultHasher;
-    use std::hash::{Hash, Hasher};
-    let s = serde_json::to_string(params).unwrap_or_default();
+    use std::hash::Hasher;
     let mut h = DefaultHasher::new();
-    s.hash(&mut h);
+    hash_value(params, &mut h);
     h.finish()
+}
+
+/// Stable, key-order-independent hash of a JSON value. Object entries are
+/// sorted lexicographically before hashing so two semantically equal payloads
+/// (`{"a":1,"b":2}` and `{"b":2,"a":1}`) collide on the same cache key
+/// regardless of whether `serde_json`'s `preserve_order` feature is enabled
+/// anywhere in the workspace (the feature is additive — any transitive dep
+/// can flip the default `Map` from `BTreeMap` to `IndexMap`).
+///
+/// A per-variant discriminator byte and a length prefix on collections keep
+/// the hash unambiguous across types (`null` vs `"null"`, `[1,2]` vs `[1,[2]]`).
+fn hash_value<H: std::hash::Hasher>(value: &serde_json::Value, hasher: &mut H) {
+    use std::hash::Hash;
+    match value {
+        serde_json::Value::Null => 0u8.hash(hasher),
+        serde_json::Value::Bool(b) => {
+            1u8.hash(hasher);
+            b.hash(hasher);
+        }
+        serde_json::Value::Number(n) => {
+            2u8.hash(hasher);
+            n.to_string().hash(hasher);
+        }
+        serde_json::Value::String(s) => {
+            3u8.hash(hasher);
+            s.hash(hasher);
+        }
+        serde_json::Value::Array(arr) => {
+            4u8.hash(hasher);
+            (arr.len() as u64).hash(hasher);
+            for v in arr {
+                hash_value(v, hasher);
+            }
+        }
+        serde_json::Value::Object(obj) => {
+            5u8.hash(hasher);
+            let mut entries: Vec<(&String, &serde_json::Value)> = obj.iter().collect();
+            entries.sort_unstable_by(|a, b| a.0.cmp(b.0));
+            (entries.len() as u64).hash(hasher);
+            for (k, v) in entries {
+                k.hash(hasher);
+                hash_value(v, hasher);
+            }
+        }
+    }
 }
 
 #[async_trait]
@@ -552,6 +611,25 @@ mod tests {
         );
         assert_eq!(derived.prompts_list, coded.prompts_list);
         assert_eq!(derived.max_entries_per_server, coded.max_entries_per_server);
+    }
+
+    #[test]
+    fn params_hash_is_canonical_across_key_order() {
+        // Two semantically-equal params with different key insertion order
+        // must hash identically — otherwise `resources/list` with a
+        // `{cursor, filter}` shape would suffer surprising cache misses
+        // depending on how the inbound client built the JSON.
+        let a = serde_json::json!({"a": 1, "b": {"x": [1, 2], "y": "z"}});
+        let b = serde_json::json!({"b": {"y": "z", "x": [1, 2]}, "a": 1});
+        assert_eq!(params_hash(&a), params_hash(&b));
+        // Different values must still differ.
+        let c = serde_json::json!({"a": 1, "b": {"y": "z", "x": [1, 3]}});
+        assert_ne!(params_hash(&a), params_hash(&c));
+        // Type discrimination: `null` vs the string "null".
+        assert_ne!(
+            params_hash(&serde_json::Value::Null),
+            params_hash(&serde_json::json!("null"))
+        );
     }
 
     #[tokio::test]

--- a/crates/bitrouter-sdk/src/mcp/caching_executor.rs
+++ b/crates/bitrouter-sdk/src/mcp/caching_executor.rs
@@ -1,0 +1,579 @@
+//! TTL-cached [`Executor`](super::Executor) — wraps another executor with a
+//! per-server cache for cheap list calls (`tools/list`, `resources/list`,
+//! `resources/templates/list`, `prompts/list`).
+//!
+//! Non-list methods (`tools/call`, `resources/read`, `prompts/get`) and
+//! aggregate targets pass straight through.
+//!
+//! Cache entries expire on TTL. When the inner executor is hooked up to a
+//! `notifications/*_list_changed` source via [`with_invalidation`], affected
+//! entries are also evicted on demand. The TTL on each entry honours the MCP
+//! spec's `ttlMs` cache-control hint when present in the upstream `_meta`.
+//!
+//! Caching applies per [`McpTarget::Direct`] member; when used inside an
+//! [`super::AggregatingExecutor`], the cache key includes the per-member
+//! server name so a cold aggregate fan-out warms each leaf cache
+//! independently.
+
+use std::collections::{HashMap, VecDeque};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use futures::stream::{self, BoxStream, StreamExt};
+use tokio::sync::broadcast;
+
+use super::{
+    Executor, InvalidationEvent, InvalidationKind, McpRequest, McpResponse, McpStreamPart,
+    McpTarget,
+};
+use crate::error::Result;
+
+// Defaults for `CacheTtls` and the YAML-facing `McpCacheConfig`
+// (`crates/bitrouter-sdk/src/config/mod.rs`) — single source of truth so a
+// `mcp.cache:` block with all-defaults behaves identically to no
+// `mcp.cache:` block at all.
+const DEFAULT_TOOLS_LIST_TTL_SECS: u64 = 60;
+const DEFAULT_RESOURCES_LIST_TTL_SECS: u64 = 60;
+const DEFAULT_RESOURCES_TEMPLATES_LIST_TTL_SECS: u64 = 300;
+const DEFAULT_PROMPTS_LIST_TTL_SECS: u64 = 300;
+/// Default per-server LRU bound. Pub so the config layer can spell the same
+/// number without re-declaring it.
+pub const DEFAULT_MAX_ENTRIES_PER_SERVER: usize = 64;
+
+/// Per-method cache TTLs. `Duration::ZERO` disables caching for that method.
+#[derive(Debug, Clone)]
+pub struct CacheTtls {
+    /// TTL for `tools/list`.
+    pub tools_list: Duration,
+    /// TTL for `resources/list`.
+    pub resources_list: Duration,
+    /// TTL for `resources/templates/list`.
+    pub resources_templates_list: Duration,
+    /// TTL for `prompts/list`.
+    pub prompts_list: Duration,
+    /// Max entries per server (LRU eviction safety bound).
+    pub max_entries_per_server: usize,
+}
+
+impl Default for CacheTtls {
+    fn default() -> Self {
+        Self {
+            tools_list: Duration::from_secs(DEFAULT_TOOLS_LIST_TTL_SECS),
+            resources_list: Duration::from_secs(DEFAULT_RESOURCES_LIST_TTL_SECS),
+            resources_templates_list: Duration::from_secs(
+                DEFAULT_RESOURCES_TEMPLATES_LIST_TTL_SECS,
+            ),
+            prompts_list: Duration::from_secs(DEFAULT_PROMPTS_LIST_TTL_SECS),
+            max_entries_per_server: DEFAULT_MAX_ENTRIES_PER_SERVER,
+        }
+    }
+}
+
+#[cfg(feature = "config_file")]
+impl From<&crate::config::McpCacheConfig> for CacheTtls {
+    fn from(cfg: &crate::config::McpCacheConfig) -> Self {
+        Self {
+            tools_list: Duration::from_secs(cfg.tools_list_ttl_secs),
+            resources_list: Duration::from_secs(cfg.resources_list_ttl_secs),
+            resources_templates_list: Duration::from_secs(cfg.resources_templates_list_ttl_secs),
+            prompts_list: Duration::from_secs(cfg.prompts_list_ttl_secs),
+            max_entries_per_server: cfg.max_entries_per_server,
+        }
+    }
+}
+
+impl CacheTtls {
+    fn ttl_for(&self, method: &str) -> Option<Duration> {
+        let d = match method {
+            "tools/list" => self.tools_list,
+            "resources/list" => self.resources_list,
+            "resources/templates/list" => self.resources_templates_list,
+            "prompts/list" => self.prompts_list,
+            _ => return None,
+        };
+        if d.is_zero() { None } else { Some(d) }
+    }
+}
+
+#[derive(Hash, Eq, PartialEq, Clone)]
+struct CacheKey {
+    server_name: String,
+    method: &'static str,
+    params_hash: u64,
+}
+
+#[derive(Clone)]
+struct CacheEntry {
+    value: serde_json::Value,
+    inserted_at: Instant,
+    ttl: Duration,
+}
+
+impl CacheEntry {
+    fn is_fresh(&self, now: Instant) -> bool {
+        now.duration_since(self.inserted_at) < self.ttl
+    }
+}
+
+/// Per-server LRU + TTL cache.
+struct ServerCache {
+    entries: HashMap<CacheKey, CacheEntry>,
+    /// Insertion order — popped from the front when over the size bound.
+    order: VecDeque<CacheKey>,
+    max_entries: usize,
+}
+
+impl ServerCache {
+    fn new(max_entries: usize) -> Self {
+        Self {
+            entries: HashMap::new(),
+            order: VecDeque::new(),
+            max_entries,
+        }
+    }
+
+    fn get(&self, key: &CacheKey, now: Instant) -> Option<serde_json::Value> {
+        self.entries
+            .get(key)
+            .filter(|e| e.is_fresh(now))
+            .map(|e| e.value.clone())
+    }
+
+    fn insert(&mut self, key: CacheKey, entry: CacheEntry) {
+        if !self.entries.contains_key(&key) {
+            self.order.push_back(key.clone());
+        }
+        self.entries.insert(key, entry);
+        while self.entries.len() > self.max_entries {
+            if let Some(oldest) = self.order.pop_front() {
+                self.entries.remove(&oldest);
+            } else {
+                break;
+            }
+        }
+    }
+
+    fn evict_method(&mut self, method: &'static str) {
+        self.entries.retain(|k, _| k.method != method);
+        self.order.retain(|k| k.method != method);
+    }
+
+    fn clear(&mut self) {
+        self.entries.clear();
+        self.order.clear();
+    }
+}
+
+/// Wrap an inner [`Executor`] with a TTL cache for list-shaped methods.
+pub struct CachingExecutor<E: Executor> {
+    inner: Arc<E>,
+    ttls: CacheTtls,
+    caches: Arc<Mutex<HashMap<String, ServerCache>>>,
+}
+
+impl<E: Executor + 'static> CachingExecutor<E> {
+    /// Build a cache around `inner` with the per-method TTLs in `ttls`.
+    pub fn new(inner: Arc<E>, ttls: CacheTtls) -> Self {
+        Self {
+            inner,
+            ttls,
+            caches: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Subscribe the cache to an [`InvalidationEvent`] stream — typically
+    /// [`super::RmcpExecutor::invalidation_receiver`]. Returns `self` so the
+    /// builder reads naturally.
+    pub fn with_invalidation(self, mut rx: broadcast::Receiver<InvalidationEvent>) -> Self {
+        let caches = self.caches.clone();
+        tokio::spawn(async move {
+            loop {
+                match rx.recv().await {
+                    Ok(event) => apply_invalidation(&caches, &event),
+                    // Receiver closed — nothing more will come.
+                    Err(broadcast::error::RecvError::Closed) => break,
+                    // Lagged — invalidate everything we know about to stay
+                    // safe (silent stale data is worse than a fresh re-fetch).
+                    Err(broadcast::error::RecvError::Lagged(_)) => {
+                        if let Ok(mut map) = caches.lock() {
+                            for (_, sc) in map.iter_mut() {
+                                sc.clear();
+                            }
+                        }
+                    }
+                }
+            }
+        });
+        self
+    }
+
+    fn cache_lookup(&self, key: &CacheKey) -> Option<serde_json::Value> {
+        let now = Instant::now();
+        let map = self.caches.lock().ok()?;
+        map.get(&key.server_name).and_then(|sc| sc.get(key, now))
+    }
+
+    fn cache_insert(&self, key: CacheKey, value: serde_json::Value, ttl: Duration) {
+        let Ok(mut map) = self.caches.lock() else {
+            return;
+        };
+        let sc = map
+            .entry(key.server_name.clone())
+            .or_insert_with(|| ServerCache::new(self.ttls.max_entries_per_server));
+        sc.insert(
+            key,
+            CacheEntry {
+                value,
+                inserted_at: Instant::now(),
+                ttl,
+            },
+        );
+    }
+}
+
+fn apply_invalidation(
+    caches: &Arc<Mutex<HashMap<String, ServerCache>>>,
+    event: &InvalidationEvent,
+) {
+    let Ok(mut map) = caches.lock() else {
+        return;
+    };
+    let Some(sc) = map.get_mut(&event.server_name) else {
+        return;
+    };
+    match event.kind {
+        InvalidationKind::ToolsListChanged => sc.evict_method("tools/list"),
+        InvalidationKind::ResourcesListChanged => {
+            sc.evict_method("resources/list");
+            sc.evict_method("resources/templates/list");
+        }
+        InvalidationKind::PromptsListChanged => sc.evict_method("prompts/list"),
+        InvalidationKind::Reinitialized => sc.clear(),
+    }
+}
+
+/// Identify which method the executor will cache for, if any, and the TTL to
+/// stamp on the entry. Honours the MCP spec's `_meta.ttlMs` cache-control
+/// hint when present (`upstream_hint`).
+fn cached_method(method: &str) -> Option<&'static str> {
+    match method {
+        "tools/list" => Some("tools/list"),
+        "resources/list" => Some("resources/list"),
+        "resources/templates/list" => Some("resources/templates/list"),
+        "prompts/list" => Some("prompts/list"),
+        _ => None,
+    }
+}
+
+fn extract_ttl_hint(result: &serde_json::Value) -> Option<Duration> {
+    let ms = result
+        .get("_meta")
+        .and_then(|m| m.get("ttlMs"))
+        .and_then(|v| v.as_u64())?;
+    Some(Duration::from_millis(ms))
+}
+
+fn params_hash(params: &serde_json::Value) -> u64 {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    let s = serde_json::to_string(params).unwrap_or_default();
+    let mut h = DefaultHasher::new();
+    s.hash(&mut h);
+    h.finish()
+}
+
+#[async_trait]
+impl<E: Executor + 'static> Executor for CachingExecutor<E> {
+    async fn execute(&self, target: &McpTarget, request: &McpRequest) -> Result<McpResponse> {
+        let (server_name, method) = match (target, cached_method(&request.method)) {
+            (McpTarget::Direct { server_name, .. }, Some(m)) => (server_name.clone(), m),
+            // Aggregate or non-cacheable method — pass straight through.
+            _ => return self.inner.execute(target, request).await,
+        };
+        let default_ttl = match self.ttls.ttl_for(method) {
+            Some(d) => d,
+            None => return self.inner.execute(target, request).await,
+        };
+        let key = CacheKey {
+            server_name,
+            method,
+            params_hash: params_hash(&request.params),
+        };
+        if let Some(value) = self.cache_lookup(&key) {
+            tracing::debug!(
+                server = %key.server_name,
+                method = %key.method,
+                "mcp cache: hit",
+            );
+            return Ok(McpResponse {
+                request_id: request.request_id.clone(),
+                result: value,
+            });
+        }
+        tracing::debug!(
+            server = %key.server_name,
+            method = %key.method,
+            "mcp cache: miss",
+        );
+        let response = self.inner.execute(target, request).await?;
+        let ttl = extract_ttl_hint(&response.result).unwrap_or(default_ttl);
+        self.cache_insert(key, response.result.clone(), ttl);
+        Ok(response)
+    }
+
+    async fn execute_streaming(
+        &self,
+        target: &McpTarget,
+        request: &McpRequest,
+    ) -> Result<BoxStream<'static, Result<McpStreamPart>>> {
+        // For cacheable list methods, serve from cache as a single-element
+        // stream without going upstream when fresh. Non-cacheable methods
+        // delegate so progress notifications pass through.
+        let cacheable = match (target, cached_method(&request.method)) {
+            (McpTarget::Direct { server_name, .. }, Some(method)) => self
+                .ttls
+                .ttl_for(method)
+                .map(|ttl| (server_name.clone(), method, ttl)),
+            _ => None,
+        };
+        let Some((server_name, method, default_ttl)) = cacheable else {
+            return self.inner.execute_streaming(target, request).await;
+        };
+
+        let key = CacheKey {
+            server_name,
+            method,
+            params_hash: params_hash(&request.params),
+        };
+        if let Some(value) = self.cache_lookup(&key) {
+            let response = McpResponse {
+                request_id: request.request_id.clone(),
+                result: value,
+            };
+            return Ok(stream::once(async move { Ok(McpStreamPart::Final(response)) }).boxed());
+        }
+
+        // Miss — proxy the inner stream, but stamp the cache when the
+        // terminal `Final` frame arrives so subsequent SSE requests for the
+        // same list become hits.
+        let inner_stream = self.inner.execute_streaming(target, request).await?;
+        let caches = self.caches.clone();
+        let max_entries = self.ttls.max_entries_per_server;
+        let key_for_stream = key.clone();
+        let wrapped = inner_stream.map(move |item| {
+            if let Ok(McpStreamPart::Final(ref response)) = item {
+                let ttl = extract_ttl_hint(&response.result).unwrap_or(default_ttl);
+                if let Ok(mut map) = caches.lock() {
+                    let sc = map
+                        .entry(key_for_stream.server_name.clone())
+                        .or_insert_with(|| ServerCache::new(max_entries));
+                    sc.insert(
+                        key_for_stream.clone(),
+                        CacheEntry {
+                            value: response.result.clone(),
+                            inserted_at: Instant::now(),
+                            ttl,
+                        },
+                    );
+                }
+            }
+            item
+        });
+        Ok(wrapped.boxed())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::caller::CallerContext;
+    use crate::mcp::McpTransport;
+    use async_trait::async_trait;
+    use std::collections::HashMap;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct CountingExecutor {
+        calls: AtomicUsize,
+        value: serde_json::Value,
+    }
+
+    #[async_trait]
+    impl Executor for CountingExecutor {
+        async fn execute(&self, _t: &McpTarget, request: &McpRequest) -> Result<McpResponse> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(McpResponse {
+                request_id: request.request_id.clone(),
+                result: self.value.clone(),
+            })
+        }
+    }
+
+    fn target(name: &str) -> McpTarget {
+        McpTarget::Direct {
+            server_name: name.into(),
+            transport: McpTransport::Stdio {
+                command: "/bin/true".into(),
+                args: vec![],
+                env: HashMap::new(),
+            },
+        }
+    }
+
+    fn list_req(server: &str, method: &str) -> McpRequest {
+        McpRequest::direct(
+            server,
+            method,
+            serde_json::json!({}),
+            CallerContext::new("k", "u"),
+        )
+    }
+
+    #[tokio::test]
+    async fn second_tools_list_within_ttl_is_a_cache_hit() {
+        let inner = Arc::new(CountingExecutor {
+            calls: AtomicUsize::new(0),
+            value: serde_json::json!({"tools": []}),
+        });
+        let exec = CachingExecutor::new(inner.clone(), CacheTtls::default());
+        let _ = exec
+            .execute(&target("a"), &list_req("a", "tools/list"))
+            .await
+            .unwrap();
+        let _ = exec
+            .execute(&target("a"), &list_req("a", "tools/list"))
+            .await
+            .unwrap();
+        assert_eq!(inner.calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn ttl_zero_disables_caching() {
+        let inner = Arc::new(CountingExecutor {
+            calls: AtomicUsize::new(0),
+            value: serde_json::json!({"tools": []}),
+        });
+        let ttls = CacheTtls {
+            tools_list: Duration::ZERO,
+            ..CacheTtls::default()
+        };
+        let exec = CachingExecutor::new(inner.clone(), ttls);
+        let _ = exec
+            .execute(&target("a"), &list_req("a", "tools/list"))
+            .await
+            .unwrap();
+        let _ = exec
+            .execute(&target("a"), &list_req("a", "tools/list"))
+            .await
+            .unwrap();
+        assert_eq!(inner.calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn invalidation_evicts_affected_method() {
+        let inner = Arc::new(CountingExecutor {
+            calls: AtomicUsize::new(0),
+            value: serde_json::json!({"tools": []}),
+        });
+        let (tx, rx) = broadcast::channel(8);
+        let exec = CachingExecutor::new(inner.clone(), CacheTtls::default()).with_invalidation(rx);
+        let _ = exec
+            .execute(&target("a"), &list_req("a", "tools/list"))
+            .await
+            .unwrap();
+        // Warm cache.
+        assert_eq!(inner.calls.load(Ordering::SeqCst), 1);
+        tx.send(InvalidationEvent {
+            server_name: "a".into(),
+            kind: InvalidationKind::ToolsListChanged,
+        })
+        .unwrap();
+        // Give the spawned receiver task a chance to drain.
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        let _ = exec
+            .execute(&target("a"), &list_req("a", "tools/list"))
+            .await
+            .unwrap();
+        assert_eq!(inner.calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn non_cacheable_method_passes_through() {
+        let inner = Arc::new(CountingExecutor {
+            calls: AtomicUsize::new(0),
+            value: serde_json::json!({"ok": true}),
+        });
+        let exec = CachingExecutor::new(inner.clone(), CacheTtls::default());
+        let _ = exec
+            .execute(&target("a"), &list_req("a", "tools/call"))
+            .await
+            .unwrap();
+        let _ = exec
+            .execute(&target("a"), &list_req("a", "tools/call"))
+            .await
+            .unwrap();
+        assert_eq!(inner.calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn aggregate_target_passes_through() {
+        let inner = Arc::new(CountingExecutor {
+            calls: AtomicUsize::new(0),
+            value: serde_json::json!({"tools": []}),
+        });
+        let exec = CachingExecutor::new(inner.clone(), CacheTtls::default());
+        let target = McpTarget::Aggregate { members: vec![] };
+        let _ = exec
+            .execute(&target, &list_req("anything", "tools/list"))
+            .await
+            .unwrap();
+        let _ = exec
+            .execute(&target, &list_req("anything", "tools/list"))
+            .await
+            .unwrap();
+        assert_eq!(inner.calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[cfg(feature = "config_file")]
+    #[test]
+    fn mcp_cache_config_defaults_match_cache_ttls() {
+        // The two Default impls (config-layer YAML shape vs. runtime cache
+        // type) MUST agree so a `mcp.cache:` block with all-defaults behaves
+        // identically to no `mcp.cache:` block at all.
+        let cfg = crate::config::McpCacheConfig::default();
+        let derived: CacheTtls = (&cfg).into();
+        let coded = CacheTtls::default();
+        assert_eq!(derived.tools_list, coded.tools_list);
+        assert_eq!(derived.resources_list, coded.resources_list);
+        assert_eq!(
+            derived.resources_templates_list,
+            coded.resources_templates_list
+        );
+        assert_eq!(derived.prompts_list, coded.prompts_list);
+        assert_eq!(derived.max_entries_per_server, coded.max_entries_per_server);
+    }
+
+    #[tokio::test]
+    async fn upstream_ttl_hint_is_honoured() {
+        let inner = Arc::new(CountingExecutor {
+            calls: AtomicUsize::new(0),
+            value: serde_json::json!({
+                "tools": [],
+                "_meta": { "ttlMs": 50 }
+            }),
+        });
+        let exec = CachingExecutor::new(inner.clone(), CacheTtls::default());
+        let _ = exec
+            .execute(&target("a"), &list_req("a", "tools/list"))
+            .await
+            .unwrap();
+        assert_eq!(inner.calls.load(Ordering::SeqCst), 1);
+        // First call cached with 50ms TTL — wait past it and confirm refetch.
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        let _ = exec
+            .execute(&target("a"), &list_req("a", "tools/list"))
+            .await
+            .unwrap();
+        assert_eq!(inner.calls.load(Ordering::SeqCst), 2);
+    }
+}

--- a/crates/bitrouter-sdk/src/mcp/config_routing.rs
+++ b/crates/bitrouter-sdk/src/mcp/config_routing.rs
@@ -1,6 +1,6 @@
 //! Routing table backed by the `mcp_servers` map in `bitrouter.yaml`.
 //!
-//! Pure lookup: server-name → [`McpTarget`]. No discovery, no per-caller
+//! Pure lookup: [`ServerSelector`] → [`McpTarget`]. No discovery, no per-caller
 //! ACL — those belong in a [`super::PreRequestHook`] or [`super::RouteHook`].
 
 use std::collections::HashMap;
@@ -8,34 +8,83 @@ use std::collections::HashMap;
 use async_trait::async_trait;
 
 use super::transport::{McpServerConfig, McpTransport};
-use super::{McpTarget, RoutingTable};
+use super::{AggregateMember, McpTarget, RoutingTable, ServerSelector};
 use crate::caller::CallerContext;
 use crate::error::{BitrouterError, Result};
 
-/// In-memory `name → transport` map populated from config at startup.
+/// One entry's view of the per-server aggregate config — what the binary's
+/// assembly hands to [`ConfigMcpRoutingTable::from_configs`] alongside the
+/// transport. Captured here so the binary's config-parsing layer doesn't have
+/// to know the SDK's internal types.
+#[derive(Debug, Clone)]
+pub struct McpServerAggregateConfig {
+    /// Whether this server participates in the aggregate fan-out endpoint.
+    /// Default: `true`.
+    pub aggregate: bool,
+    /// Prefix prepended to upstream tool/prompt names when this server
+    /// participates in aggregate fan-out. Default: `{server_name}__`.
+    pub tool_prefix: String,
+}
+
+impl McpServerAggregateConfig {
+    /// Defaults for one server: aggregate on, prefix `{server_name}__`.
+    pub fn default_for(server_name: &str) -> Self {
+        Self {
+            aggregate: true,
+            tool_prefix: format!("{server_name}__"),
+        }
+    }
+}
+
+/// In-memory routing data populated from config at startup.
 #[derive(Debug, Default, Clone)]
 pub struct ConfigMcpRoutingTable {
     servers: HashMap<String, McpTransport>,
+    aggregate_members: Vec<AggregateMember>,
 }
 
 impl ConfigMcpRoutingTable {
-    /// Build from a `name → McpServerConfig` map. Validates every entry; the
-    /// first invalid entry stops the build so a startup misconfiguration is
-    /// loud, not silent.
+    /// Build from a `name → (config, aggregate_config)` map. Validates every
+    /// entry; the first invalid entry stops the build so a startup
+    /// misconfiguration is loud, not silent.
+    ///
+    /// `aggregate_config` is the per-server `aggregate` / `tool_prefix`
+    /// settings. Pass [`McpServerAggregateConfig::default_for`] if the binary
+    /// has no per-server overrides.
     pub fn from_configs<I>(entries: I) -> Result<Self>
     where
-        I: IntoIterator<Item = (String, McpServerConfig)>,
+        I: IntoIterator<Item = (String, McpServerConfig, McpServerAggregateConfig)>,
     {
         let mut servers = HashMap::new();
-        for (key, cfg) in entries {
+        let mut members: Vec<AggregateMember> = Vec::new();
+        let mut seen_prefixes: HashMap<String, String> = HashMap::new();
+        for (key, cfg, agg) in entries {
             cfg.validate()
                 .map_err(|e| BitrouterError::internal(e.to_string()))?;
+            if agg.aggregate {
+                if let Some(other) = seen_prefixes.get(&agg.tool_prefix) {
+                    return Err(BitrouterError::internal(format!(
+                        "mcp aggregate: servers '{other}' and '{key}' share tool_prefix \
+                         '{}' — prefixes must be unique among aggregate members",
+                        agg.tool_prefix
+                    )));
+                }
+                seen_prefixes.insert(agg.tool_prefix.clone(), key.clone());
+                members.push(AggregateMember {
+                    server_name: key.clone(),
+                    tool_prefix: agg.tool_prefix.clone(),
+                    transport: cfg.transport.clone(),
+                });
+            }
             // The `name` field is allowed to differ from the map key (operators
             // sometimes alias) — the map key wins for routing lookups, since
             // that's what `/mcp/{server}` hits.
             servers.insert(key, cfg.transport);
         }
-        Ok(Self { servers })
+        Ok(Self {
+            servers,
+            aggregate_members: members,
+        })
     }
 
     /// True if no servers are configured. The binary uses this to decide
@@ -54,18 +103,34 @@ impl ConfigMcpRoutingTable {
     pub fn lookup(&self, server: &str) -> Option<&McpTransport> {
         self.servers.get(server)
     }
+
+    /// The aggregate members snapshot, in registration order.
+    pub fn aggregate_members(&self) -> &[AggregateMember] {
+        &self.aggregate_members
+    }
 }
 
 #[async_trait]
 impl RoutingTable for ConfigMcpRoutingTable {
-    async fn resolve(&self, server: &str, _caller: &CallerContext) -> Result<McpTarget> {
-        let transport = self.servers.get(server).cloned().ok_or_else(|| {
-            BitrouterError::NotFound(format!("no mcp server configured for '{server}'"))
-        })?;
-        Ok(McpTarget {
-            server_name: server.to_string(),
-            transport,
-        })
+    async fn resolve(
+        &self,
+        selector: &ServerSelector,
+        _caller: &CallerContext,
+    ) -> Result<McpTarget> {
+        match selector {
+            ServerSelector::Direct(server) => {
+                let transport = self.servers.get(server).cloned().ok_or_else(|| {
+                    BitrouterError::NotFound(format!("no mcp server configured for '{server}'"))
+                })?;
+                Ok(McpTarget::Direct {
+                    server_name: server.clone(),
+                    transport,
+                })
+            }
+            ServerSelector::Aggregate => Ok(McpTarget::Aggregate {
+                members: self.aggregate_members.clone(),
+            }),
+        }
     }
 }
 
@@ -73,16 +138,17 @@ impl RoutingTable for ConfigMcpRoutingTable {
 mod tests {
     use super::*;
 
-    fn server(name: &str, url: &str) -> (String, McpServerConfig) {
+    fn server(name: &str, url: &str) -> (String, McpServerConfig, McpServerAggregateConfig) {
         (
             name.to_string(),
-            McpServerConfig {
-                name: name.to_string(),
-                transport: McpTransport::Http {
+            McpServerConfig::with_defaults(
+                name,
+                McpTransport::Http {
                     url: url.to_string(),
                     headers: Default::default(),
                 },
-            },
+            ),
+            McpServerAggregateConfig::default_for(name),
         )
     }
 
@@ -95,34 +161,133 @@ mod tests {
         let table =
             ConfigMcpRoutingTable::from_configs([server("ctx7", "https://mcp.example.com/v1/mcp")])
                 .unwrap();
-        let target = table.resolve("ctx7", &caller()).await.unwrap();
-        assert_eq!(target.server_name, "ctx7");
-        match target.transport {
-            McpTransport::Http { url, .. } => {
-                assert_eq!(url, "https://mcp.example.com/v1/mcp");
+        let target = table
+            .resolve(&ServerSelector::Direct("ctx7".into()), &caller())
+            .await
+            .unwrap();
+        match target {
+            McpTarget::Direct {
+                server_name,
+                transport,
+            } => {
+                assert_eq!(server_name, "ctx7");
+                match transport {
+                    McpTransport::Http { url, .. } => {
+                        assert_eq!(url, "https://mcp.example.com/v1/mcp");
+                    }
+                    _ => panic!("expected Http transport"),
+                }
             }
-            _ => panic!("expected Http transport"),
+            _ => panic!("expected Direct target"),
         }
     }
 
     #[tokio::test]
     async fn unknown_server_returns_not_found() {
         let table = ConfigMcpRoutingTable::from_configs([server("ctx7", "https://x")]).unwrap();
-        let err = table.resolve("missing", &caller()).await.unwrap_err();
+        let err = table
+            .resolve(&ServerSelector::Direct("missing".into()), &caller())
+            .await
+            .unwrap_err();
         assert_eq!(err.status(), 404);
+    }
+
+    #[tokio::test]
+    async fn aggregate_selector_returns_all_opted_in_members() {
+        let table = ConfigMcpRoutingTable::from_configs([
+            server("a", "https://a"),
+            server("b", "https://b"),
+        ])
+        .unwrap();
+        let target = table
+            .resolve(&ServerSelector::Aggregate, &caller())
+            .await
+            .unwrap();
+        match target {
+            McpTarget::Aggregate { members } => {
+                assert_eq!(members.len(), 2);
+                let mut prefixes: Vec<_> = members.iter().map(|m| m.tool_prefix.clone()).collect();
+                prefixes.sort();
+                assert_eq!(prefixes, vec!["a__".to_string(), "b__".to_string()]);
+            }
+            _ => panic!("expected Aggregate target"),
+        }
+    }
+
+    #[tokio::test]
+    async fn aggregate_excludes_opted_out_servers() {
+        let (_, cfg_a, _) = server("a", "https://a");
+        let (_, cfg_b, _) = server("b", "https://b");
+        let table = ConfigMcpRoutingTable::from_configs([
+            (
+                "a".to_string(),
+                cfg_a,
+                McpServerAggregateConfig {
+                    aggregate: false,
+                    tool_prefix: "a__".into(),
+                },
+            ),
+            (
+                "b".to_string(),
+                cfg_b,
+                McpServerAggregateConfig::default_for("b"),
+            ),
+        ])
+        .unwrap();
+        let target = table
+            .resolve(&ServerSelector::Aggregate, &caller())
+            .await
+            .unwrap();
+        match target {
+            McpTarget::Aggregate { members } => {
+                assert_eq!(members.len(), 1);
+                assert_eq!(members[0].server_name, "b");
+            }
+            _ => panic!("expected Aggregate target"),
+        }
+    }
+
+    #[test]
+    fn duplicate_prefix_is_rejected() {
+        let (_, cfg_a, _) = server("a", "https://a");
+        let (_, cfg_b, _) = server("b", "https://b");
+        let err = ConfigMcpRoutingTable::from_configs([
+            (
+                "a".to_string(),
+                cfg_a,
+                McpServerAggregateConfig {
+                    aggregate: true,
+                    tool_prefix: "shared__".into(),
+                },
+            ),
+            (
+                "b".to_string(),
+                cfg_b,
+                McpServerAggregateConfig {
+                    aggregate: true,
+                    tool_prefix: "shared__".into(),
+                },
+            ),
+        ])
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("share tool_prefix"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]
     fn invalid_entry_fails_construction() {
         let bad = (
             "bad".to_string(),
-            McpServerConfig {
-                name: "bad".into(),
-                transport: McpTransport::Http {
+            McpServerConfig::with_defaults(
+                "bad",
+                McpTransport::Http {
                     url: String::new(),
                     headers: Default::default(),
                 },
-            },
+            ),
+            McpServerAggregateConfig::default_for("bad"),
         );
         assert!(ConfigMcpRoutingTable::from_configs([bad]).is_err());
     }

--- a/crates/bitrouter-sdk/src/mcp/mod.rs
+++ b/crates/bitrouter-sdk/src/mcp/mod.rs
@@ -55,26 +55,18 @@ pub mod config_routing;
 #[cfg(feature = "mcp")]
 pub mod rmcp_executor;
 
-pub use transport::{McpServerConfig, McpTransport};
-
-#[cfg(feature = "mcp")]
-pub use config_routing::ConfigMcpRoutingTable;
-#[cfg(feature = "mcp")]
-pub use rmcp_executor::RmcpExecutor;
-// `AggregatingExecutor`, `CachingExecutor`, `CacheTtls` are intentionally
-// not re-exported here — guideline #2 in CLAUDE.md (no `pub use` inside a
-// `pub mod`). Reach them via their submodule paths
-// (`mcp::aggregating_executor::AggregatingExecutor`,
-// `mcp::caching_executor::{CacheTtls, CachingExecutor}`).
+// Per CLAUDE.md guideline #2 we do not `pub use` from these submodules.
+// Downstream code reaches the types directly:
+// - `mcp::transport::{McpServerConfig, McpTransport}`
+// - `mcp::config_routing::ConfigMcpRoutingTable`
+// - `mcp::rmcp_executor::RmcpExecutor`
+// - `mcp::aggregating_executor::AggregatingExecutor`
+// - `mcp::caching_executor::{CacheTtls, CachingExecutor}`
 //
-// TODO(mcp-reexport-cleanup): the `McpServerConfig`, `McpTransport`,
-// `ConfigMcpRoutingTable`, and `RmcpExecutor` re-exports above predate
-// guideline #2 and currently violate it. They are kept for source-compat
-// with downstream consumers (e.g. `bitrouter-cloud` imports
-// `bitrouter_sdk::mcp::RmcpExecutor`). Removing them is a breaking change
-// for the SDK public surface, so it is intentionally deferred to its own
-// PR rather than bundled into this feature work — the cleanup PR must
-// rewrite every downstream import site in one shot.
+// `McpTransport` is named in this file's own type definitions
+// (`AggregateMember`, `McpTarget`), so a private `use` brings it into local
+// scope without re-exporting it.
+use transport::McpTransport;
 
 /// Which upstream(s) an inbound MCP request targets.
 ///

--- a/crates/bitrouter-sdk/src/mcp/mod.rs
+++ b/crates/bitrouter-sdk/src/mcp/mod.rs
@@ -66,9 +66,15 @@ pub use rmcp_executor::RmcpExecutor;
 // `pub mod`). Reach them via their submodule paths
 // (`mcp::aggregating_executor::AggregatingExecutor`,
 // `mcp::caching_executor::{CacheTtls, CachingExecutor}`).
-// The pre-existing `transport`, `config_routing`, and `rmcp_executor`
-// re-exports above predate this rule and are kept for source-compat with
-// downstream consumers; cleaning them up is tracked separately.
+//
+// TODO(mcp-reexport-cleanup): the `McpServerConfig`, `McpTransport`,
+// `ConfigMcpRoutingTable`, and `RmcpExecutor` re-exports above predate
+// guideline #2 and currently violate it. They are kept for source-compat
+// with downstream consumers (e.g. `bitrouter-cloud` imports
+// `bitrouter_sdk::mcp::RmcpExecutor`). Removing them is a breaking change
+// for the SDK public surface, so it is intentionally deferred to its own
+// PR rather than bundled into this feature work — the cleanup PR must
+// rewrite every downstream import site in one shot.
 
 /// Which upstream(s) an inbound MCP request targets.
 ///

--- a/crates/bitrouter-sdk/src/mcp/mod.rs
+++ b/crates/bitrouter-sdk/src/mcp/mod.rs
@@ -10,14 +10,15 @@
 //! `language_model::Pipeline` (compile-time protocol isolation). Reuse of
 //! cross-cutting logic is via shared crate-root library code, not shared traits.
 //!
-//! Spec refs (revision pinned to `2025-06-18`):
+//! Spec refs (latest accepted: `2025-11-25`; earlier `2025-06-18`,
+//! `2025-03-26`, `2024-11-05` still negotiable):
 //! - JSON-RPC envelope (Request / Response / Notification / Error):
-//!   <https://modelcontextprotocol.io/specification/2025-06-18/basic>
+//!   <https://modelcontextprotocol.io/specification/2025-11-25/basic>
 //! - Streamable HTTP transport (`Origin`, `MCP-Session-Id`,
 //!   `MCP-Protocol-Version`, SSE response variant):
-//!   <https://modelcontextprotocol.io/specification/2025-06-18/basic/transports>
+//!   <https://modelcontextprotocol.io/specification/2025-11-25/basic/transports>
 //! - Method catalogue (`tools/list`, `tools/call`, etc.):
-//!   <https://modelcontextprotocol.io/specification/2025-06-18>
+//!   <https://modelcontextprotocol.io/specification/2025-11-25>
 //!
 //! The HTTP server (`crates/bitrouter-sdk/src/server.rs::mcp_invoke`) handles
 //! the wire-format concerns — `id` round-trip, error envelope, Origin
@@ -37,6 +38,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use futures::stream::{self, BoxStream, StreamExt};
 
 use crate::caller::CallerContext;
 use crate::error::{BitrouterError, Result};
@@ -44,6 +46,10 @@ use crate::language_model::HookDecision;
 
 pub mod transport;
 
+#[cfg(feature = "mcp")]
+pub mod aggregating_executor;
+#[cfg(feature = "mcp")]
+pub mod caching_executor;
 #[cfg(feature = "mcp")]
 pub mod config_routing;
 #[cfg(feature = "mcp")]
@@ -55,14 +61,37 @@ pub use transport::{McpServerConfig, McpTransport};
 pub use config_routing::ConfigMcpRoutingTable;
 #[cfg(feature = "mcp")]
 pub use rmcp_executor::RmcpExecutor;
+// `AggregatingExecutor`, `CachingExecutor`, `CacheTtls` are intentionally
+// not re-exported here — guideline #2 in CLAUDE.md (no `pub use` inside a
+// `pub mod`). Reach them via their submodule paths
+// (`mcp::aggregating_executor::AggregatingExecutor`,
+// `mcp::caching_executor::{CacheTtls, CachingExecutor}`).
+// The pre-existing `transport`, `config_routing`, and `rmcp_executor`
+// re-exports above predate this rule and are kept for source-compat with
+// downstream consumers; cleaning them up is tracked separately.
 
-/// An inbound MCP request — a JSON-RPC call against a named MCP server.
+/// Which upstream(s) an inbound MCP request targets.
+///
+/// `Direct(name)` corresponds to `POST /mcp/{name}` and dispatches to one
+/// configured server. `Aggregate` corresponds to the virtual aggregate endpoint
+/// (typically `POST /mcp`) and fans out across every server marked
+/// `aggregate: true` in `bitrouter.yaml`.
+#[derive(Debug, Clone)]
+pub enum ServerSelector {
+    /// `POST /mcp/{name}` — single named upstream.
+    Direct(String),
+    /// `POST /mcp` (or the configured aggregate route) — fan out across every
+    /// server with `aggregate: true`.
+    Aggregate,
+}
+
+/// An inbound MCP request — a JSON-RPC call against one or more MCP servers.
 #[derive(Debug, Clone)]
 pub struct McpRequest {
     /// Unique request id.
     pub request_id: String,
-    /// The MCP server name being addressed (`/mcp/{name}`).
-    pub server: String,
+    /// Which upstream(s) this request targets.
+    pub selector: ServerSelector,
     /// The JSON-RPC method (e.g. `tools/call`, `tools/list`).
     pub method: String,
     /// The JSON-RPC params.
@@ -72,8 +101,8 @@ pub struct McpRequest {
 }
 
 impl McpRequest {
-    /// Build a request with a fresh uuid id.
-    pub fn new(
+    /// Build a direct (single-server) request with a fresh uuid id.
+    pub fn direct(
         server: impl Into<String>,
         method: impl Into<String>,
         params: serde_json::Value,
@@ -81,7 +110,22 @@ impl McpRequest {
     ) -> Self {
         Self {
             request_id: uuid::Uuid::new_v4().to_string(),
-            server: server.into(),
+            selector: ServerSelector::Direct(server.into()),
+            method: method.into(),
+            params,
+            caller,
+        }
+    }
+
+    /// Build an aggregate (fan-out) request with a fresh uuid id.
+    pub fn aggregate(
+        method: impl Into<String>,
+        params: serde_json::Value,
+        caller: CallerContext,
+    ) -> Self {
+        Self {
+            request_id: uuid::Uuid::new_v4().to_string(),
+            selector: ServerSelector::Aggregate,
             method: method.into(),
             params,
             caller,
@@ -98,20 +142,94 @@ pub struct McpResponse {
     pub result: serde_json::Value,
 }
 
-/// One resolved MCP routing target — a concrete upstream MCP server.
+/// One member of an aggregate fan-out — the per-server view used by
+/// [`AggregatingExecutor`] when dispatching `tools/list` / `tools/call` / etc.
+/// across multiple upstreams.
 #[derive(Debug, Clone)]
-pub struct McpTarget {
+pub struct AggregateMember {
     /// The upstream MCP server name.
     pub server_name: String,
+    /// Prepended verbatim to upstream tool/prompt names.
+    /// Default at config-load time: `{server_name}__`.
+    pub tool_prefix: String,
     /// How to reach the upstream — Streamable HTTP or stdio child-process.
     pub transport: McpTransport,
 }
 
-/// Resolves an MCP server name into a routing target.
+/// One resolved MCP routing target.
+///
+/// `Direct` is one upstream; `Aggregate` is a fan-out across N upstreams (its
+/// members are the servers marked `aggregate: true` in `bitrouter.yaml`).
+#[derive(Debug, Clone)]
+pub enum McpTarget {
+    /// One named upstream.
+    Direct {
+        /// The upstream server name.
+        server_name: String,
+        /// How to reach the upstream.
+        transport: McpTransport,
+    },
+    /// Fan-out across many upstreams.
+    Aggregate {
+        /// The per-server members of the aggregate.
+        members: Vec<AggregateMember>,
+    },
+}
+
+/// Resolves a [`ServerSelector`] into a routing target.
 #[async_trait]
 pub trait RoutingTable: Send + Sync {
-    /// Resolve `server` into a target.
-    async fn resolve(&self, server: &str, caller: &CallerContext) -> Result<McpTarget>;
+    /// Resolve `selector` into a target.
+    async fn resolve(&self, selector: &ServerSelector, caller: &CallerContext)
+    -> Result<McpTarget>;
+}
+
+/// One cache-invalidation event published by the upstream-side handler
+/// (typically [`rmcp_executor::RmcpExecutor`]) when an MCP server sends a
+/// `notifications/*` indicating its tool/resource/prompt list changed. The
+/// [`caching_executor::CachingExecutor`] subscribes to this stream and evicts
+/// the affected cache entries.
+#[derive(Debug, Clone)]
+pub struct InvalidationEvent {
+    /// The MCP server whose state changed.
+    pub server_name: String,
+    /// Which slice of cached state changed.
+    pub kind: InvalidationKind,
+}
+
+/// Which slice of cached state an [`InvalidationEvent`] is about.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InvalidationKind {
+    /// `notifications/tools/list_changed` — drop the server's `tools/list`
+    /// cache.
+    ToolsListChanged,
+    /// `notifications/resources/list_changed` — drop the server's
+    /// `resources/list` (and `resources/templates/list`) caches.
+    ResourcesListChanged,
+    /// `notifications/prompts/list_changed` — drop the server's
+    /// `prompts/list` cache.
+    PromptsListChanged,
+    /// The connection re-handshook — drop every cached entry for the server.
+    Reinitialized,
+}
+
+/// One frame of a streaming MCP execution.
+///
+/// `Final` terminates the stream — exactly one per stream, after which no more
+/// items follow. [`ExecutionHook::on_success`] fires once `Final` arrives, so
+/// implementers of [`Executor::execute_streaming`] MUST end every successful
+/// stream with `Final` and MUST NOT emit `Final` more than once.
+#[derive(Debug, Clone)]
+pub enum McpStreamPart {
+    /// JSON-RPC notification with no `id` (progress / log / etc.).
+    Notification {
+        /// The JSON-RPC method (e.g. `notifications/progress`).
+        method: String,
+        /// The JSON-RPC params.
+        params: serde_json::Value,
+    },
+    /// JSON-RPC response — terminates the stream.
+    Final(McpResponse),
 }
 
 /// Performs the actual upstream MCP JSON-RPC call.
@@ -119,6 +237,21 @@ pub trait RoutingTable: Send + Sync {
 pub trait Executor: Send + Sync {
     /// Execute `request` against `target`.
     async fn execute(&self, target: &McpTarget, request: &McpRequest) -> Result<McpResponse>;
+
+    /// Streaming variant.
+    ///
+    /// The default impl wraps [`execute`](Self::execute) into a one-item
+    /// stream so existing executors keep compiling unchanged. Override to
+    /// emit `notifications/progress` (or other server→client notifications)
+    /// before the final response.
+    async fn execute_streaming(
+        &self,
+        target: &McpTarget,
+        request: &McpRequest,
+    ) -> Result<BoxStream<'static, Result<McpStreamPart>>> {
+        let response = self.execute(target, request).await?;
+        Ok(stream::once(async move { Ok(McpStreamPart::Final(response)) }).boxed())
+    }
 }
 
 /// Stage 1 — MCP pre-request checks (auth / policy). Independent of
@@ -194,6 +327,49 @@ pub struct Pipeline {
 impl Pipeline {
     /// Execute an MCP request through the three-stage pure-routing pipeline.
     pub async fn execute(&self, request: McpRequest) -> Result<McpResponse> {
+        let (mut ctx, target) = self.prepare(request).await?;
+        let response = self.executor.execute(&target, &ctx.request).await?;
+        for hook in &self.execution_hooks {
+            hook.on_success(&ctx, &response).await?;
+        }
+        // Consume `ctx` so it's gone after hooks fire — keeps the unused
+        // `target` slot from leaking past the call.
+        let _ = ctx.target.take();
+        Ok(response)
+    }
+
+    /// Streaming variant of [`execute`](Self::execute). The first two stages
+    /// (pre-request hooks, route resolution) run synchronously before the
+    /// stream is returned; the stream itself yields the execution frames.
+    /// [`ExecutionHook::on_success`] fires once the terminating
+    /// [`McpStreamPart::Final`] is observed.
+    pub async fn execute_streaming(
+        &self,
+        request: McpRequest,
+    ) -> Result<BoxStream<'static, Result<McpStreamPart>>> {
+        let (ctx, target) = self.prepare(request).await?;
+        let inner = self
+            .executor
+            .execute_streaming(&target, &ctx.request)
+            .await?;
+        let hooks = self.execution_hooks.clone();
+        let ctx = Arc::new(ctx);
+        let stream = inner.then(move |item| {
+            let hooks = hooks.clone();
+            let ctx = ctx.clone();
+            async move {
+                if let Ok(McpStreamPart::Final(ref response)) = item {
+                    for hook in hooks.iter() {
+                        hook.on_success(&ctx, response).await?;
+                    }
+                }
+                item
+            }
+        });
+        Ok(stream.boxed())
+    }
+
+    async fn prepare(&self, request: McpRequest) -> Result<(McpContext, McpTarget)> {
         let mut ctx = McpContext::new(request);
 
         // Stage 1 — pre-request checks.
@@ -207,19 +383,14 @@ impl Pipeline {
         // Stage 2 — route resolution.
         let mut target = self
             .routing_table
-            .resolve(&ctx.request.server, ctx.caller())
+            .resolve(&ctx.request.selector, ctx.caller())
             .await?;
         for hook in &self.route_hooks {
             hook.resolve(&mut target, &mut ctx).await?;
         }
         ctx.target = Some(target.clone());
 
-        // Stage 3 — execute.
-        let response = self.executor.execute(&target, &ctx.request).await?;
-        for hook in &self.execution_hooks {
-            hook.on_success(&ctx, &response).await?;
-        }
-        Ok(response)
+        Ok((ctx, target))
     }
 }
 
@@ -298,20 +469,24 @@ mod tests {
     struct StaticTable;
     #[async_trait]
     impl RoutingTable for StaticTable {
-        async fn resolve(&self, server: &str, _caller: &CallerContext) -> Result<McpTarget> {
-            if server == "known" {
-                Ok(McpTarget {
-                    server_name: server.to_string(),
+        async fn resolve(
+            &self,
+            selector: &ServerSelector,
+            _caller: &CallerContext,
+        ) -> Result<McpTarget> {
+            match selector {
+                ServerSelector::Direct(name) if name == "known" => Ok(McpTarget::Direct {
+                    server_name: name.clone(),
                     transport: McpTransport::Stdio {
                         command: "/bin/true".into(),
                         args: vec![],
                         env: Default::default(),
                     },
-                })
-            } else {
-                Err(BitrouterError::NotFound(format!(
-                    "no mcp server '{server}'"
-                )))
+                }),
+                ServerSelector::Direct(name) => {
+                    Err(BitrouterError::NotFound(format!("no mcp server '{name}'")))
+                }
+                ServerSelector::Aggregate => Ok(McpTarget::Aggregate { members: vec![] }),
             }
         }
     }
@@ -338,7 +513,7 @@ mod tests {
     }
 
     fn req(server: &str) -> McpRequest {
-        McpRequest::new(
+        McpRequest::direct(
             server,
             "tools/list",
             serde_json::json!({}),
@@ -375,5 +550,25 @@ mod tests {
         let pipeline = b.build().unwrap();
         let err = pipeline.execute(req("known")).await.unwrap_err();
         assert_eq!(err.status(), 401);
+    }
+
+    #[tokio::test]
+    async fn mcp_streaming_default_wraps_execute_into_single_final() {
+        let mut b = PipelineBuilder::new();
+        b.routing_table(Arc::new(StaticTable))
+            .executor(Arc::new(EchoExecutor));
+        let pipeline = b.build().unwrap();
+        let mut stream = pipeline.execute_streaming(req("known")).await.unwrap();
+        let mut frames = Vec::new();
+        while let Some(item) = stream.next().await {
+            frames.push(item.unwrap());
+        }
+        assert_eq!(frames.len(), 1);
+        match &frames[0] {
+            McpStreamPart::Final(resp) => {
+                assert_eq!(resp.result["echoed"], "tools/list");
+            }
+            McpStreamPart::Notification { .. } => panic!("expected Final, got Notification"),
+        }
     }
 }

--- a/crates/bitrouter-sdk/src/mcp/mod.rs
+++ b/crates/bitrouter-sdk/src/mcp/mod.rs
@@ -143,8 +143,8 @@ pub struct McpResponse {
 }
 
 /// One member of an aggregate fan-out — the per-server view used by
-/// [`AggregatingExecutor`] when dispatching `tools/list` / `tools/call` / etc.
-/// across multiple upstreams.
+/// [`aggregating_executor::AggregatingExecutor`] when dispatching
+/// `tools/list` / `tools/call` / etc. across multiple upstreams.
 #[derive(Debug, Clone)]
 pub struct AggregateMember {
     /// The upstream MCP server name.

--- a/crates/bitrouter-sdk/src/mcp/rmcp_executor.rs
+++ b/crates/bitrouter-sdk/src/mcp/rmcp_executor.rs
@@ -417,7 +417,7 @@ fn stream_tools_call(
                 return;
             }
         };
-        let mut subscriber = conn.progress.subscribe(handle.progress_token.clone()).await;
+        let mut subscriber = Some(conn.progress.subscribe(handle.progress_token.clone()).await);
         let request_id = request.request_id.clone();
         let server = server_name.clone();
         let call_fut = async move {
@@ -429,9 +429,20 @@ fn stream_tools_call(
         tokio::pin!(call_fut);
 
         loop {
+            // The progress arm awaits `pending()` once the subscriber has
+            // closed — that future is `Poll::Pending` forever, so the `biased`
+            // select stops hot-polling this branch and waits cleanly for
+            // `call_fut` to resolve. (A bare `subscriber.next().await` would
+            // resolve to `None` instantly each tick and burn CPU.)
+            let next_notif = async {
+                match subscriber.as_mut() {
+                    Some(s) => s.next().await,
+                    None => std::future::pending::<Option<_>>().await,
+                }
+            };
             tokio::select! {
                 biased;
-                notif = subscriber.next() => {
+                notif = next_notif => {
                     match notif {
                         Some(n) => {
                             let params = serde_json::to_value(&n).unwrap_or(serde_json::Value::Null);
@@ -441,9 +452,10 @@ fn stream_tools_call(
                             });
                         }
                         None => {
-                            // Subscriber closed before the call returned — keep
-                            // polling the call future; no more notifications
-                            // will arrive but the response still might.
+                            // Subscriber closed before the call returned —
+                            // drop it so subsequent iterations sit on
+                            // `pending()` instead of re-polling a closed stream.
+                            subscriber = None;
                         }
                     }
                 }

--- a/crates/bitrouter-sdk/src/mcp/rmcp_executor.rs
+++ b/crates/bitrouter-sdk/src/mcp/rmcp_executor.rs
@@ -22,12 +22,15 @@ use rmcp::ServiceExt;
 use rmcp::handler::client::ClientHandler;
 use rmcp::handler::client::progress::ProgressDispatcher;
 use rmcp::model::{
-    CallToolRequestParams, ClientInfo, CreateElicitationRequestParams, CreateElicitationResult,
-    CreateMessageRequestParams, CreateMessageResult, ErrorCode, ErrorData as McpError,
-    GetPromptRequestParams, Implementation, ListRootsResult, NumberOrString,
-    ProgressNotificationParam, ProgressToken, ReadResourceRequestParams,
+    CallToolRequest, CallToolRequestParams, ClientInfo, ClientRequest,
+    CreateElicitationRequestParams, CreateElicitationResult, CreateMessageRequestParams,
+    CreateMessageResult, ErrorCode, ErrorData as McpError, GetPromptRequestParams, Implementation,
+    ListRootsResult, ProgressNotificationParam, ReadResourceRequestParams, ServerResult,
 };
-use rmcp::service::{NotificationContext, Peer, RequestContext, RoleClient, RunningService};
+use rmcp::service::{
+    NotificationContext, Peer, PeerRequestOptions, RequestContext, RoleClient, RunningService,
+    ServiceError,
+};
 use tokio::sync::{Mutex, broadcast};
 
 use super::transport::McpTransport;
@@ -378,54 +381,50 @@ fn direct_target(target: &McpTarget) -> Result<(&str, &McpTransport)> {
     }
 }
 
-/// Drive `tools/call` with a parallel progress-notification stream. The
-/// caller-supplied params get a `_meta.progressToken` injected so the upstream
-/// knows it may emit progress; notifications matching that token are yielded
-/// as [`McpStreamPart::Notification`] frames before the terminal
-/// [`McpStreamPart::Final`].
+/// Drive `tools/call` with a parallel progress-notification stream.
+///
+/// rmcp's `Peer::call_tool` shorthand goes through `send_request`, which
+/// **unconditionally overwrites** `_meta.progressToken` with the service's own
+/// provider value (see `service.rs::send_request_with_option`). That means
+/// any token we inject at the params layer is silently clobbered before the
+/// request hits the wire. We use `send_cancellable_request` instead so the
+/// returned `RequestHandle` tells us the token rmcp actually chose, then
+/// subscribe to it on the [`ProgressDispatcher`] before awaiting the response.
 fn stream_tools_call(
     conn: PooledConnection,
     server_name: String,
     request: McpRequest,
 ) -> impl futures::Stream<Item = Result<McpStreamPart>> + Send + 'static {
     async_stream::stream! {
-        // Generate a fresh progress token and inject it into params._meta so
-        // the upstream is opted-in. The MCP spec carries progressToken in
-        // `_meta.progressToken`; the client picks the value, the server echoes
-        // it on every notifications/progress.
-        let token_string = uuid::Uuid::new_v4().to_string();
-        let token = ProgressToken(NumberOrString::String(token_string.clone().into()));
+        let call_params: CallToolRequestParams =
+            match serde_json::from_value(request.params.clone()) {
+                Ok(p) => p,
+                Err(e) => {
+                    yield Err(bad_params(&server_name, "tools/call", e));
+                    return;
+                }
+            };
+        let call_request = ClientRequest::CallToolRequest(CallToolRequest::new(call_params));
 
-        let mut params_value = request.params.clone();
-        if !params_value.is_object() {
-            params_value = serde_json::json!({});
-        }
-        if let Some(obj) = params_value.as_object_mut() {
-            let meta = obj
-                .entry("_meta".to_string())
-                .or_insert(serde_json::json!({}));
-            if let Some(meta_obj) = meta.as_object_mut() {
-                meta_obj
-                    .entry("progressToken".to_string())
-                    .or_insert(serde_json::Value::String(token_string));
-            }
-        }
-        let call_params: CallToolRequestParams = match serde_json::from_value(params_value) {
-            Ok(p) => p,
+        let peer = conn.service.peer().clone();
+        let handle = match peer
+            .send_cancellable_request(call_request, PeerRequestOptions::no_options())
+            .await
+        {
+            Ok(h) => h,
             Err(e) => {
-                yield Err(bad_params(&server_name, "tools/call", e));
+                yield Err(upstream(&server_name, format!("tools/call: {e}")));
                 return;
             }
         };
-
-        let mut subscriber = conn.progress.subscribe(token).await;
-        let peer = conn.service.peer().clone();
+        let mut subscriber = conn.progress.subscribe(handle.progress_token.clone()).await;
         let request_id = request.request_id.clone();
         let server = server_name.clone();
         let call_fut = async move {
-            peer.call_tool(call_params)
-                .await
-                .map_err(|e| upstream(&server, format!("tools/call: {e}")))
+            handle.await_response().await.map_err(|e| match e {
+                ServiceError::McpError(err) => upstream(&server, format!("tools/call: {err}")),
+                other => upstream(&server, format!("tools/call: {other}")),
+            })
         };
         tokio::pin!(call_fut);
 
@@ -450,12 +449,18 @@ fn stream_tools_call(
                 }
                 call_result = &mut call_fut => {
                     match call_result {
-                        Ok(result) => {
+                        Ok(ServerResult::CallToolResult(result)) => {
                             let value = serde_json::to_value(&result).unwrap_or(serde_json::Value::Null);
                             yield Ok(McpStreamPart::Final(McpResponse {
                                 request_id,
                                 result: value,
                             }));
+                        }
+                        Ok(other) => {
+                            yield Err(upstream(
+                                &server_name,
+                                format!("tools/call: unexpected server result {other:?}"),
+                            ));
                         }
                         Err(e) => yield Err(e),
                     }

--- a/crates/bitrouter-sdk/src/mcp/rmcp_executor.rs
+++ b/crates/bitrouter-sdk/src/mcp/rmcp_executor.rs
@@ -17,25 +17,40 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use futures::stream::{self, BoxStream, StreamExt};
 use rmcp::ServiceExt;
 use rmcp::handler::client::ClientHandler;
+use rmcp::handler::client::progress::ProgressDispatcher;
 use rmcp::model::{
-    CallToolRequestParams, ClientInfo, GetPromptRequestParams, Implementation,
-    ReadResourceRequestParams,
+    CallToolRequestParams, ClientInfo, CreateElicitationRequestParams, CreateElicitationResult,
+    CreateMessageRequestParams, CreateMessageResult, ErrorCode, ErrorData as McpError,
+    GetPromptRequestParams, Implementation, ListRootsResult, NumberOrString,
+    ProgressNotificationParam, ProgressToken, ReadResourceRequestParams,
 };
-use rmcp::service::{Peer, RoleClient, RunningService};
-use tokio::sync::Mutex;
+use rmcp::service::{NotificationContext, Peer, RequestContext, RoleClient, RunningService};
+use tokio::sync::{Mutex, broadcast};
 
 use super::transport::McpTransport;
-use super::{Executor, McpRequest, McpResponse, McpTarget};
+use super::{
+    Executor, InvalidationEvent, InvalidationKind, McpRequest, McpResponse, McpStreamPart,
+    McpTarget,
+};
 use crate::error::{BitrouterError, Result};
 
-/// Minimal [`ClientHandler`] — we don't yet expose server→client sampling /
-/// elicitation back to the pipeline caller. The default trait impls reject
-/// those requests with `MethodNotFound`, which is the correct behaviour for
-/// a transparent router that hasn't been asked to support them yet.
-#[derive(Debug, Clone, Default)]
-struct BitrouterMcpClient;
+/// [`ClientHandler`] for upstream MCP servers reached through [`RmcpExecutor`].
+///
+/// Holds a per-connection [`ProgressDispatcher`] so `execute_streaming` can
+/// subscribe to `notifications/progress` and forward them as
+/// [`McpStreamPart::Notification`]. Also forwards
+/// `notifications/tools/list_changed` (and siblings) onto the shared
+/// invalidation channel so a [`super::CachingExecutor`] can evict stale
+/// entries promptly.
+#[derive(Debug, Clone)]
+struct BitrouterMcpClient {
+    server_name: String,
+    progress: Arc<ProgressDispatcher>,
+    invalidation: Arc<broadcast::Sender<InvalidationEvent>>,
+}
 
 impl ClientHandler for BitrouterMcpClient {
     fn get_info(&self) -> ClientInfo {
@@ -43,16 +58,163 @@ impl ClientHandler for BitrouterMcpClient {
         info.client_info = Implementation::new("bitrouter", env!("CARGO_PKG_VERSION"));
         info
     }
+
+    fn on_progress(
+        &self,
+        params: ProgressNotificationParam,
+        _context: NotificationContext<RoleClient>,
+    ) -> impl std::future::Future<Output = ()> + Send + '_ {
+        let dispatcher = self.progress.clone();
+        async move {
+            dispatcher.handle_notification(params).await;
+        }
+    }
+
+    fn on_tool_list_changed(
+        &self,
+        _context: NotificationContext<RoleClient>,
+    ) -> impl std::future::Future<Output = ()> + Send + '_ {
+        let server_name = self.server_name.clone();
+        let tx = self.invalidation.clone();
+        async move {
+            let _ = tx.send(InvalidationEvent {
+                server_name,
+                kind: InvalidationKind::ToolsListChanged,
+            });
+        }
+    }
+
+    fn on_resource_list_changed(
+        &self,
+        _context: NotificationContext<RoleClient>,
+    ) -> impl std::future::Future<Output = ()> + Send + '_ {
+        let server_name = self.server_name.clone();
+        let tx = self.invalidation.clone();
+        async move {
+            let _ = tx.send(InvalidationEvent {
+                server_name,
+                kind: InvalidationKind::ResourcesListChanged,
+            });
+        }
+    }
+
+    fn on_prompt_list_changed(
+        &self,
+        _context: NotificationContext<RoleClient>,
+    ) -> impl std::future::Future<Output = ()> + Send + '_ {
+        let server_name = self.server_name.clone();
+        let tx = self.invalidation.clone();
+        async move {
+            let _ = tx.send(InvalidationEvent {
+                server_name,
+                kind: InvalidationKind::PromptsListChanged,
+            });
+        }
+    }
+
+    // Server→client requests — `sampling/createMessage`, `elicitation/create`,
+    // `roots/list`. The bitrouter gateway is stateless: the inbound client
+    // connected via a single HTTP request, with no channel back through which
+    // we could relay a server→client request. Rather than rmcp's silent
+    // defaults (the spec's #1 silent-breakage complaint of MCP-through-gateway
+    // in 2026), we surface an explicit, spec-shaped `-32601` so the upstream
+    // server's tool-call logic sees the rejection and can branch on it.
+    fn create_message(
+        &self,
+        _params: CreateMessageRequestParams,
+        _context: RequestContext<RoleClient>,
+    ) -> impl std::future::Future<Output = std::result::Result<CreateMessageResult, McpError>> + Send + '_
+    {
+        let server = self.server_name.clone();
+        async move {
+            tracing::warn!(
+                server = %server,
+                method = "sampling/createMessage",
+                "mcp gateway rejected server→client request (stateless inbound)",
+            );
+            Err(deny_error("sampling/createMessage"))
+        }
+    }
+
+    fn create_elicitation(
+        &self,
+        _request: CreateElicitationRequestParams,
+        _context: RequestContext<RoleClient>,
+    ) -> impl std::future::Future<Output = std::result::Result<CreateElicitationResult, McpError>>
+    + Send
+    + '_ {
+        let server = self.server_name.clone();
+        async move {
+            tracing::warn!(
+                server = %server,
+                method = "elicitation/create",
+                "mcp gateway rejected server→client request (stateless inbound)",
+            );
+            Err(deny_error("elicitation/create"))
+        }
+    }
+
+    fn list_roots(
+        &self,
+        _context: RequestContext<RoleClient>,
+    ) -> impl std::future::Future<Output = std::result::Result<ListRootsResult, McpError>> + Send + '_
+    {
+        let server = self.server_name.clone();
+        async move {
+            tracing::warn!(
+                server = %server,
+                method = "roots/list",
+                "mcp gateway rejected server→client request (stateless inbound)",
+            );
+            Err(deny_error("roots/list"))
+        }
+    }
+}
+
+fn deny_error(method: &'static str) -> McpError {
+    McpError::new(
+        ErrorCode::METHOD_NOT_FOUND,
+        format!(
+            "bitrouter gateway does not relay server→client requests. The inbound client \
+             connected statelessly; configure a direct MCP client connection if you need \
+             {method}."
+        ),
+        None,
+    )
+}
+
+/// One pooled upstream connection — the running rmcp service plus the
+/// progress dispatcher its client holds (cloned-Arc) so the executor can
+/// subscribe per call.
+#[derive(Clone)]
+struct PooledConnection {
+    service: Arc<RunningService<RoleClient, BitrouterMcpClient>>,
+    progress: Arc<ProgressDispatcher>,
 }
 
 /// Pooled rmcp client used by [`RmcpExecutor`].
-type Pool = Mutex<HashMap<String, Arc<RunningService<RoleClient, BitrouterMcpClient>>>>;
+type Pool = Mutex<HashMap<String, PooledConnection>>;
+
+/// Broadcast capacity for the invalidation channel. Sized to absorb a burst
+/// of `notifications/*_list_changed` from a freshly reconnected server
+/// without dropping events for the caching subscriber.
+const INVALIDATION_CHANNEL_CAPACITY: usize = 256;
 
 /// [`Executor`] that forwards [`McpRequest`]s to upstream MCP servers via
 /// rmcp.
-#[derive(Default)]
 pub struct RmcpExecutor {
     pool: Pool,
+    invalidation_tx: Arc<broadcast::Sender<InvalidationEvent>>,
+}
+
+impl Default for RmcpExecutor {
+    fn default() -> Self {
+        let (tx, _rx) = broadcast::channel(INVALIDATION_CHANNEL_CAPACITY);
+        Self {
+            pool: Default::default(),
+            invalidation_tx: Arc::new(tx),
+        }
+    }
 }
 
 impl RmcpExecutor {
@@ -61,12 +223,21 @@ impl RmcpExecutor {
         Self::default()
     }
 
-    async fn peer_for(
+    /// Subscribe to upstream cache-invalidation notifications. Each
+    /// `notifications/tools/list_changed` (or sibling) from any pooled server
+    /// produces one event on this channel — typically consumed by a
+    /// [`super::CachingExecutor`].
+    pub fn invalidation_receiver(&self) -> broadcast::Receiver<InvalidationEvent> {
+        self.invalidation_tx.subscribe()
+    }
+
+    async fn connection_for(
         &self,
-        target: &McpTarget,
-    ) -> Result<Arc<RunningService<RoleClient, BitrouterMcpClient>>> {
+        server_name: &str,
+        transport: &McpTransport,
+    ) -> Result<PooledConnection> {
         // Fast path: already connected.
-        if let Some(existing) = self.pool.lock().await.get(&target.server_name).cloned() {
+        if let Some(existing) = self.pool.lock().await.get(server_name).cloned() {
             return Ok(existing);
         }
         // Slow path: dial. We drop the lock across the network round-trip so
@@ -74,18 +245,31 @@ impl RmcpExecutor {
         // another. If two requests race to dial the same server, both will
         // dial; the second one's value silently replaces the first in the
         // pool — fine because either RunningService is correct.
-        let service = connect(target).await?;
-        let arc = Arc::new(service);
+        let progress = Arc::new(ProgressDispatcher::new());
+        let client = BitrouterMcpClient {
+            server_name: server_name.to_string(),
+            progress: progress.clone(),
+            invalidation: self.invalidation_tx.clone(),
+        };
+        let service = connect(server_name, transport, client).await?;
+        let entry = PooledConnection {
+            service: Arc::new(service),
+            progress,
+        };
         self.pool
             .lock()
             .await
-            .insert(target.server_name.clone(), Arc::clone(&arc));
-        Ok(arc)
+            .insert(server_name.to_string(), entry.clone());
+        Ok(entry)
     }
 }
 
-async fn connect(target: &McpTarget) -> Result<RunningService<RoleClient, BitrouterMcpClient>> {
-    match &target.transport {
+async fn connect(
+    server_name: &str,
+    transport: &McpTransport,
+    client: BitrouterMcpClient,
+) -> Result<RunningService<RoleClient, BitrouterMcpClient>> {
+    match transport {
         McpTransport::Http { url, headers } => {
             // Streamable HTTP transport per the MCP spec
             // <https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#streamable-http>.
@@ -100,14 +284,12 @@ async fn connect(target: &McpTarget) -> Result<RunningService<RoleClient, Bitrou
             for (k, v) in headers {
                 let name: HeaderName = k.parse().map_err(|e| {
                     BitrouterError::internal(format!(
-                        "mcp '{}': invalid header name '{k}': {e}",
-                        target.server_name
+                        "mcp '{server_name}': invalid header name '{k}': {e}"
                     ))
                 })?;
                 let value: HeaderValue = v.parse().map_err(|e| {
                     BitrouterError::internal(format!(
-                        "mcp '{}': invalid header value for '{k}': {e}",
-                        target.server_name
+                        "mcp '{server_name}': invalid header value for '{k}': {e}"
                     ))
                 })?;
                 header_map.insert(name, value);
@@ -118,10 +300,10 @@ async fn connect(target: &McpTarget) -> Result<RunningService<RoleClient, Bitrou
                 )
                 .custom_headers(header_map);
             let transport = rmcp::transport::StreamableHttpClientTransport::from_config(cfg);
-            BitrouterMcpClient
+            client
                 .serve(transport)
                 .await
-                .map_err(|e| upstream(&target.server_name, format!("HTTP connect: {e}")))
+                .map_err(|e| upstream(server_name, format!("HTTP connect: {e}")))
         }
         McpTransport::Stdio { command, args, env } => {
             // stdio child-process transport per the MCP spec
@@ -132,11 +314,11 @@ async fn connect(target: &McpTarget) -> Result<RunningService<RoleClient, Bitrou
                 cmd.env(k, v);
             }
             let transport = rmcp::transport::TokioChildProcess::new(cmd)
-                .map_err(|e| upstream(&target.server_name, format!("spawning '{command}': {e}")))?;
-            BitrouterMcpClient
+                .map_err(|e| upstream(server_name, format!("spawning '{command}': {e}")))?;
+            client
                 .serve(transport)
                 .await
-                .map_err(|e| upstream(&target.server_name, format!("stdio connect: {e}")))
+                .map_err(|e| upstream(server_name, format!("stdio connect: {e}")))
         }
     }
 }
@@ -155,21 +337,140 @@ fn bad_params(server: &str, method: &str, msg: impl std::fmt::Display) -> Bitrou
 #[async_trait]
 impl Executor for RmcpExecutor {
     async fn execute(&self, target: &McpTarget, request: &McpRequest) -> Result<McpResponse> {
-        let peer = self.peer_for(target).await?.peer().clone();
-        let result = dispatch(&peer, target, request).await?;
+        let (server_name, transport) = direct_target(target)?;
+        let conn = self.connection_for(server_name, transport).await?;
+        let peer = conn.service.peer().clone();
+        let result = dispatch(&peer, server_name, request).await?;
         Ok(McpResponse {
             request_id: request.request_id.clone(),
             result,
         })
     }
+
+    async fn execute_streaming(
+        &self,
+        target: &McpTarget,
+        request: &McpRequest,
+    ) -> Result<BoxStream<'static, Result<McpStreamPart>>> {
+        // Streaming is only meaningful for `tools/call`: every other dispatched
+        // method is a one-shot list/read with no upstream notifications, so
+        // the default impl (wrap `execute` as a single `Final`) covers them.
+        if request.method != "tools/call" {
+            let response = self.execute(target, request).await?;
+            return Ok(stream::once(async move { Ok(McpStreamPart::Final(response)) }).boxed());
+        }
+        let (server_name, transport) = direct_target(target)?;
+        let conn = self.connection_for(server_name, transport).await?;
+        Ok(stream_tools_call(conn, server_name.to_string(), request.clone()).boxed())
+    }
+}
+
+fn direct_target(target: &McpTarget) -> Result<(&str, &McpTransport)> {
+    match target {
+        McpTarget::Direct {
+            server_name,
+            transport,
+        } => Ok((server_name.as_str(), transport)),
+        McpTarget::Aggregate { .. } => Err(BitrouterError::internal(
+            "RmcpExecutor cannot handle Aggregate targets directly — wrap it in an \
+             AggregatingExecutor",
+        )),
+    }
+}
+
+/// Drive `tools/call` with a parallel progress-notification stream. The
+/// caller-supplied params get a `_meta.progressToken` injected so the upstream
+/// knows it may emit progress; notifications matching that token are yielded
+/// as [`McpStreamPart::Notification`] frames before the terminal
+/// [`McpStreamPart::Final`].
+fn stream_tools_call(
+    conn: PooledConnection,
+    server_name: String,
+    request: McpRequest,
+) -> impl futures::Stream<Item = Result<McpStreamPart>> + Send + 'static {
+    async_stream::stream! {
+        // Generate a fresh progress token and inject it into params._meta so
+        // the upstream is opted-in. The MCP spec carries progressToken in
+        // `_meta.progressToken`; the client picks the value, the server echoes
+        // it on every notifications/progress.
+        let token_string = uuid::Uuid::new_v4().to_string();
+        let token = ProgressToken(NumberOrString::String(token_string.clone().into()));
+
+        let mut params_value = request.params.clone();
+        if !params_value.is_object() {
+            params_value = serde_json::json!({});
+        }
+        if let Some(obj) = params_value.as_object_mut() {
+            let meta = obj
+                .entry("_meta".to_string())
+                .or_insert(serde_json::json!({}));
+            if let Some(meta_obj) = meta.as_object_mut() {
+                meta_obj
+                    .entry("progressToken".to_string())
+                    .or_insert(serde_json::Value::String(token_string));
+            }
+        }
+        let call_params: CallToolRequestParams = match serde_json::from_value(params_value) {
+            Ok(p) => p,
+            Err(e) => {
+                yield Err(bad_params(&server_name, "tools/call", e));
+                return;
+            }
+        };
+
+        let mut subscriber = conn.progress.subscribe(token).await;
+        let peer = conn.service.peer().clone();
+        let request_id = request.request_id.clone();
+        let server = server_name.clone();
+        let call_fut = async move {
+            peer.call_tool(call_params)
+                .await
+                .map_err(|e| upstream(&server, format!("tools/call: {e}")))
+        };
+        tokio::pin!(call_fut);
+
+        loop {
+            tokio::select! {
+                biased;
+                notif = subscriber.next() => {
+                    match notif {
+                        Some(n) => {
+                            let params = serde_json::to_value(&n).unwrap_or(serde_json::Value::Null);
+                            yield Ok(McpStreamPart::Notification {
+                                method: "notifications/progress".to_string(),
+                                params,
+                            });
+                        }
+                        None => {
+                            // Subscriber closed before the call returned — keep
+                            // polling the call future; no more notifications
+                            // will arrive but the response still might.
+                        }
+                    }
+                }
+                call_result = &mut call_fut => {
+                    match call_result {
+                        Ok(result) => {
+                            let value = serde_json::to_value(&result).unwrap_or(serde_json::Value::Null);
+                            yield Ok(McpStreamPart::Final(McpResponse {
+                                request_id,
+                                result: value,
+                            }));
+                        }
+                        Err(e) => yield Err(e),
+                    }
+                    return;
+                }
+            }
+        }
+    }
 }
 
 async fn dispatch(
     peer: &Peer<RoleClient>,
-    target: &McpTarget,
+    server: &str,
     request: &McpRequest,
 ) -> Result<serde_json::Value> {
-    let server = target.server_name.as_str();
     let method = request.method.as_str();
     match method {
         "tools/list" => {
@@ -248,7 +549,7 @@ mod tests {
     use std::collections::HashMap;
 
     fn req(server: &str, method: &str) -> McpRequest {
-        McpRequest::new(
+        McpRequest::direct(
             server,
             method,
             serde_json::json!({}),
@@ -268,7 +569,7 @@ mod tests {
     #[tokio::test]
     async fn stdio_connect_failure_surfaces_as_502_upstream() {
         let exec = RmcpExecutor::new();
-        let target = McpTarget {
+        let target = McpTarget::Direct {
             server_name: "ghost".into(),
             transport: McpTransport::Stdio {
                 command: "/bin/false".into(),
@@ -292,7 +593,7 @@ mod tests {
     #[tokio::test]
     async fn stdio_spawn_failure_surfaces_as_502_upstream() {
         let exec = RmcpExecutor::new();
-        let target = McpTarget {
+        let target = McpTarget::Direct {
             server_name: "ghost".into(),
             transport: McpTransport::Stdio {
                 command: "/definitely/does/not/exist/bitrouter-mcp-test".into(),
@@ -305,5 +606,18 @@ mod tests {
             .await
             .unwrap_err();
         assert_eq!(err.status(), 502, "unexpected error: {err}");
+    }
+
+    #[tokio::test]
+    async fn executor_rejects_aggregate_targets() {
+        let exec = RmcpExecutor::new();
+        let target = McpTarget::Aggregate { members: vec![] };
+        let err = exec
+            .execute(&target, &req("anything", "tools/list"))
+            .await
+            .unwrap_err();
+        // Internal — RmcpExecutor without an AggregatingExecutor wrapper is
+        // a programming bug, not a transport failure.
+        assert_eq!(err.status(), 500, "unexpected error: {err}");
     }
 }

--- a/crates/bitrouter-sdk/src/mcp/rmcp_executor.rs
+++ b/crates/bitrouter-sdk/src/mcp/rmcp_executor.rs
@@ -226,7 +226,7 @@ impl RmcpExecutor {
     /// Subscribe to upstream cache-invalidation notifications. Each
     /// `notifications/tools/list_changed` (or sibling) from any pooled server
     /// produces one event on this channel — typically consumed by a
-    /// [`super::CachingExecutor`].
+    /// [`super::caching_executor::CachingExecutor`].
     pub fn invalidation_receiver(&self) -> broadcast::Receiver<InvalidationEvent> {
         self.invalidation_tx.subscribe()
     }

--- a/crates/bitrouter-sdk/src/mcp/transport.rs
+++ b/crates/bitrouter-sdk/src/mcp/transport.rs
@@ -62,6 +62,33 @@ pub struct McpServerConfig {
     pub name: String,
     /// Wire transport.
     pub transport: McpTransport,
+    /// Whether this server participates in the aggregate fan-out endpoint
+    /// (typically `POST /mcp`). Default: `true`.
+    #[serde(default = "default_true")]
+    pub aggregate: bool,
+    /// Prefix prepended to upstream tool/prompt names when this server
+    /// participates in aggregate fan-out. When `None`, the config-load layer
+    /// fills in `{server_name}__`.
+    #[serde(default)]
+    pub tool_prefix: Option<String>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl McpServerConfig {
+    /// Build a server config with default aggregation settings (`aggregate:
+    /// true`, `tool_prefix: None` so the config-load layer fills in
+    /// `{name}__`). Convenience for tests and programmatic config builders.
+    pub fn with_defaults(name: impl Into<String>, transport: McpTransport) -> Self {
+        Self {
+            name: name.into(),
+            transport,
+            aggregate: true,
+            tool_prefix: None,
+        }
+    }
 }
 
 /// Errors returned by [`McpServerConfig::validate`].
@@ -132,15 +159,15 @@ mod tests {
 
     #[test]
     fn http_transport_round_trips_through_serde() {
-        let cfg = McpServerConfig {
-            name: "ctx7".into(),
-            transport: McpTransport::Http {
+        let cfg = McpServerConfig::with_defaults(
+            "ctx7",
+            McpTransport::Http {
                 url: "https://mcp.example.com/v1/mcp".into(),
                 headers: [("Authorization".to_string(), "Bearer x".to_string())]
                     .into_iter()
                     .collect(),
             },
-        };
+        );
         let json = serde_json::to_value(&cfg).unwrap();
         assert_eq!(json["transport"]["type"], "http");
         assert_eq!(json["transport"]["url"], "https://mcp.example.com/v1/mcp");
@@ -150,14 +177,14 @@ mod tests {
 
     #[test]
     fn stdio_transport_round_trips_through_serde() {
-        let cfg = McpServerConfig {
-            name: "local-git".into(),
-            transport: McpTransport::Stdio {
+        let cfg = McpServerConfig::with_defaults(
+            "local-git",
+            McpTransport::Stdio {
                 command: "uvx".into(),
                 args: vec!["mcp-server-git".into()],
                 env: Default::default(),
             },
-        };
+        );
         let json = serde_json::to_value(&cfg).unwrap();
         assert_eq!(json["transport"]["type"], "stdio");
         assert_eq!(json["transport"]["command"], "uvx");
@@ -166,14 +193,43 @@ mod tests {
     }
 
     #[test]
+    fn aggregate_and_tool_prefix_defaults_when_omitted() {
+        // Bare entry — `aggregate` and `tool_prefix` are absent in the YAML
+        // shape but must materialise as the documented defaults.
+        let json = serde_json::json!({
+            "name": "x",
+            "transport": { "type": "http", "url": "https://x" }
+        });
+        let cfg: McpServerConfig = serde_json::from_value(json).unwrap();
+        assert!(cfg.aggregate, "aggregate must default to true");
+        assert!(
+            cfg.tool_prefix.is_none(),
+            "tool_prefix must default to None so the config-load layer fills in '{{name}}__'"
+        );
+    }
+
+    #[test]
+    fn aggregate_opt_out_round_trips() {
+        let json = serde_json::json!({
+            "name": "linear",
+            "transport": { "type": "http", "url": "https://linear" },
+            "aggregate": false,
+            "tool_prefix": "lin__"
+        });
+        let cfg: McpServerConfig = serde_json::from_value(json).unwrap();
+        assert!(!cfg.aggregate);
+        assert_eq!(cfg.tool_prefix.as_deref(), Some("lin__"));
+    }
+
+    #[test]
     fn validate_rejects_empty_name() {
-        let cfg = McpServerConfig {
-            name: String::new(),
-            transport: McpTransport::Http {
+        let cfg = McpServerConfig::with_defaults(
+            String::new(),
+            McpTransport::Http {
                 url: "https://x".into(),
                 headers: Default::default(),
             },
-        };
+        );
         assert!(matches!(
             cfg.validate(),
             Err(McpConfigError::InvalidName { .. })
@@ -182,13 +238,13 @@ mod tests {
 
     #[test]
     fn validate_rejects_slash_in_name() {
-        let cfg = McpServerConfig {
-            name: "foo/bar".into(),
-            transport: McpTransport::Http {
+        let cfg = McpServerConfig::with_defaults(
+            "foo/bar",
+            McpTransport::Http {
                 url: "https://x".into(),
                 headers: Default::default(),
             },
-        };
+        );
         assert!(matches!(
             cfg.validate(),
             Err(McpConfigError::InvalidName { .. })
@@ -197,13 +253,13 @@ mod tests {
 
     #[test]
     fn validate_rejects_reserved_sse_name() {
-        let cfg = McpServerConfig {
-            name: "sse".into(),
-            transport: McpTransport::Http {
+        let cfg = McpServerConfig::with_defaults(
+            "sse",
+            McpTransport::Http {
                 url: "https://x".into(),
                 headers: Default::default(),
             },
-        };
+        );
         assert!(matches!(
             cfg.validate(),
             Err(McpConfigError::InvalidName { .. })
@@ -212,13 +268,13 @@ mod tests {
 
     #[test]
     fn validate_rejects_empty_http_url() {
-        let cfg = McpServerConfig {
-            name: "x".into(),
-            transport: McpTransport::Http {
+        let cfg = McpServerConfig::with_defaults(
+            "x",
+            McpTransport::Http {
                 url: String::new(),
                 headers: Default::default(),
             },
-        };
+        );
         assert!(matches!(
             cfg.validate(),
             Err(McpConfigError::EmptyHttpUrl { .. })
@@ -227,14 +283,14 @@ mod tests {
 
     #[test]
     fn validate_rejects_empty_stdio_command() {
-        let cfg = McpServerConfig {
-            name: "x".into(),
-            transport: McpTransport::Stdio {
+        let cfg = McpServerConfig::with_defaults(
+            "x",
+            McpTransport::Stdio {
                 command: String::new(),
                 args: vec![],
                 env: Default::default(),
             },
-        };
+        );
         assert!(matches!(
             cfg.validate(),
             Err(McpConfigError::EmptyStdioCommand { .. })
@@ -244,25 +300,25 @@ mod tests {
     #[test]
     fn validate_accepts_well_formed_http_and_stdio() {
         assert!(
-            McpServerConfig {
-                name: "ctx7".into(),
-                transport: McpTransport::Http {
+            McpServerConfig::with_defaults(
+                "ctx7",
+                McpTransport::Http {
                     url: "https://x".into(),
                     headers: Default::default(),
                 },
-            }
+            )
             .validate()
             .is_ok()
         );
         assert!(
-            McpServerConfig {
-                name: "git".into(),
-                transport: McpTransport::Stdio {
+            McpServerConfig::with_defaults(
+                "git",
+                McpTransport::Stdio {
                     command: "uvx".into(),
                     args: vec!["mcp-server-git".into()],
                     env: Default::default(),
                 },
-            }
+            )
             .validate()
             .is_ok()
         );

--- a/crates/bitrouter-sdk/src/server.rs
+++ b/crates/bitrouter-sdk/src/server.rs
@@ -63,7 +63,11 @@ impl App {
             skip_auth: self.skip_auth(),
             metrics_renderer: self.metrics_renderer().cloned(),
         };
-        let router = build_router(state);
+        let options = RouterOptions {
+            omit_v1_models: false,
+            mcp_aggregate_route: self.mcp_aggregate_route().map(String::from),
+        };
+        let router = build_router_with_options(state, options);
         let listener = tokio::net::TcpListener::bind(listen)
             .await
             .map_err(|e| BitrouterError::internal(format!("bind {listen}: {e}")))?;
@@ -120,10 +124,14 @@ const MAX_BODY_BYTES: usize = 16 * 1024 * 1024;
 /// own richer variant of a built-in route (e.g. bitrouter-cloud's enriched
 /// `/v1/models`) opt out of the SDK's plainer version here so
 /// [`axum::Router::merge`] does not panic on the duplicate path.
-#[derive(Default, Clone, Copy)]
+#[derive(Default, Clone)]
 pub struct RouterOptions {
     /// When `true`, omit `GET /v1/models` from the returned router.
     pub omit_v1_models: bool,
+    /// Path for the aggregate MCP endpoint (`Some("/mcp")` by typical
+    /// convention). `None` omits the aggregate route — only per-server routes
+    /// (`/mcp/{server}`) are mounted.
+    pub mcp_aggregate_route: Option<String>,
 }
 
 /// Build the axum router for the given state.
@@ -143,8 +151,11 @@ pub fn build_router_with_options(state: AppState, options: RouterOptions) -> Rou
     if !options.omit_v1_models {
         router = router.route("/v1/models", get(list_models));
     }
+    router = router.route("/mcp/{server}", post(mcp_invoke));
+    if let Some(path) = options.mcp_aggregate_route {
+        router = router.route(&path, post(mcp_invoke_aggregate));
+    }
     router
-        .route("/mcp/{server}", post(mcp_invoke))
         .route("/metrics", get(prometheus_metrics))
         .route("/health", get(health))
         .layer(axum::extract::DefaultBodyLimit::max(MAX_BODY_BYTES))
@@ -184,6 +195,25 @@ async fn mcp_invoke(
     Path(server): Path<String>,
     headers: HeaderMap,
     Json(body): Json<serde_json::Value>,
+) -> Response {
+    mcp_invoke_inner(state, mcp::ServerSelector::Direct(server), headers, body).await
+}
+
+/// `POST /mcp` — the aggregate (fan-out) MCP endpoint. Mounted only when
+/// `RouterOptions.mcp_aggregate_route` is `Some(path)`.
+async fn mcp_invoke_aggregate(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(body): Json<serde_json::Value>,
+) -> Response {
+    mcp_invoke_inner(state, mcp::ServerSelector::Aggregate, headers, body).await
+}
+
+async fn mcp_invoke_inner(
+    state: AppState,
+    selector: mcp::ServerSelector,
+    headers: HeaderMap,
+    body: serde_json::Value,
 ) -> Response {
     let Some(pipeline) = state.mcp.clone() else {
         return BitrouterError::NotFound("mcp pipeline not configured".to_string()).into_response();
@@ -227,7 +257,23 @@ async fn mcp_invoke(
     } else {
         CallerContext::anonymous()
     };
-    let request = mcp::McpRequest::new(server, method, params, caller);
+    let request = match selector {
+        mcp::ServerSelector::Direct(server) => {
+            mcp::McpRequest::direct(server, method, params, caller)
+        }
+        mcp::ServerSelector::Aggregate => mcp::McpRequest::aggregate(method, params, caller),
+    };
+
+    // SSE branch per the MCP Streamable HTTP spec — if the client opts in via
+    // `Accept: text/event-stream` we return the JSON-RPC frames as `data:`
+    // events. JSON clients get the buffered JSON shape (the existing path).
+    if accepts_event_stream(&headers) {
+        return match pipeline.execute_streaming(request).await {
+            Ok(stream) => sse_response(inbound_id, stream),
+            Err(e) => mcp_pipeline_error_response(inbound_id, &e),
+        };
+    }
+
     match pipeline.execute(request).await {
         Ok(response) => Json(serde_json::json!({
             "jsonrpc": "2.0",
@@ -235,40 +281,95 @@ async fn mcp_invoke(
             "result": response.result,
         }))
         .into_response(),
-        Err(e) => {
-            // JSON-RPC error envelope (see spec link above). Pipeline failures
-            // are returned at HTTP 200 with `error.code` mapped from the
-            // BitrouterError variant; unknown-server (`NotFound` from
-            // `RoutingTable::resolve`) maps to JSON-RPC "Method not found"
-            // (-32601). Pre-request denies / upstream errors keep their HTTP
-            // status so MCP-unaware proxies still surface them — but the body
-            // remains a JSON-RPC error object for the spec-aware client.
-            let (status, code) = match &e {
-                BitrouterError::NotFound(_) => (axum::http::StatusCode::NOT_FOUND, -32601),
-                BitrouterError::BadRequest { .. } => (axum::http::StatusCode::BAD_REQUEST, -32602),
-                BitrouterError::Unauthorized(_) => (axum::http::StatusCode::UNAUTHORIZED, -32000),
-                BitrouterError::Forbidden(_) => (axum::http::StatusCode::FORBIDDEN, -32000),
-                BitrouterError::PaymentRequired(_) => {
-                    (axum::http::StatusCode::PAYMENT_REQUIRED, -32000)
-                }
-                _ => (axum::http::StatusCode::INTERNAL_SERVER_ERROR, -32603),
-            };
-            (
-                status,
-                Json(serde_json::json!({
-                    "jsonrpc": "2.0",
-                    "id": inbound_id,
-                    "error": { "code": code, "message": e.to_string() },
-                })),
-            )
-                .into_response()
-        }
+        Err(e) => mcp_pipeline_error_response(inbound_id, &e),
     }
 }
 
+/// Map a [`BitrouterError`] from the MCP pipeline into the JSON-RPC error
+/// envelope. Pipeline failures are returned with `error.code` mapped from the
+/// `BitrouterError` variant; unknown-server (`NotFound` from
+/// `RoutingTable::resolve`) maps to JSON-RPC "Method not found" (-32601).
+/// Pre-request denies / upstream errors keep their HTTP status so MCP-unaware
+/// proxies still surface them — but the body remains a JSON-RPC error object
+/// for the spec-aware client.
+fn mcp_pipeline_error_response(inbound_id: serde_json::Value, e: &BitrouterError) -> Response {
+    let (status, code) = match e {
+        BitrouterError::NotFound(_) => (axum::http::StatusCode::NOT_FOUND, -32601),
+        BitrouterError::BadRequest { .. } => (axum::http::StatusCode::BAD_REQUEST, -32602),
+        BitrouterError::Unauthorized(_) => (axum::http::StatusCode::UNAUTHORIZED, -32000),
+        BitrouterError::Forbidden(_) => (axum::http::StatusCode::FORBIDDEN, -32000),
+        BitrouterError::PaymentRequired(_) => (axum::http::StatusCode::PAYMENT_REQUIRED, -32000),
+        _ => (axum::http::StatusCode::INTERNAL_SERVER_ERROR, -32603),
+    };
+    (
+        status,
+        Json(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": inbound_id,
+            "error": { "code": code, "message": e.to_string() },
+        })),
+    )
+        .into_response()
+}
+
+/// True if the client opted into the SSE response variant.
+fn accepts_event_stream(headers: &HeaderMap) -> bool {
+    headers
+        .get(axum::http::header::ACCEPT)
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|s| {
+            s.split(',')
+                .any(|p| p.trim().starts_with("text/event-stream"))
+        })
+}
+
+/// Build an `Sse` response from a stream of [`mcp::McpStreamPart`]s. Each part
+/// becomes one SSE `data:` event carrying the JSON-RPC notification or
+/// response. The stream closes after the terminating `Final` is sent.
+fn sse_response(
+    inbound_id: serde_json::Value,
+    stream: futures::stream::BoxStream<'static, crate::error::Result<mcp::McpStreamPart>>,
+) -> Response {
+    use axum::response::sse::{Event, KeepAlive, Sse};
+    let inbound_id = Arc::new(inbound_id);
+    let event_stream = stream.map(move |item| {
+        let inbound_id = inbound_id.clone();
+        match item {
+            Ok(mcp::McpStreamPart::Notification { method, params }) => {
+                let payload = serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "method": method,
+                    "params": params,
+                });
+                Ok::<_, Infallible>(Event::default().data(payload.to_string()))
+            }
+            Ok(mcp::McpStreamPart::Final(response)) => {
+                let payload = serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": &*inbound_id,
+                    "result": response.result,
+                });
+                Ok(Event::default().data(payload.to_string()))
+            }
+            Err(e) => {
+                let payload = serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": &*inbound_id,
+                    "error": { "code": -32603, "message": e.to_string() },
+                });
+                Ok(Event::default().data(payload.to_string()))
+            }
+        }
+    });
+    Sse::new(event_stream)
+        .keep_alive(KeepAlive::default())
+        .into_response()
+}
+
 /// MCP supported transport protocol versions. Update when adding spec revisions.
-/// See <https://modelcontextprotocol.io/specification/2025-06-18/basic/lifecycle>.
-const MCP_SUPPORTED_PROTOCOL_VERSIONS: &[&str] = &["2025-06-18", "2025-03-26", "2024-11-05"];
+/// See <https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle>.
+const MCP_SUPPORTED_PROTOCOL_VERSIONS: &[&str] =
+    &["2025-11-25", "2025-06-18", "2025-03-26", "2024-11-05"];
 
 /// Validates the MCP Streamable HTTP transport headers per the spec at
 /// <https://modelcontextprotocol.io/specification/2025-06-18/basic/transports>.

--- a/crates/bitrouter-sdk/src/server.rs
+++ b/crates/bitrouter-sdk/src/server.rs
@@ -325,14 +325,30 @@ fn accepts_event_stream(headers: &HeaderMap) -> bool {
 
 /// Build an `Sse` response from a stream of [`mcp::McpStreamPart`]s. Each part
 /// becomes one SSE `data:` event carrying the JSON-RPC notification or
-/// response. The stream closes after the terminating `Final` is sent.
+/// response. The stream closes after the terminating frame — either the
+/// `Final` result or the first error — so JSON-RPC semantics hold (one
+/// terminal frame per `id`) and a client that has already seen the answer
+/// never sits on an open connection waiting for nothing.
 fn sse_response(
     inbound_id: serde_json::Value,
     stream: futures::stream::BoxStream<'static, crate::error::Result<mcp::McpStreamPart>>,
 ) -> Response {
     use axum::response::sse::{Event, KeepAlive, Sse};
     let inbound_id = Arc::new(inbound_id);
-    let event_stream = stream.map(move |item| {
+    // `scan` carries a "have we emitted the terminal frame?" flag. Once true,
+    // the next poll returns `None` and the SSE stream closes — `take_while`
+    // would drop the terminal frame itself, and `futures` has no
+    // `take_while_inclusive`, so this is the portable equivalent.
+    let terminated_stream = stream.scan(false, |done, item| {
+        if *done {
+            return std::future::ready(None);
+        }
+        if matches!(item, Ok(mcp::McpStreamPart::Final(_)) | Err(_)) {
+            *done = true;
+        }
+        std::future::ready(Some(item))
+    });
+    let event_stream = terminated_stream.map(move |item| {
         let inbound_id = inbound_id.clone();
         match item {
             Ok(mcp::McpStreamPart::Notification { method, params }) => {


### PR DESCRIPTION
## Summary

Closes #483. Refactors the MCP gateway in `bitrouter-sdk` into a competitive v1.x gateway across four pillars, plus a spec bump to `2025-11-25`. Pillar 1's type refactor (`McpRequest.server: String` → `selector: ServerSelector`, `McpTarget` struct → enum) is the only breaking change, concentrated in the first commit so the rest are additive.

- **Pillar 1 — Aggregation.** Virtual `POST /mcp` (path configurable via `mcp.aggregate.route`) fans out across every `aggregate: true` server. `{tool_prefix}{tool_name}` rewriting in `tools/list` / `prompts/list` responses; longest-prefix-wins routing for `tools/call` / `prompts/get`. Partial failures surface under `result._bitrouterErrors = [{server, error}]` (the `_bitrouter` prefix namespaces gateway-injected fields). Fan-out is concurrent (`futures::future::join_all`) so cold-cache latency is `max(per-server)`, not the sum.
- **Pillar 2 — List caching.** `CachingExecutor` wraps the leaves with TTL+LRU per-server cache for `tools/list` / `resources/list` / `resources/templates/list` / `prompts/list`. Honors the spec's `_meta.ttlMs` hint. Invalidated promptly via a broadcast channel driven by upstream `notifications/*_list_changed`. Streaming hits and misses both populate the cache so the SSE path doesn't silently bypass it. Cache keys are hashed with a canonical (key-sorted) JSON walk so semantically-equal params with different insertion order hit the same entry.
- **Pillar 3 — Explicit deny.** `BitrouterMcpClient` overrides `create_message` / `create_elicitation` / `list_roots` to return JSON-RPC `-32601` with a documented message, plus `tracing::warn!` with structured fields so observability can count them.
- **Pillar 4 — SSE response variant.** `Accept: text/event-stream` on either `/mcp` or `/mcp/{server}` returns Streamable HTTP SSE. `tools/call` streams `notifications/progress` via rmcp's `ProgressDispatcher` (token auto-injected into `_meta.progressToken`) ahead of the terminal frame. The SSE stream closes after the terminal frame (Final or error) so JSON-RPC's one-terminal-per-id contract holds and clients never sit on an open connection after the answer.

Composition in `apps/bitrouter/src/assemble.rs`: `AggregatingExecutor → CachingExecutor → RmcpExecutor`. Caches sit at the leaves so a single-server `notifications/list_changed` only invalidates that server's slice.

### Config additions (all optional, sensible defaults)

```yaml
mcp:
  aggregate: { enabled: true, route: "/mcp" }
  cache:
    enabled: true
    tools_list_ttl_secs: 60
    resources_list_ttl_secs: 60
    resources_templates_list_ttl_secs: 300
    prompts_list_ttl_secs: 300
    max_entries_per_server: 64
mcp_servers:
  github:
    transport: { type: http, url: "..." }
    aggregate: true            # default
    tool_prefix: "github__"    # default {name}__
```

### Notable behavior changes for v1.0-alpha users

- Tool names returned by `tools/list` on the **aggregate** route are now `{prefix}{name}` (default `{server}__{name}`). The per-server route `/mcp/{server}` keeps the unmodified names.
- New top-level `mcp:` key in `bitrouter.yaml` — fully optional; absent block behaves identically to all-default values (guarded by `mcp_cache_config_defaults_match_cache_ttls` test).
- `RouterOptions` gained `mcp_aggregate_route: Option<String>`; `App::mcp_aggregate_route(...)` builder method drives `App::serve`.
- **`RouterOptions` is no longer `Copy`** (compile-break for downstream consumers that passed it by value to multiple callees). The new `mcp_aggregate_route: Option<String>` is heap-owned config, so `Copy` is no longer derivable. Downstream code that did `foo(opts); bar(opts);` needs an explicit `.clone()`. `Default + Clone` are retained.

### What's next (not in this PR, per spec scope)

- **OAuth client-credentials** in a new `plugins/bitrouter-mcp` crate (carries `oauth2`/`jsonwebtoken` weight).
- **`bitrouter tools list/status` CLI** learning to call the aggregate endpoint when the daemon is running.
- **Reinitialized invalidation emitter** — the variant exists; an emitter on connection re-handshake is a small follow-up.
- **`pub use` re-exports in `mcp/mod.rs`** that pre-date guideline #2 in `CLAUDE.md` — flagged in code with `TODO(mcp-reexport-cleanup)`; the cleanup is its own PR because removing them is a breaking change for the SDK public surface (downstream consumers like `bitrouter-cloud` import `bitrouter_sdk::mcp::RmcpExecutor`).

### Review follow-ups addressed

Fixes from the in-PR review (commit on top of the original feature commit):

- **High** — `AggregatingExecutor::fanout_list` now uses `futures::future::join_all` so cold-cache fan-out across N servers is `max(per-server)` latency, not `Σ`.
- **High** — `stream_tools_call`'s `tokio::select!` no longer hot-spins after the progress subscriber closes: the subscriber is held in an `Option` and swapped to `pending()` once it returns `None`.
- **Medium** — `params_hash` canonicalises object key order (recursive sort) so `{"a":1,"b":2}` and `{"b":2,"a":1}` collide on the same cache key regardless of any transitive dep enabling `serde_json/preserve_order`. Pinned by `params_hash_is_canonical_across_key_order`.
- **Medium** — SSE error / Final frames now close the stream (via `scan` carrying a terminated flag) rather than emitting and waiting for the underlying source to close.
- **Low** — Gateway-injected `_errors` renamed to `_bitrouterErrors` so it cannot collide with anything an upstream method may legitimately put in `result`.
- **Low** — `CachingExecutor` holds the invalidation receiver's `JoinHandle` and `abort()`s it on `Drop` so the spawned task does not outlive the executor when the broadcast sender (on the inner `RmcpExecutor`) is longer-lived.
- **Nit** — Aggregate-route collision message now spells out the shallow-check scope (last-path-segment overlap only; axum will catch other shapes at mount time).

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --all-features --workspace` — 206 SDK tests + 22 e2e tests + all plugin tests pass; 0 failures
- [x] New tests cover: aggregation dispatch (6 cases inc. partial-failure + longest-prefix-wins), cache hit/miss/TTL/invalidation/`ttlMs` hint, SSE wire shape end-to-end, aggregate vs direct vs SSE on a single router, executor rejects aggregate without wrapper, drift detection between `McpCacheConfig::default` and `CacheTtls::default`, **canonical `params_hash` across key order**
- [ ] Manual smoke: stand up `bitrouter` with two HTTP MCP upstreams, hit `POST /mcp tools/list` (no `Accept`), confirm merged + prefixed tools
- [ ] Manual smoke: same, with `Accept: text/event-stream`, confirm SSE response and `data:` frames
- [ ] Manual smoke: hit `POST /mcp/github tools/call` with `{name: "tool", ...}`, confirm prefix is **not** required on the per-server route
- [ ] Manual smoke: confirm `cargo run -- tools list` still works (CLI verbs are unchanged in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
