### PR TITLE
feat(cloud-sdk): namespace-scoped management client + CLI

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -213,7 +213,7 @@ Removes every stored credential for the provider (subscription OAuth tokens and 
 
 ### `bitrouter auth login` / `logout` / `whoami`
 
-Cloud sign-in, distinct from the per-provider `bitrouter login` flow above. Signs the CLI into your BitRouter Cloud account via the RFC 8628 OAuth Device Authorization Grant; the resulting bearer authenticates inbound calls to the cloud `/v1/*` surface (inference, key management, BYOK, policy, billing) and is auto-refreshed on use.
+Cloud sign-in, distinct from the per-provider `bitrouter login` flow above. Signs the CLI into your BitRouter Cloud account via the RFC 8628 OAuth Device Authorization Grant. The browser approval page asks you to pick which workspace to grant the CLI access to — the resulting credential is **namespace-baked** (workspace-baked), and all subsequent `bitrouter cloud` calls target that workspace implicitly. To switch workspaces, re-run `bitrouter auth login`. The credential is auto-refreshed on use; rotation preserves the namespace binding.
 
 ```
 bitrouter auth login [--oauth-as <URL>] [--client-id <ID>] [--scope <SCOPE>]
@@ -225,9 +225,9 @@ bitrouter auth whoami
 | --- | --- | --- |
 | `--oauth-as` | `https://api.bitrouter.ai` (env: `BITROUTER_OAUTH_AS`) | Authorization server base URL — override only for a self-hosted deployment |
 | `--client-id` | `bitrouter-cli` (env: `BITROUTER_OAUTH_CLIENT_ID`) | Public OAuth client id |
-| `--scope` | broad developer set (env: `BITROUTER_OAUTH_SCOPE`) | Space-delimited scopes to request. Default includes `inference:invoke`, `usage:read`, `keys:read`/`write`, `billing:read`, `policy:read`/`write`, `byok:read`/`write`, `account:read`. Sensitive scopes (`billing:write`, `clients:read`/`write`, `account:write`) are opt-in. |
+| `--scope` | broad developer set (env: `BITROUTER_OAUTH_SCOPE`) | Space-delimited scopes to request. Default includes `inference:invoke`, `usage:read`, `keys:read`/`write`, `billing:read`, `policy:read`/`write`, `byok:read`/`write`, `namespace:read`. Sensitive scopes (`billing:write`, `clients:read`/`write`, `user:write`) are opt-in. |
 
-Credentials are persisted at `<data-dir>/account-credentials.json` (mode `0600` on Unix). `whoami` answers from the local file with no network call.
+Credentials are persisted at `<data-dir>/account-credentials.json` (mode `0600` on Unix). `whoami` answers from the local file with no network call; it also prints the bound namespace.
 
 ---
 
@@ -249,7 +249,9 @@ bitrouter key sign --user <id> --policy strict
 
 ## Cloud account management
 
-`bitrouter cloud …` drives the BitRouter Cloud `/v1/*` management surface (keys, usage, billing, policies, BYOK, OAuth clients) using the credential persisted by [`bitrouter auth login`](#bitrouter-auth-login--logout--whoami). Sign in first, then call any subcommand.
+`bitrouter cloud …` drives the BitRouter Cloud `/v1/*` management surface using the credential persisted by [`bitrouter auth login`](#bitrouter-auth-login--logout--whoami). Sign in first, then call any subcommand.
+
+The credential is **namespace-baked** — keys, usage, policies, and OAuth clients are all scoped to the workspace chosen at login. The `{nsid}` path segment is resolved implicitly; callers never pass a workspace argument. `billing` and `byok` are user-level and reach across all your workspaces regardless.
 
 Every leaf accepts `--json` to print the raw response body instead of the human-readable summary. On a 403 whose description is `missing required scope: <s>`, the CLI prints a copy-pasteable re-login hint that appends the missing scope to your current set.
 
@@ -259,11 +261,22 @@ Every leaf accepts `--json` to print the raw response body instead of the human-
 bitrouter cloud whoami
 ```
 
-Prints the cloud identity stored on this machine alongside the `/v1/*` base URL the CLI will target. Reads the local credentials file only — no network call.
+Prints the cloud identity and the bound namespace alongside the `/v1/*` base URL the CLI will target. Reads the local credentials file only — no network call.
+
+### `bitrouter cloud namespace`
+
+Inspect the workspaces you own and the one this CLI session is baked to. Workspace creation and deletion are Console-only operations (control-plane scope).
+
+```
+bitrouter cloud namespace list    [--json]
+bitrouter cloud namespace current [--json]
+```
+
+`list` fetches all namespaces you own and marks the active one. `current` is offline — it reads the local credential and prints the bound namespace id without a network call. If the credential predates namespace-scoping, it prints `(no namespace — run \`bitrouter auth login\`)`.
 
 ### `bitrouter cloud keys`
 
-Manage `brk_` API keys on your account.
+Manage `brk_` API keys in the active workspace. All minted keys are workspace-baked to the same namespace as the caller and cannot upscale their scopes beyond the caller's.
 
 ```
 bitrouter cloud keys list [--json]
@@ -285,6 +298,8 @@ bitrouter cloud requests [--limit <N>] [--offset <N>] [--json]
 `usage` defaults to a 30-day rolling window. `requests` clamps the page size to `[1, 100]` and defaults to 25.
 
 ### `bitrouter cloud billing`
+
+User-level — not workspace-scoped; reflects the account-wide wallet regardless of which workspace the CLI is signed in to.
 
 ```
 bitrouter cloud billing balance [--json]
@@ -312,7 +327,7 @@ bitrouter cloud policy effective --principal-type <TYPE> --principal-id <ID> [--
 bitrouter cloud policy for-principal <TYPE> <ID> [--json]
 ```
 
-`--spec` reads the flat inner spec body as JSON from a file path or `-` for stdin. Principal types: `account`, `api_key`, `oauth_token`, `oauth_client`. `disable` parks a policy without deleting it — the engine skips disabled rows at request time.
+`--spec` reads the flat inner spec body as JSON from a file path or `-` for stdin. Principal types: `namespace`, `api_key`, `oauth_token`, `oauth_client`. `disable` parks a policy without deleting it — the engine skips disabled rows at request time.
 
 ### `bitrouter cloud budget` / `bitrouter cloud preset`
 
@@ -336,7 +351,7 @@ Budget `--limit-micro-usd` must be strictly positive (the engine treats `<= 0` a
 
 ### `bitrouter cloud byok`
 
-Manage bring-your-own-key provider keys. The cloud only stores already-sealed ciphertext — seal against the cloud's current X25519 public key (separate fetch) before calling.
+User-level — not workspace-scoped; BYOK provider keys are account-wide. The cloud only stores already-sealed ciphertext — seal against the cloud's current X25519 public key (separate fetch) before calling.
 
 ```
 bitrouter cloud byok list [--json]

--- a/apps/bitrouter/src/cloud/cli.rs
+++ b/apps/bitrouter/src/cloud/cli.rs
@@ -27,8 +27,8 @@ use bitrouter_cloud_sdk::management::types::{
     BudgetWindow as SdkBudgetWindow, ClientType as SdkClientType, PolicyKind as SdkPolicyKind,
 };
 use bitrouter_cloud_sdk::management::{
-    Error as SdkError, ManagementClient, billing, budgets, byok, keys, oauth_clients, policies,
-    presets, usage,
+    Error as SdkError, ManagementClient, billing, budgets, byok, keys, namespaces, oauth_clients,
+    policies, presets, usage,
 };
 
 /// `bitrouter cloud …`. All variants land in [`run`].
@@ -37,7 +37,12 @@ pub enum CloudAction {
     /// Print the cloud identity stored on this machine alongside the
     /// `/v1/*` base URL the CLI will target.
     Whoami,
-    /// Manage `brk_` API keys on your account.
+    /// Inspect the namespaces you own and the one this CLI is bound to.
+    Namespace {
+        #[command(subcommand)]
+        action: NamespaceAction,
+    },
+    /// Manage `brk_` API keys in your namespace.
     Keys {
         #[command(subcommand)]
         action: KeysAction,
@@ -77,6 +82,20 @@ pub enum CloudAction {
         #[command(subcommand)]
         action: OauthClientAction,
     },
+}
+
+// ===== Namespace =====
+
+#[derive(Debug, Subcommand)]
+pub enum NamespaceAction {
+    /// List the namespaces you own. The one this CLI is signed in to is
+    /// marked `(active)`. Switching namespaces is a re-login:
+    /// `bitrouter auth login` and pick a different namespace in the
+    /// browser.
+    List(JsonFlag),
+    /// Print the namespace this CLI's credential is bound to. Offline —
+    /// reads the local credential, no network call.
+    Current(JsonFlag),
 }
 
 // ===== Keys =====
@@ -255,7 +274,7 @@ pub struct PolicyUpdateArgs {
 pub struct PolicyBindArgs {
     /// The policy id.
     pub id: String,
-    /// Principal kind (`account`, `api_key`, `oauth_token`,
+    /// Principal kind (`namespace`, `api_key`, `oauth_token`,
     /// `oauth_client`).
     #[arg(long)]
     pub principal_type: String,
@@ -278,7 +297,7 @@ pub struct PolicyUnbindArgs {
 
 #[derive(Debug, clap::Args)]
 pub struct EffectiveArgs {
-    /// Principal kind (`account`, `api_key`, `oauth_token`,
+    /// Principal kind (`namespace`, `api_key`, `oauth_token`,
     /// `oauth_client`).
     #[arg(long)]
     pub principal_type: String,
@@ -589,6 +608,7 @@ pub async fn run(action: CloudAction) -> Result<()> {
 async fn run_inner(action: CloudAction) -> std::result::Result<(), SdkError> {
     match action {
         CloudAction::Whoami => whoami().await,
+        CloudAction::Namespace { action } => run_namespace(action).await,
         CloudAction::Keys { action } => run_keys(action).await,
         CloudAction::Usage(args) => run_usage(args).await,
         CloudAction::Requests(args) => run_requests(args).await,
@@ -611,6 +631,10 @@ async fn whoami() -> std::result::Result<(), SdkError> {
     // base URL `bitrouter cloud …` will target.
     let client = client()?;
     println!("cloud base URL: {}", client.base_url());
+    println!(
+        "namespace:      {}",
+        client.namespace_id().unwrap_or("(none)")
+    );
     let store = CredentialsStore::default_path().map_err(SdkError::Auth)?;
     if let Some(creds) = store.current() {
         println!("scope:          {}", creds.scope);
@@ -622,6 +646,51 @@ async fn whoami() -> std::result::Result<(), SdkError> {
         println!("(not signed in — run `bitrouter auth login`)");
     }
     Ok(())
+}
+
+// ----- Namespace -----
+
+async fn run_namespace(action: NamespaceAction) -> std::result::Result<(), SdkError> {
+    let client = client()?;
+    match action {
+        NamespaceAction::List(flag) => {
+            let resp = client.list_namespaces().await?;
+            let active = client.namespace_id().map(str::to_owned);
+            emit(flag.json, &resp, |r| {
+                format_namespace_list(r, active.as_deref())
+            })
+        }
+        NamespaceAction::Current(flag) => {
+            // Offline — the namespace is baked into the local credential.
+            let nsid = client.namespace_id();
+            if flag.json {
+                let body = serde_json::json!({ "namespace_id": nsid });
+                println!("{}", serde_json::to_string_pretty(&body)?);
+            } else {
+                match nsid {
+                    Some(id) => println!("{id}"),
+                    None => println!("(no namespace — run `bitrouter auth login`)"),
+                }
+            }
+            Ok(())
+        }
+    }
+}
+
+fn format_namespace_list(resp: &namespaces::NamespaceListResponse, active: Option<&str>) -> String {
+    if resp.data.is_empty() {
+        return "no namespaces".to_owned();
+    }
+    let mut out = String::new();
+    for ns in &resp.data {
+        let marker = if Some(ns.id.as_str()) == active {
+            "  (active)"
+        } else {
+            ""
+        };
+        out.push_str(&format!("{:<28}  {}{}\n", ns.id, ns.name, marker));
+    }
+    out
 }
 
 // ----- Keys -----

--- a/crates/bitrouter-cloud-sdk/src/auth/commands.rs
+++ b/crates/bitrouter-cloud-sdk/src/auth/commands.rs
@@ -183,6 +183,10 @@ pub async fn whoami() -> Result<()> {
             println!("client id:            {}", creds.client_id);
             println!("scope:                {}", creds.scope);
             println!(
+                "namespace:            {}",
+                creds.namespace_id.as_deref().unwrap_or("(none)")
+            );
+            println!(
                 "subject:              {}",
                 creds.subject.as_deref().unwrap_or("(unknown)")
             );

--- a/crates/bitrouter-cloud-sdk/src/auth/credentials.rs
+++ b/crates/bitrouter-cloud-sdk/src/auth/credentials.rs
@@ -58,6 +58,17 @@ pub struct Credentials {
     /// The AS base URL the device-flow was run against. Captured for the
     /// same reason as `client_id`.
     pub authorization_server: String,
+    /// Namespace the credential is baked into. Every device-flow token
+    /// the CLI obtains is namespace-baked, so this is normally `Some`.
+    /// Absent for a namespace-null credential (the console web session,
+    /// which the CLI never holds) — and for a credential file written
+    /// before namespace-scoping shipped, where it signals "re-login to
+    /// get a namespace-scoped token". Read once at client construction
+    /// to resolve the implicit `{nsid}` in management calls; preserved
+    /// verbatim across refreshes since rotation never rebinds the
+    /// namespace.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub namespace_id: Option<String>,
     /// Subject identifier returned by the AS (typically `sub` from an
     /// OpenID Connect ID token). Optional — populated when the AS
     /// returned an `id_token` claim the flow could decode. Used by
@@ -80,6 +91,7 @@ impl std::fmt::Debug for Credentials {
             .field("scope", &self.scope)
             .field("client_id", &self.client_id)
             .field("authorization_server", &self.authorization_server)
+            .field("namespace_id", &self.namespace_id)
             .field("subject", &self.subject)
             .finish()
     }
@@ -257,6 +269,10 @@ impl CredentialsStore {
             scope,
             client_id: creds.client_id,
             authorization_server: creds.authorization_server,
+            // Rotation never rebinds the namespace — the AS echoes the
+            // original binding, but prefer the stored value so a server
+            // that omits it on refresh can't silently drop the binding.
+            namespace_id: token_set.namespace_id.or(creds.namespace_id),
             subject: creds.subject,
         };
         let bearer = refreshed.access_token.clone();
@@ -324,6 +340,7 @@ mod tests {
             scope: "inference:invoke".into(),
             client_id: "cid".into(),
             authorization_server: "https://as.example.com".into(),
+            namespace_id: Some("ns-1".into()),
             subject: Some("user-42".into()),
         }
     }
@@ -345,6 +362,7 @@ mod tests {
         assert_eq!(got.scope, creds.scope);
         assert_eq!(got.client_id, creds.client_id);
         assert_eq!(got.authorization_server, creds.authorization_server);
+        assert_eq!(got.namespace_id, creds.namespace_id);
         assert_eq!(got.subject, creds.subject);
     }
 

--- a/crates/bitrouter-cloud-sdk/src/auth/credentials.rs
+++ b/crates/bitrouter-cloud-sdk/src/auth/credentials.rs
@@ -269,10 +269,13 @@ impl CredentialsStore {
             scope,
             client_id: creds.client_id,
             authorization_server: creds.authorization_server,
-            // Rotation never rebinds the namespace — the AS echoes the
-            // original binding, but prefer the stored value so a server
-            // that omits it on refresh can't silently drop the binding.
-            namespace_id: token_set.namespace_id.or(creds.namespace_id),
+            // Rotation never rebinds the namespace: the stored binding
+            // wins. Preferring it (over the refresh response) means a
+            // server that omits — or, worse, changes — the field on
+            // refresh can't silently move the credential to a different
+            // namespace. The token-set value is only a fallback for the
+            // (not-expected) case where the stored binding was absent.
+            namespace_id: creds.namespace_id.or(token_set.namespace_id),
             subject: creds.subject,
         };
         let bearer = refreshed.access_token.clone();

--- a/crates/bitrouter-cloud-sdk/src/auth/flow.rs
+++ b/crates/bitrouter-cloud-sdk/src/auth/flow.rs
@@ -67,6 +67,12 @@ struct TokenResponse {
     refresh_token_expires_in: Option<u64>,
     #[serde(default)]
     scope: Option<String>,
+    /// Non-standard bitrouter extension: the namespace the issued token
+    /// is baked into. `Some` for every device-flow token; absent for a
+    /// namespace-null credential. Persisted so the management client can
+    /// resolve the implicit namespace for `/v1/namespaces/{nsid}/…` calls.
+    #[serde(default)]
+    namespace_id: Option<String>,
     /// OIDC id_token, used to extract the `sub` claim for `whoami`.
     #[serde(default)]
     id_token: Option<String>,
@@ -94,6 +100,9 @@ pub struct TokenSet {
     pub refresh_token_expires_at: Option<DateTime<Utc>>,
     /// Scope the AS granted (may be narrower than requested).
     pub scope: Option<String>,
+    /// Namespace the issued token is baked into, when the AS reported
+    /// one. `None` for a namespace-null credential.
+    pub namespace_id: Option<String>,
     /// Subject claim extracted from an `id_token`, when one is present.
     pub subject: Option<String>,
 }
@@ -388,6 +397,7 @@ pub fn credentials_from_token_set(token_set: TokenSet, settings: &Settings) -> C
         scope: token_set.scope.unwrap_or_else(|| settings.scope.clone()),
         client_id: settings.client_id.clone(),
         authorization_server: settings.authorization_server.clone(),
+        namespace_id: token_set.namespace_id,
         subject: token_set.subject,
     }
 }
@@ -416,6 +426,7 @@ fn token_set_from_response(access_token: String, parsed: TokenResponse) -> Token
         refresh_token: parsed.refresh_token,
         refresh_token_expires_at,
         scope: parsed.scope,
+        namespace_id: parsed.namespace_id,
         subject,
     }
 }
@@ -522,6 +533,7 @@ mod tests {
             refresh_token: Some("RT".into()),
             refresh_token_expires_at: None,
             scope: None,
+            namespace_id: Some("ns-1".into()),
             subject: None,
         };
         let s = settings();
@@ -530,6 +542,7 @@ mod tests {
         assert_eq!(creds.scope, s.scope);
         assert_eq!(creds.client_id, s.client_id);
         assert_eq!(creds.authorization_server, s.authorization_server);
+        assert_eq!(creds.namespace_id.as_deref(), Some("ns-1"));
     }
 
     #[test]

--- a/crates/bitrouter-cloud-sdk/src/auth/settings.rs
+++ b/crates/bitrouter-cloud-sdk/src/auth/settings.rs
@@ -26,23 +26,27 @@ pub const DEFAULT_CLIENT_ID: &str = "bitrouter-cli";
 ///
 /// The set follows the `gh auth login` heuristic: grant the broad
 /// "work" scopes a developer expects from a terminal session, hold
-/// back the truly sensitive ones behind an explicit `--scope`. Sensitive
-/// scopes deliberately left out (opt in with `--scope` if you need
-/// them):
+/// back the truly sensitive ones behind an explicit `--scope`. The set
+/// is entirely data-plane — every scope here is mintable into a
+/// namespace-baked credential, which is what the device flow issues.
+/// Control-plane scopes are deliberately left out (and can't be granted
+/// to a namespace-baked CLI token anyway — the server refuses them):
 ///   - `billing:write` — initiates a Stripe checkout flow
-///   - `account:write` — account settings, including deletion
-///   - `clients:read` / `clients:write` — registering OAuth clients
+///   - `user:write` — account settings, including deletion
+///   - `clients:write` — registering OAuth clients (namespace-scoped)
+///   - `namespace:write` — create / delete namespaces (console-only)
 ///
-/// The actual issued scope is still the intersection
-/// `caller_role ∩ client_allowed_scopes ∩ requested`, so a user
-/// without the role for one of these scopes silently drops it at
+/// `namespace:read` is included so `bitrouter cloud namespace list`
+/// works out of the box. The actual issued scope is still the
+/// intersection `caller_role ∩ client_allowed_scopes ∩ requested`, so a
+/// user without the role for one of these scopes silently drops it at
 /// issuance — they only get the broad set their role admits.
 pub const DEFAULT_SCOPE: &str = "inference:invoke usage:read \
                                  keys:read keys:write \
                                  billing:read \
                                  policy:read policy:write \
                                  byok:read byok:write \
-                                 account:read";
+                                 namespace:read";
 
 /// Environment variable for the authorization server base URL.
 pub const AS_ENV: &str = "BITROUTER_OAUTH_AS";

--- a/crates/bitrouter-cloud-sdk/src/management/budgets.rs
+++ b/crates/bitrouter-cloud-sdk/src/management/budgets.rs
@@ -1,9 +1,12 @@
-//! `/v1/budgets*` — typed CRUD wrappers over the `policies` rows whose
-//! `kind = 'budget'`. Sugar over [`super::policies`] with a flat wire
-//! shape and no `kind`/`spec` envelope.
+//! `/v1/namespaces/{nsid}/budgets*` — typed CRUD wrappers over the
+//! `policies` rows whose `kind = 'budget'`. Sugar over
+//! [`super::policies`] with a flat wire shape and no `kind`/`spec`
+//! envelope.
 //!
 //! Mirrors `bitrouter_cloud::v1::http::management::budgets`. Same
-//! `policy:read` / `policy:write` scopes as the generic surface.
+//! `policy:read` / `policy:write` scopes as the generic surface. The
+//! `{nsid}` segment is resolved from the credential — see
+//! [`super::ManagementClient::namespaced`].
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -71,37 +74,41 @@ pub struct DeleteBudgetResponse {
 }
 
 impl ManagementClient {
-    /// `GET /v1/budgets` — list every budget on the account.
+    /// `GET /v1/namespaces/{nsid}/budgets` — list every budget in the
+    /// namespace.
     pub async fn list_budgets(&self) -> Result<BudgetListResponse> {
-        self.get_json("/v1/budgets").await
-    }
-
-    /// `GET /v1/budgets/{id}` — fetch one budget. Returns
-    /// [`super::Error::NotFound`] if the id belongs to a non-budget
-    /// policy row.
-    pub async fn get_budget(&self, id: &str) -> Result<BudgetEnvelope> {
-        let path = format!("/v1/budgets/{id}");
+        let path = self.namespaced("/budgets")?;
         self.get_json(&path).await
     }
 
-    /// `POST /v1/budgets` — create a budget.
-    pub async fn create_budget(&self, body: &CreateBudgetRequest) -> Result<BudgetEnvelope> {
-        self.post_json("/v1/budgets", body).await
+    /// `GET /v1/namespaces/{nsid}/budgets/{id}` — fetch one budget.
+    /// Returns [`super::Error::NotFound`] if the id belongs to a
+    /// non-budget policy row.
+    pub async fn get_budget(&self, id: &str) -> Result<BudgetEnvelope> {
+        let path = self.namespaced(&format!("/budgets/{id}"))?;
+        self.get_json(&path).await
     }
 
-    /// `PUT /v1/budgets/{id}` — patch one or more fields of a budget.
+    /// `POST /v1/namespaces/{nsid}/budgets` — create a budget.
+    pub async fn create_budget(&self, body: &CreateBudgetRequest) -> Result<BudgetEnvelope> {
+        let path = self.namespaced("/budgets")?;
+        self.post_json(&path, body).await
+    }
+
+    /// `PUT /v1/namespaces/{nsid}/budgets/{id}` — patch one or more
+    /// fields of a budget.
     pub async fn update_budget(
         &self,
         id: &str,
         body: &UpdateBudgetRequest,
     ) -> Result<BudgetEnvelope> {
-        let path = format!("/v1/budgets/{id}");
+        let path = self.namespaced(&format!("/budgets/{id}"))?;
         self.put_json(&path, body).await
     }
 
-    /// `DELETE /v1/budgets/{id}` — remove a budget.
+    /// `DELETE /v1/namespaces/{nsid}/budgets/{id}` — remove a budget.
     pub async fn delete_budget(&self, id: &str) -> Result<DeleteBudgetResponse> {
-        let path = format!("/v1/budgets/{id}");
+        let path = self.namespaced(&format!("/budgets/{id}"))?;
         self.delete_json(&path).await
     }
 }

--- a/crates/bitrouter-cloud-sdk/src/management/budgets.rs
+++ b/crates/bitrouter-cloud-sdk/src/management/budgets.rs
@@ -5,8 +5,7 @@
 //!
 //! Mirrors `bitrouter_cloud::v1::http::management::budgets`. Same
 //! `policy:read` / `policy:write` scopes as the generic surface. The
-//! `{nsid}` segment is resolved from the credential — see
-//! [`super::ManagementClient::namespaced`].
+//! `{nsid}` segment is resolved from the credential's baked namespace.
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};

--- a/crates/bitrouter-cloud-sdk/src/management/error.rs
+++ b/crates/bitrouter-cloud-sdk/src/management/error.rs
@@ -23,6 +23,17 @@ pub enum Error {
     #[error("not signed in — run `bitrouter auth login` first")]
     NotSignedIn,
 
+    /// The stored credential carries no namespace, but the requested
+    /// operation is namespace-scoped. The CLI's device-flow tokens are
+    /// always namespace-baked, so in practice this means the credential
+    /// file predates namespace-scoping — re-running `bitrouter auth
+    /// login` mints a namespace-bound token.
+    #[error(
+        "credential is not scoped to a namespace — run `bitrouter auth login` to get a \
+         namespace-scoped credential"
+    )]
+    NoNamespace,
+
     /// OAuth token resolution or refresh failed (e.g. refresh token
     /// expired, AS metadata unreachable). The user should re-run
     /// `bitrouter auth login`.

--- a/crates/bitrouter-cloud-sdk/src/management/keys.rs
+++ b/crates/bitrouter-cloud-sdk/src/management/keys.rs
@@ -3,8 +3,7 @@
 //!
 //! Mirrors `bitrouter_cloud::v1::http::management::keys`. Scopes:
 //! `keys:read` for list, `keys:write` for mint and revoke. The `{nsid}`
-//! segment is resolved from the credential — see
-//! [`super::ManagementClient::namespaced`].
+//! segment is resolved from the credential's baked namespace.
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};

--- a/crates/bitrouter-cloud-sdk/src/management/keys.rs
+++ b/crates/bitrouter-cloud-sdk/src/management/keys.rs
@@ -1,8 +1,10 @@
-//! `/v1/keys` — list, mint, and revoke `brk_` API keys for the
-//! caller's account.
+//! `/v1/namespaces/{nsid}/keys` — list, mint, and revoke `brk_` API keys
+//! in the client's namespace.
 //!
 //! Mirrors `bitrouter_cloud::v1::http::management::keys`. Scopes:
-//! `keys:read` for list, `keys:write` for mint and revoke.
+//! `keys:read` for list, `keys:write` for mint and revoke. The `{nsid}`
+//! segment is resolved from the credential — see
+//! [`super::ManagementClient::namespaced`].
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -81,25 +83,28 @@ pub struct MintApiKeyResponse {
 pub struct RevokeApiKeyResponse {
     /// Always `true` on success — the server returns 404 (mapped to
     /// [`super::Error::NotFound`]) when the row doesn't exist or
-    /// belongs to a different account.
+    /// belongs to a different namespace.
     pub revoked: bool,
 }
 
 impl ManagementClient {
-    /// `GET /v1/keys` — list API keys on the caller's account.
+    /// `GET /v1/namespaces/{nsid}/keys` — list API keys in the client's
+    /// namespace.
     pub async fn list_keys(&self) -> Result<ApiKeyListResponse> {
-        self.get_json("/v1/keys").await
+        let path = self.namespaced("/keys")?;
+        self.get_json(&path).await
     }
 
-    /// `POST /v1/keys` — mint a new API key. The returned `token` is
-    /// the only copy of the plaintext.
+    /// `POST /v1/namespaces/{nsid}/keys` — mint a new API key. The
+    /// returned `token` is the only copy of the plaintext.
     pub async fn mint_key(&self, body: &MintApiKeyRequest) -> Result<MintApiKeyResponse> {
-        self.post_json("/v1/keys", body).await
+        let path = self.namespaced("/keys")?;
+        self.post_json(&path, body).await
     }
 
-    /// `DELETE /v1/keys/{id}` — revoke a key by id.
+    /// `DELETE /v1/namespaces/{nsid}/keys/{id}` — revoke a key by id.
     pub async fn revoke_key(&self, id: &str) -> Result<RevokeApiKeyResponse> {
-        let path = format!("/v1/keys/{id}");
+        let path = self.namespaced(&format!("/keys/{id}"))?;
         self.delete_json(&path).await
     }
 }

--- a/crates/bitrouter-cloud-sdk/src/management/mod.rs
+++ b/crates/bitrouter-cloud-sdk/src/management/mod.rs
@@ -9,20 +9,33 @@
 //! transparently within
 //! [`crate::auth::credentials::REFRESH_WINDOW`] of expiry.
 //!
+//! ## Namespace scoping
+//!
+//! The server bifurcates the management surface (see
+//! `bitrouter_cloud::v1::http::management`): namespace-scoped endpoints
+//! live under `/v1/namespaces/{nsid}/…`, user-level endpoints stay flat.
+//! The CLI's credential is namespace-baked, so the client captures its
+//! `namespace_id` at construction and resolves the `{nsid}` segment
+//! implicitly via [`ManagementClient::namespaced`] — callers never pass
+//! a namespace argument. User-level endpoints (`namespaces`, `billing`,
+//! `byok`) ignore the namespace and key on the subject user server-side.
+//!
 //! ## Endpoint coverage
 //!
 //! Methods are split across per-resource modules and exposed as
-//! additional `impl ManagementClient` blocks. See:
+//! additional `impl ManagementClient` blocks. Namespace-scoped (✱) vs
+//! user-level:
 //!
-//! - [`keys`] — `/v1/keys`
-//! - [`usage`] — `/v1/usage`, `/v1/requests`
+//! - [`namespaces`] — `/v1/namespaces` (list, read-only)
+//! - [`keys`] ✱ — `/v1/namespaces/{nsid}/keys`
+//! - [`usage`] ✱ — `…/usage`, `…/requests`
 //! - [`billing`] — `/v1/billing/*`
-//! - [`policies`] — `/v1/policies*`, including `/v1/policies/effective`
+//! - [`policies`] ✱ — `…/policies*`, including `…/policies/effective`
 //!   and per-principal listing
-//! - [`budgets`] — `/v1/budgets*` (typed sugar)
-//! - [`presets`] — `/v1/presets*` (typed sugar)
+//! - [`budgets`] ✱ — `…/budgets*` (typed sugar)
+//! - [`presets`] ✱ — `…/presets*` (typed sugar)
 //! - [`byok`] — `/v1/byok/keys*`
-//! - [`oauth_clients`] — `/v1/oauth/clients*`
+//! - [`oauth_clients`] ✱ — `…/oauth/clients*`
 //!
 //! ## Errors
 //!
@@ -52,6 +65,7 @@ pub mod budgets;
 pub mod byok;
 pub mod error;
 pub mod keys;
+pub mod namespaces;
 pub mod oauth_clients;
 pub mod policies;
 pub mod presets;
@@ -91,6 +105,13 @@ pub struct ManagementClient {
     /// implicitly invalidates the cache (the next `ManagementClient`
     /// instance reads the new URL from disk).
     metadata: Arc<Mutex<Option<AsMetadata>>>,
+    /// The namespace the stored credential is baked into, captured at
+    /// construction. `Some` for every device-flow token; `None` only
+    /// for a namespace-null credential or a pre-namespace credential
+    /// file. Namespace-scoped methods resolve the `{nsid}` path segment
+    /// from this via [`ManagementClient::namespaced`]. Immutable for the
+    /// client's lifetime — refresh never rebinds the namespace.
+    namespace_id: Option<String>,
 }
 
 impl ManagementClient {
@@ -114,12 +135,14 @@ impl ManagementClient {
             .map_err(Error::Auth)?;
         let creds = store.current().ok_or(Error::NotSignedIn)?;
         let base_url = creds.authorization_server.trim_end_matches('/').to_owned();
+        let namespace_id = creds.namespace_id.clone();
         let http = build_http_client()?;
         Ok(Self {
             base_url,
             http,
             store: Arc::new(Mutex::new(store)),
             metadata: Arc::new(Mutex::new(None)),
+            namespace_id,
         })
     }
 
@@ -133,11 +156,13 @@ impl ManagementClient {
         http: reqwest::Client,
         store: CredentialsStore,
     ) -> Self {
+        let namespace_id = store.current().and_then(|c| c.namespace_id.clone());
         Self {
             base_url: base_url.trim_end_matches('/').to_owned(),
             http,
             store: Arc::new(Mutex::new(store)),
             metadata: Arc::new(Mutex::new(None)),
+            namespace_id,
         }
     }
 
@@ -145,6 +170,24 @@ impl ManagementClient {
     /// diagnostics — `bitrouter cloud whoami` prints it.
     pub fn base_url(&self) -> &str {
         &self.base_url
+    }
+
+    /// The namespace this client's credential is baked into, or `None`
+    /// for a namespace-null / pre-namespace credential. `bitrouter cloud
+    /// whoami` prints it; `namespace list` marks the active one.
+    pub fn namespace_id(&self) -> Option<&str> {
+        self.namespace_id.as_deref()
+    }
+
+    /// Build a namespace-scoped path `/v1/namespaces/{nsid}{suffix}`,
+    /// erroring with [`Error::NoNamespace`] when the credential carries
+    /// no namespace. `suffix` must start with `/` (e.g. `/keys`,
+    /// `/policies/effective`). Centralising the join keeps every
+    /// namespace-scoped method from re-deriving the prefix and guards
+    /// the "no namespace" case in exactly one place.
+    pub(super) fn namespaced(&self, suffix: &str) -> Result<String> {
+        let nsid = self.namespace_id.as_deref().ok_or(Error::NoNamespace)?;
+        Ok(format!("/v1/namespaces/{nsid}{suffix}"))
     }
 
     /// Fetch a current bearer, refreshing if the stored access token

--- a/crates/bitrouter-cloud-sdk/src/management/mod.rs
+++ b/crates/bitrouter-cloud-sdk/src/management/mod.rs
@@ -16,9 +16,9 @@
 //! live under `/v1/namespaces/{nsid}/…`, user-level endpoints stay flat.
 //! The CLI's credential is namespace-baked, so the client captures its
 //! `namespace_id` at construction and resolves the `{nsid}` segment
-//! implicitly via [`ManagementClient::namespaced`] — callers never pass
-//! a namespace argument. User-level endpoints (`namespaces`, `billing`,
-//! `byok`) ignore the namespace and key on the subject user server-side.
+//! implicitly — callers never pass a namespace argument. User-level
+//! endpoints (`namespaces`, `billing`, `byok`) ignore the namespace and
+//! key on the subject user server-side.
 //!
 //! ## Endpoint coverage
 //!

--- a/crates/bitrouter-cloud-sdk/src/management/namespaces.rs
+++ b/crates/bitrouter-cloud-sdk/src/management/namespaces.rs
@@ -1,0 +1,45 @@
+//! `/v1/namespaces` — list the namespaces the signed-in user owns.
+//!
+//! Mirrors `bitrouter_cloud::v1::http::management::namespaces`. This is a
+//! user-level endpoint (keyed on the subject user server-side, not the
+//! credential's baked namespace), so it works for any signed-in
+//! credential and needs no `{nsid}` segment.
+//!
+//! Only the read path is exposed. Creating and deleting namespaces
+//! requires the control-plane `namespace:write` scope, which the server
+//! refuses to mint into a namespace-baked CLI credential — that lifecycle
+//! is console-only in v1. The CLI uses this list to show which namespaces
+//! exist (and which one the current credential is bound to) so a user can
+//! decide whether to re-login against a different namespace.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use super::{ManagementClient, Result};
+
+/// One namespace the caller owns, as returned by `GET /v1/namespaces`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NamespaceEnvelope {
+    /// Server-assigned namespace id (the `{nsid}` used in every
+    /// namespace-scoped path).
+    pub id: String,
+    /// Operator-supplied name, unique per owner.
+    pub name: String,
+    /// When the namespace was created.
+    pub created_at: DateTime<Utc>,
+}
+
+/// Wire shape returned by `GET /v1/namespaces`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NamespaceListResponse {
+    /// One envelope per namespace the caller owns.
+    pub data: Vec<NamespaceEnvelope>,
+}
+
+impl ManagementClient {
+    /// `GET /v1/namespaces` — list every namespace the signed-in user
+    /// owns. Requires `namespace:read` (in the default scope set).
+    pub async fn list_namespaces(&self) -> Result<NamespaceListResponse> {
+        self.get_json("/v1/namespaces").await
+    }
+}

--- a/crates/bitrouter-cloud-sdk/src/management/oauth_clients.rs
+++ b/crates/bitrouter-cloud-sdk/src/management/oauth_clients.rs
@@ -1,14 +1,18 @@
-//! `/v1/oauth/clients*` — manage the caller's OAuth client
-//! registrations.
+//! `/v1/namespaces/{nsid}/oauth/clients*` — manage the OAuth client
+//! registrations in the client's namespace.
 //!
 //! Mirrors `bitrouter_cloud::v1::http::management::oauth_clients`. The
 //! freshly minted `client_secret` (for confidential clients) is
-//! returned exactly once in the register response and never again.
+//! returned exactly once in the register response and never again. The
+//! `{nsid}` segment is resolved from the credential — see
+//! [`super::ManagementClient::namespaced`].
 //!
-//! Scopes: `clients:read` / `clients:write`. Neither is in the
-//! default scope set ([`crate::auth::settings::DEFAULT_SCOPE`]); a
-//! caller who wants this surface must re-login with `--scope` to
-//! request them.
+//! Scopes: `clients:read` / `clients:write`. `clients:write` is a
+//! control-plane scope the server refuses to mint into a namespace-baked
+//! CLI credential, so registering / mutating clients is console-only in
+//! v1; `clients:read` is not in the default scope set
+//! ([`crate::auth::settings::DEFAULT_SCOPE`]) either, so listing needs a
+//! re-login with `--scope clients:read`.
 
 use serde::{Deserialize, Serialize};
 
@@ -112,36 +116,39 @@ pub struct DeleteOauthClientResponse {
 }
 
 impl ManagementClient {
-    /// `GET /v1/oauth/clients` — list every OAuth client on the
-    /// account.
+    /// `GET /v1/namespaces/{nsid}/oauth/clients` — list every OAuth
+    /// client in the namespace.
     pub async fn list_oauth_clients(&self) -> Result<OauthClientListResponse> {
-        self.get_json("/v1/oauth/clients").await
+        let path = self.namespaced("/oauth/clients")?;
+        self.get_json(&path).await
     }
 
-    /// `POST /v1/oauth/clients` — register a new client. For
-    /// confidential clients, the response's `client_secret` is the
-    /// one-time plaintext.
+    /// `POST /v1/namespaces/{nsid}/oauth/clients` — register a new
+    /// client. For confidential clients, the response's `client_secret`
+    /// is the one-time plaintext.
     pub async fn register_oauth_client(
         &self,
         body: &RegisterOauthClientRequest,
     ) -> Result<RegisterOauthClientResponse> {
-        self.post_json("/v1/oauth/clients", body).await
+        let path = self.namespaced("/oauth/clients")?;
+        self.post_json(&path, body).await
     }
 
-    /// `PUT /v1/oauth/clients/{client_id}` — patch one or more
-    /// fields.
+    /// `PUT /v1/namespaces/{nsid}/oauth/clients/{client_id}` — patch
+    /// one or more fields.
     pub async fn update_oauth_client(
         &self,
         client_id: &str,
         body: &UpdateOauthClientRequest,
     ) -> Result<OauthClientEnvelope> {
-        let path = format!("/v1/oauth/clients/{client_id}");
+        let path = self.namespaced(&format!("/oauth/clients/{client_id}"))?;
         self.put_json(&path, body).await
     }
 
-    /// `DELETE /v1/oauth/clients/{client_id}` — remove a client.
+    /// `DELETE /v1/namespaces/{nsid}/oauth/clients/{client_id}` —
+    /// remove a client.
     pub async fn delete_oauth_client(&self, client_id: &str) -> Result<DeleteOauthClientResponse> {
-        let path = format!("/v1/oauth/clients/{client_id}");
+        let path = self.namespaced(&format!("/oauth/clients/{client_id}"))?;
         self.delete_json(&path).await
     }
 }

--- a/crates/bitrouter-cloud-sdk/src/management/oauth_clients.rs
+++ b/crates/bitrouter-cloud-sdk/src/management/oauth_clients.rs
@@ -4,8 +4,7 @@
 //! Mirrors `bitrouter_cloud::v1::http::management::oauth_clients`. The
 //! freshly minted `client_secret` (for confidential clients) is
 //! returned exactly once in the register response and never again. The
-//! `{nsid}` segment is resolved from the credential — see
-//! [`super::ManagementClient::namespaced`].
+//! `{nsid}` segment is resolved from the credential's baked namespace.
 //!
 //! Scopes: `clients:read` / `clients:write`. `clients:write` is a
 //! control-plane scope the server refuses to mint into a namespace-baked

--- a/crates/bitrouter-cloud-sdk/src/management/policies.rs
+++ b/crates/bitrouter-cloud-sdk/src/management/policies.rs
@@ -1,9 +1,11 @@
-//! `/v1/policies*` — generic CRUD over the typed policy registry plus
-//! binding, enable/disable, per-principal listing, and the effective-
-//! policy preview.
+//! `/v1/namespaces/{nsid}/policies*` — generic CRUD over the typed
+//! policy registry plus binding, enable/disable, per-principal listing,
+//! and the effective-policy preview.
 //!
 //! Mirrors `bitrouter_cloud::v1::http::management::policies`. Scopes:
-//! `policy:read` for reads, `policy:write` for everything else.
+//! `policy:read` for reads, `policy:write` for everything else. The
+//! `{nsid}` segment is resolved from the credential — see
+//! [`super::ManagementClient::namespaced`].
 //!
 //! The shape used for `spec` is the **flat inner body** (e.g. `{
 //! "window": "day", "limit_micro_usd": 1000 }` for a budget), not the
@@ -88,7 +90,7 @@ pub struct DeletePolicyResponse {
 /// Body for `POST /v1/policies/{id}/bind`.
 #[derive(Debug, Clone, Serialize)]
 pub struct BindPolicyRequest {
-    /// One of `account`, `api_key`, `oauth_token`, `oauth_client`.
+    /// One of `namespace`, `api_key`, `oauth_token`, `oauth_client`.
     pub principal_type: String,
     /// Id of the principal — interpretation depends on
     /// `principal_type`.
@@ -127,7 +129,7 @@ pub struct BindingEnvelope {
     pub id: String,
     /// Owning policy id.
     pub policy_id: String,
-    /// One of `account`, `api_key`, `oauth_token`, `oauth_client`.
+    /// One of `namespace`, `api_key`, `oauth_token`, `oauth_client`.
     pub principal_type: String,
     /// Id of the principal this binding targets.
     pub principal_id: String,
@@ -142,10 +144,10 @@ pub struct BindingListResponse {
 
 /// Query string for `GET /v1/policies/effective`. Both fields are
 /// required: there's no "for me" shortcut because the engine
-/// computes account-vs-credential composition differently.
+/// computes namespace-vs-credential composition differently.
 #[derive(Debug, Clone, Serialize)]
 pub struct EffectivePolicyQuery {
-    /// One of `account`, `api_key`, `oauth_token`, `oauth_client`.
+    /// One of `namespace`, `api_key`, `oauth_token`, `oauth_client`.
     pub principal_type: String,
     /// Id of the principal the preview is computed for.
     pub principal_id: String,
@@ -170,92 +172,102 @@ pub struct EffectivePolicy {
 }
 
 impl ManagementClient {
-    /// `GET /v1/policies` — list policies on the caller's account,
-    /// optionally narrowed by kind.
+    /// `GET /v1/namespaces/{nsid}/policies` — list policies in the
+    /// client's namespace, optionally narrowed by kind.
     pub async fn list_policies(&self, query: &ListPoliciesQuery) -> Result<PolicyListResponse> {
-        self.get_with_query("/v1/policies", query).await
+        let path = self.namespaced("/policies")?;
+        self.get_with_query(&path, query).await
     }
 
-    /// `GET /v1/policies/{id}` — fetch a single policy.
+    /// `GET /v1/namespaces/{nsid}/policies/{id}` — fetch a single
+    /// policy.
     pub async fn get_policy(&self, id: &str) -> Result<PolicyEnvelope> {
-        let path = format!("/v1/policies/{id}");
+        let path = self.namespaced(&format!("/policies/{id}"))?;
         self.get_json(&path).await
     }
 
-    /// `POST /v1/policies` — create a new policy.
+    /// `POST /v1/namespaces/{nsid}/policies` — create a new policy.
     pub async fn create_policy(&self, body: &CreatePolicyRequest) -> Result<PolicyEnvelope> {
-        self.post_json("/v1/policies", body).await
+        let path = self.namespaced("/policies")?;
+        self.post_json(&path, body).await
     }
 
-    /// `PUT /v1/policies/{id}` — patch name and/or spec.
+    /// `PUT /v1/namespaces/{nsid}/policies/{id}` — patch name and/or
+    /// spec.
     pub async fn update_policy(
         &self,
         id: &str,
         body: &UpdatePolicyRequest,
     ) -> Result<PolicyEnvelope> {
-        let path = format!("/v1/policies/{id}");
+        let path = self.namespaced(&format!("/policies/{id}"))?;
         self.put_json(&path, body).await
     }
 
-    /// `DELETE /v1/policies/{id}` — remove a policy. Cascades to its
-    /// bindings server-side.
+    /// `DELETE /v1/namespaces/{nsid}/policies/{id}` — remove a policy.
+    /// Cascades to its bindings server-side.
     pub async fn delete_policy(&self, id: &str) -> Result<DeletePolicyResponse> {
-        let path = format!("/v1/policies/{id}");
+        let path = self.namespaced(&format!("/policies/{id}"))?;
         self.delete_json(&path).await
     }
 
-    /// `POST /v1/policies/{id}/bind` — attach a policy to a principal.
+    /// `POST /v1/namespaces/{nsid}/policies/{id}/bind` — attach a
+    /// policy to a principal.
     pub async fn bind_policy(
         &self,
         id: &str,
         body: &BindPolicyRequest,
     ) -> Result<BindPolicyResponse> {
-        let path = format!("/v1/policies/{id}/bind");
+        let path = self.namespaced(&format!("/policies/{id}/bind"))?;
         self.post_json(&path, body).await
     }
 
-    /// `DELETE /v1/policies/{id}/bind/{binding_id}` — detach one
-    /// binding.
+    /// `DELETE /v1/namespaces/{nsid}/policies/{id}/bind/{binding_id}` —
+    /// detach one binding.
     pub async fn unbind_policy(&self, id: &str, binding_id: &str) -> Result<UnbindPolicyResponse> {
-        let path = format!("/v1/policies/{id}/bind/{binding_id}");
+        let path = self.namespaced(&format!("/policies/{id}/bind/{binding_id}"))?;
         self.delete_json(&path).await
     }
 
-    /// `GET /v1/policies/{id}/bindings` — list bindings for one
-    /// policy.
+    /// `GET /v1/namespaces/{nsid}/policies/{id}/bindings` — list
+    /// bindings for one policy.
     pub async fn list_policy_bindings(&self, id: &str) -> Result<BindingListResponse> {
-        let path = format!("/v1/policies/{id}/bindings");
+        let path = self.namespaced(&format!("/policies/{id}/bindings"))?;
         self.get_json(&path).await
     }
 
-    /// `POST /v1/policies/{id}/disable` — park a policy. The row
-    /// stays in the table; the engine skips it at request time.
+    /// `POST /v1/namespaces/{nsid}/policies/{id}/disable` — park a
+    /// policy. The row stays in the table; the engine skips it at
+    /// request time.
     pub async fn disable_policy(&self, id: &str) -> Result<ToggleResponse> {
-        let path = format!("/v1/policies/{id}/disable");
+        let path = self.namespaced(&format!("/policies/{id}/disable"))?;
         self.post_empty(&path).await
     }
 
-    /// `POST /v1/policies/{id}/enable` — un-park a previously
-    /// disabled policy.
+    /// `POST /v1/namespaces/{nsid}/policies/{id}/enable` — un-park a
+    /// previously disabled policy.
     pub async fn enable_policy(&self, id: &str) -> Result<ToggleResponse> {
-        let path = format!("/v1/policies/{id}/enable");
+        let path = self.namespaced(&format!("/policies/{id}/enable"))?;
         self.post_empty(&path).await
     }
 
-    /// `GET /v1/principals/{type}/{id}/policies` — every policy bound
-    /// to a given principal.
+    /// `GET /v1/namespaces/{nsid}/principals/{type}/{id}/policies` —
+    /// every policy bound to a given principal.
     pub async fn list_principal_policies(
         &self,
         principal_type: &str,
         principal_id: &str,
     ) -> Result<PolicyListResponse> {
-        let path = format!("/v1/principals/{principal_type}/{principal_id}/policies");
+        let path = self.namespaced(&format!(
+            "/principals/{principal_type}/{principal_id}/policies"
+        ))?;
         self.get_json(&path).await
     }
 
-    /// `GET /v1/policies/effective` — preview the effective policy for
-    /// a principal without making a real inference call.
+    /// `GET /v1/namespaces/{nsid}/policies/effective` — preview the
+    /// effective policy for a principal without making a real inference
+    /// call.
     pub async fn effective_policy(&self, query: &EffectivePolicyQuery) -> Result<EffectivePolicy> {
-        self.get_with_query("/v1/policies/effective", query).await
+        let path = self.namespaced("/policies/effective")?;
+        self.get_with_query(&path, query).await
     }
 }

--- a/crates/bitrouter-cloud-sdk/src/management/policies.rs
+++ b/crates/bitrouter-cloud-sdk/src/management/policies.rs
@@ -4,8 +4,7 @@
 //!
 //! Mirrors `bitrouter_cloud::v1::http::management::policies`. Scopes:
 //! `policy:read` for reads, `policy:write` for everything else. The
-//! `{nsid}` segment is resolved from the credential — see
-//! [`super::ManagementClient::namespaced`].
+//! `{nsid}` segment is resolved from the credential's baked namespace.
 //!
 //! The shape used for `spec` is the **flat inner body** (e.g. `{
 //! "window": "day", "limit_micro_usd": 1000 }` for a budget), not the

--- a/crates/bitrouter-cloud-sdk/src/management/presets.rs
+++ b/crates/bitrouter-cloud-sdk/src/management/presets.rs
@@ -1,8 +1,10 @@
-//! `/v1/presets*` — typed CRUD wrappers over the `policies` rows whose
-//! `kind = 'preset'`. A preset is a named bundle of an optional
-//! `guardrail`, `budget`, and / or `rate_limit` clause.
+//! `/v1/namespaces/{nsid}/presets*` — typed CRUD wrappers over the
+//! `policies` rows whose `kind = 'preset'`. A preset is a named bundle
+//! of an optional `guardrail`, `budget`, and / or `rate_limit` clause.
 //!
-//! Mirrors `bitrouter_cloud::v1::http::management::presets`.
+//! Mirrors `bitrouter_cloud::v1::http::management::presets`. The
+//! `{nsid}` segment is resolved from the credential — see
+//! [`super::ManagementClient::namespaced`].
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -102,35 +104,39 @@ pub struct DeletePresetResponse {
 }
 
 impl ManagementClient {
-    /// `GET /v1/presets` — list every preset on the account.
+    /// `GET /v1/namespaces/{nsid}/presets` — list every preset in the
+    /// namespace.
     pub async fn list_presets(&self) -> Result<PresetListResponse> {
-        self.get_json("/v1/presets").await
-    }
-
-    /// `GET /v1/presets/{id}` — fetch one preset.
-    pub async fn get_preset(&self, id: &str) -> Result<PresetEnvelope> {
-        let path = format!("/v1/presets/{id}");
+        let path = self.namespaced("/presets")?;
         self.get_json(&path).await
     }
 
-    /// `POST /v1/presets` — create a preset.
-    pub async fn create_preset(&self, body: &CreatePresetRequest) -> Result<PresetEnvelope> {
-        self.post_json("/v1/presets", body).await
+    /// `GET /v1/namespaces/{nsid}/presets/{id}` — fetch one preset.
+    pub async fn get_preset(&self, id: &str) -> Result<PresetEnvelope> {
+        let path = self.namespaced(&format!("/presets/{id}"))?;
+        self.get_json(&path).await
     }
 
-    /// `PUT /v1/presets/{id}` — patch a preset's name and/or clauses.
+    /// `POST /v1/namespaces/{nsid}/presets` — create a preset.
+    pub async fn create_preset(&self, body: &CreatePresetRequest) -> Result<PresetEnvelope> {
+        let path = self.namespaced("/presets")?;
+        self.post_json(&path, body).await
+    }
+
+    /// `PUT /v1/namespaces/{nsid}/presets/{id}` — patch a preset's name
+    /// and/or clauses.
     pub async fn update_preset(
         &self,
         id: &str,
         body: &UpdatePresetRequest,
     ) -> Result<PresetEnvelope> {
-        let path = format!("/v1/presets/{id}");
+        let path = self.namespaced(&format!("/presets/{id}"))?;
         self.put_json(&path, body).await
     }
 
-    /// `DELETE /v1/presets/{id}` — remove a preset.
+    /// `DELETE /v1/namespaces/{nsid}/presets/{id}` — remove a preset.
     pub async fn delete_preset(&self, id: &str) -> Result<DeletePresetResponse> {
-        let path = format!("/v1/presets/{id}");
+        let path = self.namespaced(&format!("/presets/{id}"))?;
         self.delete_json(&path).await
     }
 }

--- a/crates/bitrouter-cloud-sdk/src/management/presets.rs
+++ b/crates/bitrouter-cloud-sdk/src/management/presets.rs
@@ -3,8 +3,7 @@
 //! of an optional `guardrail`, `budget`, and / or `rate_limit` clause.
 //!
 //! Mirrors `bitrouter_cloud::v1::http::management::presets`. The
-//! `{nsid}` segment is resolved from the credential — see
-//! [`super::ManagementClient::namespaced`].
+//! `{nsid}` segment is resolved from the credential's baked namespace.
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};

--- a/crates/bitrouter-cloud-sdk/src/management/tests.rs
+++ b/crates/bitrouter-cloud-sdk/src/management/tests.rs
@@ -235,12 +235,16 @@ async fn refreshes_bearer_within_refresh_window_then_calls_management() {
     Mock::given(method("POST"))
         .and(wm_path("/oauth/token"))
         .and(body_string_contains("grant_type=refresh_token"))
+        // The refresh response carries a *different* namespace_id. The
+        // stored binding must win — rotation never rebinds the namespace
+        // — so this value is deliberately ignored on persist.
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "access_token": "refreshed",
             "token_type": "Bearer",
             "expires_in": 3600,
             "refresh_token": "rotated-rt",
             "scope": "keys:read",
+            "namespace_id": "ns-evil",
         })))
         .expect(1)
         .mount(&server)
@@ -277,6 +281,12 @@ async fn refreshes_bearer_within_refresh_window_then_calls_management() {
     assert_eq!(
         reloaded.current().unwrap().refresh_token.as_deref(),
         Some("rotated-rt"),
+    );
+    // The stored namespace survives rotation; the refresh response's
+    // conflicting `ns-evil` is ignored.
+    assert_eq!(
+        reloaded.current().unwrap().namespace_id.as_deref(),
+        Some("ns-1"),
     );
 }
 

--- a/crates/bitrouter-cloud-sdk/src/management/tests.rs
+++ b/crates/bitrouter-cloud-sdk/src/management/tests.rs
@@ -39,6 +39,7 @@ fn fresh_creds(as_url: &str) -> Credentials {
         scope: "keys:read keys:write policy:read policy:write".into(),
         client_id: "bitrouter-cli".into(),
         authorization_server: as_url.to_owned(),
+        namespace_id: Some("ns-1".into()),
         subject: Some("u-1".into()),
     }
 }
@@ -73,7 +74,7 @@ async fn list_keys_attaches_bearer_and_decodes_body() {
     let server = MockServer::start().await;
     metadata_mock(&server).await;
     Mock::given(method("GET"))
-        .and(wm_path("/v1/keys"))
+        .and(wm_path("/v1/namespaces/ns-1/keys"))
         .and(header("authorization", "Bearer AT"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "data": [{
@@ -106,7 +107,7 @@ async fn mint_key_posts_json_body_and_returns_secret() {
     let server = MockServer::start().await;
     metadata_mock(&server).await;
     Mock::given(method("POST"))
-        .and(wm_path("/v1/keys"))
+        .and(wm_path("/v1/namespaces/ns-1/keys"))
         .and(header("authorization", "Bearer AT"))
         .and(body_string_contains("\"display_name\":\"ci\""))
         .and(body_string_contains("\"scopes\":[\"policy:read\"]"))
@@ -143,7 +144,7 @@ async fn forbidden_with_scope_message_is_parsed() {
     let server = MockServer::start().await;
     metadata_mock(&server).await;
     Mock::given(method("DELETE"))
-        .and(wm_path("/v1/keys/k_x"))
+        .and(wm_path("/v1/namespaces/ns-1/keys/k_x"))
         .respond_with(ResponseTemplate::new(403).set_body_json(json!({
             "error": "forbidden",
             "error_description": "missing required scope: keys:write",
@@ -173,7 +174,7 @@ async fn not_found_maps_to_typed_variant() {
     let server = MockServer::start().await;
     metadata_mock(&server).await;
     Mock::given(method("GET"))
-        .and(wm_path("/v1/policies/ghost"))
+        .and(wm_path("/v1/namespaces/ns-1/policies/ghost"))
         .respond_with(ResponseTemplate::new(404).set_body_json(json!({
             "error": "not_found",
             "error_description": "policy not found",
@@ -211,7 +212,7 @@ async fn metadata_fetched_once_across_multiple_calls() {
         .mount(&server)
         .await;
     Mock::given(method("GET"))
-        .and(wm_path("/v1/keys"))
+        .and(wm_path("/v1/namespaces/ns-1/keys"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "data": [] })))
         .mount(&server)
         .await;
@@ -245,7 +246,7 @@ async fn refreshes_bearer_within_refresh_window_then_calls_management() {
         .mount(&server)
         .await;
     Mock::given(method("GET"))
-        .and(wm_path("/v1/keys"))
+        .and(wm_path("/v1/namespaces/ns-1/keys"))
         .and(header("authorization", "Bearer refreshed"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "data": [] })))
         .expect(1)
@@ -265,6 +266,7 @@ async fn refreshes_bearer_within_refresh_window_then_calls_management() {
             scope: "keys:read".into(),
             client_id: "bitrouter-cli".into(),
             authorization_server: server.uri(),
+            namespace_id: Some("ns-1".into()),
             subject: None,
         })
         .unwrap();
@@ -276,6 +278,55 @@ async fn refreshes_bearer_within_refresh_window_then_calls_management() {
         reloaded.current().unwrap().refresh_token.as_deref(),
         Some("rotated-rt"),
     );
+}
+
+#[tokio::test]
+async fn list_namespaces_hits_flat_user_level_path() {
+    let server = MockServer::start().await;
+    metadata_mock(&server).await;
+    Mock::given(method("GET"))
+        .and(wm_path("/v1/namespaces"))
+        .and(header("authorization", "Bearer AT"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": [
+                { "id": "ns-1", "name": "default", "created_at": "2026-05-25T00:00:00Z" },
+                { "id": "ns-2", "name": "staging", "created_at": "2026-05-26T00:00:00Z" }
+            ]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let path = tmp_creds_path("list-ns");
+    let mut store = CredentialsStore::load(&path).unwrap();
+    store.save(fresh_creds(&server.uri())).unwrap();
+    let client = build_client(&server, &path);
+
+    assert_eq!(client.namespace_id(), Some("ns-1"));
+    let resp = client.list_namespaces().await.unwrap();
+    assert_eq!(resp.data.len(), 2);
+    assert_eq!(resp.data[0].id, "ns-1");
+    assert_eq!(resp.data[1].name, "staging");
+}
+
+#[tokio::test]
+async fn namespace_scoped_call_without_namespace_errors_before_network() {
+    // A credential file written before namespace-scoping has no
+    // namespace_id. Namespace-scoped methods must fail fast with
+    // NoNamespace rather than firing a malformed request. No mocks are
+    // mounted, so a stray HTTP call would surface as a transport error
+    // and fail this test.
+    let server = MockServer::start().await;
+    metadata_mock(&server).await;
+    let path = tmp_creds_path("no-ns");
+    let mut store = CredentialsStore::load(&path).unwrap();
+    let mut creds = fresh_creds(&server.uri());
+    creds.namespace_id = None;
+    store.save(creds).unwrap();
+    let client = build_client(&server, &path);
+
+    assert_eq!(client.namespace_id(), None);
+    let err = client.list_keys().await.unwrap_err();
+    assert!(matches!(err, Error::NoNamespace), "got {err:?}");
 }
 
 #[tokio::test]

--- a/crates/bitrouter-cloud-sdk/src/management/usage.rs
+++ b/crates/bitrouter-cloud-sdk/src/management/usage.rs
@@ -3,8 +3,7 @@
 //! require `usage:read`.
 //!
 //! Mirrors `bitrouter_cloud::v1::http::management::usage`. The `{nsid}`
-//! segment is resolved from the credential — see
-//! [`super::ManagementClient::namespaced`].
+//! segment is resolved from the credential's baked namespace.
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};

--- a/crates/bitrouter-cloud-sdk/src/management/usage.rs
+++ b/crates/bitrouter-cloud-sdk/src/management/usage.rs
@@ -1,8 +1,10 @@
-//! `/v1/usage` and `/v1/requests` — aggregate spend / token counts and
-//! the request history for the caller's account. Both require
-//! `usage:read`.
+//! `/v1/namespaces/{nsid}/usage` and `…/requests` — aggregate spend /
+//! token counts and the request history for the client's namespace. Both
+//! require `usage:read`.
 //!
-//! Mirrors `bitrouter_cloud::v1::http::management::usage`.
+//! Mirrors `bitrouter_cloud::v1::http::management::usage`. The `{nsid}`
+//! segment is resolved from the credential — see
+//! [`super::ManagementClient::namespaced`].
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -97,13 +99,17 @@ pub struct RequestEnvelope {
 }
 
 impl ManagementClient {
-    /// `GET /v1/usage` — aggregate spend + token counts over a window.
+    /// `GET /v1/namespaces/{nsid}/usage` — aggregate spend + token
+    /// counts over a window.
     pub async fn usage_aggregate(&self, query: &UsageQuery) -> Result<UsageResponse> {
-        self.get_with_query("/v1/usage", query).await
+        let path = self.namespaced("/usage")?;
+        self.get_with_query(&path, query).await
     }
 
-    /// `GET /v1/requests` — paged list of recent requests.
+    /// `GET /v1/namespaces/{nsid}/requests` — paged list of recent
+    /// requests.
     pub async fn list_requests(&self, query: &RequestsQuery) -> Result<RequestsResponse> {
-        self.get_with_query("/v1/requests", query).await
+        let path = self.namespaced("/requests")?;
+        self.get_with_query(&path, query).await
     }
 }

--- a/crates/bitrouter-cloud-sdk/src/provider/applier.rs
+++ b/crates/bitrouter-cloud-sdk/src/provider/applier.rs
@@ -335,6 +335,7 @@ mod tests {
                 scope: "inference:invoke".into(),
                 client_id: "bitrouter-cli".into(),
                 authorization_server: "https://as.invalid".into(),
+                namespace_id: Some("ns-1".into()),
                 subject: Some("u-1".into()),
             })
             .unwrap();
@@ -363,6 +364,7 @@ mod tests {
                 scope: "inference:invoke".into(),
                 client_id: "bitrouter-cli".into(),
                 authorization_server: uri.clone(),
+                namespace_id: Some("ns-1".into()),
                 subject: Some("u-1".into()),
             })
             .unwrap();
@@ -410,6 +412,7 @@ mod tests {
                 scope: "inference:invoke".into(),
                 client_id: "bitrouter-cli".into(),
                 authorization_server: uri,
+                namespace_id: Some("ns-1".into()),
                 subject: Some("u-1".into()),
             })
             .unwrap();
@@ -450,6 +453,7 @@ mod tests {
                 scope: "inference:invoke".into(),
                 client_id: "bitrouter-cli".into(),
                 authorization_server: uri,
+                namespace_id: None,
                 subject: None,
             })
             .unwrap();
@@ -488,6 +492,7 @@ mod tests {
                 scope: "inference:invoke".into(),
                 client_id: "bitrouter-cli".into(),
                 authorization_server: uri,
+                namespace_id: None,
                 subject: None,
             })
             .unwrap();

--- a/crates/bitrouter-cloud-sdk/tests/oauth_device_flow.rs
+++ b/crates/bitrouter-cloud-sdk/tests/oauth_device_flow.rs
@@ -133,6 +133,7 @@ impl Respond for DeviceGrantResponder {
                 "refresh_token": "RT-INITIAL",
                 "refresh_token_expires_in": 86400,
                 "scope": "inference:invoke usage:read",
+                "namespace_id": "ns-1",
             }))
         }
     }
@@ -186,6 +187,9 @@ async fn end_to_end_device_flow_with_mock_authorization_server() {
         token_set.scope.as_deref(),
         Some("inference:invoke usage:read")
     );
+    // The namespace the AS baked the token into round-trips through
+    // the device-flow success response into the TokenSet.
+    assert_eq!(token_set.namespace_id.as_deref(), Some("ns-1"));
     // Two token-endpoint hits: one pending, one success.
     assert_eq!(poll_count.load(Ordering::SeqCst), 2);
 
@@ -200,6 +204,8 @@ async fn end_to_end_device_flow_with_mock_authorization_server() {
     let mut store = CredentialsStore::load(&path).unwrap();
     let loaded = store.current().expect("loaded credentials");
     assert_eq!(loaded.access_token, "AT-INITIAL");
+    // The namespace binding survives serialise → disk → reload.
+    assert_eq!(loaded.namespace_id.as_deref(), Some("ns-1"));
 
     // 5. Force a refresh by mutating expires_at to be within the
     //    REFRESH_WINDOW, then asking for current_token.


### PR DESCRIPTION
## Summary

Migrates the `bitrouter-cloud-sdk` management client and the `bitrouter cloud` CLI to the **namespace-scoped** management surface (server PR-45). The credential issued by `bitrouter auth login` is namespace-baked — the browser device-approval page picks which namespace to grant — so the client resolves the `{nsid}` path segment **implicitly** from the stored credential. Callers never pass a namespace argument.

Pairs with the server/console change in `bitrouter-cloud` (PR #347).

## SDK changes

- **Credential plumbing**: `Credentials`, `TokenSet`, and the device-flow `TokenResponse` gain `namespace_id`. Threaded through `credentials_from_token_set`; preserved across refreshes (rotation never rebinds the namespace).
- **Default scope**: drop retired `account:read`, add `namespace:read` so `namespace list` works out of the box.
- **`ManagementClient`**: captures `namespace_id` at construction, exposes `namespace_id()`, and adds a private `namespaced()` helper that builds `/v1/namespaces/{nsid}/…` paths — erroring with the new `Error::NoNamespace` when a stale/namespace-null credential has none (graceful "re-login" path).
- **Path migration**: `keys`, `usage`, `policies`, `budgets`, `presets`, `oauth_clients` → namespace-scoped. `billing` + `byok` stay user-level (flat). *Verified against the actual server routes, not the blueprint prose — which was wrong on both byok and clients.*
- **New `namespaces` module**: read-only `list_namespaces()`. Create/delete are console-only (control-plane `namespace:write`).

## CLI changes

- New `bitrouter cloud namespace list` (marks the active namespace) and `namespace current` (offline).
- `whoami` (both `auth` and `cloud`) prints the active namespace.

## Test plan

- [x] `cargo nextest run -p bitrouter-cloud-sdk` — 59/59 pass (incl. new NoNamespace, list_namespaces, and device-flow namespace round-trip tests)
- [x] `cargo clippy` both crates — clean
- [x] `cargo fmt --check` — clean
- [x] `bitrouter` app test targets compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)