### PR TITLE
refactor(cli)!: subcommand cleanup (placeholders + auth)

### DIFF
--- a/apps/bitrouter/src/assemble.rs
+++ b/apps/bitrouter/src/assemble.rs
@@ -397,7 +397,7 @@ pub async fn build_app_with_path(
 /// Build the per-provider `AuthAppliers` registry. Each entry covers a
 /// provider whose credential flow needs more than the per-protocol
 /// `Transport::authorise` default — today: `bitrouter` (the official
-/// hosted gateway; OAuth from `bitrouter auth login` with a
+/// hosted gateway; OAuth from `bitrouter cloud login` with a
 /// `BITROUTER_API_KEY` fallback), GitHub Copilot (device-code OAuth +
 /// token exchange), Anthropic (dual API-key / Pro/Max subscription
 /// OAuth), OpenAI Codex (ChatGPT-subscription OAuth).

--- a/apps/bitrouter/src/cloud/cli.rs
+++ b/apps/bitrouter/src/cloud/cli.rs
@@ -45,7 +45,7 @@ pub enum CloudAction {
     /// the built-in `bitrouter` provider uses for inference, so
     /// `providers login bitrouter` is an alias for this command.
     Login {
-        /// Authorization server URL. Defaults to https://api.bitrouter.ai;
+        /// Authorization server URL. Defaults to <https://api.bitrouter.ai>;
         /// override only for a self-hosted deployment (env: BITROUTER_OAUTH_AS).
         #[arg(long = "oauth-as", value_name = "URL")]
         authorization_server: Option<String>,

--- a/apps/bitrouter/src/cloud/cli.rs
+++ b/apps/bitrouter/src/cloud/cli.rs
@@ -14,7 +14,7 @@
 //! All errors flow through one place ([`run`]); 403 responses whose
 //! description matches the server's `missing required scope: <s>` shape
 //! get a tailored re-login hint pointing the user at
-//! `bitrouter auth login --scope "<existing scopes> <missing>"`.
+//! `bitrouter cloud login --scope "<existing scopes> <missing>"`.
 
 use std::path::PathBuf;
 
@@ -22,6 +22,7 @@ use anyhow::Result;
 use chrono::{DateTime, Utc};
 use clap::{Subcommand, ValueEnum};
 
+use bitrouter_cloud_sdk::auth::commands::{LoginInputs, login, logout};
 use bitrouter_cloud_sdk::auth::credentials::{CredentialsStore, default_credentials_path};
 use bitrouter_cloud_sdk::management::types::{
     BudgetWindow as SdkBudgetWindow, ClientType as SdkClientType, PolicyKind as SdkPolicyKind,
@@ -37,6 +38,38 @@ pub enum CloudAction {
     /// Print the cloud identity stored on this machine alongside the
     /// `/v1/*` base URL the CLI will target.
     Whoami,
+    /// Sign in to BitRouter Cloud from this terminal.
+    ///
+    /// Prints a verification URL — open it, approve, and this CLI stores an
+    /// access token it refreshes automatically. This is the same credential
+    /// the built-in `bitrouter` provider uses for inference, so
+    /// `providers login bitrouter` is an alias for this command.
+    Login {
+        /// Authorization server URL. Defaults to https://api.bitrouter.ai;
+        /// override only for a self-hosted deployment (env: BITROUTER_OAUTH_AS).
+        #[arg(long = "oauth-as", value_name = "URL")]
+        authorization_server: Option<String>,
+        /// OAuth client id. Defaults to `bitrouter-cli`; override only for a
+        /// self-hosted deployment (env: BITROUTER_OAUTH_CLIENT_ID).
+        #[arg(long = "client-id", value_name = "ID")]
+        client_id: Option<String>,
+        /// Permissions to request, as a space-delimited list. Defaults to a
+        /// broad "developer" set; pass a narrower or wider list to override
+        /// (env: BITROUTER_OAUTH_SCOPE).
+        #[arg(long, value_name = "SCOPE")]
+        scope: Option<String>,
+    },
+    /// Sign out: revoke the stored token at the server (best-effort) and
+    /// delete the local credentials file.
+    Logout {
+        /// Override the authorization server URL recorded in the
+        /// credentials file for the revocation call.
+        #[arg(long = "oauth-as", value_name = "URL")]
+        authorization_server: Option<String>,
+        /// Override the recorded OAuth client id for the revocation call.
+        #[arg(long = "client-id", value_name = "ID")]
+        client_id: Option<String>,
+    },
     /// Inspect the namespaces you own and the one this CLI is bound to.
     Namespace {
         #[command(subcommand)]
@@ -90,7 +123,7 @@ pub enum CloudAction {
 pub enum NamespaceAction {
     /// List the namespaces you own. The one this CLI is signed in to is
     /// marked `(active)`. Switching namespaces is a re-login:
-    /// `bitrouter auth login` and pick a different namespace in the
+    /// `bitrouter cloud login` and pick a different namespace in the
     /// browser.
     List(JsonFlag),
     /// Print the namespace this CLI's credential is bound to. Offline —
@@ -608,6 +641,28 @@ pub async fn run(action: CloudAction) -> Result<()> {
 async fn run_inner(action: CloudAction) -> std::result::Result<(), SdkError> {
     match action {
         CloudAction::Whoami => whoami().await,
+        CloudAction::Login {
+            authorization_server,
+            client_id,
+            scope,
+        } => login(LoginInputs {
+            authorization_server,
+            client_id,
+            scope,
+        })
+        .await
+        .map(|_| ())
+        .map_err(SdkError::Auth),
+        CloudAction::Logout {
+            authorization_server,
+            client_id,
+        } => logout(LoginInputs {
+            authorization_server,
+            client_id,
+            scope: None,
+        })
+        .await
+        .map_err(SdkError::Auth),
         CloudAction::Namespace { action } => run_namespace(action).await,
         CloudAction::Keys { action } => run_keys(action).await,
         CloudAction::Usage(args) => run_usage(args).await,
@@ -627,7 +682,7 @@ fn client() -> std::result::Result<ManagementClient, SdkError> {
 
 async fn whoami() -> std::result::Result<(), SdkError> {
     // Doesn't hit the network — reads the local credentials file so
-    // it works offline. Mirrors `bitrouter auth whoami` but adds the
+    // it works offline. Mirrors `bitrouter cloud whoami` but adds the
     // base URL `bitrouter cloud …` will target.
     let client = client()?;
     println!("cloud base URL: {}", client.base_url());
@@ -643,7 +698,7 @@ async fn whoami() -> std::result::Result<(), SdkError> {
         }
         println!("credentials:    {}", store.path().display());
     } else {
-        println!("(not signed in — run `bitrouter auth login`)");
+        println!("(not signed in — run `bitrouter cloud login`)");
     }
     Ok(())
 }
@@ -669,7 +724,7 @@ async fn run_namespace(action: NamespaceAction) -> std::result::Result<(), SdkEr
             } else {
                 match nsid {
                     Some(id) => println!("{id}"),
-                    None => println!("(no namespace — run `bitrouter auth login`)"),
+                    None => println!("(no namespace — run `bitrouter cloud login`)"),
                 }
             }
             Ok(())
@@ -1375,7 +1430,7 @@ fn opt_json_input(
 
 /// `--scope` accepts both repeated flags and a single space-delimited
 /// list per flag — mirroring how the same value is handled by
-/// `bitrouter auth login --scope`. Empty tokens are dropped.
+/// `bitrouter cloud login --scope`. Empty tokens are dropped.
 fn split_scope_args(scopes: &[String]) -> Vec<String> {
     let mut out = Vec::new();
     for raw in scopes {
@@ -1393,7 +1448,7 @@ fn print_error_hint(err: &SdkError) {
         SdkError::NotSignedIn => {
             eprintln!();
             eprintln!("  Sign in first:");
-            eprintln!("    bitrouter auth login");
+            eprintln!("    bitrouter cloud login");
         }
         SdkError::Forbidden {
             missing_scope: Some(scope),
@@ -1402,10 +1457,10 @@ fn print_error_hint(err: &SdkError) {
             eprintln!();
             eprintln!("  This command requires the scope: {scope}");
             if let Some(extended) = suggested_scope(scope) {
-                eprintln!("  Re-run `bitrouter auth login --scope \"{extended}\"` to add it.");
+                eprintln!("  Re-run `bitrouter cloud login --scope \"{extended}\"` to add it.");
             } else {
                 eprintln!(
-                    "  Re-run `bitrouter auth login --scope \"<your current scope> {scope}\"`."
+                    "  Re-run `bitrouter cloud login --scope \"<your current scope> {scope}\"`."
                 );
             }
         }

--- a/apps/bitrouter/src/cloud/mod.rs
+++ b/apps/bitrouter/src/cloud/mod.rs
@@ -6,7 +6,7 @@
 //!
 //! - [`enable_in_zero_config`] — auto-add the `bitrouter` provider to the in-memory
 //!   zero-config `providers:` map when the user has signed in via
-//!   `bitrouter auth login` (an `account-credentials.json` file is present
+//!   `bitrouter cloud login` (an `account-credentials.json` file is present
 //!   at the default path). The env-var path (`$BITROUTER_API_KEY`) is
 //!   already covered by [`bitrouter_providers::zero_config`].
 //! - [`build_auth_applier`] — construct the
@@ -34,7 +34,7 @@ use bitrouter_sdk::config::{Config, ProviderConfig};
 use bitrouter_sdk::language_model::{AuthApplier, auth::AuthAppliers};
 
 /// Insert the `bitrouter` provider into `config.providers` when the user
-/// has run `bitrouter auth login` (i.e. the credentials file exists at the
+/// has run `bitrouter cloud login` (i.e. the credentials file exists at the
 /// default path) and the entry is not already present.
 ///
 /// No-op when the credentials file is absent — `bitrouter_providers::zero_config`

--- a/apps/bitrouter/src/main.rs
+++ b/apps/bitrouter/src/main.rs
@@ -2,11 +2,12 @@
 //!
 //! Subcommand surface: `serve` / `start` / `stop` / `restart` /
 //! `reload` / `status` / `route` / `init` / `key sign` / `models` / `tools` /
-//! `policy create` / `providers list` / `login` / `logout` / `agents` /
-//! `agent-proxy` / `auth` / `cloud` / `skills`. Daemon control runs over a
-//! local IPC endpoint (a Unix domain socket, or a Windows named pipe) —
-//! `start` spawns `serve` detached; the client subcommands send one
-//! [`DaemonCommand`] each.
+//! `policy create` / `providers (list|login|logout)` / `agents` /
+//! `agent-proxy` / `cloud` / `skills`. Cloud-account sign-in lives under
+//! `cloud (login|logout|whoami)`; per-provider credentials under
+//! `providers (login|logout)`. Daemon control runs over a local IPC endpoint
+//! (a Unix domain socket, or a Windows named pipe) — `start` spawns `serve`
+//! detached; the client subcommands send one [`DaemonCommand`] each.
 //!
 //! OWS wallet integration is out of scope for v1.0 (it lives in the `ows`
 //! workspace); a commented-out `Wallet` variant in `Command` reserves the
@@ -163,36 +164,6 @@ enum Command {
     // non-functional `wallet` command; uncomment this variant AND restore its
     // match arm in `run` when wiring OWS in.
     // Wallet,
-    /// Log in to an upstream provider — interactive credential setup.
-    ///
-    /// Per-provider available methods are auto-derived from the catalog:
-    /// `anthropic` prompts for **subscription** (Claude Pro/Max browser
-    /// PKCE) **or** **API key** paste; `openai-codex` runs the ChatGPT
-    /// subscription PKCE flow; `github-copilot` runs the GitHub device
-    /// code flow; everything else accepts a pasted API key. The
-    /// resulting credential is stored under
-    /// `$XDG_DATA_HOME/bitrouter/oauth-tokens.json` keyed by
-    /// `(provider_id, label)`. For cloud sign-in, see `bitrouter auth login`
-    /// — kept separate so the per-provider and cloud flows don't share a
-    /// flag surface.
-    Login {
-        /// Provider id to log in to (e.g. `anthropic`, `openai-codex`,
-        /// `github-copilot`).
-        provider: String,
-        /// Account label this credential is stored under. Defaults to
-        /// `default`. Use a non-default label to keep multiple accounts
-        /// of the same provider side by side — reference them from
-        /// `accounts:` entries in `bitrouter.yaml`.
-        #[arg(short, long, default_value = "default")]
-        label: String,
-    },
-    /// Log out of an upstream provider — clears every stored credential
-    /// for the provider (subscription OAuth and pasted API keys alike).
-    /// For cloud sign-out, see `bitrouter auth logout`.
-    Logout {
-        /// Provider id whose stored credentials should be removed.
-        provider: String,
-    },
     /// ACP agent lifecycle — list the catalog, check configured agents,
     /// print install stubs. `bitrouter agent-proxy <id>` is the separate
     /// stdio bridge an editor spawns.
@@ -214,18 +185,8 @@ enum Command {
         #[arg(short, long)]
         config: Option<PathBuf>,
     },
-    /// Sign in to bitrouter from this terminal.
-    ///
-    /// After `bitrouter auth login`, this CLI uses your account credentials
-    /// automatically for inference, key management, billing, BYOK, and the
-    /// rest of the management surface.
-    Auth {
-        #[command(subcommand)]
-        action: AuthAction,
-    },
-    /// Manage your BitRouter Cloud account — API keys, usage, billing,
-    /// policies, BYOK, OAuth clients. Requires `bitrouter auth login`
-    /// first.
+    /// Manage your BitRouter Cloud account — sign in/out, API keys, usage,
+    /// billing, policies, BYOK, OAuth clients. Start with `cloud login`.
     Cloud {
         #[command(subcommand)]
         action: bitrouter::cloud::cli::CloudAction,
@@ -236,46 +197,6 @@ enum Command {
         #[command(subcommand)]
         action: bitrouter::skills::cli::SkillsAction,
     },
-}
-
-#[derive(Subcommand)]
-enum AuthAction {
-    /// Sign in to bitrouter.
-    ///
-    /// Prints a verification URL — open it in your browser, approve, and
-    /// this CLI receives an access token it stores locally and refreshes
-    /// automatically.
-    Login {
-        /// Authorization server URL. Defaults to https://api.bitrouter.ai;
-        /// override only for a self-hosted deployment (env: BITROUTER_OAUTH_AS).
-        #[arg(long = "oauth-as", value_name = "URL")]
-        authorization_server: Option<String>,
-        /// OAuth client id. Defaults to `bitrouter-cli`; override only for a
-        /// self-hosted deployment (env: BITROUTER_OAUTH_CLIENT_ID).
-        #[arg(long = "client-id", value_name = "ID")]
-        client_id: Option<String>,
-        /// Permissions to request, as a space-delimited list. Defaults to a
-        /// broad "developer" set (inference, key management, billing-read,
-        /// policy, BYOK, namespace-read); pass a narrower or wider list to
-        /// override (env: BITROUTER_OAUTH_SCOPE).
-        #[arg(long, value_name = "SCOPE")]
-        scope: Option<String>,
-    },
-    /// Sign out: revoke the stored token at the server (best-effort) and
-    /// delete the local credentials file.
-    Logout {
-        /// Override the authorization server URL recorded in the
-        /// credentials file for the revocation call.
-        #[arg(long = "oauth-as", value_name = "URL")]
-        authorization_server: Option<String>,
-        /// Override the recorded OAuth client id for the revocation call.
-        #[arg(long = "client-id", value_name = "ID")]
-        client_id: Option<String>,
-    },
-    /// Show who is signed in on this machine.
-    ///
-    /// Reads the locally stored credentials — no network call.
-    Whoami,
 }
 
 #[derive(Subcommand)]
@@ -401,6 +322,28 @@ enum ProviderAction {
         #[arg(short, long)]
         config: Option<PathBuf>,
     },
+    /// Log in to an upstream provider — interactive credential setup.
+    ///
+    /// Per-provider methods are auto-derived from the catalog: `anthropic`
+    /// prompts for subscription (browser PKCE) or API-key paste;
+    /// `openai-codex` runs the ChatGPT PKCE flow; `github-copilot` the GitHub
+    /// device flow; everything else accepts a pasted API key. Logging in to
+    /// the built-in `bitrouter` provider runs the same cloud sign-in as
+    /// `bitrouter cloud login`.
+    Login {
+        /// Provider id (e.g. `anthropic`, `openai-codex`, `bitrouter`).
+        provider: String,
+        /// Account label this credential is stored under (default `default`).
+        /// Ignored for the `bitrouter` provider (it uses the cloud credential).
+        #[arg(short, long, default_value = "default")]
+        label: String,
+    },
+    /// Log out of an upstream provider — clears every stored credential for
+    /// it. For the built-in `bitrouter` provider this is `cloud logout`.
+    Logout {
+        /// Provider id whose stored credentials should be removed.
+        provider: String,
+    },
 }
 
 #[tokio::main]
@@ -484,51 +427,13 @@ async fn run() -> Result<()> {
         Command::Observe { action } => observe(action).await,
         Command::Policy { action } => policy(action).await,
         Command::Providers { action } => providers(action).await,
-        Command::Login { provider, label } => {
-            bitrouter::commands::login_provider(&provider, &label).await
-        }
-        Command::Logout { provider } => bitrouter::commands::logout_provider(&provider).await,
         Command::Agents { action } => agents_cmd(action).await,
         Command::AgentProxy { agent, config } => {
             let source = bitrouter::paths::resolve_config(config.as_deref())?;
             agent_proxy_cmd(&agent, &source).await
         }
-        Command::Auth { action } => auth_cmd(action).await,
         Command::Cloud { action } => bitrouter::cloud::cli::run(action).await,
         Command::Skills { action } => bitrouter::skills::cli::run(action).await,
-    }
-}
-
-// ===== `bitrouter auth …` (OAuth 2.0 device flow against a user-supplied AS) =====
-
-async fn auth_cmd(action: AuthAction) -> Result<()> {
-    use bitrouter_cloud_sdk::auth::commands::{LoginInputs, login, logout, whoami};
-    match action {
-        AuthAction::Login {
-            authorization_server,
-            client_id,
-            scope,
-        } => {
-            login(LoginInputs {
-                authorization_server,
-                client_id,
-                scope,
-            })
-            .await?;
-            Ok(())
-        }
-        AuthAction::Logout {
-            authorization_server,
-            client_id,
-        } => {
-            logout(LoginInputs {
-                authorization_server,
-                client_id,
-                scope: None,
-            })
-            .await
-        }
-        AuthAction::Whoami => whoami().await,
     }
 }
 
@@ -943,7 +848,7 @@ fn announce_zero_config(
 /// Multi-line guidance shown when zero-config detects no credential of any
 /// kind. The recommendation chain is intentional:
 ///
-///   1. `bitrouter auth login` — one OAuth account, every supported model.
+///   1. `bitrouter cloud login` — one OAuth account, every supported model.
 ///   2. `BITROUTER_API_KEY` — long-lived `brk_…` key, same coverage.
 ///   3. Any upstream provider the user already pays for, locally.
 ///
@@ -960,7 +865,7 @@ fn print_onboarding_hint() {
     eprintln!();
     eprintln!("  1. Sign in to BitRouter Cloud — one account covers every model:");
     eprintln!();
-    eprintln!("       bitrouter auth login");
+    eprintln!("       bitrouter cloud login");
     eprintln!("       bitrouter cloud --help        # manage keys, usage, policies, billing");
     eprintln!();
     eprintln!("  2. Or paste a BitRouter API key:");
@@ -1333,6 +1238,32 @@ async fn providers(action: ProviderAction) -> Result<()> {
                 );
             }
             Ok(())
+        }
+        ProviderAction::Login { provider, label } => {
+            // The built-in `bitrouter` provider authenticates with the cloud
+            // OAuth credential, so logging into it IS the cloud sign-in
+            // (`cloud login`); other providers use the per-provider store.
+            if provider == "bitrouter" {
+                bitrouter::cloud::cli::run(bitrouter::cloud::cli::CloudAction::Login {
+                    authorization_server: None,
+                    client_id: None,
+                    scope: None,
+                })
+                .await
+            } else {
+                bitrouter::commands::login_provider(&provider, &label).await
+            }
+        }
+        ProviderAction::Logout { provider } => {
+            if provider == "bitrouter" {
+                bitrouter::cloud::cli::run(bitrouter::cloud::cli::CloudAction::Logout {
+                    authorization_server: None,
+                    client_id: None,
+                })
+                .await
+            } else {
+                bitrouter::commands::logout_provider(&provider).await
+            }
         }
     }
 }

--- a/apps/bitrouter/src/main.rs
+++ b/apps/bitrouter/src/main.rs
@@ -2,15 +2,15 @@
 //!
 //! Subcommand surface: `serve` / `start` / `stop` / `restart` /
 //! `reload` / `status` / `route` / `init` / `key sign` / `models` / `tools` /
-//! `policy create` / `providers (list|use)` / `wallet` / `login` / `logout` /
-//! `whoami` / `agents`. Daemon control runs over a local IPC endpoint
-//! (a Unix domain socket, or a Windows named pipe) — `start` spawns
-//! `serve` detached; the client subcommands send one [`DaemonCommand`] each.
+//! `policy create` / `providers list` / `login` / `logout` / `agents` /
+//! `agent-proxy` / `auth` / `cloud` / `skills`. Daemon control runs over a
+//! local IPC endpoint (a Unix domain socket, or a Windows named pipe) —
+//! `start` spawns `serve` detached; the client subcommands send one
+//! [`DaemonCommand`] each.
 //!
-//! v1.0 ships the routing / settlement subsystems wired here. Subsystems that
-//! belong to *other* services (OWS wallet, cloud login, ACP runtime) print an
-//! honest "not implemented in v1.0" message rather than faking output — see
-//! 007's notes on cross-system scope.
+//! OWS wallet integration is out of scope for v1.0 (it lives in the `ows`
+//! workspace); a commented-out `Wallet` variant in `Command` reserves the
+//! name for a future integration without shipping a non-functional command.
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -158,8 +158,11 @@ enum Command {
         #[command(subcommand)]
         action: ProviderAction,
     },
-    /// OWS wallet integration — not implemented in v1.0.
-    Wallet,
+    // Reserved for a future OWS wallet integration (delivered by the `ows`
+    // workspace, not bitrouter). Intentionally commented out so v1.0 ships no
+    // non-functional `wallet` command; uncomment this variant AND restore its
+    // match arm in `run` when wiring OWS in.
+    // Wallet,
     /// Log in to an upstream provider — interactive credential setup.
     ///
     /// Per-provider available methods are auto-derived from the catalog:
@@ -169,14 +172,13 @@ enum Command {
     /// code flow; everything else accepts a pasted API key. The
     /// resulting credential is stored under
     /// `$XDG_DATA_HOME/bitrouter/oauth-tokens.json` keyed by
-    /// `(provider_id, label)`. For cloud sign-in (no argument), see
-    /// `bitrouter auth login` instead — kept separate so the per-
-    /// provider and cloud flows don't share a flag surface.
+    /// `(provider_id, label)`. For cloud sign-in, see `bitrouter auth login`
+    /// — kept separate so the per-provider and cloud flows don't share a
+    /// flag surface.
     Login {
         /// Provider id to log in to (e.g. `anthropic`, `openai-codex`,
-        /// `github-copilot`). Omit and the CLI redirects you to
-        /// `bitrouter auth login` for the cloud flow.
-        provider: Option<String>,
+        /// `github-copilot`).
+        provider: String,
         /// Account label this credential is stored under. Defaults to
         /// `default`. Use a non-default label to keep multiple accounts
         /// of the same provider side by side — reference them from
@@ -186,16 +188,11 @@ enum Command {
     },
     /// Log out of an upstream provider — clears every stored credential
     /// for the provider (subscription OAuth and pasted API keys alike).
-    /// For cloud sign-out (no argument), see `bitrouter auth logout`.
+    /// For cloud sign-out, see `bitrouter auth logout`.
     Logout {
         /// Provider id whose stored credentials should be removed.
-        /// Omit and the CLI redirects you to `bitrouter auth logout`.
-        provider: Option<String>,
+        provider: String,
     },
-    /// Legacy shim. Cloud identity now lives under
-    /// `bitrouter auth whoami` (local) and `bitrouter cloud whoami`
-    /// (local + base URL); this prints a pointer to those.
-    Whoami,
     /// ACP agent lifecycle — list the catalog, check configured agents,
     /// print install stubs. `bitrouter agent-proxy <id>` is the separate
     /// stdio bridge an editor spawns.
@@ -404,13 +401,6 @@ enum ProviderAction {
         #[arg(short, long)]
         config: Option<PathBuf>,
     },
-    /// Select an active provider. v1 has no "current provider" concept (003
-    /// §5.2 dropped the v0 DEFAULT_PROVIDER fallback) — this command is a
-    /// no-op kept for surface compatibility with v0's `providers use`.
-    Use {
-        /// Provider id (accepted but not persisted).
-        id: String,
-    },
 }
 
 #[tokio::main]
@@ -494,46 +484,10 @@ async fn run() -> Result<()> {
         Command::Observe { action } => observe(action).await,
         Command::Policy { action } => policy(action).await,
         Command::Providers { action } => providers(action).await,
-        Command::Wallet => {
-            print_unimplemented(
-                "wallet",
-                "OWS wallet integration is delivered by the `ows` workspace, not\n\
-                 by bitrouter. v1.0 ships the routing / settlement layer only.",
-            );
-            Ok(())
+        Command::Login { provider, label } => {
+            bitrouter::commands::login_provider(&provider, &label).await
         }
-        Command::Login { provider, label } => match provider.as_deref() {
-            Some(name) => bitrouter::commands::login_provider(name, &label).await,
-            None => {
-                print_unimplemented(
-                    "login",
-                    "`bitrouter login` is the per-provider OAuth surface.\n\
-                     For cloud sign-in, run `bitrouter auth login`.\n\
-                     For a local virtual key, run `bitrouter key sign --user <id>`.",
-                );
-                Ok(())
-            }
-        },
-        Command::Logout { provider } => match provider.as_deref() {
-            Some(name) => bitrouter::commands::logout_provider(name).await,
-            None => {
-                print_unimplemented(
-                    "logout",
-                    "`bitrouter logout` is the per-provider OAuth surface.\n\
-                     For cloud sign-out, run `bitrouter auth logout`.",
-                );
-                Ok(())
-            }
-        },
-        Command::Whoami => {
-            print_unimplemented(
-                "whoami",
-                "`bitrouter whoami` (top-level) is a legacy shim. Use:\n\
-                 - `bitrouter auth whoami`  — local cloud identity (offline read).\n\
-                 - `bitrouter cloud whoami` — same identity plus the configured /v1/* base URL.",
-            );
-            Ok(())
-        }
+        Command::Logout { provider } => bitrouter::commands::logout_provider(&provider).await,
         Command::Agents { action } => agents_cmd(action).await,
         Command::AgentProxy { agent, config } => {
             let source = bitrouter::paths::resolve_config(config.as_deref())?;
@@ -1380,13 +1334,6 @@ async fn providers(action: ProviderAction) -> Result<()> {
             }
             Ok(())
         }
-        ProviderAction::Use { id } => {
-            println!("v1 has no \"current provider\" — `providers use {id}` is a no-op.");
-            println!(
-                "  request a specific provider per-call via the model name or routing\n  prefs; bind a default by editing `bitrouter.yaml`."
-            );
-            Ok(())
-        }
     }
 }
 
@@ -1662,14 +1609,6 @@ fn pid_path_for(socket: &Path) -> PathBuf {
     let mut p = socket.to_path_buf();
     p.set_extension("pid");
     p
-}
-
-fn print_unimplemented(name: &str, detail: &str) {
-    eprintln!("`bitrouter {name}` is not implemented in v1.0.");
-    eprintln!();
-    for line in detail.lines() {
-        eprintln!("  {line}");
-    }
 }
 
 /// Liveness check: on Unix `kill -0 <pid>` returns success iff the pid is

--- a/crates/bitrouter-cloud-sdk/src/auth/commands.rs
+++ b/crates/bitrouter-cloud-sdk/src/auth/commands.rs
@@ -1,4 +1,4 @@
-//! `bitrouter auth <login|logout|whoami>` entry points.
+//! `bitrouter cloud login` / `logout` device-flow entry points.
 //!
 //! The CLI in `apps/bitrouter/src/main.rs` parses the subcommand + flags
 //! into [`LoginInputs`] and hands off to the functions here.
@@ -11,7 +11,7 @@ use super::flow;
 use super::metadata::{self, AsMetadata};
 use super::settings::{Settings, resolve_from_env};
 
-/// User-supplied flag values for `bitrouter auth login` / `logout`.
+/// User-supplied flag values for `bitrouter cloud login` / `logout`.
 /// The CLI passes them straight through.
 #[derive(Debug, Default, Clone)]
 pub struct LoginInputs {
@@ -35,7 +35,7 @@ pub fn http_client() -> Result<reqwest::Client> {
 }
 
 /// Run the device-authorization grant against the configured AS and
-/// persist the resulting tokens. Used by `bitrouter auth login`.
+/// persist the resulting tokens. Used by `bitrouter cloud login`.
 pub async fn login(inputs: LoginInputs) -> Result<Credentials> {
     let settings = resolve_from_env(
         inputs.authorization_server.as_deref(),
@@ -88,7 +88,7 @@ pub async fn login(inputs: LoginInputs) -> Result<Credentials> {
 }
 
 /// Revoke the stored tokens (best-effort) and clear the local file.
-/// Used by `bitrouter auth logout`.
+/// Used by `bitrouter cloud logout`.
 pub async fn logout(inputs: LoginInputs) -> Result<()> {
     let mut store = CredentialsStore::default_path().context("opening credentials store")?;
     let prior = match store.current().cloned() {
@@ -203,7 +203,7 @@ pub async fn whoami() -> Result<()> {
                 .map(|p| p.display().to_string())
                 .unwrap_or_else(|_| "<unresolved>".into());
             println!("not signed in (no credentials at {default})");
-            println!("  run `bitrouter auth login` to sign in");
+            println!("  run `bitrouter cloud login` to sign in");
             Ok(())
         }
     }

--- a/crates/bitrouter-cloud-sdk/src/auth/credentials.rs
+++ b/crates/bitrouter-cloud-sdk/src/auth/credentials.rs
@@ -1,4 +1,4 @@
-//! On-disk OAuth credentials for the `bitrouter auth` user-account flow.
+//! On-disk OAuth credentials for the `bitrouter cloud` user-account flow.
 //!
 //! Single JSON file at `<data-dir>/account-credentials.json`. The file
 //! is owner-only (mode `0o600` on Unix) — these tokens grant access to
@@ -34,7 +34,7 @@ pub struct Credentials {
     /// `Authorization: Bearer <access_token>` (RFC 6750 §2.1).
     pub access_token: String,
     /// RFC 6749 §1.5 refresh token. Optional — the AS may decline to
-    /// issue one, or `bitrouter auth login` may have been run with a
+    /// issue one, or `bitrouter cloud login` may have been run with a
     /// scope the AS refuses to refresh.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub refresh_token: Option<String>,
@@ -229,17 +229,17 @@ impl CredentialsStore {
         let creds = self
             .current
             .as_ref()
-            .context("no stored credentials — run `bitrouter auth login` first")?
+            .context("no stored credentials — run `bitrouter cloud login` first")?
             .clone();
         if !creds.access_token_near_expiry(REFRESH_WINDOW) {
             return Ok(creds.access_token);
         }
         let refresh_token = creds.refresh_token.as_deref().context(
-            "access token expired and no refresh token is stored — run `bitrouter auth login`",
+            "access token expired and no refresh token is stored — run `bitrouter cloud login`",
         )?;
         if !creds.refresh_token_usable() {
             anyhow::bail!(
-                "refresh token has itself expired — run `bitrouter auth login` to re-authenticate"
+                "refresh token has itself expired — run `bitrouter cloud login` to re-authenticate"
             );
         }
         let token_set = flow::refresh(

--- a/crates/bitrouter-cloud-sdk/src/auth/flow.rs
+++ b/crates/bitrouter-cloud-sdk/src/auth/flow.rs
@@ -1,5 +1,5 @@
 //! Device Authorization Grant client — RFC 8628 — plus the small
-//! ancillary HTTP exchanges the `bitrouter auth` flow needs:
+//! ancillary HTTP exchanges the `bitrouter cloud` sign-in flow needs:
 //! - refresh-token exchange (RFC 6749 §6),
 //! - best-effort token revocation (RFC 7009).
 //!
@@ -433,7 +433,7 @@ fn token_set_from_response(access_token: String, parsed: TokenResponse) -> Token
 
 /// Pull the `sub` claim out of a serialized JWT-shaped id_token without
 /// verifying its signature. We do NOT trust this for authorization —
-/// it's only surfaced by `bitrouter auth whoami` as a hint of "which
+/// it's only surfaced by `bitrouter cloud whoami` as a hint of "which
 /// account did I sign in as", and the AS already signed the
 /// access_token that grants the actual access. RFC 9068 + RFC 7519
 /// describe the structure; per OpenID Connect Core §3.1.3.7 the

--- a/crates/bitrouter-cloud-sdk/src/auth/metadata.rs
+++ b/crates/bitrouter-cloud-sdk/src/auth/metadata.rs
@@ -19,7 +19,7 @@ use super::settings::require_secure_url;
 /// `device_authorization_endpoint` (RFC 8628 §4) is the only endpoint
 /// the device flow strictly requires alongside `token_endpoint` (RFC
 /// 6749 §3.2). `revocation_endpoint` (RFC 7009 §3) is best-effort — when
-/// the AS doesn't advertise one, `bitrouter auth logout` skips the
+/// the AS doesn't advertise one, `bitrouter cloud logout` skips the
 /// network call and just deletes the local file.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 pub struct AsMetadata {

--- a/crates/bitrouter-cloud-sdk/src/auth/settings.rs
+++ b/crates/bitrouter-cloud-sdk/src/auth/settings.rs
@@ -3,7 +3,7 @@
 //! is read, so the precedence rule lives in exactly one location.
 //!
 //! Defaults are set to the project's hosted authorization server so a
-//! plain `bitrouter auth login` works out of the box. The
+//! plain `bitrouter cloud login` works out of the box. The
 //! implementation is a generic RFC 8628 client — anyone running their
 //! own authorization server overrides the defaults via flags or env
 //! vars.
@@ -11,7 +11,7 @@
 use anyhow::Result;
 
 /// Default authorization server URL. Points at the project's hosted
-/// service so `bitrouter auth login` works with no flags. Override
+/// service so `bitrouter cloud login` works with no flags. Override
 /// with `--oauth-as` or [`AS_ENV`] to target a different deployment.
 pub const DEFAULT_AS: &str = "https://api.bitrouter.ai";
 

--- a/crates/bitrouter-cloud-sdk/src/lib.rs
+++ b/crates/bitrouter-cloud-sdk/src/lib.rs
@@ -10,7 +10,7 @@
 //!    authorization server. Implements RFC 8628 device-flow login,
 //!    RFC 6749 §6 refresh, and RFC 7009 best-effort revocation, plus an
 //!    on-disk credentials store (mode `0o600` on Unix). The
-//!    `bitrouter auth login` / `logout` / `whoami` subcommands wire to the
+//!    `bitrouter cloud login` / `logout` / `whoami` subcommands wire to the
 //!    entry points in [`auth::commands`].
 //! 2. [`provider`] — a [`bitrouter_sdk::language_model::AuthApplier`]
 //!    implementation for the `bitrouter` provider (the official hosted
@@ -24,7 +24,7 @@
 //!    `/v1/*` management surface (`keys`, `usage`, `billing`, `policies`,
 //!    `budgets`, `presets`, `byok`, `oauth_clients`). Shares the auth
 //!    module's credentials store, so it transparently picks up the
-//!    bearer that `bitrouter auth login` persisted and refreshes it on
+//!    bearer that `bitrouter cloud login` persisted and refreshes it on
 //!    the same RFC 6749 §6 / §4.14 schedule. Drives the
 //!    `bitrouter cloud` CLI subcommands.
 //!

--- a/crates/bitrouter-cloud-sdk/src/management/error.rs
+++ b/crates/bitrouter-cloud-sdk/src/management/error.rs
@@ -19,24 +19,24 @@ use thiserror::Error;
 #[derive(Debug, Error)]
 pub enum Error {
     /// No credentials on disk — the user has not yet run
-    /// `bitrouter auth login`.
-    #[error("not signed in — run `bitrouter auth login` first")]
+    /// `bitrouter cloud login`.
+    #[error("not signed in — run `bitrouter cloud login` first")]
     NotSignedIn,
 
     /// The stored credential carries no namespace, but the requested
     /// operation is namespace-scoped. The CLI's device-flow tokens are
     /// always namespace-baked, so in practice this means the credential
-    /// file predates namespace-scoping — re-running `bitrouter auth
+    /// file predates namespace-scoping — re-running `bitrouter cloud
     /// login` mints a namespace-bound token.
     #[error(
-        "credential is not scoped to a namespace — run `bitrouter auth login` to get a \
+        "credential is not scoped to a namespace — run `bitrouter cloud login` to get a \
          namespace-scoped credential"
     )]
     NoNamespace,
 
     /// OAuth token resolution or refresh failed (e.g. refresh token
     /// expired, AS metadata unreachable). The user should re-run
-    /// `bitrouter auth login`.
+    /// `bitrouter cloud login`.
     #[error("failed to resolve a BitRouter Cloud access token: {0:#}")]
     Auth(#[source] anyhow::Error),
 
@@ -110,7 +110,7 @@ pub enum Error {
 impl Error {
     /// When this is a 403 carrying a `missing required scope: <name>`
     /// description, return the scope name. Used by the CLI to print
-    /// the `bitrouter auth login --scope …` hint.
+    /// the `bitrouter cloud login --scope …` hint.
     pub fn missing_scope(&self) -> Option<&str> {
         match self {
             Error::Forbidden { missing_scope, .. } => missing_scope.as_deref(),

--- a/crates/bitrouter-cloud-sdk/src/management/mod.rs
+++ b/crates/bitrouter-cloud-sdk/src/management/mod.rs
@@ -4,7 +4,7 @@
 //! `presets`, `byok`, `oauth_clients` — is the same one the web console
 //! consumes. It accepts either a `brk_` API key or a `bra_` OAuth
 //! access token. This client always presents the latter: it reads the
-//! credential persisted by `bitrouter auth login`
+//! credential persisted by `bitrouter cloud login`
 //! ([`crate::auth::credentials::CredentialsStore`]) and refreshes it
 //! transparently within
 //! [`crate::auth::credentials::REFRESH_WINDOW`] of expiry.

--- a/crates/bitrouter-cloud-sdk/src/provider/applier.rs
+++ b/crates/bitrouter-cloud-sdk/src/provider/applier.rs
@@ -3,7 +3,7 @@
 //!
 //! Two credential sources are tried in order:
 //!
-//! 1. **OAuth access token** persisted by `bitrouter auth login`
+//! 1. **OAuth access token** persisted by `bitrouter cloud login`
 //!    ([`crate::auth::credentials::CredentialsStore`]). When the stored
 //!    access token is within
 //!    [`crate::auth::credentials::REFRESH_WINDOW`] of expiry the store's
@@ -32,7 +32,7 @@
 //! The RFC 8414 authorization-server metadata document is fetched on the
 //! first call that exercises the OAuth branch and cached for the process
 //! lifetime. The cache key is the AS URL recorded in the credentials
-//! file, so a `bitrouter auth login` against a fresh AS will trigger a
+//! file, so a `bitrouter cloud login` against a fresh AS will trigger a
 //! re-fetch on the first inference call.
 //!
 //! References:
@@ -68,7 +68,7 @@ pub const PROVIDER_ID: &str = "bitrouter";
 /// the CLI prints back to the user; the longer multi-step prompt at zero
 /// config time is rendered separately by `apps/bitrouter`.
 pub fn onboarding_hint() -> &'static str {
-    "no BitRouter Cloud credential — run `bitrouter auth login` or set BITROUTER_API_KEY=brk_…"
+    "no BitRouter Cloud credential — run `bitrouter cloud login` or set BITROUTER_API_KEY=brk_…"
 }
 
 /// `AuthApplier` for `provider_name == "bitrouter"`.
@@ -315,7 +315,7 @@ mod tests {
         match err {
             BitrouterError::Upstream { status, message } => {
                 assert_eq!(status, 401);
-                assert!(message.contains("bitrouter auth login"), "msg={message}");
+                assert!(message.contains("bitrouter cloud login"), "msg={message}");
                 assert!(message.contains("BITROUTER_API_KEY"), "msg={message}");
             }
             other => panic!("expected Upstream 401, got {other:?}"),


### PR DESCRIPTION
Pre-1.0 CLI **subcommand cleanup**, two parts:

## 1. Remove placeholder commands
The CLI shipped five "placeholder" surfaces that printed a redirect or were no-ops (all exited 0).
- **`wallet`** — commented out, kept only as a source `Command` variant + note, reserving the name for a future **OWS** integration. Not compiled in v1.0.
- **`whoami`** (top-level legacy shim), **`providers use`** (no-op) — removed.
- **`login`/`logout`** no-argument redirect — `<provider>` is now required.
- Removed the unused `print_unimplemented` helper.

## 2. Regroup auth under cloud / providers
The old surface used "login" for two different things (`auth login` = cloud account; `login <provider>` = provider credential). Namespaced by what you authenticate:
- `auth {login,logout,whoami}` → **`cloud {login,logout,whoami}`**; top-level `auth` removed.
- top-level `login/logout <provider>` → **`providers {login,logout} <provider>`**.
- **`providers login bitrouter`** ⇒ `cloud login` (and `providers logout bitrouter` ⇒ `cloud logout`): the built-in `bitrouter` provider authenticates with the cloud OAuth credential (the `BitrouterCloudAuthApplier` already resolves it), so they're the same operation — shared code.
- All user-facing "run `bitrouter auth login`" hints (CLI + cloud-sdk error messages) updated to `bitrouter cloud login`.

`cloud login`/`logout` reuse the existing `bitrouter_cloud_sdk::auth::commands::{login,logout}` device flow; `cloud whoami` keeps its base-URL-aware output. The now-app-unused `auth::commands::whoami` lib helper is left in place (its sibling `current_bearer` is removed in #523; pruning both can follow to avoid an adjacent-edit conflict between the PRs).

## ⚠️ Breaking
Removes `wallet` (compiled), `whoami`, `providers use`, `bitrouter auth …`, and top-level `bitrouter login/logout <provider>`. Cloud sign-in is `cloud login`; provider creds are `providers login <p>`.

## Verification
`cargo nextest run --all-features --workspace` → 661 passed; `cargo clippy --all-features --workspace --all-targets` → 0 warnings; `cargo fmt -- --check` clean. Ran the binary: `auth`/`wallet`/`whoami`/`providers use` now error `unrecognized subcommand`; `cloud login/logout/whoami` and `providers list/login/logout` resolve; `cloud whoami` returns live identity; `providers login <unknown>` hits the real provider path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)