### PR TITLE
feat(observe)!: split otel feature into transport sub-features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -819,6 +819,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tonic",
  "tower-http",
  "tracing",
  "tracing-opentelemetry",
@@ -2643,7 +2644,6 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tonic",
- "tracing",
 ]
 
 [[package]]
@@ -3418,6 +3418,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -3436,6 +3437,15 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -4464,8 +4474,11 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
+ "rustls-native-certs",
+ "rustls-pemfile",
  "socket2 0.5.10",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tower 0.4.13",
  "tower-layer",

--- a/apps/bitrouter/Cargo.toml
+++ b/apps/bitrouter/Cargo.toml
@@ -21,7 +21,7 @@ bitrouter-sdk = { workspace = true, features = ["server", "config_file", "mcp", 
 bitrouter-cloud-sdk.workspace = true
 bitrouter-providers = { workspace = true, features = ["pkce"] }
 bitrouter-guardrails.workspace = true
-bitrouter-observe = { workspace = true, features = ["otel"] }
+bitrouter-observe = { workspace = true, features = ["otel-http"] }
 chrono.workspace = true
 sha2.workspace = true
 base64.workspace = true

--- a/plugins/bitrouter-observe/Cargo.toml
+++ b/plugins/bitrouter-observe/Cargo.toml
@@ -19,7 +19,13 @@ tracing.workspace = true
 # Pinned to 0.27.x — the API churns minor-to-minor in this stack.
 opentelemetry = { version = "0.27", optional = true }
 opentelemetry_sdk = { version = "0.27", optional = true, features = ["rt-tokio", "trace", "metrics"] }
-opentelemetry-otlp = { version = "0.27", optional = true, features = ["http-proto", "reqwest-client", "reqwest-rustls", "trace", "metrics"] }
+# Transport features (`http-proto`, `grpc-tonic`, the reqwest/tonic TLS
+# variants) are NOT enabled here — they are layered on by the `otel-http` /
+# `otel-grpc` sub-features below. `default-features = false` drops the upstream
+# defaults (`grpc-tonic`, `logs`, `internal-logs`) so a build only ever pulls
+# in the transport stack it actually selected. `trace` + `metrics` are the
+# signal kinds this plugin emits and are transport-independent.
+opentelemetry-otlp = { version = "0.27", optional = true, default-features = false, features = ["trace", "metrics"] }
 opentelemetry-semantic-conventions = { version = "0.27", optional = true }
 # tracing ↔ OpenTelemetry bridge. Pinned to the 0.28.x line, which targets
 # opentelemetry 0.27. https://crates.io/crates/tracing-opentelemetry
@@ -34,11 +40,21 @@ tracing-subscriber = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true, features = ["rt", "sync"] }
 http = { workspace = true, optional = true }
 dashmap = { version = "6", optional = true }
+# OTLP/gRPC transport (tonic). Only compiled under `otel-grpc`; the bulk of the
+# gRPC stack arrives through `opentelemetry-otlp/grpc-tonic`. We depend on tonic
+# directly solely for `tonic::metadata::MetadataMap`, used to forward the
+# configured headers as gRPC request metadata.
+tonic = { version = "0.12", optional = true, default-features = false }
 
 [features]
 default = []
-# OpenTelemetry exporter — traces and metrics with multi-tenant attribution.
-otel = [
+
+# Shared, transport-agnostic observability stack: span exporter, metrics,
+# inbound HTTP TraceLayer, and the tracing↔OTel bridge — everything except the
+# OTLP wire transport. It carries no transport on its own, so enabling it
+# WITHOUT `otel-http` or `otel-grpc` is a compile error (see `lib.rs`). Pick a
+# transport feature below; each pulls this in automatically.
+otel-base = [
     "dep:opentelemetry",
     "dep:opentelemetry_sdk",
     "dep:opentelemetry-otlp",
@@ -52,6 +68,26 @@ otel = [
     "dep:dashmap",
 ]
 
+# OTLP/HTTP + protobuf transport over reqwest with rustls. Maps to upstream
+# `opentelemetry-otlp/{http-proto,reqwest-client,reqwest-rustls}`.
+otel-http = [
+    "otel-base",
+    "opentelemetry-otlp/http-proto",
+    "opentelemetry-otlp/reqwest-client",
+    "opentelemetry-otlp/reqwest-rustls",
+]
+
+# OTLP/gRPC transport over tonic with rustls (native trust roots). Maps to
+# upstream `opentelemetry-otlp/{grpc-tonic,tls-roots}`. May be enabled
+# alongside `otel-http` (e.g. under `--all-features`); when both are present,
+# HTTP takes runtime precedence (see `otel::transport`).
+otel-grpc = [
+    "otel-base",
+    "dep:tonic",
+    "opentelemetry-otlp/grpc-tonic",
+    "opentelemetry-otlp/tls-roots",
+]
+
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }
 criterion = { version = "0.5", features = ["async_tokio"] }
@@ -59,4 +95,4 @@ criterion = { version = "0.5", features = ["async_tokio"] }
 [[bench]]
 name = "observe_overhead"
 harness = false
-required-features = ["otel"]
+required-features = ["otel-http"]

--- a/plugins/bitrouter-observe/src/lib.rs
+++ b/plugins/bitrouter-observe/src/lib.rs
@@ -6,8 +6,22 @@
 
 #![forbid(unsafe_code)]
 
-#[cfg(feature = "otel")]
+// The observability stack is transport-agnostic but cannot function without a
+// wire transport. `otel-base` carries the stack; `otel-http` / `otel-grpc` add
+// a transport. Guard against `otel-base` being enabled on its own (e.g. a
+// downstream typo or a stray `dep:` activation) with a clear message instead
+// of a wall of "cannot find function `span_exporter`" errors.
+#[cfg(all(
+    feature = "otel-base",
+    not(any(feature = "otel-http", feature = "otel-grpc"))
+))]
+compile_error!(
+    "the OpenTelemetry stack needs a transport: enable `otel-http` for \
+     OTLP/HTTP, or `otel-grpc` for OTLP/gRPC"
+);
+
+#[cfg(feature = "otel-base")]
 pub mod otel;
 
-/// Whether the OpenTelemetry exporter is compiled in.
-pub const OTEL_ENABLED: bool = cfg!(feature = "otel");
+/// Whether the OpenTelemetry exporter is compiled in (under any transport).
+pub const OTEL_ENABLED: bool = cfg!(feature = "otel-base");

--- a/plugins/bitrouter-observe/src/otel/config.rs
+++ b/plugins/bitrouter-observe/src/otel/config.rs
@@ -1,8 +1,10 @@
 //! Configuration for the OpenTelemetry exporter.
 //!
-//! The exporter is OTLP/HTTP+protobuf only. HTTP/JSON and gRPC are left for
-//! a follow-up (the issue lists them; the previous draft shipped a config
-//! variant that hard-errored at runtime, which is worse than absent).
+//! The OTLP wire transport (OTLP/HTTP+protobuf vs OTLP/gRPC) is a *compile-time*
+//! choice driven by the crate's `otel-http` / `otel-grpc` cargo features — see
+//! [`crate::otel::transport`]. This config is transport-agnostic: the same
+//! `endpoint` and `headers` feed whichever transport was compiled in (gRPC
+//! forwards the headers as request metadata).
 //!
 //! All standard `OTEL_*` env vars take precedence over YAML, matching the
 //! upstream OTel SDK spec: <https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/>.

--- a/plugins/bitrouter-observe/src/otel/config.rs
+++ b/plugins/bitrouter-observe/src/otel/config.rs
@@ -2,7 +2,7 @@
 //!
 //! The OTLP wire transport (OTLP/HTTP+protobuf vs OTLP/gRPC) is a *compile-time*
 //! choice driven by the crate's `otel-http` / `otel-grpc` cargo features — see
-//! [`crate::otel::transport`]. This config is transport-agnostic: the same
+//! the `otel::transport` module. This config is transport-agnostic: the same
 //! `endpoint` and `headers` feed whichever transport was compiled in (gRPC
 //! forwards the headers as request metadata).
 //!

--- a/plugins/bitrouter-observe/src/otel/exporter.rs
+++ b/plugins/bitrouter-observe/src/otel/exporter.rs
@@ -39,7 +39,6 @@ use opentelemetry::{
     propagation::{Extractor, Injector},
     trace::{Span, SpanKind, Status, TraceContextExt, Tracer},
 };
-use opentelemetry_otlp::{SpanExporter, WithExportConfig, WithHttpConfig};
 use opentelemetry_sdk::propagation::TraceContextPropagator;
 use opentelemetry_sdk::trace::{
     BatchConfigBuilder, BatchSpanProcessor, RandomIdGenerator, Sampler, Tracer as SdkTracer,
@@ -149,11 +148,9 @@ impl OtelExporter {
 
         let resource = build_resource(&config);
 
-        let span_exporter: SpanExporter = SpanExporter::builder()
-            .with_http()
-            .with_endpoint(&config.endpoint)
-            .with_headers(config.headers.clone())
-            .build()?;
+        // Transport (OTLP/HTTP vs OTLP/gRPC) is chosen at compile time by the
+        // crate's feature flags — see `crate::otel::transport`.
+        let span_exporter = crate::otel::transport::span_exporter(&config)?;
 
         let batch_config = BatchConfigBuilder::default()
             .with_max_queue_size(config.traces.batch.max_queue_size)

--- a/plugins/bitrouter-observe/src/otel/metrics.rs
+++ b/plugins/bitrouter-observe/src/otel/metrics.rs
@@ -11,7 +11,6 @@ use std::time::Duration;
 
 use opentelemetry::KeyValue;
 use opentelemetry::metrics::{Counter, Histogram, Meter, MeterProvider};
-use opentelemetry_otlp::{MetricExporter, WithExportConfig, WithHttpConfig};
 use opentelemetry_sdk::Resource;
 use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
 
@@ -45,11 +44,9 @@ impl OtelMetrics {
         api_key_limiter: Arc<CardinalityLimiter>,
         user_id_limiter: Arc<CardinalityLimiter>,
     ) -> Result<Self, Box<dyn std::error::Error>> {
-        let exporter = MetricExporter::builder()
-            .with_http()
-            .with_endpoint(&config.endpoint)
-            .with_headers(config.headers.clone())
-            .build()?;
+        // Transport (OTLP/HTTP vs OTLP/gRPC) is chosen at compile time by the
+        // crate's feature flags — see `crate::otel::transport`.
+        let exporter = crate::otel::transport::metric_exporter(config)?;
 
         let reader = PeriodicReader::builder(exporter, opentelemetry_sdk::runtime::Tokio)
             .with_interval(Duration::from_millis(config.metrics.export_interval_ms))

--- a/plugins/bitrouter-observe/src/otel/mod.rs
+++ b/plugins/bitrouter-observe/src/otel/mod.rs
@@ -4,14 +4,19 @@
 //! conventions (<https://opentelemetry.io/docs/specs/semconv/gen-ai/>):
 //! HTTP SERVER → `chat` INTERNAL → (`route` INTERNAL, per-hop `chat` CLIENT
 //! spans, `settle` INTERNAL). Inbound W3C trace context is honoured;
-//! outbound `traceparent` is injected on every upstream hop. OTLP/HTTP+
-//! protobuf push for both traces and metrics.
+//! outbound `traceparent` is injected on every upstream hop.
+//!
+//! The OTLP wire transport is selected at compile time by the crate's feature
+//! flags — `otel-http` (OTLP/HTTP+protobuf) and/or `otel-grpc` (OTLP/gRPC).
+//! See [`transport`] for the selection rules. Both traces and metrics ride the
+//! same chosen transport.
 
 mod cardinality;
 mod config;
 mod exporter;
 pub mod http_layer;
 mod metrics;
+mod transport;
 
 pub use cardinality::CardinalityLimiter;
 pub use config::{BatchConfig, MetricsConfig, OtelConfig, SamplerKind, TraceConfig};

--- a/plugins/bitrouter-observe/src/otel/mod.rs
+++ b/plugins/bitrouter-observe/src/otel/mod.rs
@@ -8,8 +8,8 @@
 //!
 //! The OTLP wire transport is selected at compile time by the crate's feature
 //! flags — `otel-http` (OTLP/HTTP+protobuf) and/or `otel-grpc` (OTLP/gRPC).
-//! See [`transport`] for the selection rules. Both traces and metrics ride the
-//! same chosen transport.
+//! See the `transport` module for the selection rules. Both traces and metrics
+//! ride the same chosen transport.
 
 mod cardinality;
 mod config;

--- a/plugins/bitrouter-observe/src/otel/transport.rs
+++ b/plugins/bitrouter-observe/src/otel/transport.rs
@@ -1,0 +1,99 @@
+//! OTLP wire-transport selection.
+//!
+//! The OpenTelemetry stack ships several transports behind upstream
+//! `opentelemetry-otlp` features. This crate surfaces two of them as cargo
+//! features so a build only compiles the dependency stack it uses:
+//!
+//! - `otel-http` — OTLP/HTTP + protobuf over reqwest + rustls
+//!   (`opentelemetry-otlp/{http-proto,reqwest-client,reqwest-rustls}`).
+//! - `otel-grpc` — OTLP/gRPC over tonic + rustls
+//!   (`opentelemetry-otlp/{grpc-tonic,tls-roots}`).
+//!
+//! Both can be compiled in at once (e.g. under `--all-features`); when they
+//! are, **HTTP takes precedence** so the default OTLP endpoint
+//! (`http://localhost:4318`) keeps working out of the box. To run gRPC,
+//! compile only `otel-grpc` (`--no-default-features --features otel-grpc`).
+//! `with_endpoint`/header forwarding behave identically across the two, so a
+//! deterministic winner keeps behaviour predictable. The `otel` module only
+//! compiles when `otel-base` is on, and `lib.rs` guarantees at least one
+//! transport accompanies it, so exactly one `imp` below is ever active.
+//!
+//! Both builders forward [`OtelConfig::endpoint`] and [`OtelConfig::headers`].
+//! HTTP carries the headers as HTTP headers; gRPC carries them as request
+//! metadata (the wire equivalent).
+
+use crate::otel::config::OtelConfig;
+
+#[cfg(all(feature = "otel-grpc", not(feature = "otel-http")))]
+mod imp {
+    use super::OtelConfig;
+
+    use opentelemetry_otlp::{MetricExporter, SpanExporter, WithExportConfig, WithTonicConfig};
+    use tonic::metadata::MetadataMap;
+
+    /// Translate the configured headers into gRPC metadata. Invalid header
+    /// names/values are skipped rather than failing the whole build of the
+    /// exporter — observability must never take down request processing, and a
+    /// malformed custom header should not be fatal.
+    fn metadata(config: &OtelConfig) -> MetadataMap {
+        let mut headers = http::HeaderMap::new();
+        for (k, v) in &config.headers {
+            if let (Ok(name), Ok(value)) = (
+                http::HeaderName::from_bytes(k.as_bytes()),
+                http::HeaderValue::from_str(v),
+            ) {
+                headers.insert(name, value);
+            }
+        }
+        MetadataMap::from_headers(headers)
+    }
+
+    pub(crate) fn span_exporter(
+        config: &OtelConfig,
+    ) -> Result<SpanExporter, Box<dyn std::error::Error>> {
+        Ok(SpanExporter::builder()
+            .with_tonic()
+            .with_endpoint(&config.endpoint)
+            .with_metadata(metadata(config))
+            .build()?)
+    }
+
+    pub(crate) fn metric_exporter(
+        config: &OtelConfig,
+    ) -> Result<MetricExporter, Box<dyn std::error::Error>> {
+        Ok(MetricExporter::builder()
+            .with_tonic()
+            .with_endpoint(&config.endpoint)
+            .with_metadata(metadata(config))
+            .build()?)
+    }
+}
+
+#[cfg(feature = "otel-http")]
+mod imp {
+    use super::OtelConfig;
+
+    use opentelemetry_otlp::{MetricExporter, SpanExporter, WithExportConfig, WithHttpConfig};
+
+    pub(crate) fn span_exporter(
+        config: &OtelConfig,
+    ) -> Result<SpanExporter, Box<dyn std::error::Error>> {
+        Ok(SpanExporter::builder()
+            .with_http()
+            .with_endpoint(&config.endpoint)
+            .with_headers(config.headers.clone())
+            .build()?)
+    }
+
+    pub(crate) fn metric_exporter(
+        config: &OtelConfig,
+    ) -> Result<MetricExporter, Box<dyn std::error::Error>> {
+        Ok(MetricExporter::builder()
+            .with_http()
+            .with_endpoint(&config.endpoint)
+            .with_headers(config.headers.clone())
+            .build()?)
+    }
+}
+
+pub(crate) use imp::{metric_exporter, span_exporter};


### PR DESCRIPTION
## What & why

The `bitrouter-observe` plugin gated its whole OpenTelemetry stack behind a single `otel` feature. That feature always pulled OTLP/HTTP (reqwest+rustls), **and** left `opentelemetry-otlp` on its default features — so the tonic/gRPC + logs stack was compiled in too, despite only HTTP ever being used. There was no way to ask for a leaner build or to pick gRPC.

This adds finer-grained feature control: `otel-xxx` sub-features that each control the OTLP dependency stack (HTTP vs gRPC), named to match the upstream `opentelemetry-otlp` 0.27 feature flags.

## Feature graph

| Feature | Role | Upstream `opentelemetry-otlp` features |
|---|---|---|
| `otel-base` | Shared, transport-agnostic stack (span exporter, metrics, inbound HTTP `TraceLayer`, tracing↔OTel bridge). No wire transport on its own. | — |
| `otel-http` | OTLP/HTTP + protobuf over reqwest + rustls | `http-proto`, `reqwest-client`, `reqwest-rustls` |
| `otel-grpc` | OTLP/gRPC over tonic + rustls (native roots) | `grpc-tonic`, `tls-roots` |

- `opentelemetry-otlp` is now `default-features = false` (drops upstream `grpc-tonic` + `logs` + `internal-logs`), so a build pulls only the transport it selected.
- New `otel::transport` module: two `#[cfg]`-gated impls behind one `span_exporter`/`metric_exporter` surface. When both transports are compiled in (e.g. `--all-features`), **HTTP wins at runtime** so the default `http://localhost:4318` endpoint keeps working.
- `lib.rs` `compile_error!` guards `otel-base` enabled without a transport, with an actionable message.

## Breaking change

The `otel` cargo feature is **removed**. Depend on `otel-http` (previous behaviour) or `otel-grpc`. The downstream `bitrouter` app and the bench `required-features` are updated to `otel-http`.

## Verification

- Builds: `otel-http`, `otel-grpc`, `--all-features` — all green
- Negative: `otel-base` alone fails with the intended `compile_error!`
- `cargo tree`: `otel-http` build no longer drops in tonic's gRPC channel/transport stack
- `cargo test` (otel-http): 12 passed
- `cargo clippy --all-features`: clean (no `#[allow]`)
- `cargo fmt --check`: clean
- Downstream `bitrouter` app builds on `features = ["otel-http"]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)