### PR TITLE
fix(cli): correct auth login --scope help to namespace-read

### DIFF
--- a/apps/bitrouter/src/main.rs
+++ b/apps/bitrouter/src/main.rs
@@ -253,7 +253,7 @@ enum AuthAction {
         client_id: Option<String>,
         /// Permissions to request, as a space-delimited list. Defaults to a
         /// broad "developer" set (inference, key management, billing-read,
-        /// policy, BYOK, account-read); pass a narrower or wider list to
+        /// policy, BYOK, namespace-read); pass a narrower or wider list to
         /// override (env: BITROUTER_OAUTH_SCOPE).
         #[arg(long, value_name = "SCOPE")]
         scope: Option<String>,


### PR DESCRIPTION
## What

`bitrouter auth login --help` still described the default `--scope` developer set as including **`account-read`**. The `account` → `namespace` scope rename (#508) updated the real `DEFAULT_SCOPE` constant and `CLI.md`, but missed the clap doc comment at `apps/bitrouter/src/main.rs:262`. This is the only remaining stale `account`-scope reference in the tree (verified by repo-wide grep).

## Relationship to #510

The **functional** bug reported in #510 — default `bitrouter auth login` sending the retired `account:read` and being rejected with `400 invalid_scope` (`unknown scope resource 'account'`) against post-rename cloud envs — was **already fixed by #508** (`f4ff599c`), which changed `DEFAULT_SCOPE` to request `namespace:read`. The issue author flagged uncertainty about where the constant lived and asked to confirm the tag; #508 is the answer.

This PR cleans up the leftover help-text drift so the `--help` output matches the scope the CLI actually requests, and closes out #510.

## Verification

- `cargo build -p bitrouter` succeeds.
- `bitrouter auth login --help` now renders `... policy, BYOK, namespace-read ...`.

Closes #510

🤖 Generated with [Claude Code](https://claude.com/claude-code)