### PR TITLE
feat(cli): bitrouter cloud subcommand for /v1/* management

### DIFF
--- a/apps/bitrouter/src/cloud/cli.rs
+++ b/apps/bitrouter/src/cloud/cli.rs
@@ -1,0 +1,1361 @@
+//! `bitrouter cloud …` — typed wrappers around every endpoint on
+//! [`bitrouter_cloud_sdk::management::ManagementClient`].
+//!
+//! The subcommand tree is grouped by resource (`keys`, `usage`,
+//! `billing`, `policy`, `budget`, `preset`, `byok`, `oauth-client`)
+//! plus a top-level `whoami` that prints the local identity + the
+//! configured cloud base URL. Every leaf accepts `--json` for raw
+//! response output; the default is a compact human-readable form.
+//!
+//! Spec inputs that need a free-form JSON body (the generic
+//! `policy create` / `policy update` and every `preset create` /
+//! `preset update` clause) are read from a file path or `-` for stdin.
+//!
+//! All errors flow through one place ([`run`]); 403 responses whose
+//! description matches the server's `missing required scope: <s>` shape
+//! get a tailored re-login hint pointing the user at
+//! `bitrouter auth login --scope "<existing scopes> <missing>"`.
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use clap::{Subcommand, ValueEnum};
+
+use bitrouter_cloud_sdk::auth::credentials::{CredentialsStore, default_credentials_path};
+use bitrouter_cloud_sdk::management::types::{
+    BudgetWindow as SdkBudgetWindow, ClientType as SdkClientType, PolicyKind as SdkPolicyKind,
+};
+use bitrouter_cloud_sdk::management::{
+    Error as SdkError, ManagementClient, billing, budgets, byok, keys, oauth_clients, policies,
+    presets, usage,
+};
+
+/// `bitrouter cloud …`. All variants land in [`run`].
+#[derive(Debug, Subcommand)]
+pub enum CloudAction {
+    /// Print the cloud identity stored on this machine alongside the
+    /// `/v1/*` base URL the CLI will target.
+    Whoami,
+    /// Manage `brk_` API keys on your account.
+    Keys {
+        #[command(subcommand)]
+        action: KeysAction,
+    },
+    /// Read aggregate spend / token counts for your account.
+    Usage(UsageArgs),
+    /// Page through recent inference requests.
+    Requests(RequestsArgs),
+    /// Credit balance and Stripe checkout.
+    Billing {
+        #[command(subcommand)]
+        action: BillingAction,
+    },
+    /// Generic CRUD over the typed policy registry.
+    Policy {
+        #[command(subcommand)]
+        action: PolicyAction,
+    },
+    /// Typed wrapper over budget-kind policies.
+    Budget {
+        #[command(subcommand)]
+        action: BudgetAction,
+    },
+    /// Typed wrapper over preset-kind policies.
+    Preset {
+        #[command(subcommand)]
+        action: PresetAction,
+    },
+    /// Bring-your-own-key provider keys.
+    Byok {
+        #[command(subcommand)]
+        action: ByokAction,
+    },
+    /// Registered OAuth clients on your account.
+    #[command(name = "oauth-client")]
+    OauthClient {
+        #[command(subcommand)]
+        action: OauthClientAction,
+    },
+}
+
+// ===== Keys =====
+
+#[derive(Debug, Subcommand)]
+pub enum KeysAction {
+    /// List API keys on your account.
+    List(JsonFlag),
+    /// Mint a new API key. The plaintext is printed once.
+    Mint(MintKeyArgs),
+    /// Revoke a key by id.
+    Revoke(RevokeKeyArgs),
+}
+
+#[derive(Debug, clap::Args)]
+pub struct MintKeyArgs {
+    /// Operator-supplied display name.
+    #[arg(long)]
+    pub name: String,
+    /// Wire-format scope tokens (repeat the flag, or pass a single
+    /// space-delimited list). Must be a subset of your effective scopes.
+    #[arg(long = "scope", value_name = "SCOPE")]
+    pub scopes: Vec<String>,
+    /// Optional expiry (RFC 3339, e.g. `2026-12-31T00:00:00Z`).
+    #[arg(long)]
+    pub expires_at: Option<DateTime<Utc>>,
+    #[command(flatten)]
+    pub json: JsonFlag,
+}
+
+#[derive(Debug, clap::Args)]
+pub struct RevokeKeyArgs {
+    /// The key id (e.g. `k_…`).
+    pub id: String,
+    #[command(flatten)]
+    pub json: JsonFlag,
+}
+
+// ===== Usage / Requests =====
+
+#[derive(Debug, clap::Args)]
+pub struct UsageArgs {
+    /// Lower bound (RFC 3339). Defaults to `to - 30 days`.
+    #[arg(long)]
+    pub from: Option<DateTime<Utc>>,
+    /// Upper bound (RFC 3339). Defaults to now.
+    #[arg(long)]
+    pub to: Option<DateTime<Utc>>,
+    #[command(flatten)]
+    pub json: JsonFlag,
+}
+
+#[derive(Debug, clap::Args)]
+pub struct RequestsArgs {
+    /// Page size (server clamps to `[1, 100]`).
+    #[arg(long)]
+    pub limit: Option<u64>,
+    /// Offset into the result set.
+    #[arg(long)]
+    pub offset: Option<u64>,
+    #[command(flatten)]
+    pub json: JsonFlag,
+}
+
+// ===== Billing =====
+
+#[derive(Debug, Subcommand)]
+pub enum BillingAction {
+    /// Show the account's credit balance.
+    Balance(JsonFlag),
+    /// Start a Stripe checkout session for a credit top-up.
+    /// Requires the `billing:write` scope.
+    Checkout(CheckoutArgs),
+}
+
+#[derive(Debug, clap::Args)]
+pub struct CheckoutArgs {
+    /// Amount in USD cents.
+    #[arg(long)]
+    pub amount_cents: i64,
+    #[command(flatten)]
+    pub json: JsonFlag,
+}
+
+// ===== Policy =====
+
+#[derive(Debug, Subcommand)]
+pub enum PolicyAction {
+    /// List policies on your account.
+    List(PolicyListArgs),
+    /// Fetch one policy.
+    Get(IdArg),
+    /// Create a policy. Spec body is read from `--spec <file|->`.
+    Create(PolicyCreateArgs),
+    /// Update a policy's name and / or spec.
+    Update(PolicyUpdateArgs),
+    /// Delete a policy.
+    Delete(IdArg),
+    /// Attach a policy to a principal.
+    Bind(PolicyBindArgs),
+    /// Detach one binding from a policy.
+    Unbind(PolicyUnbindArgs),
+    /// Park a policy — the engine skips it at request time.
+    Disable(IdArg),
+    /// Re-enable a previously disabled policy.
+    Enable(IdArg),
+    /// List the bindings of one policy.
+    Bindings(IdArg),
+    /// Preview the effective policy for a principal.
+    Effective(EffectiveArgs),
+    /// List every policy bound to a principal.
+    #[command(name = "for-principal")]
+    ForPrincipal(ForPrincipalArgs),
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum PolicyKindArg {
+    Budget,
+    RateLimit,
+    Guardrail,
+    Preset,
+}
+
+impl From<PolicyKindArg> for SdkPolicyKind {
+    fn from(value: PolicyKindArg) -> Self {
+        match value {
+            PolicyKindArg::Budget => SdkPolicyKind::Budget,
+            PolicyKindArg::RateLimit => SdkPolicyKind::RateLimit,
+            PolicyKindArg::Guardrail => SdkPolicyKind::Guardrail,
+            PolicyKindArg::Preset => SdkPolicyKind::Preset,
+        }
+    }
+}
+
+#[derive(Debug, clap::Args)]
+pub struct PolicyListArgs {
+    /// Narrow the list to one kind.
+    #[arg(long)]
+    pub kind: Option<PolicyKindArg>,
+    #[command(flatten)]
+    pub json: JsonFlag,
+}
+
+#[derive(Debug, clap::Args)]
+pub struct PolicyCreateArgs {
+    /// Operator-supplied display name.
+    #[arg(long)]
+    pub name: String,
+    /// Kind discriminator — selects which shape `--spec` must take.
+    #[arg(long)]
+    pub kind: PolicyKindArg,
+    /// Path to a JSON file containing the flat inner spec body, or
+    /// `-` to read from stdin.
+    #[arg(long)]
+    pub spec: PathBuf,
+    #[command(flatten)]
+    pub json: JsonFlag,
+}
+
+#[derive(Debug, clap::Args)]
+pub struct PolicyUpdateArgs {
+    /// The policy id.
+    pub id: String,
+    /// New name. Omit to leave unchanged.
+    #[arg(long)]
+    pub name: Option<String>,
+    /// New spec. Path to a JSON file or `-` for stdin. Omit to leave
+    /// unchanged.
+    #[arg(long)]
+    pub spec: Option<PathBuf>,
+    #[command(flatten)]
+    pub json: JsonFlag,
+}
+
+#[derive(Debug, clap::Args)]
+pub struct PolicyBindArgs {
+    /// The policy id.
+    pub id: String,
+    /// Principal kind (`account`, `api_key`, `oauth_token`,
+    /// `oauth_client`).
+    #[arg(long)]
+    pub principal_type: String,
+    /// Principal id — interpretation depends on `--principal-type`.
+    #[arg(long)]
+    pub principal_id: String,
+    #[command(flatten)]
+    pub json: JsonFlag,
+}
+
+#[derive(Debug, clap::Args)]
+pub struct PolicyUnbindArgs {
+    /// The policy id.
+    pub id: String,
+    /// The binding id (from `cloud policy bindings <id>`).
+    pub binding_id: String,
+    #[command(flatten)]
+    pub json: JsonFlag,
+}
+
+#[derive(Debug, clap::Args)]
+pub struct EffectiveArgs {
+    /// Principal kind (`account`, `api_key`, `oauth_token`,
+    /// `oauth_client`).
+    #[arg(long)]
+    pub principal_type: String,
+    /// Principal id.
+    #[arg(long)]
+    pub principal_id: String,
+    #[command(flatten)]
+    pub json: JsonFlag,
+}
+
+#[derive(Debug, clap::Args)]
+pub struct ForPrincipalArgs {
+    /// Principal kind.
+    pub principal_type: String,
+    /// Principal id.
+    pub principal_id: String,
+    #[command(flatten)]
+    pub json: JsonFlag,
+}
+
+// ===== Budget =====
+
+#[derive(Debug, Subcommand)]
+pub enum BudgetAction {
+    /// List every budget on the account.
+    List(JsonFlag),
+    /// Fetch one budget.
+    Get(IdArg),
+    /// Create a budget.
+    Create(BudgetCreateArgs),
+    /// Patch a budget's fields.
+    Update(BudgetUpdateArgs),
+    /// Remove a budget.
+    Delete(IdArg),
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum BudgetWindowArg {
+    Day,
+    Month,
+    Total,
+}
+
+impl From<BudgetWindowArg> for SdkBudgetWindow {
+    fn from(value: BudgetWindowArg) -> Self {
+        match value {
+            BudgetWindowArg::Day => SdkBudgetWindow::Day,
+            BudgetWindowArg::Month => SdkBudgetWindow::Month,
+            BudgetWindowArg::Total => SdkBudgetWindow::Total,
+        }
+    }
+}
+
+#[derive(Debug, clap::Args)]
+pub struct BudgetCreateArgs {
+    /// Display name.
+    #[arg(long)]
+    pub name: String,
+    /// Rolling-spend window.
+    #[arg(long)]
+    pub window: BudgetWindowArg,
+    /// Spend cap in micro-USD (must be strictly positive).
+    #[arg(long)]
+    pub limit_micro_usd: i64,
+    #[command(flatten)]
+    pub json: JsonFlag,
+}
+
+#[derive(Debug, clap::Args)]
+pub struct BudgetUpdateArgs {
+    /// The budget id.
+    pub id: String,
+    /// New name.
+    #[arg(long)]
+    pub name: Option<String>,
+    /// New window.
+    #[arg(long)]
+    pub window: Option<BudgetWindowArg>,
+    /// New cap (must be strictly positive when supplied).
+    #[arg(long)]
+    pub limit_micro_usd: Option<i64>,
+    #[command(flatten)]
+    pub json: JsonFlag,
+}
+
+// ===== Preset =====
+
+#[derive(Debug, Subcommand)]
+pub enum PresetAction {
+    /// List every preset on the account.
+    List(JsonFlag),
+    /// Fetch one preset.
+    Get(IdArg),
+    /// Create a preset. Each clause is supplied as a JSON file
+    /// (or `-` for stdin).
+    Create(PresetCreateArgs),
+    /// Patch a preset's clauses. Use `--clear-*` to drop a clause.
+    Update(PresetUpdateArgs),
+    /// Remove a preset.
+    Delete(IdArg),
+}
+
+#[derive(Debug, clap::Args)]
+pub struct PresetCreateArgs {
+    /// Display name.
+    #[arg(long)]
+    pub name: String,
+    /// Optional guardrail clause (JSON file or `-`).
+    #[arg(long)]
+    pub guardrail: Option<PathBuf>,
+    /// Optional budget clause.
+    #[arg(long)]
+    pub budget: Option<PathBuf>,
+    /// Optional rate-limit clause.
+    #[arg(long)]
+    pub rate_limit: Option<PathBuf>,
+    #[command(flatten)]
+    pub json: JsonFlag,
+}
+
+#[derive(Debug, clap::Args)]
+pub struct PresetUpdateArgs {
+    /// The preset id.
+    pub id: String,
+    /// New name.
+    #[arg(long)]
+    pub name: Option<String>,
+    /// Replace the guardrail clause (JSON file or `-`).
+    #[arg(long)]
+    pub guardrail: Option<PathBuf>,
+    /// Replace the budget clause.
+    #[arg(long)]
+    pub budget: Option<PathBuf>,
+    /// Replace the rate-limit clause.
+    #[arg(long)]
+    pub rate_limit: Option<PathBuf>,
+    /// Drop the guardrail clause.
+    #[arg(long)]
+    pub clear_guardrail: bool,
+    /// Drop the budget clause.
+    #[arg(long)]
+    pub clear_budget: bool,
+    /// Drop the rate-limit clause.
+    #[arg(long)]
+    pub clear_rate_limit: bool,
+    #[command(flatten)]
+    pub json: JsonFlag,
+}
+
+// ===== BYOK =====
+
+#[derive(Debug, Subcommand)]
+pub enum ByokAction {
+    /// List every BYOK row on the account.
+    List(JsonFlag),
+    /// Upsert a BYOK row. Ciphertext must be sealed by the caller
+    /// against the cloud's current X25519 public key.
+    Set(ByokSetArgs),
+    /// Remove a BYOK row by provider id.
+    Delete(ByokDeleteArgs),
+}
+
+#[derive(Debug, clap::Args)]
+pub struct ByokSetArgs {
+    /// Upstream provider id (e.g. `anthropic`).
+    #[arg(long)]
+    pub provider: String,
+    /// Base64-encoded sealed-box ciphertext.
+    #[arg(long)]
+    pub ciphertext_b64: String,
+    /// KEK id used to seal `--ciphertext-b64`. Must match the cloud's
+    /// current `primary_kek_id`.
+    #[arg(long)]
+    pub kek_id: String,
+    /// Operator-visible prefix of the underlying plaintext.
+    #[arg(long)]
+    pub key_prefix: String,
+    /// Override API base for the provider.
+    #[arg(long)]
+    pub api_base: Option<String>,
+    #[command(flatten)]
+    pub json: JsonFlag,
+}
+
+#[derive(Debug, clap::Args)]
+pub struct ByokDeleteArgs {
+    /// Provider id (the row's `provider_name`).
+    pub provider: String,
+    #[command(flatten)]
+    pub json: JsonFlag,
+}
+
+// ===== OAuth clients =====
+
+#[derive(Debug, Subcommand)]
+pub enum OauthClientAction {
+    /// List every OAuth client on the account.
+    List(JsonFlag),
+    /// Register a new client.
+    Register(OauthRegisterArgs),
+    /// Patch one or more fields of an existing client.
+    Update(OauthUpdateArgs),
+    /// Remove a client.
+    Delete(OauthDeleteArgs),
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum ClientTypeArg {
+    Confidential,
+    Public,
+}
+
+impl From<ClientTypeArg> for SdkClientType {
+    fn from(value: ClientTypeArg) -> Self {
+        match value {
+            ClientTypeArg::Confidential => SdkClientType::Confidential,
+            ClientTypeArg::Public => SdkClientType::Public,
+        }
+    }
+}
+
+#[derive(Debug, clap::Args)]
+pub struct OauthRegisterArgs {
+    /// Display name.
+    #[arg(long)]
+    pub name: String,
+    /// Client type.
+    #[arg(long = "type")]
+    pub client_type: ClientTypeArg,
+    /// Redirect URI. Repeat for multiple values.
+    #[arg(long = "redirect-uri")]
+    pub redirect_uris: Vec<String>,
+    /// Wire-format scope. Repeat for multiple values.
+    #[arg(long = "scope", value_name = "SCOPE")]
+    pub allowed_scopes: Vec<String>,
+    /// Grant type — at least one of `authorization_code`,
+    /// `refresh_token`, or the RFC 8628 URN.
+    #[arg(long = "grant")]
+    pub allowed_grant_types: Vec<String>,
+    #[command(flatten)]
+    pub json: JsonFlag,
+}
+
+#[derive(Debug, clap::Args)]
+pub struct OauthUpdateArgs {
+    /// The client id (the public `client_id`, not the row id).
+    pub client_id: String,
+    /// New display name.
+    #[arg(long)]
+    pub name: Option<String>,
+    /// Replace the redirect-URI list. Repeat for multiple values.
+    #[arg(long = "redirect-uri")]
+    pub redirect_uris: Option<Vec<String>>,
+    /// Replace the scope set.
+    #[arg(long = "scope", value_name = "SCOPE")]
+    pub allowed_scopes: Option<Vec<String>>,
+    /// Replace the grant-type list.
+    #[arg(long = "grant")]
+    pub allowed_grant_types: Option<Vec<String>>,
+    #[command(flatten)]
+    pub json: JsonFlag,
+}
+
+#[derive(Debug, clap::Args)]
+pub struct OauthDeleteArgs {
+    /// The client id.
+    pub client_id: String,
+    #[command(flatten)]
+    pub json: JsonFlag,
+}
+
+// ===== Shared little-arg structs =====
+
+#[derive(Debug, clap::Args)]
+pub struct IdArg {
+    /// The resource id.
+    pub id: String,
+    #[command(flatten)]
+    pub json: JsonFlag,
+}
+
+/// Shared `--json` switch. Flatten into every leaf so the user can
+/// always opt out of the text formatter.
+#[derive(Debug, Default, Clone, Copy, clap::Args)]
+pub struct JsonFlag {
+    /// Print the response as raw JSON instead of the human-readable
+    /// summary.
+    #[arg(long)]
+    pub json: bool,
+}
+
+// =====================================================================
+// Runner
+// =====================================================================
+
+/// Entry point dispatched by `apps/bitrouter/src/main.rs`.
+pub async fn run(action: CloudAction) -> Result<()> {
+    let result = run_inner(action).await;
+    match result {
+        Ok(()) => Ok(()),
+        Err(err) => {
+            print_error_hint(&err);
+            Err(err.into())
+        }
+    }
+}
+
+async fn run_inner(action: CloudAction) -> std::result::Result<(), SdkError> {
+    match action {
+        CloudAction::Whoami => whoami().await,
+        CloudAction::Keys { action } => run_keys(action).await,
+        CloudAction::Usage(args) => run_usage(args).await,
+        CloudAction::Requests(args) => run_requests(args).await,
+        CloudAction::Billing { action } => run_billing(action).await,
+        CloudAction::Policy { action } => run_policy(action).await,
+        CloudAction::Budget { action } => run_budget(action).await,
+        CloudAction::Preset { action } => run_preset(action).await,
+        CloudAction::Byok { action } => run_byok(action).await,
+        CloudAction::OauthClient { action } => run_oauth_client(action).await,
+    }
+}
+
+fn client() -> std::result::Result<ManagementClient, SdkError> {
+    ManagementClient::from_default_credentials()
+}
+
+async fn whoami() -> std::result::Result<(), SdkError> {
+    // Doesn't hit the network — reads the local credentials file so
+    // it works offline. Mirrors `bitrouter auth whoami` but adds the
+    // base URL `bitrouter cloud …` will target.
+    let client = client()?;
+    println!("cloud base URL: {}", client.base_url());
+    let store = CredentialsStore::default_path().map_err(SdkError::Auth)?;
+    if let Some(creds) = store.current() {
+        println!("scope:          {}", creds.scope);
+        if let Some(sub) = creds.subject.as_deref() {
+            println!("subject:        {sub}");
+        }
+        println!("credentials:    {}", store.path().display());
+    } else {
+        println!("(not signed in — run `bitrouter auth login`)");
+    }
+    Ok(())
+}
+
+// ----- Keys -----
+
+async fn run_keys(action: KeysAction) -> std::result::Result<(), SdkError> {
+    let client = client()?;
+    match action {
+        KeysAction::List(flag) => emit(flag.json, &client.list_keys().await?, format_keys_list),
+        KeysAction::Mint(args) => {
+            let body = keys::MintApiKeyRequest {
+                display_name: args.name,
+                scopes: split_scope_args(&args.scopes),
+                expires_at: args.expires_at,
+            };
+            let resp = client.mint_key(&body).await?;
+            emit(args.json.json, &resp, format_mint_key)
+        }
+        KeysAction::Revoke(args) => {
+            let resp = client.revoke_key(&args.id).await?;
+            emit(args.json.json, &resp, |r| format!("revoked: {}", r.revoked))
+        }
+    }
+}
+
+fn format_keys_list(resp: &keys::ApiKeyListResponse) -> String {
+    if resp.data.is_empty() {
+        return "no keys".to_owned();
+    }
+    let mut out = String::new();
+    for k in &resp.data {
+        out.push_str(&format!(
+            "{:<24}  {:<24}  scopes=[{}]  prefix={}\n",
+            k.id,
+            k.display_name,
+            k.scopes.join(", "),
+            k.key_prefix,
+        ));
+    }
+    out
+}
+
+fn format_mint_key(resp: &keys::MintApiKeyResponse) -> String {
+    format!(
+        "id:           {id}\nname:         {name}\nprefix:       {prefix}\nscopes:       [{scopes}]\ntoken:        {token}   (shown once — save it now)\n",
+        id = resp.id,
+        name = resp.display_name,
+        prefix = resp.key_prefix,
+        scopes = resp.scopes.join(", "),
+        token = resp.token,
+    )
+}
+
+// ----- Usage / requests -----
+
+async fn run_usage(args: UsageArgs) -> std::result::Result<(), SdkError> {
+    let client = client()?;
+    let resp = client
+        .usage_aggregate(&usage::UsageQuery {
+            from: args.from,
+            to: args.to,
+        })
+        .await?;
+    emit(args.json.json, &resp, |r| {
+        format!(
+            "window:            {from} → {to}\nspend (micro-USD): {spend}\nprompt tokens:     {pt}\ncompletion tokens: {ct}\nrequests:          {rc}\n",
+            from = r.from.to_rfc3339(),
+            to = r.to.to_rfc3339(),
+            spend = r.spend_micro_usd,
+            pt = r.prompt_tokens,
+            ct = r.completion_tokens,
+            rc = r.request_count,
+        )
+    })
+}
+
+async fn run_requests(args: RequestsArgs) -> std::result::Result<(), SdkError> {
+    let client = client()?;
+    let resp = client
+        .list_requests(&usage::RequestsQuery {
+            limit: args.limit,
+            offset: args.offset,
+        })
+        .await?;
+    emit(args.json.json, &resp, format_requests)
+}
+
+fn format_requests(resp: &usage::RequestsResponse) -> String {
+    if resp.data.is_empty() {
+        return "no requests".to_owned();
+    }
+    let mut out = String::new();
+    for r in &resp.data {
+        out.push_str(&format!(
+            "{}  {:<10}  {:<24}  {:>10} µUSD  prompt={:<6} completion={:<6}\n",
+            r.created_at.to_rfc3339(),
+            r.status,
+            r.model_id.clone().unwrap_or_else(|| "—".into()),
+            r.final_charge_micro_usd
+                .map(|v| v.to_string())
+                .unwrap_or_else(|| "—".into()),
+            r.prompt_tokens,
+            r.completion_tokens,
+        ));
+    }
+    out.push_str(&format!("\nlimit={} offset={}\n", resp.limit, resp.offset));
+    out
+}
+
+// ----- Billing -----
+
+async fn run_billing(action: BillingAction) -> std::result::Result<(), SdkError> {
+    let client = client()?;
+    match action {
+        BillingAction::Balance(flag) => {
+            let resp = client.billing_balance().await?;
+            emit(flag.json, &resp, |r| {
+                format!(
+                    "balance:    {} {} (micro-USD)\npending:    {} {}\navailable:  {} {}\n",
+                    r.balance_micro_usd,
+                    r.currency,
+                    r.pending_debits_micro_usd,
+                    r.currency,
+                    r.available_micro_usd,
+                    r.currency,
+                )
+            })
+        }
+        BillingAction::Checkout(args) => {
+            let resp = client
+                .create_checkout_session(&billing::CheckoutSessionRequest {
+                    amount_cents: args.amount_cents,
+                })
+                .await?;
+            emit(args.json.json, &resp, |r| {
+                format!("session id: {}\ncheckout url: {}\n", r.id, r.url)
+            })
+        }
+    }
+}
+
+// ----- Policy -----
+
+async fn run_policy(action: PolicyAction) -> std::result::Result<(), SdkError> {
+    let client = client()?;
+    match action {
+        PolicyAction::List(args) => {
+            let resp = client
+                .list_policies(&policies::ListPoliciesQuery {
+                    kind: args.kind.map(Into::into),
+                })
+                .await?;
+            emit(args.json.json, &resp, format_policy_list)
+        }
+        PolicyAction::Get(args) => {
+            let resp = client.get_policy(&args.id).await?;
+            emit(args.json.json, &resp, format_policy_one)
+        }
+        PolicyAction::Create(args) => {
+            let spec = read_json_input(&args.spec)?;
+            let resp = client
+                .create_policy(&policies::CreatePolicyRequest {
+                    name: args.name,
+                    kind: args.kind.into(),
+                    spec,
+                })
+                .await?;
+            emit(args.json.json, &resp, format_policy_one)
+        }
+        PolicyAction::Update(args) => {
+            let spec = match args.spec.as_ref() {
+                Some(p) => Some(read_json_input(p)?),
+                None => None,
+            };
+            let resp = client
+                .update_policy(
+                    &args.id,
+                    &policies::UpdatePolicyRequest {
+                        name: args.name,
+                        spec,
+                    },
+                )
+                .await?;
+            emit(args.json.json, &resp, format_policy_one)
+        }
+        PolicyAction::Delete(args) => {
+            let resp = client.delete_policy(&args.id).await?;
+            emit(args.json.json, &resp, |r| {
+                format!("deleted: {}\n", r.deleted)
+            })
+        }
+        PolicyAction::Bind(args) => {
+            let resp = client
+                .bind_policy(
+                    &args.id,
+                    &policies::BindPolicyRequest {
+                        principal_type: args.principal_type,
+                        principal_id: args.principal_id,
+                    },
+                )
+                .await?;
+            emit(args.json.json, &resp, |r| {
+                format!("binding id: {}\n", r.binding_id)
+            })
+        }
+        PolicyAction::Unbind(args) => {
+            let resp = client.unbind_policy(&args.id, &args.binding_id).await?;
+            emit(args.json.json, &resp, |r| {
+                format!("unbound: {}\n", r.unbound)
+            })
+        }
+        PolicyAction::Disable(args) => {
+            let resp = client.disable_policy(&args.id).await?;
+            emit(args.json.json, &resp, |r| {
+                format!("disabled: {}\n", r.disabled)
+            })
+        }
+        PolicyAction::Enable(args) => {
+            let resp = client.enable_policy(&args.id).await?;
+            emit(args.json.json, &resp, |r| {
+                format!("disabled: {}\n", r.disabled)
+            })
+        }
+        PolicyAction::Bindings(args) => {
+            let resp = client.list_policy_bindings(&args.id).await?;
+            emit(args.json.json, &resp, format_binding_list)
+        }
+        PolicyAction::Effective(args) => {
+            let resp = client
+                .effective_policy(&policies::EffectivePolicyQuery {
+                    principal_type: args.principal_type,
+                    principal_id: args.principal_id,
+                })
+                .await?;
+            emit(args.json.json, &resp, format_effective_policy)
+        }
+        PolicyAction::ForPrincipal(args) => {
+            let resp = client
+                .list_principal_policies(&args.principal_type, &args.principal_id)
+                .await?;
+            emit(args.json.json, &resp, format_policy_list)
+        }
+    }
+}
+
+fn format_policy_list(resp: &policies::PolicyListResponse) -> String {
+    if resp.data.is_empty() {
+        return "no policies".to_owned();
+    }
+    let mut out = String::new();
+    for p in &resp.data {
+        let disabled = if p.disabled_at.is_some() {
+            " (disabled)"
+        } else {
+            ""
+        };
+        out.push_str(&format!(
+            "{:<24}  {:<24}  kind={}{}\n",
+            p.id,
+            p.name,
+            p.kind.as_str(),
+            disabled,
+        ));
+    }
+    out
+}
+
+fn format_policy_one(p: &policies::PolicyEnvelope) -> String {
+    let mut out = format!(
+        "id:    {}\nname:  {}\nkind:  {}\n",
+        p.id,
+        p.name,
+        p.kind.as_str(),
+    );
+    if let Some(d) = p.disabled_at {
+        out.push_str(&format!("disabled_at: {}\n", d.to_rfc3339()));
+    }
+    out.push_str(&format!(
+        "spec:\n{}\n",
+        serde_json::to_string_pretty(&p.spec).unwrap_or_else(|_| "{}".to_owned())
+    ));
+    out
+}
+
+fn format_binding_list(resp: &policies::BindingListResponse) -> String {
+    if resp.data.is_empty() {
+        return "no bindings".to_owned();
+    }
+    let mut out = String::new();
+    for b in &resp.data {
+        out.push_str(&format!(
+            "{:<24}  policy={:<24}  principal={}:{}\n",
+            b.id, b.policy_id, b.principal_type, b.principal_id,
+        ));
+    }
+    out
+}
+
+fn format_effective_policy(p: &policies::EffectivePolicy) -> String {
+    let mut out = String::new();
+    out.push_str(&format!("budgets:    {} entries\n", p.budgets.len()));
+    out.push_str(&format!("rate_limits: {} entries\n", p.rate_limits.len()));
+    out.push_str(&format!(
+        "guardrail:  {}\n",
+        if p.guardrail.is_some() { "set" } else { "—" }
+    ));
+    if !p.budgets.is_empty() || !p.rate_limits.is_empty() || p.guardrail.is_some() {
+        out.push_str("\nfull body:\n");
+        if let Ok(pretty) = serde_json::to_string_pretty(p) {
+            out.push_str(&pretty);
+            out.push('\n');
+        }
+    }
+    out
+}
+
+// ----- Budget -----
+
+async fn run_budget(action: BudgetAction) -> std::result::Result<(), SdkError> {
+    let client = client()?;
+    match action {
+        BudgetAction::List(flag) => {
+            let resp = client.list_budgets().await?;
+            emit(flag.json, &resp, format_budget_list)
+        }
+        BudgetAction::Get(args) => {
+            let resp = client.get_budget(&args.id).await?;
+            emit(args.json.json, &resp, format_budget_one)
+        }
+        BudgetAction::Create(args) => {
+            let resp = client
+                .create_budget(&budgets::CreateBudgetRequest {
+                    name: args.name,
+                    window: args.window.into(),
+                    limit_micro_usd: args.limit_micro_usd,
+                })
+                .await?;
+            emit(args.json.json, &resp, format_budget_one)
+        }
+        BudgetAction::Update(args) => {
+            let resp = client
+                .update_budget(
+                    &args.id,
+                    &budgets::UpdateBudgetRequest {
+                        name: args.name,
+                        window: args.window.map(Into::into),
+                        limit_micro_usd: args.limit_micro_usd,
+                    },
+                )
+                .await?;
+            emit(args.json.json, &resp, format_budget_one)
+        }
+        BudgetAction::Delete(args) => {
+            let resp = client.delete_budget(&args.id).await?;
+            emit(args.json.json, &resp, |r| {
+                format!("deleted: {}\n", r.deleted)
+            })
+        }
+    }
+}
+
+fn format_budget_list(resp: &budgets::BudgetListResponse) -> String {
+    if resp.data.is_empty() {
+        return "no budgets".to_owned();
+    }
+    let mut out = String::new();
+    for b in &resp.data {
+        out.push_str(&format!(
+            "{:<24}  {:<24}  window={:?}  limit={} µUSD{}\n",
+            b.id,
+            b.name,
+            b.window,
+            b.limit_micro_usd,
+            if b.disabled_at.is_some() {
+                " (disabled)"
+            } else {
+                ""
+            },
+        ));
+    }
+    out
+}
+
+fn format_budget_one(b: &budgets::BudgetEnvelope) -> String {
+    let mut out = format!(
+        "id:              {}\nname:            {}\nwindow:          {:?}\nlimit (µUSD):    {}\n",
+        b.id, b.name, b.window, b.limit_micro_usd,
+    );
+    if let Some(d) = b.disabled_at {
+        out.push_str(&format!("disabled_at:     {}\n", d.to_rfc3339()));
+    }
+    out
+}
+
+// ----- Preset -----
+
+async fn run_preset(action: PresetAction) -> std::result::Result<(), SdkError> {
+    let client = client()?;
+    match action {
+        PresetAction::List(flag) => {
+            let resp = client.list_presets().await?;
+            emit(flag.json, &resp, format_preset_list)
+        }
+        PresetAction::Get(args) => {
+            let resp = client.get_preset(&args.id).await?;
+            emit(args.json.json, &resp, format_preset_one)
+        }
+        PresetAction::Create(args) => {
+            let body = presets::CreatePresetRequest {
+                name: args.name,
+                guardrail: opt_json_input(args.guardrail.as_ref())?,
+                budget: opt_json_input(args.budget.as_ref())?,
+                rate_limit: opt_json_input(args.rate_limit.as_ref())?,
+            };
+            let resp = client.create_preset(&body).await?;
+            emit(args.json.json, &resp, format_preset_one)
+        }
+        PresetAction::Update(args) => {
+            let body = presets::UpdatePresetRequest {
+                name: args.name,
+                guardrail: opt_json_input(args.guardrail.as_ref())?,
+                budget: opt_json_input(args.budget.as_ref())?,
+                rate_limit: opt_json_input(args.rate_limit.as_ref())?,
+                clear_guardrail: args.clear_guardrail,
+                clear_budget: args.clear_budget,
+                clear_rate_limit: args.clear_rate_limit,
+            };
+            let resp = client.update_preset(&args.id, &body).await?;
+            emit(args.json.json, &resp, format_preset_one)
+        }
+        PresetAction::Delete(args) => {
+            let resp = client.delete_preset(&args.id).await?;
+            emit(args.json.json, &resp, |r| {
+                format!("deleted: {}\n", r.deleted)
+            })
+        }
+    }
+}
+
+fn format_preset_list(resp: &presets::PresetListResponse) -> String {
+    if resp.data.is_empty() {
+        return "no presets".to_owned();
+    }
+    let mut out = String::new();
+    for p in &resp.data {
+        let clauses = [
+            ("guardrail", p.guardrail.is_some()),
+            ("budget", p.budget.is_some()),
+            ("rate_limit", p.rate_limit.is_some()),
+        ]
+        .iter()
+        .filter(|(_, set)| *set)
+        .map(|(name, _)| *name)
+        .collect::<Vec<_>>()
+        .join(",");
+        out.push_str(&format!(
+            "{:<24}  {:<24}  clauses=[{}]{}\n",
+            p.id,
+            p.name,
+            clauses,
+            if p.disabled_at.is_some() {
+                " (disabled)"
+            } else {
+                ""
+            },
+        ));
+    }
+    out
+}
+
+fn format_preset_one(p: &presets::PresetEnvelope) -> String {
+    let mut out = format!("id:    {}\nname:  {}\n", p.id, p.name);
+    if let Some(d) = p.disabled_at {
+        out.push_str(&format!("disabled_at: {}\n", d.to_rfc3339()));
+    }
+    for (label, value) in [
+        ("guardrail", &p.guardrail),
+        ("budget", &p.budget),
+        ("rate_limit", &p.rate_limit),
+    ] {
+        if let Some(v) = value {
+            out.push_str(&format!(
+                "{label}:\n{}\n",
+                serde_json::to_string_pretty(v).unwrap_or_else(|_| "{}".to_owned())
+            ));
+        }
+    }
+    out
+}
+
+// ----- BYOK -----
+
+async fn run_byok(action: ByokAction) -> std::result::Result<(), SdkError> {
+    let client = client()?;
+    match action {
+        ByokAction::List(flag) => {
+            let resp = client.list_byok_keys().await?;
+            emit(flag.json, &resp, format_byok_list)
+        }
+        ByokAction::Set(args) => {
+            let body = byok::UpsertByokKeyRequest {
+                provider_name: args.provider,
+                ciphertext_b64: args.ciphertext_b64,
+                kek_id: args.kek_id,
+                key_prefix: args.key_prefix,
+                api_base: args.api_base,
+            };
+            let resp = client.upsert_byok_key(&body).await?;
+            emit(args.json.json, &resp, |r| {
+                format!(
+                    "provider:  {}\nkek_id:    {}\nprefix:    {}\n",
+                    r.provider_name, r.kek_id, r.key_prefix,
+                )
+            })
+        }
+        ByokAction::Delete(args) => {
+            let resp = client.delete_byok_key(&args.provider).await?;
+            emit(args.json.json, &resp, |r| {
+                format!("deleted: {}\n", r.deleted)
+            })
+        }
+    }
+}
+
+fn format_byok_list(resp: &byok::ByokKeyListResponse) -> String {
+    if resp.data.is_empty() {
+        return "no byok keys".to_owned();
+    }
+    let mut out = String::new();
+    for k in &resp.data {
+        out.push_str(&format!(
+            "{:<20}  prefix={:<10}  kek={:<24}  last_used={}\n",
+            k.provider_name,
+            k.key_prefix,
+            k.kek_id,
+            k.last_used_at
+                .map(|t| t.to_rfc3339())
+                .unwrap_or_else(|| "—".into()),
+        ));
+    }
+    out
+}
+
+// ----- OAuth clients -----
+
+async fn run_oauth_client(action: OauthClientAction) -> std::result::Result<(), SdkError> {
+    let client = client()?;
+    match action {
+        OauthClientAction::List(flag) => {
+            let resp = client.list_oauth_clients().await?;
+            emit(flag.json, &resp, format_oauth_client_list)
+        }
+        OauthClientAction::Register(args) => {
+            let body = oauth_clients::RegisterOauthClientRequest {
+                client_name: args.name,
+                client_type: args.client_type.into(),
+                redirect_uris: args.redirect_uris,
+                allowed_scopes: args.allowed_scopes,
+                allowed_grant_types: args.allowed_grant_types,
+            };
+            let resp = client.register_oauth_client(&body).await?;
+            emit(args.json.json, &resp, format_oauth_client_register)
+        }
+        OauthClientAction::Update(args) => {
+            let body = oauth_clients::UpdateOauthClientRequest {
+                client_name: args.name,
+                redirect_uris: args.redirect_uris,
+                allowed_scopes: args.allowed_scopes,
+                allowed_grant_types: args.allowed_grant_types,
+            };
+            let resp = client.update_oauth_client(&args.client_id, &body).await?;
+            emit(args.json.json, &resp, format_oauth_client_envelope)
+        }
+        OauthClientAction::Delete(args) => {
+            let resp = client.delete_oauth_client(&args.client_id).await?;
+            emit(args.json.json, &resp, |r| {
+                format!("deleted: {}\n", r.deleted)
+            })
+        }
+    }
+}
+
+fn format_oauth_client_list(resp: &oauth_clients::OauthClientListResponse) -> String {
+    if resp.data.is_empty() {
+        return "no clients".to_owned();
+    }
+    let mut out = String::new();
+    for c in &resp.data {
+        out.push_str(&format!(
+            "{:<24}  {:<24}  type={:?}  grants=[{}]  scopes=[{}]\n",
+            c.client_id,
+            c.client_name,
+            c.client_type,
+            c.allowed_grant_types.join(","),
+            c.allowed_scopes.join(","),
+        ));
+    }
+    out
+}
+
+fn format_oauth_client_envelope(c: &oauth_clients::OauthClientEnvelope) -> String {
+    format!(
+        "id:           {}\nclient_id:    {}\nname:         {}\ntype:         {:?}\nredirect_uris: {:?}\nscopes:       [{}]\ngrants:       [{}]\n",
+        c.id,
+        c.client_id,
+        c.client_name,
+        c.client_type,
+        c.redirect_uris,
+        c.allowed_scopes.join(", "),
+        c.allowed_grant_types.join(", "),
+    )
+}
+
+fn format_oauth_client_register(c: &oauth_clients::RegisterOauthClientResponse) -> String {
+    let mut out = format!(
+        "id:           {}\nclient_id:    {}\nname:         {}\ntype:         {:?}\nredirect_uris: {:?}\nscopes:       [{}]\ngrants:       [{}]\n",
+        c.id,
+        c.client_id,
+        c.client_name,
+        c.client_type,
+        c.redirect_uris,
+        c.allowed_scopes.join(", "),
+        c.allowed_grant_types.join(", "),
+    );
+    if let Some(secret) = c.client_secret.as_deref() {
+        out.push_str(&format!(
+            "client_secret: {secret}   (shown once — save it now)\n"
+        ));
+    }
+    out
+}
+
+// =====================================================================
+// Output + error helpers
+// =====================================================================
+
+fn emit<T, F>(json: bool, value: &T, fmt: F) -> std::result::Result<(), SdkError>
+where
+    T: serde::Serialize,
+    F: FnOnce(&T) -> String,
+{
+    if json {
+        let pretty = serde_json::to_string_pretty(value)?;
+        println!("{pretty}");
+    } else {
+        let text = fmt(value);
+        if !text.is_empty() {
+            // Trim a single trailing newline so we don't double-space
+            // when the formatter already appended one.
+            let trimmed = text.strip_suffix('\n').unwrap_or(&text);
+            println!("{trimmed}");
+        }
+    }
+    Ok(())
+}
+
+fn read_json_input(path: &std::path::Path) -> std::result::Result<serde_json::Value, SdkError> {
+    use std::io::Read;
+    let raw = if path == std::path::Path::new("-") {
+        let mut buf = String::new();
+        std::io::stdin().read_to_string(&mut buf).map_err(|e| {
+            SdkError::Auth(anyhow::Error::new(e).context("reading JSON from stdin"))
+        })?;
+        buf
+    } else {
+        std::fs::read_to_string(path).map_err(|e| {
+            SdkError::Auth(
+                anyhow::Error::new(e).context(format!("reading JSON from {}", path.display())),
+            )
+        })?
+    };
+    serde_json::from_str::<serde_json::Value>(&raw).map_err(SdkError::from)
+}
+
+fn opt_json_input(
+    path: Option<&PathBuf>,
+) -> std::result::Result<Option<serde_json::Value>, SdkError> {
+    match path {
+        Some(p) => Ok(Some(read_json_input(p)?)),
+        None => Ok(None),
+    }
+}
+
+/// `--scope` accepts both repeated flags and a single space-delimited
+/// list per flag — mirroring how the same value is handled by
+/// `bitrouter auth login --scope`. Empty tokens are dropped.
+fn split_scope_args(scopes: &[String]) -> Vec<String> {
+    let mut out = Vec::new();
+    for raw in scopes {
+        for token in raw.split_whitespace() {
+            if !token.is_empty() {
+                out.push(token.to_owned());
+            }
+        }
+    }
+    out
+}
+
+fn print_error_hint(err: &SdkError) {
+    match err {
+        SdkError::NotSignedIn => {
+            eprintln!();
+            eprintln!("  Sign in first:");
+            eprintln!("    bitrouter auth login");
+        }
+        SdkError::Forbidden {
+            missing_scope: Some(scope),
+            ..
+        } => {
+            eprintln!();
+            eprintln!("  This command requires the scope: {scope}");
+            if let Some(extended) = suggested_scope(scope) {
+                eprintln!("  Re-run `bitrouter auth login --scope \"{extended}\"` to add it.");
+            } else {
+                eprintln!(
+                    "  Re-run `bitrouter auth login --scope \"<your current scope> {scope}\"`."
+                );
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Best-effort: read the locally stored scope and append `missing` to
+/// it, so the hint we print is copy-pasteable. Returns `None` when the
+/// credentials file is unreadable.
+fn suggested_scope(missing: &str) -> Option<String> {
+    let path = default_credentials_path().ok()?;
+    let store = CredentialsStore::load(&path).ok()?;
+    let current = store.current()?.scope.clone();
+    if current.split_whitespace().any(|s| s == missing) {
+        // Already present — probably the server is rejecting something
+        // we can't auto-fix. Don't suggest a duplicate.
+        Some(current)
+    } else {
+        Some(format!("{current} {missing}"))
+    }
+}

--- a/apps/bitrouter/src/cloud/mod.rs
+++ b/apps/bitrouter/src/cloud/mod.rs
@@ -1,6 +1,8 @@
-//! Glue between [`bitrouter_cloud_sdk`] and the bitrouter assembly layer.
+//! Glue between [`bitrouter_cloud_sdk`] and the bitrouter assembly
+//! layer, plus the `bitrouter cloud …` CLI entry points (see [`cli`]).
 //!
-//! Two responsibilities, both keyed on the `"bitrouter"` provider id:
+//! Two daemon-side responsibilities, both keyed on the `"bitrouter"`
+//! provider id:
 //!
 //! - [`enable_in_zero_config`] — auto-add the `bitrouter` provider to the in-memory
 //!   zero-config `providers:` map when the user has signed in via
@@ -15,6 +17,12 @@
 //! the providers crate stays free of any dependency on
 //! `bitrouter-cloud-sdk`; the SDK and the catalog can be consumed
 //! independently by downstream tooling.
+//!
+//! The [`cli`] sub-module owns the `bitrouter cloud` subcommand surface
+//! — typed wrappers around every endpoint on
+//! [`bitrouter_cloud_sdk::management::ManagementClient`].
+
+pub mod cli;
 
 use std::sync::Arc;
 

--- a/apps/bitrouter/src/main.rs
+++ b/apps/bitrouter/src/main.rs
@@ -169,12 +169,13 @@ enum Command {
     /// code flow; everything else accepts a pasted API key. The
     /// resulting credential is stored under
     /// `$XDG_DATA_HOME/bitrouter/oauth-tokens.json` keyed by
-    /// `(provider_id, label)`. Cloud login (no argument) is not in v1.0
-    /// scope.
+    /// `(provider_id, label)`. For cloud sign-in (no argument), see
+    /// `bitrouter auth login` instead — kept separate so the per-
+    /// provider and cloud flows don't share a flag surface.
     Login {
         /// Provider id to log in to (e.g. `anthropic`, `openai-codex`,
-        /// `github-copilot`). Omit for the v0-style cloud login flow
-        /// (not implemented in v1.0).
+        /// `github-copilot`). Omit and the CLI redirects you to
+        /// `bitrouter auth login` for the cloud flow.
         provider: Option<String>,
         /// Account label this credential is stored under. Defaults to
         /// `default`. Use a non-default label to keep multiple accounts
@@ -185,12 +186,15 @@ enum Command {
     },
     /// Log out of an upstream provider — clears every stored credential
     /// for the provider (subscription OAuth and pasted API keys alike).
-    /// Cloud logout (no argument) is not in v1.0 scope.
+    /// For cloud sign-out (no argument), see `bitrouter auth logout`.
     Logout {
         /// Provider id whose stored credentials should be removed.
+        /// Omit and the CLI redirects you to `bitrouter auth logout`.
         provider: Option<String>,
     },
-    /// Print the authenticated cloud identity — not implemented in v1.0.
+    /// Legacy shim. Cloud identity now lives under
+    /// `bitrouter auth whoami` (local) and `bitrouter cloud whoami`
+    /// (local + base URL); this prints a pointer to those.
     Whoami,
     /// ACP agent lifecycle — list the catalog, check configured agents,
     /// print install stubs. `bitrouter agent-proxy <id>` is the separate
@@ -221,6 +225,13 @@ enum Command {
     Auth {
         #[command(subcommand)]
         action: AuthAction,
+    },
+    /// Manage your BitRouter Cloud account — API keys, usage, billing,
+    /// policies, BYOK, OAuth clients. Requires `bitrouter auth login`
+    /// first.
+    Cloud {
+        #[command(subcommand)]
+        action: bitrouter::cloud::cli::CloudAction,
     },
 }
 
@@ -483,9 +494,9 @@ async fn run() -> Result<()> {
             None => {
                 print_unimplemented(
                     "login",
-                    "Cloud login is not in v1.0 scope. Run\n\
-                     `bitrouter login <provider>` for per-provider auth (anthropic, openai-codex, github-copilot, …),\n\
-                     or mint a local virtual key with `bitrouter key sign --user <id>`.",
+                    "`bitrouter login` is the per-provider OAuth surface.\n\
+                     For cloud sign-in, run `bitrouter auth login`.\n\
+                     For a local virtual key, run `bitrouter key sign --user <id>`.",
                 );
                 Ok(())
             }
@@ -495,8 +506,8 @@ async fn run() -> Result<()> {
             None => {
                 print_unimplemented(
                     "logout",
-                    "See `bitrouter logout <provider>` for per-provider OAuth logout.\n\
-                     No cloud session in v1.0.",
+                    "`bitrouter logout` is the per-provider OAuth surface.\n\
+                     For cloud sign-out, run `bitrouter auth logout`.",
                 );
                 Ok(())
             }
@@ -504,8 +515,9 @@ async fn run() -> Result<()> {
         Command::Whoami => {
             print_unimplemented(
                 "whoami",
-                "Cloud identity is not in v1.0 scope. Local callers are identified\n\
-                 by the `brvk_` virtual key (see `bitrouter key sign`).",
+                "`bitrouter whoami` (top-level) is a legacy shim. Use:\n\
+                 - `bitrouter auth whoami`  — local cloud identity (offline read).\n\
+                 - `bitrouter cloud whoami` — same identity plus the configured /v1/* base URL.",
             );
             Ok(())
         }
@@ -515,6 +527,7 @@ async fn run() -> Result<()> {
             agent_proxy_cmd(&agent, &source).await
         }
         Command::Auth { action } => auth_cmd(action).await,
+        Command::Cloud { action } => bitrouter::cloud::cli::run(action).await,
     }
 }
 
@@ -883,6 +896,7 @@ fn print_onboarding_hint() {
     eprintln!("  1. Sign in to BitRouter Cloud — one account covers every model:");
     eprintln!();
     eprintln!("       bitrouter auth login");
+    eprintln!("       bitrouter cloud --help        # manage keys, usage, policies, billing");
     eprintln!();
     eprintln!("  2. Or paste a BitRouter API key:");
     eprintln!();

--- a/crates/bitrouter-cloud-sdk/src/lib.rs
+++ b/crates/bitrouter-cloud-sdk/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! ## Scope
 //!
-//! Today this crate ships two pieces of functionality:
+//! Today this crate ships three pieces of functionality:
 //!
 //! 1. [`auth`] — OAuth 2.0 sign-in for the CLI against the BitRouter Cloud
 //!    authorization server. Implements RFC 8628 device-flow login,
@@ -20,6 +20,13 @@
 //!    [`auth::credentials::REFRESH_WINDOW`] of expiry); falls back to a
 //!    static `brk_…` API key carried on the routing target; otherwise
 //!    returns a 401 with onboarding guidance.
+//! 3. [`management`] — a typed HTTP client for the BitRouter Cloud
+//!    `/v1/*` management surface (`keys`, `usage`, `billing`, `policies`,
+//!    `budgets`, `presets`, `byok`, `oauth_clients`). Shares the auth
+//!    module's credentials store, so it transparently picks up the
+//!    bearer that `bitrouter auth login` persisted and refreshes it on
+//!    the same RFC 6749 §6 / §4.14 schedule. Drives the
+//!    `bitrouter cloud` CLI subcommands.
 //!
 //! ## Authoritative references
 //!
@@ -29,19 +36,12 @@
 //! - RFC 8414 — Authorization Server Metadata: <https://www.rfc-editor.org/rfc/rfc8414>
 //! - RFC 8628 — Device Authorization Grant: <https://www.rfc-editor.org/rfc/rfc8628>
 //! - RFC 9700 — OAuth 2.0 Security Best Current Practice: <https://www.rfc-editor.org/rfc/rfc9700>
-//!
-//! ## Future scope
-//!
-//! A typed client for the BitRouter Cloud management surface
-//! (`/v1/keys`, `/v1/policies`, `/v1/byok`, `/v1/billing`, `/v1/usage`,
-//! `/v1/oauth_clients`, …) will land here as a parallel module — the same
-//! shape as `gh` / `vercel` / `railway` ship their CLI clients. Not in
-//! scope for this release.
 
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]
 
 pub mod auth;
+pub mod management;
 pub mod provider;
 
 pub use provider::BitrouterCloudAuthApplier;

--- a/crates/bitrouter-cloud-sdk/src/management/billing.rs
+++ b/crates/bitrouter-cloud-sdk/src/management/billing.rs
@@ -1,0 +1,58 @@
+//! `/v1/billing/*` — credit balance and Stripe checkout sessions.
+//!
+//! Mirrors `bitrouter_cloud::v1::http::management::billing`. The
+//! checkout endpoint requires `billing:write`, which is *not* in the
+//! default scope set ([`crate::auth::settings::DEFAULT_SCOPE`]); callers
+//! who want it must re-login with `--scope '… billing:write'`.
+
+use serde::{Deserialize, Serialize};
+
+use super::{ManagementClient, Result};
+
+/// Wire shape for `GET /v1/billing/balance`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BalanceResponse {
+    /// Raw balance from the credit account (before pending debits).
+    pub balance_micro_usd: i64,
+    /// Sum of pending debits not yet drained into the credit account.
+    pub pending_debits_micro_usd: i64,
+    /// `max(balance - pending, 0)` — what the next inference call
+    /// will see.
+    pub available_micro_usd: i64,
+    /// Currency code (today: `"USD"`).
+    pub currency: String,
+}
+
+/// Body for `POST /v1/billing/checkout/sessions`.
+#[derive(Debug, Clone, Serialize)]
+pub struct CheckoutSessionRequest {
+    /// Credit-purchase amount in USD cents (not micro-USD). Subject
+    /// to the node's configured min/max bounds.
+    pub amount_cents: i64,
+}
+
+/// Wire shape returned by `POST /v1/billing/checkout/sessions`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CheckoutSessionResponse {
+    /// Stripe Checkout session ID.
+    pub id: String,
+    /// Hosted checkout URL — open in a browser to complete payment.
+    pub url: String,
+}
+
+impl ManagementClient {
+    /// `GET /v1/billing/balance` — read the account's credit balance.
+    pub async fn billing_balance(&self) -> Result<BalanceResponse> {
+        self.get_json("/v1/billing/balance").await
+    }
+
+    /// `POST /v1/billing/checkout/sessions` — start a Stripe checkout
+    /// flow for a credit top-up. The response carries a URL the user
+    /// should open to complete payment.
+    pub async fn create_checkout_session(
+        &self,
+        body: &CheckoutSessionRequest,
+    ) -> Result<CheckoutSessionResponse> {
+        self.post_json("/v1/billing/checkout/sessions", body).await
+    }
+}

--- a/crates/bitrouter-cloud-sdk/src/management/budgets.rs
+++ b/crates/bitrouter-cloud-sdk/src/management/budgets.rs
@@ -1,0 +1,107 @@
+//! `/v1/budgets*` — typed CRUD wrappers over the `policies` rows whose
+//! `kind = 'budget'`. Sugar over [`super::policies`] with a flat wire
+//! shape and no `kind`/`spec` envelope.
+//!
+//! Mirrors `bitrouter_cloud::v1::http::management::budgets`. Same
+//! `policy:read` / `policy:write` scopes as the generic surface.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use super::types::BudgetWindow;
+use super::{ManagementClient, Result};
+
+/// One budget as it appears on the wire.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BudgetEnvelope {
+    /// Server-assigned policy id.
+    pub id: String,
+    /// Operator-supplied name.
+    pub name: String,
+    /// Rolling spend window.
+    pub window: BudgetWindow,
+    /// Spend cap in micro-USD.
+    pub limit_micro_usd: i64,
+    /// `None` for enabled rows; toggle via
+    /// [`ManagementClient::disable_policy`] / `enable_policy`.
+    #[serde(default)]
+    pub disabled_at: Option<DateTime<Utc>>,
+}
+
+/// Wire shape returned by `GET /v1/budgets`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BudgetListResponse {
+    /// One envelope per budget.
+    pub data: Vec<BudgetEnvelope>,
+}
+
+/// Body for `POST /v1/budgets`.
+#[derive(Debug, Clone, Serialize)]
+pub struct CreateBudgetRequest {
+    /// Operator-supplied display name. Must be non-empty.
+    pub name: String,
+    /// Rolling spend window.
+    pub window: BudgetWindow,
+    /// Spend cap in micro-USD. Must be strictly positive — the
+    /// server refuses `<= 0` because the engine treats it as "no
+    /// policy".
+    pub limit_micro_usd: i64,
+}
+
+/// Body for `PUT /v1/budgets/{id}`. Each field is optional;
+/// `None` ⇒ leave that column unchanged.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct UpdateBudgetRequest {
+    /// New name. `None` ⇒ unchanged.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// New window. `None` ⇒ unchanged.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub window: Option<BudgetWindow>,
+    /// New cap. When supplied, must be strictly positive.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit_micro_usd: Option<i64>,
+}
+
+/// Response from `DELETE /v1/budgets/{id}`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeleteBudgetResponse {
+    /// Always `true` on success.
+    pub deleted: bool,
+}
+
+impl ManagementClient {
+    /// `GET /v1/budgets` — list every budget on the account.
+    pub async fn list_budgets(&self) -> Result<BudgetListResponse> {
+        self.get_json("/v1/budgets").await
+    }
+
+    /// `GET /v1/budgets/{id}` — fetch one budget. Returns
+    /// [`super::Error::NotFound`] if the id belongs to a non-budget
+    /// policy row.
+    pub async fn get_budget(&self, id: &str) -> Result<BudgetEnvelope> {
+        let path = format!("/v1/budgets/{id}");
+        self.get_json(&path).await
+    }
+
+    /// `POST /v1/budgets` — create a budget.
+    pub async fn create_budget(&self, body: &CreateBudgetRequest) -> Result<BudgetEnvelope> {
+        self.post_json("/v1/budgets", body).await
+    }
+
+    /// `PUT /v1/budgets/{id}` — patch one or more fields of a budget.
+    pub async fn update_budget(
+        &self,
+        id: &str,
+        body: &UpdateBudgetRequest,
+    ) -> Result<BudgetEnvelope> {
+        let path = format!("/v1/budgets/{id}");
+        self.put_json(&path, body).await
+    }
+
+    /// `DELETE /v1/budgets/{id}` — remove a budget.
+    pub async fn delete_budget(&self, id: &str) -> Result<DeleteBudgetResponse> {
+        let path = format!("/v1/budgets/{id}");
+        self.delete_json(&path).await
+    }
+}

--- a/crates/bitrouter-cloud-sdk/src/management/byok.rs
+++ b/crates/bitrouter-cloud-sdk/src/management/byok.rs
@@ -1,0 +1,109 @@
+//! `/v1/byok/keys*` — list, upsert, and delete the caller's per-
+//! provider bring-your-own-key entries.
+//!
+//! Mirrors `bitrouter_cloud::v1::http::management::byok_keys`. The
+//! cloud only stores already-sealed ciphertext — callers seal against
+//! the cloud's current X25519 public key (fetched separately via
+//! `GET /v1/byok/encryption-pubkey`; not covered by this client
+//! today) and pass the base64-encoded sealed-box body in
+//! [`UpsertByokKeyRequest::ciphertext_b64`].
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use super::{ManagementClient, Result};
+
+/// One BYOK key row on the wire.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ByokKeyEnvelope {
+    /// Upstream provider identifier (e.g. `anthropic`).
+    pub provider_name: String,
+    /// Id of the cloud KEK that sealed the stored ciphertext.
+    pub kek_id: String,
+    /// Operator-visible prefix of the underlying plaintext (e.g. for
+    /// matching a leaked key to a row without leaking the secret).
+    pub key_prefix: String,
+    /// Override API base for the provider. `None` ⇒ provider default.
+    #[serde(default)]
+    pub api_base: Option<String>,
+    /// When the row was created.
+    pub created_at: DateTime<Utc>,
+    /// When the row was last updated.
+    pub updated_at: DateTime<Utc>,
+    /// Last time the gateway successfully decrypted + used this key.
+    #[serde(default)]
+    pub last_used_at: Option<DateTime<Utc>>,
+    /// Last time the gateway saw a failure attributed to this key.
+    #[serde(default)]
+    pub last_failure_at: Option<DateTime<Utc>>,
+    /// Tag for the most recent failure (e.g. `"unauthorized"`).
+    #[serde(default)]
+    pub last_failure_kind: Option<String>,
+}
+
+/// Wire shape returned by `GET /v1/byok/keys`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ByokKeyListResponse {
+    /// One envelope per BYOK row on the account.
+    pub data: Vec<ByokKeyEnvelope>,
+}
+
+/// Body for `POST /v1/byok/keys`. Idempotent — re-upserting the same
+/// `provider_name` replaces the prior row.
+#[derive(Debug, Clone, Serialize)]
+pub struct UpsertByokKeyRequest {
+    /// Upstream provider identifier.
+    pub provider_name: String,
+    /// Base64-encoded sealed-box ciphertext, sealed against the
+    /// cloud's current X25519 public key.
+    pub ciphertext_b64: String,
+    /// Id of the KEK used to seal `ciphertext_b64`. Must match the
+    /// cloud's current `primary_kek_id` — older KEKs are rejected at
+    /// upsert time.
+    pub kek_id: String,
+    /// Operator-visible prefix the console renders alongside the row.
+    pub key_prefix: String,
+    /// Override API base for the provider. `None` ⇒ provider default.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub api_base: Option<String>,
+}
+
+/// Response from `POST /v1/byok/keys`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpsertByokKeyResponse {
+    /// Echo of the upserted provider id.
+    pub provider_name: String,
+    /// Echo of the KEK id used.
+    pub kek_id: String,
+    /// Echo of the key prefix.
+    pub key_prefix: String,
+}
+
+/// Response from `DELETE /v1/byok/keys/{provider}`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeleteByokKeyResponse {
+    /// Always `true` on success.
+    pub deleted: bool,
+}
+
+impl ManagementClient {
+    /// `GET /v1/byok/keys` — list every BYOK row on the account.
+    pub async fn list_byok_keys(&self) -> Result<ByokKeyListResponse> {
+        self.get_json("/v1/byok/keys").await
+    }
+
+    /// `POST /v1/byok/keys` — upsert a BYOK row.
+    pub async fn upsert_byok_key(
+        &self,
+        body: &UpsertByokKeyRequest,
+    ) -> Result<UpsertByokKeyResponse> {
+        self.post_json("/v1/byok/keys", body).await
+    }
+
+    /// `DELETE /v1/byok/keys/{provider}` — remove a BYOK row by
+    /// provider id.
+    pub async fn delete_byok_key(&self, provider: &str) -> Result<DeleteByokKeyResponse> {
+        let path = format!("/v1/byok/keys/{provider}");
+        self.delete_json(&path).await
+    }
+}

--- a/crates/bitrouter-cloud-sdk/src/management/error.rs
+++ b/crates/bitrouter-cloud-sdk/src/management/error.rs
@@ -1,0 +1,202 @@
+//! Wire-form error envelope returned by the BitRouter Cloud `/v1/*`
+//! management surface, mirrored here so the CLI can match on the same
+//! taxonomy without depending on the server crate.
+//!
+//! The server response shape is `{ "error": <code>, "error_description":
+//! <msg> }` per [`bitrouter_cloud::v1::http::management::error`]. Codes
+//! are: `bad_request | unauthorized | forbidden | not_found | conflict |
+//! internal`.
+
+use serde::Deserialize;
+use thiserror::Error;
+
+/// Error returned by every [`crate::management::ManagementClient`] call.
+///
+/// Variants 1:1 with the server's wire error codes, plus the local
+/// failure modes (no credentials, network, JSON decode). The CLI maps
+/// each onto a user-facing message; [`Error::missing_scope`] gives the
+/// scope-suggestion path a structured hook to react to a 403.
+#[derive(Debug, Error)]
+pub enum Error {
+    /// No credentials on disk — the user has not yet run
+    /// `bitrouter auth login`.
+    #[error("not signed in — run `bitrouter auth login` first")]
+    NotSignedIn,
+
+    /// OAuth token resolution or refresh failed (e.g. refresh token
+    /// expired, AS metadata unreachable). The user should re-run
+    /// `bitrouter auth login`.
+    #[error("failed to resolve a BitRouter Cloud access token: {0:#}")]
+    Auth(#[source] anyhow::Error),
+
+    /// Server-reported `400 bad_request`. The body's `error_description`
+    /// is carried in `message`.
+    #[error("bad request: {message}")]
+    BadRequest {
+        /// Human-facing description from the server.
+        message: String,
+    },
+
+    /// Server-reported `401 unauthorized` — the bearer was rejected
+    /// after we attached it. Usually means the token has been revoked
+    /// or the user logged out from another machine.
+    #[error("unauthorized: {message}")]
+    Unauthorized {
+        /// Human-facing description from the server.
+        message: String,
+    },
+
+    /// Server-reported `403 forbidden` — credential verified but the
+    /// principal lacks the required scope. When `missing_scope` is
+    /// populated the CLI prints a hint suggesting re-login with the
+    /// missing scope appended.
+    #[error("forbidden: {message}")]
+    Forbidden {
+        /// Human-facing description from the server.
+        message: String,
+        /// Parsed scope name when the description matches the
+        /// server's `missing required scope: <scope>` format.
+        missing_scope: Option<String>,
+    },
+
+    /// Server-reported `404 not_found`.
+    #[error("not found: {message}")]
+    NotFound {
+        /// Human-facing description from the server.
+        message: String,
+    },
+
+    /// Server-reported `409 conflict`.
+    #[error("conflict: {message}")]
+    Conflict {
+        /// Human-facing description from the server.
+        message: String,
+    },
+
+    /// Server-reported `500 internal` or any other unexpected HTTP
+    /// status (e.g. 502 from a CDN, 503 during a deploy). `status` is
+    /// the raw HTTP code.
+    #[error("server error (HTTP {status}): {message}")]
+    Server {
+        /// Raw HTTP status code.
+        status: u16,
+        /// Best-effort message — either the server's
+        /// `error_description` or the literal response body.
+        message: String,
+    },
+
+    /// Reqwest-level transport failure (DNS, TLS, timeout, connection
+    /// refused). The inner error preserves the original cause.
+    #[error("transport error: {0}")]
+    Transport(#[from] reqwest::Error),
+
+    /// Response body was not valid JSON or did not match the expected
+    /// schema.
+    #[error("decoding server response: {0}")]
+    Decode(#[from] serde_json::Error),
+}
+
+impl Error {
+    /// When this is a 403 carrying a `missing required scope: <name>`
+    /// description, return the scope name. Used by the CLI to print
+    /// the `bitrouter auth login --scope …` hint.
+    pub fn missing_scope(&self) -> Option<&str> {
+        match self {
+            Error::Forbidden { missing_scope, .. } => missing_scope.as_deref(),
+            _ => None,
+        }
+    }
+}
+
+/// Server-side error envelope as defined by
+/// `bitrouter_cloud::v1::http::management::error::ErrorBody`.
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct ErrorBody {
+    pub error: String,
+    pub error_description: String,
+}
+
+impl ErrorBody {
+    /// Promote a deserialised body + status into an [`Error`].
+    pub(super) fn into_error(self, status: u16) -> Error {
+        match self.error.as_str() {
+            "bad_request" => Error::BadRequest {
+                message: self.error_description,
+            },
+            "unauthorized" => Error::Unauthorized {
+                message: self.error_description,
+            },
+            "forbidden" => {
+                let missing_scope = parse_missing_scope(&self.error_description);
+                Error::Forbidden {
+                    message: self.error_description,
+                    missing_scope,
+                }
+            }
+            "not_found" => Error::NotFound {
+                message: self.error_description,
+            },
+            "conflict" => Error::Conflict {
+                message: self.error_description,
+            },
+            _ => Error::Server {
+                status,
+                message: self.error_description,
+            },
+        }
+    }
+}
+
+/// Server-side `require_scope` rejection text is exactly
+/// `"missing required scope: <scope>"` (see
+/// `bitrouter_cloud::v1::http::management::auth::require_scope`).
+/// Match that prefix exactly so we never mis-parse a future, broader
+/// 403 message into a fake scope hint.
+fn parse_missing_scope(description: &str) -> Option<String> {
+    let trimmed = description.trim();
+    trimmed
+        .strip_prefix("missing required scope: ")
+        .map(|s| s.trim().to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn body_maps_to_forbidden_with_scope() {
+        let body = ErrorBody {
+            error: "forbidden".into(),
+            error_description: "missing required scope: keys:write".into(),
+        };
+        let err = body.into_error(403);
+        assert_eq!(err.missing_scope(), Some("keys:write"));
+        assert!(matches!(err, Error::Forbidden { .. }));
+    }
+
+    #[test]
+    fn body_maps_unknown_code_to_server() {
+        let body = ErrorBody {
+            error: "something_new".into(),
+            error_description: "huh".into(),
+        };
+        let err = body.into_error(500);
+        match err {
+            Error::Server { status, message } => {
+                assert_eq!(status, 500);
+                assert_eq!(message, "huh");
+            }
+            other => panic!("expected Server, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn missing_scope_is_none_for_other_403_descriptions() {
+        let body = ErrorBody {
+            error: "forbidden".into(),
+            error_description: "calling principal has no account_id".into(),
+        };
+        let err = body.into_error(403);
+        assert_eq!(err.missing_scope(), None);
+    }
+}

--- a/crates/bitrouter-cloud-sdk/src/management/error.rs
+++ b/crates/bitrouter-cloud-sdk/src/management/error.rs
@@ -3,7 +3,7 @@
 //! taxonomy without depending on the server crate.
 //!
 //! The server response shape is `{ "error": <code>, "error_description":
-//! <msg> }` per [`bitrouter_cloud::v1::http::management::error`]. Codes
+//! <msg> }` per `bitrouter_cloud::v1::http::management::error`. Codes
 //! are: `bad_request | unauthorized | forbidden | not_found | conflict |
 //! internal`.
 

--- a/crates/bitrouter-cloud-sdk/src/management/keys.rs
+++ b/crates/bitrouter-cloud-sdk/src/management/keys.rs
@@ -1,0 +1,105 @@
+//! `/v1/keys` — list, mint, and revoke `brk_` API keys for the
+//! caller's account.
+//!
+//! Mirrors `bitrouter_cloud::v1::http::management::keys`. Scopes:
+//! `keys:read` for list, `keys:write` for mint and revoke.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use super::{ManagementClient, Result};
+
+/// Wire shape returned by `GET /v1/keys`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiKeyListResponse {
+    /// One envelope per key on the account.
+    pub data: Vec<ApiKeyEnvelope>,
+}
+
+/// One row of the `api_keys` table, read-side projection.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiKeyEnvelope {
+    /// Server-assigned identifier (the `id` column).
+    pub id: String,
+    /// Operator-supplied friendly name.
+    pub display_name: String,
+    /// First few characters of the plaintext token, for matching a
+    /// leaked secret to its row without storing the secret.
+    pub key_prefix: String,
+    /// Scopes granted to this key, in wire-string form
+    /// (e.g. `"keys:read"`, `"policy:*"`).
+    pub scopes: Vec<String>,
+    /// Optional expiry. Past expiry the key is refused at the
+    /// gateway.
+    #[serde(default)]
+    pub expires_at: Option<DateTime<Utc>>,
+    /// Last time the gateway saw this key.
+    #[serde(default)]
+    pub last_used_at: Option<DateTime<Utc>>,
+    /// When the key was revoked, if ever.
+    #[serde(default)]
+    pub revoked_at: Option<DateTime<Utc>>,
+    /// When the row was created.
+    pub created_at: DateTime<Utc>,
+}
+
+/// Body for `POST /v1/keys`.
+#[derive(Debug, Clone, Serialize)]
+pub struct MintApiKeyRequest {
+    /// Operator-supplied friendly name. Must be non-empty.
+    pub display_name: String,
+    /// Requested scopes (wire-string form). Each must be a subset of
+    /// the caller's effective scopes — RFC 6749 §3.3 forbids
+    /// upscaling.
+    pub scopes: Vec<String>,
+    /// Optional expiry. Omit for a non-expiring key.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<DateTime<Utc>>,
+}
+
+/// Response from `POST /v1/keys`. `token` is the **one-time** plaintext
+/// — the server has no copy after this response.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MintApiKeyResponse {
+    /// Plaintext `brk_…` token. Show once, then discard.
+    pub token: String,
+    /// Server-assigned id for the persisted row.
+    pub id: String,
+    /// Visible prefix of the token, persisted for the row.
+    pub key_prefix: String,
+    /// Echo of the requested display name.
+    pub display_name: String,
+    /// Echo of the requested scopes (after parsing).
+    pub scopes: Vec<String>,
+    /// Echo of the requested expiry.
+    #[serde(default)]
+    pub expires_at: Option<DateTime<Utc>>,
+}
+
+/// Response from `DELETE /v1/keys/{id}`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RevokeApiKeyResponse {
+    /// Always `true` on success — the server returns 404 (mapped to
+    /// [`super::Error::NotFound`]) when the row doesn't exist or
+    /// belongs to a different account.
+    pub revoked: bool,
+}
+
+impl ManagementClient {
+    /// `GET /v1/keys` — list API keys on the caller's account.
+    pub async fn list_keys(&self) -> Result<ApiKeyListResponse> {
+        self.get_json("/v1/keys").await
+    }
+
+    /// `POST /v1/keys` — mint a new API key. The returned `token` is
+    /// the only copy of the plaintext.
+    pub async fn mint_key(&self, body: &MintApiKeyRequest) -> Result<MintApiKeyResponse> {
+        self.post_json("/v1/keys", body).await
+    }
+
+    /// `DELETE /v1/keys/{id}` — revoke a key by id.
+    pub async fn revoke_key(&self, id: &str) -> Result<RevokeApiKeyResponse> {
+        let path = format!("/v1/keys/{id}");
+        self.delete_json(&path).await
+    }
+}

--- a/crates/bitrouter-cloud-sdk/src/management/mod.rs
+++ b/crates/bitrouter-cloud-sdk/src/management/mod.rs
@@ -1,0 +1,294 @@
+//! Typed HTTP client for the BitRouter Cloud `/v1/*` management surface.
+//!
+//! The surface — `keys`, `usage`, `billing`, `policies`, `budgets`,
+//! `presets`, `byok`, `oauth_clients` — is the same one the web console
+//! consumes. It accepts either a `brk_` API key or a `bra_` OAuth
+//! access token. This client always presents the latter: it reads the
+//! credential persisted by `bitrouter auth login`
+//! ([`crate::auth::credentials::CredentialsStore`]) and refreshes it
+//! transparently within
+//! [`crate::auth::credentials::REFRESH_WINDOW`] of expiry.
+//!
+//! ## Endpoint coverage
+//!
+//! Methods are split across per-resource modules and exposed as
+//! additional `impl ManagementClient` blocks. See:
+//!
+//! - [`keys`] — `/v1/keys`
+//! - [`usage`] — `/v1/usage`, `/v1/requests`
+//! - [`billing`] — `/v1/billing/*`
+//! - [`policies`] — `/v1/policies*`, including `/v1/policies/effective`
+//!   and per-principal listing
+//! - [`budgets`] — `/v1/budgets*` (typed sugar)
+//! - [`presets`] — `/v1/presets*` (typed sugar)
+//! - [`byok`] — `/v1/byok/keys*`
+//! - [`oauth_clients`] — `/v1/oauth/clients*`
+//!
+//! ## Errors
+//!
+//! Every method returns [`Result<T>`] where the error is the
+//! single-typed [`enum@Error`] mirroring the server's wire-error taxonomy
+//! plus the local failure modes (no credentials, transport, decode). A
+//! 403 with the server's `missing required scope: <s>` body shape is
+//! parsed into [`Error::Forbidden`] with `missing_scope = Some(s)` so
+//! the CLI can suggest a re-login with the missing scope appended.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Context;
+use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue};
+use reqwest::{Method, StatusCode};
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+use tokio::sync::Mutex;
+
+use crate::auth::credentials::{CredentialsStore, default_credentials_path};
+use crate::auth::metadata::{self, AsMetadata};
+
+pub mod billing;
+pub mod budgets;
+pub mod byok;
+pub mod error;
+pub mod keys;
+pub mod oauth_clients;
+pub mod policies;
+pub mod presets;
+pub mod types;
+pub mod usage;
+
+#[cfg(test)]
+mod tests;
+
+pub use error::Error;
+
+/// Convenience `Result` alias used by every method on
+/// [`ManagementClient`].
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Typed client for the BitRouter Cloud `/v1/*` management surface.
+///
+/// Construct via [`ManagementClient::from_default_credentials`] (which
+/// reads `<data-dir>/account-credentials.json`) and call the per-method
+/// helpers defined in this module's sub-modules.
+#[derive(Debug)]
+pub struct ManagementClient {
+    /// Cloud base URL (no trailing slash). The credentials file's
+    /// `authorization_server` field is the source of truth — `bitrouter
+    /// auth login` against `https://my-self-hosted.example.com` makes
+    /// this client target that same host.
+    base_url: String,
+    http: reqwest::Client,
+    /// Locked across the disk-read → refresh → persist sequence per RFC
+    /// 6749 §6 rotation safety. A concurrent refresh from another task
+    /// would race the AS into invalidating the older refresh token —
+    /// the mutex serialises that path. Matches the pattern used by
+    /// [`crate::provider::BitrouterCloudAuthApplier`].
+    store: Arc<Mutex<CredentialsStore>>,
+    /// AS metadata cached for the process lifetime. The AS URL is
+    /// captured at construction so a re-login against a different AS
+    /// implicitly invalidates the cache (the next `ManagementClient`
+    /// instance reads the new URL from disk).
+    metadata: Arc<Mutex<Option<AsMetadata>>>,
+}
+
+impl ManagementClient {
+    /// Build a client from the default credentials path
+    /// (`<data-dir>/account-credentials.json`). Errors with
+    /// [`Error::NotSignedIn`] when the file is absent so callers can
+    /// print the onboarding hint without a stack trace.
+    pub fn from_default_credentials() -> Result<Self> {
+        let path = default_credentials_path()
+            .context("resolving BitRouter Cloud credentials path")
+            .map_err(Error::Auth)?;
+        Self::from_credentials_path(path)
+    }
+
+    /// Build a client reading the credentials file at `path`. Used by
+    /// tests to point at a temporary directory and by callers that
+    /// override the default location.
+    pub fn from_credentials_path(path: PathBuf) -> Result<Self> {
+        let store = CredentialsStore::load(&path)
+            .with_context(|| format!("reading credentials at {}", path.display()))
+            .map_err(Error::Auth)?;
+        let creds = store.current().ok_or(Error::NotSignedIn)?;
+        let base_url = creds.authorization_server.trim_end_matches('/').to_owned();
+        let http = build_http_client()?;
+        Ok(Self {
+            base_url,
+            http,
+            store: Arc::new(Mutex::new(store)),
+            metadata: Arc::new(Mutex::new(None)),
+        })
+    }
+
+    /// Construct with an explicit base URL and HTTP client. Used by
+    /// the wiremock test harness so a single mock server stands in
+    /// for both the AS metadata + token endpoints and the `/v1/*`
+    /// management endpoints.
+    #[cfg(test)]
+    pub(crate) fn with_parts(
+        base_url: String,
+        http: reqwest::Client,
+        store: CredentialsStore,
+    ) -> Self {
+        Self {
+            base_url: base_url.trim_end_matches('/').to_owned(),
+            http,
+            store: Arc::new(Mutex::new(store)),
+            metadata: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    /// The base URL this client targets. Exposed primarily for
+    /// diagnostics — `bitrouter cloud whoami` prints it.
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    /// Fetch a current bearer, refreshing if the stored access token
+    /// is within
+    /// [`crate::auth::credentials::REFRESH_WINDOW`] of expiry. The
+    /// rotated refresh token (if any) is persisted before the bearer
+    /// is returned.
+    async fn bearer(&self) -> Result<String> {
+        let mut store = self.store.lock().await;
+        let creds = store
+            .current()
+            .ok_or(Error::NotSignedIn)?
+            .authorization_server
+            .clone();
+        let metadata = self.resolve_metadata(&creds).await?;
+        store
+            .current_token(&self.http, &metadata)
+            .await
+            .map_err(Error::Auth)
+    }
+
+    async fn resolve_metadata(&self, as_url: &str) -> Result<AsMetadata> {
+        let mut cell = self.metadata.lock().await;
+        if let Some(cached) = cell.as_ref() {
+            return Ok(cached.clone());
+        }
+        let fresh = metadata::fetch(&self.http, as_url)
+            .await
+            .with_context(|| format!("fetching AS metadata at {as_url}"))
+            .map_err(Error::Auth)?;
+        *cell = Some(fresh.clone());
+        Ok(fresh)
+    }
+
+    /// Build a request with `Authorization: Bearer …` already attached.
+    /// Per-method helpers layer the JSON body / query string on top.
+    async fn authed(&self, method: Method, path: &str) -> Result<reqwest::RequestBuilder> {
+        let bearer = self.bearer().await?;
+        let url = format!("{}{}", self.base_url, path);
+        let value = HeaderValue::from_str(&format!("Bearer {bearer}"))
+            .context("encoding Authorization header")
+            .map_err(Error::Auth)?;
+        let mut headers = HeaderMap::new();
+        headers.insert(AUTHORIZATION, value);
+        Ok(self.http.request(method, url).headers(headers))
+    }
+
+    pub(super) async fn get_json<Resp: DeserializeOwned>(&self, path: &str) -> Result<Resp> {
+        let req = self.authed(Method::GET, path).await?;
+        execute_json(req).await
+    }
+
+    pub(super) async fn get_with_query<Q: Serialize, Resp: DeserializeOwned>(
+        &self,
+        path: &str,
+        query: &Q,
+    ) -> Result<Resp> {
+        let req = self.authed(Method::GET, path).await?.query(query);
+        execute_json(req).await
+    }
+
+    pub(super) async fn post_json<Body: Serialize, Resp: DeserializeOwned>(
+        &self,
+        path: &str,
+        body: &Body,
+    ) -> Result<Resp> {
+        let req = self.authed(Method::POST, path).await?.json(body);
+        execute_json(req).await
+    }
+
+    pub(super) async fn post_empty<Resp: DeserializeOwned>(&self, path: &str) -> Result<Resp> {
+        let req = self.authed(Method::POST, path).await?;
+        execute_json(req).await
+    }
+
+    pub(super) async fn put_json<Body: Serialize, Resp: DeserializeOwned>(
+        &self,
+        path: &str,
+        body: &Body,
+    ) -> Result<Resp> {
+        let req = self.authed(Method::PUT, path).await?.json(body);
+        execute_json(req).await
+    }
+
+    pub(super) async fn delete_json<Resp: DeserializeOwned>(&self, path: &str) -> Result<Resp> {
+        let req = self.authed(Method::DELETE, path).await?;
+        execute_json(req).await
+    }
+}
+
+/// Reusable reqwest client with the SDK user-agent and a sensible
+/// timeout. Centralised so every outgoing call sends a consistent UA
+/// (RFC 9110 §10.1.5).
+fn build_http_client() -> Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .user_agent(concat!("bitrouter-cloud-sdk/", env!("CARGO_PKG_VERSION")))
+        .timeout(Duration::from_secs(30))
+        .build()
+        .context("building bitrouter-cloud-sdk HTTP client")
+        .map_err(Error::Auth)
+}
+
+/// Drive a built request to completion, mapping a non-2xx response
+/// onto the server's `{ error, error_description }` envelope and a 2xx
+/// body onto `Resp`. Empty 2xx bodies (e.g. `204 No Content`) are
+/// disallowed — every server endpoint in v1 returns a JSON body, so an
+/// empty success is treated as a decode error.
+async fn execute_json<Resp: DeserializeOwned>(req: reqwest::RequestBuilder) -> Result<Resp> {
+    let resp = req.send().await?;
+    let status = resp.status();
+    let body_bytes = resp.bytes().await?;
+    if status.is_success() {
+        let parsed = serde_json::from_slice::<Resp>(&body_bytes)?;
+        return Ok(parsed);
+    }
+    Err(map_error_response(status, &body_bytes))
+}
+
+fn map_error_response(status: StatusCode, body: &[u8]) -> Error {
+    // Try the structured `{ error, error_description }` envelope first.
+    if let Ok(envelope) = serde_json::from_slice::<error::ErrorBody>(body) {
+        return envelope.into_error(status.as_u16());
+    }
+    // Fall back to whatever the body says (or the status reason when
+    // the body is empty / non-UTF-8). 401 / 403 from an intermediary
+    // (e.g. a CDN authn layer) will land here.
+    let message = String::from_utf8_lossy(body).into_owned();
+    let message = if message.trim().is_empty() {
+        status
+            .canonical_reason()
+            .unwrap_or("unexpected status")
+            .to_owned()
+    } else {
+        message
+    };
+    match status.as_u16() {
+        400 => Error::BadRequest { message },
+        401 => Error::Unauthorized { message },
+        403 => Error::Forbidden {
+            message,
+            missing_scope: None,
+        },
+        404 => Error::NotFound { message },
+        409 => Error::Conflict { message },
+        s => Error::Server { status: s, message },
+    }
+}

--- a/crates/bitrouter-cloud-sdk/src/management/oauth_clients.rs
+++ b/crates/bitrouter-cloud-sdk/src/management/oauth_clients.rs
@@ -1,0 +1,147 @@
+//! `/v1/oauth/clients*` — manage the caller's OAuth client
+//! registrations.
+//!
+//! Mirrors `bitrouter_cloud::v1::http::management::oauth_clients`. The
+//! freshly minted `client_secret` (for confidential clients) is
+//! returned exactly once in the register response and never again.
+//!
+//! Scopes: `clients:read` / `clients:write`. Neither is in the
+//! default scope set ([`crate::auth::settings::DEFAULT_SCOPE`]); a
+//! caller who wants this surface must re-login with `--scope` to
+//! request them.
+
+use serde::{Deserialize, Serialize};
+
+use super::types::ClientType;
+use super::{ManagementClient, Result};
+
+/// One OAuth client registration on the wire.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OauthClientEnvelope {
+    /// Internal row id (UUID).
+    pub id: String,
+    /// The public `client_id` the AS advertises on flows.
+    pub client_id: String,
+    /// Operator-supplied display name.
+    pub client_name: String,
+    /// Confidential vs public — confidential clients carry a
+    /// `client_secret`, public clients are PKCE-only.
+    pub client_type: ClientType,
+    /// Exact-match redirect URIs honoured at the authorize endpoint.
+    pub redirect_uris: Vec<String>,
+    /// Wire-string scopes the AS will allow this client to request.
+    pub allowed_scopes: Vec<String>,
+    /// Grant types this client may use (`authorization_code`,
+    /// `refresh_token`, or the RFC 8628 device-code URN).
+    pub allowed_grant_types: Vec<String>,
+}
+
+/// Wire shape returned by `GET /v1/oauth/clients`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OauthClientListResponse {
+    /// One envelope per client on the account.
+    pub data: Vec<OauthClientEnvelope>,
+}
+
+/// Body for `POST /v1/oauth/clients`.
+#[derive(Debug, Clone, Serialize)]
+pub struct RegisterOauthClientRequest {
+    /// Operator-supplied display name. Must be non-empty.
+    pub client_name: String,
+    /// Confidential vs public.
+    pub client_type: ClientType,
+    /// Exact-match redirect URIs. Empty for purely device-flow
+    /// clients.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub redirect_uris: Vec<String>,
+    /// Wire-string scopes (e.g. `"keys:read"`, `"policy:*"`).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub allowed_scopes: Vec<String>,
+    /// Grant types — must include at least one of
+    /// `authorization_code`, `refresh_token`,
+    /// `urn:ietf:params:oauth:grant-type:device_code`.
+    pub allowed_grant_types: Vec<String>,
+}
+
+/// Response from `POST /v1/oauth/clients`. `client_secret` is `Some`
+/// for confidential clients and is the one-and-only copy of the
+/// plaintext — show once, then discard.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RegisterOauthClientResponse {
+    /// Internal row id.
+    pub id: String,
+    /// Public `client_id`.
+    pub client_id: String,
+    /// One-time plaintext secret — `None` for public clients.
+    pub client_secret: Option<String>,
+    /// Echo of the requested display name.
+    pub client_name: String,
+    /// Echo of the client type.
+    pub client_type: ClientType,
+    /// Echo of the redirect URIs.
+    pub redirect_uris: Vec<String>,
+    /// Echo of the parsed scope set.
+    pub allowed_scopes: Vec<String>,
+    /// Echo of the parsed grant types.
+    pub allowed_grant_types: Vec<String>,
+}
+
+/// Body for `PUT /v1/oauth/clients/{client_id}`. Each field is
+/// independently optional — `None` ⇒ unchanged.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct UpdateOauthClientRequest {
+    /// New display name.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_name: Option<String>,
+    /// Replacement redirect-URI list (full replacement, not patch).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub redirect_uris: Option<Vec<String>>,
+    /// Replacement scope set (full replacement).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub allowed_scopes: Option<Vec<String>>,
+    /// Replacement grant-type list.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub allowed_grant_types: Option<Vec<String>>,
+}
+
+/// Response from `DELETE /v1/oauth/clients/{client_id}`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeleteOauthClientResponse {
+    /// Always `true` on success.
+    pub deleted: bool,
+}
+
+impl ManagementClient {
+    /// `GET /v1/oauth/clients` — list every OAuth client on the
+    /// account.
+    pub async fn list_oauth_clients(&self) -> Result<OauthClientListResponse> {
+        self.get_json("/v1/oauth/clients").await
+    }
+
+    /// `POST /v1/oauth/clients` — register a new client. For
+    /// confidential clients, the response's `client_secret` is the
+    /// one-time plaintext.
+    pub async fn register_oauth_client(
+        &self,
+        body: &RegisterOauthClientRequest,
+    ) -> Result<RegisterOauthClientResponse> {
+        self.post_json("/v1/oauth/clients", body).await
+    }
+
+    /// `PUT /v1/oauth/clients/{client_id}` — patch one or more
+    /// fields.
+    pub async fn update_oauth_client(
+        &self,
+        client_id: &str,
+        body: &UpdateOauthClientRequest,
+    ) -> Result<OauthClientEnvelope> {
+        let path = format!("/v1/oauth/clients/{client_id}");
+        self.put_json(&path, body).await
+    }
+
+    /// `DELETE /v1/oauth/clients/{client_id}` — remove a client.
+    pub async fn delete_oauth_client(&self, client_id: &str) -> Result<DeleteOauthClientResponse> {
+        let path = format!("/v1/oauth/clients/{client_id}");
+        self.delete_json(&path).await
+    }
+}

--- a/crates/bitrouter-cloud-sdk/src/management/policies.rs
+++ b/crates/bitrouter-cloud-sdk/src/management/policies.rs
@@ -1,0 +1,261 @@
+//! `/v1/policies*` — generic CRUD over the typed policy registry plus
+//! binding, enable/disable, per-principal listing, and the effective-
+//! policy preview.
+//!
+//! Mirrors `bitrouter_cloud::v1::http::management::policies`. Scopes:
+//! `policy:read` for reads, `policy:write` for everything else.
+//!
+//! The shape used for `spec` is the **flat inner body** (e.g. `{
+//! "window": "day", "limit_micro_usd": 1000 }` for a budget), not the
+//! tagged outer form — see the server doc-comment on
+//! `bitrouter_cloud::policy::spec::PolicySpec::from_row`. Callers
+//! either pass typed sub-structs from [`super::types`] or a raw
+//! [`serde_json::Value`] (e.g. for guardrails / rate-limits which we
+//! don't yet model as Rust structs in this crate).
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use super::types::PolicyKind;
+use super::{ManagementClient, Result};
+
+/// One row from `GET /v1/policies` or its single-row variants.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PolicyEnvelope {
+    /// Server-assigned identifier.
+    pub id: String,
+    /// Operator-supplied name.
+    pub name: String,
+    /// Discriminator for the row's spec body.
+    pub kind: PolicyKind,
+    /// Flat inner spec body — caller-typed downstream.
+    pub spec: serde_json::Value,
+    /// `None` for enabled rows; `Some` once an operator has parked
+    /// the policy via `disable_policy`. Disabled rows are still
+    /// returned by reads; the engine skips them at request time.
+    #[serde(default)]
+    pub disabled_at: Option<DateTime<Utc>>,
+}
+
+/// Wire shape returned by every list-style policy endpoint.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PolicyListResponse {
+    /// One envelope per policy.
+    pub data: Vec<PolicyEnvelope>,
+}
+
+/// Query string for `GET /v1/policies`.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct ListPoliciesQuery {
+    /// Narrow the result to a single kind. `None` returns every kind.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<PolicyKind>,
+}
+
+/// Body for `POST /v1/policies`.
+#[derive(Debug, Clone, Serialize)]
+pub struct CreatePolicyRequest {
+    /// Operator-supplied display name. Must be non-empty.
+    pub name: String,
+    /// Discriminator — selects which shape `spec` must take.
+    pub kind: PolicyKind,
+    /// Flat inner spec body. Server validates against `kind`.
+    pub spec: serde_json::Value,
+}
+
+/// Body for `PUT /v1/policies/{id}`. Both fields are optional —
+/// `None` leaves the column untouched. Kind changes aren't supported;
+/// when supplied, the spec must serialise against the row's existing
+/// kind.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct UpdatePolicyRequest {
+    /// New name. `None` ⇒ unchanged.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// New spec. `None` ⇒ unchanged.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub spec: Option<serde_json::Value>,
+}
+
+/// Response for `DELETE /v1/policies/{id}`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeletePolicyResponse {
+    /// Always `true` on success (404 maps to
+    /// [`super::Error::NotFound`]).
+    pub deleted: bool,
+}
+
+/// Body for `POST /v1/policies/{id}/bind`.
+#[derive(Debug, Clone, Serialize)]
+pub struct BindPolicyRequest {
+    /// One of `account`, `api_key`, `oauth_token`, `oauth_client`.
+    pub principal_type: String,
+    /// Id of the principal — interpretation depends on
+    /// `principal_type`.
+    pub principal_id: String,
+}
+
+/// Response for `POST /v1/policies/{id}/bind`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BindPolicyResponse {
+    /// Id of the new binding row, addressable by `DELETE
+    /// /v1/policies/{id}/bind/{binding_id}`.
+    pub binding_id: String,
+}
+
+/// Response for `DELETE /v1/policies/{id}/bind/{binding_id}`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UnbindPolicyResponse {
+    /// Always `true` on success.
+    pub unbound: bool,
+}
+
+/// Response for `POST /v1/policies/{id}/disable` and
+/// `/v1/policies/{id}/enable`. `disabled` reflects the **post-call**
+/// state (idempotent — re-disabling returns the same body).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToggleResponse {
+    /// `true` when the policy is now disabled.
+    pub disabled: bool,
+}
+
+/// One binding row, as returned by
+/// `GET /v1/policies/{id}/bindings`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BindingEnvelope {
+    /// Binding row id.
+    pub id: String,
+    /// Owning policy id.
+    pub policy_id: String,
+    /// One of `account`, `api_key`, `oauth_token`, `oauth_client`.
+    pub principal_type: String,
+    /// Id of the principal this binding targets.
+    pub principal_id: String,
+}
+
+/// Wire shape returned by `GET /v1/policies/{id}/bindings`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BindingListResponse {
+    /// One envelope per binding on the policy.
+    pub data: Vec<BindingEnvelope>,
+}
+
+/// Query string for `GET /v1/policies/effective`. Both fields are
+/// required: there's no "for me" shortcut because the engine
+/// computes account-vs-credential composition differently.
+#[derive(Debug, Clone, Serialize)]
+pub struct EffectivePolicyQuery {
+    /// One of `account`, `api_key`, `oauth_token`, `oauth_client`.
+    pub principal_type: String,
+    /// Id of the principal the preview is computed for.
+    pub principal_id: String,
+}
+
+/// Wire shape returned by `GET /v1/policies/effective`. Mirrors
+/// `bitrouter_cloud::policy::engine::EffectivePolicy` — a flat list
+/// per kind, plus a single guardrail composed under most-restrictive-
+/// wins.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct EffectivePolicy {
+    /// All budget clauses that would apply to a request.
+    #[serde(default)]
+    pub budgets: Vec<serde_json::Value>,
+    /// All rate-limit clauses that would apply.
+    #[serde(default)]
+    pub rate_limits: Vec<serde_json::Value>,
+    /// Combined guardrail (most-restrictive-wins). `None` means no
+    /// guardrail policy applied.
+    #[serde(default)]
+    pub guardrail: Option<serde_json::Value>,
+}
+
+impl ManagementClient {
+    /// `GET /v1/policies` — list policies on the caller's account,
+    /// optionally narrowed by kind.
+    pub async fn list_policies(&self, query: &ListPoliciesQuery) -> Result<PolicyListResponse> {
+        self.get_with_query("/v1/policies", query).await
+    }
+
+    /// `GET /v1/policies/{id}` — fetch a single policy.
+    pub async fn get_policy(&self, id: &str) -> Result<PolicyEnvelope> {
+        let path = format!("/v1/policies/{id}");
+        self.get_json(&path).await
+    }
+
+    /// `POST /v1/policies` — create a new policy.
+    pub async fn create_policy(&self, body: &CreatePolicyRequest) -> Result<PolicyEnvelope> {
+        self.post_json("/v1/policies", body).await
+    }
+
+    /// `PUT /v1/policies/{id}` — patch name and/or spec.
+    pub async fn update_policy(
+        &self,
+        id: &str,
+        body: &UpdatePolicyRequest,
+    ) -> Result<PolicyEnvelope> {
+        let path = format!("/v1/policies/{id}");
+        self.put_json(&path, body).await
+    }
+
+    /// `DELETE /v1/policies/{id}` — remove a policy. Cascades to its
+    /// bindings server-side.
+    pub async fn delete_policy(&self, id: &str) -> Result<DeletePolicyResponse> {
+        let path = format!("/v1/policies/{id}");
+        self.delete_json(&path).await
+    }
+
+    /// `POST /v1/policies/{id}/bind` — attach a policy to a principal.
+    pub async fn bind_policy(
+        &self,
+        id: &str,
+        body: &BindPolicyRequest,
+    ) -> Result<BindPolicyResponse> {
+        let path = format!("/v1/policies/{id}/bind");
+        self.post_json(&path, body).await
+    }
+
+    /// `DELETE /v1/policies/{id}/bind/{binding_id}` — detach one
+    /// binding.
+    pub async fn unbind_policy(&self, id: &str, binding_id: &str) -> Result<UnbindPolicyResponse> {
+        let path = format!("/v1/policies/{id}/bind/{binding_id}");
+        self.delete_json(&path).await
+    }
+
+    /// `GET /v1/policies/{id}/bindings` — list bindings for one
+    /// policy.
+    pub async fn list_policy_bindings(&self, id: &str) -> Result<BindingListResponse> {
+        let path = format!("/v1/policies/{id}/bindings");
+        self.get_json(&path).await
+    }
+
+    /// `POST /v1/policies/{id}/disable` — park a policy. The row
+    /// stays in the table; the engine skips it at request time.
+    pub async fn disable_policy(&self, id: &str) -> Result<ToggleResponse> {
+        let path = format!("/v1/policies/{id}/disable");
+        self.post_empty(&path).await
+    }
+
+    /// `POST /v1/policies/{id}/enable` — un-park a previously
+    /// disabled policy.
+    pub async fn enable_policy(&self, id: &str) -> Result<ToggleResponse> {
+        let path = format!("/v1/policies/{id}/enable");
+        self.post_empty(&path).await
+    }
+
+    /// `GET /v1/principals/{type}/{id}/policies` — every policy bound
+    /// to a given principal.
+    pub async fn list_principal_policies(
+        &self,
+        principal_type: &str,
+        principal_id: &str,
+    ) -> Result<PolicyListResponse> {
+        let path = format!("/v1/principals/{principal_type}/{principal_id}/policies");
+        self.get_json(&path).await
+    }
+
+    /// `GET /v1/policies/effective` — preview the effective policy for
+    /// a principal without making a real inference call.
+    pub async fn effective_policy(&self, query: &EffectivePolicyQuery) -> Result<EffectivePolicy> {
+        self.get_with_query("/v1/policies/effective", query).await
+    }
+}

--- a/crates/bitrouter-cloud-sdk/src/management/presets.rs
+++ b/crates/bitrouter-cloud-sdk/src/management/presets.rs
@@ -1,0 +1,136 @@
+//! `/v1/presets*` — typed CRUD wrappers over the `policies` rows whose
+//! `kind = 'preset'`. A preset is a named bundle of an optional
+//! `guardrail`, `budget`, and / or `rate_limit` clause.
+//!
+//! Mirrors `bitrouter_cloud::v1::http::management::presets`.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use super::{ManagementClient, Result};
+
+/// One preset on the wire. The sub-policy fields are optional so an
+/// empty preset (no clauses) is representable; the engine ignores
+/// empty presets at request time.
+///
+/// `guardrail` / `budget` / `rate_limit` are deserialised as raw
+/// [`serde_json::Value`] for simplicity — callers that want strong
+/// typing for the inner clauses can do `serde_json::from_value`
+/// against e.g. `crate::management::types::BudgetWindow`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PresetEnvelope {
+    /// Server-assigned policy id.
+    pub id: String,
+    /// Operator-supplied name.
+    pub name: String,
+    /// Guardrail clause, if set.
+    #[serde(default)]
+    pub guardrail: Option<serde_json::Value>,
+    /// Budget clause, if set.
+    #[serde(default)]
+    pub budget: Option<serde_json::Value>,
+    /// Rate-limit clause, if set.
+    #[serde(default)]
+    pub rate_limit: Option<serde_json::Value>,
+    /// `None` for enabled rows.
+    #[serde(default)]
+    pub disabled_at: Option<DateTime<Utc>>,
+}
+
+/// Wire shape returned by `GET /v1/presets`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PresetListResponse {
+    /// One envelope per preset.
+    pub data: Vec<PresetEnvelope>,
+}
+
+/// Body for `POST /v1/presets`.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct CreatePresetRequest {
+    /// Operator-supplied display name. Must be non-empty.
+    pub name: String,
+    /// Optional guardrail clause (server-validated against
+    /// `GuardrailSpec`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub guardrail: Option<serde_json::Value>,
+    /// Optional budget clause.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub budget: Option<serde_json::Value>,
+    /// Optional rate-limit clause.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rate_limit: Option<serde_json::Value>,
+}
+
+/// Body for `PUT /v1/presets/{id}`. Each clause field is independently
+/// optional. To **drop** a clause from a preset, set the matching
+/// `clear_*` flag — the server does not honour JSON `null` for this.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct UpdatePresetRequest {
+    /// New name. `None` ⇒ unchanged.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// Replace the guardrail clause. `None` ⇒ unchanged.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub guardrail: Option<serde_json::Value>,
+    /// Replace the budget clause. `None` ⇒ unchanged.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub budget: Option<serde_json::Value>,
+    /// Replace the rate-limit clause. `None` ⇒ unchanged.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rate_limit: Option<serde_json::Value>,
+    /// When `true`, drop the guardrail clause from the stored preset.
+    /// Overrides `guardrail` if both are present.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub clear_guardrail: bool,
+    /// When `true`, drop the budget clause.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub clear_budget: bool,
+    /// When `true`, drop the rate-limit clause.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub clear_rate_limit: bool,
+}
+
+fn is_false(b: &bool) -> bool {
+    !*b
+}
+
+/// Response from `DELETE /v1/presets/{id}`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeletePresetResponse {
+    /// Always `true` on success.
+    pub deleted: bool,
+}
+
+impl ManagementClient {
+    /// `GET /v1/presets` — list every preset on the account.
+    pub async fn list_presets(&self) -> Result<PresetListResponse> {
+        self.get_json("/v1/presets").await
+    }
+
+    /// `GET /v1/presets/{id}` — fetch one preset.
+    pub async fn get_preset(&self, id: &str) -> Result<PresetEnvelope> {
+        let path = format!("/v1/presets/{id}");
+        self.get_json(&path).await
+    }
+
+    /// `POST /v1/presets` — create a preset.
+    pub async fn create_preset(&self, body: &CreatePresetRequest) -> Result<PresetEnvelope> {
+        self.post_json("/v1/presets", body).await
+    }
+
+    /// `PUT /v1/presets/{id}` — patch a preset's name and/or clauses.
+    pub async fn update_preset(
+        &self,
+        id: &str,
+        body: &UpdatePresetRequest,
+    ) -> Result<PresetEnvelope> {
+        let path = format!("/v1/presets/{id}");
+        self.put_json(&path, body).await
+    }
+
+    /// `DELETE /v1/presets/{id}` — remove a preset.
+    pub async fn delete_preset(&self, id: &str) -> Result<DeletePresetResponse> {
+        let path = format!("/v1/presets/{id}");
+        self.delete_json(&path).await
+    }
+}

--- a/crates/bitrouter-cloud-sdk/src/management/tests.rs
+++ b/crates/bitrouter-cloud-sdk/src/management/tests.rs
@@ -1,0 +1,306 @@
+//! Wiremock-backed tests for [`crate::management::ManagementClient`].
+//!
+//! The pattern mirrors `crate::provider::applier::tests`: stand up one
+//! `MockServer`, point both the AS metadata endpoint and the `/v1/*`
+//! routes at it, persist a fresh credentials file in a temp dir, build
+//! the client with [`ManagementClient::with_parts`].
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use chrono::{Duration as ChronoDuration, Utc};
+use serde_json::json;
+use wiremock::matchers::{body_string_contains, header, method, path as wm_path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use super::*;
+use crate::auth::credentials::{Credentials, CredentialsStore};
+
+fn tmp_creds_path(label: &str) -> PathBuf {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!(
+        "bitrouter-cloud-mgmt-{label}-{}-{id}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir.join("account-credentials.json")
+}
+
+fn fresh_creds(as_url: &str) -> Credentials {
+    Credentials {
+        access_token: "AT".into(),
+        refresh_token: Some("RT".into()),
+        expires_at: Utc::now() + ChronoDuration::seconds(3600),
+        refresh_token_expires_at: None,
+        token_type: "Bearer".into(),
+        scope: "keys:read keys:write policy:read policy:write".into(),
+        client_id: "bitrouter-cli".into(),
+        authorization_server: as_url.to_owned(),
+        subject: Some("u-1".into()),
+    }
+}
+
+fn http_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .unwrap()
+}
+
+async fn metadata_mock(server: &MockServer) {
+    let uri = server.uri();
+    Mock::given(method("GET"))
+        .and(wm_path("/.well-known/oauth-authorization-server"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "issuer": uri,
+            "device_authorization_endpoint": format!("{uri}/oauth/device_authorization"),
+            "token_endpoint": format!("{uri}/oauth/token"),
+        })))
+        .mount(server)
+        .await;
+}
+
+fn build_client(server: &MockServer, creds_path: &PathBuf) -> ManagementClient {
+    let store = CredentialsStore::load(creds_path).unwrap();
+    ManagementClient::with_parts(server.uri(), http_client(), store)
+}
+
+#[tokio::test]
+async fn list_keys_attaches_bearer_and_decodes_body() {
+    let server = MockServer::start().await;
+    metadata_mock(&server).await;
+    Mock::given(method("GET"))
+        .and(wm_path("/v1/keys"))
+        .and(header("authorization", "Bearer AT"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": [{
+                "id": "k_1",
+                "display_name": "ci",
+                "key_prefix": "brk_ci",
+                "scopes": ["keys:read", "policy:read"],
+                "expires_at": null,
+                "last_used_at": null,
+                "revoked_at": null,
+                "created_at": "2026-05-25T00:00:00Z"
+            }]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let path = tmp_creds_path("list-keys");
+    let mut store = CredentialsStore::load(&path).unwrap();
+    store.save(fresh_creds(&server.uri())).unwrap();
+    let client = build_client(&server, &path);
+
+    let resp = client.list_keys().await.unwrap();
+    assert_eq!(resp.data.len(), 1);
+    assert_eq!(resp.data[0].display_name, "ci");
+    assert_eq!(resp.data[0].scopes, vec!["keys:read", "policy:read"]);
+}
+
+#[tokio::test]
+async fn mint_key_posts_json_body_and_returns_secret() {
+    let server = MockServer::start().await;
+    metadata_mock(&server).await;
+    Mock::given(method("POST"))
+        .and(wm_path("/v1/keys"))
+        .and(header("authorization", "Bearer AT"))
+        .and(body_string_contains("\"display_name\":\"ci\""))
+        .and(body_string_contains("\"scopes\":[\"policy:read\"]"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "token": "brk_ci.secret",
+            "id": "k_42",
+            "key_prefix": "brk_ci",
+            "display_name": "ci",
+            "scopes": ["policy:read"],
+            "expires_at": null,
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let path = tmp_creds_path("mint");
+    let mut store = CredentialsStore::load(&path).unwrap();
+    store.save(fresh_creds(&server.uri())).unwrap();
+    let client = build_client(&server, &path);
+
+    let resp = client
+        .mint_key(&keys::MintApiKeyRequest {
+            display_name: "ci".into(),
+            scopes: vec!["policy:read".into()],
+            expires_at: None,
+        })
+        .await
+        .unwrap();
+    assert_eq!(resp.token, "brk_ci.secret");
+    assert_eq!(resp.id, "k_42");
+}
+
+#[tokio::test]
+async fn forbidden_with_scope_message_is_parsed() {
+    let server = MockServer::start().await;
+    metadata_mock(&server).await;
+    Mock::given(method("DELETE"))
+        .and(wm_path("/v1/keys/k_x"))
+        .respond_with(ResponseTemplate::new(403).set_body_json(json!({
+            "error": "forbidden",
+            "error_description": "missing required scope: keys:write",
+        })))
+        .mount(&server)
+        .await;
+    let path = tmp_creds_path("forbidden");
+    let mut store = CredentialsStore::load(&path).unwrap();
+    store.save(fresh_creds(&server.uri())).unwrap();
+    let client = build_client(&server, &path);
+
+    let err = client.revoke_key("k_x").await.unwrap_err();
+    match err {
+        Error::Forbidden {
+            ref message,
+            missing_scope: Some(ref scope),
+        } => {
+            assert_eq!(scope, "keys:write");
+            assert!(message.contains("keys:write"), "message: {message}");
+        }
+        other => panic!("expected Forbidden with missing_scope, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn not_found_maps_to_typed_variant() {
+    let server = MockServer::start().await;
+    metadata_mock(&server).await;
+    Mock::given(method("GET"))
+        .and(wm_path("/v1/policies/ghost"))
+        .respond_with(ResponseTemplate::new(404).set_body_json(json!({
+            "error": "not_found",
+            "error_description": "policy not found",
+        })))
+        .mount(&server)
+        .await;
+    let path = tmp_creds_path("notfound");
+    let mut store = CredentialsStore::load(&path).unwrap();
+    store.save(fresh_creds(&server.uri())).unwrap();
+    let client = build_client(&server, &path);
+
+    let err = client.get_policy("ghost").await.unwrap_err();
+    assert!(matches!(err, Error::NotFound { .. }));
+}
+
+#[tokio::test]
+async fn missing_credentials_file_returns_not_signed_in() {
+    let path = tmp_creds_path("nosign");
+    let err = ManagementClient::from_credentials_path(path).unwrap_err();
+    assert!(matches!(err, Error::NotSignedIn));
+}
+
+#[tokio::test]
+async fn metadata_fetched_once_across_multiple_calls() {
+    let server = MockServer::start().await;
+    // expect(1) on the metadata mock proves the cache is honoured.
+    Mock::given(method("GET"))
+        .and(wm_path("/.well-known/oauth-authorization-server"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "issuer": server.uri(),
+            "device_authorization_endpoint": format!("{}/oauth/device_authorization", server.uri()),
+            "token_endpoint": format!("{}/oauth/token", server.uri()),
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(wm_path("/v1/keys"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "data": [] })))
+        .mount(&server)
+        .await;
+    let path = tmp_creds_path("cache");
+    let mut store = CredentialsStore::load(&path).unwrap();
+    store.save(fresh_creds(&server.uri())).unwrap();
+    let client = build_client(&server, &path);
+
+    for _ in 0..3 {
+        let _ = client.list_keys().await.unwrap();
+    }
+    // The MockServer's drop-time assertions fire here.
+    drop(server);
+}
+
+#[tokio::test]
+async fn refreshes_bearer_within_refresh_window_then_calls_management() {
+    let server = MockServer::start().await;
+    metadata_mock(&server).await;
+    Mock::given(method("POST"))
+        .and(wm_path("/oauth/token"))
+        .and(body_string_contains("grant_type=refresh_token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "access_token": "refreshed",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+            "refresh_token": "rotated-rt",
+            "scope": "keys:read",
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(wm_path("/v1/keys"))
+        .and(header("authorization", "Bearer refreshed"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "data": [] })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let path = tmp_creds_path("refresh");
+    let mut store = CredentialsStore::load(&path).unwrap();
+    // Within the refresh window — bearer() will exchange.
+    store
+        .save(Credentials {
+            access_token: "stale".into(),
+            refresh_token: Some("rt-original".into()),
+            expires_at: Utc::now() + ChronoDuration::seconds(10),
+            refresh_token_expires_at: None,
+            token_type: "Bearer".into(),
+            scope: "keys:read".into(),
+            client_id: "bitrouter-cli".into(),
+            authorization_server: server.uri(),
+            subject: None,
+        })
+        .unwrap();
+    let client = build_client(&server, &path);
+
+    let _ = client.list_keys().await.unwrap();
+    let reloaded = CredentialsStore::load(&path).unwrap();
+    assert_eq!(
+        reloaded.current().unwrap().refresh_token.as_deref(),
+        Some("rotated-rt"),
+    );
+}
+
+#[tokio::test]
+async fn unknown_error_code_falls_back_to_server_variant() {
+    let server = MockServer::start().await;
+    metadata_mock(&server).await;
+    Mock::given(method("GET"))
+        .and(wm_path("/v1/billing/balance"))
+        .respond_with(ResponseTemplate::new(502).set_body_json(json!({
+            "error": "bad_gateway",
+            "error_description": "upstream stripe failure",
+        })))
+        .mount(&server)
+        .await;
+    let path = tmp_creds_path("server-err");
+    let mut store = CredentialsStore::load(&path).unwrap();
+    store.save(fresh_creds(&server.uri())).unwrap();
+    let client = build_client(&server, &path);
+
+    let err = client.billing_balance().await.unwrap_err();
+    match err {
+        Error::Server { status, message } => {
+            assert_eq!(status, 502);
+            assert_eq!(message, "upstream stripe failure");
+        }
+        other => panic!("expected Server, got {other:?}"),
+    }
+}

--- a/crates/bitrouter-cloud-sdk/src/management/types.rs
+++ b/crates/bitrouter-cloud-sdk/src/management/types.rs
@@ -1,0 +1,140 @@
+//! Typed enums mirrored from the BitRouter Cloud crate.
+//!
+//! These shapes are stable parts of the `/v1/*` wire contract, so we
+//! re-declare them here rather than depend on the server crate. Each
+//! enum has the same `#[serde(rename_all = "snake_case")]` rendering
+//! as its server-side counterpart.
+
+use serde::{Deserialize, Serialize};
+
+/// Discriminator stored in `policies.kind`.
+///
+/// Mirrors `bitrouter_cloud::policy::spec::PolicyKind`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PolicyKind {
+    /// Spend cap over a rolling window.
+    Budget,
+    /// Request / token rate limit over a sliding window.
+    RateLimit,
+    /// Per-request constraints (model allow/deny, max tokens, etc.).
+    Guardrail,
+    /// Named bundle of the other three kinds.
+    Preset,
+}
+
+impl PolicyKind {
+    /// Wire-form string for this kind.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            PolicyKind::Budget => "budget",
+            PolicyKind::RateLimit => "rate_limit",
+            PolicyKind::Guardrail => "guardrail",
+            PolicyKind::Preset => "preset",
+        }
+    }
+}
+
+/// Rolling-spend window for a budget policy.
+///
+/// Mirrors `bitrouter_cloud::policy::spec::BudgetWindow`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BudgetWindow {
+    /// 24 hours rolling.
+    Day,
+    /// 30 days rolling.
+    Month,
+    /// Lifetime — accumulates indefinitely.
+    Total,
+}
+
+/// BYOK posture for a guardrail policy.
+///
+/// Mirrors `bitrouter_cloud::policy::spec::ByokRequirement`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ByokRequirement {
+    /// Inference call MUST be served via a BYOK provider key.
+    Required,
+    /// Inference call MUST NOT be served via a BYOK provider key.
+    Forbidden,
+    /// Either path is acceptable. Equivalent to no constraint.
+    Optional,
+}
+
+/// OAuth client kind.
+///
+/// Mirrors `bitrouter_cloud::oauth::clients::ClientType`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ClientType {
+    /// Backend-credentialed client; presents `client_secret` at the
+    /// token endpoint.
+    Confidential,
+    /// No client secret; PKCE is mandatory.
+    Public,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn policy_kind_round_trips_through_json() {
+        for k in [
+            PolicyKind::Budget,
+            PolicyKind::RateLimit,
+            PolicyKind::Guardrail,
+            PolicyKind::Preset,
+        ] {
+            let s = serde_json::to_string(&k).unwrap();
+            let back: PolicyKind = serde_json::from_str(&s).unwrap();
+            assert_eq!(back, k);
+        }
+    }
+
+    #[test]
+    fn budget_window_wire_form_is_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&BudgetWindow::Day).unwrap(),
+            "\"day\""
+        );
+        assert_eq!(
+            serde_json::to_string(&BudgetWindow::Month).unwrap(),
+            "\"month\""
+        );
+        assert_eq!(
+            serde_json::to_string(&BudgetWindow::Total).unwrap(),
+            "\"total\""
+        );
+    }
+
+    #[test]
+    fn client_type_wire_form_is_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&ClientType::Confidential).unwrap(),
+            "\"confidential\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ClientType::Public).unwrap(),
+            "\"public\""
+        );
+    }
+
+    #[test]
+    fn byok_requirement_wire_form_is_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&ByokRequirement::Required).unwrap(),
+            "\"required\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ByokRequirement::Forbidden).unwrap(),
+            "\"forbidden\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ByokRequirement::Optional).unwrap(),
+            "\"optional\""
+        );
+    }
+}

--- a/crates/bitrouter-cloud-sdk/src/management/usage.rs
+++ b/crates/bitrouter-cloud-sdk/src/management/usage.rs
@@ -1,0 +1,109 @@
+//! `/v1/usage` and `/v1/requests` — aggregate spend / token counts and
+//! the request history for the caller's account. Both require
+//! `usage:read`.
+//!
+//! Mirrors `bitrouter_cloud::v1::http::management::usage`.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use super::{ManagementClient, Result};
+
+/// Query string for `GET /v1/usage`. Both bounds are optional — the
+/// server defaults to a 30-day rolling window when neither is set.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct UsageQuery {
+    /// Lower bound (inclusive). Defaults to `to - 30 days`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub from: Option<DateTime<Utc>>,
+    /// Upper bound (exclusive). Defaults to `now`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub to: Option<DateTime<Utc>>,
+}
+
+/// Wire shape for `GET /v1/usage`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UsageResponse {
+    /// Effective lower bound used (echoed for clarity when defaulted).
+    pub from: DateTime<Utc>,
+    /// Effective upper bound used.
+    pub to: DateTime<Utc>,
+    /// Total spend in micro-USD over the window.
+    pub spend_micro_usd: i64,
+    /// Prompt-token count over the window.
+    pub prompt_tokens: i64,
+    /// Completion-token count over the window.
+    pub completion_tokens: i64,
+    /// Number of admitted requests in the window.
+    pub request_count: i64,
+}
+
+/// Query string for `GET /v1/requests` — paged list of recent requests.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct RequestsQuery {
+    /// Page size (server clamps to `[1, 100]`; defaults to 25).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u64>,
+    /// Offset into the result set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub offset: Option<u64>,
+}
+
+/// Wire shape for `GET /v1/requests`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RequestsResponse {
+    /// One envelope per request in this page.
+    pub data: Vec<RequestEnvelope>,
+    /// Effective page size used.
+    pub limit: u64,
+    /// Effective offset used.
+    pub offset: u64,
+}
+
+/// One row of the `requests` table.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RequestEnvelope {
+    /// Internal row id.
+    pub id: String,
+    /// `x-request-id` value seen on the wire (often a uuid).
+    pub request_id: String,
+    /// `pending` / `succeeded` / `failed` / `streaming` …
+    pub status: String,
+    /// Canonical model id (e.g. `claude-opus-4-7`).
+    #[serde(default)]
+    pub model_id: Option<String>,
+    /// Upstream provider id (e.g. `anthropic`).
+    #[serde(default)]
+    pub provider_id: Option<String>,
+    /// Prompt-token count for this single request.
+    pub prompt_tokens: i64,
+    /// Completion-token count.
+    pub completion_tokens: i64,
+    /// Final settled charge in micro-USD; absent until settlement
+    /// completes.
+    #[serde(default)]
+    pub final_charge_micro_usd: Option<i64>,
+    /// `cloud_credit` / `byok` / etc.
+    #[serde(default)]
+    pub funding_source: Option<String>,
+    /// `Some(true)` when the response was served as a stream.
+    #[serde(default)]
+    pub streamed: Option<bool>,
+    /// When the request was admitted.
+    pub created_at: DateTime<Utc>,
+    /// When the request finished (success or failure).
+    #[serde(default)]
+    pub completed_at: Option<DateTime<Utc>>,
+}
+
+impl ManagementClient {
+    /// `GET /v1/usage` — aggregate spend + token counts over a window.
+    pub async fn usage_aggregate(&self, query: &UsageQuery) -> Result<UsageResponse> {
+        self.get_with_query("/v1/usage", query).await
+    }
+
+    /// `GET /v1/requests` — paged list of recent requests.
+    pub async fn list_requests(&self, query: &RequestsQuery) -> Result<RequestsResponse> {
+        self.get_with_query("/v1/requests", query).await
+    }
+}


### PR DESCRIPTION
## Summary

Adds a `bitrouter cloud` CLI subcommand tree that drives the BitRouter Cloud `/v1/*` management surface — keys, usage, billing, policies, budgets, presets, BYOK, OAuth clients — using the OAuth credential `bitrouter auth login` already persists. Two layers:

- **`bitrouter-cloud-sdk::management`** — typed `ManagementClient` plus one sub-module per resource family (wire types + a method per endpoint). Shares the auth module's `CredentialsStore`, so the bearer is refreshed on the same RFC 6749 §6 / §4.14 single-flight schedule as the LLM provider applier. Typed `Error` mirrors the server's `{ error, error_description }` taxonomy and parses `"missing required scope: <s>"` into `Error::Forbidden { missing_scope: Some(s), .. }`.
- **`apps/bitrouter::cloud::cli`** — `bitrouter cloud {whoami, keys, usage, requests, billing, policy, budget, preset, byok, oauth-client}`. Every leaf accepts `--json`; the default text formatter is `systemctl`-style key:value blocks and small tables. Spec inputs for `policy {create,update}` and `preset {create,update}` clauses read from a file path or `-` for stdin. On a 403 with `missing_scope` the CLI reads the local scope and prints a copy-pasteable `bitrouter auth login --scope "<current> <missing>"` hint.

`cloud.rs` is reshaped into `cloud/{mod.rs, cli.rs}` so the new CLI lives next to the existing zero-config / applier glue.

Touch-ups: drop the "future scope" note in `bitrouter-cloud-sdk/src/lib.rs` now that the management client exists; the onboarding hint points at `bitrouter cloud --help` next to `bitrouter auth login`; the `bitrouter {login,logout,whoami}` (no-arg) stubs redirect to `bitrouter auth …` / `bitrouter cloud whoami` instead of saying "not in v1.0 scope".

## Test plan

- [x] `cargo fmt -- --check` clean
- [x] `cargo clippy --all-features` clean
- [x] `cargo nextest run --all-features` — 508/508 passing (15 new tests in `management::`)
- [x] `cargo test --doc` clean
- [x] `bitrouter cloud --help` and `bitrouter cloud {keys,policy} --help` render the expected subcommand trees
- [ ] End-to-end against a real `api.bitrouter.ai` account: `bitrouter auth login` → `bitrouter cloud whoami` → `bitrouter cloud keys list` → `bitrouter cloud usage` → `bitrouter cloud policy list`
- [ ] 403 path: revoke a scope locally (or call `bitrouter cloud oauth-client list` without `clients:read`) and confirm the re-login hint suggests the right scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)