### PR TITLE
docs: add /bitrouter Agent Skill to monorepo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,20 @@ See `README.md` and `DEVELOPMENT.md` for full project introduction and architect
 3. **NEVER** use `.unwrap`, `.expect` or `panic!` to make the Rust program panic.
 4. **NEVER** over-design types, functions and methods that is never used in the feature or fix you are working on. We don't allow dead code.
 
+## Agent Skill
+
+The `/bitrouter` Agent Skill lives in `skills/bitrouter/` and is the source of
+truth for how agents drive BitRouter. It documents facts that drift easily —
+the listen port (`127.0.0.1:4356`), env var names (`GEMINI_API_KEY`, not
+`GOOGLE_API_KEY`; `OPENCODE_ZEN_API_KEY` shared by Zen and Go), the
+`provider/model` slash form, and which CLI subcommands exist.
+
+1. **ALWAYS** update `skills/bitrouter/` in the same change when you alter a CLI
+   flag, listen port, env var, default config, or harness wiring step. The skill
+   must not describe a CLI that no longer matches `apps/bitrouter`.
+2. Keep `skills/bitrouter/SKILL.md` under ~200 lines; deep detail goes in
+   `skills/bitrouter/references/`.
+
 ## Contributing
 
 1. **ALWAYS** use the **conventional** git commit message format. Keep the title under 60 characters. The message body and footer can be any length.

--- a/README.md
+++ b/README.md
@@ -132,12 +132,25 @@ bitrouter cloud keys / usage / billing / …     # manage keys, usage, billing, 
 
 See [`CLI.md`](CLI.md) for flags, config resolution, and examples.
 
+## Agent Skill
+
+BitRouter ships an [Agent Skill](https://agentskills.io) — `/bitrouter` — so AI
+coding agents can install, configure, migrate to, and troubleshoot BitRouter on
+their own. It lives in this repo at [`skills/bitrouter/`](skills/), kept in sync
+with the code.
+
+```bash
+bitrouter skills add bitrouter        # via BitRouter's own installer
+npx skills add bitrouter/bitrouter    # via the generic skills CLI
+```
+
 ## Documentation
 
 - [`CLI.md`](CLI.md) — full CLI reference with flags and examples
 - [`DEVELOPMENT.md`](DEVELOPMENT.md) — workspace architecture and SDK internals
 - [`CONTRIBUTING.md`](CONTRIBUTING.md) — contribution workflow, issue reporting, and provider updates
 - [`CLAUDE.md`](CLAUDE.md) — guidance for AI coding agents working in this repository
+- [`skills/`](skills/) — the `/bitrouter` Agent Skill (source of truth)
 
 ## Roadmap
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,51 @@
+# Agent Skills
+
+This directory is the **source of truth** for BitRouter's [Agent Skill](https://agentskills.io).
+It lives in the monorepo so the skill's facts (port `4356`, env var names, CLI
+subcommands, harness wiring) stay in lockstep with the code that defines them —
+a skill change ships in the same PR as the change that motivates it.
+
+## What's here
+
+One skill: **`/bitrouter`**, at [`bitrouter/`](bitrouter/).
+
+```
+skills/bitrouter/
+├── SKILL.md          # entry point — keep under ~200 lines
+└── references/       # loaded on demand
+    ├── cloud-setup.md
+    ├── cli.md
+    ├── providers.md
+    ├── diagnose.md
+    ├── migrate-from-*.md
+    └── harness-*.md
+```
+
+It covers the Local-or-Cloud decision, install, daemon lifecycle, cloud
+onboarding, provider config, migration off other gateways, diagnostics, and
+per-harness wiring. Follows the [Agent Skills specification](https://agentskills.io/specification).
+
+## Install
+
+Every install rail resolves this directory by its repo path —
+`bitrouter/bitrouter` → `skills/bitrouter` — so no separate package is needed.
+
+```bash
+# BitRouter's own installer (subdir-aware via the registry hub)
+bitrouter skills add bitrouter
+
+# Generic skills CLI — discovers skills/ automatically
+npx skills add bitrouter/bitrouter
+
+# Claude Code (manual)
+cp -r skills/bitrouter ~/.claude/skills/
+```
+
+## Editing conventions
+
+- Keep `SKILL.md` under ~200 lines; deep detail goes in `references/`.
+- Each reference file is independently consumable — don't assume a sibling was loaded.
+- When you change a CLI flag, port, env var, or harness step in the code, update
+  the matching fact here in the same change. See the "Facts that are easy to get
+  wrong" section in the repo's agent guidance.
+- Validate with the [skills-ref](https://github.com/agentskills/agentskills/tree/main/skills-ref) library: `skills-ref validate ./skills/bitrouter`.

--- a/skills/bitrouter/SKILL.md
+++ b/skills/bitrouter/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: bitrouter
+description: >
+  Use this skill when the user wants to install, configure, run, or
+  troubleshoot BitRouter — an LLM proxy that runs two ways: a local Rust
+  daemon at http://localhost:4356 (BYOK) or BitRouter Cloud at
+  https://api.bitrouter.ai/v1 (managed, brk_* keys, Stripe credits or
+  x402 wallet). Unifies OpenAI, Anthropic, Google, OpenRouter, GitHub
+  Copilot, and OpenCode Zen/Go behind one endpoint. Also covers signup
+  on bitrouter.ai, minting brk_ API keys, migrating off LiteLLM /
+  OpenRouter / any OpenAI- or Anthropic-compatible gateway, editing
+  bitrouter.yaml, and wiring coding-agent harnesses (Claude Code, Codex,
+  Hermes Agent, OpenClaw). Trigger on "set up a local LLM proxy",
+  "managed AI gateway", "replace litellm", "point claude code at a
+  proxy", "bitrouter cloud", "brk_ key", anything naming bitrouter.yaml,
+  port 4356, or api.bitrouter.ai — even when the user does not name
+  BitRouter directly.
+version: 1.0.0
+license: Apache-2.0
+metadata:
+  author: BitRouterAI
+  tags: [llm, proxy, routing, openai, anthropic, google, gemini, openrouter, copilot, opencode, ai-gateway, claude-code, codex]
+---
+
+# BitRouter
+
+BitRouter routes OpenAI- or Anthropic-shaped requests to any LLM provider. It runs **two ways**: a local Rust daemon at `http://127.0.0.1:4356` (BYOK — your keys, your machine) or a managed cloud service at `https://api.bitrouter.ai/v1` (one bill, no per-provider keys).
+
+## 1. Ask first: Local or Cloud?
+
+Before touching anything, ask the user this:
+
+> Do you want to run BitRouter **locally** (install the daemon, BYOK with your own provider API keys, you pay each upstream directly) or use **BitRouter Cloud** (managed proxy at `api.bitrouter.ai`, one bill via Stripe credits or x402 wallet payments, no per-provider keys needed)?
+
+### If Local
+Continue to §2 (Install). Skip the Cloud paths below.
+
+### If Cloud — four entry points
+
+1. **Web playground (zero install, fastest demo).** Send the user to <https://bitrouter.ai> → sign up → top up credits via Stripe → use the in-browser playground. No code changes needed.
+
+2. **API key in their SDK (most common production path).** On <https://bitrouter.ai> → Dashboard → API Keys → mint a `brk_*` key. Then in their code:
+
+   ```python
+   from openai import OpenAI
+   client = OpenAI(
+       base_url="https://api.bitrouter.ai/v1",
+       api_key="brk_...",
+   )
+   client.chat.completions.create(
+       model="openai/gpt-4o",
+       messages=[{"role": "user", "content": "hi"}],
+   )
+   ```
+
+   No local daemon installed. Works with the Anthropic SDK too — drop `/v1` from the base URL.
+
+3. **Permissionless wallet (Solana / EVM, no account).** Sign an SOL_EDDSA JWT with the user's wallet, hit `api.bitrouter.ai` directly, x402/MPP handles payment. Crypto-native flow; point the user at <https://bitrouter.ai> docs for details — don't try to script the JWT signing yourself.
+
+4. **Headless CLI (`bitrouter auth login`).** RFC 8628 device-flow OAuth, persists the credential to `$XDG_DATA_HOME/bitrouter/account-credentials.json` (auto-refreshed). When the credentials file is present, the local daemon auto-adds the `bitrouter` provider in zero-config mode, so every entitled model is routable as `bitrouter:<model-id>` against `localhost:4356` — no manual `brk_*` paste, no `bitrouter.yaml` changes. `bitrouter cloud --help` then drives the full /v1/* management surface (keys / usage / billing / policy / budget / preset / byok / oauth-client). See `references/cloud-setup.md` path D.
+
+See `references/cloud-setup.md` for deeper detail (dashboard URLs, credit model, key rotation, wallet flow, CLI sign-in).
+
+## 2. Install (Local only)
+
+```bash
+curl --proto '=https' --tlsv1.2 -LsSf https://bitrouter.ai/install.sh | sh
+```
+
+macOS users may prefer `brew install bitrouter/tap/bitrouter`; environments that already manage global npm tools can use `npm install -g bitrouter`. Windows:
+
+```powershell
+powershell -ExecutionPolicy Bypass -c "irm https://bitrouter.ai/install.ps1 | iex"
+```
+
+`https://bitrouter.ai/install.{sh,ps1}` is the canonical entry point — it proxies the latest GitHub release's cargo-dist installer and survives transient asset-publishing gaps by falling back to the most recent release that actually has the installer attached.
+
+Verify: `bitrouter --version`. If `command not found`, see `references/diagnose.md`.
+
+## 3. Run (Local only)
+
+BitRouter has no interactive setup wizard — onboarding is two commands.
+
+**Zero-config (BYOK).** Export any of the supported env vars and start the daemon. It auto-enables every provider whose key is present.
+
+```bash
+export OPENAI_API_KEY=sk-...           # openai
+export ANTHROPIC_API_KEY=sk-ant-...    # anthropic
+export GEMINI_API_KEY=...              # google  (NOT GOOGLE_API_KEY)
+export OPENROUTER_API_KEY=sk-or-...    # openrouter
+export OPENCODE_ZEN_API_KEY=...        # opencode-zen AND opencode-go (shared)
+
+bitrouter start          # detached daemon, logs to ~/.bitrouter/bitrouter.log
+bitrouter status         # green dot + pid / listen / model count
+```
+
+The daemon writes its runtime files (`bitrouter.sock`, `bitrouter.pid`, `bitrouter.log`, optional `bitrouter.db`) into `~/.bitrouter/`.
+
+**With a config file.** When you want explicit control (multi-account, MCP servers, ACP agents, custom providers):
+
+```bash
+bitrouter init                    # writes ./bitrouter.yaml (skip_auth: true)
+$EDITOR bitrouter.yaml
+bitrouter start --config ./bitrouter.yaml
+```
+
+Config search order, lowest-priority last: `./bitrouter.yaml` → `$BITROUTER_HOME/bitrouter.yaml` → `~/.bitrouter/bitrouter.yaml` → zero-config in-memory.
+
+**GitHub Copilot.** Different — OAuth device flow, not an env var:
+
+```bash
+bitrouter login github-copilot    # browser device flow, token stored on disk
+```
+
+## 4. Connect your SDK
+
+Point any OpenAI- or Anthropic-shaped SDK at the daemon. The credential the daemon validates is set by `server.skip_auth` (true in the starter config — credential-less local requests admitted; flip to `false` and mint a virtual key with `bitrouter key sign --user <id>` for multi-tenant).
+
+```python
+from openai import OpenAI
+client = OpenAI(base_url="http://localhost:4356/v1", api_key="unused")
+client.chat.completions.create(
+    model="openai/gpt-4o",                # provider/model
+    messages=[{"role": "user", "content": "hi"}],
+)
+```
+
+Resolve a model name without making a request: `bitrouter route openai/gpt-4o`.
+
+> For Cloud, swap `http://localhost:4356/v1` → `https://api.bitrouter.ai/v1` and `api_key="unused"` → `api_key="brk_..."`. Everything else stays identical.
+
+## 5. References
+
+Read these on demand — don't load them all upfront.
+
+| File | When to read |
+|---|---|
+| `references/cloud-setup.md` | User chose Cloud — signup walkthrough, key mint, billing, wallet path |
+| `references/cli.md` | Full subcommand reference + what each one does |
+| `references/providers.md` | Add / configure providers, multi-account, MCP servers, custom OpenAI-compatible endpoints |
+| `references/diagnose.md` | Install issues, daemon won't start, connection refused, provider errors, log locations |
+| `references/migrate-from-litellm.md` | Migrating off LiteLLM |
+| `references/migrate-from-openrouter.md` | Migrating off OpenRouter (or keeping it as a fallback) |
+| `references/migrate-from-openai-compatible.md` | Migrating from raw OpenAI keys, Azure, Together, Groq, Ollama, LM Studio, or any other OpenAI-compatible endpoint |
+| `references/migrate-from-anthropic-compatible.md` | Migrating from raw Anthropic keys or any Anthropic-Messages-shaped gateway |
+| `references/harness-claude-code.md` | Wiring Claude Code at `localhost:4356` |
+| `references/harness-codex.md` | Wiring Codex CLI |
+| `references/harness-hermes-agent.md` | Wiring Hermes Agent |
+| `references/harness-openclaw.md` | Wiring OpenClaw |
+
+## 6. Gotchas
+
+- **Always ask Local-or-Cloud first.** The default of "just install locally" is wrong for users who want managed billing — they should never install the daemon at all.
+- **Cloud sign-in is `bitrouter auth login`, not `bitrouter login`.** The top-level `bitrouter login <provider>` surface is still per-provider OAuth (today: `github-copilot`); the cloud bridge landed as a separate `bitrouter auth …` subcommand tree to avoid colliding with it. Bare `bitrouter login` / `bitrouter logout` / `bitrouter whoami` now print a redirect pointing at `bitrouter auth login` / `bitrouter auth logout` / `bitrouter auth whoami` and `bitrouter cloud whoami`.
+- **Cloud management is `bitrouter cloud …`.** After `bitrouter auth login`, run `bitrouter cloud --help` for the subcommand index: `keys`, `usage`, `requests`, `billing`, `policy`, `budget`, `preset`, `byok`, `oauth-client`. Every leaf accepts `--json`.
+- **Local port: `127.0.0.1:4356`.** Old docs (and the upstream README) sometimes say 8787 — those are stale.
+- **Cloud endpoints:** `https://api.bitrouter.ai/v1` for the OpenAI shape; `https://api.bitrouter.ai` (no `/v1`) for the Anthropic SDK — same asymmetry as Local.
+- **Google's env var is `GEMINI_API_KEY`**, matching Google's own SDKs. `GOOGLE_API_KEY` is not auto-detected; override in `bitrouter.yaml` if you must.
+- **Reload propagates env changes:** `export OPENAI_API_KEY=new...; bitrouter reload` updates the running daemon — no restart needed.
+- **`bitrouter providers add/remove/test/stats` do not exist.** Only `bitrouter providers list` and `bitrouter providers use` (the latter is a v0-compat no-op). Edit `bitrouter.yaml` and `bitrouter reload`.
+- **No `bitrouter doctor`.** Diagnostics are: `bitrouter status`, `bitrouter route <model>`, `bitrouter models`, `bitrouter providers list`, log file at `~/.bitrouter/bitrouter.log`.

--- a/skills/bitrouter/references/cli.md
+++ b/skills/bitrouter/references/cli.md
@@ -1,0 +1,111 @@
+# CLI reference
+
+Every subcommand the v1 binary actually exposes. Anything not listed here doesn't exist — don't suggest `bitrouter doctor`, `bitrouter providers add`, `bitrouter cloud connect`, or `bitrouter auth status` (cloud identity is `bitrouter auth whoami`, see below).
+
+## Daemon lifecycle
+
+| Command | Effect |
+|---|---|
+| `bitrouter serve [--config PATH]` | Run the HTTP server + control socket **in the foreground**. Ctrl-C to stop. |
+| `bitrouter start [--config PATH] [--log PATH]` | Spawn `serve` as a detached background process. Stdout/stderr go to `~/.bitrouter/bitrouter.log` unless `--log` overrides. Refuses to start over a live daemon. |
+| `bitrouter stop [--config PATH] [--socket PATH]` | Graceful shutdown via the control socket. |
+| `bitrouter restart [--config PATH] [--log PATH] [--socket PATH]` | Stop, wait up to 30s for in-flight requests to drain, then start. Escalates to SIGKILL on timeout. |
+| `bitrouter reload [--config PATH] [--socket PATH]` | Hot-reload the running daemon's config + routing table. **Also re-pushes provider env vars** from the current shell into the daemon, so `export OPENAI_API_KEY=new...; bitrouter reload` rotates the key without a restart. SIGHUP to the daemon process has the same effect. |
+| `bitrouter status [--config PATH] [--socket PATH]` | `systemctl status`-style block: pid / listen / model count / socket. Reports `stopped` (exit 0) when no daemon is reachable. |
+
+## Inspection
+
+| Command | Effect |
+|---|---|
+| `bitrouter route <model> [--config PATH]` | Resolve a model name through the routing table. Tries the running daemon first (live table), falls back to standalone config resolution. Prints the provider/service chain. |
+| `bitrouter models [--config PATH] [--provider ID]` | List every routable model the config exposes. Filter by provider. |
+| `bitrouter providers list [--config PATH]` | Tab-aligned: `ID  MODELS  ACTIVE  API_BASE`. |
+| `bitrouter tools list [--config PATH]` | Enumerate tools advertised by every configured MCP server (one `tools/list` round-trip per server). |
+| `bitrouter tools status [--config PATH]` | Health-check each MCP server. Latency or error per row. |
+| `bitrouter tools discover <server> [--config PATH]` | Print a YAML stub for the discovered server, paste into `mcp_servers:`. |
+| `bitrouter agents list [--config PATH]` | Show bundled v1 ACP catalog + which are configured. |
+| `bitrouter agents check [--config PATH]` | Spawn each configured ACP agent and verify `initialize` round-trip. |
+| `bitrouter agents install <id>` | Print a paste-ready YAML stub for catalog entry `<id>`. |
+| `bitrouter observe status [--json] [--config PATH] [--socket PATH]` | OTel exporter snapshot: wired / endpoint / sampler / cardinality usage / in-flight spans. JSON output for tooling. |
+
+## Setup helpers
+
+| Command | Effect |
+|---|---|
+| `bitrouter init [--config PATH]` | Write a starter `bitrouter.yaml` (default `./bitrouter.yaml`). Refuses to overwrite. Mirrors the zero-config defaults — `skip_auth: true`, `listen: 127.0.0.1:4356`, all built-in providers stubbed as `{}` so they auto-enable when their env var is set. |
+| `bitrouter providers use <id>` | **No-op** in v1 (kept for v0 compatibility). Prints a hint to edit `bitrouter.yaml` instead. |
+| `bitrouter policy create <id> [--dir DIR]` | Write a starter policy file under `--dir` (default `./policies`). Bind to a key with `bitrouter key sign --user <id> --policy <id>`. |
+| `bitrouter key sign --user <id> [--db URL] [--policy ID]` | Mint a `brvk_…` virtual key in the auth DB. Plaintext is shown once; only its SHA-256 hash is stored. Default DB is `sqlite://./bitrouter.db`. |
+
+## Per-provider OAuth
+
+| Command | Effect |
+|---|---|
+| `bitrouter login <provider>` | Per-provider OAuth. Today the only supported provider is **`github-copilot`** — runs the GitHub device flow and stores `ghu_…` under `$XDG_DATA_HOME/bitrouter/oauth-tokens.json`. |
+| `bitrouter logout <provider>` | Remove the stored OAuth token for `<provider>`. |
+| `bitrouter login` (no arg) | Legacy shim. Prints a pointer to `bitrouter auth login` (for cloud sign-in) and `bitrouter key sign --user <id>` (for local virtual keys). |
+| `bitrouter logout` (no arg) | Legacy shim. Pointer to `bitrouter auth logout`. |
+| `bitrouter whoami` (no arg) | Legacy shim. Pointer to `bitrouter auth whoami` (offline local read) and `bitrouter cloud whoami` (local read + cloud base URL). |
+
+## BitRouter Cloud sign-in (`bitrouter auth …`)
+
+OAuth 2.0 device-flow sign-in against the BitRouter Cloud authorization server. The persisted credential drives both the `bitrouter` provider in the local daemon and the management subcommands below.
+
+| Command | Effect |
+|---|---|
+| `bitrouter auth login [--oauth-as URL] [--client-id ID] [--scope SCOPE]` | RFC 8628 device-flow login. Prints an approval URL, polls the token endpoint, and persists access + refresh tokens to `$XDG_DATA_HOME/bitrouter/account-credentials.json` (mode 0600 on Unix). Auto-refreshes within 60 s of access-token expiry on every subsequent call. Defaults: AS `https://api.bitrouter.ai`, client id `bitrouter-cli`, scope set covering `inference:invoke usage:read keys:* billing:read policy:* byok:* account:read`. Override the AS or scope for a self-hosted deployment or to opt into the sensitive scopes (`billing:write`, `account:write`, `clients:*`). |
+| `bitrouter auth logout` | Best-effort RFC 7009 revoke at the AS, then delete the local credentials file. |
+| `bitrouter auth whoami` | Print the local credential's AS, client id, scope, subject, expiry. Reads the on-disk file only — no network. |
+
+Side effect: when the credentials file exists, the local daemon auto-adds the `bitrouter` provider to the zero-config providers map, so every model your account is entitled to is routable as `bitrouter:<model-id>` against `localhost:4356` without further configuration.
+
+## BitRouter Cloud management (`bitrouter cloud …`)
+
+Typed wrappers over the `/v1/*` management API on the cloud. Requires `bitrouter auth login` first. Every leaf accepts `--json` for raw response output; default is a `systemctl`-style key:value block (single resource) or a small table (lists). On a 403 with `missing required scope: <s>`, the CLI prints a copy-pasteable `bitrouter auth login --scope "<current> <s>"` hint.
+
+| Command | Effect |
+|---|---|
+| `bitrouter cloud whoami` | Cloud base URL + local subject/scope from the credentials file. Offline. |
+| `bitrouter cloud keys list / mint / revoke` | List `brk_…` API keys, mint a new one (plaintext shown once), revoke by id. Scopes: `keys:read` / `keys:write`. |
+| `bitrouter cloud usage [--from RFC3339] [--to RFC3339]` | Aggregate spend (micro-USD) + token counts over a window (default last 30 days). Scope: `usage:read`. |
+| `bitrouter cloud requests [--limit N] [--offset N]` | Paged request history. Scope: `usage:read`. |
+| `bitrouter cloud billing balance` | Credit balance + pending debits + available (`max(balance - pending, 0)`). Scope: `billing:read`. |
+| `bitrouter cloud billing checkout --amount-cents N` | Start a Stripe checkout session for a credit top-up. Returns a hosted URL. Scope: `billing:write` (opt-in via `--scope` at login). |
+| `bitrouter cloud policy list/get/create/update/delete/bind/unbind/disable/enable/bindings/effective/for-principal` | Generic CRUD over policy registry. `create` and `update --spec` accept a JSON file path or `-` for stdin. `effective` and `for-principal` answer "what would happen for this principal" without making an actual inference call. Scope: `policy:read` / `policy:write`. |
+| `bitrouter cloud budget list/get/create/update/delete` | Typed sugar over budget-kind policies. |
+| `bitrouter cloud preset list/get/create/update/delete` | Typed sugar over preset-kind policies. |
+| `bitrouter cloud byok list/set/delete` | BYOK provider keys. `set` takes already-sealed ciphertext (`--ciphertext-b64` + `--kek-id` matching the cloud's current X25519 public key). Scope: `byok:read` / `byok:write`. |
+| `bitrouter cloud oauth-client list/register/update/delete` | Registered OAuth clients on the account. Confidential clients return `client_secret` exactly once at `register`. Scope: `clients:read` / `clients:write` (opt-in via `--scope`). |
+
+## ACP bridge
+
+| Command | Effect |
+|---|---|
+| `bitrouter agent-proxy <agent> [--config PATH]` | Stdio bridge between an ACP-aware editor and an upstream agent declared under `agents:`. Editor spawns this binary as a subprocess. Routes JSON-RPC newline-framed over stdio. |
+
+## Unimplemented in v1.0
+
+These print `not implemented in v1.0` today and are unlikely to land in the proxy binary:
+
+- `bitrouter wallet` — OWS wallet integration lives in the separate `ows` workspace, not in the proxy binary.
+
+The bare `bitrouter login` / `bitrouter logout` / `bitrouter whoami` (no argument) are **not** in this list — they print a redirect (exit 0) pointing the user at the right surface (`bitrouter auth …` for cloud sign-in, `bitrouter key sign` for local virtual keys, `bitrouter cloud whoami` for cloud identity).
+
+## Config resolution
+
+Every command that takes `--config` resolves the path in this order when the flag is omitted:
+
+1. `./bitrouter.yaml` (current working directory)
+2. `$BITROUTER_HOME/bitrouter.yaml`
+3. `~/.bitrouter/bitrouter.yaml`
+4. Zero-config in-memory defaults (no file)
+
+The daemon `chdir`s to the directory holding the resolved config on startup, so every relative path inside the config (`database.url: sqlite://./bitrouter.db`, policy/agent file references) resolves against that directory, not the launcher's CWD.
+
+## Signals
+
+| Signal | Behavior |
+|---|---|
+| SIGHUP | Hot-reload config + routing table (same as `bitrouter reload`). |
+| SIGINT / SIGTERM | Graceful shutdown: flush OTel exporter, remove pid file, exit 0. |
+| SIGKILL | No cleanup — pid file will be stale and `bitrouter status` will report it. `bitrouter start` cleans up stale pid files automatically before launching. |

--- a/skills/bitrouter/references/cloud-setup.md
+++ b/skills/bitrouter/references/cloud-setup.md
@@ -1,0 +1,168 @@
+# Cloud setup
+
+The user chose **BitRouter Cloud** (managed proxy at `api.bitrouter.ai`, one bill, no per-provider keys). This file covers the four entry points and the operational details for each: web playground (A), dashboard-minted API key in code (B), permissionless wallet (C), and headless CLI sign-in (D — recommended for terminal-first users).
+
+## A. Web playground (no install, no code)
+
+Fastest demo path. Send the user here:
+
+1. Visit <https://bitrouter.ai>.
+2. Sign up (email / OAuth — handled by the console's better-auth).
+3. Top up credits via Stripe checkout on the console's billing page.
+4. Use the in-browser playground to send chat requests against any supported model.
+
+No SDK, no local daemon, no API key. Stop here if the user just wants to evaluate or run one-off prompts.
+
+## B. API key (`brk_*`) for SDK use — the production path
+
+This is the path agents should default to for any "I want to call BitRouter from my code" question.
+
+### Mint a key
+
+1. <https://bitrouter.ai> → Dashboard → API Keys.
+2. Click "Create key", give it a device name (e.g. `laptop`, `prod-worker`).
+3. Copy the `brk_…` string immediately — only its SHA-256 hash is stored, so the plaintext is shown once.
+
+### Use it in code
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://api.bitrouter.ai/v1",
+    api_key="brk_...",
+)
+client.chat.completions.create(
+    model="openai/gpt-4o",
+    messages=[{"role": "user", "content": "hi"}],
+)
+```
+
+Anthropic SDK:
+
+```python
+from anthropic import Anthropic
+
+client = Anthropic(
+    base_url="https://api.bitrouter.ai",   # no /v1
+    api_key="brk_...",
+)
+client.messages.create(
+    model="anthropic/claude-sonnet-4-5",
+    max_tokens=256,
+    messages=[{"role": "user", "content": "hi"}],
+)
+```
+
+### Operate the key
+
+- **Rotation / revocation:** Dashboard → API Keys → revoke (per-row). Keys are matched by their `sha256` hash; a revoked key's hash can be reused by a new key without collision.
+- **Billing:** every request decrements the user's Postgres `credit_balances` row by the cost of the actual tokens consumed (not an estimate). Top-up via Stripe in the console — credits are tracked in cents.
+- **Overdraft:** the gate allows a small overdraft if many concurrent requests collectively exceed the balance estimate, but the next request after the balance hits zero will be rejected. Top up before running large batches.
+
+## C. Permissionless wallet — no signup, crypto-native
+
+For users who want to skip account creation entirely. Sign a JWT with a Solana (Ed25519) or EVM (secp256k1) wallet; BitRouter's `bitrouter-node` verifies the signature against the CAIP-10 `iss` claim and routes the request. Payment goes through x402 / MPP escrow on-chain.
+
+This is fiddly to script — recommend pointing the user at <https://bitrouter.ai> docs rather than writing the JWT signing flow inline. Key facts the agent should know without going deeper:
+
+- The `iss` claim is CAIP-10: `solana:<base58 pubkey>` or `eip155:1:<0x address>`.
+- The JOSE `alg` is `SOL_EDDSA` (BitRouter-native, distinct from RFC 7515's `EdDSA`).
+- Cross-`alg` forgery (wallet `iss` with `EdDSA`, or thumbprint `iss` with `SOL_EDDSA`) is rejected before signature verification, so don't try to "fix" mismatches by changing the header.
+- Balance lives in a Mongo `charge_balances` collection keyed by wallet — separate from the Stripe-credit Postgres path.
+
+## D. Headless CLI (`bitrouter auth login`) — recommended for terminal-first users
+
+This is the seam between Local and Cloud, closed by `bitrouter auth login` (landed in v1, see also `references/cli.md`).
+
+### Sign in
+
+```bash
+bitrouter auth login
+# Open this URL in your browser:
+#   https://api.bitrouter.ai/oauth/device?user_code=ABCD-EFGH
+# Waiting for authorization (the code expires in 600s)…
+```
+
+Mechanism: RFC 8628 device-authorization grant against the AS advertised at `https://api.bitrouter.ai/.well-known/oauth-authorization-server`. The CLI polls the token endpoint, exchanges the device code for an access + refresh token pair, and persists both to `$XDG_DATA_HOME/bitrouter/account-credentials.json` (mode 0600 on Unix). Every subsequent call auto-refreshes within 60 s of access-token expiry — sign in once per machine.
+
+Override the AS for a self-hosted deployment: `bitrouter auth login --oauth-as https://my-self-hosted.example.com`.
+
+Sensitive scopes are off the default grant set — opt in at login time:
+
+```bash
+# To use `bitrouter cloud billing checkout` and/or `bitrouter cloud oauth-client …`:
+bitrouter auth login --scope "inference:invoke usage:read keys:read keys:write \
+                              billing:read billing:write \
+                              policy:read policy:write byok:read byok:write \
+                              account:read clients:read clients:write"
+```
+
+### Auto-enable for the local daemon
+
+When the credentials file is present, the local `bitrouter` daemon auto-adds the `bitrouter` provider to the in-memory zero-config providers map (see `apps/bitrouter/src/cloud/mod.rs::enable_in_zero_config`). Every model the account is entitled to becomes routable as `bitrouter:<model-id>` against `http://localhost:4356` — no `bitrouter.yaml` changes, no `BITROUTER_API_KEY` env var.
+
+```python
+client = OpenAI(base_url="http://localhost:4356/v1", api_key="unused")
+client.chat.completions.create(
+    model="bitrouter/gpt-4o",      # served via the user's cloud subscription
+    messages=[{"role": "user", "content": "hi"}],
+)
+```
+
+Cloud and BYOK coexist — providers with `${PROVIDER_API_KEY}` in the environment stay configured alongside the cloud provider.
+
+### Manage the account from the terminal
+
+After sign-in, `bitrouter cloud …` covers the full `/v1/*` management API:
+
+```bash
+bitrouter cloud whoami                 # cloud base URL + local subject/scope
+bitrouter cloud usage                  # last 30 days of spend (micro-USD)
+bitrouter cloud keys list              # provisioned brk_… API keys
+bitrouter cloud keys mint --name laptop --scope "policy:read"
+bitrouter cloud billing balance        # credit balance
+bitrouter cloud policy list            # account-bound policies
+bitrouter cloud byok list              # BYOK provider keys
+```
+
+Every leaf accepts `--json` for raw response output. See `references/cli.md` for the full subcommand index.
+
+### Sign out
+
+```bash
+bitrouter auth logout
+```
+
+Runs an RFC 7009 best-effort revoke at the AS, then deletes the local credentials file. Idempotent — re-running with no credentials present is a no-op.
+
+## What Cloud does for the user that Local doesn't
+
+- **No provider keys to manage.** One `brk_*` instead of `OPENAI_API_KEY` + `ANTHROPIC_API_KEY` + `GEMINI_API_KEY` + …
+- **One bill.** Stripe credits for fiat, x402 wallet for crypto. No reconciling N upstream invoices.
+- **Curated registry.** Cloud uses a pinned `provider-registry` baked into the deploy image, so model availability and protocol routing match what the playground previews.
+- **No daemon to keep alive.** No `bitrouter status`, no `~/.bitrouter/`, no log rotation.
+
+## What Local does for the user that Cloud doesn't
+
+- **No third party in the request path.** Latency, privacy, audit trail all stay on the user's machine.
+- **Custom providers.** Local can target Ollama, Azure OpenAI deployments, internal endpoints — Cloud's registry is fixed.
+- **MCP / ACP wiring.** `mcp_servers:` and `agents:` in `bitrouter.yaml` are a Local-only feature today.
+- **No usage cost above what the upstream charges.** BYOK is at-cost; Cloud adds the platform's margin.
+
+## Switching between Local and Cloud
+
+The SDK base URL is the only thing that changes — model identifiers and SDK code are identical:
+
+```python
+# Local
+client = OpenAI(base_url="http://localhost:4356/v1", api_key="unused")
+
+# Cloud
+client = OpenAI(base_url="https://api.bitrouter.ai/v1", api_key="brk_...")
+
+# both:
+client.chat.completions.create(model="openai/gpt-4o", messages=[...])
+```
+
+A user can run both side-by-side (different base URLs in different environments) — Cloud for production, Local for offline development, no code branching needed.

--- a/skills/bitrouter/references/diagnose.md
+++ b/skills/bitrouter/references/diagnose.md
@@ -1,0 +1,185 @@
+# Diagnose
+
+Real diagnostic flow against the v1 binary. There is no `bitrouter doctor` — diagnostics are composed from `status`, `route`, `models`, `providers list`, and the log file.
+
+> **Work one hypothesis at a time.** After each change, re-run `bitrouter status` and the command that originally failed. Don't try the next fix until you've confirmed the current one didn't resolve it — shotgunning multiple changes makes it impossible to attribute the eventual success and often introduces new failures.
+
+## First six checks
+
+```bash
+bitrouter --version                           # 1. installed?
+bitrouter status                              # 2. daemon running?
+bitrouter providers list                      # 3. providers configured + active?
+bitrouter models                              # 4. routing table populated?
+bitrouter route openai/gpt-4o                 # 5. one specific model resolves?
+tail -n 80 ~/.bitrouter/bitrouter.log         # 6. recent daemon output
+```
+
+`bitrouter status` prints `bitrouter is stopped` (exit 0) when no daemon answers the control socket — that's the answer to the question, not a failure. Look at the log next.
+
+## Symptom: "command not found" after install
+
+```bash
+command -v bitrouter
+echo $PATH
+ls "$HOME/.cargo/bin/bitrouter" 2>/dev/null
+```
+
+The shell installer drops the binary in `$CARGO_HOME/bin` (default `~/.cargo/bin`). Add to PATH:
+
+```bash
+echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> ~/.zshrc
+exec $SHELL -l
+```
+
+For Homebrew, check `brew doctor`. For npm, ensure `npm bin -g` is on PATH.
+
+## Symptom: shell installer fails with SSL error
+
+`curl: (60) SSL certificate problem` means your system trust store is out of date. Update root certs or fall back to `brew install bitrouter/tap/bitrouter` or `npm install -g bitrouter`.
+
+## Symptom: brew can't find the formula
+
+`brew install bitrouter/tap/bitrouter` should auto-tap. If it doesn't:
+
+```bash
+brew tap bitrouter/tap
+brew install bitrouter
+```
+
+## Uninstall
+
+| Installed via | Remove with |
+|---|---|
+| Shell installer | `rm "$(command -v bitrouter)"` |
+| Homebrew | `brew uninstall bitrouter` (optionally `brew untap bitrouter/tap`) |
+| npm | `npm uninstall -g bitrouter` |
+
+State under `~/.bitrouter/` survives uninstall — `rm -rf ~/.bitrouter` for a clean slate.
+
+## Symptom: daemon won't start
+
+```bash
+bitrouter start
+# error: bitrouter is already running (pid 12345); use `restart` or `stop` first
+```
+
+A live daemon already holds the socket. Either `bitrouter restart` or `bitrouter stop && bitrouter start`. The `start` path automatically cleans up stale pid files when no process matches.
+
+If the daemon exits within 250ms of spawn, `bitrouter start` quotes the failure log tail back to stderr — read it. Common causes:
+
+- **Port collision.** `lsof -i :4356` to see what's bound. Edit `server.listen` to a free port, restart.
+- **Config parse error.** The log tail shows the YAML line; fix and retry.
+- **Database lock.** Stale sqlite lock from a SIGKILL'd previous run — `rm ~/.bitrouter/bitrouter.db-shm ~/.bitrouter/bitrouter.db-wal` (the main `.db` file is safe to keep).
+
+## Symptom: "connection refused" from a client
+
+```bash
+curl -v http://localhost:4356/health      # daemon health
+curl -v http://localhost:4356/v1/models   # routing table over HTTP
+```
+
+If `bitrouter status` says running but curl fails:
+
+- **Wrong port.** Old skill versions said 8787 — the real default is **4356**.
+- **`0.0.0.0` vs `127.0.0.1`.** `bitrouter init` writes `127.0.0.1:4356` for safety. Code default for `ServerConfig` is `0.0.0.0:4356`. Both serve localhost clients — but if the client is in a container/VM hitting the host, you need `0.0.0.0`.
+- **Firewall.** macOS: `sudo pfctl -d` to test (temporary). Linux: `sudo ufw allow 4356`.
+
+## Symptom: provider errors at request time
+
+```bash
+bitrouter providers list                  # ACTIVE column
+bitrouter route openai/gpt-4o             # does the chain resolve?
+```
+
+If `ACTIVE` is `no` for a built-in provider, its env var wasn't set when the daemon started — or its OAuth token is missing (`github-copilot`). Two fixes:
+
+```bash
+# A) re-export and hot-reload (no restart needed)
+export OPENAI_API_KEY=sk-...
+bitrouter reload
+
+# B) for github-copilot, run the device flow
+bitrouter login github-copilot
+bitrouter reload
+```
+
+If the upstream itself is the problem, test it directly:
+
+```bash
+curl https://api.openai.com/v1/models \
+  -H "Authorization: Bearer $OPENAI_API_KEY"
+```
+
+## Symptom: "model not found"
+
+```bash
+bitrouter models                          # what's actually routable
+bitrouter models --provider openai        # filter
+bitrouter route <exact model id>          # resolution + chain
+```
+
+Model identifiers are **`provider/model`** in v1 (not the old `provider:model` colon form some legacy docs still show). The exact id strings come from the built-in catalog or your config's `models:` list — `bitrouter models` is authoritative.
+
+## Symptom: env var change didn't propagate
+
+```bash
+export OPENAI_API_KEY=sk-new-...
+bitrouter reload          # re-pushes provider env vars into daemon
+```
+
+`reload` snapshots every env-var-credentialed built-in's value from your shell and hands them to the daemon. SIGHUP to the daemon pid is the alternative. If neither picks up the new value, restart: `bitrouter restart`.
+
+## Symptom: MCP / ACP not working
+
+```bash
+bitrouter tools status              # MCP server liveness + latency
+bitrouter tools list                # advertised tools
+bitrouter agents check              # spawn each ACP agent, verify `initialize`
+```
+
+`tools status` shows per-server latency or the error inline. `agents check` will exit with a non-success row when an ACP agent's stdio bridge fails — check that the `command` / `args` in your `agents:` config resolve on PATH (`npx`, `uvx`, etc.).
+
+## Symptom: degraded latency
+
+```bash
+time curl -sS http://localhost:4356/health
+time curl -sS http://localhost:4356/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"openai/gpt-4o-mini","messages":[{"role":"user","content":"hi"}],"max_tokens":5}'
+```
+
+Compare to a direct upstream call. If `/health` is fast but completions are slow, the upstream is the bottleneck — pick a different provider for the same model via routing or by adjusting account_strategy.
+
+## Where everything lives
+
+```
+~/.bitrouter/
+├── bitrouter.yaml         # if you ran `bitrouter init`
+├── bitrouter.db           # sqlite, virtual keys + metering
+├── bitrouter.sock         # daemon control socket
+├── bitrouter.pid          # daemon pid (best-effort, cleaned on graceful exit)
+└── bitrouter.log          # stdout+stderr of the detached daemon
+```
+
+Per-provider OAuth tokens (github-copilot today) live under `$XDG_DATA_HOME/bitrouter/oauth-tokens.json`. The BitRouter Cloud session created by `bitrouter auth login` lives at `$XDG_DATA_HOME/bitrouter/account-credentials.json` (mode 0600 on Unix). On macOS both default to `~/Library/Application Support/bitrouter/`.
+
+If `bitrouter auth whoami` shows an expired token and the refresh exchange fails (network outage, server-side revocation), the fix is to re-run `bitrouter auth login`. Re-login is idempotent — it overwrites the existing credentials file in place.
+
+## Clean reset
+
+```bash
+bitrouter stop || true
+rm -rf ~/.bitrouter
+# reinstall is not required — state was the only thing wiped
+bitrouter start
+```
+
+## Observability snapshot
+
+```bash
+bitrouter observe status            # OTel exporter wired? endpoint? cardinality?
+bitrouter observe status --json     # machine-readable
+```
+
+`compiled: no` means the binary was built without the OTel feature — install from a release build, not a custom `cargo install --no-default-features` invocation.

--- a/skills/bitrouter/references/harness-claude-code.md
+++ b/skills/bitrouter/references/harness-claude-code.md
@@ -1,0 +1,52 @@
+# Harness: Claude Code
+
+Wire Anthropic's Claude Code CLI to route its model calls through BitRouter at `http://localhost:4356`.
+
+> **Cloud users:** swap `http://localhost:4356` → `https://api.bitrouter.ai` (Anthropic SDK drops the `/v1`) and use a `brk_*` key instead of `"unused"`. No daemon to install. See `references/cloud-setup.md`.
+
+## Prerequisites
+
+- BitRouter installed and running (`bitrouter status` shows green).
+- The `anthropic` provider active in BitRouter (`bitrouter providers list` should show `active: yes`).
+- Claude Code installed and authenticated normally at least once.
+
+## Configuration
+
+> **TODO:** fill in the exact env var or settings.json path that points Claude Code at a custom Anthropic-shaped base URL. Confirmed knobs to capture:
+> - The env var name(s) Claude Code reads for `ANTHROPIC_BASE_URL` / `ANTHROPIC_API_KEY` override.
+> - Whether `~/.claude/settings.json` carries the override and the exact field path.
+> - The auth header expectation when `bitrouter`'s `skip_auth: true` is on (any token? a `brvk_…` virtual key?).
+> - Anything Claude Code does differently for stream vs. non-stream that BitRouter needs to know about.
+
+```bash
+# placeholder — replace with the verified one-liner
+export ANTHROPIC_BASE_URL="http://localhost:4356"
+export ANTHROPIC_API_KEY="unused"      # bitrouter handles upstream auth
+```
+
+## Model selection
+
+> **TODO:** confirm whether Claude Code accepts `anthropic/claude-sonnet-4-5` (BitRouter's `provider/model` form) or only bare `claude-sonnet-4-5`. If only bare names, document the `models:` alias pattern to add to `bitrouter.yaml`:
+
+```yaml
+# bitrouter.yaml — alias bare Claude Code model names to BitRouter's provider/model
+models:
+  claude-sonnet-4-5:
+    upstream_id: "anthropic/claude-sonnet-4-5"
+  claude-haiku-4-5:
+    upstream_id: "anthropic/claude-haiku-4-5"
+```
+
+## Verify
+
+```bash
+# from the shell that exported the override:
+claude --version
+# run a one-shot query — the daemon log should show an /v1/messages hit
+echo "say hi" | claude
+tail -n 20 ~/.bitrouter/bitrouter.log
+```
+
+## Notes & gotchas
+
+> **TODO:** capture anything specific to Claude Code that surprised you in testing — e.g., whether tool use round-trips work end-to-end through BitRouter, whether streaming buffering behaves, any auth header strictness.

--- a/skills/bitrouter/references/harness-codex.md
+++ b/skills/bitrouter/references/harness-codex.md
@@ -1,0 +1,48 @@
+# Harness: Codex CLI
+
+Wire OpenAI's Codex CLI to route its model calls through BitRouter at `http://localhost:4356`.
+
+> **Cloud users:** swap `http://localhost:4356/v1` → `https://api.bitrouter.ai/v1` and use a `brk_*` key instead of `"unused"`. No daemon to install. See `references/cloud-setup.md`.
+
+## Prerequisites
+
+- BitRouter installed and running (`bitrouter status` shows green).
+- The `openai` provider active in BitRouter, or whichever provider hosts the gpt-5.x-codex family you want (`github-copilot` and `opencode-zen` both serve Codex-family models via the Responses API).
+- Codex CLI installed.
+
+## Configuration
+
+> **TODO:** fill in the exact env var or config file path that points Codex at a custom OpenAI-shaped base URL. Confirmed knobs to capture:
+> - The env var Codex reads for `OPENAI_BASE_URL` / `OPENAI_API_KEY` override (one of `OPENAI_BASE_URL`, `OPENAI_API_BASE`, or a Codex-specific name).
+> - Whether `~/.codex/config.toml` or similar carries the override and the exact field path.
+> - Whether Codex pins itself to the Responses API or also uses Chat Completions — BitRouter routes per-model, so the harness can stay protocol-agnostic.
+> - The auth header expectation when BitRouter's `skip_auth: true` is on.
+
+```bash
+# placeholder — replace with the verified one-liner
+export OPENAI_BASE_URL="http://localhost:4356/v1"
+export OPENAI_API_KEY="unused"
+```
+
+## Model selection
+
+> **TODO:** confirm Codex's model identifier convention. BitRouter accepts `openai/gpt-5.5-codex`, `github-copilot/gpt-5.5-codex`, and `opencode-zen/opencode/gpt-5.5-codex` — the harness probably wants a bare name (`gpt-5.5-codex`). Add an alias:
+
+```yaml
+models:
+  gpt-5.5-codex:
+    upstream_id: "openai/gpt-5.5-codex"   # or github-copilot / opencode-zen, your call
+```
+
+## Verify
+
+```bash
+# in the shell with the overrides exported
+codex --version
+echo "fix the bug in main.py" | codex
+tail -n 20 ~/.bitrouter/bitrouter.log
+```
+
+## Notes & gotchas
+
+> **TODO:** capture anything specific to Codex that surprised you — e.g., whether the diff/apply tool calls round-trip cleanly, whether reasoning tokens are preserved, how Codex handles 401s from the upstream when BitRouter falls through accounts.

--- a/skills/bitrouter/references/harness-hermes-agent.md
+++ b/skills/bitrouter/references/harness-hermes-agent.md
@@ -1,0 +1,46 @@
+# Harness: Hermes Agent
+
+Wire Hermes Agent to route its model calls through BitRouter at `http://localhost:4356`.
+
+> **Cloud users:** swap `http://localhost:4356/v1` → `https://api.bitrouter.ai/v1` (or drop `/v1` for the Anthropic shape) and use a `brk_*` key instead of `"unused"`. No daemon to install. See `references/cloud-setup.md`.
+
+## Prerequisites
+
+- BitRouter installed and running (`bitrouter status` shows green).
+- Whichever provider Hermes targets is `active` in `bitrouter providers list`.
+- Hermes Agent installed.
+
+## Configuration
+
+> **TODO:** fill in everything below — this stub exists so the routing exists in the skill index, but it has not been validated.
+>
+> Specifics to capture:
+> - Hermes' canonical project home / install command (link to repo).
+> - The env var or config field that overrides the model endpoint base URL.
+> - Whether Hermes speaks OpenAI Chat Completions, OpenAI Responses, or Anthropic Messages on the wire — BitRouter supports all three but the harness has to send something it expects.
+> - Auth header convention when `skip_auth: true` is on.
+> - Any model-id normalization Hermes does before sending the request.
+
+```bash
+# placeholder — replace with the verified env vars / config edits
+# export HERMES_LLM_BASE_URL="http://localhost:4356/v1"
+# export HERMES_LLM_API_KEY="unused"
+```
+
+## Model selection
+
+> **TODO:** add the `models:` aliases that match Hermes' expected model identifiers, e.g.
+
+```yaml
+models:
+  # hermes-default:
+  #   upstream_id: "anthropic/claude-sonnet-4-5"
+```
+
+## Verify
+
+> **TODO:** one-line smoke test that triggers a single LLM call and lets the user confirm via `tail -n 20 ~/.bitrouter/bitrouter.log` that it landed.
+
+## Notes & gotchas
+
+> **TODO:** anything Hermes-specific you learn while wiring it.

--- a/skills/bitrouter/references/harness-openclaw.md
+++ b/skills/bitrouter/references/harness-openclaw.md
@@ -1,0 +1,55 @@
+# Harness: OpenClaw
+
+Wire OpenClaw to route its model calls through BitRouter at `http://localhost:4356`. OpenClaw has a native BitRouter plugin — prefer that over generic base-URL overrides.
+
+> **Cloud users:** the native plugin should support cloud endpoints out of the box once configured to point at `https://api.bitrouter.ai` with a `brk_*` key — verify against the plugin's docs. For the generic base-URL fallback, swap `http://localhost:4356` → `https://api.bitrouter.ai` and supply the `brk_*` key. See `references/cloud-setup.md`.
+
+## Prerequisites
+
+- BitRouter installed and running (`bitrouter status` shows green).
+- An active provider that serves the models OpenClaw drives (Claude family → `anthropic` or `github-copilot`; OpenAI family → `openai`).
+- OpenClaw installed (`github.com/openclaw/openclaw`).
+
+## Native plugin path (preferred)
+
+The BitRouter <> OpenClaw native plugin lives at `github.com/bitrouter/bitrouter-openclaw`.
+
+> **TODO:** fill in the exact install + configure steps for the native plugin. Specifics to capture:
+> - The plugin install one-liner (npm? a binary drop? a config block in OpenClaw's settings?).
+> - The OpenClaw config field that activates the BitRouter route (e.g. provider id, base URL, account selector).
+> - Whether the plugin uses the control socket (`bitrouter.sock`) for richer info or just HTTP.
+> - Any feature OpenClaw gets from the native plugin that the generic base-URL path does NOT (account failover, routing prefs, tool fan-out, etc.).
+
+## Generic base-URL fallback
+
+If you can't use the native plugin (or want to verify connectivity first), override OpenClaw's LLM endpoint:
+
+> **TODO:** identify the env var / config field. OpenClaw is OpenAI-compatible at minimum, so:
+
+```bash
+# placeholder — replace with the verified one-liner
+export OPENCLAW_BASE_URL="http://localhost:4356/v1"
+export OPENCLAW_API_KEY="unused"
+```
+
+## Model selection
+
+OpenClaw drives multiple model families. Add `models:` aliases for whatever it expects:
+
+```yaml
+models:
+  # openclaw-driver:
+  #   upstream_id: "anthropic/claude-sonnet-4-5"
+  # openclaw-sub:
+  #   upstream_id: "github-copilot/gpt-5.5-codex"
+```
+
+> **TODO:** confirm OpenClaw's actual model-id convention and replace the examples above.
+
+## Verify
+
+> **TODO:** capture the smoke test — e.g., a one-prompt OpenClaw invocation that produces a single LLM call you can verify in `~/.bitrouter/bitrouter.log`.
+
+## Notes & gotchas
+
+> **TODO:** anything OpenClaw-specific learned in testing — especially around the ACP bridge (`bitrouter agent-proxy`) if OpenClaw also speaks ACP.

--- a/skills/bitrouter/references/migrate-from-anthropic-compatible.md
+++ b/skills/bitrouter/references/migrate-from-anthropic-compatible.md
@@ -1,0 +1,117 @@
+# Migrate from an Anthropic-compatible source
+
+Use this when your current setup speaks **Anthropic Messages** on the wire — directly against `api.anthropic.com`, against Amazon Bedrock's Anthropic surface, against Google Vertex's Anthropic surface, or against any third-party that exposes `POST /v1/messages`.
+
+Generic move: point the client at `http://localhost:4356` (no `/v1`) instead of the upstream, let BitRouter hold the credential, and the SDK keeps working unchanged.
+
+> **Cloud alternative:** same move, different host — point the client at `https://api.bitrouter.ai` (no `/v1`) with a `brk_*` key. No daemon, no Anthropic key to manage. See `references/cloud-setup.md`. The rest of this file is the self-hosted path.
+
+## A) Direct Anthropic (raw API key, no proxy)
+
+If `ANTHROPIC_API_KEY` is in your environment, no config file needed.
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+bitrouter start
+```
+
+```python
+# old
+from anthropic import Anthropic
+client = Anthropic()
+
+# new — same SDK, different base
+client = Anthropic(base_url="http://localhost:4356", api_key="unused")
+client.messages.create(
+    model="anthropic/claude-sonnet-4-5",
+    max_tokens=256,
+    messages=[{"role": "user", "content": "hi"}],
+)
+```
+
+The built-in `anthropic` provider auto-enabled when the env var was set.
+
+## B) Amazon Bedrock (Anthropic surface)
+
+Bedrock exposes Anthropic models behind AWS SigV4 auth, not bearer tokens — different enough that the v1 BitRouter has a dedicated `bitrouter-bedrock` crate. To check what the v1 surface accepts in your build:
+
+```bash
+bitrouter providers list
+# look for `bedrock` or similar
+```
+
+> **TODO** — confirm the exact v1 provider id and config shape for Bedrock. Check `crates/bitrouter-bedrock` in the bitrouter repo, or <https://bitrouter.ai>. The general pattern is:
+
+```yaml
+providers:
+  bedrock:
+    # placeholder — verify in v1 docs
+    api_base: "https://bedrock-runtime.us-east-1.amazonaws.com"
+    api_protocol: { "*": anthropic }
+    # AWS credentials come from the standard provider chain
+    # (env vars, ~/.aws/credentials, IAM role)
+```
+
+## C) Google Vertex AI (Anthropic surface)
+
+Vertex serves Claude models with Google IAM auth. Same caveat as Bedrock — confirm the v1 provider id:
+
+```yaml
+providers:
+  vertex:
+    # placeholder — verify in v1 docs
+    api_base: "https://us-central1-aiplatform.googleapis.com/v1/projects/PROJECT/locations/us-central1/publishers/anthropic/models"
+    api_protocol: { "*": anthropic }
+```
+
+> **TODO** — fill in once verified against the codebase.
+
+## D) Any other Anthropic-Messages-shaped endpoint
+
+Some self-hosted gateways and aggregators (LiteLLM in `/messages` mode, Helicone in pass-through, a custom proxy your team runs) speak Anthropic Messages. Add them as a custom provider with `api_protocol` set to `anthropic`:
+
+```yaml
+providers:
+  internal-claude:
+    api_base: "https://claude.internal.example.com"
+    api_key: "${INTERNAL_CLAUDE_KEY}"
+    api_protocol: { "*": anthropic }
+    models:
+      - { id: "claude-sonnet-4-5" }
+      - { id: "claude-haiku-4-5" }
+```
+
+## Client switch (universal)
+
+```python
+# old
+from anthropic import Anthropic
+client = Anthropic(api_key=os.environ["ANTHROPIC_API_KEY"])
+
+# new
+client = Anthropic(base_url="http://localhost:4356", api_key="unused")
+```
+
+> **Note the missing `/v1`.** The Anthropic SDK appends `/v1/messages` itself. The OpenAI SDK, by contrast, expects the base to end in `/v1` — that's why the two SDKs use different BitRouter base URLs.
+
+## Cross-protocol bonus
+
+Once you're proxying through BitRouter, the same daemon can serve the **OpenAI** SDK against the **Anthropic** provider (and vice versa) — BitRouter cross-protocol-routes. So you can keep the Anthropic SDK in code that already uses it, and use the OpenAI SDK against `model="anthropic/claude-sonnet-4-5"` in code that wants one client.
+
+## Verify
+
+```bash
+bitrouter start
+bitrouter providers list                  # anthropic active: yes
+bitrouter route anthropic/claude-sonnet-4-5
+
+curl http://localhost:4356/v1/messages \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model":"anthropic/claude-sonnet-4-5",
+    "max_tokens":5,
+    "messages":[{"role":"user","content":"ping"}]
+  }'
+```
+
+If anything fails verification, see `diagnose.md`.

--- a/skills/bitrouter/references/migrate-from-litellm.md
+++ b/skills/bitrouter/references/migrate-from-litellm.md
@@ -1,0 +1,126 @@
+# Migrate from LiteLLM
+
+LiteLLM's `model_list` maps cleanly to BitRouter's `providers:` (credentials + base URLs) plus `models:` (your aliases). Your client code mostly only needs the base URL flipped.
+
+> **Cloud alternative:** if the user is open to managed routing instead of self-hosting, the equivalent of "stop running LiteLLM" is "point your SDK at `https://api.bitrouter.ai/v1` with a `brk_*` key" — no daemon, no YAML, no provider keys. See `references/cloud-setup.md`. The rest of this file covers the self-hosted (local daemon) migration.
+
+## The shape of the move
+
+| LiteLLM | BitRouter |
+|---|---|
+| `model_list[].model_name` | `models.<alias>` |
+| `model_list[].litellm_params.model` (e.g. `openai/gpt-4o`) | `models.<alias>.upstream_id` (same `provider/model` form) |
+| `model_list[].litellm_params.api_key` | `providers.<id>.api_key` (or omit — built-ins auto-resolve from env) |
+| `model_list[].litellm_params.api_base` | `providers.<id>.api_base` (only needed for custom endpoints) |
+| Default port `:8000` | `:4356` |
+
+## Example translation
+
+**Old `litellm_config.yaml`**
+
+```yaml
+model_list:
+  - model_name: gpt-4
+    litellm_params:
+      model: openai/gpt-4o
+      api_key: ${OPENAI_API_KEY}
+  - model_name: claude
+    litellm_params:
+      model: anthropic/claude-sonnet-4-5
+      api_key: ${ANTHROPIC_API_KEY}
+  - model_name: fast
+    litellm_params:
+      model: anthropic/claude-haiku-4-5
+```
+
+**New `bitrouter.yaml`**
+
+```yaml
+server:
+  listen: "127.0.0.1:4356"
+  skip_auth: true
+
+providers:
+  openai: {}         # uses OPENAI_API_KEY
+  anthropic: {}      # uses ANTHROPIC_API_KEY
+
+models:
+  gpt-4:
+    upstream_id: "openai/gpt-4o"
+  claude:
+    upstream_id: "anthropic/claude-sonnet-4-5"
+  fast:
+    upstream_id: "anthropic/claude-haiku-4-5"
+
+inherit_defaults: true
+```
+
+## Client switch
+
+```python
+# old
+from litellm import completion
+response = completion(model="gpt-4", messages=[...])
+
+# new — same alias, OpenAI SDK against bitrouter
+from openai import OpenAI
+client = OpenAI(base_url="http://localhost:4356/v1", api_key="unused")
+response = client.chat.completions.create(model="gpt-4", messages=[...])
+```
+
+## Cutover
+
+```bash
+# 1. start bitrouter alongside the running litellm
+bitrouter start
+
+# 2. verify aliases resolve
+bitrouter route gpt-4
+bitrouter route claude
+
+# 3. smoke test
+curl http://localhost:4356/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"gpt-4","messages":[{"role":"user","content":"ping"}],"max_tokens":5}'
+
+# 4. flip your app's base URL from :8000 to :4356
+# 5. stop litellm
+pkill -f 'litellm' || true
+```
+
+## Mapping LiteLLM features
+
+| LiteLLM | BitRouter equivalent |
+|---|---|
+| `master_key` | `bitrouter key sign --user <id>` (mint `brvk_…` virtual keys); set `server.skip_auth: false` |
+| `router_settings.fallbacks` | Provider `accounts` with `account_strategy: failover`, or per-pattern `derives` |
+| `router_settings.routing_strategy: simple-shuffle` | `account_strategy: balance` on a multi-account provider |
+| `litellm_params.rpm` / `tpm` | `providers.<id>.rate_limits` (glob-prefix pattern map) |
+| Callbacks / logging | `bitrouter observe status`; OTel exporter via env (`OTEL_EXPORTER_OTLP_ENDPOINT`) |
+
+For richer routing (`derives`, multi-account, per-pattern `api_protocol`), see `providers.md`.
+
+## Docker Compose
+
+```yaml
+# old
+services:
+  litellm:
+    image: ghcr.io/berriai/litellm:latest
+    ports: ["8000:8000"]
+
+# new — pin a tag in production
+services:
+  bitrouter:
+    image: ghcr.io/bitrouter/bitrouter:latest    # TODO: confirm image path
+    ports: ["4356:4356"]
+    volumes:
+      - ~/.bitrouter:/root/.bitrouter
+    environment:
+      - OPENAI_API_KEY
+      - ANTHROPIC_API_KEY
+      - GEMINI_API_KEY
+      - OPENROUTER_API_KEY
+```
+
+If anything fails verification, see `diagnose.md`.

--- a/skills/bitrouter/references/migrate-from-openai-compatible.md
+++ b/skills/bitrouter/references/migrate-from-openai-compatible.md
@@ -1,0 +1,132 @@
+# Migrate from an OpenAI-compatible source
+
+Use this when your current setup speaks **OpenAI Chat Completions** (or Responses) on the wire — directly against `api.openai.com`, against Azure OpenAI, or against any third-party that exposes that surface (Together, Groq, Perplexity, Fireworks, DeepInfra, vLLM, Ollama, LM Studio, …).
+
+Generic move: point the client at `http://localhost:4356/v1` instead of the upstream, let BitRouter hold the credential, and the rest of the SDK keeps working.
+
+> **Cloud alternative:** the same generic move works for BitRouter Cloud — point the client at `https://api.bitrouter.ai/v1` with a `brk_*` key. No daemon, no provider keys to manage. See `references/cloud-setup.md`. The rest of this file is the self-hosted path.
+
+## A) Direct OpenAI (raw API key, no proxy)
+
+The simplest case. If `OPENAI_API_KEY` is in your environment, no config file is needed.
+
+```bash
+export OPENAI_API_KEY=sk-...
+bitrouter start
+```
+
+```python
+# old
+client = OpenAI(api_key=os.environ["OPENAI_API_KEY"])
+
+# new
+client = OpenAI(base_url="http://localhost:4356/v1", api_key="unused")
+client.chat.completions.create(model="openai/gpt-4o", messages=[...])
+```
+
+That's it — the built-in `openai` provider auto-enabled when the env var was set.
+
+## B) Azure OpenAI
+
+Azure's per-deployment naming maps onto BitRouter's `models[]` list. Credentials and base URL go on a custom provider:
+
+```yaml
+providers:
+  azure:
+    api_base: "https://YOUR_RESOURCE.openai.azure.com"
+    api_key: "${AZURE_OPENAI_KEY}"
+    models:
+      - { id: "gpt-4o",        upstream_id: "gpt4-deployment" }
+      - { id: "gpt-4o-mini",   upstream_id: "gpt4-mini-deployment" }
+      - { id: "text-embedding-3-large", upstream_id: "embedding-deployment" }
+```
+
+Then:
+
+```python
+client = OpenAI(base_url="http://localhost:4356/v1", api_key="unused")
+client.chat.completions.create(model="azure/gpt-4o", messages=[...])
+```
+
+> Azure's `api-version` query parameter and per-region routing aren't covered by the BitRouter v1 schema in detail — confirm against the live docs at <https://bitrouter.ai> if your setup needs them.
+
+## C) Together / Groq / Fireworks / Perplexity / DeepInfra
+
+All of these are OpenAI-shaped behind their own host. Pattern:
+
+```yaml
+providers:
+  together:
+    api_base: "https://api.together.xyz/v1"
+    api_key: "${TOGETHER_API_KEY}"
+    auto_discover: true            # pull /v1/models at startup + reload
+
+  groq:
+    api_base: "https://api.groq.com/openai/v1"
+    api_key: "${GROQ_API_KEY}"
+    auto_discover: true
+
+  perplexity:
+    api_base: "https://api.perplexity.ai"
+    api_key: "${PERPLEXITY_API_KEY}"
+    models:
+      - { id: "llama-3.1-sonar-large-128k-online" }
+```
+
+`auto_discover: true` lets BitRouter learn the model catalog from `/v1/models` at startup and on reload — useful for providers that ship new models frequently.
+
+Client side, nothing changes vs. raw OpenAI — only the model identifier changes:
+
+```python
+client.chat.completions.create(model="groq/llama-3.1-70b-versatile", messages=[...])
+```
+
+## D) Local: Ollama / LM Studio / vLLM
+
+No credential needed (these are usually unauthenticated on localhost). Add as a custom provider and either list models explicitly or let auto-discovery fill them in.
+
+```yaml
+providers:
+  ollama:
+    api_base: "http://localhost:11434/v1"
+    models:
+      - { id: "llama3.1:70b" }
+      - { id: "codellama:34b" }
+      - { id: "qwen2.5:32b" }
+    tags: [local, free]
+
+  lmstudio:
+    api_base: "http://localhost:1234/v1"
+    auto_discover: true
+    tags: [local, free]
+```
+
+Tags help with use-case routing — `RoutingPrefs.require_tags: [local]` keeps requests off the cloud.
+
+## E) Anything else OpenAI-shaped
+
+Same recipe: drop in a custom provider with `api_base` + `api_key` (or omit for unauthenticated local endpoints), list models or set `auto_discover: true`. If the endpoint uses a non-standard request format, it's not actually OpenAI-compatible — open an issue at <https://github.com/bitrouter/bitrouter/issues> for adapter support, or write a `provider/model`-specific `api_protocol` mapping in your config.
+
+## Client switch (universal)
+
+```python
+# whatever you were using before, the new line is:
+client = OpenAI(base_url="http://localhost:4356/v1", api_key="unused")
+```
+
+The Anthropic SDK works too if you happen to call Claude models — point it at `http://localhost:4356` (no `/v1`) and BitRouter cross-protocol-routes for you.
+
+## Verify
+
+```bash
+bitrouter start
+bitrouter providers list                  # all the providers you added should be active
+bitrouter models                          # routable surface
+bitrouter route azure/gpt-4o              # whatever id you expect
+
+curl http://localhost:4356/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"azure/gpt-4o","messages":[{"role":"user","content":"ping"}],"max_tokens":5}'
+```
+
+If anything fails verification, see `diagnose.md`.

--- a/skills/bitrouter/references/migrate-from-openrouter.md
+++ b/skills/bitrouter/references/migrate-from-openrouter.md
@@ -1,0 +1,95 @@
+# Migrate from OpenRouter
+
+OpenRouter is a cloud aggregator; BitRouter is a local proxy. You don't have to choose — BitRouter has a built-in `openrouter` provider, so the cleanest migration runs both side-by-side and lets you decide later whether to keep OpenRouter for the long tail or rip it out.
+
+> **Cloud-for-cloud alternative:** if the user wants to swap one managed service for another (skip local hosting entirely), point them at `https://api.bitrouter.ai/v1` with a `brk_*` key — see `references/cloud-setup.md`. The rest of this file covers self-hosted (local daemon) migration.
+
+## Path A: keep OpenRouter as a fallback (recommended)
+
+Direct providers in front (faster, cheaper, no markup); OpenRouter behind for models you don't have direct access to.
+
+```yaml
+server:
+  listen: "127.0.0.1:4356"
+  skip_auth: true
+
+providers:
+  openai: {}         # uses OPENAI_API_KEY
+  anthropic: {}      # uses ANTHROPIC_API_KEY
+  google: {}         # uses GEMINI_API_KEY
+  openrouter: {}     # uses OPENROUTER_API_KEY — built-in
+
+models:
+  # alias OpenRouter-only models so client code stays clean
+  llama-70b:
+    upstream_id: "openrouter/meta-llama/llama-3.1-70b-instruct"
+  qwen-72b:
+    upstream_id: "openrouter/qwen/qwen-2.5-72b-instruct"
+
+inherit_defaults: true
+```
+
+Once direct providers are credentialed, point your code at the BitRouter alias (`gpt-4o`, `claude-sonnet-4-5`, etc.) and OpenRouter only gets hit when you ask for an OpenRouter-specific model.
+
+## Path B: replace OpenRouter entirely
+
+If you only used OpenRouter for first-party models (OpenAI, Anthropic, Google), drop `openrouter` from `providers:` and credential the direct providers instead. Code-side, swap the model identifiers:
+
+```python
+# old: OpenRouter prefixes everything with the upstream
+model="openai/gpt-4o"
+model="anthropic/claude-3.5-sonnet"
+
+# new: same form, but routed locally and only billed once
+model="openai/gpt-4o"
+model="anthropic/claude-sonnet-4-5"
+```
+
+## Client switch
+
+```python
+# old
+client = OpenAI(
+    base_url="https://openrouter.ai/api/v1",
+    api_key=os.environ["OPENROUTER_API_KEY"],
+)
+
+# new — credential lives in the daemon, not the client
+client = OpenAI(
+    base_url="http://localhost:4356/v1",
+    api_key="unused",
+)
+```
+
+If you used OpenRouter's stat-tracking headers (`HTTP-Referer`, `X-Title`), they pass through unchanged when you keep the `openrouter` provider in BitRouter — the daemon forwards request headers untouched.
+
+## Verify
+
+```bash
+bitrouter start
+bitrouter providers list                  # openrouter should show active: yes
+bitrouter route openrouter/meta-llama/llama-3.1-70b-instruct
+bitrouter route openai/gpt-4o             # direct, not via openrouter
+
+curl http://localhost:4356/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"llama-70b","messages":[{"role":"user","content":"ping"}],"max_tokens":5}'
+```
+
+## Cost-aware aliasing
+
+A common reason to migrate is to stop paying OpenRouter's markup on models you can hit directly. The pattern:
+
+```yaml
+models:
+  # client asks for "gpt-4o" — bitrouter hits openai directly,
+  # not openrouter/openai/gpt-4o
+  gpt-4o:
+    upstream_id: "openai/gpt-4o"
+  claude-sonnet:
+    upstream_id: "anthropic/claude-sonnet-4-5"
+```
+
+Then your application code keeps requesting `gpt-4o` / `claude-sonnet`, and you've stripped the cloud aggregator off the path without touching the client.
+
+If anything fails verification, see `diagnose.md`.

--- a/skills/bitrouter/references/providers.md
+++ b/skills/bitrouter/references/providers.md
@@ -1,0 +1,199 @@
+# Providers & routing
+
+How to configure `providers:`, `models:`, `mcp_servers:`, and `agents:` in `bitrouter.yaml`. Reflects the v1 schema in `crates/bitrouter-sdk/src/config/mod.rs` — fields and strategies not listed here do not exist.
+
+## Built-in providers
+
+Seven providers ship in the binary. Each has a baked-in `api_base`, `api_protocol`, and credential env var. Listing them with an empty body in `bitrouter.yaml` enables them — built-in defaults fill the rest.
+
+| Provider id | Env var | Auth | Notes |
+|---|---|---|---|
+| `openai` | `OPENAI_API_KEY` | Bearer | Chat Completions default; Responses API also live |
+| `anthropic` | `ANTHROPIC_API_KEY` | Header `x-api-key` | Messages API |
+| `google` | `GEMINI_API_KEY` | Header `x-goog-api-key` | Generative Language API — **not** `GOOGLE_API_KEY` |
+| `openrouter` | `OPENROUTER_API_KEY` | Bearer | Forwards every OpenRouter model |
+| `github-copilot` | — (OAuth) | Device flow | `bitrouter login github-copilot`; per-model protocol map (Claude → Anthropic, gpt-5.x-codex → Responses, rest → Chat) |
+| `opencode-zen` | `OPENCODE_ZEN_API_KEY` | Bearer | Curated models, per-family protocol routing |
+| `opencode-go` | `OPENCODE_ZEN_API_KEY` (shared) | Bearer | Low-cost subscription tier — same credential as Zen |
+
+Zero-config mode auto-enables every built-in whose env var is present. A built-in without its credential gets `active: false` and falls out of the routing table — startup still succeeds.
+
+## Minimal config
+
+```yaml
+# bitrouter.yaml — the smallest file that does useful work
+server:
+  listen: "127.0.0.1:4356"
+  skip_auth: true
+
+providers:
+  openai: {}        # uses OPENAI_API_KEY
+  anthropic: {}     # uses ANTHROPIC_API_KEY
+  google: {}        # uses GEMINI_API_KEY
+
+inherit_defaults: true
+```
+
+`inherit_defaults: true` (the workspace default) is what makes `openai: {}` work — it fills `api_base`, `api_protocol`, the model catalog, and the env-resolved `api_key` from the built-in entry. Set it to `false` only when you want to override everything explicitly.
+
+## Custom OpenAI-compatible providers
+
+Anything that speaks OpenAI Chat Completions on a known base URL fits here. No built-in needed.
+
+```yaml
+providers:
+  ollama:
+    api_base: "http://localhost:11434/v1"
+    api_protocol: { "*": openai }     # default; can be omitted
+    models:
+      - { id: "llama3.1:70b" }
+      - { id: "codellama:34b" }
+
+  groq:
+    api_base: "https://api.groq.com/openai/v1"
+    api_key: "${GROQ_API_KEY}"
+    auto_discover: true               # pull /v1/models at startup + reload
+
+  azure:
+    api_base: "https://YOUR_RESOURCE.openai.azure.com"
+    api_key: "${AZURE_OPENAI_KEY}"
+    # Azure speaks Chat Completions on the same base; deployment names go in `models`
+    models:
+      - { id: "gpt-4o", upstream_id: "gpt4-deployment" }
+```
+
+`api_protocol` accepts a glob-prefix pattern map: `{ "claude-*": anthropic, "gpt-5.5-codex": responses, "*": openai }` is valid and matches most-specific-first.
+
+## Multi-account (failover or balance)
+
+When you hold two subscriptions to the same upstream, expand the provider into accounts:
+
+```yaml
+providers:
+  opencode-go:
+    account_strategy: failover        # or "balance"
+    accounts:
+      - { api_key: "${OPENCODE_GO_KEY_A}", label: primary }
+      - { api_key: "${OPENCODE_GO_KEY_B}", label: backup }
+```
+
+- `failover` (default): try `primary` first; drop to `backup` on retryable failure (5xx / 429 / timeout / credit-exhaustion).
+- `balance`: process-random rotation so each account roughly shares load; the remaining accounts still act as failover targets for that request.
+
+Per-account `api_base` is allowed for multi-region setups — empty inherits the provider's.
+
+## Rate limits
+
+```yaml
+providers:
+  openai:
+    rate_limits:
+      "gpt-4*":      { requests_per_minute: 60,  tokens_per_minute: 90000 }
+      "gpt-4o-mini": { requests_per_minute: 200, tokens_per_minute: 200000 }
+```
+
+Glob-prefix patterns, same precedence as `api_protocol`. Each `(provider, pattern)` bucket gets an independent window.
+
+## Tags & routing
+
+Routing prefs filter providers by tag — `require_tags: [cheap]` keeps only tagged providers in scope:
+
+```yaml
+providers:
+  openai:
+    tags: [cloud, paid]
+  ollama:
+    tags: [local, free, cheap]
+```
+
+## Derives (provider inheritance)
+
+```yaml
+providers:
+  openai:
+    api_key: "${OPENAI_API_KEY}"
+  openai-dev:
+    derives: openai
+    api_key: "${OPENAI_DEV_KEY}"     # only the credential differs
+```
+
+`derives` flows `api_protocol`, `rate_limits`, `models`, `tags`, and `auto_discover` from the named provider into empty fields of this one.
+
+## Virtual models
+
+The top-level `models:` block defines named models that don't map 1:1 to a single provider. The full schema is broader than this skill covers — see `crates/bitrouter-sdk/src/config/mod.rs::VirtualModel`. The pattern that 90% of users want is a simple alias:
+
+```yaml
+models:
+  fast:
+    # routes to whichever provider declares this id first
+    upstream_id: "claude-haiku-4-5"
+  cheap-coder:
+    upstream_id: "opencode-go/glm-5.1"
+```
+
+For richer routing (priority chains, splits), check the v1 docs at <https://bitrouter.ai> — the schema is richer than what was previously documented in the agent-skills repo.
+
+## MCP servers
+
+```yaml
+mcp_servers:
+  ctx7:
+    name: ctx7
+    transport:
+      type: http
+      url: https://mcp.context7.com/mcp
+      headers:
+        Authorization: "Bearer ${CTX7_TOKEN}"
+
+  git:
+    name: git
+    transport:
+      type: stdio
+      command: uvx
+      args: ["mcp-server-git"]
+```
+
+Once configured, `POST /mcp/<name>` proxies JSON-RPC through. Inspect with `bitrouter tools list` / `bitrouter tools status` / `bitrouter tools discover <name>`.
+
+## ACP agents
+
+```yaml
+agents:
+  claude:
+    name: claude
+    transport:
+      type: stdio
+      command: npx
+      args: ["-y", "@zed-industries/claude-code-acp@latest"]
+
+  codex:
+    name: codex
+    transport:
+      type: stdio
+      command: npx
+      args: ["-y", "@zed-industries/codex-acp@latest"]
+```
+
+Editors spawn the bridge with `bitrouter agent-proxy <id>`. `bitrouter agents list` shows the bundled catalog (use `bitrouter agents install <id>` to print a paste-ready stub).
+
+## Apply changes
+
+```bash
+bitrouter reload                      # hot-reload running daemon
+# or SIGHUP to the daemon pid — same effect
+# or `bitrouter restart` for a clean cycle
+```
+
+`reload` also re-pushes the current shell's provider env vars into the daemon, so an `export OPENAI_API_KEY=new...; bitrouter reload` sequence rotates the key live.
+
+## What's not supported (don't suggest these)
+
+Older versions of this skill mentioned features that **do not exist** in the v1 schema:
+
+- `cost_limits` (daily/monthly USD caps per provider) — not parsed.
+- `strategy: conditional` with `prompt_tokens` rules — not parsed.
+- `strategy: least_cost` — not parsed.
+- `safety_settings`, `features.computer_use`, `features.json_mode` provider blocks — not parsed.
+- `bitrouter providers add/remove/test/stats/export/import` subcommands — only `list` and `use` (no-op) exist.
+- `bitrouter config validate/reload/show` — config validation happens on load; use `bitrouter reload` for the daemon.


### PR DESCRIPTION
## What

Makes the monorepo the **source of truth** for the `/bitrouter` Agent Skill, now living at [`skills/bitrouter/`](skills/bitrouter/). Previously it lived in the standalone `BitRouterAI/agent-skills` repo, which is now deprecated.

## Why

The skill is mostly facts that drift — listen port (`4356`), env var names (`GEMINI_API_KEY`, `OPENCODE_ZEN_API_KEY`), the `provider/model` slash form, and which CLI subcommands exist. Co-locating it with the code means a skill update ships in the **same PR** as the change that motivates it, instead of silently going stale in a separate repo.

Distribution does **not** depend on npm — every rail resolves the GitHub repo + subdir:

```bash
npx skills add bitrouter/bitrouter    # generic skills CLI (discovers skills/)
bitrouter skills add bitrouter        # bitrouter-skills crate's GitSubdir source
```

## Changes

- `skills/bitrouter/` — the skill (`SKILL.md` + `references/`), moved in unchanged
- `skills/README.md` — source-of-truth note and install rails
- `README.md` — Agent Skill section + Documentation link
- `CLAUDE.md` — rule to update the skill alongside any CLI flag / port / env var change

## Follow-ups (outside this PR)

- Archiving the standalone `BitRouterAI/agent-skills` repo (handled separately)
- If `api.bitrouter.ai`'s skills hub stores a source entry for `bitrouter`, point it at `GitSubdir { url: bitrouter/bitrouter, path: skills/bitrouter }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)