### PR TITLE
chore(mcp): drop pub use re-exports per CLAUDE.md #2

### DIFF
--- a/apps/bitrouter/src/assemble.rs
+++ b/apps/bitrouter/src/assemble.rs
@@ -16,8 +16,8 @@ use bitrouter_sdk::language_model::protocol::OutboundDispatch;
 use bitrouter_sdk::language_model::{AuthAppliers, HttpExecutor, HttpTimeouts};
 use bitrouter_sdk::mcp::aggregating_executor::AggregatingExecutor;
 use bitrouter_sdk::mcp::caching_executor::{CacheTtls, CachingExecutor};
-use bitrouter_sdk::mcp::config_routing::McpServerAggregateConfig;
-use bitrouter_sdk::mcp::{ConfigMcpRoutingTable, RmcpExecutor};
+use bitrouter_sdk::mcp::config_routing::{ConfigMcpRoutingTable, McpServerAggregateConfig};
+use bitrouter_sdk::mcp::rmcp_executor::RmcpExecutor;
 
 use bitrouter_guardrails::{Action, GuardrailPreHook, GuardrailRule, GuardrailStreamHook, RuleSet};
 use bitrouter_observe::OTEL_ENABLED;

--- a/apps/bitrouter/src/tools.rs
+++ b/apps/bitrouter/src/tools.rs
@@ -15,7 +15,9 @@ use std::time::{Duration, Instant};
 
 use bitrouter_sdk::caller::CallerContext;
 use bitrouter_sdk::config::Config;
-use bitrouter_sdk::mcp::{Executor, McpRequest, McpTarget, McpTransport, RmcpExecutor};
+use bitrouter_sdk::mcp::rmcp_executor::RmcpExecutor;
+use bitrouter_sdk::mcp::transport::McpTransport;
+use bitrouter_sdk::mcp::{Executor, McpRequest, McpTarget};
 
 /// One row in `bitrouter tools list`.
 #[derive(Debug, Clone)]
@@ -224,7 +226,7 @@ fn render_discovery(server: &str, transport: &McpTransport, tools: &[ToolSummary
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bitrouter_sdk::mcp::McpServerConfig;
+    use bitrouter_sdk::mcp::transport::McpServerConfig;
     use std::collections::HashMap;
 
     fn cfg_with(server_id: &str, server_cfg: McpServerConfig) -> Config {

--- a/apps/bitrouter/tests/e2e.rs
+++ b/apps/bitrouter/tests/e2e.rs
@@ -328,8 +328,9 @@ plugins:
 async fn e2e_mcp_route_invokes_the_pure_routing_pipeline() {
     use async_trait::async_trait;
     use bitrouter_sdk::App;
+    use bitrouter_sdk::mcp::transport::McpTransport;
     use bitrouter_sdk::mcp::{
-        Executor, McpRequest, McpResponse, McpTarget, McpTransport, RoutingTable, ServerSelector,
+        Executor, McpRequest, McpResponse, McpTarget, RoutingTable, ServerSelector,
     };
     use http::Request;
     use std::sync::Arc;
@@ -542,9 +543,9 @@ async fn e2e_mcp_route_invokes_the_pure_routing_pipeline() {
 async fn e2e_mcp_aggregate_and_sse_endpoints() {
     use async_trait::async_trait;
     use bitrouter_sdk::App;
+    use bitrouter_sdk::mcp::transport::McpTransport;
     use bitrouter_sdk::mcp::{
-        AggregateMember, Executor, McpRequest, McpResponse, McpTarget, McpTransport, RoutingTable,
-        ServerSelector,
+        AggregateMember, Executor, McpRequest, McpResponse, McpTarget, RoutingTable, ServerSelector,
     };
     use bitrouter_sdk::server::{RouterOptions, build_router_with_options};
     use http::Request;

--- a/crates/bitrouter-sdk/src/config/mod.rs
+++ b/crates/bitrouter-sdk/src/config/mod.rs
@@ -64,7 +64,7 @@ pub struct Config {
     /// Upstream MCP servers, keyed by server id. The id is what appears in
     /// `POST /mcp/{id}` and what the `mcp` pipeline's routing table looks up.
     /// Empty by default — when empty, the binary does not mount the MCP route.
-    pub mcp_servers: HashMap<String, crate::mcp::McpServerConfig>,
+    pub mcp_servers: HashMap<String, crate::mcp::transport::McpServerConfig>,
     /// Upstream ACP agents, keyed by agent id. Looked up by the `acp`
     /// pipeline's routing table; the `bitrouter agent-proxy <id>` CLI
     /// dispatches against this. Empty by default.

--- a/crates/bitrouter-sdk/src/mcp/aggregating_executor.rs
+++ b/crates/bitrouter-sdk/src/mcp/aggregating_executor.rs
@@ -294,7 +294,7 @@ impl<E: Executor + 'static> Executor for AggregatingExecutor<E> {
 mod tests {
     use super::*;
     use crate::caller::CallerContext;
-    use crate::mcp::McpTransport;
+    use crate::mcp::transport::McpTransport;
     use async_trait::async_trait;
     use std::collections::HashMap;
     use std::sync::Mutex;

--- a/crates/bitrouter-sdk/src/mcp/caching_executor.rs
+++ b/crates/bitrouter-sdk/src/mcp/caching_executor.rs
@@ -190,8 +190,8 @@ impl<E: Executor + 'static> CachingExecutor<E> {
     }
 
     /// Subscribe the cache to an [`InvalidationEvent`] stream — typically
-    /// [`super::RmcpExecutor::invalidation_receiver`]. Returns `self` so the
-    /// builder reads naturally.
+    /// [`super::rmcp_executor::RmcpExecutor::invalidation_receiver`]. Returns
+    /// `self` so the builder reads naturally.
     pub fn with_invalidation(mut self, mut rx: broadcast::Receiver<InvalidationEvent>) -> Self {
         let caches = self.caches.clone();
         let handle = tokio::spawn(async move {

--- a/crates/bitrouter-sdk/src/mcp/caching_executor.rs
+++ b/crates/bitrouter-sdk/src/mcp/caching_executor.rs
@@ -448,7 +448,7 @@ impl<E: Executor + 'static> Executor for CachingExecutor<E> {
 mod tests {
     use super::*;
     use crate::caller::CallerContext;
-    use crate::mcp::McpTransport;
+    use crate::mcp::transport::McpTransport;
     use async_trait::async_trait;
     use std::collections::HashMap;
     use std::sync::atomic::{AtomicUsize, Ordering};

--- a/crates/bitrouter-sdk/src/mcp/mod.rs
+++ b/crates/bitrouter-sdk/src/mcp/mod.rs
@@ -55,26 +55,18 @@ pub mod config_routing;
 #[cfg(feature = "mcp")]
 pub mod rmcp_executor;
 
-pub use transport::{McpServerConfig, McpTransport};
-
-#[cfg(feature = "mcp")]
-pub use config_routing::ConfigMcpRoutingTable;
-#[cfg(feature = "mcp")]
-pub use rmcp_executor::RmcpExecutor;
-// `AggregatingExecutor`, `CachingExecutor`, `CacheTtls` are intentionally
-// not re-exported here — guideline #2 in CLAUDE.md (no `pub use` inside a
-// `pub mod`). Reach them via their submodule paths
-// (`mcp::aggregating_executor::AggregatingExecutor`,
-// `mcp::caching_executor::{CacheTtls, CachingExecutor}`).
+// Per CLAUDE.md guideline #2 we do not `pub use` from these submodules.
+// Downstream code reaches the types directly:
+// - `mcp::transport::{McpServerConfig, McpTransport}`
+// - `mcp::config_routing::ConfigMcpRoutingTable`
+// - `mcp::rmcp_executor::RmcpExecutor`
+// - `mcp::aggregating_executor::AggregatingExecutor`
+// - `mcp::caching_executor::{CacheTtls, CachingExecutor}`
 //
-// TODO(mcp-reexport-cleanup): the `McpServerConfig`, `McpTransport`,
-// `ConfigMcpRoutingTable`, and `RmcpExecutor` re-exports above predate
-// guideline #2 and currently violate it. They are kept for source-compat
-// with downstream consumers (e.g. `bitrouter-cloud` imports
-// `bitrouter_sdk::mcp::RmcpExecutor`). Removing them is a breaking change
-// for the SDK public surface, so it is intentionally deferred to its own
-// PR rather than bundled into this feature work — the cleanup PR must
-// rewrite every downstream import site in one shot.
+// `McpTransport` is named in this file's own type definitions
+// (`AggregateMember`, `McpTarget`), so a private `use` brings it into local
+// scope without re-exporting it.
+use transport::McpTransport;
 
 /// Which upstream(s) an inbound MCP request targets.
 ///


### PR DESCRIPTION
## Summary

Stacked on top of #484. Removes the three `pub use` re-exports in `crates/bitrouter-sdk/src/mcp/mod.rs` that pre-date guideline #2 in `CLAUDE.md` (`NEVER re-export components in a public mod`):

```rust
// removed:
pub use transport::{McpServerConfig, McpTransport};
pub use config_routing::ConfigMcpRoutingTable;
pub use rmcp_executor::RmcpExecutor;
```

Every internal call site is rewritten to the submodule path:

| short path (removed) | new path |
|---|---|
| `mcp::McpServerConfig` | `mcp::transport::McpServerConfig` |
| `mcp::McpTransport` | `mcp::transport::McpTransport` |
| `mcp::ConfigMcpRoutingTable` | `mcp::config_routing::ConfigMcpRoutingTable` |
| `mcp::RmcpExecutor` | `mcp::rmcp_executor::RmcpExecutor` |

`McpTransport` is named in `mcp/mod.rs` itself (in the `AggregateMember` and `McpTarget` type definitions), so a **private** `use transport::McpTransport;` brings it into local scope without re-exporting it (the guideline forbids `pub use` only).

This closes the loop on the `TODO(mcp-reexport-cleanup)` marker added in the review follow-up commit to #484.

### Why a separate PR

Cleanup is a source-compat break for any downstream consumer that imports the short paths (e.g. `bitrouter-cloud`). Keeping it out of the feature PR keeps the review surface focused on the gateway behavior and makes this rewrite easy to revert in isolation if a downstream import is missed.

### Files touched

- `crates/bitrouter-sdk/src/mcp/mod.rs` — drop re-exports, add private `use transport::McpTransport;`
- `crates/bitrouter-sdk/src/config/mod.rs` — `crate::mcp::McpServerConfig` → `crate::mcp::transport::McpServerConfig`
- `crates/bitrouter-sdk/src/mcp/{aggregating,caching}_executor.rs` — test imports
- `apps/bitrouter/src/assemble.rs` — `ConfigMcpRoutingTable`, `RmcpExecutor` imports
- `apps/bitrouter/src/tools.rs` — `McpTransport`, `RmcpExecutor`, `McpServerConfig` imports
- `apps/bitrouter/tests/e2e.rs` — `McpTransport` import in two test bodies

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --all-features --workspace` — all 206 SDK + 22 e2e + plugin tests pass; 0 failures, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)