### PR TITLE
fix(sdk/anthropic): fold cache buckets into prompt_tokens (Usage subset contract)

### DIFF
--- a/crates/bitrouter-sdk/src/language_model/protocol/anthropic.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/anthropic.rs
@@ -607,6 +607,9 @@ fn render_message(m: &Message) -> serde_json::Value {
 }
 
 fn parse_usage(value: &serde_json::Value) -> Option<Usage> {
+    if value.get("input_tokens").is_none() && value.get("output_tokens").is_none() {
+        return None;
+    }
     let input = value
         .get("input_tokens")
         .and_then(|v| v.as_u64())
@@ -615,12 +618,23 @@ fn parse_usage(value: &serde_json::Value) -> Option<Usage> {
         .get("output_tokens")
         .and_then(|v| v.as_u64())
         .unwrap_or(0);
-    if value.get("input_tokens").is_none() && value.get("output_tokens").is_none() {
-        return None;
-    }
     // Cache fields are Anthropic-specific; absent on providers that don't
     // implement prompt caching. Ref:
     // <https://docs.anthropic.com/en/api/messages> → `usage` object.
+    //
+    // Wire vs SDK contract: Anthropic's `input_tokens` is the *uncached*
+    // portion of the prompt and is reported **alongside** (not inclusive
+    // of) `cache_read_input_tokens` / `cache_creation_input_tokens`. The
+    // canonical [`Usage::cache_read_tokens`] / [`Usage::cache_write_tokens`]
+    // are documented as subsets of [`Usage::prompt_tokens`] — matching how
+    // OpenAI Chat / Responses and Google report cached prompt tokens.
+    //
+    // Without folding the cache buckets back into `prompt_tokens` here,
+    // downstream billing layers that derive `no_cache = prompt_tokens -
+    // cache_read - cache_write` would saturate to 0 on a cache-heavy
+    // request and silently undercharge the uncached portion. Fold them
+    // (saturating against `u64::MAX` so a malicious upstream can't
+    // overflow the sum) so the canonical IR matches its own contract.
     let cache_read = value
         .get("cache_read_input_tokens")
         .and_then(|v| v.as_u64())
@@ -630,7 +644,7 @@ fn parse_usage(value: &serde_json::Value) -> Option<Usage> {
         .and_then(|v| v.as_u64())
         .unwrap_or(0);
     Some(Usage {
-        prompt_tokens: input,
+        prompt_tokens: input.saturating_add(cache_read).saturating_add(cache_write),
         completion_tokens: output,
         reasoning_tokens: 0,
         cache_read_tokens: cache_read,
@@ -755,33 +769,41 @@ impl StreamDecoder for AnthropicStreamDecoder {
             }
             "content_block_stop" => {}
             "message_delta" => {
-                if let Some(output) = json
-                    .get("usage")
-                    .and_then(|u| u.get("output_tokens"))
-                    .and_then(|v| v.as_u64())
-                {
-                    self.usage.completion_tokens = output;
-                }
-                if let Some(input) = json
-                    .get("usage")
-                    .and_then(|u| u.get("input_tokens"))
-                    .and_then(|v| v.as_u64())
-                {
-                    self.usage.prompt_tokens = input;
-                }
-                if let Some(cache_read) = json
-                    .get("usage")
-                    .and_then(|u| u.get("cache_read_input_tokens"))
-                    .and_then(|v| v.as_u64())
-                {
-                    self.usage.cache_read_tokens = cache_read;
-                }
-                if let Some(cache_write) = json
-                    .get("usage")
-                    .and_then(|u| u.get("cache_creation_input_tokens"))
-                    .and_then(|v| v.as_u64())
-                {
-                    self.usage.cache_write_tokens = cache_write;
+                // `message_delta.usage` carries the cumulative final counts.
+                // Anthropic emits its wire-level `input_tokens` (the
+                // *uncached* portion) alongside the cache buckets; the
+                // canonical [`Usage::prompt_tokens`] is inclusive of those
+                // buckets (matches `parse_usage` above). Back out the prior
+                // exclusive input from the inclusive total so a delta that
+                // only refreshes a subset of fields still recomputes
+                // `prompt_tokens` consistently.
+                if let Some(u) = json.get("usage") {
+                    let prior_excl_input = self
+                        .usage
+                        .prompt_tokens
+                        .saturating_sub(self.usage.cache_read_tokens)
+                        .saturating_sub(self.usage.cache_write_tokens);
+                    let new_excl_input = u
+                        .get("input_tokens")
+                        .and_then(|v| v.as_u64())
+                        .unwrap_or(prior_excl_input);
+                    if let Some(cache_read) =
+                        u.get("cache_read_input_tokens").and_then(|v| v.as_u64())
+                    {
+                        self.usage.cache_read_tokens = cache_read;
+                    }
+                    if let Some(cache_write) = u
+                        .get("cache_creation_input_tokens")
+                        .and_then(|v| v.as_u64())
+                    {
+                        self.usage.cache_write_tokens = cache_write;
+                    }
+                    if let Some(output) = u.get("output_tokens").and_then(|v| v.as_u64()) {
+                        self.usage.completion_tokens = output;
+                    }
+                    self.usage.prompt_tokens = new_excl_input
+                        .saturating_add(self.usage.cache_read_tokens)
+                        .saturating_add(self.usage.cache_write_tokens);
                 }
                 if let Some(reason) = json
                     .get("delta")
@@ -935,9 +957,23 @@ impl AnthropicStreamEncoder {
 
 /// Build an Anthropic-shaped `usage` object that always emits
 /// `input_tokens` / `output_tokens` and adds the cache fields when non-zero.
+///
+/// Wire format note: Anthropic reports `input_tokens` as the *uncached*
+/// portion of the prompt — the cache buckets are reported alongside, not
+/// included in `input_tokens`. The canonical [`Usage::prompt_tokens`] is
+/// the **inclusive** total (matches OpenAI / Google semantics; see
+/// `parse_usage`), so we subtract the cache buckets back out here to
+/// reconstruct the wire format. Saturating-sub guards against a caller
+/// constructing a `Usage` whose cache totals exceed `prompt_tokens` —
+/// shouldn't happen in practice, but a malformed canonical IR shouldn't
+/// underflow the wire payload either.
 fn render_usage(u: &Usage) -> serde_json::Value {
     let mut map = serde_json::Map::new();
-    map.insert("input_tokens".into(), u.prompt_tokens.into());
+    let excl_input = u
+        .prompt_tokens
+        .saturating_sub(u.cache_read_tokens)
+        .saturating_sub(u.cache_write_tokens);
+    map.insert("input_tokens".into(), excl_input.into());
     map.insert("output_tokens".into(), u.completion_tokens.into());
     if u.cache_read_tokens > 0 {
         map.insert("cache_read_input_tokens".into(), u.cache_read_tokens.into());

--- a/crates/bitrouter-sdk/src/language_model/protocol/anthropic.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/anthropic.rs
@@ -619,13 +619,23 @@ fn parse_usage(value: &serde_json::Value) -> Option<Usage> {
         .and_then(|v| v.as_u64())
         .unwrap_or(0);
     // Cache fields are Anthropic-specific; absent on providers that don't
-    // implement prompt caching. Ref:
-    // <https://docs.anthropic.com/en/api/messages> → `usage` object.
+    // implement prompt caching. Refs:
+    // - <https://docs.anthropic.com/en/api/messages> → `usage` object
+    // - <https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching>
+    //   → "Tracking cache performance"
     //
     // Wire vs SDK contract: Anthropic's `input_tokens` is the *uncached*
-    // portion of the prompt and is reported **alongside** (not inclusive
-    // of) `cache_read_input_tokens` / `cache_creation_input_tokens`. The
-    // canonical [`Usage::cache_read_tokens`] / [`Usage::cache_write_tokens`]
+    // portion of the prompt (tokens after the last cache breakpoint) and
+    // is reported **alongside** (not inclusive of) `cache_read_input_tokens`
+    // / `cache_creation_input_tokens`. The prompt-caching guide documents
+    // the relationship explicitly:
+    //
+    //     total_input_tokens
+    //         = cache_read_input_tokens
+    //         + cache_creation_input_tokens
+    //         + input_tokens
+    //
+    // The canonical [`Usage::cache_read_tokens`] / [`Usage::cache_write_tokens`]
     // are documented as subsets of [`Usage::prompt_tokens`] — matching how
     // OpenAI Chat / Responses and Google report cached prompt tokens.
     //
@@ -769,13 +779,16 @@ impl StreamDecoder for AnthropicStreamDecoder {
             }
             "content_block_stop" => {}
             "message_delta" => {
-                // `message_delta.usage` carries the cumulative final counts.
+                // `message_delta.usage` carries the cumulative final counts
+                // (<https://docs.anthropic.com/en/api/messages-streaming>).
                 // Anthropic emits its wire-level `input_tokens` (the
-                // *uncached* portion) alongside the cache buckets; the
-                // canonical [`Usage::prompt_tokens`] is inclusive of those
-                // buckets (matches `parse_usage` above). Back out the prior
-                // exclusive input from the inclusive total so a delta that
-                // only refreshes a subset of fields still recomputes
+                // *uncached* portion, per
+                // <https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching>)
+                // alongside the cache buckets; the canonical
+                // [`Usage::prompt_tokens`] is inclusive of those buckets
+                // (matches `parse_usage` above). Back out the prior exclusive
+                // input from the inclusive total so a delta that only
+                // refreshes a subset of fields still recomputes
                 // `prompt_tokens` consistently.
                 if let Some(u) = json.get("usage") {
                     let prior_excl_input = self
@@ -960,8 +973,11 @@ impl AnthropicStreamEncoder {
 ///
 /// Wire format note: Anthropic reports `input_tokens` as the *uncached*
 /// portion of the prompt — the cache buckets are reported alongside, not
-/// included in `input_tokens`. The canonical [`Usage::prompt_tokens`] is
-/// the **inclusive** total (matches OpenAI / Google semantics; see
+/// included in `input_tokens`. The prompt-caching guide documents the
+/// relationship as `total = cache_read + cache_creation + input_tokens`
+/// (<https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching>
+/// → "Tracking cache performance"). The canonical [`Usage::prompt_tokens`]
+/// is the **inclusive** total (matches OpenAI / Google semantics; see
 /// `parse_usage`), so we subtract the cache buckets back out here to
 /// reconstruct the wire format. Saturating-sub guards against a caller
 /// constructing a `Usage` whose cache totals exceed `prompt_tokens` —

--- a/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
@@ -766,6 +766,13 @@ fn anthropic_cache_tokens_round_trip() {
     // `cache_creation_input_tokens` in `usage`. Parser captures them, encoder
     // emits them on the non-streaming response, and on `message_delta` they
     // accompany the streaming finalisation.
+    //
+    // SDK contract: `cache_read_tokens` / `cache_write_tokens` are **subsets
+    // of** `prompt_tokens` (matches OpenAI / Google). Anthropic's wire format
+    // is the opposite — `input_tokens` is the uncached portion, reported
+    // alongside the cache buckets — so the parser folds the cache totals
+    // back into `prompt_tokens` and the renderer unfolds them when writing
+    // the wire payload.
     let adapter = adapter_for(ApiProtocol::Anthropic);
     let body = serde_json::json!({
         "id": "msg_1",
@@ -785,13 +792,147 @@ fn anthropic_cache_tokens_round_trip() {
     let usage = result.usage.unwrap();
     assert_eq!(usage.cache_read_tokens, 80);
     assert_eq!(usage.cache_write_tokens, 20);
+    // Canonical IR: prompt_tokens is the inclusive total (100 + 80 + 20).
+    assert_eq!(usage.prompt_tokens, 200);
     let rendered = adapter
         .render_response(&result, &sample_prompt(), "msg_1")
         .unwrap();
     assert_eq!(rendered["usage"]["cache_read_input_tokens"], 80);
     assert_eq!(rendered["usage"]["cache_creation_input_tokens"], 20);
-    // input_tokens still emitted alongside (audit1 §13).
+    // Wire format: input_tokens excludes the cache buckets (audit1 §13).
+    // Round-trips to the same 100 the upstream sent.
     assert_eq!(rendered["usage"]["input_tokens"], 100);
+}
+
+#[test]
+fn anthropic_cache_tokens_match_subset_contract() {
+    // Regression: the canonical `Usage` doc-comment states that
+    // `cache_read_tokens` and `cache_write_tokens` are **subsets of**
+    // `prompt_tokens`. Anthropic's wire payload uses the opposite
+    // convention (uncached `input_tokens` + sibling cache fields), so
+    // the parser must fold the cache buckets into `prompt_tokens` or
+    // downstream billing layers that compute `no_cache = prompt_tokens
+    // - cache_read - cache_write` saturate to 0 on cache-heavy
+    // requests and silently undercharge the uncached portion.
+    let adapter = adapter_for(ApiProtocol::Anthropic);
+    let body = serde_json::json!({
+        "id": "msg_1",
+        "type": "message",
+        "role": "assistant",
+        "model": "claude-sonnet-4",
+        "content": [{"type": "text", "text": "ok"}],
+        "stop_reason": "end_turn",
+        "usage": {
+            // A realistic cache-hit-heavy request: 5K uncached prompt,
+            // 30K cache reads, 0 cache writes. Without folding into
+            // `prompt_tokens`, the billing-layer subtraction (5000 -
+            // 30000 - 0) saturates to 0 and the 5000 uncached tokens
+            // get billed at $0.
+            "input_tokens": 5_000,
+            "output_tokens": 200,
+            "cache_read_input_tokens": 30_000,
+        }
+    });
+    let usage = adapter.parse_response(body).unwrap().usage.unwrap();
+    assert_eq!(usage.cache_read_tokens, 30_000);
+    assert_eq!(usage.cache_write_tokens, 0);
+    assert_eq!(usage.prompt_tokens, 35_000);
+    // Holds the doc-comment invariant byte-for-byte.
+    assert!(
+        usage.prompt_tokens >= usage.cache_read_tokens + usage.cache_write_tokens,
+        "Usage::prompt_tokens must be inclusive of cache buckets: \
+         got prompt={} cache_read={} cache_write={}",
+        usage.prompt_tokens,
+        usage.cache_read_tokens,
+        usage.cache_write_tokens,
+    );
+}
+
+#[test]
+fn anthropic_usage_with_no_cache_fields_keeps_prompt_tokens_unchanged() {
+    // Belt-and-braces: when an upstream omits the cache fields entirely
+    // (the common case for non-Anthropic Anthropic-API-compatible
+    // upstreams, or Anthropic requests without prompt caching), the
+    // canonical `prompt_tokens` must equal Anthropic's wire-level
+    // `input_tokens` — the cache-fold is a no-op when both cache
+    // totals are 0.
+    let adapter = adapter_for(ApiProtocol::Anthropic);
+    let body = serde_json::json!({
+        "id": "msg_1",
+        "type": "message",
+        "role": "assistant",
+        "model": "claude-sonnet-4",
+        "content": [{"type": "text", "text": "ok"}],
+        "stop_reason": "end_turn",
+        "usage": {
+            "input_tokens": 1_234,
+            "output_tokens": 56,
+        }
+    });
+    let usage = adapter.parse_response(body).unwrap().usage.unwrap();
+    assert_eq!(usage.prompt_tokens, 1_234);
+    assert_eq!(usage.cache_read_tokens, 0);
+    assert_eq!(usage.cache_write_tokens, 0);
+}
+
+#[test]
+fn anthropic_stream_preserves_cache_inclusive_prompt_tokens() {
+    // The stream decoder receives `message_start` (which carries the
+    // full cache breakdown) and `message_delta` (which typically only
+    // refreshes `output_tokens`). The terminal Usage frame must reflect
+    // the inclusive prompt_tokens contract — the test pins this so a
+    // future refactor of the delta path can't quietly drop the
+    // cache-fold and undercharge again.
+    let decoder = adapter_for(ApiProtocol::Anthropic);
+    let mut stream_decoder = decoder.stream_decoder();
+
+    let start = SseEvent {
+        event: Some("message_start".into()),
+        data: serde_json::json!({
+            "type": "message_start",
+            "message": {
+                "id": "msg_1",
+                "type": "message",
+                "role": "assistant",
+                "model": "claude-sonnet-4",
+                "content": [],
+                "stop_reason": null,
+                "usage": {
+                    "input_tokens": 5_000,
+                    "output_tokens": 0,
+                    "cache_read_input_tokens": 30_000,
+                    "cache_creation_input_tokens": 20,
+                }
+            }
+        })
+        .to_string(),
+    };
+    let _ = stream_decoder.decode(&start).unwrap();
+
+    // A message_delta that only carries `output_tokens` (the common
+    // shape per Anthropic streaming docs) must NOT zero out the cache
+    // buckets nor revert prompt_tokens to the wire-level exclusive value.
+    let delta = SseEvent {
+        event: Some("message_delta".into()),
+        data: serde_json::json!({
+            "type": "message_delta",
+            "delta": { "stop_reason": "end_turn" },
+            "usage": { "output_tokens": 200 }
+        })
+        .to_string(),
+    };
+    let parts = stream_decoder.decode(&delta).unwrap();
+    let usage = parts
+        .iter()
+        .find_map(|p| match p {
+            StreamPart::Usage { usage } => Some(*usage),
+            _ => None,
+        })
+        .expect("terminal Usage frame missing");
+    assert_eq!(usage.cache_read_tokens, 30_000);
+    assert_eq!(usage.cache_write_tokens, 20);
+    assert_eq!(usage.completion_tokens, 200);
+    assert_eq!(usage.prompt_tokens, 5_000 + 30_000 + 20);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Anthropic's wire `usage.input_tokens` is the **uncached** portion of the prompt — `cache_read_input_tokens` and `cache_creation_input_tokens` are reported **alongside** it, not as subsets. The canonical [`Usage`](https://github.com/bitrouter/bitrouter/blob/main/crates/bitrouter-sdk/src/language_model/types.rs#L242-L263) struct documents `cache_read_tokens` / `cache_write_tokens` as **"Subset of `prompt_tokens`"** (matching OpenAI Chat / Responses and Google). The Anthropic adapter previously violated that contract.
- Downstream consumers that compute `no_cache = prompt_tokens - cache_read - cache_write` (notably `bitrouter-cloud`'s settlement layer) saturated to 0 on cache-heavy Anthropic requests, **silently undercharging the uncached portion** — or, when only a `no_cache` price was configured for an Anthropic model, returning `None` from the charge calculator and **skipping the debit entirely**.
- Fold the cache buckets back into `prompt_tokens` in the parser, the streaming `message_delta` path, and unfold them in `render_usage` so the wire round-trip is byte-identical.

## Why this matters

For a realistic cache-heavy Anthropic request:

| Field | Anthropic wire | Old IR | New IR |
|---|---|---|---|
| `input_tokens` (uncached) | 5,000 | `prompt_tokens = 5,000` | `prompt_tokens = 35,000` ✓ |
| `cache_read_input_tokens` | 30,000 | `cache_read_tokens = 30,000` | `cache_read_tokens = 30,000` |
| `cache_creation_input_tokens` | 0 | `cache_write_tokens = 0` | `cache_write_tokens = 0` |

Downstream `no_cache = prompt_tokens.saturating_sub(cache_read + cache_write)`:
- **Old**: `5_000 - 30_000 = 0` → uncached 5k tokens billed at $0.
- **New**: `35_000 - 30_000 = 5_000` → correct.

## What changed

- `parse_usage` (non-streaming): `prompt_tokens = input + cache_read + cache_write` (saturating).
- Streaming `message_delta`: back out the prior exclusive input from the inclusive total before applying the delta, so a delta that only refreshes `output_tokens` (the common case per [Anthropic's streaming docs](https://docs.anthropic.com/en/docs/build-with-claude/streaming)) doesn't quietly drop the cache-fold.
- `render_usage`: subtract the cache buckets when writing `input_tokens` so parse → IR → render is byte-identical with the original wire payload.

## Tests

Three new tests pin the contract:
- `anthropic_cache_tokens_match_subset_contract` — asserts `prompt_tokens >= cache_read + cache_write` on a realistic cache-hit-heavy request.
- `anthropic_usage_with_no_cache_fields_keeps_prompt_tokens_unchanged` — non-caching requests behave identically to before.
- `anthropic_stream_preserves_cache_inclusive_prompt_tokens` — guards the streaming-delta path against future refactors silently regressing the fold.

`anthropic_cache_tokens_round_trip` (the existing test) is updated to assert the new inclusive `prompt_tokens=200` value alongside the unchanged wire-level `input_tokens=100` round-trip.

## Test plan

- [x] `cargo nextest run` — **536 / 536 pass** (full workspace).
- [x] `cargo clippy --all-features --all-targets -- -D warnings` — clean.
- [x] `cargo fmt -- --check` — clean.
- [x] The existing `anthropic_cache_tokens_round_trip` continues to pass; `rendered["usage"]["input_tokens"]` still equals the original wire `100`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)