### PR TITLE
refactor(sdk)!: rename API protocols to spec names

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ Built-in providers are defined as TOML files under [`crates/bitrouter-providers/
 
 ### Adding a new built-in provider
 
-If the provider uses an already-supported wire protocol (OpenAI Chat, OpenAI Responses, Anthropic Messages, Google Generative AI):
+If the provider uses an already-supported wire protocol (Chat Completions, Responses, Messages, Generate Content):
 
 1. Add a new TOML file under `crates/bitrouter-providers/providers/`. The filename stem **must** equal the `id` field inside.
 2. Register it in the `EMBEDDED` array in [`crates/bitrouter-providers/src/builtin.rs`](crates/bitrouter-providers/src/builtin.rs) and bump the count assertion in that file's tests.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -24,7 +24,7 @@ The layering is strictly one-directional — **`plugins → sdk`**, **`apps → 
      - `language_model` — the main pipeline: LLM completions with the full hook chain (pre-request → route → execute → settle), an interleaved stream stage, and read-only observation.
      - `mcp` — Model Context Protocol routing (pure routing, no settlement).
      - `acp` — Agent Client Protocol routing (pure routing, no settlement).
-   - **Four wire-protocol adapters** — OpenAI Chat, OpenAI Responses, Anthropic Messages, Google Generative AI — each with an inbound side (parse a client request / encode a client response + SSE) and an outbound side (render a provider request / decode a provider response + SSE). Any inbound protocol can be served by any outbound protocol.
+   - **Four wire-protocol adapters** — Chat Completions, Responses, Messages, Generate Content — each with an inbound side (parse a client request / encode a client response + SSE) and an outbound side (render a provider request / decode a provider response + SSE). Any inbound protocol can be served by any outbound protocol.
    - **Hook traits** — `PreRequestHook`, `RouteHook`, `ExecutionHook`, `StreamHook`, `SettlementRecorder`, `ObserveHook` — the extension points every plugin and the binary's builtin hooks implement.
    - **Config + routing** — YAML parsing, `${VAR}` substitution, the `ConfigRoutingTable`.
    - The **axum HTTP server** and the `App` builder.
@@ -59,7 +59,7 @@ A streaming LLM request moves through the workspace like this:
    - **Route** — the `RoutingTable` resolves the model name to a fallback chain of `RoutingTarget`s (provider + upstream model id + protocol); `RouteHook`s may rewrite the chain.
    - **Execute** — the executor dials the first target; on failure the `FallbackPolicy` decides whether to try the next. The **outbound adapter** for the target's protocol renders the provider request and decodes the provider response (and its SSE stream).
    - **Settlement** — every `SettlementRecorder` runs (metering, etc.), success or failure.
-4. For streaming, the canonical `StreamPart` stream flows through the `StreamHook` stage and is re-encoded by the inbound adapter into the **client's** protocol — so a client written for OpenAI Responses can transparently use an Anthropic-protocol upstream, and vice versa.
+4. For streaming, the canonical `StreamPart` stream flows through the `StreamHook` stage and is re-encoded by the inbound adapter into the **client's** protocol — so a client written for the Responses protocol can transparently use a Messages upstream, and vice versa.
 5. `ObserveHook`s receive read-only lifecycle events throughout (Prometheus, OTLP).
 
 The `mcp` and `acp` pipelines are simpler: pure routing with no settlement.
@@ -88,10 +88,10 @@ The axum server lives behind the SDK's `server` feature (`crates/bitrouter-sdk/s
 
 | Route                               | Handler                          |
 | ----------------------------------- | -------------------------------- |
-| `POST /v1/chat/completions`         | OpenAI Chat Completions inbound  |
-| `POST /v1/responses`                | OpenAI Responses inbound         |
-| `POST /v1/messages`                 | Anthropic Messages inbound       |
-| `POST /v1beta/models/{model_action}`| Google Generative AI inbound     |
+| `POST /v1/chat/completions`         | Chat Completions inbound         |
+| `POST /v1/responses`                | Responses inbound                |
+| `POST /v1/messages`                 | Messages inbound                 |
+| `POST /v1beta/models/{model_action}`| Generate Content inbound         |
 | `GET  /v1/models`                   | model catalog listing            |
 | `POST /mcp/{server}`                | MCP gateway (JSON-RPC proxy)     |
 | `GET  /metrics`                     | Prometheus exposition            |

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Manage keys, usage, billing, policies, and BYOK from the same CLI — see `bitro
 ## Features
 
 - **Multi-provider routing** — unified access to OpenAI, Anthropic, Google, OpenRouter, OpenCode Zen / Go, BitRouter Cloud, GitHub Copilot, ChatGPT Codex, and Amazon Bedrock; configure multiple accounts per provider with failover or round-robin load-balancing ([`sdk`](crates/bitrouter-sdk/) · [`providers`](crates/bitrouter-providers/))
-- **Cross-protocol routing** — any client protocol (OpenAI Chat, OpenAI Responses, Anthropic Messages, Google Gemini) against any upstream; BitRouter translates transparently ([`sdk`](crates/bitrouter-sdk/))
+- **Cross-protocol routing** — any client protocol (Chat Completions, Responses, Messages, Generate Content) against any upstream; BitRouter translates transparently ([`sdk`](crates/bitrouter-sdk/))
 - **Zero-config** — auto-detects providers from environment variables; no config file needed to get started ([`providers`](crates/bitrouter-providers/))
 - **MCP gateway** — proxy for MCP servers; agents discover and call tools across hosts ([`sdk`](crates/bitrouter-sdk/))
 - **ACP integration** — manage coding agent sessions (Claude Code, OpenAI Codex, Gemini CLI) via the CLI ([`sdk`](crates/bitrouter-sdk/))
@@ -84,7 +84,7 @@ Manage keys, usage, billing, policies, and BYOK from the same CLI — see `bitro
 | Google          | ✅     | Generative AI API                                              |
 | Amazon Bedrock  | ✅     | Via AWS SDK (opt-in)                                           |
 | OpenRouter      | ✅     | Chat Completions + Responses API                               |
-| OpenCode Zen    | ✅     | Curated models across OpenAI, Anthropic, Google protocols      |
+| OpenCode Zen    | ✅     | Curated models across Chat Completions, Messages, and Generate Content protocols      |
 | OpenCode Go     | ✅     | Low-cost subscription for open coding models                   |
 | BitRouter Cloud | ✅     | OAuth sign-in (`bitrouter auth login`); cloud-managed routing  |
 | GitHub Copilot  | ✅     | GitHub OAuth device flow (`bitrouter login github-copilot`)    |

--- a/apps/bitrouter/tests/e2e.rs
+++ b/apps/bitrouter/tests/e2e.rs
@@ -24,8 +24,8 @@ use serde_json::{Value, json};
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
-/// Stand up a wiremock upstream speaking OpenAI Chat Completions.
-async fn mock_openai_upstream() -> MockServer {
+/// Stand up a wiremock upstream speaking Chat Completions.
+async fn mock_chat_completions_upstream() -> MockServer {
     let server = MockServer::start().await;
     Mock::given(method("POST"))
         .and(path("/chat/completions"))
@@ -60,7 +60,7 @@ providers:
     api_base: {upstream}
     api_key: test-key
     api_protocol:
-      - "*": openai
+      - "*": chat_completions
     models:
       - id: test-model
         pricing:
@@ -85,7 +85,7 @@ fn chat_prompt() -> Prompt {
 
 #[tokio::test]
 async fn e2e_assembled_pipeline_routes_to_mock_provider() {
-    let upstream = mock_openai_upstream().await;
+    let upstream = mock_chat_completions_upstream().await;
     let cfg = config_for(&upstream.uri());
 
     // Assemble the FULL app — db + migrations + routing + auth + policy +
@@ -134,7 +134,7 @@ async fn e2e_assembled_pipeline_routes_to_mock_provider() {
 async fn e2e_http_server_chat_completions_end_to_end() {
     use axum_test::TestServer;
 
-    let upstream = mock_openai_upstream().await;
+    let upstream = mock_chat_completions_upstream().await;
     let cfg = config_for(&upstream.uri());
     let assembled = bitrouter::build_app(&cfg).await.expect("app assembles");
 
@@ -190,7 +190,7 @@ async fn e2e_http_server_chat_completions_end_to_end() {
 
 #[tokio::test]
 async fn e2e_unknown_model_is_a_clean_404() {
-    let upstream = mock_openai_upstream().await;
+    let upstream = mock_chat_completions_upstream().await;
     let cfg = config_for(&upstream.uri());
     let assembled = bitrouter::build_app(&cfg).await.expect("app assembles");
     let pipeline = assembled.app.language_model().unwrap().clone();
@@ -213,7 +213,7 @@ async fn e2e_metering_drives_policy_spend_cap() {
     // a rolling-window gate, not a per-request budget.)
     use bitrouter::auth::{NewApiKey, db as auth_db, generate};
 
-    let upstream = mock_openai_upstream().await;
+    let upstream = mock_chat_completions_upstream().await;
 
     // Same provider/pricing as `config_for`, but augmented with a policy
     // directory containing a single `pol_cap` policy with a 50µ$ ceiling.
@@ -244,7 +244,7 @@ providers:
     api_base: {upstream}
     api_key: test-key
     api_protocol:
-      - "*": openai
+      - "*": chat_completions
     models:
       - id: test-model
         pricing:
@@ -761,8 +761,8 @@ async fn e2e_mcp_aggregate_and_sse_endpoints() {
 // inbound protocol's native shape and asserts it lands at the right native
 // field on the wire to the upstream:
 //
-//   OpenAI Chat:      response_format.json_schema.schema
-//   OpenAI Responses: text.format.schema
+//   Chat Completions:      response_format.json_schema.schema
+//   Responses: text.format.schema
 //   Anthropic:        output_config.format.schema
 //   Google:           generationConfig.responseSchema  (paired with
 //                     responseMimeType == "application/json")
@@ -801,7 +801,7 @@ const MODEL_VIA_GOOGLE: &str = "model-via-google";
 async fn upstream_for_all_protocols() -> MockServer {
     let server = MockServer::start().await;
 
-    // OpenAI Chat — POST /chat/completions
+    // Chat Completions — POST /chat/completions
     Mock::given(method("POST"))
         .and(path("/chat/completions"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
@@ -818,7 +818,7 @@ async fn upstream_for_all_protocols() -> MockServer {
         .mount(&server)
         .await;
 
-    // OpenAI Responses — POST /responses
+    // Responses — POST /responses
     Mock::given(method("POST"))
         .and(path("/responses"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
@@ -836,7 +836,7 @@ async fn upstream_for_all_protocols() -> MockServer {
         .mount(&server)
         .await;
 
-    // Anthropic Messages — POST /messages
+    // Messages — POST /messages
     Mock::given(method("POST"))
         .and(path("/messages"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
@@ -851,7 +851,7 @@ async fn upstream_for_all_protocols() -> MockServer {
         .mount(&server)
         .await;
 
-    // Google — POST /models/{model}:generateContent (model id varies per
+    // Generate Content — POST /models/{model}:generateContent (model id varies per
     // test; match on path prefix + suffix).
     Mock::given(method("POST"))
         .and(wiremock::matchers::path_regex(
@@ -889,14 +889,14 @@ providers:
     api_base: {upstream}
     api_key: test-key
     api_protocol:
-      - "*": openai
+      - "*": chat_completions
     models:
       - id: {MODEL_VIA_OPENAI}
   via_anthropic:
     api_base: {upstream}
     api_key: test-key
     api_protocol:
-      - "*": anthropic
+      - "*": messages
     models:
       - id: {MODEL_VIA_ANTHROPIC}
   via_responses:
@@ -910,7 +910,7 @@ providers:
     api_base: {upstream}
     api_key: test-key
     api_protocol:
-      - "*": google
+      - "*": generate_content
     models:
       - id: {MODEL_VIA_GOOGLE}
 "#
@@ -934,7 +934,7 @@ async fn matrix_server() -> (TestServer, MockServer) {
 
 // ----- inbound request builders (one per inbound protocol) -----
 
-fn inbound_openai_chat(model: &str) -> Value {
+fn inbound_chat_completions(model: &str) -> Value {
     json!({
         "model": model,
         "messages": [{ "role": "user", "content": "weather?" }],
@@ -960,7 +960,7 @@ fn inbound_anthropic(model: &str) -> Value {
     })
 }
 
-fn inbound_openai_responses(model: &str) -> Value {
+fn inbound_responses(model: &str) -> Value {
     json!({
         "model": model,
         "input": "weather?",
@@ -976,7 +976,7 @@ fn inbound_openai_responses(model: &str) -> Value {
 }
 
 fn inbound_google() -> Value {
-    // Google carries the model in the URL, not the body.
+    // Generate Content carries the model in the URL, not the body.
     json!({
         "contents": [{ "role": "user", "parts": [{ "text": "weather?" }] }],
         "generationConfig": {
@@ -988,37 +988,37 @@ fn inbound_google() -> Value {
 
 #[derive(Clone, Copy)]
 enum Inbound {
-    OpenAiChat,
-    Anthropic,
-    OpenAiResponses,
-    Google,
+    ChatCompletions,
+    Messages,
+    Responses,
+    GenerateContent,
 }
 
 #[derive(Clone, Copy)]
 enum Outbound {
-    OpenAiChat,
-    Anthropic,
-    OpenAiResponses,
-    Google,
+    ChatCompletions,
+    Messages,
+    Responses,
+    GenerateContent,
 }
 
 impl Outbound {
     fn model(self) -> &'static str {
         match self {
-            Outbound::OpenAiChat => MODEL_VIA_OPENAI,
-            Outbound::Anthropic => MODEL_VIA_ANTHROPIC,
-            Outbound::OpenAiResponses => MODEL_VIA_RESPONSES,
-            Outbound::Google => MODEL_VIA_GOOGLE,
+            Outbound::ChatCompletions => MODEL_VIA_OPENAI,
+            Outbound::Messages => MODEL_VIA_ANTHROPIC,
+            Outbound::Responses => MODEL_VIA_RESPONSES,
+            Outbound::GenerateContent => MODEL_VIA_GOOGLE,
         }
     }
 
     fn path_segment(self) -> &'static str {
         match self {
-            Outbound::OpenAiChat => "/chat/completions",
-            Outbound::Anthropic => "/messages",
-            Outbound::OpenAiResponses => "/responses",
-            // Google's path contains the model id; matched via prefix below.
-            Outbound::Google => "/models/",
+            Outbound::ChatCompletions => "/chat/completions",
+            Outbound::Messages => "/messages",
+            Outbound::Responses => "/responses",
+            // Generate Content's path contains the model id; matched via prefix below.
+            Outbound::GenerateContent => "/models/",
         }
     }
 }
@@ -1026,10 +1026,10 @@ impl Outbound {
 /// POST `body` to the inbound route matching `inbound`.
 async fn post_inbound(server: &TestServer, inbound: Inbound, model: &str, body: &Value) {
     let response = match inbound {
-        Inbound::OpenAiChat => server.post("/v1/chat/completions").json(body).await,
-        Inbound::Anthropic => server.post("/v1/messages").json(body).await,
-        Inbound::OpenAiResponses => server.post("/v1/responses").json(body).await,
-        Inbound::Google => {
+        Inbound::ChatCompletions => server.post("/v1/chat/completions").json(body).await,
+        Inbound::Messages => server.post("/v1/messages").json(body).await,
+        Inbound::Responses => server.post("/v1/responses").json(body).await,
+        Inbound::GenerateContent => {
             server
                 .post(&format!("/v1beta/models/{model}:generateContent"))
                 .json(body)
@@ -1045,7 +1045,7 @@ async fn post_inbound(server: &TestServer, inbound: Inbound, model: &str, body: 
 async fn captured_outbound(upstream: &MockServer, outbound: Outbound) -> Value {
     let received = upstream.received_requests().await.unwrap_or_default();
     let suffix = match outbound {
-        Outbound::Google => ":generateContent",
+        Outbound::GenerateContent => ":generateContent",
         _ => "",
     };
     let matches: Vec<_> = received
@@ -1073,7 +1073,7 @@ async fn captured_outbound(upstream: &MockServer, outbound: Outbound) -> Value {
 fn assert_native_schema(outbound: Outbound, body: &Value) {
     let want = matrix_schema();
     match outbound {
-        Outbound::OpenAiChat => {
+        Outbound::ChatCompletions => {
             assert_eq!(
                 body["response_format"]["type"], "json_schema",
                 "openai chat outbound must set response_format.type=json_schema; body: {body}",
@@ -1083,7 +1083,7 @@ fn assert_native_schema(outbound: Outbound, body: &Value) {
                 "openai chat outbound must carry the schema under \
                  response_format.json_schema.schema; body: {body}",
             );
-            // OpenAI Chat requires `name`; the renderer must supply a default
+            // Chat Completions requires `name`; the renderer must supply a default
             // when the inbound (Anthropic, Google) didn't carry one. Either
             // the caller-supplied name or the default `"response"` is fine.
             assert!(
@@ -1091,7 +1091,7 @@ fn assert_native_schema(outbound: Outbound, body: &Value) {
                 "openai chat outbound must always set a name; body: {body}",
             );
         }
-        Outbound::Anthropic => {
+        Outbound::Messages => {
             assert_eq!(
                 body["output_config"]["format"]["type"], "json_schema",
                 "anthropic outbound must set output_config.format.type=json_schema; body: {body}",
@@ -1101,7 +1101,7 @@ fn assert_native_schema(outbound: Outbound, body: &Value) {
                 "anthropic outbound must carry the schema under \
                  output_config.format.schema; body: {body}",
             );
-            // Anthropic's GA shape doesn't carry name/strict — the renderer
+            // Messages' GA shape doesn't carry name/strict — the renderer
             // must drop them, not forward them as unknown fields.
             assert!(
                 body["output_config"]["format"].get("name").is_none(),
@@ -1118,7 +1118,7 @@ fn assert_native_schema(outbound: Outbound, body: &Value) {
                  body: {body}",
             );
         }
-        Outbound::OpenAiResponses => {
+        Outbound::Responses => {
             assert_eq!(
                 body["text"]["format"]["type"], "json_schema",
                 "responses outbound must set text.format.type=json_schema; body: {body}",
@@ -1132,7 +1132,7 @@ fn assert_native_schema(outbound: Outbound, body: &Value) {
                 "responses outbound must always set a name; body: {body}",
             );
         }
-        Outbound::Google => {
+        Outbound::GenerateContent => {
             assert_eq!(
                 body["generationConfig"]["responseMimeType"], "application/json",
                 "google outbound must set generationConfig.responseMimeType=application/json; \
@@ -1152,10 +1152,10 @@ async fn run_cell(inbound: Inbound, outbound: Outbound) {
     let (server, upstream) = matrix_server().await;
     let model = outbound.model();
     let body = match inbound {
-        Inbound::OpenAiChat => inbound_openai_chat(model),
-        Inbound::Anthropic => inbound_anthropic(model),
-        Inbound::OpenAiResponses => inbound_openai_responses(model),
-        Inbound::Google => inbound_google(),
+        Inbound::ChatCompletions => inbound_chat_completions(model),
+        Inbound::Messages => inbound_anthropic(model),
+        Inbound::Responses => inbound_responses(model),
+        Inbound::GenerateContent => inbound_google(),
     };
     post_inbound(&server, inbound, model, &body).await;
     let upstream_body = captured_outbound(&upstream, outbound).await;
@@ -1165,81 +1165,81 @@ async fn run_cell(inbound: Inbound, outbound: Outbound) {
 // ----- 4×4 matrix -----
 
 #[tokio::test]
-async fn e2e_response_format_openai_chat_in_to_openai_chat_out() {
-    run_cell(Inbound::OpenAiChat, Outbound::OpenAiChat).await;
+async fn e2e_response_format_chat_completions_in_to_chat_completions_out() {
+    run_cell(Inbound::ChatCompletions, Outbound::ChatCompletions).await;
 }
 
 #[tokio::test]
-async fn e2e_response_format_openai_chat_in_to_anthropic_out() {
-    run_cell(Inbound::OpenAiChat, Outbound::Anthropic).await;
+async fn e2e_response_format_chat_completions_in_to_messages_out() {
+    run_cell(Inbound::ChatCompletions, Outbound::Messages).await;
 }
 
 #[tokio::test]
-async fn e2e_response_format_openai_chat_in_to_responses_out() {
-    run_cell(Inbound::OpenAiChat, Outbound::OpenAiResponses).await;
+async fn e2e_response_format_chat_completions_in_to_responses_out() {
+    run_cell(Inbound::ChatCompletions, Outbound::Responses).await;
 }
 
 #[tokio::test]
-async fn e2e_response_format_openai_chat_in_to_google_out() {
-    run_cell(Inbound::OpenAiChat, Outbound::Google).await;
+async fn e2e_response_format_chat_completions_in_to_generate_content_out() {
+    run_cell(Inbound::ChatCompletions, Outbound::GenerateContent).await;
 }
 
 #[tokio::test]
-async fn e2e_response_format_anthropic_in_to_openai_chat_out() {
-    run_cell(Inbound::Anthropic, Outbound::OpenAiChat).await;
+async fn e2e_response_format_messages_in_to_chat_completions_out() {
+    run_cell(Inbound::Messages, Outbound::ChatCompletions).await;
 }
 
 #[tokio::test]
-async fn e2e_response_format_anthropic_in_to_anthropic_out() {
-    run_cell(Inbound::Anthropic, Outbound::Anthropic).await;
+async fn e2e_response_format_messages_in_to_messages_out() {
+    run_cell(Inbound::Messages, Outbound::Messages).await;
 }
 
 #[tokio::test]
-async fn e2e_response_format_anthropic_in_to_responses_out() {
-    run_cell(Inbound::Anthropic, Outbound::OpenAiResponses).await;
+async fn e2e_response_format_messages_in_to_responses_out() {
+    run_cell(Inbound::Messages, Outbound::Responses).await;
 }
 
 #[tokio::test]
-async fn e2e_response_format_anthropic_in_to_google_out() {
-    run_cell(Inbound::Anthropic, Outbound::Google).await;
+async fn e2e_response_format_messages_in_to_generate_content_out() {
+    run_cell(Inbound::Messages, Outbound::GenerateContent).await;
 }
 
 #[tokio::test]
-async fn e2e_response_format_responses_in_to_openai_chat_out() {
-    run_cell(Inbound::OpenAiResponses, Outbound::OpenAiChat).await;
+async fn e2e_response_format_responses_in_to_chat_completions_out() {
+    run_cell(Inbound::Responses, Outbound::ChatCompletions).await;
 }
 
 #[tokio::test]
-async fn e2e_response_format_responses_in_to_anthropic_out() {
-    run_cell(Inbound::OpenAiResponses, Outbound::Anthropic).await;
+async fn e2e_response_format_responses_in_to_messages_out() {
+    run_cell(Inbound::Responses, Outbound::Messages).await;
 }
 
 #[tokio::test]
 async fn e2e_response_format_responses_in_to_responses_out() {
-    run_cell(Inbound::OpenAiResponses, Outbound::OpenAiResponses).await;
+    run_cell(Inbound::Responses, Outbound::Responses).await;
 }
 
 #[tokio::test]
-async fn e2e_response_format_responses_in_to_google_out() {
-    run_cell(Inbound::OpenAiResponses, Outbound::Google).await;
+async fn e2e_response_format_responses_in_to_generate_content_out() {
+    run_cell(Inbound::Responses, Outbound::GenerateContent).await;
 }
 
 #[tokio::test]
-async fn e2e_response_format_google_in_to_openai_chat_out() {
-    run_cell(Inbound::Google, Outbound::OpenAiChat).await;
+async fn e2e_response_format_generate_content_in_to_chat_completions_out() {
+    run_cell(Inbound::GenerateContent, Outbound::ChatCompletions).await;
 }
 
 #[tokio::test]
-async fn e2e_response_format_google_in_to_anthropic_out() {
-    run_cell(Inbound::Google, Outbound::Anthropic).await;
+async fn e2e_response_format_generate_content_in_to_messages_out() {
+    run_cell(Inbound::GenerateContent, Outbound::Messages).await;
 }
 
 #[tokio::test]
-async fn e2e_response_format_google_in_to_responses_out() {
-    run_cell(Inbound::Google, Outbound::OpenAiResponses).await;
+async fn e2e_response_format_generate_content_in_to_responses_out() {
+    run_cell(Inbound::GenerateContent, Outbound::Responses).await;
 }
 
 #[tokio::test]
-async fn e2e_response_format_google_in_to_google_out() {
-    run_cell(Inbound::Google, Outbound::Google).await;
+async fn e2e_response_format_generate_content_in_to_generate_content_out() {
+    run_cell(Inbound::GenerateContent, Outbound::GenerateContent).await;
 }

--- a/apps/bitrouter/tests/full_stack.rs
+++ b/apps/bitrouter/tests/full_stack.rs
@@ -164,7 +164,7 @@ providers:
     api_base: {upstream}
     api_key: test-key
     api_protocol:
-      - "*": openai
+      - "*": chat_completions
     models:
       - id: test-model
         pricing:
@@ -230,7 +230,7 @@ plugins:
     }
 }
 
-/// OpenAI-style SSE: role; content with an SSN-shaped span; finish
+/// Chat Completions-style SSE: role; content with an SSN-shaped span; finish
 /// chunk carrying `usage` (so MeteringRecorder has something to price);
 /// then `[DONE]`.
 fn build_sse_stream_with_ssn() -> String {
@@ -266,7 +266,7 @@ fn build_sse_stream_with_ssn() -> String {
     out
 }
 
-/// A clean OpenAI Chat Completions body the auth/policy/guardrails path
+/// A clean Chat Completions body the auth/policy/guardrails path
 /// should let through.
 fn clean_body(stream: bool) -> serde_json::Value {
     serde_json::json!({

--- a/apps/bitrouter/tests/observe_hierarchy.rs
+++ b/apps/bitrouter/tests/observe_hierarchy.rs
@@ -145,7 +145,7 @@ providers:
     api_base: {upstream}
     api_key: test-key
     api_protocol:
-      - "*": openai
+      - "*": chat_completions
     models:
       - id: test-model
         pricing:

--- a/crates/bitrouter-cloud-sdk/src/provider/applier.rs
+++ b/crates/bitrouter-cloud-sdk/src/provider/applier.rs
@@ -260,7 +260,7 @@ mod tests {
             service_id: "gpt-4o".to_string(),
             api_base: "https://api.bitrouter.ai/v1".to_string(),
             api_key: key.to_string(),
-            api_protocol: ApiProtocol::Openai,
+            api_protocol: ApiProtocol::ChatCompletions,
             account_label: None,
             api_key_override: None,
             api_base_override: None,

--- a/crates/bitrouter-providers/providers/anthropic.toml
+++ b/crates/bitrouter-providers/providers/anthropic.toml
@@ -15,7 +15,7 @@
 id = "anthropic"
 display_name = "Anthropic"
 api_base = "https://api.anthropic.com/v1"
-api_protocol = "anthropic"
+api_protocol = "messages"
 doc_url = "https://docs.anthropic.com/en/api/messages"
 
 [auth]

--- a/crates/bitrouter-providers/providers/bitrouter.toml
+++ b/crates/bitrouter-providers/providers/bitrouter.toml
@@ -1,7 +1,7 @@
 # BitRouter Cloud — the official hosted gateway. The router speaks every
 # bitrouter-supported LLM protocol on the same base URL; the default mapping
-# below sends every model id over OpenAI Chat Completions. Users who want
-# the same model over Anthropic Messages or OpenAI Responses can override
+# below sends every model id over Chat Completions. Users who want
+# the same model over Messages or Responses can override
 # `api_protocol` in their bitrouter.yaml.
 #
 # Authentication uses RFC 6750 Bearer credentials. Two sources are supported
@@ -27,7 +27,7 @@
 id = "bitrouter"
 display_name = "BitRouter Cloud"
 api_base = "https://api.bitrouter.ai/v1"
-api_protocol = "openai"
+api_protocol = "chat_completions"
 doc_url = "https://docs.bitrouter.ai"
 
 [auth]

--- a/crates/bitrouter-providers/providers/github-copilot.toml
+++ b/crates/bitrouter-providers/providers/github-copilot.toml
@@ -17,10 +17,10 @@
 #    Copilot Bearer (see crates/bitrouter-providers/src/copilot/exchange.rs).
 #
 # Per-model protocol routing (Copilot multiplexes families behind one host):
-# - claude-*               → Anthropic Messages
-# - gpt-*-codex / gpt-5.5  → OpenAI Responses (Chat Completions returns 404
+# - claude-*               → Messages
+# - gpt-*-codex / gpt-5.5  → Responses (Chat Completions returns 404
 #                             on these in Copilot's edition)
-# - everything else        → OpenAI Chat Completions
+# - everything else        → Chat Completions
 #
 # The `oauth` AuthScheme stores routing metadata only — the actual exchange
 # + integration headers live in the `bitrouter-providers::copilot` module
@@ -32,14 +32,14 @@ api_base = "https://api.githubcopilot.com"
 doc_url = "https://docs.github.com/en/copilot/reference/api-reference/copilot-api-endpoints"
 
 [api_protocol]
-"claude-*" = "anthropic"
+"claude-*" = "messages"
 "gpt-5.5" = "responses"
 "gpt-5.5-codex" = "responses"
 "gpt-5.1-codex" = "responses"
 "gpt-5.1-codex-mini" = "responses"
 "gpt-5.3-codex" = "responses"
 "gpt-5.2-codex" = "responses"
-"*" = "openai"
+"*" = "chat_completions"
 
 [auth]
 kind = "oauth"

--- a/crates/bitrouter-providers/providers/google.toml
+++ b/crates/bitrouter-providers/providers/google.toml
@@ -13,9 +13,9 @@
 # `bitrouter.yaml`.
 
 id = "google"
-display_name = "Google Generative AI"
+display_name = "Generate Content"
 api_base = "https://generativelanguage.googleapis.com/v1beta"
-api_protocol = "google"
+api_protocol = "generate_content"
 doc_url = "https://ai.google.dev/api"
 
 [auth]

--- a/crates/bitrouter-providers/providers/openai-codex.toml
+++ b/crates/bitrouter-providers/providers/openai-codex.toml
@@ -21,7 +21,7 @@
 # - OpenClaw Codex OAuth runtime:
 #   https://github.com/openclaw/openclaw/blob/main/extensions/openai/openai-codex-oauth.runtime.ts
 #
-# Wire protocol: Codex speaks the OpenAI Responses API exclusively. The
+# Wire protocol: Codex speaks the Responses API exclusively. The
 # `openai` Chat Completions endpoint is not reachable from this base URL,
 # so `api_protocol` is pinned to `responses` (no glob fan-out needed).
 #

--- a/crates/bitrouter-providers/providers/openai.toml
+++ b/crates/bitrouter-providers/providers/openai.toml
@@ -14,7 +14,7 @@
 id = "openai"
 display_name = "OpenAI"
 api_base = "https://api.openai.com/v1"
-api_protocol = "openai"
+api_protocol = "chat_completions"
 doc_url = "https://platform.openai.com/docs/api-reference"
 
 [auth]

--- a/crates/bitrouter-providers/providers/opencode-go.toml
+++ b/crates/bitrouter-providers/providers/opencode-go.toml
@@ -20,8 +20,8 @@ doc_url = "https://opencode.ai/docs/go/"
 # advertised by the gateway's `/models` endpoint
 # (`opencode-go/<vendor-prefixed-name>`). Longest match wins.
 [api_protocol]
-"opencode-go/minimax-*" = "anthropic"
-"*" = "openai"
+"opencode-go/minimax-*" = "messages"
+"*" = "chat_completions"
 
 [auth]
 kind = "bearer"

--- a/crates/bitrouter-providers/providers/opencode-zen.toml
+++ b/crates/bitrouter-providers/providers/opencode-zen.toml
@@ -27,9 +27,9 @@ doc_url = "https://opencode.ai/docs/zen/"
 # (`opencode/<vendor-prefixed-name>`). Longest match wins.
 [api_protocol]
 "opencode/gpt-*" = "responses"
-"opencode/claude-*" = "anthropic"
-"opencode/gemini-*" = "google"
-"*" = "openai"
+"opencode/claude-*" = "messages"
+"opencode/gemini-*" = "generate_content"
+"*" = "chat_completions"
 
 [auth]
 kind = "bearer"

--- a/crates/bitrouter-providers/providers/openrouter.toml
+++ b/crates/bitrouter-providers/providers/openrouter.toml
@@ -4,7 +4,7 @@
 # - https://openrouter.ai/docs/api-reference/authentication
 #   ("Pass your API key in the `Authorization: Bearer <KEY>` header.")
 # - https://openrouter.ai/docs/api-reference/overview
-#   (base URL `https://openrouter.ai/api/v1`; OpenAI Chat Completions wire
+#   (base URL `https://openrouter.ai/api/v1`; Chat Completions wire
 #   format; provider routing happens inside OpenRouter)
 #
 # Optional `HTTP-Referer` and `X-Title` headers for OpenRouter's attribution
@@ -14,7 +14,7 @@
 id = "openrouter"
 display_name = "OpenRouter"
 api_base = "https://openrouter.ai/api/v1"
-api_protocol = "openai"
+api_protocol = "chat_completions"
 doc_url = "https://openrouter.ai/docs/api-reference/overview"
 
 [auth]

--- a/crates/bitrouter-providers/src/anthropic/headers.rs
+++ b/crates/bitrouter-providers/src/anthropic/headers.rs
@@ -1,10 +1,10 @@
 //! Header constants for the Anthropic provider's request shaping.
 //!
-//! These mirror the values [`AnthropicTransport::authorise`] would have set
+//! These mirror the values [`MessagesTransport::authorise`] would have set
 //! by default — pulled out here so the OAuth-aware `AuthApplier` can apply
 //! the same constants when no OAuth credential is in play.
 //!
-//! [`AnthropicTransport::authorise`]: bitrouter_sdk::language_model::protocol::anthropic
+//! [`MessagesTransport::authorise`]: bitrouter_sdk::language_model::protocol::messages
 
 /// The pinned `anthropic-version` value. Anthropic's API requires every
 /// request to declare a version (`https://docs.anthropic.com/en/api/versioning`);

--- a/crates/bitrouter-providers/src/anthropic/mod.rs
+++ b/crates/bitrouter-providers/src/anthropic/mod.rs
@@ -307,7 +307,7 @@ impl AuthApplier for AnthropicOAuthApplier {
             None => {
                 // No store entry — fall through to the routing-target's
                 // configured key (env-var path). Mirrors what
-                // `AnthropicTransport::authorise` would have done.
+                // `MessagesTransport::authorise` would have done.
                 let key = target.effective_api_key();
                 if key.is_empty() {
                     return Err(BitrouterError::Upstream {
@@ -364,7 +364,7 @@ mod tests {
             service_id: "claude-opus-4-7".to_string(),
             api_base: "https://api.anthropic.com/v1".to_string(),
             api_key: String::new(),
-            api_protocol: ApiProtocol::Anthropic,
+            api_protocol: ApiProtocol::Messages,
             account_label: label.map(String::from),
             api_key_override: None,
             api_base_override: None,

--- a/crates/bitrouter-providers/src/apply.rs
+++ b/crates/bitrouter-providers/src/apply.rs
@@ -223,7 +223,10 @@ mod tests {
         apply_builtin_defaults(&mut config);
         let p = &config.providers["openai"];
         assert_eq!(p.api_base, "https://api.openai.com/v1");
-        assert_eq!(p.api_protocol.resolve("gpt-4o"), Some(&ApiProtocol::Openai));
+        assert_eq!(
+            p.api_protocol.resolve("gpt-4o"),
+            Some(&ApiProtocol::ChatCompletions)
+        );
     }
 
     #[test]
@@ -234,7 +237,10 @@ mod tests {
         let p = &config.providers["openai"];
         // user-set api_base wins; api_protocol still gets the built-in default
         assert_eq!(p.api_base, "https://gateway.internal.example/v1");
-        assert_eq!(p.api_protocol.resolve("gpt-4o"), Some(&ApiProtocol::Openai));
+        assert_eq!(
+            p.api_protocol.resolve("gpt-4o"),
+            Some(&ApiProtocol::ChatCompletions)
+        );
     }
 
     #[test]
@@ -284,7 +290,7 @@ mod tests {
             assert_eq!(p.api_key, "sk-ant-test");
             assert_eq!(
                 p.api_protocol.resolve("claude-opus-4-1"),
-                Some(&ApiProtocol::Anthropic)
+                Some(&ApiProtocol::Messages)
             );
         });
     }

--- a/crates/bitrouter-providers/src/builtin.rs
+++ b/crates/bitrouter-providers/src/builtin.rs
@@ -110,7 +110,7 @@ mod tests {
         use bitrouter_sdk::language_model::types::ApiProtocol;
         assert_eq!(
             entry.api_protocol.resolve("gpt-4o"),
-            Some(ApiProtocol::Openai)
+            Some(ApiProtocol::ChatCompletions)
         );
     }
 
@@ -132,7 +132,7 @@ mod tests {
     fn opencode_zen_per_model_protocols() {
         use bitrouter_sdk::language_model::types::ApiProtocol;
         let zen = find("opencode-zen").unwrap();
-        // GPT family → OpenAI Responses (zen serves them via /responses).
+        // GPT family → Responses (zen serves them via /responses).
         assert_eq!(
             zen.api_protocol.resolve("opencode/gpt-5.5"),
             Some(ApiProtocol::Responses)
@@ -141,24 +141,24 @@ mod tests {
             zen.api_protocol.resolve("opencode/gpt-5.3-codex"),
             Some(ApiProtocol::Responses)
         );
-        // Claude family → Anthropic Messages.
+        // Claude family → Messages.
         assert_eq!(
             zen.api_protocol.resolve("opencode/claude-opus-4.7"),
-            Some(ApiProtocol::Anthropic)
+            Some(ApiProtocol::Messages)
         );
         // Gemini family → Google.
         assert_eq!(
             zen.api_protocol.resolve("opencode/gemini-3.1-pro"),
-            Some(ApiProtocol::Google)
+            Some(ApiProtocol::GenerateContent)
         );
-        // Everything else (qwen, glm, kimi, minimax, …) → OpenAI Chat.
+        // Everything else (qwen, glm, kimi, minimax, …) → Chat Completions.
         assert_eq!(
             zen.api_protocol.resolve("opencode/qwen3.6-plus"),
-            Some(ApiProtocol::Openai)
+            Some(ApiProtocol::ChatCompletions)
         );
         assert_eq!(
             zen.api_protocol.resolve("opencode/minimax-m2.7"),
-            Some(ApiProtocol::Openai)
+            Some(ApiProtocol::ChatCompletions)
         );
     }
 
@@ -166,23 +166,23 @@ mod tests {
     fn opencode_go_per_model_protocols() {
         use bitrouter_sdk::language_model::types::ApiProtocol;
         let go = find("opencode-go").unwrap();
-        // MiniMax → Anthropic Messages (go serves MiniMax via /messages).
+        // MiniMax → Messages (go serves MiniMax via /messages).
         assert_eq!(
             go.api_protocol.resolve("opencode-go/minimax-m2.7"),
-            Some(ApiProtocol::Anthropic)
+            Some(ApiProtocol::Messages)
         );
-        // Everyone else (glm, kimi, deepseek, mimo, qwen) → OpenAI Chat.
+        // Everyone else (glm, kimi, deepseek, mimo, qwen) → Chat Completions.
         assert_eq!(
             go.api_protocol.resolve("opencode-go/glm-5.1"),
-            Some(ApiProtocol::Openai)
+            Some(ApiProtocol::ChatCompletions)
         );
         assert_eq!(
             go.api_protocol.resolve("opencode-go/kimi-k2.6"),
-            Some(ApiProtocol::Openai)
+            Some(ApiProtocol::ChatCompletions)
         );
         assert_eq!(
             go.api_protocol.resolve("opencode-go/deepseek-v4-pro"),
-            Some(ApiProtocol::Openai)
+            Some(ApiProtocol::ChatCompletions)
         );
     }
 
@@ -206,25 +206,25 @@ mod tests {
     fn github_copilot_per_model_protocols() {
         use bitrouter_sdk::language_model::types::ApiProtocol;
         let copilot = find("github-copilot").unwrap();
-        // Claude family → Anthropic Messages.
+        // Claude family → Messages.
         assert_eq!(
             copilot.api_protocol.resolve("claude-sonnet-4.6"),
-            Some(ApiProtocol::Anthropic)
+            Some(ApiProtocol::Messages)
         );
-        // GPT-5-codex → OpenAI Responses (chat-completions returns 404 in
+        // GPT-5-codex → Responses (chat-completions returns 404 in
         // Copilot for these models).
         assert_eq!(
             copilot.api_protocol.resolve("gpt-5.3-codex"),
             Some(ApiProtocol::Responses)
         );
-        // Default → OpenAI Chat Completions.
+        // Default → Chat Completions.
         assert_eq!(
             copilot.api_protocol.resolve("gpt-4o"),
-            Some(ApiProtocol::Openai)
+            Some(ApiProtocol::ChatCompletions)
         );
         assert_eq!(
             copilot.api_protocol.resolve("gemini-2.5-pro"),
-            Some(ApiProtocol::Openai)
+            Some(ApiProtocol::ChatCompletions)
         );
     }
 

--- a/crates/bitrouter-providers/src/copilot/mod.rs
+++ b/crates/bitrouter-providers/src/copilot/mod.rs
@@ -216,7 +216,7 @@ mod tests {
             service_id: "claude-sonnet-4.6".to_string(),
             api_base: "https://api.githubcopilot.com".to_string(),
             api_key: String::new(),
-            api_protocol: ApiProtocol::Anthropic,
+            api_protocol: ApiProtocol::Messages,
             account_label: None,
             api_key_override: None,
             api_base_override: None,

--- a/crates/bitrouter-providers/src/entry.rs
+++ b/crates/bitrouter-providers/src/entry.rs
@@ -48,13 +48,13 @@ pub struct ProviderEntry {
 ///
 /// `#[serde(untagged)]` so the TOML can write either:
 /// ```toml
-/// api_protocol = "openai"
+/// api_protocol = "chat_completions"
 /// ```
 /// or
 /// ```toml
 /// [api_protocol]
-/// "claude-*" = "anthropic"
-/// "*" = "openai"
+/// "claude-*" = "messages"
+/// "*" = "chat_completions"
 /// ```
 #[derive(Debug, Clone, Deserialize)]
 #[serde(untagged)]
@@ -167,7 +167,7 @@ mod tests {
             id = "openai"
             display_name = "OpenAI"
             api_base = "https://api.openai.com/v1"
-            api_protocol = "openai"
+            api_protocol = "chat_completions"
             doc_url = "https://platform.openai.com/docs/api-reference"
 
             [auth]
@@ -180,7 +180,7 @@ mod tests {
         assert_eq!(entry.auth.env_var(), Some("OPENAI_API_KEY"));
         assert_eq!(
             entry.api_protocol.resolve("gpt-4o"),
-            Some(ApiProtocol::Openai)
+            Some(ApiProtocol::ChatCompletions)
         );
     }
 
@@ -190,7 +190,7 @@ mod tests {
             id = "anthropic"
             display_name = "Anthropic"
             api_base = "https://api.anthropic.com/v1"
-            api_protocol = "anthropic"
+            api_protocol = "messages"
             doc_url = "https://docs.anthropic.com/en/api/messages"
 
             [auth]
@@ -220,7 +220,7 @@ mod tests {
 
     #[test]
     fn parses_per_model_protocol_map() {
-        // opencode-zen-shape: claude-* → anthropic, default → openai.
+        // opencode-zen-shape: claude-* → messages, default → chat_completions.
         let src = r#"
             id = "opencode-zen"
             display_name = "opencode zen"
@@ -228,8 +228,8 @@ mod tests {
             doc_url = "https://example.com"
 
             [api_protocol]
-            "claude-*" = "anthropic"
-            "*" = "openai"
+            "claude-*" = "messages"
+            "*" = "chat_completions"
 
             [auth]
             kind = "bearer"
@@ -238,11 +238,11 @@ mod tests {
         let entry: ProviderEntry = toml::from_str(src).unwrap();
         assert_eq!(
             entry.api_protocol.resolve("claude-opus-4-1"),
-            Some(ApiProtocol::Anthropic)
+            Some(ApiProtocol::Messages)
         );
         assert_eq!(
             entry.api_protocol.resolve("gpt-5-mini"),
-            Some(ApiProtocol::Openai)
+            Some(ApiProtocol::ChatCompletions)
         );
     }
 
@@ -254,7 +254,7 @@ mod tests {
             id = "x"
             display_name = "X"
             apt_base = "https://x.example/v1"
-            api_protocol = "openai"
+            api_protocol = "chat_completions"
             doc_url = "https://x.example"
             [auth]
             kind = "bearer"

--- a/crates/bitrouter-sdk/src/config/mod.rs
+++ b/crates/bitrouter-sdk/src/config/mod.rs
@@ -425,11 +425,11 @@ impl ProviderConfig {
 pub fn infer_protocol(api_base: &str) -> ApiProtocol {
     let host = api_base.to_ascii_lowercase();
     if host.contains("anthropic.com") {
-        ApiProtocol::Anthropic
+        ApiProtocol::Messages
     } else if host.contains("googleapis.com") || host.contains("generativelanguage") {
-        ApiProtocol::Google
+        ApiProtocol::GenerateContent
     } else {
-        ApiProtocol::Openai
+        ApiProtocol::ChatCompletions
     }
 }
 
@@ -700,7 +700,7 @@ pub async fn load(path: impl AsRef<std::path::Path>) -> Result<Config> {
 /// Best-effort model discovery. For every provider with
 /// `auto_discover: true` and no declared `models`, `GET {api_base}/models` and
 /// populate the model list from the response (`{ "data": [{ "id": … }] }`,
-/// the OpenAI / Anthropic shape). A provider whose discovery call fails is
+/// the Chat Completions / Messages shape). A provider whose discovery call fails is
 /// left as-is with a WARN — discovery never aborts startup.
 ///
 /// The HTTP client is built with bounded `connect_timeout` + `timeout` so an

--- a/crates/bitrouter-sdk/src/config/registry.rs
+++ b/crates/bitrouter-sdk/src/config/registry.rs
@@ -154,7 +154,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             anthropic.api_protocol,
-            crate::language_model::types::ApiProtocol::Anthropic
+            crate::language_model::types::ApiProtocol::Messages
         );
         let _ = tokio::fs::remove_dir_all(&dir).await;
     }

--- a/crates/bitrouter-sdk/src/config/tests.rs
+++ b/crates/bitrouter-sdk/src/config/tests.rs
@@ -47,7 +47,7 @@ providers:
     api_base: https://api.openai.com/v1
     api_key: ${BR_CFG_KEY}
     api_protocol:
-      - "*": openai
+      - "*": chat_completions
       - "gpt-5*": responses
     rate_limits:
       - "*": { requests_per_minute: 60 }
@@ -68,7 +68,7 @@ providers:
 
     // glob-prefix precedence: `gpt-5*` pattern beats `*`
     assert_eq!(openai.protocol_for("gpt-5"), ApiProtocol::Responses);
-    assert_eq!(openai.protocol_for("gpt-4o"), ApiProtocol::Openai);
+    assert_eq!(openai.protocol_for("gpt-4o"), ApiProtocol::ChatCompletions);
     // per-model override beats the pattern
     assert_eq!(openai.protocol_for("o3"), ApiProtocol::Responses);
 
@@ -93,19 +93,19 @@ providers:
 fn protocol_inference_from_api_base() {
     assert_eq!(
         infer_protocol("https://api.anthropic.com/v1"),
-        ApiProtocol::Anthropic
+        ApiProtocol::Messages
     );
     assert_eq!(
         infer_protocol("https://generativelanguage.googleapis.com/v1beta"),
-        ApiProtocol::Google
+        ApiProtocol::GenerateContent
     );
     assert_eq!(
         infer_protocol("https://api.openai.com/v1"),
-        ApiProtocol::Openai
+        ApiProtocol::ChatCompletions
     );
     assert_eq!(
         infer_protocol("https://my-llm.example.com/v1"),
-        ApiProtocol::Openai
+        ApiProtocol::ChatCompletions
     );
 }
 
@@ -117,7 +117,7 @@ providers:
     api_base: https://api.openai.com/v1
     api_key: parent
     api_protocol:
-      - "*": openai
+      - "*": chat_completions
       - "gpt-5*": responses
     rate_limits:
       - "*": { rpm: 1000 }

--- a/crates/bitrouter-sdk/src/language_model/protocol/chat_completions.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/chat_completions.rs
@@ -1,4 +1,4 @@
-//! OpenAI Chat Completions adapter.
+//! Chat Completions adapter.
 //!
 //! Official reference: <https://platform.openai.com/docs/api-reference/chat>
 //! Streaming format: <https://platform.openai.com/docs/api-reference/chat-streaming>
@@ -23,16 +23,16 @@ use crate::language_model::types::{
     ResponseFormat, Role, RoutingTarget, StreamPart, Usage,
 };
 
-/// The OpenAI Chat Completions inbound + outbound protocol adapter.
-pub struct OpenAiChatAdapter;
+/// The Chat Completions inbound + outbound protocol adapter.
+pub struct ChatCompletionsAdapter;
 
-/// HTTP transport for OpenAI Chat: `POST {api_base}/chat/completions` with
+/// HTTP transport for Chat Completions: `POST {api_base}/chat/completions` with
 /// `Authorization: Bearer <api_key>`.
-pub struct OpenAiChatTransport;
+pub struct ChatCompletionsTransport;
 
 // ===== wire request types =====
 
-/// OpenAI Chat Completions request body
+/// Chat Completions request body
 /// (<https://platform.openai.com/docs/api-reference/chat/create>).
 ///
 /// `pub` so downstream crates (notably `bitrouter-cloud`) can derive an
@@ -171,9 +171,9 @@ fn content_text(value: &serde_json::Value) -> String {
     }
 }
 
-impl InboundAdapter for OpenAiChatAdapter {
+impl InboundAdapter for ChatCompletionsAdapter {
     fn protocol(&self) -> ApiProtocol {
-        ApiProtocol::Openai
+        ApiProtocol::ChatCompletions
     }
 
     fn parse_request(&self, body: serde_json::Value) -> Result<Prompt> {
@@ -258,7 +258,7 @@ impl InboundAdapter for OpenAiChatAdapter {
                 top_p: req.top_p,
                 max_tokens: req.max_tokens.or(req.max_completion_tokens),
                 reasoning_effort: req.reasoning_effort,
-                // Every OpenAI-Chat field we don't have a typed slot for —
+                // Every Chat Completions field we don't have a typed slot for —
                 // tool_choice, stop / stop_sequences, seed, n,
                 // presence/frequency_penalty, logit_bias, … — rides along
                 // in `extra` and is splatted back on render. Note:
@@ -352,9 +352,9 @@ impl InboundAdapter for OpenAiChatAdapter {
     }
 }
 
-impl OutboundAdapter for OpenAiChatAdapter {
+impl OutboundAdapter for ChatCompletionsAdapter {
     fn protocol(&self) -> ApiProtocol {
-        ApiProtocol::Openai
+        ApiProtocol::ChatCompletions
     }
 
     fn render_request(&self, prompt: &Prompt) -> Result<serde_json::Value> {
@@ -402,7 +402,7 @@ impl OutboundAdapter for OpenAiChatAdapter {
         if let Some(re) = &prompt.params.reasoning_effort {
             req.insert("reasoning_effort".into(), re.clone().into());
         }
-        // Render the canonical response_format into OpenAI Chat's native shape.
+        // Render the canonical response_format into Chat Completions' native shape.
         // Inserted before the extras splat so it wins over any legacy
         // `response_format` left in extras (typed slot wins, matching how
         // other params are handled).
@@ -449,8 +449,8 @@ impl OutboundAdapter for OpenAiChatAdapter {
         // for the reasoning trace on the Chat envelope. Other OpenAI-compatible
         // upstreams expose the same data under `reasoning` (some OpenRouter
         // passthroughs) or `thinking` (Aliyun). Accept whichever is present.
-        // None of these are documented on OpenAI Chat itself; the canonical
-        // OpenAI Chat object does not carry a reasoning trace.
+        // None of these are documented on Chat Completions itself; the canonical
+        // Chat Completions object does not carry a reasoning trace.
         if let Some(reasoning) = ["reasoning_content", "reasoning", "thinking"]
             .iter()
             .find_map(|key| {
@@ -472,7 +472,7 @@ impl OutboundAdapter for OpenAiChatAdapter {
         {
             content.push(Content::Text { text });
         }
-        // OpenAI Chat's `message.refusal` (when non-empty) is the model's
+        // Chat Completions' `message.refusal` (when non-empty) is the model's
         // declined-response text. Carry it through so the caller sees the
         // refusal rather than an empty assistant message. Spec:
         // <https://platform.openai.com/docs/api-reference/chat/object>.
@@ -525,7 +525,7 @@ impl OutboundAdapter for OpenAiChatAdapter {
                 }
             });
         let usage = body.get("usage").and_then(parse_usage);
-        // OpenAI Chat Completions: top-level `id` (`chatcmpl-...`).
+        // Chat Completions: top-level `id` (`chatcmpl-...`).
         // <https://platform.openai.com/docs/api-reference/chat/object>
         let response_id = body
             .get("id")
@@ -572,7 +572,7 @@ fn parse_chat_response_format(
     })
 }
 
-/// Render a canonical [`ResponseFormat`] into OpenAI Chat's native
+/// Render a canonical [`ResponseFormat`] into Chat Completions' native
 /// `{ type: "json_schema", json_schema: { name, strict, schema } }`. OpenAI
 /// requires `name`; supply a stable default when the caller didn't set one.
 fn render_chat_response_format(rf: &ResponseFormat) -> serde_json::Value {
@@ -596,9 +596,9 @@ fn render_chat_response_format(rf: &ResponseFormat) -> serde_json::Value {
 }
 
 #[async_trait]
-impl Transport for OpenAiChatTransport {
+impl Transport for ChatCompletionsTransport {
     fn protocol(&self) -> ApiProtocol {
-        ApiProtocol::Openai
+        ApiProtocol::ChatCompletions
     }
 
     fn endpoint_url(&self, target: &RoutingTarget, _stream: bool) -> String {
@@ -714,7 +714,7 @@ fn parse_usage(value: &serde_json::Value) -> Option<Usage> {
         .and_then(|d| d.get("reasoning_tokens"))
         .and_then(|v| v.as_u64())
         .unwrap_or(0);
-    // OpenAI Chat surfaces cached prompt tokens under
+    // Chat Completions surfaces cached prompt tokens under
     // `prompt_tokens_details.cached_tokens` — subset of `prompt_tokens`. Ref:
     // <https://platform.openai.com/docs/api-reference/chat/object> →
     // `usage` object. Some OpenAI-compatible providers (e.g. DeepSeek)
@@ -752,7 +752,7 @@ fn render_usage(usage: &Usage) -> serde_json::Value {
 
 // ===== streaming =====
 
-/// Decodes OpenAI Chat `data:` SSE chunks into canonical stream parts. Explicit
+/// Decodes Chat Completions `data:` SSE chunks into canonical stream parts. Explicit
 /// state machine — unknown chunk shapes are ignored, never panicked on.
 #[derive(Default)]
 struct ChatStreamDecoder {
@@ -784,7 +784,7 @@ impl StreamDecoder for ChatStreamDecoder {
         let mut parts = Vec::new();
         // Surface the upstream response id once, before any deltas. Every
         // chunk repeats the top-level `id` (`chatcmpl-...`); we emit it a
-        // single time for observability. Not in the OpenAI Chat object's
+        // single time for observability. Not in the Chat Completions object's
         // delta — purely the envelope id.
         // <https://platform.openai.com/docs/api-reference/chat/streaming>
         if !self.response_started_emitted
@@ -864,7 +864,7 @@ impl StreamDecoder for ChatStreamDecoder {
     }
 }
 
-/// Encodes canonical stream parts into OpenAI Chat `data:` SSE chunks.
+/// Encodes canonical stream parts into Chat Completions `data:` SSE chunks.
 struct ChatStreamEncoder {
     request_id: String,
     model: String,
@@ -972,7 +972,7 @@ impl StreamEncoder for ChatStreamEncoder {
                 frames.push(self.chunk(serde_json::Value::Object(delta), Some(&reason_str)));
             }
             StreamPart::ResponseCompleted { status, .. } => {
-                // Inbound was OpenAI Responses; Chat has no response-completed
+                // Inbound was Responses; Chat has no response-completed
                 // concept — terminate with a finish chunk derived from status.
                 let reason = if status == "incomplete" {
                     FinishReason::Length
@@ -988,7 +988,7 @@ impl StreamEncoder for ChatStreamEncoder {
     }
 
     fn encode_error(&mut self, message: &str) -> Vec<SseFrame> {
-        // OpenAI surfaces a mid-stream error as a chunk carrying an `error`
+        // Chat Completions surfaces a mid-stream error as a chunk carrying an `error`
         // object, followed by the `[DONE]` sentinel.
         vec![
             SseFrame::Event {
@@ -1006,7 +1006,7 @@ impl StreamEncoder for ChatStreamEncoder {
     }
 
     fn finish(&mut self) -> Result<Vec<SseFrame>> {
-        // OpenAI Chat terminates the stream with a literal `[DONE]` sentinel.
+        // Chat Completions terminates the stream with a literal `[DONE]` sentinel.
         Ok(vec![SseFrame::Event {
             event: None,
             data: "[DONE]".to_string(),

--- a/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
@@ -1,4 +1,4 @@
-//! Google Generative AI (`generateContent`) adapter.
+//! Generate Content (`generateContent`) adapter.
 //!
 //! Official reference: <https://ai.google.dev/api/generate-content>
 //! Streaming: <https://ai.google.dev/api/generate-content#method:-models.streamgeneratecontent>
@@ -23,25 +23,25 @@ use crate::language_model::types::{
     ResponseFormat, Role, RoutingTarget, StreamPart, Usage,
 };
 
-/// The Google Generative AI protocol adapter.
-pub struct GoogleAdapter;
+/// The Generate Content protocol adapter.
+pub struct GenerateContentAdapter;
 
-/// HTTP transport for Google Generative AI:
+/// HTTP transport for Generate Content:
 /// `POST {api_base}/models/{model}:generateContent` (or
 /// `:streamGenerateContent?alt=sse` for streaming) with the `x-goog-api-key`
 /// header — documented at
 /// <https://ai.google.dev/gemini-api/docs/api-key>.
-pub struct GoogleTransport;
+pub struct GenerateContentTransport;
 
 /// Sentinel key under which top-level Google extras (`toolConfig`,
 /// `safetySettings`, `cachedContent`, …) ride through `GenerationParams::extra`.
-/// Only `GoogleAdapter::render_request` reads it — every other adapter ignores
+/// Only `GenerateContentAdapter::render_request` reads it — every other adapter ignores
 /// the namespaced key and the JSON wire shape never contains it.
 const GOOGLE_TOP_LEVEL_EXTRA_KEY: &str = "__google_top_level__";
 
 // ===== wire request types =====
 
-/// Google Generative AI `generateContent` request body
+/// Generate Content `generateContent` request body
 /// (<https://ai.google.dev/api/generate-content>).
 ///
 /// `pub` so downstream crates (notably `bitrouter-cloud`) can derive an
@@ -53,14 +53,14 @@ pub struct GenerateContentRequest {
     /// override it; defaults empty.
     #[serde(default)]
     model: String,
-    contents: Vec<GoogleContent>,
+    contents: Vec<GenerateContentContent>,
     #[serde(default)]
-    system_instruction: Option<GoogleContent>,
+    system_instruction: Option<GenerateContentContent>,
     #[serde(default)]
-    tools: Vec<GoogleTool>,
+    tools: Vec<GenerateContentTool>,
     #[serde(default)]
-    generation_config: Option<GoogleGenerationConfig>,
-    /// Injected by `server::google_generate` from the path verb
+    generation_config: Option<GenerateContentGenerationConfig>,
+    /// Injected by `server::generate_content` from the path verb
     /// (`:streamGenerateContent` → true, `:generateContent` → false).
     #[serde(default)]
     stream: bool,
@@ -77,7 +77,7 @@ pub struct GenerateContentRequest {
 /// One element of [`GenerateContentRequest`]'s `contents` array — a turn
 /// carrying optional role + `parts[]`.
 #[derive(Debug, Deserialize, JsonSchema)]
-pub struct GoogleContent {
+pub struct GenerateContentContent {
     #[serde(default)]
     role: Option<String>,
     #[serde(default)]
@@ -88,15 +88,15 @@ pub struct GoogleContent {
 /// `{ functionDeclarations: [...] }` envelope.
 #[derive(Debug, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct GoogleTool {
+pub struct GenerateContentTool {
     #[serde(default)]
-    function_declarations: Vec<GoogleFunctionDecl>,
+    function_declarations: Vec<GenerateContentFunctionDecl>,
 }
 
-/// One function declaration inside a [`GoogleTool`]: name + description +
+/// One function declaration inside a [`GenerateContentTool`]: name + description +
 /// JSON-Schema parameters.
 #[derive(Debug, Deserialize, JsonSchema)]
-pub struct GoogleFunctionDecl {
+pub struct GenerateContentFunctionDecl {
     name: String,
     #[serde(default)]
     description: Option<String>,
@@ -107,7 +107,7 @@ pub struct GoogleFunctionDecl {
 /// `generationConfig` knobs on a [`GenerateContentRequest`].
 #[derive(Debug, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct GoogleGenerationConfig {
+pub struct GenerateContentGenerationConfig {
     #[serde(default)]
     temperature: Option<f64>,
     #[serde(default)]
@@ -140,7 +140,7 @@ fn parse_role(role: Option<&str>) -> Result<Role> {
 fn role_str(role: Role) -> &'static str {
     match role {
         Role::Assistant => "model",
-        // Google has only user/model; tool results ride in a user turn.
+        // Generate Content has only user/model; tool results ride in a user turn.
         Role::User | Role::System | Role::Tool => "user",
     }
 }
@@ -221,9 +221,9 @@ fn finish_reason_str(r: &FinishReason) -> String {
     }
 }
 
-impl InboundAdapter for GoogleAdapter {
+impl InboundAdapter for GenerateContentAdapter {
     fn protocol(&self) -> ApiProtocol {
-        ApiProtocol::Google
+        ApiProtocol::GenerateContent
     }
 
     fn parse_request(&self, body: serde_json::Value) -> Result<Prompt> {
@@ -285,7 +285,7 @@ impl InboundAdapter for GoogleAdapter {
         // so cross-protocol routing can translate it. When `responseMimeType`
         // is some other value (e.g. `text/x.enum`) we leave both fields in
         // extras as an opaque Google-native pass-through.
-        let response_format = parse_google_response_format(&params.extra);
+        let response_format = parse_generate_content_response_format(&params.extra);
         if response_format.is_some() {
             params.extra.remove("responseMimeType");
             params.extra.remove("responseSchema");
@@ -293,7 +293,7 @@ impl InboundAdapter for GoogleAdapter {
         // Preserve top-level Google fields (`toolConfig`, `safetySettings`,
         // `cachedContent`, …) across the round-trip. They're namespaced so they
         // don't collide with `generationConfig`-level extras above and only the
-        // Google `render_request` lifts them back to the top level.
+        // Generate Content `render_request` lifts them back to the top level.
         if !req.extra.is_empty() {
             params.extra.insert(
                 GOOGLE_TOP_LEVEL_EXTRA_KEY.to_string(),
@@ -340,13 +340,13 @@ impl InboundAdapter for GoogleAdapter {
     }
 
     fn stream_encoder(&self, _request_id: &str, _model: &str) -> Box<dyn StreamEncoder> {
-        Box::new(GoogleStreamEncoder)
+        Box::new(GenerateContentStreamEncoder)
     }
 }
 
-impl OutboundAdapter for GoogleAdapter {
+impl OutboundAdapter for GenerateContentAdapter {
     fn protocol(&self) -> ApiProtocol {
-        ApiProtocol::Google
+        ApiProtocol::GenerateContent
     }
 
     fn render_request(&self, prompt: &Prompt) -> Result<serde_json::Value> {
@@ -432,7 +432,7 @@ impl OutboundAdapter for GoogleAdapter {
             .and_then(|f| f.as_str())
             .and_then(finish_reason);
         let usage = body.get("usageMetadata").and_then(parse_usage);
-        // Google Generative AI: top-level `responseId`.
+        // Generate Content: top-level `responseId`.
         // <https://ai.google.dev/api/generate-content#GenerateContentResponse>
         let response_id = body
             .get("responseId")
@@ -447,7 +447,7 @@ impl OutboundAdapter for GoogleAdapter {
     }
 
     fn stream_decoder(&self) -> Box<dyn StreamDecoder> {
-        Box::new(GoogleStreamDecoder::default())
+        Box::new(GenerateContentStreamDecoder::default())
     }
 
     fn supports_response_format(&self) -> bool {
@@ -459,7 +459,7 @@ impl OutboundAdapter for GoogleAdapter {
 /// into the canonical [`ResponseFormat`]. Triggers only when
 /// `responseMimeType == "application/json"` *and* a `responseSchema` is set —
 /// other MIME modes (e.g. `text/x.enum`) have no schema to translate.
-fn parse_google_response_format(
+fn parse_generate_content_response_format(
     extra: &std::collections::HashMap<String, serde_json::Value>,
 ) -> Option<ResponseFormat> {
     if extra.get("responseMimeType").and_then(|v| v.as_str()) != Some("application/json") {
@@ -474,9 +474,9 @@ fn parse_google_response_format(
 }
 
 #[async_trait]
-impl Transport for GoogleTransport {
+impl Transport for GenerateContentTransport {
     fn protocol(&self) -> ApiProtocol {
-        ApiProtocol::Google
+        ApiProtocol::GenerateContent
     }
 
     fn endpoint_url(&self, target: &RoutingTarget, stream: bool) -> String {
@@ -557,17 +557,17 @@ fn parse_usage(value: &serde_json::Value) -> Option<Usage> {
 
 // ===== streaming =====
 
-/// Google `streamGenerateContent` SSE decoder. Each `data:` line is a full
+/// Generate Content `streamGenerateContent` SSE decoder. Each `data:` line is a full
 /// `GenerateContentResponse` with partial candidates.
 #[derive(Default)]
-struct GoogleStreamDecoder {
+struct GenerateContentStreamDecoder {
     finished: bool,
     /// Whether the one-shot [`StreamPart::ResponseStarted`] has been emitted.
     /// Every chunk repeats `responseId`; we surface it only once.
     response_started_emitted: bool,
 }
 
-impl StreamDecoder for GoogleStreamDecoder {
+impl StreamDecoder for GenerateContentStreamDecoder {
     fn decode(&mut self, event: &SseEvent) -> Result<Vec<StreamPart>> {
         let data = event.data.trim();
         if data.is_empty() {
@@ -636,11 +636,11 @@ impl StreamDecoder for GoogleStreamDecoder {
     }
 }
 
-/// Google `streamGenerateContent` SSE encoder — each canonical part becomes one
+/// Generate Content `streamGenerateContent` SSE encoder — each canonical part becomes one
 /// `GenerateContentResponse` chunk.
-struct GoogleStreamEncoder;
+struct GenerateContentStreamEncoder;
 
-impl StreamEncoder for GoogleStreamEncoder {
+impl StreamEncoder for GenerateContentStreamEncoder {
     fn encode(&mut self, part: &StreamPart) -> Result<Vec<SseFrame>> {
         let chunk = match part {
             // Observability-only metadata (upstream response id) — never
@@ -683,7 +683,7 @@ impl StreamEncoder for GoogleStreamEncoder {
                 }]
             }),
             StreamPart::ResponseCompleted { status, usage, .. } => {
-                // Inbound was OpenAI Responses; Google has no response-completed
+                // Inbound was Responses; Generate Content has no response-completed
                 // concept — emit a terminal candidate with a mapped
                 // `finishReason`, plus `usageMetadata` if usage was carried.
                 let finish_reason = if status == "incomplete" {
@@ -715,7 +715,7 @@ impl StreamEncoder for GoogleStreamEncoder {
     }
 
     fn encode_error(&mut self, message: &str) -> Vec<SseFrame> {
-        // Google surfaces a mid-stream error as a chunk carrying an `error`
+        // Generate Content surfaces a mid-stream error as a chunk carrying an `error`
         // object (mirrors the non-streaming error envelope).
         vec![SseFrame::Event {
             event: None,

--- a/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
@@ -1,4 +1,4 @@
-//! Anthropic Messages adapter.
+//! Messages adapter.
 //!
 //! Official reference: <https://docs.anthropic.com/en/api/messages>
 //! Streaming: <https://docs.anthropic.com/en/docs/build-with-claude/streaming>
@@ -26,18 +26,18 @@ use crate::language_model::types::{
     ResponseFormat, Role, RoutingTarget, StreamPart, Usage,
 };
 
-/// The Anthropic Messages inbound + outbound protocol adapter.
-pub struct AnthropicAdapter;
+/// The Messages inbound + outbound protocol adapter.
+pub struct MessagesAdapter;
 
-/// HTTP transport for Anthropic Messages: `POST {api_base}/messages` with
+/// HTTP transport for Messages: `POST {api_base}/messages` with
 /// `x-api-key` + `anthropic-version: 2023-06-01`. The version constant is the
 /// only released revision as of 2026-05; cf.
 /// <https://platform.claude.com/docs/en/api/versioning>.
-pub struct AnthropicTransport;
+pub struct MessagesTransport;
 
 // ===== wire request types =====
 
-/// Anthropic Messages request body (<https://docs.anthropic.com/en/api/messages>).
+/// Messages request body (<https://docs.anthropic.com/en/api/messages>).
 ///
 /// `pub` so downstream crates (notably `bitrouter-cloud`) can derive an
 /// OpenAPI schema from the canonical wire shape without redeclaring it.
@@ -47,9 +47,9 @@ pub struct MessagesRequest {
     /// String or an array of `{type:"text", text}` blocks (#227 → #228).
     #[serde(default)]
     system: Option<serde_json::Value>,
-    messages: Vec<AnthropicMessage>,
+    messages: Vec<MessagesMessage>,
     #[serde(default)]
-    tools: Vec<AnthropicTool>,
+    tools: Vec<MessagesTool>,
     #[serde(default)]
     max_tokens: Option<u32>,
     #[serde(default)]
@@ -69,7 +69,7 @@ pub struct MessagesRequest {
 
 /// One element of [`MessagesRequest`]'s `messages` array — a `{ role, content }` turn.
 #[derive(Debug, Deserialize, JsonSchema)]
-pub struct AnthropicMessage {
+pub struct MessagesMessage {
     role: String,
     /// String or an array of content blocks.
     content: serde_json::Value,
@@ -77,7 +77,7 @@ pub struct AnthropicMessage {
 
 /// One element of [`MessagesRequest`]'s `tools` array — Anthropic's tool definition shape.
 #[derive(Debug, Deserialize, JsonSchema)]
-pub struct AnthropicTool {
+pub struct MessagesTool {
     name: String,
     #[serde(default)]
     description: Option<String>,
@@ -98,7 +98,7 @@ fn parse_system(value: &serde_json::Value) -> String {
     }
 }
 
-/// Anthropic `tool_result.content` may be a string or an array of blocks (#364).
+/// Messages `tool_result.content` may be a string or an array of blocks (#364).
 fn tool_result_text(value: &serde_json::Value) -> String {
     match value {
         serde_json::Value::String(s) => s.clone(),
@@ -185,7 +185,7 @@ fn parse_role(role: &str) -> Result<Role> {
     match role {
         "user" => Ok(Role::User),
         "assistant" => Ok(Role::Assistant),
-        // Anthropic has no top-level system/tool role; tool results ride inside
+        // Messages has no top-level system/tool role; tool results ride inside
         // a user-role message. An unexpected role is a hard error (#454-4).
         other => Err(BitrouterError::bad_request(format!(
             "unknown anthropic message role '{other}' (expected user/assistant)"
@@ -209,7 +209,7 @@ fn stop_reason_to_finish(s: &str) -> Option<FinishReason> {
 /// upstream error doesn't blanket-convert to 502 (which masks
 /// `invalid_request_error` / `rate_limit_error` / `authentication_error`).
 /// Ref: <https://docs.anthropic.com/en/api/errors>.
-fn anthropic_error_status(err_type: &str) -> u16 {
+fn messages_error_status(err_type: &str) -> u16 {
     match err_type {
         "invalid_request_error" => 400,
         "authentication_error" => 401,
@@ -229,16 +229,16 @@ fn finish_to_stop_reason(r: &FinishReason) -> String {
         FinishReason::ToolCalls => "tool_use".to_string(),
         FinishReason::ContentFilter => "refusal".to_string(),
         FinishReason::Other(s) => s.clone(),
-        // Anthropic has no native "error" finish — pick `end_turn` so the
+        // Messages has no native "error" finish — pick `end_turn` so the
         // wire envelope is well-formed; outbound encoders emit a separate
         // error frame ahead of this when the canonical IR carries an error.
         FinishReason::Error(_) => "end_turn".to_string(),
     }
 }
 
-impl InboundAdapter for AnthropicAdapter {
+impl InboundAdapter for MessagesAdapter {
     fn protocol(&self) -> ApiProtocol {
-        ApiProtocol::Anthropic
+        ApiProtocol::Messages
     }
 
     fn parse_request(&self, body: serde_json::Value) -> Result<Prompt> {
@@ -284,7 +284,7 @@ impl InboundAdapter for AnthropicAdapter {
             })
             .collect();
 
-        // Anthropic's GA structured-outputs lives under
+        // Messages' GA structured-outputs lives under
         // `output_config.format`. Some clients still emit the deprecated flat
         // `output_format` (vercel/ai#12298) — accept it as a graceful alias.
         // Only the alias that actually matched is stripped from extras, so
@@ -351,7 +351,7 @@ impl InboundAdapter for AnthropicAdapter {
     }
 
     fn stream_encoder(&self, request_id: &str, model: &str) -> Box<dyn StreamEncoder> {
-        Box::new(AnthropicStreamEncoder {
+        Box::new(MessagesStreamEncoder {
             request_id: request_id.to_string(),
             model: model.to_string(),
             started: false,
@@ -362,9 +362,9 @@ impl InboundAdapter for AnthropicAdapter {
     }
 }
 
-impl OutboundAdapter for AnthropicAdapter {
+impl OutboundAdapter for MessagesAdapter {
     fn protocol(&self) -> ApiProtocol {
-        ApiProtocol::Anthropic
+        ApiProtocol::Messages
     }
 
     fn render_request(&self, prompt: &Prompt) -> Result<serde_json::Value> {
@@ -395,7 +395,7 @@ impl OutboundAdapter for AnthropicAdapter {
                     .into(),
             );
         }
-        // Anthropic requires max_tokens; default to a sane ceiling if unset.
+        // Messages requires max_tokens; default to a sane ceiling if unset.
         req.insert(
             "max_tokens".into(),
             prompt.params.max_tokens.unwrap_or(4096).into(),
@@ -413,7 +413,7 @@ impl OutboundAdapter for AnthropicAdapter {
         if let Some(rf) = &prompt.response_format {
             req.insert(
                 "output_config".into(),
-                serde_json::json!({ "format": render_anthropic_response_format(rf) }),
+                serde_json::json!({ "format": render_messages_response_format(rf) }),
             );
         }
         // Splat anthropic-specific extras (tool_choice, stop_sequences, …) back
@@ -472,7 +472,7 @@ impl OutboundAdapter for AnthropicAdapter {
             .and_then(|s| s.as_str())
             .and_then(stop_reason_to_finish);
         let usage = body.get("usage").and_then(parse_usage);
-        // Anthropic Messages: top-level `id` (`msg_...`).
+        // Messages: top-level `id` (`msg_...`).
         // <https://docs.anthropic.com/en/api/messages>
         let response_id = body
             .get("id")
@@ -487,7 +487,7 @@ impl OutboundAdapter for AnthropicAdapter {
     }
 
     fn stream_decoder(&self) -> Box<dyn StreamDecoder> {
-        Box::new(AnthropicStreamDecoder::default())
+        Box::new(MessagesStreamDecoder::default())
     }
 
     fn supports_response_format(&self) -> bool {
@@ -526,15 +526,15 @@ fn json_schema_from(format: &serde_json::Value) -> Option<ResponseFormat> {
 
 /// Render a canonical [`ResponseFormat`] into Anthropic's
 /// `{ type: "json_schema", schema }` body that sits under `output_config.format`.
-fn render_anthropic_response_format(rf: &ResponseFormat) -> serde_json::Value {
+fn render_messages_response_format(rf: &ResponseFormat) -> serde_json::Value {
     let ResponseFormat::JsonSchema { schema, .. } = rf;
     serde_json::json!({ "type": "json_schema", "schema": schema })
 }
 
 #[async_trait]
-impl Transport for AnthropicTransport {
+impl Transport for MessagesTransport {
     fn protocol(&self) -> ApiProtocol {
-        ApiProtocol::Anthropic
+        ApiProtocol::Messages
     }
 
     fn endpoint_url(&self, target: &RoutingTarget, _stream: bool) -> String {
@@ -644,7 +644,7 @@ fn parse_usage(value: &serde_json::Value) -> Option<Usage> {
     //
     // The canonical [`Usage::cache_read_tokens`] / [`Usage::cache_write_tokens`]
     // are documented as subsets of [`Usage::prompt_tokens`] — matching how
-    // OpenAI Chat / Responses and Google report cached prompt tokens.
+    // Chat Completions / Responses and Generate Content report cached prompt tokens.
     //
     // Without folding the cache buckets back into `prompt_tokens` here,
     // downstream billing layers that derive `no_cache = prompt_tokens -
@@ -671,12 +671,12 @@ fn parse_usage(value: &serde_json::Value) -> Option<Usage> {
 
 // ===== streaming =====
 
-/// Anthropic SSE decoder. Explicit state machine over the
+/// Messages SSE decoder. Explicit state machine over the
 /// `message_start` / `content_block_start` / `content_block_delta` /
 /// `content_block_stop` / `message_delta` / `message_stop` / `ping` / `error`
 /// event set.
 #[derive(Default)]
-struct AnthropicStreamDecoder {
+struct MessagesStreamDecoder {
     /// per content-block index → tool id (empty string for non-tool blocks),
     /// so an `input_json_delta` knows which canonical tool call it belongs to.
     block_tool_ids: Vec<String>,
@@ -690,7 +690,7 @@ enum BlockKind {
     ToolUse,
 }
 
-impl StreamDecoder for AnthropicStreamDecoder {
+impl StreamDecoder for MessagesStreamDecoder {
     fn decode(&mut self, event: &SseEvent) -> Result<Vec<StreamPart>> {
         let event_name = event.event.as_deref().unwrap_or_default();
         // ping / unknown events are intentionally ignored — never errors (#422).
@@ -716,7 +716,7 @@ impl StreamDecoder for AnthropicStreamDecoder {
                 {
                     parts.push(StreamPart::ResponseStarted { id: id.to_string() });
                 }
-                // Anthropic emits the prompt-cache stats on the start frame,
+                // Messages emits the prompt-cache stats on the start frame,
                 // so capture them now and propagate via the terminal Usage
                 // part.
                 if let Some(usage) = json.get("message").and_then(|m| m.get("usage"))
@@ -799,7 +799,7 @@ impl StreamDecoder for AnthropicStreamDecoder {
             "message_delta" => {
                 // `message_delta.usage` carries the cumulative final counts
                 // (<https://docs.anthropic.com/en/api/messages-streaming>).
-                // Anthropic emits its wire-level `input_tokens` (the
+                // Messages emits its wire-level `input_tokens` (the
                 // *uncached* portion, per
                 // <https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching>)
                 // alongside the cache buckets; the canonical
@@ -862,7 +862,7 @@ impl StreamDecoder for AnthropicStreamDecoder {
                     .and_then(|m| m.as_str())
                     .unwrap_or("anthropic stream error");
                 return Err(BitrouterError::Upstream {
-                    status: anthropic_error_status(err_type),
+                    status: messages_error_status(err_type),
                     message: msg.to_string(),
                 });
             }
@@ -873,7 +873,7 @@ impl StreamDecoder for AnthropicStreamDecoder {
     }
 }
 
-/// Anthropic SSE encoder. Emits the full event envelope: `message_start`,
+/// Messages SSE encoder. Emits the full event envelope: `message_start`,
 /// per-block `content_block_start` / `_delta` / `_stop`, `message_delta`,
 /// `message_stop`.
 ///
@@ -890,7 +890,7 @@ enum EncoderBlockKind {
     ToolUse,
 }
 
-struct AnthropicStreamEncoder {
+struct MessagesStreamEncoder {
     request_id: String,
     model: String,
     started: bool,
@@ -901,7 +901,7 @@ struct AnthropicStreamEncoder {
     block_index: usize,
 }
 
-impl AnthropicStreamEncoder {
+impl MessagesStreamEncoder {
     fn ev(name: &str, data: serde_json::Value) -> SseFrame {
         SseFrame::Event {
             event: Some(name.to_string()),
@@ -995,7 +995,7 @@ impl AnthropicStreamEncoder {
 /// relationship as `total = cache_read + cache_creation + input_tokens`
 /// (<https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching>
 /// → "Tracking cache performance"). The canonical [`Usage::prompt_tokens`]
-/// is the **inclusive** total (matches OpenAI / Google semantics; see
+/// is the **inclusive** total (matches Chat Completions / Generate Content semantics; see
 /// `parse_usage`), so we subtract the cache buckets back out here to
 /// reconstruct the wire format. Saturating-sub guards against a caller
 /// constructing a `Usage` whose cache totals exceed `prompt_tokens` —
@@ -1021,7 +1021,7 @@ fn render_usage(u: &Usage) -> serde_json::Value {
     serde_json::Value::Object(map)
 }
 
-impl StreamEncoder for AnthropicStreamEncoder {
+impl StreamEncoder for MessagesStreamEncoder {
     fn encode(&mut self, part: &StreamPart) -> Result<Vec<SseFrame>> {
         let mut frames = Vec::new();
         self.ensure_started(&mut frames);
@@ -1100,14 +1100,14 @@ impl StreamEncoder for AnthropicStreamEncoder {
             StreamPart::Usage { .. } => {}
             StreamPart::ResponseStarted { .. } => {
                 // Observability-only metadata (upstream response id); the
-                // Anthropic-protocol client gets its id from the
+                // Messages-protocol client gets its id from the
                 // `message_start` event `ensure_started` emits.
             }
             StreamPart::Finish { reason } => {
                 self.emit_terminal(&mut frames, &finish_to_stop_reason(reason), None);
             }
             StreamPart::ResponseCompleted { status, usage, .. } => {
-                // Inbound was OpenAI Responses; map its status onto Anthropic's
+                // Inbound was Responses; map its status onto Messages'
                 // `stop_reason` and carry the usage if present.
                 let stop_reason = if status == "incomplete" {
                     "max_tokens"
@@ -1121,7 +1121,7 @@ impl StreamEncoder for AnthropicStreamEncoder {
     }
 
     fn encode_error(&mut self, message: &str) -> Vec<SseFrame> {
-        // Anthropic surfaces a mid-stream error as a named `error` event.
+        // Messages surfaces a mid-stream error as a named `error` event.
         vec![Self::ev(
             "error",
             serde_json::json!({

--- a/crates/bitrouter-sdk/src/language_model/protocol/mod.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/mod.rs
@@ -1,7 +1,7 @@
 //! Protocol adapters for the `language_model` protocol.
 //!
-//! Four built-in wire protocols — OpenAI Chat Completions, OpenAI Responses,
-//! Anthropic Messages, Google Generative AI — each convert to/from the
+//! Four built-in wire protocols — Chat Completions, Responses,
+//! Messages, Generate Content — each convert to/from the
 //! canonical internal representation ([`Prompt`] / [`GenerateResult`] /
 //! [`StreamPart`]). Any inbound protocol can be paired with any outbound
 //! protocol (the 4×4 conversion matrix).
@@ -76,10 +76,10 @@ use crate::language_model::types::{
     ApiProtocol, GenerateResult, Prompt, RoutingTarget, StreamPart,
 };
 
-pub mod anthropic;
-pub mod google;
-pub mod openai_chat;
-pub mod openai_responses;
+pub mod chat_completions;
+pub mod generate_content;
+pub mod messages;
+pub mod responses;
 
 #[cfg(test)]
 mod tests;
@@ -206,7 +206,7 @@ pub trait StreamEncoder: Send {
     }
 
     /// Called once at clean stream end; emit any trailing frames (e.g. the
-    /// OpenAI `[DONE]` sentinel — note Responses must **not** emit it, #454-2).
+    /// Chat Completions `[DONE]` sentinel — note Responses must **not** emit it, #454-2).
     fn finish(&mut self) -> Result<Vec<SseFrame>> {
         Ok(Vec::new())
     }
@@ -216,10 +216,10 @@ pub trait StreamEncoder: Send {
 /// have no inbound adapter — the SDK never serves them to clients.
 pub fn inbound_adapter_for(protocol: &ApiProtocol) -> Option<Box<dyn InboundAdapter>> {
     match protocol {
-        ApiProtocol::Openai => Some(Box::new(openai_chat::OpenAiChatAdapter)),
-        ApiProtocol::Anthropic => Some(Box::new(anthropic::AnthropicAdapter)),
-        ApiProtocol::Responses => Some(Box::new(openai_responses::OpenAiResponsesAdapter)),
-        ApiProtocol::Google => Some(Box::new(google::GoogleAdapter)),
+        ApiProtocol::ChatCompletions => Some(Box::new(chat_completions::ChatCompletionsAdapter)),
+        ApiProtocol::Messages => Some(Box::new(messages::MessagesAdapter)),
+        ApiProtocol::Responses => Some(Box::new(responses::ResponsesAdapter)),
+        ApiProtocol::GenerateContent => Some(Box::new(generate_content::GenerateContentAdapter)),
         ApiProtocol::Custom(_) => None,
     }
 }
@@ -256,20 +256,20 @@ impl OutboundDispatch {
     pub fn builtin() -> Self {
         let mut d = Self::empty();
         d.register(
-            Arc::new(openai_chat::OpenAiChatAdapter),
-            Arc::new(openai_chat::OpenAiChatTransport),
+            Arc::new(chat_completions::ChatCompletionsAdapter),
+            Arc::new(chat_completions::ChatCompletionsTransport),
         );
         d.register(
-            Arc::new(anthropic::AnthropicAdapter),
-            Arc::new(anthropic::AnthropicTransport),
+            Arc::new(messages::MessagesAdapter),
+            Arc::new(messages::MessagesTransport),
         );
         d.register(
-            Arc::new(openai_responses::OpenAiResponsesAdapter),
-            Arc::new(openai_responses::OpenAiResponsesTransport),
+            Arc::new(responses::ResponsesAdapter),
+            Arc::new(responses::ResponsesTransport),
         );
         d.register(
-            Arc::new(google::GoogleAdapter),
-            Arc::new(google::GoogleTransport),
+            Arc::new(generate_content::GenerateContentAdapter),
+            Arc::new(generate_content::GenerateContentTransport),
         );
         d
     }

--- a/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
@@ -1,4 +1,4 @@
-//! OpenAI Responses adapter.
+//! Responses adapter.
 //!
 //! Official reference: <https://platform.openai.com/docs/api-reference/responses>
 //! Streaming events: <https://platform.openai.com/docs/api-reference/responses-streaming>
@@ -32,16 +32,16 @@ use crate::language_model::types::{
     ResponseFormat, Role, RoutingTarget, StreamPart, Usage,
 };
 
-/// The OpenAI Responses protocol adapter.
-pub struct OpenAiResponsesAdapter;
+/// The Responses protocol adapter.
+pub struct ResponsesAdapter;
 
-/// HTTP transport for OpenAI Responses: `POST {api_base}/responses` with
+/// HTTP transport for Responses: `POST {api_base}/responses` with
 /// `Authorization: Bearer <api_key>`.
-pub struct OpenAiResponsesTransport;
+pub struct ResponsesTransport;
 
 // ===== wire request types =====
 
-/// OpenAI Responses request body
+/// Responses request body
 /// (<https://platform.openai.com/docs/api-reference/responses/create>).
 ///
 /// `pub` so downstream crates (notably `bitrouter-cloud`) can derive an
@@ -254,7 +254,7 @@ fn finish_from_status(status: &str) -> Option<FinishReason> {
     }
 }
 
-impl InboundAdapter for OpenAiResponsesAdapter {
+impl InboundAdapter for ResponsesAdapter {
     fn protocol(&self) -> ApiProtocol {
         ApiProtocol::Responses
     }
@@ -362,7 +362,7 @@ impl InboundAdapter for OpenAiResponsesAdapter {
     }
 }
 
-impl OutboundAdapter for OpenAiResponsesAdapter {
+impl OutboundAdapter for ResponsesAdapter {
     fn protocol(&self) -> ApiProtocol {
         ApiProtocol::Responses
     }
@@ -492,7 +492,7 @@ impl OutboundAdapter for OpenAiResponsesAdapter {
             .and_then(|s| s.as_str())
             .and_then(finish_from_status);
         let usage = body.get("usage").and_then(parse_usage);
-        // OpenAI Responses: top-level `id` (`resp_...`).
+        // Responses: top-level `id` (`resp_...`).
         // <https://platform.openai.com/docs/api-reference/responses/object>
         let response_id = body
             .get("id")
@@ -561,7 +561,7 @@ fn render_responses_response_format(rf: &ResponseFormat) -> serde_json::Value {
 }
 
 #[async_trait]
-impl Transport for OpenAiResponsesTransport {
+impl Transport for ResponsesTransport {
     fn protocol(&self) -> ApiProtocol {
         ApiProtocol::Responses
     }
@@ -735,7 +735,7 @@ fn parse_usage(value: &serde_json::Value) -> Option<Usage> {
 
 // ===== streaming =====
 
-/// OpenAI Responses SSE decoder. Explicit state machine over the lifecycle
+/// Responses SSE decoder. Explicit state machine over the lifecycle
 /// envelope. Tracks `item_id → call_id` so `function_call_arguments.delta`
 /// events map back to the canonical tool-call id (#434).
 #[derive(Default)]
@@ -897,7 +897,7 @@ impl StreamDecoder for ResponsesStreamDecoder {
     }
 }
 
-/// OpenAI Responses SSE encoder. Emits the complete lifecycle envelope:
+/// Responses SSE encoder. Emits the complete lifecycle envelope:
 ///
 /// ```text
 /// response.created
@@ -992,7 +992,7 @@ impl ResponsesStreamEncoder {
                 "status": "in_progress",
                 "output": [],
             });
-            // The OpenAI Responses stream opens with `response.created`
+            // The Responses stream opens with `response.created`
             // *then* `response.in_progress`. Codex CLI's state machine
             // waits for `in_progress` before it starts consuming output
             // items — emit both.
@@ -1365,8 +1365,8 @@ impl StreamEncoder for ResponsesStreamEncoder {
                 // `response.created` event `ensure_created` emits.
             }
             StreamPart::Finish { reason } => {
-                // A bare `Finish` (e.g. inbound was OpenAI Chat / Anthropic /
-                // Google) — synthesise the terminal envelope from the reason.
+                // A bare `Finish` (e.g. inbound was Chat Completions / Messages /
+                // Generate Content) — synthesise the terminal envelope from the reason.
                 let status = match reason {
                     FinishReason::Length => "incomplete",
                     FinishReason::Error(_) => "failed",

--- a/crates/bitrouter-sdk/src/language_model/protocol/snapshots/chat_completions_request.json
+++ b/crates/bitrouter-sdk/src/language_model/protocol/snapshots/chat_completions_request.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "ChatRequest",
-  "description": "OpenAI Chat Completions request body\n(<https://platform.openai.com/docs/api-reference/chat/create>).\n\n`pub` so downstream crates (notably `bitrouter-cloud`) can derive an\nOpenAPI schema from the canonical wire shape without redeclaring it.",
+  "description": "Chat Completions request body\n(<https://platform.openai.com/docs/api-reference/chat/create>).\n\n`pub` so downstream crates (notably `bitrouter-cloud`) can derive an\nOpenAPI schema from the canonical wire shape without redeclaring it.",
   "type": "object",
   "properties": {
     "max_completion_tokens": {

--- a/crates/bitrouter-sdk/src/language_model/protocol/snapshots/generate_content_request.json
+++ b/crates/bitrouter-sdk/src/language_model/protocol/snapshots/generate_content_request.json
@@ -1,19 +1,19 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "GenerateContentRequest",
-  "description": "Google Generative AI `generateContent` request body\n(<https://ai.google.dev/api/generate-content>).\n\n`pub` so downstream crates (notably `bitrouter-cloud`) can derive an\nOpenAPI schema from the canonical wire shape without redeclaring it.",
+  "description": "Generate Content `generateContent` request body\n(<https://ai.google.dev/api/generate-content>).\n\n`pub` so downstream crates (notably `bitrouter-cloud`) can derive an\nOpenAPI schema from the canonical wire shape without redeclaring it.",
   "type": "object",
   "properties": {
     "contents": {
       "type": "array",
       "items": {
-        "$ref": "#/$defs/GoogleContent"
+        "$ref": "#/$defs/GenerateContentContent"
       }
     },
     "generationConfig": {
       "anyOf": [
         {
-          "$ref": "#/$defs/GoogleGenerationConfig"
+          "$ref": "#/$defs/GenerateContentGenerationConfig"
         },
         {
           "type": "null"
@@ -26,14 +26,14 @@
       "default": ""
     },
     "stream": {
-      "description": "Injected by `server::google_generate` from the path verb\n(`:streamGenerateContent` → true, `:generateContent` → false).",
+      "description": "Injected by `server::generate_content` from the path verb\n(`:streamGenerateContent` → true, `:generateContent` → false).",
       "type": "boolean",
       "default": false
     },
     "systemInstruction": {
       "anyOf": [
         {
-          "$ref": "#/$defs/GoogleContent"
+          "$ref": "#/$defs/GenerateContentContent"
         },
         {
           "type": "null"
@@ -43,7 +43,7 @@
     "tools": {
       "type": "array",
       "items": {
-        "$ref": "#/$defs/GoogleTool"
+        "$ref": "#/$defs/GenerateContentTool"
       }
     }
   },
@@ -51,7 +51,7 @@
     "contents"
   ],
   "$defs": {
-    "GoogleContent": {
+    "GenerateContentContent": {
       "description": "One element of [`GenerateContentRequest`]'s `contents` array — a turn\ncarrying optional role + `parts[]`.",
       "type": "object",
       "properties": {
@@ -69,8 +69,8 @@
         }
       }
     },
-    "GoogleFunctionDecl": {
-      "description": "One function declaration inside a [`GoogleTool`]: name + description +\nJSON-Schema parameters.",
+    "GenerateContentFunctionDecl": {
+      "description": "One function declaration inside a [`GenerateContentTool`]: name + description +\nJSON-Schema parameters.",
       "type": "object",
       "properties": {
         "description": {
@@ -91,7 +91,7 @@
         "name"
       ]
     },
-    "GoogleGenerationConfig": {
+    "GenerateContentGenerationConfig": {
       "description": "`generationConfig` knobs on a [`GenerateContentRequest`].",
       "type": "object",
       "properties": {
@@ -122,14 +122,14 @@
         }
       }
     },
-    "GoogleTool": {
+    "GenerateContentTool": {
       "description": "One element of [`GenerateContentRequest`]'s `tools` array — Google's\n`{ functionDeclarations: [...] }` envelope.",
       "type": "object",
       "properties": {
         "functionDeclarations": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/GoogleFunctionDecl"
+            "$ref": "#/$defs/GenerateContentFunctionDecl"
           }
         }
       }

--- a/crates/bitrouter-sdk/src/language_model/protocol/snapshots/messages_request.json
+++ b/crates/bitrouter-sdk/src/language_model/protocol/snapshots/messages_request.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "MessagesRequest",
-  "description": "Anthropic Messages request body (<https://docs.anthropic.com/en/api/messages>).\n\n`pub` so downstream crates (notably `bitrouter-cloud`) can derive an\nOpenAPI schema from the canonical wire shape without redeclaring it.",
+  "description": "Messages request body (<https://docs.anthropic.com/en/api/messages>).\n\n`pub` so downstream crates (notably `bitrouter-cloud`) can derive an\nOpenAPI schema from the canonical wire shape without redeclaring it.",
   "type": "object",
   "properties": {
     "max_tokens": {
@@ -16,7 +16,7 @@
     "messages": {
       "type": "array",
       "items": {
-        "$ref": "#/$defs/AnthropicMessage"
+        "$ref": "#/$defs/MessagesMessage"
       }
     },
     "model": {
@@ -41,7 +41,7 @@
     "tools": {
       "type": "array",
       "items": {
-        "$ref": "#/$defs/AnthropicTool"
+        "$ref": "#/$defs/MessagesTool"
       }
     },
     "top_p": {
@@ -58,7 +58,7 @@
     "messages"
   ],
   "$defs": {
-    "AnthropicMessage": {
+    "MessagesMessage": {
       "description": "One element of [`MessagesRequest`]'s `messages` array — a `{ role, content }` turn.",
       "type": "object",
       "properties": {
@@ -74,7 +74,7 @@
         "content"
       ]
     },
-    "AnthropicTool": {
+    "MessagesTool": {
       "description": "One element of [`MessagesRequest`]'s `tools` array — Anthropic's tool definition shape.",
       "type": "object",
       "properties": {

--- a/crates/bitrouter-sdk/src/language_model/protocol/snapshots/responses_request.json
+++ b/crates/bitrouter-sdk/src/language_model/protocol/snapshots/responses_request.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "ResponsesRequest",
-  "description": "OpenAI Responses request body\n(<https://platform.openai.com/docs/api-reference/responses/create>).\n\n`pub` so downstream crates (notably `bitrouter-cloud`) can derive an\nOpenAPI schema from the canonical wire shape without redeclaring it.\n\n`input` stays `serde_json::Value` on purpose — the Responses API accepts\neither a plain string or a heterogeneous item array (Codex multi-turn,\n#454-3), and the deeper walk happens in `parse_input` (private). Mirrors\nhow Anthropic's `system` / `content` are typed.",
+  "description": "Responses request body\n(<https://platform.openai.com/docs/api-reference/responses/create>).\n\n`pub` so downstream crates (notably `bitrouter-cloud`) can derive an\nOpenAPI schema from the canonical wire shape without redeclaring it.\n\n`input` stays `serde_json::Value` on purpose — the Responses API accepts\neither a plain string or a heterogeneous item array (Codex multi-turn,\n#454-3), and the deeper walk happens in `parse_input` (private). Mirrors\nhow Anthropic's `system` / `content` are typed.",
   "type": "object",
   "properties": {
     "input": true,

--- a/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
@@ -17,20 +17,20 @@ impl<T: InboundAdapter + OutboundAdapter> BothAdapter for T {}
 /// the same value.
 fn adapter_for(protocol: ApiProtocol) -> Box<dyn BothAdapter> {
     match protocol {
-        ApiProtocol::Openai => Box::new(openai_chat::OpenAiChatAdapter),
-        ApiProtocol::Anthropic => Box::new(anthropic::AnthropicAdapter),
-        ApiProtocol::Responses => Box::new(openai_responses::OpenAiResponsesAdapter),
-        ApiProtocol::Google => Box::new(google::GoogleAdapter),
+        ApiProtocol::ChatCompletions => Box::new(chat_completions::ChatCompletionsAdapter),
+        ApiProtocol::Messages => Box::new(messages::MessagesAdapter),
+        ApiProtocol::Responses => Box::new(responses::ResponsesAdapter),
+        ApiProtocol::GenerateContent => Box::new(generate_content::GenerateContentAdapter),
         ApiProtocol::Custom(_) => unreachable!("test helper only handles built-in protocols"),
     }
 }
 
 fn all_protocols() -> [ApiProtocol; 4] {
     [
-        ApiProtocol::Anthropic,
-        ApiProtocol::Openai,
+        ApiProtocol::Messages,
+        ApiProtocol::ChatCompletions,
         ApiProtocol::Responses,
-        ApiProtocol::Google,
+        ApiProtocol::GenerateContent,
     ]
 }
 
@@ -259,8 +259,8 @@ fn conversion_matrix_4x4_streaming() {
 /// <https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/>).
 #[test]
 fn outbound_adapters_extract_response_id() {
-    // OpenAI Chat Completions: top-level `id` (`chatcmpl-...`).
-    let openai_chat = adapter_for(ApiProtocol::Openai);
+    // Chat Completions: top-level `id` (`chatcmpl-...`).
+    let openai_chat = adapter_for(ApiProtocol::ChatCompletions);
     let body = serde_json::json!({
         "id": "chatcmpl-abc123",
         "object": "chat.completion",
@@ -274,11 +274,11 @@ fn outbound_adapters_extract_response_id() {
             .response_id
             .as_deref(),
         Some("chatcmpl-abc123"),
-        "OpenAI Chat must extract top-level `id`"
+        "Chat Completions must extract top-level `id`"
     );
 
-    // Anthropic Messages: top-level `id` (`msg_...`).
-    let anthropic = adapter_for(ApiProtocol::Anthropic);
+    // Messages: top-level `id` (`msg_...`).
+    let anthropic = adapter_for(ApiProtocol::Messages);
     let body = serde_json::json!({
         "id": "msg_01ABC",
         "type": "message",
@@ -296,8 +296,8 @@ fn outbound_adapters_extract_response_id() {
         "Anthropic must extract top-level `id`"
     );
 
-    // Google Generative AI: top-level `responseId`.
-    let google = adapter_for(ApiProtocol::Google);
+    // Generate Content: top-level `responseId`.
+    let google = adapter_for(ApiProtocol::GenerateContent);
     let body = serde_json::json!({
         "responseId": "google-resp-xyz",
         "candidates": [{"content": {"parts": [{"text": "hi"}]}, "finishReason": "STOP"}],
@@ -308,7 +308,7 @@ fn outbound_adapters_extract_response_id() {
         "Google must extract `responseId`"
     );
 
-    // OpenAI Responses: top-level `id` (`resp_...`).
+    // Responses: top-level `id` (`resp_...`).
     let responses = adapter_for(ApiProtocol::Responses);
     let body = serde_json::json!({
         "id": "resp_abc789",
@@ -323,11 +323,11 @@ fn outbound_adapters_extract_response_id() {
             .response_id
             .as_deref(),
         Some("resp_abc789"),
-        "OpenAI Responses must extract top-level `id`"
+        "Responses must extract top-level `id`"
     );
 
     // Absent id: graceful None.
-    let openai_chat = adapter_for(ApiProtocol::Openai);
+    let openai_chat = adapter_for(ApiProtocol::ChatCompletions);
     let body = serde_json::json!({
         "choices": [{"index": 0, "message": {"role": "assistant", "content": "hi"}, "finish_reason": "stop"}],
     });
@@ -339,8 +339,8 @@ fn outbound_adapters_extract_response_id() {
 }
 
 #[test]
-fn openai_chat_request_roundtrip() {
-    let adapter = adapter_for(ApiProtocol::Openai);
+fn chat_completions_request_roundtrip() {
+    let adapter = adapter_for(ApiProtocol::ChatCompletions);
     let prompt = sample_prompt();
     let json = adapter.render_request(&prompt).unwrap();
     assert_eq!(json["model"], "test-model");
@@ -352,11 +352,11 @@ fn openai_chat_request_roundtrip() {
 }
 
 #[test]
-fn openai_chat_passes_through_uncommon_params() {
+fn chat_completions_passes_through_uncommon_params() {
     // tool_choice, stop, seed, response_format, n, presence/frequency_penalty,
     // logit_bias, logprobs, top_logprobs, user, parallel_tool_calls,
     // stream_options — every field without a typed slot survives parse → render.
-    let adapter = adapter_for(ApiProtocol::Openai);
+    let adapter = adapter_for(ApiProtocol::ChatCompletions);
     let body = serde_json::json!({
         "model": "gpt-5",
         "messages": [{"role": "user", "content": "hi"}],
@@ -387,14 +387,14 @@ fn openai_chat_passes_through_uncommon_params() {
     ] {
         assert_eq!(
             rendered[key], body[key],
-            "OpenAI Chat `{key}` must survive parse/render"
+            "Chat Completions `{key}` must survive parse/render"
         );
     }
 }
 
 #[test]
-fn anthropic_passes_through_uncommon_params() {
-    let adapter = adapter_for(ApiProtocol::Anthropic);
+fn messages_passes_through_uncommon_params() {
+    let adapter = adapter_for(ApiProtocol::Messages);
     let body = serde_json::json!({
         "model": "claude-sonnet-4-6",
         "messages": [{"role": "user", "content": "hi"}],
@@ -422,8 +422,8 @@ fn anthropic_passes_through_uncommon_params() {
 }
 
 #[test]
-fn google_passes_through_uncommon_generation_config() {
-    let adapter = adapter_for(ApiProtocol::Google);
+fn generate_content_passes_through_uncommon_generation_config() {
+    let adapter = adapter_for(ApiProtocol::GenerateContent);
     let body = serde_json::json!({
         "model": "gemini-2.0-flash",
         "contents": [{"role": "user", "parts": [{"text": "hi"}]}],
@@ -480,8 +480,8 @@ fn sample_prompt_with_schema() -> Prompt {
 }
 
 #[test]
-fn openai_chat_inbound_promotes_json_schema_response_format() {
-    let adapter = adapter_for(ApiProtocol::Openai);
+fn chat_completions_inbound_promotes_json_schema_response_format() {
+    let adapter = adapter_for(ApiProtocol::ChatCompletions);
     let body = serde_json::json!({
         "model": "gpt-4o",
         "messages": [{"role": "user", "content": "weather?"}],
@@ -512,10 +512,10 @@ fn openai_chat_inbound_promotes_json_schema_response_format() {
 }
 
 #[test]
-fn openai_chat_inbound_leaves_json_object_in_extras() {
+fn chat_completions_inbound_leaves_json_object_in_extras() {
     // The legacy `{type: "json_object"}` JSON mode has no schema to translate,
     // so it must keep passing through opaquely.
-    let adapter = adapter_for(ApiProtocol::Openai);
+    let adapter = adapter_for(ApiProtocol::ChatCompletions);
     let body = serde_json::json!({
         "model": "gpt-4o",
         "messages": [{"role": "user", "content": "hi"}],
@@ -528,8 +528,8 @@ fn openai_chat_inbound_leaves_json_object_in_extras() {
 }
 
 #[test]
-fn openai_chat_outbound_renders_json_schema() {
-    let adapter = adapter_for(ApiProtocol::Openai);
+fn chat_completions_outbound_renders_json_schema() {
+    let adapter = adapter_for(ApiProtocol::ChatCompletions);
     let rendered = adapter
         .render_request(&sample_prompt_with_schema())
         .unwrap();
@@ -546,10 +546,10 @@ fn openai_chat_outbound_renders_json_schema() {
 }
 
 #[test]
-fn openai_chat_outbound_supplies_default_name() {
-    // OpenAI Chat requires `name`; renderer fills it when absent (e.g. when
+fn chat_completions_outbound_supplies_default_name() {
+    // Chat Completions requires `name`; renderer fills it when absent (e.g. when
     // the inbound was Anthropic/Google which carry no name).
-    let adapter = adapter_for(ApiProtocol::Openai);
+    let adapter = adapter_for(ApiProtocol::ChatCompletions);
     let prompt = Prompt {
         response_format: Some(ResponseFormat::JsonSchema {
             name: None,
@@ -572,8 +572,8 @@ fn openai_chat_outbound_supplies_default_name() {
 }
 
 #[test]
-fn anthropic_inbound_promotes_output_config_format() {
-    let adapter = adapter_for(ApiProtocol::Anthropic);
+fn messages_inbound_promotes_output_config_format() {
+    let adapter = adapter_for(ApiProtocol::Messages);
     let body = serde_json::json!({
         "model": "claude-opus-4-7",
         "max_tokens": 1024,
@@ -596,10 +596,10 @@ fn anthropic_inbound_promotes_output_config_format() {
 }
 
 #[test]
-fn anthropic_inbound_accepts_legacy_output_format_alias() {
+fn messages_inbound_accepts_legacy_output_format_alias() {
     // The deprecated flat `output_format` shape (pre-GA, still emitted by
     // some clients — vercel/ai#12298) must still parse cleanly.
-    let adapter = adapter_for(ApiProtocol::Anthropic);
+    let adapter = adapter_for(ApiProtocol::Messages);
     let body = serde_json::json!({
         "model": "claude-opus-4-7",
         "max_tokens": 1024,
@@ -618,11 +618,11 @@ fn anthropic_inbound_accepts_legacy_output_format_alias() {
 }
 
 #[test]
-fn anthropic_inbound_legacy_alias_does_not_disturb_output_config_siblings() {
+fn messages_inbound_legacy_alias_does_not_disturb_output_config_siblings() {
     // If the legacy `output_format` alias is what matched, an unrelated
     // `output_config` blob the client supplied must be left fully intact in
     // extras so its siblings (`unknown_key` here) survive the round trip.
-    let adapter = adapter_for(ApiProtocol::Anthropic);
+    let adapter = adapter_for(ApiProtocol::Messages);
     let body = serde_json::json!({
         "model": "claude-opus-4-7",
         "max_tokens": 1024,
@@ -640,8 +640,8 @@ fn anthropic_inbound_legacy_alias_does_not_disturb_output_config_siblings() {
 }
 
 #[test]
-fn anthropic_outbound_renders_output_config_format() {
-    let adapter = adapter_for(ApiProtocol::Anthropic);
+fn messages_outbound_renders_output_config_format() {
+    let adapter = adapter_for(ApiProtocol::Messages);
     let rendered = adapter
         .render_request(&sample_prompt_with_schema())
         .unwrap();
@@ -650,15 +650,15 @@ fn anthropic_outbound_renders_output_config_format() {
         rendered["output_config"]["format"]["schema"]["properties"]["location"]["type"],
         "string"
     );
-    // Anthropic carries no `name` / `strict` — confirm they're dropped, not
+    // Messages carries no `name` / `strict` — confirm they're dropped, not
     // forwarded as unknown fields.
     assert!(rendered["output_config"]["format"].get("name").is_none());
     assert!(rendered["output_config"]["format"].get("strict").is_none());
 }
 
 #[test]
-fn google_inbound_promotes_response_schema() {
-    let adapter = adapter_for(ApiProtocol::Google);
+fn generate_content_inbound_promotes_response_schema() {
+    let adapter = adapter_for(ApiProtocol::GenerateContent);
     let body = serde_json::json!({
         "model": "gemini-2.5-pro",
         "contents": [{"role": "user", "parts": [{"text": "weather?"}]}],
@@ -679,10 +679,10 @@ fn google_inbound_promotes_response_schema() {
 }
 
 #[test]
-fn google_inbound_leaves_enum_mime_in_extras() {
+fn generate_content_inbound_leaves_enum_mime_in_extras() {
     // `text/x.enum` has no JSON schema; must stay in extras for opaque
-    // Google-native pass-through.
-    let adapter = adapter_for(ApiProtocol::Google);
+    // Generate Content-native pass-through.
+    let adapter = adapter_for(ApiProtocol::GenerateContent);
     let body = serde_json::json!({
         "model": "gemini-2.5-pro",
         "contents": [{"role": "user", "parts": [{"text": "x"}]}],
@@ -700,8 +700,8 @@ fn google_inbound_leaves_enum_mime_in_extras() {
 }
 
 #[test]
-fn google_outbound_renders_response_schema() {
-    let adapter = adapter_for(ApiProtocol::Google);
+fn generate_content_outbound_renders_response_schema() {
+    let adapter = adapter_for(ApiProtocol::GenerateContent);
     let rendered = adapter
         .render_request(&sample_prompt_with_schema())
         .unwrap();
@@ -776,20 +776,20 @@ fn response_format_survives_cross_protocol_routing() {
         ResponseFormat::JsonSchema { schema, .. } => schema.clone(),
     };
 
-    // OpenAI Chat
-    let chat = adapter_for(ApiProtocol::Openai)
+    // Chat Completions
+    let chat = adapter_for(ApiProtocol::ChatCompletions)
         .render_request(&prompt)
         .unwrap();
     assert_eq!(chat["response_format"]["json_schema"]["schema"], schema);
 
-    // Anthropic
-    let ant = adapter_for(ApiProtocol::Anthropic)
+    // Messages
+    let ant = adapter_for(ApiProtocol::Messages)
         .render_request(&prompt)
         .unwrap();
     assert_eq!(ant["output_config"]["format"]["schema"], schema);
 
-    // Google
-    let g = adapter_for(ApiProtocol::Google)
+    // Generate Content
+    let g = adapter_for(ApiProtocol::GenerateContent)
         .render_request(&prompt)
         .unwrap();
     assert_eq!(g["generationConfig"]["responseSchema"], schema);
@@ -798,7 +798,7 @@ fn response_format_survives_cross_protocol_routing() {
         "application/json"
     );
 
-    // OpenAI Responses
+    // Responses
     let r = adapter_for(ApiProtocol::Responses)
         .render_request(&prompt)
         .unwrap();
@@ -817,14 +817,14 @@ fn builtin_adapters_advertise_response_format_support() {
 }
 
 #[test]
-fn anthropic_no_beta_header_is_emitted() {
+fn messages_no_beta_header_is_emitted() {
     // The deprecated `anthropic-beta: structured-outputs-2025-11-13` header
     // is no longer required by the Anthropic GA endpoint and is actively
     // rejected by Vertex AI (vercel/ai#10981). The Anthropic transport must
     // not introduce it as a side effect of structured outputs.
     use crate::language_model::protocol::Transport;
     use crate::language_model::types::RoutingTarget;
-    let transport = crate::language_model::protocol::anthropic::AnthropicTransport;
+    let transport = crate::language_model::protocol::messages::MessagesTransport;
     let client = reqwest::Client::new();
     let req = client
         .post("http://example.invalid/v1/messages")
@@ -835,7 +835,7 @@ fn anthropic_no_beta_header_is_emitted() {
         service_id: "claude-opus-4-7".into(),
         api_base: "http://example.invalid".into(),
         api_key: "k".into(),
-        api_protocol: ApiProtocol::Anthropic,
+        api_protocol: ApiProtocol::Messages,
         account_label: None,
         api_key_override: None,
         api_base_override: None,
@@ -848,19 +848,19 @@ fn anthropic_no_beta_header_is_emitted() {
 }
 
 #[test]
-fn anthropic_cache_tokens_round_trip() {
-    // Anthropic prompt caching exposes `cache_read_input_tokens` and
+fn messages_cache_tokens_round_trip() {
+    // Messages prompt caching exposes `cache_read_input_tokens` and
     // `cache_creation_input_tokens` in `usage`. Parser captures them, encoder
     // emits them on the non-streaming response, and on `message_delta` they
     // accompany the streaming finalisation.
     //
     // SDK contract: `cache_read_tokens` / `cache_write_tokens` are **subsets
-    // of** `prompt_tokens` (matches OpenAI / Google). Anthropic's wire format
+    // of** `prompt_tokens` (matches Chat Completions / Generate Content). Messages' wire format
     // is the opposite — `input_tokens` is the uncached portion, reported
     // alongside the cache buckets — so the parser folds the cache totals
     // back into `prompt_tokens` and the renderer unfolds them when writing
     // the wire payload.
-    let adapter = adapter_for(ApiProtocol::Anthropic);
+    let adapter = adapter_for(ApiProtocol::Messages);
     let body = serde_json::json!({
         "id": "msg_1",
         "type": "message",
@@ -892,7 +892,7 @@ fn anthropic_cache_tokens_round_trip() {
 }
 
 #[test]
-fn anthropic_cache_tokens_match_subset_contract() {
+fn messages_cache_tokens_match_subset_contract() {
     // Regression: the canonical `Usage` doc-comment states that
     // `cache_read_tokens` and `cache_write_tokens` are **subsets of**
     // `prompt_tokens`. Anthropic's wire payload uses the opposite
@@ -901,7 +901,7 @@ fn anthropic_cache_tokens_match_subset_contract() {
     // downstream billing layers that compute `no_cache = prompt_tokens
     // - cache_read - cache_write` saturate to 0 on cache-heavy
     // requests and silently undercharge the uncached portion.
-    let adapter = adapter_for(ApiProtocol::Anthropic);
+    let adapter = adapter_for(ApiProtocol::Messages);
     let body = serde_json::json!({
         "id": "msg_1",
         "type": "message",
@@ -936,14 +936,14 @@ fn anthropic_cache_tokens_match_subset_contract() {
 }
 
 #[test]
-fn anthropic_usage_with_no_cache_fields_keeps_prompt_tokens_unchanged() {
+fn messages_usage_with_no_cache_fields_keeps_prompt_tokens_unchanged() {
     // Belt-and-braces: when an upstream omits the cache fields entirely
     // (the common case for non-Anthropic Anthropic-API-compatible
     // upstreams, or Anthropic requests without prompt caching), the
     // canonical `prompt_tokens` must equal Anthropic's wire-level
     // `input_tokens` — the cache-fold is a no-op when both cache
     // totals are 0.
-    let adapter = adapter_for(ApiProtocol::Anthropic);
+    let adapter = adapter_for(ApiProtocol::Messages);
     let body = serde_json::json!({
         "id": "msg_1",
         "type": "message",
@@ -963,14 +963,14 @@ fn anthropic_usage_with_no_cache_fields_keeps_prompt_tokens_unchanged() {
 }
 
 #[test]
-fn anthropic_stream_preserves_cache_inclusive_prompt_tokens() {
+fn messages_stream_preserves_cache_inclusive_prompt_tokens() {
     // The stream decoder receives `message_start` (which carries the
     // full cache breakdown) and `message_delta` (which typically only
     // refreshes `output_tokens`). The terminal Usage frame must reflect
     // the inclusive prompt_tokens contract — the test pins this so a
     // future refactor of the delta path can't quietly drop the
     // cache-fold and undercharge again.
-    let decoder = adapter_for(ApiProtocol::Anthropic);
+    let decoder = adapter_for(ApiProtocol::Messages);
     let mut stream_decoder = decoder.stream_decoder();
 
     let start = SseEvent {
@@ -1023,10 +1023,10 @@ fn anthropic_stream_preserves_cache_inclusive_prompt_tokens() {
 }
 
 #[test]
-fn openai_chat_cache_tokens_round_trip() {
-    // OpenAI Chat surfaces cached prompt tokens via
+fn chat_completions_cache_tokens_round_trip() {
+    // Chat Completions surfaces cached prompt tokens via
     // `prompt_tokens_details.cached_tokens`. Parse → canonical → render.
-    let adapter = adapter_for(ApiProtocol::Openai);
+    let adapter = adapter_for(ApiProtocol::ChatCompletions);
     let body = serde_json::json!({
         "id": "c1",
         "choices": [{"message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}],
@@ -1049,13 +1049,13 @@ fn openai_chat_cache_tokens_round_trip() {
 }
 
 #[test]
-fn openai_chat_parse_captures_refusal_and_reasoning_aliases() {
+fn chat_completions_parse_captures_refusal_and_reasoning_aliases() {
     // `message.refusal` (when non-empty) is the OpenAI refusal text; carry it
     // as a Content::Text and set FinishReason::ContentFilter regardless of
     // what `finish_reason` says (OpenAI sometimes also says "content_filter"
     // but not always). `message.reasoning` / `message.thinking` are
     // OpenAI-compatible vendor aliases for `reasoning_content`.
-    let adapter = adapter_for(ApiProtocol::Openai);
+    let adapter = adapter_for(ApiProtocol::ChatCompletions);
 
     // refusal
     let body = serde_json::json!({
@@ -1097,13 +1097,13 @@ fn openai_chat_parse_captures_refusal_and_reasoning_aliases() {
 }
 
 #[test]
-fn anthropic_stream_encoder_closes_block_on_kind_transition() {
+fn messages_stream_encoder_closes_block_on_kind_transition() {
     // v0 #429 regression: when the canonical part stream transitions
     // text → reasoning → text → tool, the Anthropic encoder MUST emit a
     // `content_block_stop` before opening the new block kind. Strict
     // clients (Claude Code) reject a text_delta inside an open `thinking`
     // block. Ref: docs.anthropic.com/en/api/messages-streaming.
-    let adapter = adapter_for(ApiProtocol::Anthropic);
+    let adapter = adapter_for(ApiProtocol::Messages);
     let mut encoder = adapter.stream_encoder("msg_x", "claude-3-7-sonnet");
     let parts = [
         StreamPart::ReasoningDelta {
@@ -1143,12 +1143,12 @@ fn anthropic_stream_encoder_closes_block_on_kind_transition() {
 }
 
 #[test]
-fn anthropic_stream_error_maps_to_proper_http_status() {
-    // Anthropic mid-stream `error` events carry `error.type` — a 4xx must
+fn messages_stream_error_maps_to_proper_http_status() {
+    // Messages mid-stream `error` events carry `error.type` — a 4xx must
     // be threaded to `Upstream.status` so the fallback policy can decide
     // "don't retry" instead of always treating these as 5xx. Ref:
     // docs.anthropic.com/en/api/errors.
-    let adapter = adapter_for(ApiProtocol::Anthropic);
+    let adapter = adapter_for(ApiProtocol::Messages);
     let mut decoder = adapter.stream_decoder();
     let err = decoder
         .decode(&SseEvent {
@@ -1169,8 +1169,8 @@ fn anthropic_stream_error_maps_to_proper_http_status() {
 }
 
 #[test]
-fn openai_responses_stream_error_maps_to_proper_http_status() {
-    // OpenAI `response.failed` likewise — `error.type` decides
+fn responses_stream_error_maps_to_proper_http_status() {
+    // Responses `response.failed` likewise — `error.type` decides
     // `Upstream.status` so the fallback policy can tell "client did
     // something wrong" (4xx, don't retry) from "upstream broke" (5xx).
     let adapter = adapter_for(ApiProtocol::Responses);
@@ -1200,8 +1200,8 @@ fn streaming_decoders_emit_response_started_once() {
     // so observability can stamp `gen_ai.response.id` on the trace. OpenAI
     // Responses is unaffected (it carries the id on `ResponseCompleted`).
 
-    // OpenAI Chat: top-level `id` repeats on every chunk → emit once.
-    let adapter = adapter_for(ApiProtocol::Openai);
+    // Chat Completions: top-level `id` repeats on every chunk → emit once.
+    let adapter = adapter_for(ApiProtocol::ChatCompletions);
     let mut dec = adapter.stream_decoder();
     let first = dec
         .decode(&SseEvent {
@@ -1218,7 +1218,7 @@ fn streaming_decoders_emit_response_started_once() {
         first
             .iter()
             .any(|p| matches!(p, StreamPart::ResponseStarted { id } if id == "chatcmpl-stream1")),
-        "OpenAI Chat first chunk emits ResponseStarted; got {first:?}"
+        "Chat Completions first chunk emits ResponseStarted; got {first:?}"
     );
     let second = dec
         .decode(&SseEvent {
@@ -1237,8 +1237,8 @@ fn streaming_decoders_emit_response_started_once() {
         "ResponseStarted is emitted only once per stream; got {second:?}"
     );
 
-    // Anthropic: `message_start` carries `message.id` (fires once).
-    let adapter = adapter_for(ApiProtocol::Anthropic);
+    // Messages: `message_start` carries `message.id` (fires once).
+    let adapter = adapter_for(ApiProtocol::Messages);
     let mut dec = adapter.stream_decoder();
     let parts = dec
         .decode(&SseEvent {
@@ -1257,8 +1257,8 @@ fn streaming_decoders_emit_response_started_once() {
         "Anthropic message_start emits ResponseStarted; got {parts:?}"
     );
 
-    // Google: top-level `responseId` repeats on every chunk → emit once.
-    let adapter = adapter_for(ApiProtocol::Google);
+    // Generate Content: top-level `responseId` repeats on every chunk → emit once.
+    let adapter = adapter_for(ApiProtocol::GenerateContent);
     let mut dec = adapter.stream_decoder();
     let parts = dec
         .decode(&SseEvent {
@@ -1281,10 +1281,10 @@ fn streaming_decoders_emit_response_started_once() {
 #[test]
 fn chat_encoder_role_survives_leading_response_started() {
     // Regression: a leading `ResponseStarted` (now emitted first by the
-    // OpenAI Chat / Google decoders) must NOT consume the one-shot
+    // Chat Completions / Generate Content decoders) must NOT consume the one-shot
     // `role: assistant` marker. The role has to ride the first real
-    // content chunk; otherwise an OpenAI-Chat client never sees it.
-    let adapter = adapter_for(ApiProtocol::Openai);
+    // content chunk; otherwise a Chat Completions client never sees it.
+    let adapter = adapter_for(ApiProtocol::ChatCompletions);
     let mut enc = adapter.stream_encoder("chatcmpl-x", "gpt-5");
 
     // ResponseStarted arrives first — must emit no frames.
@@ -1316,7 +1316,7 @@ fn chat_encoder_role_survives_leading_response_started() {
 }
 
 #[test]
-fn openai_responses_omits_usage_when_none() {
+fn responses_omits_usage_when_none() {
     // v0 #6ae55b2 — when upstream reported no token counts, the wire shape
     // omits the `usage` key entirely. Mirrors the streaming `emit_terminal`.
     let adapter = adapter_for(ApiProtocol::Responses);
@@ -1338,11 +1338,11 @@ fn openai_responses_omits_usage_when_none() {
 }
 
 #[test]
-fn openai_chat_streaming_forces_include_usage() {
-    // OpenAI omits the trailing usage chunk unless the caller asks for it.
+fn chat_completions_streaming_forces_include_usage() {
+    // Chat Completions omits the trailing usage chunk unless the caller asks for it.
     // Settlement requires that chunk, so the outbound request injects
     // `stream_options.include_usage = true` whenever stream=true.
-    let adapter = adapter_for(ApiProtocol::Openai);
+    let adapter = adapter_for(ApiProtocol::ChatCompletions);
     let body = serde_json::json!({
         "model": "gpt-4",
         "messages": [{"role": "user", "content": "hi"}],
@@ -1377,11 +1377,11 @@ fn openai_chat_streaming_forces_include_usage() {
 }
 
 #[test]
-fn google_passes_through_top_level_extras() {
+fn generate_content_passes_through_top_level_extras() {
     // toolConfig / safetySettings / cachedContent live at the request root,
     // not under generationConfig. They must survive the round-trip.
     // Refs: <https://ai.google.dev/api/generate-content>.
-    let adapter = adapter_for(ApiProtocol::Google);
+    let adapter = adapter_for(ApiProtocol::GenerateContent);
     let body = serde_json::json!({
         "model": "gemini-2.0-flash",
         "contents": [{"role": "user", "parts": [{"text": "hi"}]}],
@@ -1404,12 +1404,12 @@ fn google_passes_through_top_level_extras() {
 }
 
 #[test]
-fn google_request_stream_flag_is_propagated() {
+fn generate_content_request_stream_flag_is_propagated() {
     // The server injects `stream: true` from a `:streamGenerateContent` path
     // verb. Before #stream-flag-fix the adapter dropped this field on the
     // floor and forced stream=false, sending streaming clients to the
     // non-streaming branch.
-    let adapter = adapter_for(ApiProtocol::Google);
+    let adapter = adapter_for(ApiProtocol::GenerateContent);
     let body = serde_json::json!({
         "model": "gemini-2.0-flash",
         "contents": [{"role": "user", "parts": [{"text": "hi"}]}],
@@ -1431,7 +1431,7 @@ fn google_request_stream_flag_is_propagated() {
 }
 
 #[test]
-fn openai_responses_passes_through_uncommon_params() {
+fn responses_passes_through_uncommon_params() {
     let adapter = adapter_for(ApiProtocol::Responses);
     let body = serde_json::json!({
         "model": "gpt-5",
@@ -1465,8 +1465,8 @@ fn openai_responses_passes_through_uncommon_params() {
 }
 
 #[test]
-fn anthropic_response_roundtrip() {
-    let adapter = adapter_for(ApiProtocol::Anthropic);
+fn messages_response_roundtrip() {
+    let adapter = adapter_for(ApiProtocol::Messages);
     let prompt = sample_prompt();
     let json = adapter
         .render_response(&sample_result(), &prompt, "msg_1")
@@ -1482,8 +1482,8 @@ fn anthropic_response_roundtrip() {
 }
 
 #[test]
-fn google_request_roundtrip() {
-    let adapter = adapter_for(ApiProtocol::Google);
+fn generate_content_request_roundtrip() {
+    let adapter = adapter_for(ApiProtocol::GenerateContent);
     let prompt = sample_prompt();
     let json = adapter.render_request(&prompt).unwrap();
     assert_eq!(json["systemInstruction"]["parts"][0]["text"], "be brief");
@@ -1522,7 +1522,7 @@ fn regression_276_ansi_escape_in_model_name() {
 /// target type name, the serde line/column, and a body preview.
 #[test]
 fn regression_367_deser_errors_are_descriptive() {
-    let adapter = adapter_for(ApiProtocol::Openai);
+    let adapter = adapter_for(ApiProtocol::ChatCompletions);
     // `messages` should be an array; a string is a type error.
     let bad = serde_json::json!({ "model": "m", "messages": "oops" });
     let err = adapter.parse_request(bad).unwrap_err();
@@ -1538,7 +1538,7 @@ fn regression_367_deser_errors_are_descriptive() {
 /// panic on the request path.
 #[test]
 fn deser_error_preview_handles_multi_byte_utf8() {
-    let adapter = adapter_for(ApiProtocol::Openai);
+    let adapter = adapter_for(ApiProtocol::ChatCompletions);
     // ~120 "é" (2 bytes) gives a body well over 240 bytes whose boundary
     // would fall inside a multi-byte rune if naïvely byte-sliced.
     let pad: String = "é".repeat(200);
@@ -1553,7 +1553,7 @@ fn deser_error_preview_handles_multi_byte_utf8() {
 /// blocks keep their order in the canonical representation.
 #[test]
 fn regression_416_mixed_text_and_tool_call_preserved() {
-    let adapter = adapter_for(ApiProtocol::Anthropic);
+    let adapter = adapter_for(ApiProtocol::Messages);
     let body = serde_json::json!({
         "model": "claude",
         "messages": [{
@@ -1577,8 +1577,8 @@ fn regression_416_mixed_text_and_tool_call_preserved() {
 /// #227 → #228 — Anthropic `system` accepts both a string and a content-block
 /// array.
 #[test]
-fn regression_227_anthropic_system_accepts_string_or_array() {
-    let adapter = adapter_for(ApiProtocol::Anthropic);
+fn regression_227_messages_system_accepts_string_or_array() {
+    let adapter = adapter_for(ApiProtocol::Messages);
 
     let as_string = serde_json::json!({
         "model": "claude",
@@ -1604,7 +1604,7 @@ fn regression_227_anthropic_system_accepts_string_or_array() {
 /// blocks round-trip.
 #[test]
 fn regression_364_tool_result_array_and_thinking() {
-    let adapter = adapter_for(ApiProtocol::Anthropic);
+    let adapter = adapter_for(ApiProtocol::Messages);
     let body = serde_json::json!({
         "model": "claude",
         "messages": [
@@ -1672,7 +1672,7 @@ fn regression_454_1_reasoning_survives_all_protocols() {
 /// downgrade to `user`.
 #[test]
 fn regression_454_4_unknown_role_is_an_error() {
-    let adapter = adapter_for(ApiProtocol::Openai);
+    let adapter = adapter_for(ApiProtocol::ChatCompletions);
     let body = serde_json::json!({
         "model": "m",
         "messages": [{ "role": "wizard", "content": "abracadabra" }],
@@ -1694,8 +1694,8 @@ fn regression_454_5_no_null_on_the_wire() {
         finish_reason: None,
         response_id: None,
     };
-    // OpenAI Chat: `usage` key is absent when there is no usage.
-    let chat = adapter_for(ApiProtocol::Openai)
+    // Chat Completions: `usage` key is absent when there is no usage.
+    let chat = adapter_for(ApiProtocol::ChatCompletions)
         .render_response(&result, &sample_prompt(), "c1")
         .unwrap();
     assert!(
@@ -1713,7 +1713,7 @@ fn regression_454_5_no_null_on_the_wire() {
         finish_reason: None,
         response_id: None,
     };
-    let chat_empty = adapter_for(ApiProtocol::Openai)
+    let chat_empty = adapter_for(ApiProtocol::ChatCompletions)
         .render_response(&empty, &sample_prompt(), "c2")
         .unwrap();
     assert_eq!(chat_empty["choices"][0]["message"]["content"], "");
@@ -2132,8 +2132,8 @@ fn regression_434_responses_tool_stream_id_mapping() {
 /// #422 — Anthropic inbound `ping` events are ignored, never treated as errors
 /// or content. (The outbound keepalive itself is covered in `stream` tests.)
 #[test]
-fn regression_422_anthropic_ping_events_ignored() {
-    let adapter = adapter_for(ApiProtocol::Anthropic);
+fn regression_422_messages_ping_events_ignored() {
+    let adapter = adapter_for(ApiProtocol::Messages);
     let mut decoder = adapter.stream_decoder();
     let ping = SseEvent {
         event: Some("ping".to_string()),
@@ -2146,7 +2146,7 @@ fn regression_422_anthropic_ping_events_ignored() {
 /// #429 — gpt-5.x style models routed through the Responses protocol round-trip
 /// correctly; the Anthropic outbound stream frames are well-formed events.
 #[test]
-fn regression_429_responses_routing_and_anthropic_frames() {
+fn regression_429_responses_routing_and_messages_frames() {
     // a gpt-5 prompt rendered for the Responses protocol
     let responses = adapter_for(ApiProtocol::Responses);
     let mut prompt = sample_prompt();
@@ -2155,8 +2155,8 @@ fn regression_429_responses_routing_and_anthropic_frames() {
     assert_eq!(req["model"], "gpt-5.1");
     assert!(req["input"].is_array(), "Responses uses an `input` array");
 
-    // Anthropic outbound stream frames are named SSE events
-    let anthropic = adapter_for(ApiProtocol::Anthropic);
+    // Messages outbound stream frames are named SSE events
+    let anthropic = adapter_for(ApiProtocol::Messages);
     let mut enc = anthropic.stream_encoder("m1", "claude");
     let frames = enc
         .encode(&StreamPart::TextDelta {
@@ -2188,7 +2188,7 @@ fn regression_454_5_usage_zero_is_numeric_not_null() {
         finish_reason: Some(FinishReason::Stop),
         response_id: None,
     };
-    let chat = adapter_for(ApiProtocol::Openai)
+    let chat = adapter_for(ApiProtocol::ChatCompletions)
         .render_response(&result, &sample_prompt(), "c1")
         .unwrap();
     assert_eq!(chat["usage"]["prompt_tokens"], 0);
@@ -2241,23 +2241,23 @@ fn assert_schema_snapshot<T: schemars::JsonSchema>(name: &str) {
 }
 
 #[test]
-fn anthropic_messages_request_schema_is_stable() {
-    assert_schema_snapshot::<anthropic::MessagesRequest>("anthropic_messages_request");
+fn messages_request_schema_is_stable() {
+    assert_schema_snapshot::<messages::MessagesRequest>("messages_request");
 }
 
 #[test]
-fn openai_chat_request_schema_is_stable() {
-    assert_schema_snapshot::<openai_chat::ChatRequest>("openai_chat_request");
+fn chat_completions_request_schema_is_stable() {
+    assert_schema_snapshot::<chat_completions::ChatRequest>("chat_completions_request");
 }
 
 #[test]
-fn google_generate_content_request_schema_is_stable() {
-    assert_schema_snapshot::<google::GenerateContentRequest>("google_generate_content_request");
+fn generate_content_request_schema_is_stable() {
+    assert_schema_snapshot::<generate_content::GenerateContentRequest>("generate_content_request");
 }
 
 #[test]
-fn openai_responses_request_schema_is_stable() {
-    assert_schema_snapshot::<openai_responses::ResponsesRequest>("openai_responses_request");
+fn responses_request_schema_is_stable() {
+    assert_schema_snapshot::<responses::ResponsesRequest>("responses_request");
 }
 
 /// `#[schemars(skip)]` on the `extra` `HashMap` must hide it from the published
@@ -2267,38 +2267,40 @@ fn openai_responses_request_schema_is_stable() {
 /// regression is obvious from the failure message.
 #[test]
 fn extra_passthrough_field_is_not_in_schema() {
-    let s = serde_json::to_value(schemars::schema_for!(anthropic::MessagesRequest)).unwrap();
+    let s = serde_json::to_value(schemars::schema_for!(messages::MessagesRequest)).unwrap();
     assert!(
         s.get("properties").and_then(|p| p.get("extra")).is_none(),
-        "Anthropic MessagesRequest schema must not expose `extra` (pass-through field)",
+        "MessagesRequest schema must not expose `extra` (pass-through field)",
     );
-    let s = serde_json::to_value(schemars::schema_for!(openai_chat::ChatRequest)).unwrap();
+    let s = serde_json::to_value(schemars::schema_for!(chat_completions::ChatRequest)).unwrap();
     assert!(
         s.get("properties").and_then(|p| p.get("extra")).is_none(),
-        "OpenAI ChatRequest schema must not expose `extra` (pass-through field)",
+        "Chat CompletionsRequest schema must not expose `extra` (pass-through field)",
     );
-    // Google has two `extra` fields — top-level and on `generationConfig`.
+    // Generate Content has two `extra` fields — top-level and on `generationConfig`.
     // Walk both points to make sure neither leaks.
-    let s = serde_json::to_value(schemars::schema_for!(google::GenerateContentRequest)).unwrap();
+    let s = serde_json::to_value(schemars::schema_for!(
+        generate_content::GenerateContentRequest
+    ))
+    .unwrap();
     assert!(
         s.get("properties").and_then(|p| p.get("extra")).is_none(),
         "Google GenerateContentRequest schema must not expose top-level `extra`",
     );
     let gen_cfg = s
         .get("$defs")
-        .and_then(|d| d.get("GoogleGenerationConfig"))
-        .expect("schema must include GoogleGenerationConfig in $defs");
+        .and_then(|d| d.get("GenerateContentGenerationConfig"))
+        .expect("schema must include GenerateContentGenerationConfig in $defs");
     assert!(
         gen_cfg
             .get("properties")
             .and_then(|p| p.get("extra"))
             .is_none(),
-        "Google GoogleGenerationConfig schema must not expose `extra`",
+        "Google GenerateContentGenerationConfig schema must not expose `extra`",
     );
-    let s =
-        serde_json::to_value(schemars::schema_for!(openai_responses::ResponsesRequest)).unwrap();
+    let s = serde_json::to_value(schemars::schema_for!(responses::ResponsesRequest)).unwrap();
     assert!(
         s.get("properties").and_then(|p| p.get("extra")).is_none(),
-        "OpenAI ResponsesRequest schema must not expose `extra` (pass-through field)",
+        "ResponsesRequest schema must not expose `extra` (pass-through field)",
     );
 }

--- a/crates/bitrouter-sdk/src/language_model/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/tests.rs
@@ -21,7 +21,7 @@ fn target(provider: &str) -> RoutingTarget {
         service_id: "test-model".to_string(),
         api_base: "https://example.invalid".to_string(),
         api_key: "k".to_string(),
-        api_protocol: ApiProtocol::Openai,
+        api_protocol: ApiProtocol::ChatCompletions,
         account_label: None,
         api_key_override: None,
         api_base_override: None,

--- a/crates/bitrouter-sdk/src/language_model/types.rs
+++ b/crates/bitrouter-sdk/src/language_model/types.rs
@@ -27,14 +27,14 @@ use crate::caller::CallerContext;
 /// The name passed to `Custom` is the registration key.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
 pub enum ApiProtocol {
-    /// OpenAI Chat Completions.
+    /// OpenAI-style Chat Completions (`POST /v1/chat/completions`).
     #[default]
-    Openai,
-    /// Anthropic Messages.
-    Anthropic,
-    /// Google Generative AI.
-    Google,
-    /// OpenAI Responses.
+    ChatCompletions,
+    /// Anthropic-style Messages (`POST /v1/messages`).
+    Messages,
+    /// Google-style Generate Content (`POST …:generateContent`).
+    GenerateContent,
+    /// Responses.
     Responses,
     /// An externally-registered protocol identified by its registration name
     /// (e.g. `"bedrock-claude"`). The SDK does not serve `Custom` protocols
@@ -43,15 +43,15 @@ pub enum ApiProtocol {
 }
 
 impl ApiProtocol {
-    /// Stable string name for this protocol (`"openai"`, `"anthropic"`, …, or
+    /// Stable string name for this protocol (`"chat_completions"`, `"messages"`, …, or
     /// the inner string for [`Custom`](Self::Custom)). Used as the wire-format
     /// representation in YAML config and as the registry key for outbound
     /// dispatch.
     pub fn as_str(&self) -> &str {
         match self {
-            Self::Openai => "openai",
-            Self::Anthropic => "anthropic",
-            Self::Google => "google",
+            Self::ChatCompletions => "chat_completions",
+            Self::Messages => "messages",
+            Self::GenerateContent => "generate_content",
             Self::Responses => "responses",
             Self::Custom(name) => name.as_str(),
         }
@@ -74,9 +74,9 @@ impl<'de> Deserialize<'de> for ApiProtocol {
     fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
         let s = String::deserialize(d)?;
         Ok(match s.as_str() {
-            "openai" => Self::Openai,
-            "anthropic" => Self::Anthropic,
-            "google" => Self::Google,
+            "chat_completions" => Self::ChatCompletions,
+            "messages" => Self::Messages,
+            "generate_content" => Self::GenerateContent,
             "responses" => Self::Responses,
             _ => Self::Custom(s),
         })
@@ -167,22 +167,22 @@ pub struct Tool {
 /// `text`, `regex`) can be added without breaking existing call sites.
 ///
 /// Each inbound adapter promotes the provider-native field into this typed
-/// slot at `parse_request` time (e.g. OpenAI Chat's `response_format`,
-/// Anthropic's `output_config.format`, Google's `generationConfig.responseSchema`).
+/// slot at `parse_request` time (e.g. Chat Completions' `response_format`,
+/// Messages' `output_config.format`, Generate Content's `generationConfig.responseSchema`).
 /// Each outbound adapter renders it back into the upstream's native shape on
 /// `render_request`. Cross-protocol routing therefore works automatically:
-/// an OpenAI-Chat client asking for `json_schema` against an Anthropic upstream
+/// a Chat Completions client asking for `json_schema` against a Messages upstream
 /// emits `output_config.format`.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ResponseFormat {
     /// Constrain output to a JSON Schema.
     JsonSchema {
-        /// Schema name. Required by OpenAI Chat / Responses; ignored by
-        /// Anthropic and Google.
+        /// Schema name. Required by Chat Completions / Responses; ignored by
+        /// Messages and Generate Content.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         name: Option<String>,
-        /// Strict-mode flag. OpenAI-only; Anthropic and Google are always strict.
+        /// Strict-mode flag. Chat Completions / Responses only; Messages and Generate Content are always strict.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         strict: Option<bool>,
         /// The JSON Schema.
@@ -249,14 +249,14 @@ pub struct Usage {
     pub reasoning_tokens: u64,
     /// Cache-read input tokens — already-cached prompt content that the
     /// provider served from cache. Subset of `prompt_tokens`. Maps to
-    /// Anthropic's `usage.cache_read_input_tokens`
-    /// (<https://docs.anthropic.com/en/api/messages>) and to OpenAI Chat's
+    /// Messages' `usage.cache_read_input_tokens`
+    /// (<https://docs.anthropic.com/en/api/messages>) and to Chat Completions'
     /// `usage.prompt_tokens_details.cached_tokens`. Default 0 when the
     /// upstream reports no cache stats.
     #[serde(default, skip_serializing_if = "is_zero_u64")]
     pub cache_read_tokens: u64,
     /// Cache-write input tokens — prompt content written to the cache this
-    /// turn. Subset of `prompt_tokens`. Maps to Anthropic's
+    /// turn. Subset of `prompt_tokens`. Maps to Messages'
     /// `usage.cache_creation_input_tokens`.
     #[serde(default, skip_serializing_if = "is_zero_u64")]
     pub cache_write_tokens: u64,
@@ -308,8 +308,8 @@ pub struct GenerateResult {
     pub usage: Option<Usage>,
     /// Finish reason, if the provider reported it.
     pub finish_reason: Option<FinishReason>,
-    /// Provider-assigned response id (e.g. OpenAI `chatcmpl-...`,
-    /// Anthropic `msg_...`, OpenAI Responses `resp_...`, Google
+    /// Provider-assigned response id (e.g. Chat Completions `chatcmpl-...`,
+    /// Messages `msg_...`, Responses `resp_...`, Generate Content
     /// `responseId`). Carried so observability can stamp it onto the OTel
     /// `gen_ai.response.id` semconv attribute and operators can correlate
     /// against the upstream provider's own logs. `None` when the provider
@@ -352,8 +352,8 @@ pub enum StreamPart {
         usage: Usage,
     },
     /// The provider-assigned response id, surfaced once near the start of
-    /// the stream — OpenAI Chat's top-level `id`, Anthropic's
-    /// `message_start.message.id`, Google's `responseId`. (OpenAI Responses
+    /// the stream — Chat Completions' top-level `id`, Anthropic's
+    /// `message_start.message.id`, Generate Content's `responseId`. (Responses
     /// carries its id on the terminal [`Self::ResponseCompleted`] instead.)
     ///
     /// Not client-facing: outbound encoders drop it (the client gets an id
@@ -371,7 +371,7 @@ pub enum StreamPart {
         /// Why generation stopped.
         reason: FinishReason,
     },
-    /// Terminal lifecycle part for OpenAI Responses — preserves the response id
+    /// Terminal lifecycle part for Responses — preserves the response id
     /// and status that a bare [`StreamPart::Finish`] would lose.
     /// Only the Responses decoder emits this; the other protocols' encoders
     /// treat it as a terminal part equivalent to `Finish`.

--- a/crates/bitrouter-sdk/src/lib.rs
+++ b/crates/bitrouter-sdk/src/lib.rs
@@ -1,8 +1,8 @@
 //! # bitrouter-sdk
 //!
 //! The BitRouter SDK: build a programmable router for LLM API traffic.
-//! Inbound requests on any of four wire protocols (OpenAI Chat, OpenAI
-//! Responses, Anthropic Messages, Google Generative AI) are normalised into a
+//! Inbound requests on any of four wire protocols (Chat Completions,
+//! Responses, Messages, Generate Content) are normalised into a
 //! canonical pipeline, run through a chain of hooks (auth, policy, settlement,
 //! guardrails, observability), dispatched to the right upstream provider, and
 //! rendered back in the inbound protocol — so a client written for one

--- a/crates/bitrouter-sdk/src/server.rs
+++ b/crates/bitrouter-sdk/src/server.rs
@@ -1,9 +1,9 @@
 //! axum HTTP server — gated behind the `server` feature.
 //!
 //! Wires all four inbound protocols to the `language_model` pipeline:
-//! - `POST /v1/messages` — Anthropic Messages
-//! - `POST /v1/chat/completions` — OpenAI Chat Completions
-//! - `POST /v1/responses` — OpenAI Responses
+//! - `POST /v1/messages` — Messages
+//! - `POST /v1/chat/completions` — Chat Completions
+//! - `POST /v1/responses` — Responses
 //! - `POST /v1beta/models/{model_action}` — Google `generateContent` /
 //!   `streamGenerateContent`
 //!
@@ -185,10 +185,10 @@ pub fn build_router(state: AppState) -> Router {
 /// tripping `Router::merge`'s duplicate-route panic).
 pub fn build_router_with_options(state: AppState, options: RouterOptions) -> Router {
     let mut router = Router::new()
-        .route("/v1/messages", post(anthropic_messages))
-        .route("/v1/chat/completions", post(openai_chat))
-        .route("/v1/responses", post(openai_responses))
-        .route("/v1beta/models/{model_action}", post(google_generate));
+        .route("/v1/messages", post(messages))
+        .route("/v1/chat/completions", post(chat_completions))
+        .route("/v1/responses", post(responses))
+        .route("/v1beta/models/{model_action}", post(generate_content));
     if !options.omit_v1_models {
         router = router.route("/v1/models", get(list_models));
     }
@@ -504,23 +504,23 @@ async fn list_models(State(state): State<AppState>) -> impl IntoResponse {
 
 // ===== inbound protocol handlers =====
 
-async fn anthropic_messages(
+async fn messages(
     State(state): State<AppState>,
     headers: HeaderMap,
     Json(body): Json<serde_json::Value>,
 ) -> Response {
-    handle(state, headers, ApiProtocol::Anthropic, body, None).await
+    handle(state, headers, ApiProtocol::Messages, body, None).await
 }
 
-async fn openai_chat(
+async fn chat_completions(
     State(state): State<AppState>,
     headers: HeaderMap,
     Json(body): Json<serde_json::Value>,
 ) -> Response {
-    handle(state, headers, ApiProtocol::Openai, body, None).await
+    handle(state, headers, ApiProtocol::ChatCompletions, body, None).await
 }
 
-async fn openai_responses(
+async fn responses(
     State(state): State<AppState>,
     headers: HeaderMap,
     Json(body): Json<serde_json::Value>,
@@ -528,9 +528,9 @@ async fn openai_responses(
     handle(state, headers, ApiProtocol::Responses, body, None).await
 }
 
-/// Google encodes the model and the streaming verb in the path segment, e.g.
+/// Generate Content encodes the model and the streaming verb in the path segment, e.g.
 /// `gemini-2.0-flash:generateContent` or `…:streamGenerateContent`.
-async fn google_generate(
+async fn generate_content(
     State(state): State<AppState>,
     Path(model_action): Path<String>,
     headers: HeaderMap,
@@ -545,13 +545,20 @@ async fn google_generate(
             .into_response();
         }
     };
-    // Google carries the model in the URL, not the body — inject it so the
+    // Generate Content carries the model in the URL, not the body — inject it so the
     // adapter sees it, and set the stream flag from the verb.
     if let Some(obj) = body.as_object_mut() {
         obj.insert("model".into(), model.clone().into());
         obj.insert("stream".into(), (action == "streamGenerateContent").into());
     }
-    handle(state, headers, ApiProtocol::Google, body, Some(model)).await
+    handle(
+        state,
+        headers,
+        ApiProtocol::GenerateContent,
+        body,
+        Some(model),
+    )
+    .await
 }
 
 /// Shared handler: parse with the inbound adapter, run the pipeline, render the

--- a/plugins/bitrouter-guardrails/src/tests.rs
+++ b/plugins/bitrouter-guardrails/src/tests.rs
@@ -91,7 +91,7 @@ fn target() -> RoutingTarget {
         service_id: "m".to_string(),
         api_base: "https://example.invalid".to_string(),
         api_key: "k".to_string(),
-        api_protocol: ApiProtocol::Openai,
+        api_protocol: ApiProtocol::ChatCompletions,
         account_label: None,
         api_key_override: None,
         api_base_override: None,

--- a/plugins/bitrouter-observe/src/otel/exporter.rs
+++ b/plugins/bitrouter-observe/src/otel/exporter.rs
@@ -625,8 +625,8 @@ impl ObserveHook for OtelExporter {
                 StreamPart::ResponseStarted { id } | StreamPart::ResponseCompleted { id, .. } => {
                     // The upstream response id, surfaced by the decoder near
                     // the start of the stream (`ResponseStarted`, emitted by
-                    // OpenAI Chat / Anthropic / Google) or on the terminal
-                    // frame (`ResponseCompleted`, OpenAI Responses). Stamp it
+                    // Chat Completions / Messages / Generate Content) or on the terminal
+                    // frame (`ResponseCompleted`, Responses). Stamp it
                     // onto the root `chat` span as `gen_ai.response.id`; the
                     // non-streaming path does the same via
                     // `GenerateResult.response_id`. Spec:
@@ -869,7 +869,7 @@ fn build_hop_request_attrs(target: &RoutingTarget, prompt: &Prompt) -> Vec<KeyVa
 /// set; `gen_ai.response.id` is read from the canonical IR's
 /// `GenerateResult.response_id`, which the outbound adapters populate
 /// from the provider-native id field (OpenAI `chatcmpl-...`, Anthropic
-/// `msg_...`, OpenAI Responses `resp_...`, Google `responseId`).
+/// `msg_...`, Responses `resp_...`, Google `responseId`).
 ///
 /// Streaming hops do not pass through here — they close at TTFB via
 /// `HopOutcome::StreamStarted` without an `ExecutionResult`. The
@@ -1031,7 +1031,7 @@ mod hop_tests {
             service_id: "test-model".to_string(),
             api_base: "https://api.example.test:8443/v1".to_string(),
             api_key: "k".to_string(),
-            api_protocol: ApiProtocol::Openai,
+            api_protocol: ApiProtocol::ChatCompletions,
             account_label: Some("primary".to_string()),
             api_key_override: None,
             api_base_override: None,
@@ -1405,7 +1405,7 @@ mod hop_tests {
 
     #[tokio::test]
     async fn stream_response_completed_lands_response_id_on_root_chat() {
-        // OpenAI Responses' terminal `response.completed` frame surfaces
+        // Responses' terminal `response.completed` frame surfaces
         // as `StreamPart::ResponseCompleted { id, .. }`. The exporter must
         // stamp it onto the root `chat` INTERNAL span as
         // `gen_ai.response.id` so streaming requests aren't missing the
@@ -1449,7 +1449,7 @@ mod hop_tests {
 
     #[tokio::test]
     async fn stream_response_started_lands_response_id_on_root_chat() {
-        // OpenAI Chat / Anthropic / Google streaming surface the upstream id
+        // Chat Completions / Messages / Generate Content streaming surface the upstream id
         // early as `StreamPart::ResponseStarted { id }`; the exporter stamps
         // it onto the root `chat` INTERNAL span as `gen_ai.response.id`, the
         // same attribute the non-streaming path and `ResponseCompleted` set.


### PR DESCRIPTION
## What & why

The four built-in wire protocols were named after model makers (`Anthropic`, `Google`, `OpenAI chat`, `OpenAI responses`) instead of the API specifications they implement. This is v0 historical baggage — and `Responses` was already spec-named, so the naming was half-done and inconsistent. Since we're still in v1 pre-release, this clears it up before release.

A provider's **company name** is now carried solely by its provider id, fully **decoupled** from the **protocol** it speaks. Example: `anthropic.toml` now has `id = "anthropic"` (company) + `api_protocol = "messages"` (API).

## `ApiProtocol` variants + serialized wire strings

| Old variant / wire string | New variant / wire string |
|---|---|
| `Openai` / `"openai"` | `ChatCompletions` / `"chat_completions"` |
| `Anthropic` / `"anthropic"` | `Messages` / `"messages"` |
| `Google` / `"google"` | `GenerateContent` / `"generate_content"` |
| `Responses` / `"responses"` | unchanged (already spec-named) |
| `Custom(String)` | unchanged |

**Google → `GenerateContent`**: named after its endpoint method (`:generateContent`, [Gemini API reference](https://ai.google.dev/api)). Matches the pre-existing `GenerateContentRequest` wire type and the `generate_content` snapshot, and keeps construction parallel with the other three (all derived from the endpoint resource, not the vendor).

## Also renamed for consistency

- **Adapter/Transport structs**: `OpenAiChatAdapter` → `ChatCompletionsAdapter`, `AnthropicTransport` → `MessagesTransport`, etc.
- **Protocol module files**: `openai_chat.rs`/`anthropic.rs`/`google.rs`/`openai_responses.rs` → `chat_completions.rs`/`messages.rs`/`generate_content.rs`/`responses.rs`
- **De-vendored wire sub-types**: `AnthropicMessage` → `MessagesMessage`, `GoogleContent` → `GenerateContentContent`, `GoogleGenerationConfig` → `GenerateContentGenerationConfig`, stream decoders/encoders, etc.
- **Built-in provider TOML**: all `api_protocol` values + glob maps (opencode-zen/opencode-go/github-copilot)
- **Schema snapshot files** (renamed + re-blessed) and **test/helper/handler/route fn names** (incl. e2e `Inbound`/`Outbound` enums, server route handlers `anthropic_messages` → `messages`, etc.)
- **Docs**: doc comments, README / DEVELOPMENT / CONTRIBUTING protocol naming, TOML routing comments

## Deliberately preserved (genuine vendor references, not protocol identifiers)

- Provider ids & TOML filenames (`anthropic`, `google`, `openai`)
- Env vars (`ANTHROPIC_API_KEY`), upstream URLs (`anthropic.com`, `generativelanguage`), the `anthropic-version` HTTP header
- OAuth/provider config & tests, `OpenAI-compatible`, Codex JWT references
- Origin/provenance notes in docs (e.g. `/// Google-style Generate Content`)
- `CHANGELOG.md` (historical record — 0 occurrences, untouched)

## ⚠️ Breaking change

`ApiProtocol` variant names **and their serialized wire strings** changed. Existing `bitrouter.yaml` configs using `api_protocol: anthropic | openai | google` must migrate to `messages | chat_completions | generate_content`. Accepted as part of the v1 pre-release cleanup.

## Verification

- `cargo nextest run --all-features` — **553 passed**, 0 failed
- `cargo test --all-features --doc` — doctests pass
- `cargo clippy --all-features --all-targets` — **0 warnings**
- `cargo fmt -- --check` — clean

Scope: 41 files changed (incl. 8 git renames), +540 / −525.

🤖 Generated with [Claude Code](https://claude.com/claude-code)