### PR TITLE
feat(skills): skills gateway client — bitrouter-skills crate + CLI

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -370,4 +370,60 @@ bitrouter cloud oauth-client update <CLIENT_ID> [--name <NAME>] [--grant <GRANT>
 bitrouter cloud oauth-client delete <CLIENT_ID> [--json]
 ```
 
+## Skills
+
+`bitrouter skills …` installs and manages Claude Code skills — directories containing a `SKILL.md` with YAML frontmatter (`name`, `description`). Skills install into the agent skills directory: `~/.claude/skills/<name>/` with `--global`, or `./.claude/skills/<name>/` (project-local) by default.
+
+Sources are auto-detected:
+
+- `owner/repo` — GitHub shorthand (optionally `owner/repo#<branch|tag|sha>`)
+- `https://github.com/owner/repo[.git]` — full GitHub URL
+- `https://github.com/owner/repo/tree/<ref>/<subdir>` — a skill in a subdirectory
+- any other `https://…`, `git://…`, or `git@…` git URL
+- `./path`, `../path`, `/abs/path`, `~/path` — a local directory (copied, not cloned)
+- a bare `name` — resolved against the registry's public hub (`--registry <URL>`, default `https://api.bitrouter.ai`)
+
+Git sources are shallow-cloned via the system `git` binary (must be on `PATH`). Plain-HTTP sources are refused (skills are executable content); symlinks in a source tree are skipped, and skill names are validated to prevent path traversal.
+
+### `bitrouter skills add <source>`
+
+```
+bitrouter skills add <SOURCE> [--skill <NAME>] [-g|--global] [-y|--yes] [--registry <URL>]
+```
+
+Clones/copies the source, discovers its `SKILL.md`, and installs it. `--skill <NAME>` selects one skill by frontmatter name when the source exposes several. Installing over an existing skill requires `-y/--yes`.
+
+### `bitrouter skills list` / `remove`
+
+```
+bitrouter skills list   [-g|--global]
+bitrouter skills remove <NAME> [-g|--global]
+```
+
+`list` prints installed skills (name + path); `remove` deletes one by name.
+
+### `bitrouter skills find <query>`
+
+```
+bitrouter skills find <QUERY> [--registry <URL>]
+```
+
+Searches the registry hub, matching `query` against name, description, and tags.
+
+### `bitrouter skills init <name>`
+
+```
+bitrouter skills init <NAME> [-o|--output <PATH>]
+```
+
+Scaffolds a starter `SKILL.md` (default `./SKILL.md`). Refuses to overwrite an existing file.
+
+### `bitrouter skills update`
+
+```
+bitrouter skills update [<NAME>] [-g|--global] [--registry <URL>]
+```
+
+Re-installs installed skills from the registry to their latest version (all installed skills, or just `<NAME>`). Skills absent from the registry are skipped; a per-skill failure is reported without aborting the rest.
+
 Grant types: `authorization_code`, `refresh_token`, `urn:ietf:params:oauth:grant-type:device_code`. For confidential clients, the freshly minted `client_secret` is returned exactly once in the `register` response.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -731,6 +731,7 @@ dependencies = [
  "bitrouter-observe",
  "bitrouter-providers",
  "bitrouter-sdk",
+ "bitrouter-skills",
  "chrono",
  "clap",
  "futures",
@@ -877,6 +878,18 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "bitrouter-skills"
+version = "1.0.0-alpha.5"
+dependencies = [
+ "reqwest 0.12.28",
+ "serde",
+ "serde-saphyr",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ bitrouter-sdk = { path = "crates/bitrouter-sdk", version = "1.0.0-alpha.5", defa
 bitrouter-bedrock = { path = "crates/bitrouter-bedrock", version = "1.0.0-alpha.5" }
 bitrouter-cloud-sdk = { path = "crates/bitrouter-cloud-sdk", version = "1.0.0-alpha.5" }
 bitrouter-providers = { path = "crates/bitrouter-providers", version = "1.0.0-alpha.5" }
+bitrouter-skills = { path = "crates/bitrouter-skills", version = "1.0.0-alpha.5" }
 bitrouter-guardrails = { path = "plugins/bitrouter-guardrails", version = "1.0.0-alpha.5" }
 bitrouter-observe = { path = "plugins/bitrouter-observe", version = "1.0.0-alpha.5", default-features = false }
 

--- a/apps/bitrouter/Cargo.toml
+++ b/apps/bitrouter/Cargo.toml
@@ -20,6 +20,7 @@ path = "src/main.rs"
 bitrouter-sdk = { workspace = true, features = ["server", "config_file", "mcp", "acp"] }
 bitrouter-cloud-sdk.workspace = true
 bitrouter-providers = { workspace = true, features = ["pkce"] }
+bitrouter-skills.workspace = true
 bitrouter-guardrails.workspace = true
 bitrouter-observe = { workspace = true, features = ["otel-http"] }
 chrono.workspace = true

--- a/apps/bitrouter/src/commands.rs
+++ b/apps/bitrouter/src/commands.rs
@@ -628,6 +628,202 @@ pub async fn logout_provider(provider_id: &str) -> Result<()> {
     Ok(())
 }
 
+// ===== skills (client installer) =====
+
+/// Default BitRouter registry queried when `bitrouter skills add <name>` is
+/// given a bare skill name rather than a git source.
+const DEFAULT_SKILLS_REGISTRY: &str = "https://api.bitrouter.ai";
+
+/// Build the HTTP client used to talk to a skills registry. Mirrors the
+/// 30-second-timeout, user-agent-tagged client the cloud SDK uses.
+fn skills_http_client() -> Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .user_agent(concat!("bitrouter-skills/", env!("CARGO_PKG_VERSION")))
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .context("building skills HTTP client")
+}
+
+/// Resolve the install target for the `--global` flag.
+fn skills_target(global: bool) -> Result<bitrouter_skills::install::InstallTarget> {
+    use bitrouter_skills::install::InstallTarget;
+    if global {
+        Ok(InstallTarget::Global)
+    } else {
+        let cwd = std::env::current_dir().context("resolving the current directory")?;
+        Ok(InstallTarget::Project { project_root: cwd })
+    }
+}
+
+/// Whether `source` is a bare registry skill name (no path/scheme), as opposed
+/// to a git source.
+fn is_bare_skill_name(source: &str) -> bool {
+    !source.contains('/') && !source.contains("://") && !source.starts_with("git@")
+}
+
+/// Resolve a registry name to its git source string via the marketplace.
+async fn resolve_registry_source(name: &str, registry: Option<&str>) -> Result<String> {
+    use bitrouter_skills::marketplace;
+    let base = registry.unwrap_or(DEFAULT_SKILLS_REGISTRY);
+    let client = skills_http_client()?;
+    let market = marketplace::fetch_marketplace(&client, base).await?;
+    let entry = market
+        .find(name)
+        .ok_or_else(|| anyhow::anyhow!("skill {name:?} not found in registry {base}"))?;
+    Ok(entry.source.clone())
+}
+
+/// `bitrouter skills add` — install a skill from a git source or registry name.
+pub async fn skills_add(
+    source: &str,
+    select: Option<&str>,
+    global: bool,
+    overwrite: bool,
+    registry: Option<&str>,
+) -> Result<()> {
+    use bitrouter_skills::{install, source as skill_source};
+
+    if source.trim().is_empty() {
+        anyhow::bail!(
+            "a skill source is required (owner/repo, a git URL, a local path, or a registry name)"
+        );
+    }
+
+    let target = skills_target(global)?;
+    let source_str = if is_bare_skill_name(source) {
+        resolve_registry_source(source, registry).await?
+    } else {
+        source.to_string()
+    };
+    let parsed = skill_source::parse_source(&source_str)?;
+    let outcome = install::install(&parsed, &target, overwrite, select, None).await?;
+    let verb = if outcome.was_updated {
+        "updated"
+    } else {
+        "installed"
+    };
+    println!("{verb} {} → {}", outcome.name, outcome.dest.display());
+    Ok(())
+}
+
+/// `bitrouter skills list` — show installed skills.
+pub fn skills_list(global: bool) -> Result<()> {
+    use bitrouter_skills::install;
+    let target = skills_target(global)?;
+    let installed = install::list_installed(&target)?;
+    if installed.is_empty() {
+        println!("no skills installed");
+        return Ok(());
+    }
+    for (name, path) in installed {
+        println!("{name}\t{}", path.display());
+    }
+    Ok(())
+}
+
+/// `bitrouter skills remove` — uninstall a skill by name.
+pub fn skills_remove(name: &str, global: bool) -> Result<()> {
+    use bitrouter_skills::install;
+    let target = skills_target(global)?;
+    let dir = install::remove(name, &target)?;
+    println!("removed {name} ({})", dir.display());
+    Ok(())
+}
+
+/// `bitrouter skills find` — search a registry.
+pub async fn skills_find(query: &str, registry: Option<&str>) -> Result<()> {
+    use bitrouter_skills::marketplace;
+    let base = registry.unwrap_or(DEFAULT_SKILLS_REGISTRY);
+    let client = skills_http_client()?;
+    let market = marketplace::fetch_marketplace(&client, base).await?;
+    let hits = market.search(query);
+    if hits.is_empty() {
+        println!("no skills matching {query:?} in {base}");
+        return Ok(());
+    }
+    for entry in hits {
+        let version = entry.version.as_deref().unwrap_or("-");
+        println!("{}\t{version}\t{}", entry.name, entry.description);
+    }
+    Ok(())
+}
+
+/// `bitrouter skills init` — scaffold a SKILL.md.
+pub fn skills_init(name: &str, output: &std::path::Path) -> Result<()> {
+    bitrouter_skills::install::validate_skill_name(name)?;
+    if output.exists() {
+        anyhow::bail!("{} already exists; refusing to overwrite", output.display());
+    }
+    let body = format!(
+        "---\nname: {name}\ndescription: TODO — one line on what this skill does and when to use it.\n---\n\n# {name}\n\nTODO: instructions for the agent.\n\n## When to use\n\n## Steps\n"
+    );
+    std::fs::write(output, body).with_context(|| format!("writing {}", output.display()))?;
+    println!("wrote {}", output.display());
+    Ok(())
+}
+
+/// `bitrouter skills update` — re-install installed skills from the registry.
+pub async fn skills_update(name: Option<&str>, global: bool, registry: Option<&str>) -> Result<()> {
+    use bitrouter_skills::{install, marketplace, source as skill_source};
+
+    let target = skills_target(global)?;
+    let base = registry.unwrap_or(DEFAULT_SKILLS_REGISTRY);
+
+    // `update` only re-installs skills that are actually installed; an explicit
+    // name must already be present (it does not double as an installer).
+    let installed: Vec<String> = install::list_installed(&target)?
+        .into_iter()
+        .map(|(n, _)| n)
+        .collect();
+    let names: Vec<String> = match name {
+        Some(n) => {
+            if !installed.iter().any(|i| i == n) {
+                anyhow::bail!("skill {n:?} is not installed; use `bitrouter skills add` first");
+            }
+            vec![n.to_string()]
+        }
+        None => installed,
+    };
+    if names.is_empty() {
+        println!("no skills installed to update");
+        return Ok(());
+    }
+
+    let client = skills_http_client()?;
+    let market = marketplace::fetch_marketplace(&client, base).await?;
+
+    // Update each skill independently: one failure must not abort the rest.
+    // Re-install into the same directory (`install_as`) so a skill stays put
+    // even if its upstream frontmatter name has drifted.
+    let mut failures = 0u32;
+    for skill_name in names {
+        match market.find(&skill_name) {
+            Some(entry) => {
+                let result = match skill_source::parse_source(&entry.source) {
+                    Ok(parsed) => {
+                        install::install(&parsed, &target, true, None, Some(&skill_name)).await
+                    }
+                    Err(e) => Err(e),
+                };
+                match result {
+                    Ok(outcome) => {
+                        println!("updated {} → {}", outcome.name, outcome.dest.display())
+                    }
+                    Err(e) => {
+                        failures += 1;
+                        eprintln!("failed to update {skill_name}: {e}");
+                    }
+                }
+            }
+            None => println!("skipped {skill_name} (not in registry {base})"),
+        }
+    }
+    if failures > 0 {
+        anyhow::bail!("{failures} skill(s) failed to update");
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/apps/bitrouter/src/lib.rs
+++ b/apps/bitrouter/src/lib.rs
@@ -23,6 +23,7 @@ pub mod metering;
 pub mod paths;
 pub mod policy;
 pub mod reload;
+pub mod skills;
 pub mod style;
 pub mod tools;
 

--- a/apps/bitrouter/src/main.rs
+++ b/apps/bitrouter/src/main.rs
@@ -233,6 +233,12 @@ enum Command {
         #[command(subcommand)]
         action: bitrouter::cloud::cli::CloudAction,
     },
+    /// Install and manage Claude Code skills from GitHub, a git URL, or a
+    /// BitRouter registry.
+    Skills {
+        #[command(subcommand)]
+        action: bitrouter::skills::cli::SkillsAction,
+    },
 }
 
 #[derive(Subcommand)]
@@ -535,6 +541,7 @@ async fn run() -> Result<()> {
         }
         Command::Auth { action } => auth_cmd(action).await,
         Command::Cloud { action } => bitrouter::cloud::cli::run(action).await,
+        Command::Skills { action } => bitrouter::skills::cli::run(action).await,
     }
 }
 

--- a/apps/bitrouter/src/skills/cli.rs
+++ b/apps/bitrouter/src/skills/cli.rs
@@ -1,0 +1,122 @@
+//! The `bitrouter skills` subcommand tree and its dispatcher.
+//!
+//! Each leaf is a thin shim over a `commands::skills_*` function (kept in the
+//! lib so the logic is testable and reusable), matching how `cloud/cli.rs`
+//! delegates to the management client.
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+use clap::Subcommand;
+
+use crate::commands;
+
+/// `bitrouter skills …`. All variants land in [`run`].
+#[derive(Debug, Subcommand)]
+pub enum SkillsAction {
+    /// Install a skill from a source (GitHub `owner/repo`, a git URL, or a
+    /// registry skill name).
+    Add(AddArgs),
+    /// List installed skills.
+    List(ScopeArgs),
+    /// Remove an installed skill by name.
+    Remove(RemoveArgs),
+    /// Search the configured registry for skills.
+    Find(FindArgs),
+    /// Scaffold a new `SKILL.md` in the current directory.
+    Init(InitArgs),
+    /// Re-install installed skills from the registry to their latest version.
+    Update(UpdateArgs),
+}
+
+#[derive(Debug, clap::Args)]
+pub struct AddArgs {
+    /// Source: `owner/repo`, a full git URL, or a registry skill name.
+    pub source: String,
+    /// When the source exposes several skills, install the one with this
+    /// frontmatter `name`.
+    #[arg(long = "skill", value_name = "NAME")]
+    pub skill: Option<String>,
+    /// Install into `~/.claude/skills/` instead of `./.claude/skills/`.
+    #[arg(long, short = 'g')]
+    pub global: bool,
+    /// Overwrite an existing install of the same skill.
+    #[arg(long, short = 'y')]
+    pub yes: bool,
+    /// Registry base URL used when `source` is a bare skill name.
+    #[arg(long, value_name = "URL")]
+    pub registry: Option<String>,
+}
+
+#[derive(Debug, clap::Args)]
+pub struct ScopeArgs {
+    /// Operate on the global skills directory (`~/.claude/skills/`).
+    #[arg(long, short = 'g')]
+    pub global: bool,
+}
+
+#[derive(Debug, clap::Args)]
+pub struct RemoveArgs {
+    /// The skill name to remove.
+    pub name: String,
+    /// Remove from the global skills directory.
+    #[arg(long, short = 'g')]
+    pub global: bool,
+}
+
+#[derive(Debug, clap::Args)]
+pub struct FindArgs {
+    /// Query matched against name, description, and tags.
+    pub query: String,
+    /// Registry base URL to search.
+    #[arg(long, value_name = "URL")]
+    pub registry: Option<String>,
+}
+
+#[derive(Debug, clap::Args)]
+pub struct InitArgs {
+    /// Skill name written into the generated frontmatter.
+    pub name: String,
+    /// Output path for the SKILL.md.
+    #[arg(long, short = 'o', default_value = "SKILL.md")]
+    pub output: PathBuf,
+}
+
+#[derive(Debug, clap::Args)]
+pub struct UpdateArgs {
+    /// Update only this skill. When omitted, updates every installed skill
+    /// found in the registry.
+    pub name: Option<String>,
+    /// Update the global skills directory.
+    #[arg(long, short = 'g')]
+    pub global: bool,
+    /// Registry base URL to update from.
+    #[arg(long, value_name = "URL")]
+    pub registry: Option<String>,
+}
+
+/// Entry point dispatched by `apps/bitrouter/src/main.rs`.
+pub async fn run(action: SkillsAction) -> Result<()> {
+    match action {
+        SkillsAction::Add(args) => {
+            commands::skills_add(
+                &args.source,
+                args.skill.as_deref(),
+                args.global,
+                args.yes,
+                args.registry.as_deref(),
+            )
+            .await
+        }
+        SkillsAction::List(args) => commands::skills_list(args.global),
+        SkillsAction::Remove(args) => commands::skills_remove(&args.name, args.global),
+        SkillsAction::Find(args) => {
+            commands::skills_find(&args.query, args.registry.as_deref()).await
+        }
+        SkillsAction::Init(args) => commands::skills_init(&args.name, &args.output),
+        SkillsAction::Update(args) => {
+            commands::skills_update(args.name.as_deref(), args.global, args.registry.as_deref())
+                .await
+        }
+    }
+}

--- a/apps/bitrouter/src/skills/mod.rs
+++ b/apps/bitrouter/src/skills/mod.rs
@@ -1,0 +1,9 @@
+//! `bitrouter skills …` — the client-side skill installer.
+//!
+//! Installs Claude Code skills from GitHub, a git URL, or a BitRouter registry
+//! into an agent's skills directory (`~/.claude/skills/` or
+//! `./.claude/skills/`). The parsing, fetching, and install logic lives in the
+//! framework-agnostic [`bitrouter_skills`] crate; this module is the CLI
+//! surface and dispatch glue, mirroring the `cloud` subcommand layout.
+
+pub mod cli;

--- a/crates/bitrouter-skills/Cargo.toml
+++ b/crates/bitrouter-skills/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "bitrouter-skills"
+description = "BitRouter skills: SKILL.md parsing, source resolution, marketplace types, and install logic."
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true
+serde-saphyr.workspace = true
+reqwest.workspace = true
+tokio = { workspace = true, features = ["process"] }
+thiserror.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }

--- a/crates/bitrouter-skills/src/frontmatter.rs
+++ b/crates/bitrouter-skills/src/frontmatter.rs
@@ -1,0 +1,240 @@
+//! Parsing the YAML frontmatter of a `SKILL.md` and discovering skills under a
+//! directory tree.
+//!
+//! A `SKILL.md` opens with a YAML frontmatter block fenced by `---` lines:
+//!
+//! ```text
+//! ---
+//! name: my-skill
+//! description: What this skill does.
+//! ---
+//!
+//! # My Skill
+//! ```
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+use crate::{Error, Result};
+
+/// Parsed frontmatter from a `SKILL.md` file.
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct SkillFrontmatter {
+    /// Canonical skill name (filesystem slug).
+    pub name: String,
+    /// Human-readable description.
+    pub description: String,
+    /// Freeform metadata map (version, author, tags, …).
+    #[serde(default)]
+    pub metadata: BTreeMap<String, serde_json::Value>,
+}
+
+/// Extract the YAML frontmatter block (the text between the first pair of `---`
+/// fence lines) from `SKILL.md` content. Returns `None` when there is no
+/// opening fence or no closing fence.
+///
+/// The closing fence must be a line that is *exactly* `---` (ignoring a
+/// trailing `\r`), so a `----` divider or a `---` appearing inside a YAML value
+/// does not prematurely terminate the block.
+fn extract_frontmatter_block(content: &str) -> Option<&str> {
+    let rest = content.strip_prefix("---")?;
+    // The opening fence line may carry a trailing `\r`; require it to be
+    // followed by a newline so a leading `---word` isn't mistaken for a fence.
+    let rest = rest
+        .strip_prefix('\n')
+        .or_else(|| rest.strip_prefix("\r\n"))?;
+    let mut offset = 0;
+    for line in rest.split_inclusive('\n') {
+        let text = line.strip_suffix('\n').unwrap_or(line);
+        let text = text.strip_suffix('\r').unwrap_or(text);
+        if text == "---" {
+            return Some(&rest[..offset]);
+        }
+        offset += line.len();
+    }
+    None
+}
+
+/// Parse the frontmatter from `SKILL.md` content.
+pub fn parse_frontmatter(content: &str) -> Result<SkillFrontmatter> {
+    let block = extract_frontmatter_block(content).ok_or(Error::MissingFrontmatter)?;
+    serde_saphyr::from_str::<SkillFrontmatter>(block).map_err(|e| Error::Frontmatter(e.to_string()))
+}
+
+/// The candidate directories searched for a `SKILL.md`, relative to a fetched
+/// source root. Mirrors the conventional layout used by the wider skills
+/// ecosystem (root, then `skills/`, then `.claude/skills/`).
+fn skill_search_roots(root: &Path) -> Vec<PathBuf> {
+    vec![
+        root.to_path_buf(),
+        root.join("skills"),
+        root.join(".claude").join("skills"),
+    ]
+}
+
+/// Discover every `SKILL.md` reachable under `root`: a `SKILL.md` directly in
+/// `root`, or one in any immediate subdirectory of the conventional skills
+/// directories. Entries that fail to parse are skipped.
+pub fn discover_all_skills(root: &Path) -> Vec<(PathBuf, SkillFrontmatter)> {
+    let mut found = Vec::new();
+    let mut seen = std::collections::BTreeSet::new();
+    let mut push = |path: PathBuf, found: &mut Vec<(PathBuf, SkillFrontmatter)>| {
+        // The conventional search roots overlap (e.g. `<root>/skills/SKILL.md`
+        // is both a child of `<root>` and the direct file of `<root>/skills`);
+        // dedup by path so a skill is never discovered twice.
+        if !seen.insert(path.clone()) {
+            return;
+        }
+        if let Ok(content) = std::fs::read_to_string(&path)
+            && let Ok(fm) = parse_frontmatter(&content)
+        {
+            found.push((path, fm));
+        }
+    };
+    for base in skill_search_roots(root) {
+        // A SKILL.md directly inside this base directory.
+        push(base.join("SKILL.md"), &mut found);
+        // A SKILL.md one level down: base/<child>/SKILL.md.
+        let Ok(entries) = std::fs::read_dir(&base) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            push(entry.path().join("SKILL.md"), &mut found);
+        }
+    }
+    found
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_name_and_description() {
+        let content = "---\nname: my-skill\ndescription: Does a thing.\n---\n\n# Body\n";
+        let fm = parse_frontmatter(content).expect("should parse");
+        assert_eq!(fm.name, "my-skill");
+        assert_eq!(fm.description, "Does a thing.");
+        assert!(fm.metadata.is_empty());
+    }
+
+    #[test]
+    fn parses_metadata_map() {
+        let content = "---\nname: s\ndescription: d\nmetadata:\n  version: \"1.2.0\"\n  internal: true\n---\nbody";
+        let fm = parse_frontmatter(content).expect("should parse");
+        assert_eq!(
+            fm.metadata.get("version"),
+            Some(&serde_json::Value::String("1.2.0".to_string()))
+        );
+        assert_eq!(
+            fm.metadata.get("internal"),
+            Some(&serde_json::Value::Bool(true))
+        );
+    }
+
+    #[test]
+    fn four_dash_line_is_not_a_closing_fence() {
+        // A `----` divider must not be mistaken for the `---` closing fence;
+        // with no exact `---` closer the frontmatter is malformed.
+        let content = "---\nname: s\ndescription: d\n----\nmore\n";
+        let err = parse_frontmatter(content).expect_err("no exact --- fence");
+        assert!(matches!(err, Error::MissingFrontmatter));
+    }
+
+    #[test]
+    fn inner_dashes_do_not_truncate_block() {
+        // A `----` value before the real fence must not cut the block short.
+        let content = "---\nname: s\ndescription: d\nnote: \"----\"\n---\nbody\n";
+        let fm = parse_frontmatter(content).expect("parses to the real fence");
+        assert_eq!(fm.name, "s");
+        assert_eq!(fm.description, "d");
+    }
+
+    #[test]
+    fn missing_frontmatter_is_an_error() {
+        let err = parse_frontmatter("# Just a heading\n").expect_err("no fence");
+        assert!(matches!(err, Error::MissingFrontmatter));
+    }
+
+    #[test]
+    fn unterminated_frontmatter_is_missing() {
+        let err = parse_frontmatter("---\nname: s\n").expect_err("no closing fence");
+        assert!(matches!(err, Error::MissingFrontmatter));
+    }
+
+    #[test]
+    fn malformed_yaml_is_a_parse_error() {
+        // Missing the required `description` field.
+        let err = parse_frontmatter("---\nname: s\n---\n").expect_err("incomplete");
+        assert!(matches!(err, Error::Frontmatter(_)));
+    }
+
+    #[test]
+    fn discovers_skill_in_root() {
+        let dir = tempdir("discover-root");
+        std::fs::write(
+            dir.join("SKILL.md"),
+            "---\nname: root-skill\ndescription: d\n---\n",
+        )
+        .unwrap();
+        let (path, fm) = discover_all_skills(&dir).into_iter().next().expect("found");
+        assert_eq!(fm.name, "root-skill");
+        assert!(path.ends_with("SKILL.md"));
+        cleanup(&dir);
+    }
+
+    #[test]
+    fn discovers_skill_in_skills_subdir() {
+        let dir = tempdir("discover-subdir");
+        let nested = dir.join("skills").join("alpha");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::write(
+            nested.join("SKILL.md"),
+            "---\nname: alpha\ndescription: d\n---\n",
+        )
+        .unwrap();
+        let (_, fm) = discover_all_skills(&dir).into_iter().next().expect("found");
+        assert_eq!(fm.name, "alpha");
+        cleanup(&dir);
+    }
+
+    #[test]
+    fn discover_all_finds_multiple() {
+        let dir = tempdir("discover-all");
+        let skills = dir.join("skills");
+        for name in ["one", "two"] {
+            let nested = skills.join(name);
+            std::fs::create_dir_all(&nested).unwrap();
+            std::fs::write(
+                nested.join("SKILL.md"),
+                format!("---\nname: {name}\ndescription: d\n---\n"),
+            )
+            .unwrap();
+        }
+        let all = discover_all_skills(&dir);
+        let mut names: Vec<_> = all.into_iter().map(|(_, fm)| fm.name).collect();
+        names.sort();
+        assert_eq!(names, vec!["one".to_string(), "two".to_string()]);
+        cleanup(&dir);
+    }
+
+    #[test]
+    fn discover_finds_nothing_when_empty() {
+        let dir = tempdir("discover-empty");
+        assert!(discover_all_skills(&dir).is_empty());
+        cleanup(&dir);
+    }
+
+    fn tempdir(label: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("brskills-fm-{label}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn cleanup(dir: &Path) {
+        let _ = std::fs::remove_dir_all(dir);
+    }
+}

--- a/crates/bitrouter-skills/src/install.rs
+++ b/crates/bitrouter-skills/src/install.rs
@@ -1,0 +1,638 @@
+//! Installing a resolved [`crate::source::SkillSource`] into an agent's skills
+//! directory.
+//!
+//! The flow is: clone the source into a temporary directory, discover the
+//! `SKILL.md` within it, validate the skill name, then copy the skill's
+//! directory into the target (`~/.claude/skills/<name>` for global installs,
+//! `./.claude/skills/<name>` for project installs).
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use crate::source::SkillSource;
+use crate::{Error, Result, frontmatter};
+
+/// Where a skill is installed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InstallTarget {
+    /// `~/.claude/skills/` — user-global skills.
+    Global,
+    /// `<project_root>/.claude/skills/` — project-local skills.
+    Project { project_root: PathBuf },
+}
+
+/// The outcome of an [`install`] call, for user-facing output.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InstallOutcome {
+    /// The canonical skill name (from frontmatter).
+    pub name: String,
+    /// The directory the skill was installed into.
+    pub dest: PathBuf,
+    /// Whether an existing install was replaced.
+    pub was_updated: bool,
+}
+
+impl InstallTarget {
+    /// The `.claude/skills` directory for this target.
+    fn skills_root(&self) -> Result<PathBuf> {
+        match self {
+            InstallTarget::Global => Ok(crate::home_dir()?.join(".claude").join("skills")),
+            InstallTarget::Project { project_root } => {
+                Ok(project_root.join(".claude").join("skills"))
+            }
+        }
+    }
+
+    /// The directory a skill named `name` installs into.
+    pub fn skill_dir(&self, name: &str) -> Result<PathBuf> {
+        validate_skill_name(name)?;
+        Ok(self.skills_root()?.join(name))
+    }
+}
+
+/// Reject names that could escape the skills directory or carry illegal
+/// characters. Allowed: ASCII letters, digits, `-`, `_`, `.`; must be
+/// non-empty and may not start with `.` or contain a path separator or `..`.
+pub fn validate_skill_name(name: &str) -> Result<()> {
+    let invalid = name.is_empty()
+        || name.starts_with('.')
+        || name.contains('/')
+        || name.contains('\\')
+        || name.contains("..")
+        || !name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'));
+    if invalid {
+        return Err(Error::InvalidSkillName(name.to_string()));
+    }
+    Ok(())
+}
+
+/// A temporary directory removed on drop.
+struct TempDir {
+    path: PathBuf,
+}
+
+impl TempDir {
+    fn new(label: &str) -> Result<Self> {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "bitrouter-skills-{label}-{}-{id}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&path);
+        std::fs::create_dir_all(&path).map_err(|e| Error::Io(format!("creating temp dir: {e}")))?;
+        Ok(Self { path })
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+/// A staging directory created as a sibling of the final install destination
+/// (so the subsequent rename is on the same filesystem and atomic). It is
+/// removed on drop unless [`Staging::disarm`] is called after a successful
+/// rename moves it away.
+struct Staging {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl Staging {
+    fn new(parent: &std::path::Path, name: &str) -> Result<Self> {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let path = parent.join(format!(".{name}.tmp.{}.{id}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&path);
+        Ok(Self { path, armed: true })
+    }
+
+    /// Cancel cleanup-on-drop (the directory has been renamed into place).
+    fn disarm(mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for Staging {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_dir_all(&self.path);
+        }
+    }
+}
+
+/// Install (or update) a skill from `source` into `target`.
+///
+/// `select` picks which skill to install when the source exposes several
+/// (matched against the frontmatter `name`); with `None` and more than one
+/// skill present, the call errors rather than guessing.
+///
+/// `install_as` overrides the installed directory name; with `None` the skill
+/// installs under its frontmatter `name`. This lets `update` re-install to the
+/// same directory even if the upstream frontmatter name drifts.
+pub async fn install(
+    source: &SkillSource,
+    target: &InstallTarget,
+    overwrite: bool,
+    select: Option<&str>,
+    install_as: Option<&str>,
+) -> Result<InstallOutcome> {
+    let temp = TempDir::new("clone")?;
+    // Materialise the source into a child of the temp dir: git sources are
+    // shallow-cloned, local sources are copied. (`git clone` requires the
+    // destination to not already exist, hence the child path.)
+    let clone_dir = temp.path.join("repo");
+    match source.local_path() {
+        Some(path) => {
+            if !path.is_dir() {
+                return Err(Error::Io(format!(
+                    "local source {} is not a directory",
+                    path.display()
+                )));
+            }
+            copy_dir(path, &clone_dir)?;
+        }
+        None => source.clone_into(&clone_dir).await?,
+    }
+
+    // Locate the SKILL.md: a subdir source narrows the search, otherwise walk
+    // the conventional locations. Re-validate the subdir at the join site —
+    // the parse-time guard is not enough for sources built by other callers.
+    let search_root = match source.subdir() {
+        Some(sub) => {
+            if !crate::source::subdir_is_safe(sub) {
+                return Err(Error::InvalidSource(format!("unsafe subdir path: {sub}")));
+            }
+            clone_dir.join(sub)
+        }
+        None => clone_dir.clone(),
+    };
+    let discovered = frontmatter::discover_all_skills(&search_root);
+    let (skill_md, fm) = match select {
+        Some(name) => discovered
+            .into_iter()
+            .find(|(_, fm)| fm.name == name)
+            .ok_or_else(|| Error::NoSkillFound(format!("{name} in {}", search_root.display())))?,
+        None => {
+            if discovered.len() > 1 {
+                let mut names: Vec<&str> =
+                    discovered.iter().map(|(_, fm)| fm.name.as_str()).collect();
+                names.sort_unstable();
+                return Err(Error::AmbiguousSkill(names.join(", ")));
+            }
+            discovered
+                .into_iter()
+                .next()
+                .ok_or_else(|| Error::NoSkillFound(search_root.display().to_string()))?
+        }
+    };
+    let skill_src_dir = skill_md
+        .parent()
+        .ok_or_else(|| Error::Io("SKILL.md has no parent directory".to_string()))?
+        .to_path_buf();
+
+    let install_name = install_as.unwrap_or(&fm.name);
+    let dest = target.skill_dir(install_name)?;
+    let was_updated = dest.exists();
+    if was_updated && !overwrite {
+        return Err(Error::AlreadyInstalled(
+            install_name.to_string(),
+            dest.display().to_string(),
+        ));
+    }
+    let parent = dest
+        .parent()
+        .ok_or_else(|| Error::Io(format!("{} has no parent", dest.display())))?;
+    std::fs::create_dir_all(parent)
+        .map_err(|e| Error::Io(format!("creating {}: {e}", parent.display())))?;
+
+    // Stage into a sibling directory then atomically rename into place, so a
+    // mid-copy failure never destroys a previously-working install.
+    let staging = Staging::new(parent, install_name)?;
+    copy_dir(&skill_src_dir, &staging.path)?;
+    if was_updated {
+        std::fs::remove_dir_all(&dest)
+            .map_err(|e| Error::Io(format!("replacing {}: {e}", dest.display())))?;
+    }
+    std::fs::rename(&staging.path, &dest)
+        .map_err(|e| Error::Io(format!("installing into {}: {e}", dest.display())))?;
+    staging.disarm();
+
+    Ok(InstallOutcome {
+        name: install_name.to_string(),
+        dest,
+        was_updated,
+    })
+}
+
+/// Remove an installed skill by name. Errors when it is not installed.
+pub fn remove(name: &str, target: &InstallTarget) -> Result<PathBuf> {
+    let dir = target.skill_dir(name)?;
+    if !dir.exists() {
+        return Err(Error::Io(format!(
+            "skill {name:?} is not installed at {}",
+            dir.display()
+        )));
+    }
+    std::fs::remove_dir_all(&dir)
+        .map_err(|e| Error::Io(format!("removing {}: {e}", dir.display())))?;
+    Ok(dir)
+}
+
+/// List installed skills under `target` as `(name, path)` pairs. Returns an
+/// empty list when the skills directory does not exist.
+pub fn list_installed(target: &InstallTarget) -> Result<Vec<(String, PathBuf)>> {
+    let root = target.skills_root()?;
+    let Ok(entries) = std::fs::read_dir(&root) else {
+        return Ok(Vec::new());
+    };
+    let mut out = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.join("SKILL.md").is_file()
+            && let Some(name) = path.file_name().and_then(|n| n.to_str())
+        {
+            out.push((name.to_string(), path));
+        }
+    }
+    out.sort_by(|a, b| a.0.cmp(&b.0));
+    Ok(out)
+}
+
+/// Recursively copy `src` into `dst`, skipping any `.git` directory.
+fn copy_dir(src: &Path, dst: &Path) -> Result<()> {
+    std::fs::create_dir_all(dst)
+        .map_err(|e| Error::Io(format!("creating {}: {e}", dst.display())))?;
+    let entries =
+        std::fs::read_dir(src).map_err(|e| Error::Io(format!("reading {}: {e}", src.display())))?;
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        if name == ".git" {
+            continue;
+        }
+        let from = entry.path();
+        let to = dst.join(&name);
+        let file_type = entry
+            .file_type()
+            .map_err(|e| Error::Io(format!("statting {}: {e}", from.display())))?;
+        // Skip symlinks: `std::fs::copy` follows them, so a planted link (e.g.
+        // to `~/.ssh/id_rsa`) would otherwise exfiltrate file contents into the
+        // installed skill. A skill never legitimately needs a symlink.
+        if file_type.is_symlink() {
+            continue;
+        }
+        if file_type.is_dir() {
+            copy_dir(&from, &to)?;
+        } else if file_type.is_file() {
+            std::fs::copy(&from, &to)
+                .map_err(|e| Error::Io(format!("copying {}: {e}", from.display())))?;
+        }
+        // Non-regular files (FIFOs, sockets, device nodes) are skipped:
+        // `std::fs::copy` on them can block or error, and a skill never needs
+        // them.
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_names_accepted() {
+        for name in ["skill", "my-skill", "my_skill", "skill.v2", "abc123"] {
+            assert!(validate_skill_name(name).is_ok(), "{name} should be valid");
+        }
+    }
+
+    #[test]
+    fn traversal_and_illegal_names_rejected() {
+        for name in [
+            "",
+            ".hidden",
+            "../evil",
+            "a/b",
+            "a\\b",
+            "..",
+            "with space",
+            "emoji😀",
+        ] {
+            assert!(
+                matches!(validate_skill_name(name), Err(Error::InvalidSkillName(_))),
+                "{name:?} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn project_skill_dir_is_deterministic() {
+        let target = InstallTarget::Project {
+            project_root: PathBuf::from("/tmp/proj"),
+        };
+        assert_eq!(
+            target.skill_dir("alpha").unwrap(),
+            PathBuf::from("/tmp/proj/.claude/skills/alpha")
+        );
+    }
+
+    #[test]
+    fn skill_dir_rejects_bad_name() {
+        let target = InstallTarget::Project {
+            project_root: PathBuf::from("/tmp/proj"),
+        };
+        assert!(matches!(
+            target.skill_dir("../escape"),
+            Err(Error::InvalidSkillName(_))
+        ));
+    }
+
+    #[test]
+    fn list_installed_empty_when_missing() {
+        let target = InstallTarget::Project {
+            project_root: PathBuf::from("/tmp/does-not-exist-brskills"),
+        };
+        assert!(list_installed(&target).unwrap().is_empty());
+    }
+
+    #[test]
+    fn list_and_remove_roundtrip() {
+        let root = unique_dir("listremove");
+        let target = InstallTarget::Project {
+            project_root: root.clone(),
+        };
+        let skill_dir = target.skill_dir("alpha").unwrap();
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: alpha\ndescription: d\n---\n",
+        )
+        .unwrap();
+
+        let listed = list_installed(&target).unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].0, "alpha");
+
+        let removed = remove("alpha", &target).unwrap();
+        assert!(!removed.exists());
+        assert!(list_installed(&target).unwrap().is_empty());
+
+        assert!(remove("alpha", &target).is_err());
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[tokio::test]
+    async fn installs_from_a_local_git_repo() {
+        if !git_available() {
+            eprintln!("skipping: git not available");
+            return;
+        }
+        let base = unique_dir("install-git");
+        // Build a source repo with a SKILL.md under skills/demo/.
+        let repo = base.join("source-repo");
+        let skill = repo.join("skills").join("demo");
+        std::fs::create_dir_all(&skill).unwrap();
+        std::fs::write(
+            skill.join("SKILL.md"),
+            "---\nname: demo\ndescription: A demo skill.\n---\n\n# Demo\n",
+        )
+        .unwrap();
+        std::fs::write(skill.join("extra.md"), "sidecar").unwrap();
+        git_init_commit(&repo);
+
+        let project = base.join("project");
+        std::fs::create_dir_all(&project).unwrap();
+        let target = InstallTarget::Project {
+            project_root: project.clone(),
+        };
+        // Clone the whole repo (no subdir narrowing) and let discovery find it.
+        let source = SkillSource::Url {
+            url: repo.display().to_string(),
+            git_ref: None,
+        };
+
+        let outcome = install(&source, &target, false, None, None)
+            .await
+            .expect("install ok");
+        assert_eq!(outcome.name, "demo");
+        assert!(!outcome.was_updated);
+        let dest = project.join(".claude/skills/demo");
+        assert!(dest.join("SKILL.md").is_file());
+        assert!(dest.join("extra.md").is_file());
+        // .git must not be copied into the install.
+        assert!(!dest.join(".git").exists());
+
+        // Re-install without overwrite fails; with overwrite updates.
+        assert!(matches!(
+            install(&source, &target, false, None, None).await,
+            Err(Error::AlreadyInstalled(_, _))
+        ));
+        let again = install(&source, &target, true, None, None)
+            .await
+            .expect("overwrite ok");
+        assert!(again.was_updated);
+
+        std::fs::remove_dir_all(&base).ok();
+    }
+
+    #[tokio::test]
+    async fn installs_selected_skill_from_multi_skill_repo() {
+        if !git_available() {
+            eprintln!("skipping: git not available");
+            return;
+        }
+        let base = unique_dir("install-select");
+        let repo = base.join("source-repo");
+        for name in ["one", "two"] {
+            let skill = repo.join("skills").join(name);
+            std::fs::create_dir_all(&skill).unwrap();
+            std::fs::write(
+                skill.join("SKILL.md"),
+                format!("---\nname: {name}\ndescription: d\n---\n"),
+            )
+            .unwrap();
+        }
+        git_init_commit(&repo);
+
+        let project = base.join("project");
+        std::fs::create_dir_all(&project).unwrap();
+        let target = InstallTarget::Project {
+            project_root: project.clone(),
+        };
+        let source = SkillSource::Url {
+            url: repo.display().to_string(),
+            git_ref: None,
+        };
+
+        let outcome = install(&source, &target, false, Some("two"), None)
+            .await
+            .expect("install selected");
+        assert_eq!(outcome.name, "two");
+        assert!(project.join(".claude/skills/two/SKILL.md").is_file());
+        assert!(!project.join(".claude/skills/one").exists());
+
+        // Selecting a non-existent skill errors.
+        assert!(matches!(
+            install(&source, &target, false, Some("nope"), None).await,
+            Err(Error::NoSkillFound(_))
+        ));
+
+        std::fs::remove_dir_all(&base).ok();
+    }
+
+    #[tokio::test]
+    async fn installs_from_a_local_directory() {
+        let base = unique_dir("install-local");
+        // A plain (non-git) local skill directory.
+        let skill = base.join("src").join("skills").join("local-demo");
+        std::fs::create_dir_all(&skill).unwrap();
+        std::fs::write(
+            skill.join("SKILL.md"),
+            "---\nname: local-demo\ndescription: d\n---\n",
+        )
+        .unwrap();
+
+        let project = base.join("project");
+        std::fs::create_dir_all(&project).unwrap();
+        let target = InstallTarget::Project {
+            project_root: project.clone(),
+        };
+        let source = SkillSource::Local {
+            path: base.join("src"),
+        };
+
+        let outcome = install(&source, &target, false, None, None)
+            .await
+            .expect("local install ok");
+        assert_eq!(outcome.name, "local-demo");
+        assert!(project.join(".claude/skills/local-demo/SKILL.md").is_file());
+
+        std::fs::remove_dir_all(&base).ok();
+    }
+
+    #[tokio::test]
+    async fn ambiguous_multi_skill_errors_without_select() {
+        let base = unique_dir("ambiguous");
+        let src = base.join("src").join("skills");
+        for name in ["one", "two"] {
+            let d = src.join(name);
+            std::fs::create_dir_all(&d).unwrap();
+            std::fs::write(
+                d.join("SKILL.md"),
+                format!("---\nname: {name}\ndescription: d\n---\n"),
+            )
+            .unwrap();
+        }
+        let target = InstallTarget::Project {
+            project_root: base.join("project"),
+        };
+        let source = SkillSource::Local {
+            path: base.join("src"),
+        };
+        let err = install(&source, &target, false, None, None)
+            .await
+            .expect_err("ambiguous");
+        assert!(matches!(err, Error::AmbiguousSkill(_)));
+        std::fs::remove_dir_all(&base).ok();
+    }
+
+    #[tokio::test]
+    async fn install_as_overrides_directory_name() {
+        let base = unique_dir("install-as");
+        let src = base.join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        // Frontmatter name differs from the directory we install under.
+        std::fs::write(
+            src.join("SKILL.md"),
+            "---\nname: upstream-name\ndescription: d\n---\n",
+        )
+        .unwrap();
+        let project = base.join("project");
+        let target = InstallTarget::Project {
+            project_root: project.clone(),
+        };
+        let source = SkillSource::Local { path: src };
+
+        let outcome = install(&source, &target, true, None, Some("pinned-dir"))
+            .await
+            .expect("install_as");
+        assert_eq!(outcome.name, "pinned-dir");
+        assert!(project.join(".claude/skills/pinned-dir/SKILL.md").is_file());
+        assert!(!project.join(".claude/skills/upstream-name").exists());
+        std::fs::remove_dir_all(&base).ok();
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn install_skips_symlinks() {
+        let base = unique_dir("install-symlink");
+        let src = base.join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::write(
+            src.join("SKILL.md"),
+            "---\nname: linky\ndescription: d\n---\n",
+        )
+        .unwrap();
+        // Plant a secret outside the source and a symlink to it inside.
+        let secret = base.join("secret.txt");
+        std::fs::write(&secret, "TOP SECRET").unwrap();
+        std::os::unix::fs::symlink(&secret, src.join("leak.txt")).unwrap();
+
+        let project = base.join("project");
+        std::fs::create_dir_all(&project).unwrap();
+        let target = InstallTarget::Project {
+            project_root: project.clone(),
+        };
+        let source = SkillSource::Local { path: src };
+        install(&source, &target, false, None, None)
+            .await
+            .expect("install");
+
+        let dest = project.join(".claude/skills/linky");
+        assert!(dest.join("SKILL.md").is_file());
+        // The symlink must not have been copied (no leaked content).
+        assert!(!dest.join("leak.txt").exists());
+        std::fs::remove_dir_all(&base).ok();
+    }
+
+    fn git_available() -> bool {
+        std::process::Command::new("git")
+            .arg("--version")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+
+    fn git_init_commit(repo: &Path) {
+        let run = |args: &[&str]| {
+            let ok = std::process::Command::new("git")
+                .args(args)
+                .current_dir(repo)
+                .env("GIT_AUTHOR_NAME", "t")
+                .env("GIT_AUTHOR_EMAIL", "t@t")
+                .env("GIT_COMMITTER_NAME", "t")
+                .env("GIT_COMMITTER_EMAIL", "t@t")
+                .output()
+                .unwrap()
+                .status
+                .success();
+            assert!(ok, "git {args:?} failed");
+        };
+        run(&["init", "-q"]);
+        run(&["add", "-A"]);
+        run(&["commit", "-q", "-m", "init"]);
+    }
+
+    fn unique_dir(label: &str) -> PathBuf {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir =
+            std::env::temp_dir().join(format!("brskills-inst-{label}-{}-{id}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+}

--- a/crates/bitrouter-skills/src/lib.rs
+++ b/crates/bitrouter-skills/src/lib.rs
@@ -1,0 +1,73 @@
+//! # bitrouter-skills
+//!
+//! Shared, framework-agnostic building blocks for BitRouter's skills gateway:
+//!
+//! - [`source`] — parse a skill source string (`owner/repo`, a git URL, a
+//!   subdirectory, or a registry name) into a [`source::SkillSource`] and fetch
+//!   it onto disk.
+//! - [`frontmatter`] — parse the YAML frontmatter of a `SKILL.md` and discover
+//!   skills under a directory tree.
+//! - [`marketplace`] — the `marketplace.json` wire types shared by the server
+//!   registry and the client installer.
+//! - [`install`] — clone/copy a resolved skill into an agent's skills
+//!   directory.
+//!
+//! This crate has no dependency on `bitrouter-sdk`; it is consumed by both the
+//! `bitrouter` CLI (client side) and, later, the server-side registry.
+
+#![forbid(unsafe_code)]
+
+pub mod frontmatter;
+pub mod install;
+pub mod marketplace;
+pub mod source;
+
+/// Errors produced across the skills crate.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// A source string could not be parsed into a [`source::SkillSource`].
+    #[error("invalid skill source: {0}")]
+    InvalidSource(String),
+    /// A `SKILL.md` was missing its YAML frontmatter block.
+    #[error("SKILL.md has no YAML frontmatter block")]
+    MissingFrontmatter,
+    /// The YAML frontmatter failed to deserialize.
+    #[error("frontmatter parse error: {0}")]
+    Frontmatter(String),
+    /// No `SKILL.md` was found while walking a fetched source tree.
+    #[error("no SKILL.md found under {0}")]
+    NoSkillFound(String),
+    /// The source exposes several skills and none was selected.
+    #[error("source exposes multiple skills ({0}); choose one with --skill <name>")]
+    AmbiguousSkill(String),
+    /// A skill name failed validation (path-traversal / illegal characters).
+    #[error(
+        "invalid skill name {0:?}: names may contain only ASCII letters, digits, '-', '_', '.' and may not start with '.' or contain path separators"
+    )]
+    InvalidSkillName(String),
+    /// A skill was already installed and overwrite was not requested.
+    #[error("skill {0:?} is already installed at {1}; pass --yes to overwrite")]
+    AlreadyInstalled(String, String),
+    /// The `git` binary failed or is unavailable.
+    #[error("git error: {0}")]
+    Git(String),
+    /// An HTTP request to a registry failed.
+    #[error("registry request error: {0}")]
+    Http(String),
+    /// A filesystem operation failed.
+    #[error("io error: {0}")]
+    Io(String),
+}
+
+/// Crate result alias.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Resolve the current user's home directory from the environment
+/// (`HOME` on Unix, `USERPROFILE` on Windows).
+pub(crate) fn home_dir() -> Result<std::path::PathBuf> {
+    let var = if cfg!(windows) { "USERPROFILE" } else { "HOME" };
+    std::env::var_os(var)
+        .filter(|v| !v.is_empty())
+        .map(std::path::PathBuf::from)
+        .ok_or_else(|| Error::Io(format!("could not resolve home directory (${var} unset)")))
+}

--- a/crates/bitrouter-skills/src/marketplace.rs
+++ b/crates/bitrouter-skills/src/marketplace.rs
@@ -1,0 +1,141 @@
+//! The `marketplace.json` wire types shared by the server-side registry and the
+//! client installer, plus helpers to fetch and search a registry.
+//!
+//! This is BitRouter's own registry shape (a flat skill list whose `source`
+//! field is any string accepted by [`crate::source::parse_source`]). The
+//! Claude Code plugin manifest is a distinct, server-only serialization built
+//! on top of these rows.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{Error, Result};
+
+/// Public hub endpoint served by a bitrouter registry, relative to its base
+/// URL.
+const HUB_PATH: &str = "/v1/skills/hub";
+
+/// A single entry in a registry marketplace.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MarketplaceEntry {
+    /// Canonical skill name / slug.
+    pub name: String,
+    /// Human-readable description.
+    pub description: String,
+    /// Source string, parseable by [`crate::source::parse_source`].
+    pub source: String,
+    /// Optional version label (informational; resolution uses `source`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    /// Optional maintainer.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub author: Option<String>,
+    /// Free-form tags used for `find` filtering.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<String>,
+}
+
+/// The body of a registry hub / marketplace response.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Marketplace {
+    /// Available skills.
+    #[serde(default)]
+    pub skills: Vec<MarketplaceEntry>,
+}
+
+impl Marketplace {
+    /// Find an entry by exact name.
+    pub fn find(&self, name: &str) -> Option<&MarketplaceEntry> {
+        self.skills.iter().find(|e| e.name == name)
+    }
+
+    /// Entries whose name, description, or tags contain `query`
+    /// (case-insensitive).
+    pub fn search(&self, query: &str) -> Vec<&MarketplaceEntry> {
+        let q = query.to_lowercase();
+        self.skills
+            .iter()
+            .filter(|e| {
+                e.name.to_lowercase().contains(&q)
+                    || e.description.to_lowercase().contains(&q)
+                    || e.tags.iter().any(|t| t.to_lowercase().contains(&q))
+            })
+            .collect()
+    }
+}
+
+/// Fetch the marketplace from a bitrouter registry base URL (e.g.
+/// `https://api.bitrouter.ai`).
+pub async fn fetch_marketplace(
+    client: &reqwest::Client,
+    registry_base: &str,
+) -> Result<Marketplace> {
+    let base = registry_base.trim_end_matches('/');
+    let url = format!("{base}{HUB_PATH}");
+    let resp = client
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| Error::Http(format!("GET {url}: {e}")))?;
+    if !resp.status().is_success() {
+        return Err(Error::Http(format!("GET {url}: status {}", resp.status())));
+    }
+    resp.json::<Marketplace>()
+        .await
+        .map_err(|e| Error::Http(format!("decoding marketplace from {url}: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> Marketplace {
+        serde_json::from_str(
+            r#"{
+                "skills": [
+                    {"name": "alpha", "description": "First skill", "source": "o/alpha", "tags": ["cli", "build"]},
+                    {"name": "beta", "description": "Second skill", "source": "o/beta", "version": "2.0.0", "author": "me"}
+                ]
+            }"#,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn deserializes_entries() {
+        let m = sample();
+        assert_eq!(m.skills.len(), 2);
+        assert_eq!(m.skills[1].version.as_deref(), Some("2.0.0"));
+        assert_eq!(m.skills[1].author.as_deref(), Some("me"));
+        assert!(m.skills[1].tags.is_empty());
+    }
+
+    #[test]
+    fn find_by_exact_name() {
+        let m = sample();
+        assert_eq!(m.find("beta").map(|e| e.source.as_str()), Some("o/beta"));
+        assert!(m.find("missing").is_none());
+    }
+
+    #[test]
+    fn search_matches_name_description_and_tags() {
+        let m = sample();
+        assert_eq!(m.search("first").len(), 1);
+        assert_eq!(m.search("build")[0].name, "alpha");
+        assert_eq!(m.search("skill").len(), 2);
+        assert!(m.search("nope").is_empty());
+    }
+
+    #[test]
+    fn round_trips_through_json() {
+        let m = sample();
+        let json = serde_json::to_string(&m).unwrap();
+        let back: Marketplace = serde_json::from_str(&json).unwrap();
+        assert_eq!(m, back);
+    }
+
+    #[test]
+    fn empty_marketplace_default() {
+        let m: Marketplace = serde_json::from_str("{}").unwrap();
+        assert!(m.skills.is_empty());
+    }
+}

--- a/crates/bitrouter-skills/src/source.rs
+++ b/crates/bitrouter-skills/src/source.rs
@@ -1,0 +1,510 @@
+//! Parsing a skill source string into a [`SkillSource`] and fetching it onto
+//! disk.
+//!
+//! Accepted forms (auto-detected, mirroring the wider ecosystem):
+//!
+//! - `owner/repo` — GitHub shorthand → [`SkillSource::Github`]
+//! - `https://github.com/owner/repo[.git]` → [`SkillSource::Github`]
+//! - `https://github.com/owner/repo/tree/<ref>/<subdir>` → [`SkillSource::GitSubdir`]
+//! - any other `https://…` / `git://…` / `git@…` URL → [`SkillSource::Url`]
+//!
+//! A trailing `#<ref>` fragment on a shorthand or plain URL selects a branch,
+//! tag, or commit.
+
+use std::path::{Path, PathBuf};
+
+use crate::{Error, Result};
+
+/// A resolved, fetchable skill source.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SkillSource {
+    /// A GitHub repository referenced by `owner/repo`.
+    Github {
+        owner: String,
+        repo: String,
+        git_ref: Option<String>,
+    },
+    /// Any git-cloneable URL that is not a recognised GitHub repo.
+    Url {
+        url: String,
+        git_ref: Option<String>,
+    },
+    /// A sub-directory within a git repository.
+    GitSubdir {
+        url: String,
+        path: String,
+        git_ref: Option<String>,
+    },
+    /// A local directory on disk (the tree is copied, not cloned).
+    Local { path: PathBuf },
+}
+
+/// Split a trailing `#<ref>` fragment off a shorthand/URL.
+fn split_ref(input: &str) -> (&str, Option<String>) {
+    match input.split_once('#') {
+        Some((head, frag)) if !frag.is_empty() => (head, Some(frag.to_string())),
+        _ => (input, None),
+    }
+}
+
+/// Build the canonical HTTPS clone URL for a GitHub repo.
+pub(crate) fn github_clone_url(owner: &str, repo: &str) -> String {
+    format!("https://github.com/{owner}/{repo}.git")
+}
+
+/// Whether a subdirectory path is safe to join onto a clone root: no `..`
+/// components and not absolute. Guards against a crafted source escaping the
+/// temporary clone directory. Enforced both at parse time and again at the
+/// join site in `install`.
+pub(crate) fn subdir_is_safe(subdir: &str) -> bool {
+    !subdir.is_empty()
+        && !subdir.starts_with('/')
+        && !subdir.split(['/', '\\']).any(|seg| seg == "..")
+}
+
+/// Interpret a `github.com` URL path as either a whole repo or a subdirectory
+/// (`/owner/repo/tree/<ref>/<subdir…>`). An explicit `#<ref>` fragment (`frag`)
+/// takes precedence over a `tree/<ref>` path segment.
+fn github_from_path(segments: &[&str], frag: Option<String>) -> Option<SkillSource> {
+    let owner = (*segments.first()?).to_string();
+    let repo = segments.get(1)?.trim_end_matches(".git").to_string();
+    if owner.is_empty() || repo.is_empty() {
+        return None;
+    }
+    // /owner/repo/tree/<ref>/<subdir...>  or  /blob/...
+    if matches!(segments.get(2), Some(&"tree") | Some(&"blob"))
+        && let Some(tree_ref) = segments.get(3)
+    {
+        let git_ref = frag.or_else(|| Some((*tree_ref).to_string()));
+        let subdir = segments[4..].join("/");
+        if subdir.is_empty() {
+            return Some(SkillSource::Github {
+                owner,
+                repo,
+                git_ref,
+            });
+        }
+        if !subdir_is_safe(&subdir) {
+            return None;
+        }
+        return Some(SkillSource::GitSubdir {
+            url: github_clone_url(&owner, &repo),
+            path: subdir,
+            git_ref,
+        });
+    }
+    Some(SkillSource::Github {
+        owner,
+        repo,
+        git_ref: frag,
+    })
+}
+
+/// Expand a leading `~` / `~/` in a local path to the home directory.
+fn expand_home(path: &str) -> Result<PathBuf> {
+    if path == "~" {
+        return crate::home_dir();
+    }
+    if let Some(rest) = path.strip_prefix("~/") {
+        return Ok(crate::home_dir()?.join(rest));
+    }
+    Ok(PathBuf::from(path))
+}
+
+/// Whether a source string denotes a local filesystem path rather than a git
+/// source or shorthand. Only explicit path forms qualify, so `owner/repo` is
+/// never mistaken for a path.
+fn looks_local(s: &str) -> bool {
+    s == "."
+        || s == ".."
+        || s.starts_with("./")
+        || s.starts_with("../")
+        || s.starts_with('/')
+        || s.starts_with("~/")
+        || s == "~"
+        || (cfg!(windows) && s.starts_with(".\\"))
+}
+
+/// Parse a source string into a [`SkillSource`].
+pub fn parse_source(input: &str) -> Result<SkillSource> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return Err(Error::InvalidSource("empty source".to_string()));
+    }
+
+    // Local filesystem paths (explicit `./`, `../`, `/`, `~/` forms).
+    if looks_local(trimmed) {
+        return Ok(SkillSource::Local {
+            path: expand_home(trimmed)?,
+        });
+    }
+
+    // Plain-HTTP sources are refused: a skill is executable content, so an
+    // on-path attacker must not be able to swap it via an unauthenticated
+    // channel. Require `https://`.
+    if trimmed.starts_with("http://") {
+        return Err(Error::InvalidSource(format!(
+            "plain-HTTP sources are not allowed (use https://): {trimmed}"
+        )));
+    }
+
+    // Split a trailing `#<ref>` once, up-front, so every branch handles it
+    // uniformly (the fragment was previously dropped for github subdir URLs).
+    let (head, frag) = split_ref(trimmed);
+
+    // Explicit HTTPS URLs.
+    if let Some(rest) = head.strip_prefix("https://") {
+        let mut host_and_path = rest.splitn(2, '/');
+        let host = host_and_path.next().unwrap_or_default();
+        let path = host_and_path.next().unwrap_or_default();
+        if host.eq_ignore_ascii_case("github.com") {
+            let segments: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
+            return github_from_path(&segments, frag)
+                .ok_or_else(|| Error::InvalidSource(format!("not a GitHub repo URL: {trimmed}")));
+        }
+        return Ok(SkillSource::Url {
+            url: head.to_string(),
+            git_ref: frag,
+        });
+    }
+
+    // scp-style git remotes (`git@host:owner/repo.git`) and `git://` URLs.
+    if head.starts_with("git@") || head.starts_with("git://") {
+        return Ok(SkillSource::Url {
+            url: head.to_string(),
+            git_ref: frag,
+        });
+    }
+
+    // Reject any other explicit scheme (e.g. `file://`, `ssh://`-less typos).
+    if head.contains("://") {
+        return Err(Error::InvalidSource(format!(
+            "unsupported scheme: {trimmed}"
+        )));
+    }
+
+    // Bare `github.com/owner/repo[/tree/<ref>/<subdir>]` (no scheme).
+    if let Some(path) = head.strip_prefix("github.com/") {
+        let segments: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
+        return github_from_path(&segments, frag)
+            .ok_or_else(|| Error::InvalidSource(format!("not a GitHub repo: {trimmed}")));
+    }
+
+    // GitHub shorthand `owner/repo` (exactly two non-empty segments).
+    let segments: Vec<&str> = head.split('/').filter(|s| !s.is_empty()).collect();
+    if segments.len() == 2 {
+        return Ok(SkillSource::Github {
+            owner: segments[0].to_string(),
+            repo: segments[1].trim_end_matches(".git").to_string(),
+            git_ref: frag,
+        });
+    }
+
+    Err(Error::InvalidSource(format!(
+        "unrecognised source {trimmed:?}; expected owner/repo, a git URL, or a github.com URL"
+    )))
+}
+
+impl SkillSource {
+    /// The branch/tag/commit selected, if any.
+    fn git_ref(&self) -> Option<&str> {
+        match self {
+            SkillSource::Github { git_ref, .. }
+            | SkillSource::Url { git_ref, .. }
+            | SkillSource::GitSubdir { git_ref, .. } => git_ref.as_deref(),
+            SkillSource::Local { .. } => None,
+        }
+    }
+
+    /// The clone URL for git sources.
+    fn clone_url(&self) -> Option<String> {
+        match self {
+            SkillSource::Github { owner, repo, .. } => Some(github_clone_url(owner, repo)),
+            SkillSource::Url { url, .. } | SkillSource::GitSubdir { url, .. } => Some(url.clone()),
+            SkillSource::Local { .. } => None,
+        }
+    }
+
+    /// The local path, when this is a [`SkillSource::Local`].
+    pub(crate) fn local_path(&self) -> Option<&Path> {
+        match self {
+            SkillSource::Local { path } => Some(path.as_path()),
+            _ => None,
+        }
+    }
+
+    /// The subdirectory within the fetched tree that holds the skill, if the
+    /// source narrows to one.
+    pub(crate) fn subdir(&self) -> Option<&str> {
+        match self {
+            SkillSource::GitSubdir { path, .. } => Some(path.as_str()),
+            _ => None,
+        }
+    }
+
+    /// Clone this source into `dest_dir` via the system `git` binary. A shallow
+    /// clone is used; a `git_ref` selects the branch/tag. Errors for a
+    /// [`SkillSource::Local`] source, which is copied rather than cloned.
+    pub async fn clone_into(&self, dest_dir: &Path) -> Result<()> {
+        let url = self
+            .clone_url()
+            .ok_or_else(|| Error::Git("local sources are copied, not cloned".to_string()))?;
+        // Reject any ref or URL that would be parsed as a git option (e.g.
+        // `#--upload-pack=…`), which would otherwise be an argument-injection
+        // path to arbitrary command execution.
+        if url.starts_with('-') {
+            return Err(Error::Git(format!(
+                "refusing clone URL starting with '-': {url}"
+            )));
+        }
+        let mut cmd = tokio::process::Command::new("git");
+        cmd.arg("clone").arg("--depth").arg("1");
+        if let Some(git_ref) = self.git_ref() {
+            if git_ref.starts_with('-') {
+                return Err(Error::Git(format!(
+                    "refusing git ref starting with '-': {git_ref}"
+                )));
+            }
+            cmd.arg("--branch").arg(git_ref);
+        }
+        // `--` ends option parsing so the URL and destination can never be
+        // interpreted as flags.
+        cmd.arg("--");
+        cmd.arg(url);
+        cmd.arg(dest_dir);
+        let output = cmd
+            .output()
+            .await
+            .map_err(|e| Error::Git(format!("running git clone: {e}")))?;
+        if !output.status.success() {
+            return Err(Error::Git(format!(
+                "git clone failed: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            )));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shorthand_owner_repo() {
+        let s = parse_source("vercel-labs/skills").unwrap();
+        assert_eq!(
+            s,
+            SkillSource::Github {
+                owner: "vercel-labs".to_string(),
+                repo: "skills".to_string(),
+                git_ref: None,
+            }
+        );
+    }
+
+    #[test]
+    fn shorthand_with_ref() {
+        let s = parse_source("owner/repo#v1.2.0").unwrap();
+        assert_eq!(
+            s,
+            SkillSource::Github {
+                owner: "owner".to_string(),
+                repo: "repo".to_string(),
+                git_ref: Some("v1.2.0".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn shorthand_strips_git_suffix() {
+        let s = parse_source("owner/repo.git").unwrap();
+        assert_eq!(
+            s,
+            SkillSource::Github {
+                owner: "owner".to_string(),
+                repo: "repo".to_string(),
+                git_ref: None,
+            }
+        );
+    }
+
+    #[test]
+    fn full_github_url() {
+        let s = parse_source("https://github.com/owner/repo").unwrap();
+        assert_eq!(
+            s,
+            SkillSource::Github {
+                owner: "owner".to_string(),
+                repo: "repo".to_string(),
+                git_ref: None,
+            }
+        );
+    }
+
+    #[test]
+    fn full_github_url_with_dot_git() {
+        let s = parse_source("https://github.com/owner/repo.git").unwrap();
+        assert!(matches!(s, SkillSource::Github { repo, .. } if repo == "repo"));
+    }
+
+    #[test]
+    fn github_tree_subdir() {
+        let s = parse_source("https://github.com/owner/repo/tree/main/skills/foo").unwrap();
+        assert_eq!(
+            s,
+            SkillSource::GitSubdir {
+                url: "https://github.com/owner/repo.git".to_string(),
+                path: "skills/foo".to_string(),
+                git_ref: Some("main".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn github_tree_no_subdir_is_repo_on_branch() {
+        let s = parse_source("https://github.com/owner/repo/tree/dev").unwrap();
+        assert_eq!(
+            s,
+            SkillSource::Github {
+                owner: "owner".to_string(),
+                repo: "repo".to_string(),
+                git_ref: Some("dev".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn bare_github_host_path() {
+        let s = parse_source("github.com/owner/repo").unwrap();
+        assert!(matches!(s, SkillSource::Github { owner, .. } if owner == "owner"));
+    }
+
+    #[test]
+    fn non_github_url_is_plain_url() {
+        let s = parse_source("https://gitlab.com/org/repo").unwrap();
+        assert_eq!(
+            s,
+            SkillSource::Url {
+                url: "https://gitlab.com/org/repo".to_string(),
+                git_ref: None,
+            }
+        );
+    }
+
+    #[test]
+    fn scp_git_remote_is_url() {
+        let s = parse_source("git@github.com:owner/repo.git").unwrap();
+        assert!(matches!(s, SkillSource::Url { .. }));
+    }
+
+    #[test]
+    fn empty_is_rejected() {
+        assert!(matches!(parse_source("   "), Err(Error::InvalidSource(_))));
+    }
+
+    #[test]
+    fn github_subdir_url_keeps_explicit_ref() {
+        // An explicit `#<ref>` fragment must override the tree ref and not be
+        // dropped for a subdir source.
+        let s = parse_source("https://github.com/o/r/tree/main/skills/foo#v2.0").unwrap();
+        assert_eq!(
+            s,
+            SkillSource::GitSubdir {
+                url: "https://github.com/o/r.git".to_string(),
+                path: "skills/foo".to_string(),
+                git_ref: Some("v2.0".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn bare_github_subdir_keeps_tree_ref() {
+        let s = parse_source("github.com/o/r/tree/dev/sub").unwrap();
+        assert_eq!(
+            s,
+            SkillSource::GitSubdir {
+                url: "https://github.com/o/r.git".to_string(),
+                path: "sub".to_string(),
+                git_ref: Some("dev".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn http_scheme_is_rejected() {
+        assert!(matches!(
+            parse_source("http://github.com/o/r"),
+            Err(Error::InvalidSource(_))
+        ));
+    }
+
+    #[test]
+    fn github_subdir_traversal_is_rejected() {
+        assert!(matches!(
+            parse_source("https://github.com/o/r/tree/main/../../etc"),
+            Err(Error::InvalidSource(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn clone_into_rejects_option_like_ref() {
+        let source = SkillSource::Github {
+            owner: "o".to_string(),
+            repo: "r".to_string(),
+            git_ref: Some("--upload-pack=/tmp/evil".to_string()),
+        };
+        let dir = std::env::temp_dir().join("brskills-inject-test");
+        let err = source.clone_into(&dir).await.expect_err("must refuse");
+        assert!(matches!(err, Error::Git(_)));
+    }
+
+    #[test]
+    fn file_scheme_is_rejected() {
+        assert!(matches!(
+            parse_source("file:///etc/passwd"),
+            Err(Error::InvalidSource(_))
+        ));
+    }
+
+    #[test]
+    fn single_segment_is_rejected() {
+        assert!(matches!(
+            parse_source("justaname"),
+            Err(Error::InvalidSource(_))
+        ));
+    }
+
+    #[test]
+    fn relative_paths_are_local() {
+        for s in ["./local", "../up", "/abs/path", "."] {
+            assert!(
+                matches!(parse_source(s), Ok(SkillSource::Local { .. })),
+                "{s:?} should be local"
+            );
+        }
+    }
+
+    #[test]
+    fn owner_repo_is_not_local() {
+        assert!(matches!(
+            parse_source("owner/repo"),
+            Ok(SkillSource::Github { .. })
+        ));
+    }
+
+    #[test]
+    fn local_path_accessor() {
+        let s = parse_source("./skills").unwrap();
+        assert_eq!(s.local_path(), Some(Path::new("./skills")));
+        assert_eq!(parse_source("o/r").unwrap().local_path(), None);
+    }
+
+    #[test]
+    fn subdir_accessor() {
+        let s = parse_source("https://github.com/o/r/tree/main/a/b").unwrap();
+        assert_eq!(s.subdir(), Some("a/b"));
+        let s2 = parse_source("o/r").unwrap();
+        assert_eq!(s2.subdir(), None);
+    }
+}


### PR DESCRIPTION
## Summary

Phase 1 (client side) of the BitRouter **skills gateway**: install and manage Claude Code skills from GitHub, git URLs, local paths, or a BitRouter registry — modeled on LiteLLM's skills gateway (server/registry) and vercel-labs/skills (client/installer), which converge on one wire format: `SKILL.md` + frontmatter, git-backed sources, and a registry hub.

> **Stacked PR.** Base is `feat/cli-namespace-scoped-management` so the diff is skills-only. Retarget to `main` once that branch merges.

## What's in it

**New crate `crates/bitrouter-skills`** — framework-agnostic, no `bitrouter-sdk` dependency, consumed by the CLI today and by the (Phase 2) server registry later:

| module | responsibility |
|---|---|
| `source` | parse `owner/repo`, github URLs, `tree/<ref>/<subdir>`, `git`/`git@` URLs, local paths → `SkillSource`; shallow clone via system `git` |
| `frontmatter` | `SKILL.md` YAML frontmatter (serde-saphyr) + discovery over the conventional layout |
| `marketplace` | `Marketplace`/`MarketplaceEntry` wire types + registry hub fetch/search — the contract a Phase 2 backend serves |
| `install` | clone/copy → discover → **atomic stage+rename** into `~/.claude/skills` or `./.claude/skills` |

**New CLI** (app crate, mirrors the `cloud` subcommand layout): `bitrouter skills add | list | remove | find | init | update`, delegating to testable `commands::skills_*` helpers. Documented in `CLI.md`.

## Design decisions

- **Crate vs plugin:** shared logic is a leaf **crate**; the CLI lives in the **app crate** (like `auth`/`metering`/`policy`), because the future server registry must reach app-crate auth — a `plugins/` crate only depends on the sdk. No invasive sdk change was needed.
- **Backend-agnostic client:** the client speaks one contract (`GET {base}/v1/skills/hub` → `Marketplace`, then resolves each skill over git), so it works against whichever backend serves it with no client change.

## Security hardening (two review passes)

- reject git **option-injection** refs (`#--upload-pack=…`) + `--` before clone positionals
- reject `..` subdir traversal at parse **and** at the join site
- skip symlinks and non-regular files when copying (no file exfiltration / FIFO hangs)
- **https-only** sources; validated skill names (no separators / leading dot / `..`)
- atomic stage+rename → a failed overwrite never destroys a working install

## Behavior fixes

- error on **ambiguous** multi-skill sources instead of installing an arbitrary one; deterministic, deduped discovery
- `install_as` keeps `update` re-installing into the same directory even if upstream frontmatter drifts
- `skills update <name>` only touches already-installed skills
- `#<ref>` no longer dropped for github subdir URLs
- blank sources rejected up front with an actionable message

## Verification

- **50** unit/integration tests in the crate (incl. a real `git clone` and symlink-skip), **610** workspace tests green
- `cargo clippy --all-features` and `cargo fmt --check` clean
- Driven end-to-end at the CLI surface: local + `git://` clone-and-install, plus the injection / ambiguity / https / overwrite / update-refusal guards. CLAUDE.md-clean (no `#[allow]`, no prod `unwrap`/`expect`/`panic!`, no re-exports in public mods, no dead code).

## What's next (Phase 2 — separate work, decided)

- **Backend lives in `bitrouter-cloud`, namespaced from day one** (not upstream): a `skills` resource under `/v1/namespaces/{nsid}/skills` + a new **public, pre-auth** `/v1/public/skills/hub` + `marketplace.json`. This makes the default `api.bitrouter.ai` hub answer the client (today it 404s) and gives org-scoped private/public skills via existing namespaces/scopes/audit. The Phase 1 client consumes it with **zero changes**.
- Also lands `bitrouter cloud skills list/create/delete/publish` (cloud-sdk + CLI, mirroring `cloud keys`).
- Open items before coding Phase 2: public-hub aggregation scope (global-curated vs per-namespace); **verify Claude Code's real `.claude-plugin/marketplace.json` schema** before freezing the wire format; trust/moderation posture for a public hub serving executable-content pointers.
- Deferred: bitrouter-hosted skill **content** (tarball bundles) behind the same source abstraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
