### PR TITLE
fix(bitrouter): drop duplicate reqwest dep entry

### DIFF
--- a/apps/bitrouter/Cargo.toml
+++ b/apps/bitrouter/Cargo.toml
@@ -38,7 +38,6 @@ serde_json.workspace = true
 async-trait.workspace = true
 reqwest.workspace = true
 anyhow = "1"
-reqwest = { workspace = true }
 thiserror.workspace = true
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary

- `apps/bitrouter/Cargo.toml` has had `reqwest` declared twice since [#481](https://github.com/bitrouter/bitrouter/pull/481) landed — once as `reqwest.workspace = true` and once as `reqwest = { workspace = true }`. TOML rejects this as a duplicate key, so every CI job that touches `cargo metadata` on `main` now fails:

  ```
  error: duplicate key
   --> apps/bitrouter/Cargo.toml:41:1
     |
  41 | reqwest = { workspace = true }
     | ^^^^^^^
  error: failed to load manifest for workspace member `…/apps/bitrouter`
  ```

  Affected jobs on the release PR ([#482](https://github.com/bitrouter/bitrouter/pull/482)) and on `main`: `fmt`, `clippy`, `test`, `msrv`, `doc`, `doctest`, `feature-isolation`, and `release-plz plan`.

- Drop the redundant table form; the inline `reqwest.workspace = true` already covers the dep.

## Test plan

- [x] `cargo metadata --format-version=1 --no-deps` parses cleanly locally
- [ ] CI on this PR runs to green (fmt / clippy / test / msrv / doc / feature-isolation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)