### PR TITLE
feat(skills)!: converge marketplace.json on Claude Code native schema

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -381,17 +381,17 @@ Sources are auto-detected:
 - `https://github.com/owner/repo/tree/<ref>/<subdir>` — a skill in a subdirectory
 - any other `https://…`, `git://…`, or `git@…` git URL
 - `./path`, `../path`, `/abs/path`, `~/path` — a local directory (copied, not cloned)
-- a bare `name` — resolved against the registry's public hub (`--registry <URL>`, default `https://api.bitrouter.ai`)
+- a bare `name` — resolved against a namespace's registry hub (`-n/--namespace <NSID>` required; `--registry <URL>`, default `https://api.bitrouter.ai`). The hub is per-namespace: `<registry>/v1/namespaces/<NSID>/skills/hub`.
 
 Git sources are shallow-cloned via the system `git` binary (must be on `PATH`). Plain-HTTP sources are refused (skills are executable content); symlinks in a source tree are skipped, and skill names are validated to prevent path traversal.
 
 ### `bitrouter skills add <source>`
 
 ```
-bitrouter skills add <SOURCE> [--skill <NAME>] [-g|--global] [-y|--yes] [--registry <URL>]
+bitrouter skills add <SOURCE> [--skill <NAME>] [-g|--global] [-y|--yes] [--registry <URL>] [-n|--namespace <NSID>]
 ```
 
-Clones/copies the source, discovers its `SKILL.md`, and installs it. `--skill <NAME>` selects one skill by frontmatter name when the source exposes several. Installing over an existing skill requires `-y/--yes`.
+Clones/copies the source, discovers its `SKILL.md`, and installs it. `--skill <NAME>` selects one skill by frontmatter name when the source exposes several. Installing over an existing skill requires `-y/--yes`. Resolving a bare `name` requires `-n/--namespace <NSID>` (the registry hub is per-namespace).
 
 ### `bitrouter skills list` / `remove`
 
@@ -405,10 +405,10 @@ bitrouter skills remove <NAME> [-g|--global]
 ### `bitrouter skills find <query>`
 
 ```
-bitrouter skills find <QUERY> [--registry <URL>]
+bitrouter skills find <QUERY> [--registry <URL>] [-n|--namespace <NSID>]
 ```
 
-Searches the registry hub, matching `query` against name, description, and tags.
+Searches a namespace's registry hub (`-n/--namespace <NSID>` required), matching `query` against name, description, keywords, and tags.
 
 ### `bitrouter skills init <name>`
 
@@ -421,9 +421,9 @@ Scaffolds a starter `SKILL.md` (default `./SKILL.md`). Refuses to overwrite an e
 ### `bitrouter skills update`
 
 ```
-bitrouter skills update [<NAME>] [-g|--global] [--registry <URL>]
+bitrouter skills update [<NAME>] [-g|--global] [--registry <URL>] [-n|--namespace <NSID>]
 ```
 
-Re-installs installed skills from the registry to their latest version (all installed skills, or just `<NAME>`). Skills absent from the registry are skipped; a per-skill failure is reported without aborting the rest.
+Re-installs installed skills from a namespace's registry hub to their latest version (`-n/--namespace <NSID>` required; all installed skills, or just `<NAME>`). Skills absent from the registry are skipped; a per-skill failure is reported without aborting the rest.
 
 Grant types: `authorization_code`, `refresh_token`, `urn:ietf:params:oauth:grant-type:device_code`. For confidential clients, the freshly minted `client_secret` is returned exactly once in the `register` response.

--- a/apps/bitrouter/src/commands.rs
+++ b/apps/bitrouter/src/commands.rs
@@ -661,16 +661,23 @@ fn is_bare_skill_name(source: &str) -> bool {
     !source.contains('/') && !source.contains("://") && !source.starts_with("git@")
 }
 
-/// Resolve a registry name to its git source string via the marketplace.
-async fn resolve_registry_source(name: &str, registry: Option<&str>) -> Result<String> {
+/// Resolve a registry name to its [`bitrouter_skills::source::SkillSource`] via
+/// the namespace's marketplace hub.
+async fn resolve_registry_source(
+    name: &str,
+    registry: Option<&str>,
+    namespace: &str,
+) -> Result<bitrouter_skills::source::SkillSource> {
     use bitrouter_skills::marketplace;
+    use bitrouter_skills::source::SkillSource;
     let base = registry.unwrap_or(DEFAULT_SKILLS_REGISTRY);
     let client = skills_http_client()?;
-    let market = marketplace::fetch_marketplace(&client, base).await?;
+    let market = marketplace::fetch_marketplace(&client, base, namespace).await?;
     let entry = market
         .find(name)
         .ok_or_else(|| anyhow::anyhow!("skill {name:?} not found in registry {base}"))?;
-    Ok(entry.source.clone())
+    SkillSource::try_from(&entry.source)
+        .with_context(|| format!("resolving registry source for {name:?}"))
 }
 
 /// `bitrouter skills add` — install a skill from a git source or registry name.
@@ -680,6 +687,7 @@ pub async fn skills_add(
     global: bool,
     overwrite: bool,
     registry: Option<&str>,
+    namespace: Option<&str>,
 ) -> Result<()> {
     use bitrouter_skills::{install, source as skill_source};
 
@@ -690,12 +698,13 @@ pub async fn skills_add(
     }
 
     let target = skills_target(global)?;
-    let source_str = if is_bare_skill_name(source) {
-        resolve_registry_source(source, registry).await?
+    let parsed = if is_bare_skill_name(source) {
+        let nsid = namespace
+            .ok_or_else(|| anyhow::anyhow!("--namespace <nsid> is required to query a registry"))?;
+        resolve_registry_source(source, registry, nsid).await?
     } else {
-        source.to_string()
+        skill_source::parse_source(source)?
     };
-    let parsed = skill_source::parse_source(&source_str)?;
     let outcome = install::install(&parsed, &target, overwrite, select, None).await?;
     let verb = if outcome.was_updated {
         "updated"
@@ -731,11 +740,17 @@ pub fn skills_remove(name: &str, global: bool) -> Result<()> {
 }
 
 /// `bitrouter skills find` — search a registry.
-pub async fn skills_find(query: &str, registry: Option<&str>) -> Result<()> {
+pub async fn skills_find(
+    query: &str,
+    registry: Option<&str>,
+    namespace: Option<&str>,
+) -> Result<()> {
     use bitrouter_skills::marketplace;
     let base = registry.unwrap_or(DEFAULT_SKILLS_REGISTRY);
+    let nsid = namespace
+        .ok_or_else(|| anyhow::anyhow!("--namespace <nsid> is required to query a registry"))?;
     let client = skills_http_client()?;
-    let market = marketplace::fetch_marketplace(&client, base).await?;
+    let market = marketplace::fetch_marketplace(&client, base, nsid).await?;
     let hits = market.search(query);
     if hits.is_empty() {
         println!("no skills matching {query:?} in {base}");
@@ -743,7 +758,8 @@ pub async fn skills_find(query: &str, registry: Option<&str>) -> Result<()> {
     }
     for entry in hits {
         let version = entry.version.as_deref().unwrap_or("-");
-        println!("{}\t{version}\t{}", entry.name, entry.description);
+        let description = entry.description.as_deref().unwrap_or("");
+        println!("{}\t{version}\t{description}", entry.name);
     }
     Ok(())
 }
@@ -763,8 +779,15 @@ pub fn skills_init(name: &str, output: &std::path::Path) -> Result<()> {
 }
 
 /// `bitrouter skills update` — re-install installed skills from the registry.
-pub async fn skills_update(name: Option<&str>, global: bool, registry: Option<&str>) -> Result<()> {
-    use bitrouter_skills::{install, marketplace, source as skill_source};
+pub async fn skills_update(
+    name: Option<&str>,
+    global: bool,
+    registry: Option<&str>,
+    namespace: Option<&str>,
+) -> Result<()> {
+    use bitrouter_skills::install;
+    use bitrouter_skills::marketplace;
+    use bitrouter_skills::source::SkillSource;
 
     let target = skills_target(global)?;
     let base = registry.unwrap_or(DEFAULT_SKILLS_REGISTRY);
@@ -789,8 +812,10 @@ pub async fn skills_update(name: Option<&str>, global: bool, registry: Option<&s
         return Ok(());
     }
 
+    let nsid = namespace
+        .ok_or_else(|| anyhow::anyhow!("--namespace <nsid> is required to query a registry"))?;
     let client = skills_http_client()?;
-    let market = marketplace::fetch_marketplace(&client, base).await?;
+    let market = marketplace::fetch_marketplace(&client, base, nsid).await?;
 
     // Update each skill independently: one failure must not abort the rest.
     // Re-install into the same directory (`install_as`) so a skill stays put
@@ -799,7 +824,7 @@ pub async fn skills_update(name: Option<&str>, global: bool, registry: Option<&s
     for skill_name in names {
         match market.find(&skill_name) {
             Some(entry) => {
-                let result = match skill_source::parse_source(&entry.source) {
+                let result = match SkillSource::try_from(&entry.source) {
                     Ok(parsed) => {
                         install::install(&parsed, &target, true, None, Some(&skill_name)).await
                     }

--- a/apps/bitrouter/src/skills/cli.rs
+++ b/apps/bitrouter/src/skills/cli.rs
@@ -46,6 +46,9 @@ pub struct AddArgs {
     /// Registry base URL used when `source` is a bare skill name.
     #[arg(long, value_name = "URL")]
     pub registry: Option<String>,
+    /// Namespace id whose registry hub to query (required for registry operations).
+    #[arg(long, short = 'n', value_name = "NSID")]
+    pub namespace: Option<String>,
 }
 
 #[derive(Debug, clap::Args)]
@@ -71,6 +74,9 @@ pub struct FindArgs {
     /// Registry base URL to search.
     #[arg(long, value_name = "URL")]
     pub registry: Option<String>,
+    /// Namespace id whose registry hub to query (required for registry operations).
+    #[arg(long, short = 'n', value_name = "NSID")]
+    pub namespace: Option<String>,
 }
 
 #[derive(Debug, clap::Args)]
@@ -93,6 +99,9 @@ pub struct UpdateArgs {
     /// Registry base URL to update from.
     #[arg(long, value_name = "URL")]
     pub registry: Option<String>,
+    /// Namespace id whose registry hub to query (required for registry operations).
+    #[arg(long, short = 'n', value_name = "NSID")]
+    pub namespace: Option<String>,
 }
 
 /// Entry point dispatched by `apps/bitrouter/src/main.rs`.
@@ -105,18 +114,29 @@ pub async fn run(action: SkillsAction) -> Result<()> {
                 args.global,
                 args.yes,
                 args.registry.as_deref(),
+                args.namespace.as_deref(),
             )
             .await
         }
         SkillsAction::List(args) => commands::skills_list(args.global),
         SkillsAction::Remove(args) => commands::skills_remove(&args.name, args.global),
         SkillsAction::Find(args) => {
-            commands::skills_find(&args.query, args.registry.as_deref()).await
+            commands::skills_find(
+                &args.query,
+                args.registry.as_deref(),
+                args.namespace.as_deref(),
+            )
+            .await
         }
         SkillsAction::Init(args) => commands::skills_init(&args.name, &args.output),
         SkillsAction::Update(args) => {
-            commands::skills_update(args.name.as_deref(), args.global, args.registry.as_deref())
-                .await
+            commands::skills_update(
+                args.name.as_deref(),
+                args.global,
+                args.registry.as_deref(),
+                args.namespace.as_deref(),
+            )
+            .await
         }
     }
 }

--- a/crates/bitrouter-skills/src/lib.rs
+++ b/crates/bitrouter-skills/src/lib.rs
@@ -2,9 +2,8 @@
 //!
 //! Shared, framework-agnostic building blocks for BitRouter's skills gateway:
 //!
-//! - [`source`] — parse a skill source string (`owner/repo`, a git URL, a
-//!   subdirectory, or a registry name) into a [`source::SkillSource`] and fetch
-//!   it onto disk.
+//! - [`source`] — parse a skill source string (`owner/repo`, a git URL, or a
+//!   subdirectory) into a [`source::SkillSource`] and fetch it onto disk.
 //! - [`frontmatter`] — parse the YAML frontmatter of a `SKILL.md` and discover
 //!   skills under a directory tree.
 //! - [`marketplace`] — the `marketplace.json` wire types shared by the server

--- a/crates/bitrouter-skills/src/marketplace.rs
+++ b/crates/bitrouter-skills/src/marketplace.rs
@@ -1,76 +1,105 @@
-//! The `marketplace.json` wire types shared by the server-side registry and the
-//! client installer, plus helpers to fetch and search a registry.
+//! Claude Code's `marketplace.json` wire types, shared by the server-side
+//! registry and the client installer, plus helpers to fetch and search a
+//! registry.
 //!
-//! This is BitRouter's own registry shape (a flat skill list whose `source`
-//! field is any string accepted by [`crate::source::parse_source`]). The
-//! Claude Code plugin manifest is a distinct, server-only serialization built
-//! on top of these rows.
+//! The shape mirrors Claude Code's native marketplace manifest:
+//! `{ name, owner, plugins: [ { name, source: <union>, description, version,
+//! author, keywords, category, tags } ] }`. The per-entry `source` is the
+//! structured [`crate::source::Source`] union (`source: "github" | "url" |
+//! "git-subdir"`), so a bitrouter registry hub can be added natively in Claude
+//! Code AND consumed by this CLI.
 
 use serde::{Deserialize, Serialize};
 
 use crate::{Error, Result};
 
-/// Public hub endpoint served by a bitrouter registry, relative to its base
-/// URL.
-const HUB_PATH: &str = "/v1/skills/hub";
+/// Marketplace owner / maintainer (Claude Code `owner`, reused for per-entry
+/// `author`).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Owner {
+    /// Display name.
+    pub name: String,
+    /// Optional contact email.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub email: Option<String>,
+}
 
-/// A single entry in a registry marketplace.
+/// A single plugin entry in a Claude Code marketplace.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MarketplaceEntry {
     /// Canonical skill name / slug.
     pub name: String,
+    /// Structured source (`github` / `url` / `git-subdir`).
+    pub source: crate::source::Source,
     /// Human-readable description.
-    pub description: String,
-    /// Source string, parseable by [`crate::source::parse_source`].
-    pub source: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
     /// Optional version label (informational; resolution uses `source`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
     /// Optional maintainer.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub author: Option<String>,
+    pub author: Option<Owner>,
+    /// Discovery keywords.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub keywords: Vec<String>,
+    /// Optional category.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub category: Option<String>,
     /// Free-form tags used for `find` filtering.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tags: Vec<String>,
 }
 
-/// The body of a registry hub / marketplace response.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+/// A Claude Code marketplace manifest.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Marketplace {
-    /// Available skills.
-    #[serde(default)]
-    pub skills: Vec<MarketplaceEntry>,
+    /// Marketplace name / slug.
+    pub name: String,
+    /// Marketplace owner.
+    pub owner: Owner,
+    /// Available plugins / skills.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub plugins: Vec<MarketplaceEntry>,
 }
 
 impl Marketplace {
     /// Find an entry by exact name.
     pub fn find(&self, name: &str) -> Option<&MarketplaceEntry> {
-        self.skills.iter().find(|e| e.name == name)
+        self.plugins.iter().find(|e| e.name == name)
     }
 
-    /// Entries whose name, description, or tags contain `query`
+    /// Entries whose name, description, keywords, or tags contain `query`
     /// (case-insensitive).
     pub fn search(&self, query: &str) -> Vec<&MarketplaceEntry> {
         let q = query.to_lowercase();
-        self.skills
+        self.plugins
             .iter()
             .filter(|e| {
                 e.name.to_lowercase().contains(&q)
-                    || e.description.to_lowercase().contains(&q)
+                    || e.description
+                        .as_deref()
+                        .unwrap_or("")
+                        .to_lowercase()
+                        .contains(&q)
+                    || e.keywords.iter().any(|k| k.to_lowercase().contains(&q))
                     || e.tags.iter().any(|t| t.to_lowercase().contains(&q))
             })
             .collect()
     }
 }
 
-/// Fetch the marketplace from a bitrouter registry base URL (e.g.
-/// `https://api.bitrouter.ai`).
+/// Fetch a namespace's marketplace from a bitrouter registry base URL.
+///
+/// e.g. base `https://api.bitrouter.ai`, namespace `abc` →
+/// `https://api.bitrouter.ai/v1/namespaces/abc/skills/hub`.
 pub async fn fetch_marketplace(
     client: &reqwest::Client,
     registry_base: &str,
+    namespace_id: &str,
 ) -> Result<Marketplace> {
     let base = registry_base.trim_end_matches('/');
-    let url = format!("{base}{HUB_PATH}");
+    let url = format!("{base}/v1/namespaces/{namespace_id}/skills/hub");
     let resp = client
         .get(&url)
         .send()
@@ -91,9 +120,22 @@ mod tests {
     fn sample() -> Marketplace {
         serde_json::from_str(
             r#"{
-                "skills": [
-                    {"name": "alpha", "description": "First skill", "source": "o/alpha", "tags": ["cli", "build"]},
-                    {"name": "beta", "description": "Second skill", "source": "o/beta", "version": "2.0.0", "author": "me"}
+                "name": "acme-skills",
+                "owner": {"name": "Acme", "email": "skills@acme.test"},
+                "plugins": [
+                    {
+                        "name": "alpha",
+                        "description": "First skill",
+                        "source": {"source": "github", "repo": "o/alpha"},
+                        "tags": ["cli", "build"]
+                    },
+                    {
+                        "name": "beta",
+                        "description": "Second skill",
+                        "source": {"source": "github", "repo": "o/beta"},
+                        "version": "2.0.0",
+                        "author": {"name": "me"}
+                    }
                 ]
             }"#,
         )
@@ -103,16 +145,36 @@ mod tests {
     #[test]
     fn deserializes_entries() {
         let m = sample();
-        assert_eq!(m.skills.len(), 2);
-        assert_eq!(m.skills[1].version.as_deref(), Some("2.0.0"));
-        assert_eq!(m.skills[1].author.as_deref(), Some("me"));
-        assert!(m.skills[1].tags.is_empty());
+        assert_eq!(m.name, "acme-skills");
+        assert_eq!(m.owner.email.as_deref(), Some("skills@acme.test"));
+        assert_eq!(m.plugins.len(), 2);
+        assert_eq!(m.plugins[1].version.as_deref(), Some("2.0.0"));
+        assert_eq!(
+            m.plugins[1].author.as_ref().map(|a| a.name.as_str()),
+            Some("me")
+        );
+        assert!(m.plugins[1].tags.is_empty());
+        assert_eq!(
+            m.plugins[0].source,
+            crate::source::Source::Github {
+                repo: "o/alpha".into(),
+                r#ref: None,
+                sha: None,
+            }
+        );
     }
 
     #[test]
     fn find_by_exact_name() {
         let m = sample();
-        assert_eq!(m.find("beta").map(|e| e.source.as_str()), Some("o/beta"));
+        assert_eq!(
+            m.find("beta").map(|e| &e.source),
+            Some(&crate::source::Source::Github {
+                repo: "o/beta".into(),
+                r#ref: None,
+                sha: None,
+            })
+        );
         assert!(m.find("missing").is_none());
     }
 
@@ -134,8 +196,10 @@ mod tests {
     }
 
     #[test]
-    fn empty_marketplace_default() {
-        let m: Marketplace = serde_json::from_str("{}").unwrap();
-        assert!(m.skills.is_empty());
+    fn minimal_marketplace_deserializes() {
+        let m: Marketplace =
+            serde_json::from_str(r#"{"name": "empty", "owner": {"name": "o"}}"#).unwrap();
+        assert!(m.plugins.is_empty());
+        assert!(m.owner.email.is_none());
     }
 }

--- a/crates/bitrouter-skills/src/source.rs
+++ b/crates/bitrouter-skills/src/source.rs
@@ -15,6 +15,124 @@ use std::path::{Path, PathBuf};
 
 use crate::{Error, Result};
 
+/// Claude Code's `marketplace.json` source union — the wire shape served by a
+/// bitrouter registry hub and consumed natively by Claude Code. Distinct from
+/// the local-resolution [`SkillSource`]: this one is serde-serializable and
+/// carries the CC discriminator (`source: "github" | "url" | "git-subdir"`),
+/// while `SkillSource` additionally models local paths (which can never be
+/// published to a registry).
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "source", rename_all = "kebab-case")]
+pub enum Source {
+    /// A GitHub repository referenced by `owner/repo`.
+    Github {
+        /// `owner/repo`.
+        repo: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        r#ref: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        sha: Option<String>,
+    },
+    /// Any git-cloneable URL.
+    Url {
+        url: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        r#ref: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        sha: Option<String>,
+    },
+    /// A sub-directory within a git repository.
+    GitSubdir {
+        url: String,
+        path: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        r#ref: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        sha: Option<String>,
+    },
+}
+
+/// Convert a resolved [`SkillSource`] into the Claude Code wire [`Source`]. Used
+/// by the bitrouter-cloud skills hub to store/serve registry entries; local
+/// sources are rejected as they cannot be published.
+impl TryFrom<&SkillSource> for Source {
+    type Error = Error;
+
+    fn try_from(value: &SkillSource) -> Result<Self> {
+        match value {
+            SkillSource::Github {
+                owner,
+                repo,
+                git_ref,
+            } => Ok(Source::Github {
+                repo: format!("{owner}/{repo}"),
+                r#ref: git_ref.clone(),
+                sha: None,
+            }),
+            SkillSource::Url { url, git_ref } => Ok(Source::Url {
+                url: url.clone(),
+                r#ref: git_ref.clone(),
+                sha: None,
+            }),
+            SkillSource::GitSubdir { url, path, git_ref } => Ok(Source::GitSubdir {
+                url: url.clone(),
+                path: path.clone(),
+                r#ref: git_ref.clone(),
+                sha: None,
+            }),
+            SkillSource::Local { .. } => Err(Error::InvalidSource(
+                "local sources cannot be published to a registry".into(),
+            )),
+        }
+    }
+}
+
+impl TryFrom<&Source> for SkillSource {
+    type Error = Error;
+
+    fn try_from(value: &Source) -> Result<Self> {
+        match value {
+            Source::Github { repo, r#ref, sha } => {
+                let (owner, name) = repo.split_once('/').ok_or_else(|| {
+                    Error::InvalidSource(format!("github repo {repo:?} must be 'owner/repo'"))
+                })?;
+                let name = name.trim_end_matches(".git");
+                if owner.is_empty() || name.is_empty() || name.contains('/') {
+                    return Err(Error::InvalidSource(format!(
+                        "github repo {repo:?} must be 'owner/repo'"
+                    )));
+                }
+                Ok(SkillSource::Github {
+                    owner: owner.to_string(),
+                    repo: name.to_string(),
+                    git_ref: r#ref.clone().or_else(|| sha.clone()),
+                })
+            }
+            Source::Url { url, r#ref, sha } => Ok(SkillSource::Url {
+                url: url.clone(),
+                git_ref: r#ref.clone().or_else(|| sha.clone()),
+            }),
+            Source::GitSubdir {
+                url,
+                path,
+                r#ref,
+                sha,
+            } => Ok(SkillSource::GitSubdir {
+                url: url.clone(),
+                path: path.clone(),
+                git_ref: r#ref.clone().or_else(|| sha.clone()),
+            }),
+        }
+    }
+}
+
+/// Normalize a flat source string into the Claude Code wire [`Source`]. Used by
+/// the bitrouter-cloud skills hub to store/serve registry entries before storing
+/// or serving them. A local path errors, which is correct for a registry.
+pub fn parse_source_to_wire(input: &str) -> Result<Source> {
+    Source::try_from(&parse_source(input)?)
+}
+
 /// A resolved, fetchable skill source.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SkillSource {
@@ -506,5 +624,175 @@ mod tests {
         assert_eq!(s.subdir(), Some("a/b"));
         let s2 = parse_source("o/r").unwrap();
         assert_eq!(s2.subdir(), None);
+    }
+
+    #[test]
+    fn wire_github_serializes_with_cc_discriminator() {
+        let s = Source::Github {
+            repo: "o/r".into(),
+            r#ref: Some("v1".into()),
+            sha: None,
+        };
+        let v = serde_json::to_value(&s).unwrap();
+        assert_eq!(
+            v,
+            serde_json::json!({"source": "github", "repo": "o/r", "ref": "v1"})
+        );
+        // No `sha` key when None.
+        assert!(v.get("sha").is_none());
+    }
+
+    #[test]
+    fn wire_git_subdir_serializes_as_kebab() {
+        let s = Source::GitSubdir {
+            url: "https://x/y.git".into(),
+            path: "sub".into(),
+            r#ref: None,
+            sha: Some("deadbeef".into()),
+        };
+        let v = serde_json::to_value(&s).unwrap();
+        assert_eq!(v["source"], "git-subdir");
+        assert_eq!(v["path"], "sub");
+        assert_eq!(v["sha"], "deadbeef");
+        assert!(v.get("ref").is_none());
+    }
+
+    #[test]
+    fn wire_round_trips_each_variant() {
+        let variants = [
+            Source::Github {
+                repo: "o/r".into(),
+                r#ref: Some("v1".into()),
+                sha: None,
+            },
+            Source::Url {
+                url: "https://gitlab.com/o/r".into(),
+                r#ref: None,
+                sha: None,
+            },
+            Source::GitSubdir {
+                url: "https://github.com/o/r.git".into(),
+                path: "skills/foo".into(),
+                r#ref: Some("main".into()),
+                sha: None,
+            },
+        ];
+        for s in variants {
+            let json = serde_json::to_string(&s).unwrap();
+            let back: Source = serde_json::from_str(&json).unwrap();
+            assert_eq!(s, back);
+        }
+    }
+
+    #[test]
+    fn parse_source_to_wire_shorthand_is_github() {
+        let s = parse_source_to_wire("owner/repo").unwrap();
+        assert_eq!(
+            s,
+            Source::Github {
+                repo: "owner/repo".into(),
+                r#ref: None,
+                sha: None,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_source_to_wire_local_errors() {
+        assert!(matches!(
+            parse_source_to_wire("./local"),
+            Err(Error::InvalidSource(_))
+        ));
+    }
+
+    #[test]
+    fn wire_github_to_skill_source_splits_owner_repo() {
+        let wire = Source::Github {
+            repo: "o/r".into(),
+            r#ref: Some("v1".into()),
+            sha: None,
+        };
+        let s = SkillSource::try_from(&wire).unwrap();
+        assert_eq!(
+            s,
+            SkillSource::Github {
+                owner: "o".into(),
+                repo: "r".into(),
+                git_ref: Some("v1".into()),
+            }
+        );
+    }
+
+    #[test]
+    fn wire_github_to_skill_source_strips_git_suffix() {
+        let wire = Source::Github {
+            repo: "o/r.git".into(),
+            r#ref: None,
+            sha: None,
+        };
+        let s = SkillSource::try_from(&wire).unwrap();
+        assert_eq!(
+            s,
+            SkillSource::Github {
+                owner: "o".into(),
+                repo: "r".into(),
+                git_ref: None,
+            }
+        );
+    }
+
+    #[test]
+    fn wire_github_to_skill_source_falls_back_to_sha() {
+        let wire = Source::Github {
+            repo: "o/r".into(),
+            r#ref: None,
+            sha: Some("abc123".into()),
+        };
+        let s = SkillSource::try_from(&wire).unwrap();
+        assert!(
+            matches!(s, SkillSource::Github { git_ref, .. } if git_ref.as_deref() == Some("abc123"))
+        );
+    }
+
+    #[test]
+    fn wire_github_without_slash_errors() {
+        let wire = Source::Github {
+            repo: "noslash".into(),
+            r#ref: None,
+            sha: None,
+        };
+        assert!(matches!(
+            SkillSource::try_from(&wire),
+            Err(Error::InvalidSource(_))
+        ));
+    }
+
+    #[test]
+    fn local_skill_source_to_wire_errors() {
+        let local = SkillSource::Local {
+            path: PathBuf::from("/tmp/x"),
+        };
+        assert!(matches!(
+            Source::try_from(&local),
+            Err(Error::InvalidSource(_))
+        ));
+    }
+
+    #[test]
+    fn skill_source_github_to_wire_joins_owner_repo() {
+        let s = SkillSource::Github {
+            owner: "o".into(),
+            repo: "r".into(),
+            git_ref: Some("v1".into()),
+        };
+        let wire = Source::try_from(&s).unwrap();
+        assert_eq!(
+            wire,
+            Source::Github {
+                repo: "o/r".into(),
+                r#ref: Some("v1".into()),
+                sha: None,
+            }
+        );
     }
 }


### PR DESCRIPTION
## Summary

Amends the `bitrouter-skills` crate's registry wire types to **Claude Code's native `marketplace.json` schema**, so a BitRouter registry hub is consumable both by native `claude plugin marketplace add <url>` and by the `bitrouter skills` client. This is the **upstream half** of the skills-gateway Phase 2 work; it unblocks the `bitrouter-cloud` backend, which will serve this exact wire shape per-namespace.

Follows up #511 (Phase 1 client). **Breaking** (`!`) — the registry wire format and `fetch_marketplace`/CLI signatures change; nothing has consumed a live hub yet.

## What changed

**`crates/bitrouter-skills`**
- `marketplace.rs` — CC shape: `Marketplace { name, owner, plugins }`, `Owner { name, email? }`, `MarketplaceEntry { name, source: Source, description?, version?, author: Option<Owner>, keywords, category?, tags }`. `find`/`search` operate over `plugins`.
- `source.rs` — new serde **`Source`** enum matching CC's union (`{"source":"github",repo,ref?,sha?}` / `url` / `git-subdir`). `SkillSource` + `parse_source` are unchanged (the installer + local-path installs still use them). Added total conversions `TryFrom<&SkillSource> for Source` (local → err) and `TryFrom<&Source> for SkillSource` (validates `owner/repo`, strips `.git`), plus `parse_source_to_wire(&str)` — the entry points the cloud hub uses to normalize/store/serve sources.
- `fetch_marketplace(client, base, namespace_id)` now targets the per-namespace hub `{base}/v1/namespaces/{nsid}/skills/hub`.

**`apps/bitrouter` CLI**
- `skills add|find|update` gain `-n/--namespace <NSID>` (required for registry/hub operations; direct git/local sources don't need it). `--registry` stays a base URL (default `https://api.bitrouter.ai`).

**Docs** — `CLI.md` updated for the per-namespace hub + `--namespace`.

## Example wire JSON
```json
{"name":"acme","owner":{"name":"Acme"},"plugins":[{"name":"deploy","source":{"source":"github","repo":"acme/deploy"},"description":"…","version":"1.0.0"}]}
```

## Verification
- `cargo test -p bitrouter-skills`: 61 passed (exact-JSON shape assertions + conversion edge cases)
- `cargo build` (workspace), `cargo clippy -p bitrouter-skills -p bitrouter --no-deps`, `cargo fmt --check`: all clean
- CLAUDE.md-clean (no `#[allow]`, no prod `unwrap`/`expect`/`panic!`, no dead code)

Versioning left to release-plz (this lands on the alpha.7 line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)