### PR TITLE
feat(guardrails)!: Plugin + per-account rule resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -774,6 +774,7 @@ dependencies = [
  "bitrouter-sdk",
  "futures",
  "regex",
+ "schemars",
  "serde",
  "serde_json",
  "tokio",

--- a/apps/bitrouter/src/assemble.rs
+++ b/apps/bitrouter/src/assemble.rs
@@ -19,7 +19,7 @@ use bitrouter_sdk::mcp::caching_executor::{CacheTtls, CachingExecutor};
 use bitrouter_sdk::mcp::config_routing::{ConfigMcpRoutingTable, McpServerAggregateConfig};
 use bitrouter_sdk::mcp::rmcp_executor::RmcpExecutor;
 
-use bitrouter_guardrails::{Action, GuardrailPreHook, GuardrailRule, GuardrailStreamHook, RuleSet};
+use bitrouter_guardrails::{GuardrailConfig, GuardrailsPlugin};
 use bitrouter_observe::OTEL_ENABLED;
 use bitrouter_observe::otel::{OtelConfig, OtelExporter, OtelObserveHook};
 use bitrouter_sdk::MetricsRenderer;
@@ -193,7 +193,9 @@ pub async fn build_app_with_path(
     let pricing_for_recorder = pricing.clone();
     let policy_store: Arc<PolicyStore> = Arc::new(load_policy_store(config).await?);
     let policy_store_for_reload = policy_store.clone();
-    let guardrail_rules = build_guardrail_rules(config)?;
+    let guardrail_rules = build_guardrail_config(config)?
+        .compile()
+        .context("compiling guardrail patterns")?;
 
     // Metrics are now pushed via OTLP, not pulled from /metrics
     // Keep metrics_renderer for compatibility but return empty response
@@ -324,17 +326,14 @@ pub async fn build_app_with_path(
         .metrics_renderer(metrics_renderer)
         .language_model(move |lm| {
             lm.routing_table(routing_table).executor(executor);
-            // Stage 1, in order: auth → policy → guardrail (upstream).
+            // Stage 1, in order: auth → policy. The guardrail plugin appends its
+            // hooks after this closure (see `.plugin(...)` below), preserving the
+            // auth → policy → guardrail order.
             lm.pre_request_hook(AuthHook::new(db_for_hooks.clone()));
             lm.pre_request_hook(PolicyHook::new(
                 policy_store.clone(),
                 Some(metering_store_for_policy),
             ));
-            if !guardrail_rules.is_empty() {
-                lm.pre_request_hook(GuardrailPreHook::new(guardrail_rules.clone()));
-                // StreamHook stage: guardrail downstream redaction / abort.
-                lm.stream_hook(GuardrailStreamHook::new(guardrail_rules));
-            }
             // OpenTelemetry exporter — register the *same* Arc as a hook
             // here. Construction happened above so `Assembled.observe`
             // can hold a query handle on it.
@@ -350,6 +349,14 @@ pub async fn build_app_with_path(
                 pricing_for_recorder,
             ));
         });
+    // Stage-1 guardrail plugin, appended after the closure so its hooks land
+    // after auth + policy in registration order. Skipped when no rules are
+    // configured, so a guardrail-free deployment registers nothing.
+    let app = if guardrail_rules.is_empty() {
+        app
+    } else {
+        app.plugin(GuardrailsPlugin::with_static(guardrail_rules))
+    };
     // Apply the optional MCP pipeline configuration in a second builder step
     // so the language_model configuration above stays the same shape it has
     // had since v0.
@@ -459,38 +466,14 @@ async fn load_policy_store(config: &Config) -> Result<PolicyStore> {
     }
 }
 
-/// Build the guardrail `RuleSet` from `plugins.bitrouter-guardrails.custom_patterns`.
-/// Each entry is `{ name, pattern, action: "block" | "redact" }`.
-fn build_guardrail_rules(config: &Config) -> Result<RuleSet> {
-    let Some(patterns) = config
-        .plugins
-        .get("bitrouter-guardrails")
-        .and_then(|c| c.get("custom_patterns"))
-        .and_then(|v| v.as_array())
-    else {
-        return Ok(RuleSet::new());
+/// Parse the guardrail data contract from `plugins.bitrouter-guardrails`
+/// (its `custom_patterns` array of `{ name, pattern, action: "block" |
+/// "redact" }`). The plugin owns the shape; this just deserialises it.
+fn build_guardrail_config(config: &Config) -> Result<GuardrailConfig> {
+    let Some(value) = config.plugins.get("bitrouter-guardrails") else {
+        return Ok(GuardrailConfig::default());
     };
-    let mut set = RuleSet::new();
-    for entry in patterns {
-        let name = entry
-            .get("name")
-            .and_then(|v| v.as_str())
-            .context("guardrail pattern missing 'name'")?;
-        let pattern = entry
-            .get("pattern")
-            .and_then(|v| v.as_str())
-            .context("guardrail pattern missing 'pattern'")?;
-        let action = match entry.get("action").and_then(|v| v.as_str()) {
-            Some("block") | None => Action::Block,
-            Some("redact") => Action::Redact,
-            Some(other) => anyhow::bail!("unknown guardrail action '{other}'"),
-        };
-        set.push(
-            GuardrailRule::new(name, pattern, action)
-                .with_context(|| format!("compiling guardrail pattern '{name}'"))?,
-        );
-    }
-    Ok(set)
+    serde_json::from_value(value.clone()).context("plugins.bitrouter-guardrails failed to parse")
 }
 
 /// Empty metrics renderer for /metrics endpoint compatibility.

--- a/crates/bitrouter-sdk/src/language_model/context.rs
+++ b/crates/bitrouter-sdk/src/language_model/context.rs
@@ -3,8 +3,9 @@
 //! view borrowed from it). `SettlementContext` lives in
 //! [`crate::language_model::settlement`].
 
+use std::any::{Any, TypeId};
 use std::collections::HashMap;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use crate::caller::CallerContext;
 use crate::event::{EventBus, PipelineEvent};
@@ -14,6 +15,32 @@ use crate::language_model::types::{
     ExecutionResult, PipelineRequest, PipelineResponse, Prompt, RoutingTarget, Usage,
 };
 use crate::plugin::PluginId;
+
+/// A type-keyed map of request-scoped extension values. Each entry is an
+/// `Arc<T>` keyed by `T`'s `TypeId`, so cloning the map is a handful of
+/// refcount bumps — cheap enough to copy from the [`PipelineContext`] into the
+/// per-stream [`StreamContext`]. This is the typed counterpart to the JSON
+/// `metadata` channel: it carries an *already-built* per-request value (e.g. a
+/// compiled guardrail rule set) that a Stage-1 hook resolves and a later
+/// [`StreamHook`](crate::language_model::StreamHook) reads on the hot path
+/// without re-parsing.
+#[derive(Clone, Default)]
+struct Extensions {
+    map: HashMap<TypeId, Arc<dyn Any + Send + Sync>>,
+}
+
+impl Extensions {
+    fn insert<T: Send + Sync + 'static>(&mut self, value: Arc<T>) {
+        self.map.insert(TypeId::of::<T>(), value);
+    }
+
+    fn get<T: Send + Sync + 'static>(&self) -> Option<Arc<T>> {
+        self.map
+            .get(&TypeId::of::<T>())
+            .cloned()
+            .and_then(|v| v.downcast::<T>().ok())
+    }
+}
 
 /// The whole-request pipeline context. Follows a water-flow model: data flows
 /// downstream, each stage appends, downstream may read everything upstream
@@ -35,6 +62,11 @@ pub struct PipelineContext {
 
     // ===== plugin extension data =====
     metadata: HashMap<PluginId, serde_json::Value>,
+    /// Typed, request-scoped extensions. Unlike `metadata` (JSON, per-stage),
+    /// these carry an already-built `Arc<T>` and are propagated into the
+    /// per-stream [`StreamContext`] so a value resolved in a pre-request hook
+    /// is readable from the stream stage.
+    extensions: Extensions,
 
     // ===== typed event bus =====
     events: EventBus,
@@ -63,6 +95,7 @@ impl PipelineContext {
             route_chain: None,
             execution_result: None,
             metadata: HashMap::new(),
+            extensions: Extensions::default(),
             events: EventBus::new(),
             outbound_trace_headers: Mutex::new(None),
         }
@@ -169,6 +202,22 @@ impl PipelineContext {
         self.metadata.get(plugin_id)
     }
 
+    /// Insert a typed, request-scoped extension, replacing any existing value
+    /// of the same type. The value is shared (`Arc`) and copied into the
+    /// per-stream [`StreamContext`], so a Stage-1 hook can deposit a value that
+    /// the downstream [`StreamHook`](crate::language_model::StreamHook) reads —
+    /// the channel JSON `metadata` can't provide because it neither survives
+    /// into the stream stage nor holds non-serialisable values.
+    pub fn insert_extension<T: Send + Sync + 'static>(&mut self, value: Arc<T>) {
+        self.extensions.insert(value);
+    }
+
+    /// Read a typed, request-scoped extension previously inserted with
+    /// [`insert_extension`](Self::insert_extension).
+    pub fn extension<T: Send + Sync + 'static>(&self) -> Option<Arc<T>> {
+        self.extensions.get()
+    }
+
     /// Emit a typed pipeline event.
     pub fn emit<E: PipelineEvent>(&mut self, event: E) {
         self.events.emit(event);
@@ -206,6 +255,9 @@ impl PipelineContext {
             final_usage: None,
             events: EventBus::new(),
             metadata: HashMap::new(),
+            // Refcount-bump copy: a value a pre-request hook deposited (e.g. the
+            // resolved guardrail rule set) rides along into the stream stage.
+            extensions: self.extensions.clone(),
         }
     }
 
@@ -285,6 +337,7 @@ pub struct StreamContext {
     pub final_usage: Option<Usage>,
     events: EventBus,
     metadata: HashMap<PluginId, serde_json::Value>,
+    extensions: Extensions,
 }
 
 impl StreamContext {
@@ -311,6 +364,12 @@ impl StreamContext {
     /// Read another plugin's metadata blob.
     pub fn get_metadata(&self, plugin_id: &PluginId) -> Option<&serde_json::Value> {
         self.metadata.get(plugin_id)
+    }
+
+    /// Read a typed, request-scoped extension propagated from the
+    /// [`PipelineContext`] (see [`PipelineContext::insert_extension`]).
+    pub fn extension<T: Send + Sync + 'static>(&self) -> Option<Arc<T>> {
+        self.extensions.get()
     }
 }
 

--- a/plugins/bitrouter-guardrails/Cargo.toml
+++ b/plugins/bitrouter-guardrails/Cargo.toml
@@ -15,6 +15,12 @@ serde.workspace = true
 serde_json.workspace = true
 regex.workspace = true
 tracing.workspace = true
+# `JsonSchema` derives on the serializable config types (`RuleSpec`,
+# `GuardrailConfig`, `Action`) so a downstream host (e.g. bitrouter-cloud) can
+# embed them in its own OpenAPI-published policy types. Mirrors how
+# `bitrouter-sdk` carries `schemars` for its wire types; already in the build
+# graph via the `bitrouter-sdk` dependency, so this adds no new crate.
+schemars.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }

--- a/plugins/bitrouter-guardrails/src/config.rs
+++ b/plugins/bitrouter-guardrails/src/config.rs
@@ -1,0 +1,93 @@
+//! Serializable guardrail configuration — the data contract the plugin runs
+//! off, independent of where it's loaded from. A host deserialises a
+//! [`GuardrailConfig`] from its own source (a config file, a control-plane
+//! database, …) and [`compile`](GuardrailConfig::compile)s it into the
+//! runtime [`RuleSet`]. The plugin never touches a config *file*; it depends
+//! only on this data.
+
+use serde::{Deserialize, Serialize};
+
+use crate::rules::{Action, GuardrailRule, RuleSet};
+
+/// One guardrail rule in serializable form: a name, a regex `pattern`, and an
+/// [`Action`]. Compiled into a [`GuardrailRule`] by [`GuardrailConfig::compile`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RuleSpec {
+    /// Human-readable rule name (surfaced in deny reasons / logs).
+    pub name: String,
+    /// The regex pattern to match.
+    pub pattern: String,
+    /// What to do on a match. Defaults to [`Action::Block`] when omitted.
+    #[serde(default)]
+    pub action: Action,
+}
+
+/// The guardrail data contract. In a config file this is the `custom_patterns`
+/// array under `plugins.bitrouter-guardrails`; a control plane builds the same
+/// shape from its own store.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct GuardrailConfig {
+    /// The configured rules.
+    #[serde(default, rename = "custom_patterns")]
+    pub rules: Vec<RuleSpec>,
+}
+
+impl GuardrailConfig {
+    /// Compile every [`RuleSpec`] into a [`RuleSet`], surfacing the first regex
+    /// that fails to compile.
+    pub fn compile(&self) -> Result<RuleSet, regex::Error> {
+        let mut set = RuleSet::new();
+        for spec in &self.rules {
+            set.push(GuardrailRule::new(&spec.name, &spec.pattern, spec.action)?);
+        }
+        Ok(set)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserialises_custom_patterns_with_default_action() {
+        let json = serde_json::json!({
+            "custom_patterns": [
+                { "name": "ssn", "pattern": r"\d{3}-\d{2}-\d{4}", "action": "redact" },
+                { "name": "secret", "pattern": "sk-[a-z0-9]+" }
+            ]
+        });
+        let cfg: GuardrailConfig = serde_json::from_value(json).unwrap();
+        assert_eq!(cfg.rules.len(), 2);
+        assert_eq!(cfg.rules[0].action, Action::Redact);
+        // Omitted action falls back to Block.
+        assert_eq!(cfg.rules[1].action, Action::Block);
+        // And every pattern compiles into a runtime rule set.
+        assert!(!cfg.compile().unwrap().is_empty());
+    }
+
+    #[test]
+    fn empty_config_compiles_to_empty_rule_set() {
+        let cfg = GuardrailConfig::default();
+        assert!(cfg.compile().unwrap().is_empty());
+    }
+
+    #[test]
+    fn unknown_action_is_a_deserialisation_error() {
+        let json = serde_json::json!({
+            "custom_patterns": [{ "name": "x", "pattern": "y", "action": "nope" }]
+        });
+        assert!(serde_json::from_value::<GuardrailConfig>(json).is_err());
+    }
+
+    #[test]
+    fn invalid_regex_surfaces_at_compile() {
+        let cfg = GuardrailConfig {
+            rules: vec![RuleSpec {
+                name: "bad".to_string(),
+                pattern: "(".to_string(),
+                action: Action::Block,
+            }],
+        };
+        assert!(cfg.compile().is_err());
+    }
+}

--- a/plugins/bitrouter-guardrails/src/config.rs
+++ b/plugins/bitrouter-guardrails/src/config.rs
@@ -9,19 +9,23 @@ use serde::{Deserialize, Serialize};
 
 use crate::rules::{Action, GuardrailRule, RuleSet};
 
-/// One guardrail rule in serializable form: a name, a regex `pattern`, and an
-/// [`Action`]. Compiled into a [`GuardrailRule`] by [`RuleSpec::compile`].
-///
-/// Derives `PartialEq`/`Eq`/`JsonSchema` so a host can embed it in its own
-/// comparable, OpenAPI-published config / policy types (e.g. bitrouter-cloud's
-/// guardrail policy clause).
+/// One guardrail rule in serializable form: a name, a regex pattern, and a
+/// match action. Compile it into a runtime rule with `RuleSpec::compile`.
+//
+// NOTE: the doc comments on this type and its fields are copied verbatim by
+// `schemars` into the JSON Schema `description`, which a host (e.g.
+// bitrouter-cloud) republishes in its OpenAPI document. Keep them as plain
+// prose — no rustdoc intra-doc links (`[`Foo`]`), which would leak the
+// bracket syntax into the published spec. (`PartialEq`/`Eq`/`JsonSchema` are
+// derived precisely so a host can embed this in its own comparable,
+// OpenAPI-published policy types.)
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct RuleSpec {
     /// Human-readable rule name (surfaced in deny reasons / logs).
     pub name: String,
     /// The regex pattern to match.
     pub pattern: String,
-    /// What to do on a match. Defaults to [`Action::Block`] when omitted.
+    /// What to do on a match. Defaults to `block` when omitted.
     #[serde(default)]
     pub action: Action,
 }

--- a/plugins/bitrouter-guardrails/src/config.rs
+++ b/plugins/bitrouter-guardrails/src/config.rs
@@ -10,8 +10,12 @@ use serde::{Deserialize, Serialize};
 use crate::rules::{Action, GuardrailRule, RuleSet};
 
 /// One guardrail rule in serializable form: a name, a regex `pattern`, and an
-/// [`Action`]. Compiled into a [`GuardrailRule`] by [`GuardrailConfig::compile`].
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// [`Action`]. Compiled into a [`GuardrailRule`] by [`RuleSpec::compile`].
+///
+/// Derives `PartialEq`/`Eq`/`JsonSchema` so a host can embed it in its own
+/// comparable, OpenAPI-published config / policy types (e.g. bitrouter-cloud's
+/// guardrail policy clause).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct RuleSpec {
     /// Human-readable rule name (surfaced in deny reasons / logs).
     pub name: String,
@@ -22,10 +26,17 @@ pub struct RuleSpec {
     pub action: Action,
 }
 
+impl RuleSpec {
+    /// Compile this spec's regex into a runtime [`GuardrailRule`].
+    pub fn compile(&self) -> Result<GuardrailRule, regex::Error> {
+        GuardrailRule::new(&self.name, &self.pattern, self.action)
+    }
+}
+
 /// The guardrail data contract. In a config file this is the `custom_patterns`
 /// array under `plugins.bitrouter-guardrails`; a control plane builds the same
 /// shape from its own store.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct GuardrailConfig {
     /// The configured rules.
     #[serde(default, rename = "custom_patterns")]
@@ -38,7 +49,7 @@ impl GuardrailConfig {
     pub fn compile(&self) -> Result<RuleSet, regex::Error> {
         let mut set = RuleSet::new();
         for spec in &self.rules {
-            set.push(GuardrailRule::new(&spec.name, &spec.pattern, spec.action)?);
+            set.push(spec.compile()?);
         }
         Ok(set)
     }

--- a/plugins/bitrouter-guardrails/src/hooks.rs
+++ b/plugins/bitrouter-guardrails/src/hooks.rs
@@ -1,9 +1,21 @@
-//! The two guardrail hooks:
+//! The guardrail hooks:
+//! - [`DepositRulesHook`] — a `language_model::PreRequestHook` that inserts a
+//!   shared [`RuleSet`] into the request's typed extensions, so the guardrail
+//!   hooks downstream see a fixed, process-global rule set;
 //! - [`GuardrailPreHook`] — a `language_model::PreRequestHook` that scans the
 //!   **request** content and denies on a `Block` rule (upstream /);
 //! - [`GuardrailStreamHook`] — a `language_model::StreamHook` that scans the
 //!   **response** stream, redacting `Redact` matches and aborting on `Block`
 //!   (downstream /).
+//!
+//! Both guardrail hooks read the active [`RuleSet`] from the pipeline's typed
+//! extensions rather than capturing one at construction — so a multi-tenant
+//! host can resolve a per-account rule set in an earlier pre-request stage and
+//! [`PipelineContext::insert_extension`] it, and the same hooks enforce it. The
+//! OSS path uses [`DepositRulesHook`] to install one global set. With no rule
+//! set present, both hooks no-op (allow / pass).
+
+use std::sync::Arc;
 
 use async_trait::async_trait;
 
@@ -51,34 +63,56 @@ fn request_text(ctx: &PipelineContext) -> String {
     buf
 }
 
-/// Upstream guardrail: scans request content, denies on a `Block` match.
-pub struct GuardrailPreHook {
-    rules: std::sync::Arc<RuleSet>,
+/// Upstream hook that deposits a shared [`RuleSet`] into the request's typed
+/// extensions, so [`GuardrailPreHook`] / [`GuardrailStreamHook`] (which read
+/// the rule set from the extensions) enforce a fixed, process-global set.
+///
+/// Used by [`crate::GuardrailsPlugin::with_static`]. A multi-tenant host
+/// instead resolves a per-account rule set in its own pre-request stage and
+/// calls [`PipelineContext::insert_extension`] directly — no deposit hook.
+pub struct DepositRulesHook {
+    rules: Arc<RuleSet>,
 }
 
-impl GuardrailPreHook {
-    /// Build an upstream guardrail hook over a rule set.
-    pub fn new(rules: RuleSet) -> Self {
-        Self {
-            rules: std::sync::Arc::new(rules),
-        }
-    }
-
-    /// Build a hook from an already-shared rule set so the two guardrail hooks
-    /// can share one `Arc<RuleSet>` and dodge per-stream-delta clones.
-    pub fn from_arc(rules: std::sync::Arc<RuleSet>) -> Self {
+impl DepositRulesHook {
+    /// Build a deposit hook over a shared rule set.
+    pub fn new(rules: Arc<RuleSet>) -> Self {
         Self { rules }
+    }
+}
+
+#[async_trait]
+impl PreRequestHook for DepositRulesHook {
+    async fn check(&self, ctx: &mut PipelineContext) -> Result<HookDecision> {
+        ctx.insert_extension(self.rules.clone());
+        Ok(HookDecision::Allow)
+    }
+}
+
+/// Upstream guardrail: scans request content, denies on a `Block` match. Reads
+/// the active [`RuleSet`] from the request's typed extensions; allows the
+/// request when none is present.
+#[derive(Default)]
+pub struct GuardrailPreHook;
+
+impl GuardrailPreHook {
+    /// Build an upstream guardrail hook.
+    pub fn new() -> Self {
+        Self
     }
 }
 
 #[async_trait]
 impl PreRequestHook for GuardrailPreHook {
     async fn check(&self, ctx: &mut PipelineContext) -> Result<HookDecision> {
-        if self.rules.is_empty() {
+        let Some(rules) = ctx.extension::<RuleSet>() else {
+            return Ok(HookDecision::Allow);
+        };
+        if rules.is_empty() {
             return Ok(HookDecision::Allow);
         }
         let text = request_text(ctx);
-        if let Some(rule_name) = self.rules.first_block(&text) {
+        if let Some(rule_name) = rules.first_block(&text) {
             return Ok(HookDecision::Deny(DenyReason::GuardrailViolation(format!(
                 "request blocked by guardrail rule '{rule_name}'"
             ))));
@@ -88,26 +122,19 @@ impl PreRequestHook for GuardrailPreHook {
 }
 
 /// Downstream guardrail: scans the response stream, redacting `Redact` matches
-/// and aborting the stream on a `Block` match.
+/// and aborting the stream on a `Block` match. Reads the active [`RuleSet`]
+/// from the stream context's typed extensions (propagated from the pre-request
+/// stage); passes the stream through untouched when none is present.
 ///
 /// The per-request sliding-window carry is persisted in `StreamContext`
 /// metadata between `on_part` calls — the hook itself is stateless and shared.
-pub struct GuardrailStreamHook {
-    rules: std::sync::Arc<RuleSet>,
-}
+#[derive(Default)]
+pub struct GuardrailStreamHook;
 
 impl GuardrailStreamHook {
-    /// Build a downstream guardrail hook over a rule set.
-    pub fn new(rules: RuleSet) -> Self {
-        Self {
-            rules: std::sync::Arc::new(rules),
-        }
-    }
-
-    /// Build a hook from an already-shared rule set so it can share an
-    /// `Arc<RuleSet>` with [`GuardrailPreHook::from_arc`] and dodge clones.
-    pub fn from_arc(rules: std::sync::Arc<RuleSet>) -> Self {
-        Self { rules }
+    /// Build a downstream guardrail hook.
+    pub fn new() -> Self {
+        Self
     }
 
     fn load_carry(ctx: &StreamContext) -> String {
@@ -134,7 +161,10 @@ impl StreamHook for GuardrailStreamHook {
     }
 
     async fn on_part(&self, ctx: &mut StreamContext, part: StreamPart) -> Result<StreamAction> {
-        if self.rules.is_empty() {
+        let Some(rules) = ctx.extension::<RuleSet>() else {
+            return Ok(StreamAction::Pass);
+        };
+        if rules.is_empty() {
             return Ok(StreamAction::Pass);
         }
         let (text, rebuild): (&str, fn(String) -> StreamPart) = match &part {
@@ -149,9 +179,10 @@ impl StreamHook for GuardrailStreamHook {
         };
 
         let carry = Self::load_carry(ctx);
-        // `Arc::clone` is a refcount bump; the matcher reuses the same
+        // `rules` is a per-delta map lookup returning a cloned `Arc` (refcount
+        // bump, no realloc); the matcher moves it in and reuses the same
         // compiled regex set without re-allocating per delta.
-        let mut matcher = SlidingWindowMatcher::with_carry(self.rules.clone(), &carry);
+        let mut matcher = SlidingWindowMatcher::with_carry(rules, &carry);
         let verdict = matcher.feed(text);
         Self::store_carry(ctx, &matcher.carry());
 

--- a/plugins/bitrouter-guardrails/src/lib.rs
+++ b/plugins/bitrouter-guardrails/src/lib.rs
@@ -2,16 +2,28 @@
 //!
 //! Content firewall plugin. Provides [`GuardrailPreHook`] (upstream / request
 //! content — denies on a `Block` rule) and [`GuardrailStreamHook`] (downstream
-//! / response stream — redacts `Redact` matches, aborts on `Block`). See
-//! design doc.
+//! / response stream — redacts `Redact` matches, aborts on `Block`).
+//!
+//! Both hooks read the active [`RuleSet`] from the pipeline's typed extensions,
+//! so the rule set can be either a fixed global set or one resolved per request
+//! by the host. [`GuardrailsPlugin`] wires the hooks into an
+//! [`bitrouter_sdk::AppBuilder`] in one call: [`GuardrailsPlugin::with_static`]
+//! for the global case (it also installs a [`DepositRulesHook`]), or
+//! [`GuardrailsPlugin::dynamic`] when the host deposits a per-request rule set
+//! itself. [`GuardrailConfig`] is the serializable data contract a host loads
+//! from any source and compiles into a [`RuleSet`]. See design doc.
 
 #![forbid(unsafe_code)]
 
+pub mod config;
 pub mod hooks;
+pub mod plugin;
 pub mod rules;
 
 #[cfg(test)]
 mod tests;
 
-pub use hooks::{GuardrailPreHook, GuardrailStreamHook};
+pub use config::{GuardrailConfig, RuleSpec};
+pub use hooks::{DepositRulesHook, GuardrailPreHook, GuardrailStreamHook};
+pub use plugin::GuardrailsPlugin;
 pub use rules::{Action, GuardrailRule, REDACTION, RuleSet, SlidingWindowMatcher, WindowResult};

--- a/plugins/bitrouter-guardrails/src/plugin.rs
+++ b/plugins/bitrouter-guardrails/src/plugin.rs
@@ -1,0 +1,61 @@
+//! [`GuardrailsPlugin`] — a [`Plugin`] convenience package that wires the
+//! guardrail hooks onto the `language_model` pipeline in one call, for both the
+//! OSS binary and any downstream host.
+//!
+//! - [`GuardrailsPlugin::with_static`] — a fixed, process-global rule set. It
+//!   installs a [`DepositRulesHook`] (which inserts the shared rule set into
+//!   every request's extensions) ahead of the two guardrail hooks.
+//! - [`GuardrailsPlugin::dynamic`] — no built-in rules. It installs only the
+//!   two guardrail hooks; the host resolves a per-request (e.g. per-account)
+//!   [`RuleSet`] in an earlier pre-request stage and deposits it via
+//!   [`PipelineContext::insert_extension`](bitrouter_sdk::language_model::PipelineContext::insert_extension).
+//!   With nothing deposited, the hooks no-op.
+
+use std::sync::Arc;
+
+use bitrouter_sdk::{AppBuilder, Plugin, PluginId};
+
+use crate::hooks::{DepositRulesHook, GuardrailPreHook, GuardrailStreamHook};
+use crate::rules::RuleSet;
+
+/// A [`Plugin`] that registers the upstream + downstream guardrail hooks.
+pub struct GuardrailsPlugin {
+    id: PluginId,
+    static_rules: Option<Arc<RuleSet>>,
+}
+
+impl GuardrailsPlugin {
+    /// Build a plugin over a fixed, process-global rule set.
+    pub fn with_static(rules: RuleSet) -> Self {
+        Self {
+            id: PluginId::new("bitrouter-guardrails"),
+            static_rules: Some(Arc::new(rules)),
+        }
+    }
+
+    /// Build a plugin with no built-in rules, for hosts that resolve and
+    /// deposit a per-request [`RuleSet`] themselves.
+    pub fn dynamic() -> Self {
+        Self {
+            id: PluginId::new("bitrouter-guardrails"),
+            static_rules: None,
+        }
+    }
+}
+
+impl Plugin for GuardrailsPlugin {
+    fn id(&self) -> &PluginId {
+        &self.id
+    }
+
+    fn install(&self, app: &mut AppBuilder) {
+        let lm = app.language_model_builder();
+        if let Some(rules) = &self.static_rules {
+            // Runs ahead of the guardrail hooks (registration order), depositing
+            // the shared rule set the two hooks then read.
+            lm.pre_request_hook(DepositRulesHook::new(rules.clone()));
+        }
+        lm.pre_request_hook(GuardrailPreHook::new());
+        lm.stream_hook(GuardrailStreamHook::new());
+    }
+}

--- a/plugins/bitrouter-guardrails/src/rules.rs
+++ b/plugins/bitrouter-guardrails/src/rules.rs
@@ -16,9 +16,12 @@ use regex::{Regex, RegexBuilder};
 const REGEX_SIZE_LIMIT: usize = 1 << 20;
 
 /// What to do when a rule matches.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum Action {
-    /// Block the content — upstream this is a 400 deny, downstream a stream abort.
+    /// Block the content — upstream this is a 400 deny, downstream a stream
+    /// abort. The default when a rule omits its action (block is the safe one).
+    #[default]
     Block,
     /// Redact the matched span — replace it with the redaction placeholder.
     Redact,

--- a/plugins/bitrouter-guardrails/src/rules.rs
+++ b/plugins/bitrouter-guardrails/src/rules.rs
@@ -16,7 +16,17 @@ use regex::{Regex, RegexBuilder};
 const REGEX_SIZE_LIMIT: usize = 1 << 20;
 
 /// What to do when a rule matches.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Default,
+    serde::Serialize,
+    serde::Deserialize,
+    schemars::JsonSchema,
+)]
 #[serde(rename_all = "snake_case")]
 pub enum Action {
     /// Block the content — upstream this is a 400 deny, downstream a stream

--- a/plugins/bitrouter-guardrails/src/tests.rs
+++ b/plugins/bitrouter-guardrails/src/tests.rs
@@ -10,7 +10,7 @@ use bitrouter_sdk::language_model::{
 };
 use futures::StreamExt;
 
-use crate::hooks::{GuardrailPreHook, GuardrailStreamHook};
+use crate::hooks::{DepositRulesHook, GuardrailPreHook, GuardrailStreamHook};
 use crate::rules::{Action, GuardrailRule, RuleSet};
 
 fn rules() -> RuleSet {
@@ -37,12 +37,31 @@ fn ctx(text: &str) -> PipelineContext {
     PipelineContext::new(req)
 }
 
+/// A context with the guardrail rule set deposited into its extensions, the way
+/// `DepositRulesHook` (or a host's per-account resolver) does at Stage 1.
+fn ctx_with_rules(text: &str) -> PipelineContext {
+    let mut c = ctx(text);
+    c.insert_extension(Arc::new(rules()));
+    c
+}
+
 // ===== upstream: GuardrailPreHook =====
 
 #[tokio::test]
 async fn pre_hook_allows_clean_request() {
-    let hook = GuardrailPreHook::new(rules());
-    let mut c = ctx("a perfectly normal question");
+    let hook = GuardrailPreHook::new();
+    let mut c = ctx_with_rules("a perfectly normal question");
+    assert!(matches!(
+        hook.check(&mut c).await.unwrap(),
+        bitrouter_sdk::language_model::HookDecision::Allow
+    ));
+}
+
+#[tokio::test]
+async fn pre_hook_allows_when_no_rules_deposited() {
+    // No extension inserted — the hook is a pure consumer and must no-op.
+    let hook = GuardrailPreHook::new();
+    let mut c = ctx("please do the FORBIDDEN thing");
     assert!(matches!(
         hook.check(&mut c).await.unwrap(),
         bitrouter_sdk::language_model::HookDecision::Allow
@@ -51,8 +70,8 @@ async fn pre_hook_allows_clean_request() {
 
 #[tokio::test]
 async fn pre_hook_blocks_forbidden_request() {
-    let hook = GuardrailPreHook::new(rules());
-    let mut c = ctx("please do the FORBIDDEN thing");
+    let hook = GuardrailPreHook::new();
+    let mut c = ctx_with_rules("please do the FORBIDDEN thing");
     match hook.check(&mut c).await.unwrap() {
         bitrouter_sdk::language_model::HookDecision::Deny(reason) => {
             let err: bitrouter_sdk::BitrouterError = reason.into();
@@ -87,11 +106,14 @@ fn routing_table() -> Arc<StaticRoutingTable> {
 
 async fn run_stream(parts: Vec<StreamPart>) -> Vec<bitrouter_sdk::Result<StreamPart>> {
     let mut b = PipelineBuilder::new();
+    // The deposit hook runs at Stage 1 and the rule set rides the extensions
+    // into the StreamContext — end-to-end proof the propagation works.
     b.routing_table(routing_table())
         .executor(Arc::new(MockExecutor::new(vec![MockResponse::Stream(
             parts,
         )])))
-        .stream_hook(GuardrailStreamHook::new(rules()));
+        .pre_request_hook(DepositRulesHook::new(Arc::new(rules())))
+        .stream_hook(GuardrailStreamHook::new());
     let pipeline = Arc::new(b.build().unwrap());
     let req = PipelineRequest::new("m", CallerContext::new("k", "u"), prompt("go", true));
     let stream = pipeline.execute_stream(req).await.unwrap();


### PR DESCRIPTION
Closes #502.

Upgrades `bitrouter-guardrails` so it assembles into **both** the OSS binary and a downstream multi-tenant host (`bitrouter-cloud`) with **per-request, per-account** rule sets — instead of one process-global `RuleSet` bound at app-build time. Implements all four parts of the issue's proposal.

## What changed

### 1. SDK (breaking): typed, request-scoped extensions
`PipelineContext` gains `insert_extension::<T>(Arc<T>)` / `extension::<T>() -> Option<Arc<T>>`, backed by a small `TypeId`-keyed map of `Arc<dyn Any + Send + Sync>`. `stream_context()` clones the map (a refcount bump per entry) into `StreamContext`, which gains `extension::<T>()`.

This is the channel that carries an already-compiled `Arc<RuleSet>` from a Stage-1 pre-request hook into the streaming stage. The JSON `metadata` channel can't: `StreamContext` is built fresh and inherits no `metadata`, and JSON can't hold a compiled `regex`. Resolution happens **once per request** in the pre-request stage; the per-token `on_part` hot path only reads the pre-resolved `Arc` (a map lookup + refcount bump, no async, no re-parse).

### 2. `GuardrailsPlugin` (SDK `Plugin` trait)
- `with_static(RuleSet)` — installs a `DepositRulesHook` (inserts the shared rule set into every request's extensions) ahead of both guardrail hooks. The OSS path.
- `dynamic()` — installs only the two guardrail hooks. For hosts that resolve a per-account `RuleSet` (keyed off `ctx.caller()`) in their own earlier pre-request stage and `insert_extension` it. The cloud path.

### 3. Serializable config contract, decoupled from the config file
New `GuardrailConfig` / `RuleSpec` (`config.rs`); the host loads it from any source and `compile()`s it into a `RuleSet`. `Action` gains serde (`snake_case`, defaults to `Block`). `apps/bitrouter` now parses `plugins.bitrouter-guardrails` via serde + `compile()` instead of hand-walking JSON. The `custom_patterns` config key and its behaviour (missing `action` ⇒ block, unknown ⇒ error) are unchanged.

### 4. Hooks become pure consumers (breaking)
`GuardrailPreHook::new()` / `GuardrailStreamHook::new()` drop the `RuleSet` argument and read `Arc<RuleSet>` from the context extensions; no rules present ⇒ no-op (allow / pass). `from_arc` is removed; `DepositRulesHook` is new.

## Ordering & compatibility
`apps/bitrouter` registers guardrails via `.plugin(GuardrailsPlugin::with_static(...))` **after** the `.language_model(|lm| …)` closure that registers auth + policy, so the final pre-request order stays **auth → policy → deposit → guardrail-pre**. The existing `full_stack` ordering test (`policy denies before guardrails`) still passes.

## Notes for reviewers
- **`dynamic()` has no in-repo caller** — it's the entry point for the downstream `bitrouter-cloud` integration (issue part 2). It's a `pub` library item, so no dead-code warning; calling it out here so it isn't flagged as unused.
- Reviewed by an independent agent pass before submission: no correctness/design/guideline findings beyond two nits (both addressed).

## Checks
`cargo fmt --check`, `cargo clippy --all-features`, `cargo nextest run --all-features` (558 pass), and doctests all green. Rebased onto current `main` (on top of #495 / #500).
