### PR TITLE
feat(bitrouter): Windows support for the daemon control surface

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,22 @@
+# Default: detect text vs binary and normalise text to LF in the index,
+# leave working-copy line endings to the platform. The exceptions below
+# pin specific file groups to LF in the working copy too — any file whose
+# bytes are compared verbatim by a test must stay LF on Windows so git's
+# autocrlf doesn't rewrite \n → \r\n on checkout and cause spurious diffs.
+* text=auto
+
+# Schema-snapshot fixtures (`crates/bitrouter-sdk/src/language_model/protocol/snapshots/*.json`)
+# are read byte-for-byte by `assert_schema_snapshot` and compared against
+# freshly-generated JSON. Pin them to LF everywhere so the test passes on
+# Windows runners regardless of the user's `core.autocrlf` setting.
+*.json text eol=lf
+
+# Source files: LF everywhere. Avoids accidental CRLF creeping into the
+# repo via a Windows contributor's editor, which would otherwise confuse
+# rustfmt and a handful of macro span diagnostics.
+*.rs       text eol=lf
+*.toml     text eol=lf
+*.yaml     text eol=lf
+*.yml      text eol=lf
+*.md       text eol=lf
+*.sh       text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,19 +23,32 @@ jobs:
           components: rustfmt
       - run: cargo fmt --all -- --check
 
+  # Linux, macOS, and Windows are all first-class platforms — clippy and test
+  # run on each, no "primary" OS. The daemon control surface in particular has
+  # platform-specific code (Unix domain socket vs Windows named pipe, SIGHUP /
+  # SIGTERM vs ctrl_c, kill vs taskkill) and the matrix catches a regression in
+  # any one of them at PR time.
   clippy:
-    name: clippy
-    runs-on: ubuntu-latest
+    name: clippy (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: clippy
-      - run: cargo clippy --workspace --all-features -- -D warnings
+      - run: cargo clippy --workspace --all-features --tests -- -D warnings
 
   test:
-    name: test
-    runs-on: ubuntu-latest
+    name: test (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -722,7 +722,7 @@ dependencies = [
  "serde-saphyr",
  "serde_json",
  "sha2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tower 0.5.3",
  "tracing",

--- a/apps/bitrouter/src/daemon.rs
+++ b/apps/bitrouter/src/daemon.rs
@@ -8,8 +8,8 @@
 //! The transport is platform-specific but the wire protocol is identical:
 //! a **Unix domain socket** (mode `0600`) on Unix, and a **Windows named
 //! pipe** (`\\.\pipe\bitrouter-…`, secured by its default owner-only DACL)
-//! on Windows. Both are encapsulated by the private [`transport`] module so
-//! the rest of this file — and every caller — is platform-agnostic.
+//! on Windows. Both are encapsulated by a private `transport` module so the
+//! rest of this file — and every caller — is platform-agnostic.
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;

--- a/apps/bitrouter/src/daemon.rs
+++ b/apps/bitrouter/src/daemon.rs
@@ -1,17 +1,22 @@
-//! Daemon control over a Unix domain socket.
+//! Daemon control over a local IPC channel.
 //!
-//! A running `bitrouter serve` listens on a control socket alongside the HTTP
-//! API. The CLI's `stop` / `restart` / `reload` / `status` / `route`
+//! A running `bitrouter serve` listens on a control endpoint alongside the
+//! HTTP API. The CLI's `stop` / `restart` / `reload` / `status` / `route`
 //! subcommands are thin clients that connect, send one newline-delimited JSON
 //! [`DaemonCommand`], and read one [`DaemonResponse`].
+//!
+//! The transport is platform-specific but the wire protocol is identical:
+//! a **Unix domain socket** (mode `0600`) on Unix, and a **Windows named
+//! pipe** (`\\.\pipe\bitrouter-…`, secured by its default owner-only DACL)
+//! on Windows. Both are encapsulated by the private [`transport`] module so
+//! the rest of this file — and every caller — is platform-agnostic.
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::net::{UnixListener, UnixStream};
+use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
 
 use bitrouter_sdk::App;
 use bitrouter_sdk::caller::CallerContext;
@@ -249,11 +254,12 @@ pub fn resolve_socket_path(config_path: &Path, cfg_socket: &str) -> PathBuf {
     }
 }
 
-/// True when `err` came from connecting to a Unix socket that nothing
+/// True when `err` came from connecting to a control endpoint that nothing
 /// is listening on — i.e. the daemon is stopped, not that something
 /// else went wrong. Inspects the chain for an io error of kind
-/// `NotFound` (socket file absent) or `ConnectionRefused` (file present
-/// but no acceptor, e.g. stale after a crash).
+/// `NotFound` (socket file / pipe absent) or `ConnectionRefused` (endpoint
+/// present but no acceptor, e.g. stale after a crash). On Windows a missing
+/// named pipe surfaces as `ERROR_FILE_NOT_FOUND`, which maps to `NotFound`.
 pub fn is_not_reachable(err: &anyhow::Error) -> bool {
     err.chain().any(|cause| {
         cause
@@ -270,11 +276,12 @@ pub fn is_not_reachable(err: &anyhow::Error) -> bool {
 
 // ===== server side =====
 
-/// Run the control-socket listener until a `Stop` command is received (then it
+/// Run the control listener until a `Stop` command is received (then it
 /// returns) — run this alongside `App::serve` under a `tokio::select!`.
 ///
-/// `listen` is the HTTP address (reported in `Status`); the socket is bound at
-/// `socket_path` and removed on return.
+/// `listen` is the HTTP address (reported in `Status`); the endpoint is bound
+/// at `socket_path` (a Unix socket file, or a named pipe derived from the path
+/// on Windows) and torn down on return.
 pub async fn run_control_socket(
     socket_path: PathBuf,
     app: Arc<App>,
@@ -282,36 +289,21 @@ pub async fn run_control_socket(
     reloader: Arc<dyn DaemonReloader>,
     observe: Arc<dyn ObserveStatusProvider>,
 ) -> Result<()> {
-    // A stale socket file from a crashed daemon would block the bind.
-    let _ = tokio::fs::remove_file(&socket_path).await;
-    let listener = UnixListener::bind(&socket_path)
-        .with_context(|| format!("binding control socket {}", socket_path.display()))?;
-    // The control surface includes Stop / Reload — only the daemon owner may
-    // reach it. UnixListener::bind respects the process umask (typically 022 →
-    // 0755); tighten to 0600 explicitly so any other local user is excluded.
-    use std::os::unix::fs::PermissionsExt;
-    tokio::fs::set_permissions(&socket_path, std::fs::Permissions::from_mode(0o600))
-        .await
-        .with_context(|| format!("chmod 0600 {}", socket_path.display()))?;
-    tracing::info!(socket = %socket_path.display(), "control socket listening (mode 0600)");
-
-    let result = accept_loop(&listener, &app, &listen, &reloader, &observe).await;
-    let _ = tokio::fs::remove_file(&socket_path).await;
+    let mut listener = transport::bind(&socket_path).await?;
+    let result = accept_loop(&mut listener, &app, &listen, &reloader, &observe).await;
+    listener.cleanup().await;
     result
 }
 
 async fn accept_loop(
-    listener: &UnixListener,
+    listener: &mut transport::ControlListener,
     app: &Arc<App>,
     listen: &str,
     reloader: &Arc<dyn DaemonReloader>,
     observe: &Arc<dyn ObserveStatusProvider>,
 ) -> Result<()> {
     loop {
-        let (stream, _addr) = listener
-            .accept()
-            .await
-            .context("accepting control-socket connection")?;
+        let stream = listener.accept().await?;
         // Handle one command per connection. A `Stop` ends the loop (and thus
         // the whole `serve`); any other command loops for the next client.
         if handle_connection(stream, app, listen, reloader, observe).await? {
@@ -322,13 +314,20 @@ async fn accept_loop(
 }
 
 /// Handle one connection. Returns `Ok(true)` if it was a `Stop` command.
-async fn handle_connection(
-    stream: UnixStream,
+///
+/// Generic over the concrete stream so the same logic drives a Unix
+/// `UnixStream` and a Windows `NamedPipeServer` — both implement the tokio
+/// async IO traits.
+async fn handle_connection<S>(
+    stream: S,
     app: &Arc<App>,
     listen: &str,
     reloader: &Arc<dyn DaemonReloader>,
     observe: &Arc<dyn ObserveStatusProvider>,
-) -> Result<bool> {
+) -> Result<bool>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
     let mut reader = BufReader::new(stream);
     let mut line = String::new();
     if reader.read_line(&mut line).await? == 0 {
@@ -427,7 +426,10 @@ async fn dispatch(
     }
 }
 
-async fn write_response(stream: &mut UnixStream, response: &DaemonResponse) -> Result<()> {
+async fn write_response<S>(stream: &mut S, response: &DaemonResponse) -> Result<()>
+where
+    S: AsyncWrite + Unpin,
+{
     let mut json = serde_json::to_string(response).context("serialising daemon response")?;
     json.push('\n');
     stream.write_all(json.as_bytes()).await?;
@@ -437,15 +439,27 @@ async fn write_response(stream: &mut UnixStream, response: &DaemonResponse) -> R
 
 // ===== client side =====
 
-/// Connect to a running daemon's control socket, send `command`, return its
+/// Connect to a running daemon's control endpoint and hand back the raw
+/// stream. Used by [`send_command`] and by integration tests that need to
+/// push bytes the normal client wouldn't (e.g. malformed input). Fails
+/// clearly if no daemon is listening.
+pub async fn connect_control(socket_path: &Path) -> Result<impl AsyncRead + AsyncWrite + Unpin> {
+    transport::connect(socket_path).await
+}
+
+/// True when something is already bound to the control endpoint at `path`
+/// (i.e. a daemon is — or was — running). On Unix this is "the socket file
+/// exists"; on Windows it probes the named pipe. `restart` uses it to decide
+/// whether to send a `Stop` and to wait for the old daemon to release the
+/// endpoint before the replacement binds.
+pub fn endpoint_in_use(path: &Path) -> bool {
+    transport::endpoint_in_use(path)
+}
+
+/// Connect to a running daemon's control endpoint, send `command`, return its
 /// response. Fails clearly if no daemon is listening.
 pub async fn send_command(socket_path: &Path, command: &DaemonCommand) -> Result<DaemonResponse> {
-    let stream = UnixStream::connect(socket_path).await.with_context(|| {
-        format!(
-            "connecting to {} — is the daemon running? (`bitrouter start`)",
-            socket_path.display()
-        )
-    })?;
+    let stream = transport::connect(socket_path).await?;
     let mut reader = BufReader::new(stream);
     let mut json = serde_json::to_string(command).context("serialising command")?;
     json.push('\n');
@@ -461,6 +475,250 @@ pub async fn send_command(socket_path: &Path, command: &DaemonCommand) -> Result
         anyhow::bail!("daemon closed the connection without responding");
     }
     serde_json::from_str(line.trim()).context("parsing daemon response")
+}
+
+// ===== platform transport =====
+
+/// Unix transport: a `tokio::net::UnixListener` bound to the socket path,
+/// tightened to mode `0600`. The socket file is removed on teardown.
+#[cfg(unix)]
+mod transport {
+    use std::path::{Path, PathBuf};
+
+    use anyhow::{Context, Result};
+    use tokio::net::{UnixListener, UnixStream};
+
+    /// Server-side listener wrapping a bound Unix socket.
+    pub struct ControlListener {
+        listener: UnixListener,
+        path: PathBuf,
+    }
+
+    /// Bind the control socket, removing any stale file first and tightening
+    /// permissions to owner-only.
+    pub async fn bind(path: &Path) -> Result<ControlListener> {
+        // A stale socket file from a crashed daemon would block the bind.
+        let _ = tokio::fs::remove_file(path).await;
+        let listener = UnixListener::bind(path)
+            .with_context(|| format!("binding control socket {}", path.display()))?;
+        // The control surface includes Stop / Reload — only the daemon owner
+        // may reach it. `UnixListener::bind` respects the process umask
+        // (typically 022 → 0755); tighten to 0600 explicitly so any other
+        // local user is excluded.
+        use std::os::unix::fs::PermissionsExt;
+        tokio::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+            .await
+            .with_context(|| format!("chmod 0600 {}", path.display()))?;
+        tracing::info!(socket = %path.display(), "control socket listening (mode 0600)");
+        Ok(ControlListener {
+            listener,
+            path: path.to_path_buf(),
+        })
+    }
+
+    impl ControlListener {
+        /// Accept the next client connection.
+        pub async fn accept(&mut self) -> Result<UnixStream> {
+            let (stream, _addr) = self
+                .listener
+                .accept()
+                .await
+                .context("accepting control-socket connection")?;
+            Ok(stream)
+        }
+
+        /// Remove the socket file on shutdown.
+        pub async fn cleanup(self) {
+            let _ = tokio::fs::remove_file(&self.path).await;
+        }
+    }
+
+    /// Connect to the control socket.
+    pub async fn connect(path: &Path) -> Result<UnixStream> {
+        UnixStream::connect(path).await.with_context(|| {
+            format!(
+                "connecting to {} — is the daemon running? (`bitrouter start`)",
+                path.display()
+            )
+        })
+    }
+
+    /// On Unix the socket is a real file: its presence means a daemon bound it.
+    pub fn endpoint_in_use(path: &Path) -> bool {
+        path.exists()
+    }
+}
+
+/// Windows transport: a named pipe whose name is derived from the control
+/// path.
+///
+/// Security: the pipe is created with the **default** security descriptor.
+/// That grants full control to the creating user, `LocalSystem` and
+/// administrators, and only `GENERIC_READ` to `Everyone` — so a co-tenant
+/// non-admin user cannot perform the read+write open a control client needs
+/// (it is denied with `ERROR_ACCESS_DENIED`) and therefore cannot issue
+/// `Stop` / `Reload`. This is the practical analog of the Unix socket's
+/// `0600` mode. Tightening to a literally owner-only DACL would require a
+/// custom `SECURITY_ATTRIBUTES` pointer via
+/// `ServerOptions::create_with_security_attributes_raw`, which is `unsafe` —
+/// and this crate is `#![forbid(unsafe_code)]`, so we rely on the default
+/// descriptor instead.
+#[cfg(windows)]
+mod transport {
+    use std::path::Path;
+    use std::time::Duration;
+
+    use anyhow::{Context, Result};
+    use tokio::net::windows::named_pipe::{
+        ClientOptions, NamedPipeClient, NamedPipeServer, ServerOptions,
+    };
+
+    /// `ERROR_PIPE_BUSY` — every pipe instance is currently connected. The
+    /// server re-arms a fresh instance immediately after each accept, so this
+    /// is a transient race the client retries through.
+    const ERROR_PIPE_BUSY: i32 = 231;
+
+    /// Map a filesystem-style control path to a named-pipe name. An explicit
+    /// `\\.\pipe\…` path is honoured verbatim; any other path is hashed into a
+    /// stable, valid pipe name so the daemon and every client agree on the
+    /// same endpoint regardless of the launcher's working directory. Windows
+    /// paths are case-insensitive, so the name is case-folded before hashing.
+    pub fn pipe_name(path: &Path) -> String {
+        let raw = path.to_string_lossy();
+        let lower = raw.to_ascii_lowercase();
+        if lower.starts_with(r"\\.\pipe\") || lower.starts_with(r"\\?\pipe\") {
+            return raw.into_owned();
+        }
+        use sha2::{Digest, Sha256};
+        let mut hasher = Sha256::new();
+        hasher.update(lower.as_bytes());
+        let digest = hasher.finalize();
+        format!(r"\\.\pipe\bitrouter-{}", hex::encode(&digest[..16]))
+    }
+
+    /// Server-side listener wrapping the currently-waiting pipe instance.
+    pub struct ControlListener {
+        name: String,
+        /// The next instance waiting for a client. `accept` hands this out and
+        /// re-arms a replacement so there is no window with no listener.
+        server: NamedPipeServer,
+    }
+
+    /// Create the first pipe instance. `first_pipe_instance(true)` makes this
+    /// fail loudly if another process already owns the name (e.g. a second
+    /// daemon racing the same control path) rather than silently sharing it.
+    pub async fn bind(path: &Path) -> Result<ControlListener> {
+        let name = pipe_name(path);
+        let server = ServerOptions::new()
+            .first_pipe_instance(true)
+            .create(&name)
+            .with_context(|| format!("creating control pipe {name}"))?;
+        tracing::info!(pipe = %name, "control pipe listening");
+        Ok(ControlListener { name, server })
+    }
+
+    impl ControlListener {
+        /// Wait for the next client, then re-arm a fresh instance and return
+        /// the connected one. Mirrors a `UnixListener::accept`.
+        pub async fn accept(&mut self) -> Result<NamedPipeServer> {
+            self.server
+                .connect()
+                .await
+                .context("waiting for control-pipe client")?;
+            let next = ServerOptions::new()
+                .create(&self.name)
+                .with_context(|| format!("re-arming control pipe {}", self.name))?;
+            Ok(std::mem::replace(&mut self.server, next))
+        }
+
+        /// Nothing to unlink — a named pipe disappears when its last instance
+        /// handle closes.
+        pub async fn cleanup(self) {}
+    }
+
+    /// Connect to the control pipe, retrying briefly through the `ERROR_PIPE_BUSY`
+    /// window the server opens while re-arming between clients.
+    pub async fn connect(path: &Path) -> Result<NamedPipeClient> {
+        let name = pipe_name(path);
+        let mut last_busy: Option<std::io::Error> = None;
+        for _ in 0..50 {
+            match ClientOptions::new().open(&name) {
+                Ok(client) => return Ok(client),
+                Err(e) if e.raw_os_error() == Some(ERROR_PIPE_BUSY) => {
+                    last_busy = Some(e);
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                }
+                Err(e) => {
+                    return Err(e).with_context(|| {
+                        format!("connecting to {name} — is the daemon running? (`bitrouter start`)")
+                    });
+                }
+            }
+        }
+        let e = last_busy.unwrap_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::TimedOut, "control pipe busy")
+        });
+        Err(e).with_context(|| format!("connecting to {name} — daemon stayed busy"))
+    }
+
+    /// Probe whether a daemon currently owns the pipe. A successful open (or a
+    /// busy reply) means it does; "not found" means it has been released.
+    pub fn endpoint_in_use(path: &Path) -> bool {
+        let name = pipe_name(path);
+        match ClientOptions::new().open(&name) {
+            Ok(_client) => true,
+            Err(e) => e.raw_os_error() == Some(ERROR_PIPE_BUSY),
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::pipe_name;
+        use std::path::PathBuf;
+
+        #[test]
+        fn explicit_pipe_path_is_returned_verbatim() {
+            // `\\.\pipe\…` is already a valid pipe name — pass it through so an
+            // operator can override the derived name in `server.control_socket`.
+            let p = PathBuf::from(r"\\.\pipe\bitrouter-custom");
+            assert_eq!(pipe_name(&p), r"\\.\pipe\bitrouter-custom");
+        }
+
+        #[test]
+        fn nt_style_pipe_path_is_returned_verbatim() {
+            let p = PathBuf::from(r"\\?\pipe\bitrouter-custom");
+            assert_eq!(pipe_name(&p), r"\\?\pipe\bitrouter-custom");
+        }
+
+        #[test]
+        fn filesystem_path_maps_to_deterministic_pipe_name() {
+            // The hash must be stable so the daemon (which binds) and the
+            // client (which connects from a possibly-different CWD) agree.
+            let a = pipe_name(&PathBuf::from(r"C:\Users\alice\.bitrouter\bitrouter.sock"));
+            let b = pipe_name(&PathBuf::from(r"C:\Users\alice\.bitrouter\bitrouter.sock"));
+            assert_eq!(a, b);
+            assert!(
+                a.starts_with(r"\\.\pipe\bitrouter-"),
+                "unexpected pipe name {a}"
+            );
+        }
+
+        #[test]
+        fn case_differences_collapse_to_one_name() {
+            // Windows paths are case-insensitive. If two invocations capitalise
+            // the drive letter differently, they must still find the same pipe.
+            let lower = pipe_name(&PathBuf::from(r"c:\users\alice\.bitrouter\bitrouter.sock"));
+            let upper = pipe_name(&PathBuf::from(r"C:\Users\Alice\.BitRouter\bitrouter.sock"));
+            assert_eq!(lower, upper);
+        }
+
+        #[test]
+        fn different_paths_map_to_different_pipe_names() {
+            let a = pipe_name(&PathBuf::from(r"C:\Users\alice\.bitrouter\bitrouter.sock"));
+            let b = pipe_name(&PathBuf::from(r"C:\Users\bob\.bitrouter\bitrouter.sock"));
+            assert_ne!(a, b);
+        }
+    }
 }
 
 // ===== PID file =====

--- a/apps/bitrouter/src/main.rs
+++ b/apps/bitrouter/src/main.rs
@@ -3,9 +3,9 @@
 //! Subcommand surface: `serve` / `start` / `stop` / `restart` /
 //! `reload` / `status` / `route` / `init` / `key sign` / `models` / `tools` /
 //! `policy create` / `providers (list|use)` / `wallet` / `login` / `logout` /
-//! `whoami` / `agents`. Daemon control runs over a Unix socket —
-//! `start` spawns `serve` detached; the client subcommands send one
-//! [`DaemonCommand`] each.
+//! `whoami` / `agents`. Daemon control runs over a local IPC endpoint
+//! (a Unix domain socket, or a Windows named pipe) — `start` spawns
+//! `serve` detached; the client subcommands send one [`DaemonCommand`] each.
 //!
 //! v1.0 ships the routing / settlement subsystems wired here. Subsystems that
 //! belong to *other* services (OWS wallet, cloud login, ACP runtime) print an
@@ -693,54 +693,86 @@ async fn serve(source: &bitrouter::paths::ConfigSource) -> Result<()> {
         observe_provider,
     );
 
-    // SIGHUP triggers a config reload — per, reload should be
-    // available via either `bitrouter reload` (the socket path) *or* a HUP
-    // signal. Same fan-out as the Reload command — every reloadable subsystem.
+    // SIGHUP triggers a config reload — reload should be available via either
+    // `bitrouter reload` (the control endpoint) *or* a HUP signal. Same fan-out
+    // as the Reload command — every reloadable subsystem. SIGHUP is Unix-only;
+    // on Windows there is no equivalent, so the HUP future stays pending and
+    // reload is reached exclusively through `bitrouter reload`.
     let hup_reloader = reloader.clone();
     let hup = async move {
-        use tokio::signal::unix::{SignalKind, signal};
-        let mut hup = match signal(SignalKind::hangup()) {
-            Ok(s) => s,
-            Err(e) => return Err::<(), _>(anyhow::Error::from(e)),
-        };
-        loop {
-            if hup.recv().await.is_none() {
-                return Ok(());
+        #[cfg(unix)]
+        {
+            use tokio::signal::unix::{SignalKind, signal};
+            let mut hup = match signal(SignalKind::hangup()) {
+                Ok(s) => s,
+                Err(e) => return Err::<(), anyhow::Error>(anyhow::Error::from(e)),
+            };
+            loop {
+                if hup.recv().await.is_none() {
+                    return Ok(());
+                }
+                match hup_reloader.reload().await {
+                    Ok(()) => tracing::info!("SIGHUP — reload succeeded"),
+                    Err(e) => tracing::warn!(error = %e, "SIGHUP reload failed"),
+                }
             }
-            match hup_reloader.reload().await {
-                Ok(()) => tracing::info!("SIGHUP — reload succeeded"),
-                Err(e) => tracing::warn!(error = %e, "SIGHUP reload failed"),
-            }
+        }
+        #[cfg(not(unix))]
+        {
+            // No SIGHUP on this platform — keep the reloader handle alive and
+            // park forever so the `select!` arm below never fires.
+            let _keep = &hup_reloader;
+            std::future::pending::<()>().await;
+            Ok::<(), anyhow::Error>(())
         }
     };
 
-    // SIGINT (ctrl-C) and SIGTERM (systemd / `kill`) end the loop the
-    // same way `bitrouter stop` does — so the shutdown path below
-    // (observe flush, pid-file cleanup) runs in every termination
-    // mode except SIGKILL.
+    // Termination signals end the loop the same way `bitrouter stop` does — so
+    // the shutdown path below (observe flush, pid-file cleanup) runs in every
+    // graceful termination mode. On Unix that's SIGINT (ctrl-C) and SIGTERM
+    // (systemd / `kill`); on Windows it's the console control events
+    // (Ctrl-C / Ctrl-Break / window close / system shutdown).
     let term = async {
-        use tokio::signal::unix::{SignalKind, signal};
-        let mut sigint = signal(SignalKind::interrupt()).map_err(anyhow::Error::from)?;
-        let mut sigterm = signal(SignalKind::terminate()).map_err(anyhow::Error::from)?;
-        tokio::select! {
-            _ = sigint.recv() => tracing::info!("SIGINT — shutting down"),
-            _ = sigterm.recv() => tracing::info!("SIGTERM — shutting down"),
+        #[cfg(unix)]
+        {
+            use tokio::signal::unix::{SignalKind, signal};
+            let mut sigint = signal(SignalKind::interrupt()).map_err(anyhow::Error::from)?;
+            let mut sigterm = signal(SignalKind::terminate()).map_err(anyhow::Error::from)?;
+            tokio::select! {
+                _ = sigint.recv() => tracing::info!("SIGINT — shutting down"),
+                _ = sigterm.recv() => tracing::info!("SIGTERM — shutting down"),
+            }
+            Ok::<(), anyhow::Error>(())
         }
-        Ok::<(), anyhow::Error>(())
+        #[cfg(windows)]
+        {
+            use tokio::signal::windows;
+            let mut ctrl_c = windows::ctrl_c().map_err(anyhow::Error::from)?;
+            let mut ctrl_break = windows::ctrl_break().map_err(anyhow::Error::from)?;
+            let mut ctrl_close = windows::ctrl_close().map_err(anyhow::Error::from)?;
+            let mut ctrl_shutdown = windows::ctrl_shutdown().map_err(anyhow::Error::from)?;
+            tokio::select! {
+                _ = ctrl_c.recv() => tracing::info!("Ctrl-C — shutting down"),
+                _ = ctrl_break.recv() => tracing::info!("Ctrl-Break — shutting down"),
+                _ = ctrl_close.recv() => tracing::info!("console close — shutting down"),
+                _ = ctrl_shutdown.recv() => tracing::info!("system shutdown — shutting down"),
+            }
+            Ok::<(), anyhow::Error>(())
+        }
     };
 
     let result = tokio::select! {
         r = http => r,
         r = control => r,
-        // SIGHUP loop never returns Ok by design; an error from signal setup
-        // is logged and we keep serving.
+        // HUP loop never returns Ok by design (Unix); an error from signal
+        // setup is logged and we keep serving. On Windows this arm is pending.
         r = hup => match r {
             Ok(()) => Ok(()),
             Err(e) => { tracing::warn!(error = %e, "SIGHUP listener unavailable"); Ok(()) }
         },
         r = term => match r {
             Ok(()) => Ok(()),
-            Err(e) => { tracing::warn!(error = %e, "SIGINT/SIGTERM listener unavailable"); Ok(()) }
+            Err(e) => { tracing::warn!(error = %e, "termination-signal listener unavailable"); Ok(()) }
         },
     };
 
@@ -801,11 +833,14 @@ async fn start(source: &bitrouter::paths::ConfigSource, log_path: &Path) -> Resu
         .try_clone()
         .context("duplicating log handle for stderr")?;
 
-    // Detach the child into its own process group so the parent shell's
-    // SIGHUP (terminal close) does not propagate to it. Otherwise closing the
-    // tab would kill the daemon. Pattern from
+    // Detach the child so the launcher's console / terminal lifecycle does not
+    // take the daemon down with it. On Unix that means a new process group so
+    // the parent shell's SIGHUP (terminal close) does not propagate — otherwise
+    // closing the tab would kill the daemon. Pattern from
     // https://doc.rust-lang.org/std/os/unix/process/trait.CommandExt.html#tymethod.process_group
-    use std::os::unix::process::CommandExt;
+    // On Windows the equivalent is DETACHED_PROCESS (the child gets no inherited
+    // console) plus CREATE_NEW_PROCESS_GROUP (a Ctrl-C / Ctrl-Break in the
+    // launcher's console is not delivered to the daemon).
     let mut cmd = std::process::Command::new(&exe);
     cmd.arg("serve");
     // For a `File` source pass `--config <abs path>` so the child
@@ -816,13 +851,23 @@ async fn start(source: &bitrouter::paths::ConfigSource, log_path: &Path) -> Resu
     if let bitrouter::paths::ConfigSource::File(path) = source {
         cmd.arg("--config").arg(path);
     }
-    let mut child = cmd
-        .stdout(std::process::Stdio::from(log))
+    cmd.stdout(std::process::Stdio::from(log))
         .stderr(std::process::Stdio::from(log_err))
-        .stdin(std::process::Stdio::null())
-        .process_group(0)
-        .spawn()
-        .context("spawning detached `bitrouter serve`")?;
+        .stdin(std::process::Stdio::null());
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        cmd.process_group(0);
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        // Winbase.h constants — avoid pulling in a `windows`/`winapi` crate.
+        const DETACHED_PROCESS: u32 = 0x0000_0008;
+        const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
+        cmd.creation_flags(DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP);
+    }
+    let mut child = cmd.spawn().context("spawning detached `bitrouter serve`")?;
 
     // Liveness grace period: if the child explodes immediately (bad config,
     // port already in use, …) we want the user to know now, not in the log.
@@ -931,8 +976,10 @@ async fn restart(
     log_path: &Path,
 ) -> Result<()> {
     // Stop is best-effort — a missing daemon is fine, we just go straight to
-    // start. Any other error from the running daemon is fatal.
-    if socket.exists() {
+    // start. Any other error from the running daemon is fatal. `endpoint_in_use`
+    // abstracts "is a daemon bound here?" across the Unix socket file and the
+    // Windows named pipe.
+    if daemon::endpoint_in_use(socket) {
         match daemon::send_command(socket, &DaemonCommand::Stop).await {
             Ok(DaemonResponse::Ok) => println!("daemon stopped"),
             Ok(DaemonResponse::Error { message }) => return Err(anyhow::anyhow!(message)),
@@ -940,16 +987,16 @@ async fn restart(
             Err(e) => tracing::warn!(error = %e, "stop failed — proceeding to start"),
         }
         //.2 allows in-flight requests up to 30s to drain. Wait that
-        // long for the socket to be released. If it still isn't, escalate to
-        // SIGKILL on the recorded pid — otherwise `start` would race the old
-        // process for the same socket and one of them would die silently.
+        // long for the endpoint to be released. If it still isn't, escalate to
+        // a forced kill of the recorded pid — otherwise `start` would race the
+        // old process for the same endpoint and one of them would die silently.
         let pid_path = pid_path_for(socket);
         if !wait_for_socket_release(socket, std::time::Duration::from_secs(30)).await {
-            tracing::warn!("socket still held after 30s — escalating to SIGKILL on pid file");
+            tracing::warn!("endpoint still held after 30s — escalating to force-kill on pid file");
             if let Some(pid) = daemon::read_pid_file(&pid_path).await {
                 force_kill(pid).await;
             }
-            // One more brief wait so the kernel cleans up the socket inode.
+            // One more brief wait so the OS cleans up the endpoint.
             wait_for_socket_release(socket, std::time::Duration::from_secs(2)).await;
             // The killed daemon never removed its pid file; do it now.
             daemon::remove_pid_file(&pid_path).await;
@@ -958,17 +1005,18 @@ async fn restart(
     start(source, log_path).await
 }
 
-/// Poll until the socket file is gone (the old daemon removes it on exit), up
-/// to `timeout`. Returns true on success, false on timeout.
+/// Poll until the control endpoint is released (the old daemon drops the Unix
+/// socket file / closes the last named-pipe instance on exit), up to
+/// `timeout`. Returns true on success, false on timeout.
 async fn wait_for_socket_release(socket: &Path, timeout: std::time::Duration) -> bool {
     let deadline = std::time::Instant::now() + timeout;
     while std::time::Instant::now() < deadline {
-        if !socket.exists() {
+        if !daemon::endpoint_in_use(socket) {
             return true;
         }
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
     }
-    !socket.exists()
+    !daemon::endpoint_in_use(socket)
 }
 
 async fn reload(socket: &Path) -> Result<()> {
@@ -1079,7 +1127,7 @@ fn print_status_row(p: &bitrouter::style::Palette, label: &str, value: &str) {
 
 async fn route(model: &str, source: &bitrouter::paths::ConfigSource, socket: &Path) -> Result<()> {
     // Try the running daemon first — its routing table reflects any `reload`s.
-    if socket.exists() {
+    if daemon::endpoint_in_use(socket) {
         match daemon::send_command(
             socket,
             &DaemonCommand::Route {
@@ -1501,9 +1549,10 @@ fn print_unimplemented(name: &str, detail: &str) {
     }
 }
 
-/// Liveness check: `kill -0 <pid>` returns success iff the pid is reachable
-/// (i.e. exists and we have permission to signal it). No actual signal is
-/// sent. We shell out to keep `apps/bitrouter` `#![forbid(unsafe_code)]`.
+/// Liveness check: on Unix `kill -0 <pid>` returns success iff the pid is
+/// reachable (i.e. exists and we have permission to signal it). No actual
+/// signal is sent. We shell out to keep `apps/bitrouter` `#![forbid(unsafe_code)]`.
+#[cfg(unix)]
 fn process_is_alive(pid: u32) -> bool {
     std::process::Command::new("kill")
         .args(["-0", &pid.to_string()])
@@ -1514,11 +1563,45 @@ fn process_is_alive(pid: u32) -> bool {
         .unwrap_or(false)
 }
 
-/// Send SIGKILL to `pid`. Best-effort — if the process is already gone the
-/// kernel returns ESRCH and we silently move on.
+/// Liveness check on Windows: `tasklist` filtered to the pid. `tasklist` ships
+/// on every Windows install, so we shell out (rather than calling the Win32
+/// API) to keep `apps/bitrouter` free of `unsafe`. When no process matches,
+/// `tasklist` prints an informational line instead of a CSV row — so we look
+/// for the quoted pid the CSV format emits (`"<pid>"`).
+#[cfg(windows)]
+fn process_is_alive(pid: u32) -> bool {
+    let output = std::process::Command::new("tasklist")
+        .args(["/FI", &format!("PID eq {pid}"), "/NH", "/FO", "CSV"])
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .output();
+    match output {
+        Ok(out) => {
+            let text = String::from_utf8_lossy(&out.stdout);
+            text.contains(&format!("\"{pid}\""))
+        }
+        Err(_) => false,
+    }
+}
+
+/// Forcibly terminate `pid`. Best-effort — if the process is already gone we
+/// silently move on. On Unix this is SIGKILL (the kernel returns ESRCH for a
+/// dead pid); on Windows it's `taskkill /F`.
+#[cfg(unix)]
 async fn force_kill(pid: u32) {
     let _ = tokio::process::Command::new("kill")
         .args(["-9", &pid.to_string()])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .await;
+}
+
+/// Forcibly terminate `pid` on Windows via `taskkill /F`. Best-effort.
+#[cfg(windows)]
+async fn force_kill(pid: u32) {
+    let _ = tokio::process::Command::new("taskkill")
+        .args(["/PID", &pid.to_string(), "/F"])
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
         .status()

--- a/apps/bitrouter/src/paths.rs
+++ b/apps/bitrouter/src/paths.rs
@@ -21,9 +21,11 @@
 //! subcommand can decide whether to load from disk or build from
 //! [`bitrouter_providers::zero_config`].
 //!
-//! On Windows / non-Unix without `$HOME`, step 5 degrades to a clear
-//! error pointing at `$BITROUTER_HOME`. Tests should always pass
-//! `-c <path>` explicitly so they never depend on the live env.
+//! On Windows `$HOME` is usually unset, so step 4/5 fall back to
+//! `%USERPROFILE%` (→ `C:\Users\<name>\.bitrouter`). With neither set,
+//! step 5 degrades to a clear error pointing at `$BITROUTER_HOME`. Tests
+//! should always pass `-c <path>` explicitly so they never depend on the
+//! live env.
 
 use std::path::{Path, PathBuf};
 
@@ -73,7 +75,8 @@ impl ConfigSource {
 }
 
 /// Resolve the config source according to the documented order. Reads
-/// the live environment (`current_dir`, `$BITROUTER_HOME`, `$HOME`).
+/// the live environment (`current_dir`, `$BITROUTER_HOME`, `$HOME`, and
+/// `%USERPROFILE%` on Windows as the `$HOME` fallback).
 /// Does **not** write anything to disk — the [`ConfigSource::Default`]
 /// branch is purely in-memory until a caller (typically `serve`) chdirs
 /// into the implicit home.
@@ -84,6 +87,12 @@ pub fn resolve_config(explicit: Option<&Path>) -> Result<ConfigSource> {
     let cwd = std::env::current_dir().ok();
     let bitrouter_home = std::env::var_os("BITROUTER_HOME").filter(|v| !v.is_empty());
     let home = std::env::var_os("HOME").filter(|v| !v.is_empty());
+    // Windows doesn't set `$HOME`; fall back to `%USERPROFILE%` so
+    // `~/.bitrouter` resolves to `C:\Users\<name>\.bitrouter` and the daemon's
+    // runtime artefacts (socket/pipe, pid, log, db) get a stable home without
+    // the operator having to set `$BITROUTER_HOME` by hand.
+    #[cfg(windows)]
+    let home = home.or_else(|| std::env::var_os("USERPROFILE").filter(|v| !v.is_empty()));
     let outcome = resolve_config_with(
         explicit,
         cwd.as_deref(),

--- a/apps/bitrouter/tests/daemon.rs
+++ b/apps/bitrouter/tests/daemon.rs
@@ -1,6 +1,9 @@
-//! Integration tests for the Unix-socket daemon control surface:
-//! roundtrip `Status` / `Route` / `Reload` / `Stop` against a fully assembled
-//! `App`. Bare-bones — no HTTP server, just the control socket.
+//! Integration tests for the daemon control surface: roundtrip
+//! `Status` / `Route` / `Reload` / `Stop` against a fully assembled `App`.
+//! Bare-bones — no HTTP server, just the control endpoint. The transport is
+//! platform-specific (a Unix domain socket, or a Windows named pipe), but
+//! these tests drive it through the platform-agnostic `daemon` API so they
+//! run unchanged on both.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -60,13 +63,19 @@ async fn write_config(dir: &std::path::Path, db_url: &str) -> std::path::PathBuf
 
 /// Build a fresh tempdir scoped to this test run.
 ///
-/// We deliberately use `/tmp` rather than `std::env::temp_dir()` (which is
-/// `$TMPDIR` = `/var/folders/.../T/` on macOS, ~48 chars by itself). Unix
-/// domain socket paths are capped at `SUN_LEN` (104 bytes on macOS, 108 on
+/// On Unix we deliberately use `/tmp` rather than `std::env::temp_dir()`
+/// (which is `$TMPDIR` = `/var/folders/.../T/` on macOS, ~48 chars by itself).
+/// Unix domain socket paths are capped at `SUN_LEN` (104 bytes on macOS, 108 on
 /// Linux); the long mac TMPDIR plus a nanosecond suffix plus `bitrouter.sock`
 /// would overflow. `/tmp` keeps every test socket comfortably under the cap.
+/// On Windows the control endpoint is a named pipe (no path-length cap on the
+/// backing file), so the platform temp dir is fine.
 fn tempdir(tag: &str) -> std::path::PathBuf {
-    std::path::PathBuf::from("/tmp").join(format!(
+    #[cfg(unix)]
+    let base = std::path::PathBuf::from("/tmp");
+    #[cfg(not(unix))]
+    let base = std::env::temp_dir();
+    base.join(format!(
         "brd-{tag}-{}-{}",
         std::process::id(),
         std::time::SystemTime::now()
@@ -74,6 +83,21 @@ fn tempdir(tag: &str) -> std::path::PathBuf {
             .unwrap()
             .as_nanos()
     ))
+}
+
+/// Wait until the daemon's control endpoint answers, so a test doesn't race
+/// the listener's bind. Cross-platform: a connect failure (listener not up
+/// yet) simply retries. `Status` is read-only, so probing with it is harmless.
+async fn wait_until_ready(socket: &std::path::Path) {
+    for _ in 0..100 {
+        if daemon::send_command(socket, &DaemonCommand::Status)
+            .await
+            .is_ok()
+        {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
 }
 
 #[tokio::test]
@@ -94,12 +118,7 @@ async fn status_route_and_stop_roundtrip_over_the_control_socket() {
     ));
 
     // Wait for the listener to be ready (bind is fast but not synchronous).
-    for _ in 0..50 {
-        if socket.exists() {
-            break;
-        }
-        tokio::time::sleep(Duration::from_millis(20)).await;
-    }
+    wait_until_ready(&socket).await;
 
     // Status → reports a real model count from the routing table.
     let status = daemon::send_command(&socket, &DaemonCommand::Status)
@@ -144,15 +163,15 @@ async fn status_route_and_stop_roundtrip_over_the_control_socket() {
         other => panic!("expected ObserveStatus, got {other:?}"),
     }
 
-    // Stop → server returns and the socket file is removed.
+    // Stop → server returns and the control endpoint is released.
     let stop = daemon::send_command(&socket, &DaemonCommand::Stop)
         .await
         .unwrap();
     assert!(matches!(stop, DaemonResponse::Ok));
     server.await.unwrap().unwrap();
     assert!(
-        !socket.exists(),
-        "socket file should be removed on shutdown"
+        !daemon::endpoint_in_use(&socket),
+        "control endpoint should be released on shutdown"
     );
 
     let _ = tokio::fs::remove_dir_all(&dir).await;
@@ -174,12 +193,7 @@ async fn reload_re_reads_the_config_file() {
         Arc::new(RoutingTableReloader(app.clone())),
         Arc::new(NoopObserveStatus { compiled_in: false }),
     ));
-    for _ in 0..50 {
-        if socket.exists() {
-            break;
-        }
-        tokio::time::sleep(Duration::from_millis(20)).await;
-    }
+    wait_until_ready(&socket).await;
 
     // Rewrite the config to drop the anthropic provider.
     let new_yaml = r#"
@@ -306,12 +320,7 @@ async fn route_for_unknown_model_returns_a_clean_error() {
         Arc::new(NoopReloader),
         Arc::new(NoopObserveStatus { compiled_in: false }),
     ));
-    for _ in 0..50 {
-        if socket.exists() {
-            break;
-        }
-        tokio::time::sleep(Duration::from_millis(20)).await;
-    }
+    wait_until_ready(&socket).await;
 
     let resp = daemon::send_command(
         &socket,
@@ -350,12 +359,7 @@ async fn concurrent_clients_are_all_served() {
         Arc::new(NoopReloader),
         Arc::new(NoopObserveStatus { compiled_in: false }),
     ));
-    for _ in 0..50 {
-        if socket.exists() {
-            break;
-        }
-        tokio::time::sleep(Duration::from_millis(20)).await;
-    }
+    wait_until_ready(&socket).await;
 
     let s1 = socket.clone();
     let s2 = socket.clone();
@@ -395,18 +399,13 @@ async fn malformed_input_does_not_take_the_server_down() {
         Arc::new(NoopReloader),
         Arc::new(NoopObserveStatus { compiled_in: false }),
     ));
-    for _ in 0..50 {
-        if socket.exists() {
-            break;
-        }
-        tokio::time::sleep(Duration::from_millis(20)).await;
-    }
+    wait_until_ready(&socket).await;
 
     // Send garbage directly — bypass send_command's JSON serialisation.
     {
         use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-        use tokio::net::UnixStream;
-        let mut s = BufReader::new(UnixStream::connect(&socket).await.unwrap());
+        let stream = daemon::connect_control(&socket).await.unwrap();
+        let mut s = BufReader::new(stream);
         s.get_mut().write_all(b"not-json-at-all\n").await.unwrap();
         s.get_mut().flush().await.unwrap();
         let mut line = String::new();
@@ -448,12 +447,7 @@ async fn reload_returns_error_when_the_config_is_broken() {
         Arc::new(RoutingTableReloader(app.clone())),
         Arc::new(NoopObserveStatus { compiled_in: false }),
     ));
-    for _ in 0..50 {
-        if socket.exists() {
-            break;
-        }
-        tokio::time::sleep(Duration::from_millis(20)).await;
-    }
+    wait_until_ready(&socket).await;
 
     // Corrupt the config on disk.
     tokio::fs::write(&cfg_path, "this: is: not: valid: yaml: [{")
@@ -483,6 +477,11 @@ async fn reload_returns_error_when_the_config_is_broken() {
     let _ = tokio::fs::remove_dir_all(&dir).await;
 }
 
+// Unix-only: this asserts the `0600` file mode. On Windows the control
+// endpoint is a named pipe whose default security descriptor already restricts
+// access to the creating user and administrators — there is no file mode to
+// check, so the test does not apply.
+#[cfg(unix)]
 #[tokio::test]
 async fn socket_file_has_owner_only_permissions() {
     // Anyone-on-the-host shouldn't be able to talk to our daemon. Verify the
@@ -502,12 +501,7 @@ async fn socket_file_has_owner_only_permissions() {
         Arc::new(NoopReloader),
         Arc::new(NoopObserveStatus { compiled_in: false }),
     ));
-    for _ in 0..50 {
-        if socket.exists() {
-            break;
-        }
-        tokio::time::sleep(Duration::from_millis(20)).await;
-    }
+    wait_until_ready(&socket).await;
 
     let meta = tokio::fs::metadata(&socket).await.unwrap();
     let mode = meta.permissions().mode() & 0o777;

--- a/apps/bitrouter/tests/e2e.rs
+++ b/apps/bitrouter/tests/e2e.rs
@@ -252,9 +252,13 @@ providers:
           output_micro_usd_per_token: 10.0
 plugins:
   bitrouter-policy:
-    policy_dir: "{policy_path}"
+    policy_dir: '{policy_path}'
 "#,
         upstream = upstream.uri(),
+        // Single-quoted YAML scalar — double quotes would interpret the
+        // backslashes in a Windows temp path (`C:\Users\…`) as escape
+        // sequences and trip the parser on `\U`. Single quotes treat the
+        // value literally; `temp_dir()` paths never contain a single quote.
         policy_path = policy_dir.display(),
     );
     let cfg: config::Config = config::parse_with(&yaml, |_| None).expect("config parses");

--- a/apps/bitrouter/tests/full_stack.rs
+++ b/apps/bitrouter/tests/full_stack.rs
@@ -141,7 +141,10 @@ providers:
           output_micro_usd_per_token: 10.0
 plugins:
   bitrouter-policy:
-    policy_dir: "{policy_path}"
+    # Single-quoted scalar — double quotes would interpret the backslashes
+    # in a Windows temp path (`C:\Users\…`) as escape sequences and trip
+    # the parser on `\U`. Single quotes treat the value literally.
+    policy_dir: '{policy_path}'
   bitrouter-guardrails:
     custom_patterns:
       - {{ name: ssn,       pattern: '\d{{3}}-\d{{2}}-\d{{4}}', action: redact }}

--- a/crates/bitrouter-sdk/src/acp/stdio_executor.rs
+++ b/crates/bitrouter-sdk/src/acp/stdio_executor.rs
@@ -605,6 +605,7 @@ mod tests {
     /// `/bin/false` exits before any handshake — the writer or reader task
     /// observes the EOF, the reaper drains pending requests, and the
     /// caller sees a clean 502.
+    #[cfg(unix)]
     #[tokio::test]
     async fn child_that_dies_immediately_surfaces_as_502() {
         let exec = AcpStdioExecutor::new();
@@ -637,6 +638,12 @@ mod tests {
     /// script reads one JSON line, echoes a `{result: ...}` response, then
     /// exits. We verify: ids round-trip, params arrive at the upstream,
     /// the result returns to the caller.
+    ///
+    /// `cfg(unix)`: the stub agent is a POSIX shell one-liner (`bash`,
+    /// `sed`, `printf`). The production code under test is platform-neutral
+    /// — spawning whatever upstream the operator configures works fine on
+    /// Windows — but we don't ship a Windows-native stub here.
+    #[cfg(unix)]
     #[tokio::test]
     async fn echo_agent_round_trips_a_request_response() {
         // A POSIX shell one-liner that:
@@ -667,6 +674,7 @@ mod tests {
 
     /// Same as above but the upstream returns a JSON-RPC `error` body. We
     /// surface it as a 502 Upstream so the caller can react.
+    #[cfg(unix)]
     #[tokio::test]
     async fn upstream_jsonrpc_error_surfaces_as_502() {
         let script = r#"
@@ -699,6 +707,7 @@ mod tests {
     /// and the next request must respawn transparently. Before the fix,
     /// the second request would either hang or be silently rejected by
     /// the pool's reuse of the corpse.
+    #[cfg(unix)]
     #[tokio::test]
     async fn pool_evicts_dead_connection_and_respawns_on_next_request() {
         // First child: answer once and exit. Second child: answer once
@@ -740,6 +749,7 @@ mod tests {
     /// emit > MAX_LINE_BYTES of bytes with no newline. The reader loop
     /// observes the cap error and exits without panicking. The pending
     /// request is then drained by the reaper when the child exits.
+    #[cfg(unix)]
     #[tokio::test]
     async fn reader_caps_oversized_line_without_unbounded_allocation() {
         // Emit 17 MiB of `x` bytes without a newline, then exit. v1's
@@ -769,6 +779,7 @@ mod tests {
     /// Notifications (no id) flow out via the broadcast channel rather than
     /// the response oneshot. Subscribe first, then drive a request that
     /// triggers an upstream notification before the response.
+    #[cfg(unix)]
     #[tokio::test]
     async fn server_notifications_reach_subscribers() {
         let script = r#"

--- a/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
@@ -1872,6 +1872,13 @@ fn assert_schema_snapshot<T: schemars::JsonSchema>(name: &str) {
             path.display()
         )
     });
+    // Normalise CRLF → LF before comparing. `.gitattributes` pins the
+    // snapshot files to LF, but a contributor without an autocrlf-aware
+    // setup (or a checkout made before that pin landed) can still end up
+    // with CRLF on disk on Windows. The freshly-generated `actual` always
+    // uses LF, so without this normalise step the test fails for a reason
+    // that has nothing to do with the schema.
+    let expected = expected.replace("\r\n", "\n");
     assert_eq!(
         expected.trim(),
         actual.trim(),


### PR DESCRIPTION
## Summary

Make `bitrouter` build and the daemon/socket subsystem function on Windows alongside Unix. The control transport is now platform-abstracted: a **Unix domain socket** (mode `0600`) on Unix, and a **Windows named pipe** at `\\.\pipe\…` (default owner-DACL) on Windows. The wire protocol is identical, so `serve` / `start` / `stop` / `restart` / `reload` / `status` / `route` all work uniformly on both.

## What changed

- **Transport** ([apps/bitrouter/src/daemon.rs](apps/bitrouter/src/daemon.rs)) — new private `transport` module with `#[cfg(unix)]` and `#[cfg(windows)]` impls. `handle_connection<S>` is now generic over any `AsyncRead + AsyncWrite + Unpin`, so the same dispatch logic drives a `UnixStream` and a `NamedPipeServer`. New public `daemon::connect_control` and `daemon::endpoint_in_use` let callers (tests, `restart`'s wait loop) ignore which transport is in play.
- **Pipe naming** — `pipe_name(path)` maps a filesystem-style control path to a stable, case-insensitive pipe name so the daemon and every client agree regardless of launcher CWD. Explicit `\\.\pipe\…` paths are passed through. Locked down by 5 unit tests.
- **Signals / process control** ([apps/bitrouter/src/main.rs](apps/bitrouter/src/main.rs)) — SIGHUP reload arm is Unix-only (parks forever on Windows; reload is reachable via `bitrouter reload`). Termination listener is SIGINT/SIGTERM on Unix and `ctrl_c` / `ctrl_break` / `ctrl_close` / `ctrl_shutdown` on Windows. `start`'s detach uses `process_group(0)` on Unix and `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP` on Windows (constants inlined to avoid a `windows`/`winapi` dep). `process_is_alive` and `force_kill` shell out to `tasklist` / `taskkill` on Windows — keeps the binary `#![forbid(unsafe_code)]`. `restart` / `route` now check liveness via `daemon::endpoint_in_use` instead of `socket.exists()`.
- **Home directory** ([apps/bitrouter/src/paths.rs](apps/bitrouter/src/paths.rs)) — `\$HOME` falls back to `%USERPROFILE%` on Windows so `~/.bitrouter` resolves naturally without forcing operators to set `BITROUTER_HOME`.
- **Tests** ([apps/bitrouter/tests/daemon.rs](apps/bitrouter/tests/daemon.rs)) — `tempdir` uses `/tmp` on Unix (SUN_LEN cap) and `temp_dir()` elsewhere; `wait_until_ready` probes via `Status` instead of `socket.exists()`; the owner-only-permissions test is gated to `cfg(unix)` (the named pipe's default DACL is the Windows analog).
- **CI** ([.github/workflows/ci.yml](.github/workflows/ci.yml)) — `clippy` and `test` run as a matrix across `ubuntu-latest`, `macos-latest`, and `windows-latest` with `fail-fast: false`. No OS is singled out as primary. `clippy` now also passes `--tests`.

## Reviewer notes

- The Windows transport relies on the named pipe's **default security descriptor** — practical analog of the Unix socket's `0600` mode. A literally owner-only DACL would need a custom `SECURITY_ATTRIBUTES` pointer via `ServerOptions::create_with_security_attributes_raw`, which is `unsafe` and incompatible with `#![forbid(unsafe_code)]`. Comment in `daemon.rs` documents this trade-off.
- The Windows accept loop re-arms a fresh pipe instance immediately after each `connect()`, and the client retries through the brief `ERROR_PIPE_BUSY` window between re-arms.
- `endpoint_in_use` on Windows opens a client to probe — this consumes a pending pipe instance on the server, but the server re-arms right after, so the side-effect is bounded.
- `cargo-dist` (release.yml) already lists `x86_64-pc-windows-msvc` as a target; this PR closes the loop by making CI also exercise that platform on every push.

## Verified locally

- `cargo check --workspace --tests --all-features` on Unix ✓
- `cargo check --workspace --tests --all-features --target x86_64-pc-windows-gnu` ✓ (cross-built via mingw-w64)
- `cargo clippy --workspace --all-features --tests -- -D warnings` on both targets ✓
- `cargo fmt -- --check` ✓
- `cargo nextest run -p bitrouter --all-features` — 179 / 179 pass

Actual `cargo test` on real Windows + macOS runners is what the new CI matrix exercises on this PR.

## Test plan

- [ ] CI `test (ubuntu-latest)` passes
- [ ] CI `test (macos-latest)` passes
- [ ] CI `test (windows-latest)` passes — especially the daemon integration tests (status/route/reload/stop, concurrent clients, malformed input, broken-config reload)
- [ ] CI `clippy` passes on all three OSes
- [ ] Manual smoke test on Windows: \`bitrouter start\` → \`bitrouter status\` → \`bitrouter reload\` → \`bitrouter stop\`, confirm pid file lifecycle and that no stale pipe instance lingers after \`Stop\`
- [ ] Manual smoke test on Windows: \`bitrouter restart\` while a client request is in flight — verify the new daemon binds the same pipe name after the old one releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)