### PR TITLE
feat(sdk)!: per-target Messages auth scheme (x-api-key | Bearer)

### DIFF
--- a/crates/bitrouter-cloud-sdk/src/provider/applier.rs
+++ b/crates/bitrouter-cloud-sdk/src/provider/applier.rs
@@ -264,6 +264,7 @@ mod tests {
             account_label: None,
             api_key_override: None,
             api_base_override: None,
+            auth_scheme: Default::default(),
         }
     }
 

--- a/crates/bitrouter-providers/src/anthropic/mod.rs
+++ b/crates/bitrouter-providers/src/anthropic/mod.rs
@@ -368,6 +368,7 @@ mod tests {
             account_label: label.map(String::from),
             api_key_override: None,
             api_base_override: None,
+            auth_scheme: Default::default(),
         }
     }
 

--- a/crates/bitrouter-providers/src/codex/mod.rs
+++ b/crates/bitrouter-providers/src/codex/mod.rs
@@ -293,6 +293,7 @@ mod tests {
             account_label: label.map(String::from),
             api_key_override: None,
             api_base_override: None,
+            auth_scheme: Default::default(),
         }
     }
 

--- a/crates/bitrouter-providers/src/copilot/mod.rs
+++ b/crates/bitrouter-providers/src/copilot/mod.rs
@@ -220,6 +220,7 @@ mod tests {
             account_label: None,
             api_key_override: None,
             api_base_override: None,
+            auth_scheme: Default::default(),
         }
     }
 

--- a/crates/bitrouter-sdk/src/config/routing_table.rs
+++ b/crates/bitrouter-sdk/src/config/routing_table.rs
@@ -111,6 +111,7 @@ fn build_targets(
             account_label: None,
             api_key_override: None,
             api_base_override: None,
+            auth_scheme: Default::default(),
         }];
     }
 
@@ -142,6 +143,7 @@ fn build_targets(
                 account_label: Some(label),
                 api_key_override: None,
                 api_base_override: None,
+                auth_scheme: Default::default(),
             }
         })
         .collect()

--- a/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
@@ -22,8 +22,8 @@ use crate::language_model::protocol::{
 };
 use crate::language_model::stream::SseFrame;
 use crate::language_model::types::{
-    ApiProtocol, Content, FinishReason, GenerateResult, GenerationParams, Message, Prompt,
-    ResponseFormat, Role, RoutingTarget, StopDetails, StreamPart, Usage,
+    ApiProtocol, AuthScheme, Content, FinishReason, GenerateResult, GenerationParams, Message,
+    Prompt, ResponseFormat, Role, RoutingTarget, StopDetails, StreamPart, Usage,
 };
 
 /// The Messages inbound + outbound protocol adapter.
@@ -657,11 +657,28 @@ impl Transport for MessagesTransport {
         target: &RoutingTarget,
     ) -> Result<reqwest::Request> {
         let key = target.effective_api_key();
-        let key_header = reqwest::header::HeaderValue::from_str(key).map_err(|e| {
-            BitrouterError::internal(format!("invalid api key for x-api-key header: {e}"))
-        })?;
-        request.headers_mut().insert("x-api-key", key_header);
-        request.headers_mut().insert(
+        let headers = request.headers_mut();
+        // Exactly one credential header — never both. The Anthropic API
+        // rejects a request carrying `x-api-key` and `Authorization` together,
+        // so the scheme is chosen per target (`RoutingTarget::auth_scheme`).
+        match target.auth_scheme {
+            AuthScheme::XApiKey => {
+                let value = reqwest::header::HeaderValue::from_str(key).map_err(|e| {
+                    BitrouterError::internal(format!("invalid api key for x-api-key header: {e}"))
+                })?;
+                headers.insert("x-api-key", value);
+            }
+            AuthScheme::Bearer => {
+                let value = reqwest::header::HeaderValue::from_str(&format!("Bearer {key}"))
+                    .map_err(|e| {
+                        BitrouterError::internal(format!(
+                            "invalid api key for authorization header: {e}"
+                        ))
+                    })?;
+                headers.insert(reqwest::header::AUTHORIZATION, value);
+            }
+        }
+        headers.insert(
             "anthropic-version",
             reqwest::header::HeaderValue::from_static("2023-06-01"),
         );

--- a/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
@@ -1191,12 +1191,67 @@ fn messages_no_beta_header_is_emitted() {
         account_label: None,
         api_key_override: None,
         api_base_override: None,
+        auth_scheme: Default::default(),
     };
     let req = futures::executor::block_on(transport.authorise(req, &target)).unwrap();
     assert!(
         req.headers().get("anthropic-beta").is_none(),
         "anthropic-beta header must not be set by the transport (deprecated and Vertex-incompatible)"
     );
+}
+
+#[test]
+fn messages_auth_scheme_selects_one_credential_header() {
+    // The Messages transport honours `RoutingTarget::auth_scheme`: `x-api-key`
+    // by default, `Authorization: Bearer` when asked — and never both, since
+    // the Anthropic API rejects a request carrying both credential headers.
+    use crate::language_model::protocol::Transport;
+    use crate::language_model::types::{AuthScheme, RoutingTarget};
+    let transport = crate::language_model::protocol::messages::MessagesTransport;
+    let client = reqwest::Client::new();
+    let base = RoutingTarget {
+        provider_name: "gw".into(),
+        service_id: "claude".into(),
+        api_base: "http://example.invalid".into(),
+        api_key: "secret".into(),
+        api_protocol: ApiProtocol::Messages,
+        account_label: None,
+        api_key_override: None,
+        api_base_override: None,
+        auth_scheme: AuthScheme::XApiKey,
+    };
+
+    // Default (x-api-key) scheme → `x-api-key` only.
+    let req = client
+        .post("http://example.invalid/v1/messages")
+        .build()
+        .unwrap();
+    let req = futures::executor::block_on(transport.authorise(req, &base)).unwrap();
+    assert_eq!(
+        req.headers().get("x-api-key").unwrap().to_str().unwrap(),
+        "secret"
+    );
+    assert!(req.headers().get(reqwest::header::AUTHORIZATION).is_none());
+
+    // Bearer scheme → `Authorization: Bearer` only.
+    let bearer = RoutingTarget {
+        auth_scheme: AuthScheme::Bearer,
+        ..base.clone()
+    };
+    let req = client
+        .post("http://example.invalid/v1/messages")
+        .build()
+        .unwrap();
+    let req = futures::executor::block_on(transport.authorise(req, &bearer)).unwrap();
+    assert_eq!(
+        req.headers()
+            .get(reqwest::header::AUTHORIZATION)
+            .unwrap()
+            .to_str()
+            .unwrap(),
+        "Bearer secret"
+    );
+    assert!(req.headers().get("x-api-key").is_none());
 }
 
 #[test]

--- a/crates/bitrouter-sdk/src/language_model/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/tests.rs
@@ -25,6 +25,7 @@ fn target(provider: &str) -> RoutingTarget {
         account_label: None,
         api_key_override: None,
         api_base_override: None,
+        auth_scheme: Default::default(),
     }
 }
 
@@ -853,6 +854,7 @@ async fn executor_rejects_response_format_on_unsupported_outbound() {
         account_label: None,
         api_key_override: None,
         api_base_override: None,
+        auth_scheme: Default::default(),
     };
     let prompt = Prompt {
         model: "m".into(),

--- a/crates/bitrouter-sdk/src/language_model/types.rs
+++ b/crates/bitrouter-sdk/src/language_model/types.rs
@@ -441,6 +441,28 @@ pub struct ExecutionResult {
     pub generation_time_ms: u64,
 }
 
+/// How an upstream's credential is presented on the wire.
+///
+/// Consulted by transports that support more than one credential scheme.
+/// Today that is only the Messages transport, which sends the key as either
+/// `x-api-key` (Anthropic's native scheme) or `Authorization: Bearer`. The
+/// Chat Completions transport (always `Authorization: Bearer`) and Generate
+/// Content transport (always `x-goog-api-key`) have a single fixed scheme and
+/// ignore this.
+///
+/// Exactly one scheme is ever sent — never both: the Anthropic API rejects a
+/// request that carries `x-api-key` and `Authorization` together.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+pub enum AuthScheme {
+    /// `x-api-key: <key>` — Anthropic's native scheme; the default.
+    #[default]
+    #[serde(rename = "x-api-key")]
+    XApiKey,
+    /// `Authorization: Bearer <key>`.
+    #[serde(rename = "bearer")]
+    Bearer,
+}
+
 /// One hop in a fallback chain: a concrete provider + model + connection info.
 ///
 /// The `Debug` impl redacts `api_key` and `api_key_override` (v0 audit S9):
@@ -470,6 +492,11 @@ pub struct RoutingTarget {
     pub api_key_override: Option<String>,
     /// Per-request api-base override, paired with `api_key_override`.
     pub api_base_override: Option<String>,
+    /// How the credential is presented to this target. Consulted by
+    /// transports that support more than one scheme — today only the Messages
+    /// transport (`x-api-key` vs `Authorization: Bearer`); others ignore it.
+    /// Defaults to [`AuthScheme::XApiKey`].
+    pub auth_scheme: AuthScheme,
 }
 
 impl std::fmt::Debug for RoutingTarget {
@@ -486,6 +513,7 @@ impl std::fmt::Debug for RoutingTarget {
                 &self.api_key_override.as_deref().map(redacted),
             )
             .field("api_base_override", &self.api_base_override)
+            .field("auth_scheme", &self.auth_scheme)
             .finish()
     }
 }

--- a/plugins/bitrouter-guardrails/src/tests.rs
+++ b/plugins/bitrouter-guardrails/src/tests.rs
@@ -95,6 +95,7 @@ fn target() -> RoutingTarget {
         account_label: None,
         api_key_override: None,
         api_base_override: None,
+        auth_scheme: Default::default(),
     }
 }
 

--- a/plugins/bitrouter-observe/src/otel/exporter.rs
+++ b/plugins/bitrouter-observe/src/otel/exporter.rs
@@ -1032,6 +1032,7 @@ mod hop_tests {
             account_label: Some("primary".to_string()),
             api_key_override: None,
             api_base_override: None,
+            auth_scheme: Default::default(),
         }
     }
 


### PR DESCRIPTION
## What

The Messages (`anthropic`) transport hard-coded `x-api-key`. This adds a
per-target credential scheme so the stock transport can authenticate with
**either** `x-api-key` or `Authorization: Bearer`, chosen per `RoutingTarget`.

- New `AuthScheme` enum in `language_model::types` (`XApiKey` default, `Bearer`), with serde wire names `x-api-key` / `bearer`.
- New `RoutingTarget::auth_scheme` field (default `XApiKey`).
- `MessagesTransport::authorise` now matches on it: `x-api-key` or `Authorization: Bearer`, plus the usual `anthropic-version`.

## Why

Consumers (notably `bitrouter-cloud`) route to Messages-**compatible** upstreams that aren't Anthropic-native — OpenAI-style gateways and aggregators that front Claude behind a `Bearer` edge. Previously the only way to reach them was to fork the transport downstream. The scheme now lives where it belongs: on the protocol transport.

## Exactly one header — never both

The transport sends a single credential header. The Anthropic API (and SDK-strict gateways) reject a request carrying `x-api-key` and `Authorization` together — *"Expected either apiKey or authToken… or for one of the headers to be explicitly omitted"* ([anthropic-sdk-csharp#47](https://github.com/anthropics/anthropic-sdk-csharp/issues/47), [litellm#29190](https://github.com/BerriAI/litellm/issues/29190)). So "support both" means *selectable per target*, not "send both."

Chat Completions (always `Authorization: Bearer`) and Generate Content (always `x-goog-api-key`) have a single fixed scheme and ignore the field.

## Breaking change

`RoutingTarget` gains a required `auth_scheme` field. All construct sites in the workspace are updated; downstream literals must add it. `AuthScheme::default()` (= `XApiKey`) preserves the previous behaviour, so the migration is mechanical and behaviour-preserving.

## Test plan
- `cargo test -p bitrouter-sdk --all-features` — green (incl. new `messages_auth_scheme_selects_one_credential_header`).
- `cargo check --workspace --all-targets` — green.
- `cargo clippy -p bitrouter-sdk --all-features --all-targets` — clean.
- `cargo fmt --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)