### PR TITLE
feat(providers): add Ambient as OpenAI-compatible provider

### DIFF
--- a/crates/bitrouter-providers/providers/ambient.toml
+++ b/crates/bitrouter-providers/providers/ambient.toml
@@ -1,0 +1,17 @@
+# Ambient — OpenAI-compatible inference API. Bearer auth on `Authorization`.
+#
+# Official auth + endpoint docs:
+# - https://docs.ambient.xyz/ (developer docs)
+# - https://api.ambient.xyz/docs (OpenAPI reference)
+# - base URL `https://api.ambient.xyz/v1`; Chat Completions wire format
+#   (`POST /v1/chat/completions`); model list at `GET /v1/models`
+
+id = "ambient"
+display_name = "Ambient"
+api_base = "https://api.ambient.xyz/v1"
+api_protocol = "chat_completions"
+doc_url = "https://docs.ambient.xyz/"
+
+[auth]
+kind = "bearer"
+env = "AMBIENT_API_KEY"

--- a/crates/bitrouter-providers/src/builtin.rs
+++ b/crates/bitrouter-providers/src/builtin.rs
@@ -29,6 +29,7 @@ const EMBEDDED: &[(&str, &str)] = &[
     ("anthropic", include_str!("../providers/anthropic.toml")),
     ("google", include_str!("../providers/google.toml")),
     ("openrouter", include_str!("../providers/openrouter.toml")),
+    ("ambient", include_str!("../providers/ambient.toml")),
     (
         "github-copilot",
         include_str!("../providers/github-copilot.toml"),
@@ -88,7 +89,7 @@ mod tests {
         let entries = load_embedded().expect("embedded TOML files must parse");
         // Bump this when adding a new provider — keeps the test honest about
         // catalog growth.
-        assert_eq!(entries.len(), 9);
+        assert_eq!(entries.len(), 10);
     }
 
     #[test]
@@ -122,6 +123,7 @@ mod tests {
         assert!(find("anthropic").is_some());
         assert!(find("google").is_some());
         assert!(find("openrouter").is_some());
+        assert!(find("ambient").is_some());
         assert!(find("github-copilot").is_some());
         assert!(find("opencode-zen").is_some());
         assert!(find("opencode-go").is_some());


### PR DESCRIPTION
[Ambient](https://ambiententerprise.ai/) serves an OpenAI-compatible API at https://api.ambient.xyz/v1 (chat completions at /v1/chat/completions, model list at /v1/models). Register it as a built-in provider with Bearer auth via AMBIENT_API_KEY.