### PR TITLE
feat(mcp): multi-tenant per-caller bearer forwarding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,6 +811,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum 0.8.9",
+ "http 1.4.0",
  "reqwest 0.12.28",
  "rmcp",
  "schemars",

--- a/apps/bitrouter/src/main.rs
+++ b/apps/bitrouter/src/main.rs
@@ -612,6 +612,11 @@ async fn mcp_cmd(action: McpAction) -> Result<()> {
                 Some(other) => return Err(anyhow::anyhow!("unknown backend '{other}'")),
             };
             let cloud_token = token.or_else(|| std::env::var("BITROUTER_TOKEN").ok());
+            if matches!(transport, bitrouter_mcp::Transport::Http) && cloud_token.is_some() {
+                eprintln!(
+                    "note: --token/BITROUTER_TOKEN is ignored for --transport http (multi-tenant; each client sends its own Authorization)"
+                );
+            }
             bitrouter_mcp::serve(bitrouter_mcp::ServeOptions {
                 transport,
                 backend,

--- a/docs/superpowers/plans/2026-06-07-bitrouter-mcp-per-caller-auth.md
+++ b/docs/superpowers/plans/2026-06-07-bitrouter-mcp-per-caller-auth.md
@@ -1,0 +1,643 @@
+# BitRouter MCP Per-Caller Bearer Forwarding — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the remote (streamable-HTTP) MCP server multi-tenant — forward each caller's `Authorization` bearer to `api.bitrouter.ai`, with an explicit `CloudAuth` credential mode and a pre-auth edge middleware.
+
+**Architecture:** A per-call `CallerAuth { bearer }` is threaded through the `Backend` trait. `CloudBackend` holds an explicit `CloudAuth` mode (`Static(token)` for stdio→cloud, `PerCaller` for http→cloud). Tool handlers read the caller's bearer from `RequestContext`'s injected `http::request::Parts`. An axum middleware rejects bearer-less HTTP→cloud requests at the edge.
+
+**Tech Stack:** Rust 2024, `rmcp` 1.7, `axum` 0.8, `reqwest`, `wiremock` (tests), `cargo-nextest`. Branch: `feat/mcp-per-caller-auth` (already checked out, stacked on the v1 work).
+
+---
+
+## Context for the implementer
+
+- The `bitrouter-mcp` crate (`/mcp`) already exists (v1, PR #530). Current state:
+  - `mcp/src/backend/mod.rs` defines `Backend` trait + types. Current trait:
+    ```rust
+    async fn complete(&self, req: CompleteRequest) -> Result<CompleteResponse, BackendError>;
+    async fn list_models(&self) -> Result<Vec<ModelInfo>, BackendError>;
+    async fn status(&self) -> Result<StatusInfo, BackendError>;
+    ```
+    `BackendError` has `DaemonUnreachable`, `Upstream`, `Transport`, `Decode`.
+  - `mcp/src/backend/local.rs` — `LocalBackend { base_url, http }`, pure reqwest.
+  - `mcp/src/backend/cloud.rs` — `CloudBackend { base_url, token: String, http }`, `new(base_url, token)`, private `bearer(&self, rb)` = `rb.bearer_auth(&self.token)`.
+  - `mcp/src/server.rs` — `BitrouterMcp` rmcp handler with 3 `#[tool]`s; `serve_stdio`, `serve_http(backend, bind)`, `build_backend(kind, local_url, cloud_url, cloud_token)`.
+  - `mcp/src/lib.rs` — `Transport`, `BackendKind`, `ServeOptions`, `serve()`.
+- Project rules (CLAUDE.md): no `#[allow]`; no `.unwrap()`/`.expect()`/`panic!` in non-test code (Option/Result combinators like `.unwrap_or_default()` OK; tests may use `.expect()`/`panic!`); no dead code. Run `cargo fmt` before every commit. Conventional commit titles < 60 chars.
+- Spec: `docs/superpowers/specs/2026-06-07-bitrouter-mcp-per-caller-auth-design.md`.
+
+## File structure (what changes)
+
+| File | Change |
+|------|--------|
+| `mcp/src/backend/mod.rs` | add `CallerAuth`, `MissingCredential`; change `Backend` trait sigs |
+| `mcp/src/backend/local.rs` | impl sigs gain `_caller: &CallerAuth` (ignored); tests updated |
+| `mcp/src/backend/cloud.rs` | `CloudAuth` enum; `auth` field; per-call credential resolution; tests |
+| `mcp/src/server.rs` | `caller_from` helper; tools take `RequestContext`; `serve_http` middleware; `build_backend` takes `Transport` |
+| `mcp/src/lib.rs` | `serve()` passes `Transport` + cloud flag |
+| `mcp/tests/multitenant_http.rs` | new integration test (two bearers forwarded) |
+| `skills/bitrouter/references/mcp-server.md` | document multi-tenant remote |
+
+---
+
+## Task 1: Thread `CallerAuth` through the `Backend` trait
+
+The trait change is atomic — every impl, call site, and test updates together so the crate compiles. `CloudBackend` keeps its `token: String` for now (CloudAuth enum is Task 2) but starts honoring a caller bearer.
+
+**Files:** `mcp/src/backend/mod.rs`, `mcp/src/backend/local.rs`, `mcp/src/backend/cloud.rs`, `mcp/src/server.rs`
+
+- [ ] **Step 1: Add `CallerAuth` + `MissingCredential` and change the trait in `mcp/src/backend/mod.rs`**
+
+Add near the other types:
+```rust
+/// The caller's bearer to forward upstream, if the inbound request carried one.
+/// Empty for stdio (the cloud backend's configured credential applies instead).
+#[derive(Debug, Default, Clone)]
+pub struct CallerAuth {
+    pub bearer: Option<String>,
+}
+```
+Add a variant to `BackendError`:
+```rust
+    #[error("no bearer token: set Authorization on the MCP client")]
+    MissingCredential,
+```
+Change the three `Backend` methods to:
+```rust
+    async fn complete(&self, caller: &CallerAuth, req: CompleteRequest) -> Result<CompleteResponse, BackendError>;
+    async fn list_models(&self, caller: &CallerAuth) -> Result<Vec<ModelInfo>, BackendError>;
+    async fn status(&self, caller: &CallerAuth) -> Result<StatusInfo, BackendError>;
+```
+
+- [ ] **Step 2: Update `LocalBackend` (ignores caller) in `mcp/src/backend/local.rs`**
+
+Add `CallerAuth` to the `use super::{…}` import. Change the three impl method signatures to take `_caller: &CallerAuth` as the first argument (bodies unchanged):
+```rust
+    async fn list_models(&self, _caller: &CallerAuth) -> Result<Vec<ModelInfo>, BackendError> { /* unchanged */ }
+    async fn complete(&self, _caller: &CallerAuth, req: CompleteRequest) -> Result<CompleteResponse, BackendError> { /* unchanged */ }
+    async fn status(&self, _caller: &CallerAuth) -> Result<StatusInfo, BackendError> { /* unchanged */ }
+```
+In the `#[cfg(test)] mod tests`, update the three call sites to pass `&CallerAuth::default()`:
+- `backend.list_models()` → `backend.list_models(&CallerAuth::default())`
+- `backend.status()` → `backend.status(&CallerAuth::default())` (both occurrences)
+Add `use super::CallerAuth;` to the test module if not already in scope via `use super::*`.
+
+- [ ] **Step 3: Update `CloudBackend` to honor a caller bearer in `mcp/src/backend/cloud.rs`**
+
+Add `CallerAuth` to the `use super::{…}` import. Change the private `bearer` helper to resolve the caller's bearer with the configured token as fallback:
+```rust
+    fn bearer(&self, caller: &CallerAuth, rb: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        let token = caller.bearer.as_deref().unwrap_or(&self.token);
+        rb.bearer_auth(token)
+    }
+```
+Change the three impl method signatures to take `caller: &CallerAuth` first, and pass `caller` to every `self.bearer(...)` call:
+```rust
+    async fn list_models(&self, caller: &CallerAuth) -> Result<Vec<ModelInfo>, BackendError> {
+        // … self.bearer(self.http.get(&url)) → self.bearer(caller, self.http.get(&url)) …
+    }
+    async fn complete(&self, caller: &CallerAuth, req: CompleteRequest) -> Result<CompleteResponse, BackendError> {
+        // … self.bearer(caller, self.http.post(&url).json(&body)) …
+    }
+    async fn status(&self, caller: &CallerAuth) -> Result<StatusInfo, BackendError> {
+        // … self.bearer(caller, self.http.get(&url)) …
+    }
+```
+Update existing cloud tests' call sites to pass `&CallerAuth::default()` (e.g. `backend.status(&CallerAuth::default())`, `backend.list_models(&CallerAuth::default())`).
+
+- [ ] **Step 4: Update the tool handlers + StubBackend in `mcp/src/server.rs`**
+
+In the three `#[tool]` methods, pass a default caller for now (real extraction is Task 3). Add `use crate::backend::CallerAuth;` to the imports. Change:
+- `self.backend.complete(req)` → `self.backend.complete(&CallerAuth::default(), req)`
+- `self.backend.list_models()` → `self.backend.list_models(&CallerAuth::default())`
+- `self.backend.status()` → `self.backend.status(&CallerAuth::default())`
+
+In `#[cfg(test)] mod tests`, the `StubBackend impl Backend` must match the new signatures:
+```rust
+        async fn complete(&self, _: &CallerAuth, _: CompleteRequest) -> Result<CompleteResponse, BackendError> { /* unchanged body */ }
+        async fn list_models(&self, _: &CallerAuth) -> Result<Vec<ModelInfo>, BackendError> { Ok(vec![]) }
+        async fn status(&self, _: &CallerAuth) -> Result<StatusInfo, BackendError> { /* unchanged body */ }
+```
+Add `CallerAuth` to the test module's `use` (e.g. `use crate::backend::{BackendError, CallerAuth, CompleteResponse, ModelInfo, StatusInfo, Usage};`).
+
+- [ ] **Step 5: Add a CloudBackend precedence test (caller bearer overrides token)**
+
+Add to `mcp/src/backend/cloud.rs` `tests`:
+```rust
+#[tokio::test]
+async fn caller_bearer_overrides_configured_token() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/v1/models"))
+        .and(header("authorization", "Bearer caller-tok"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "object": "list", "data": []
+        })))
+        .mount(&server)
+        .await;
+    let backend = CloudBackend::new(server.uri(), "configured-tok");
+    let caller = CallerAuth { bearer: Some("caller-tok".into()) };
+    backend.list_models(&caller).await.expect("list_models");
+    // wiremock asserts the request matched `Bearer caller-tok`, not the configured token.
+}
+```
+
+- [ ] **Step 6: Verify build + tests + clippy + fmt**
+
+Run: `cargo nextest run -p bitrouter-mcp`
+Expected: all pass (11 prior + 1 new = 12).
+Run: `cargo clippy -p bitrouter-mcp --all-targets` → clean. `cargo fmt` then `cargo fmt -- --check` → clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add mcp/src/backend/mod.rs mcp/src/backend/local.rs mcp/src/backend/cloud.rs mcp/src/server.rs
+git commit -m "feat(mcp): thread CallerAuth through Backend trait"
+```
+
+---
+
+## Task 2: Replace `CloudBackend.token` with the `CloudAuth` mode enum
+
+**Files:** `mcp/src/backend/cloud.rs`, `mcp/src/server.rs` (build_backend cloud arm)
+
+- [ ] **Step 1: Write the failing test for `PerCaller` with no bearer**
+
+Add to `mcp/src/backend/cloud.rs` `tests`:
+```rust
+#[tokio::test]
+async fn per_caller_without_bearer_errors() {
+    let backend = CloudBackend::new("https://api.bitrouter.ai", CloudAuth::PerCaller);
+    let err = backend
+        .list_models(&CallerAuth::default())
+        .await
+        .expect_err("should error");
+    assert!(matches!(err, BackendError::MissingCredential));
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo nextest run -p bitrouter-mcp per_caller_without_bearer_errors`
+Expected: FAIL (compile error — `CloudAuth` doesn't exist; `new` takes a token string).
+
+- [ ] **Step 3: Introduce `CloudAuth` and rework `CloudBackend`**
+
+In `mcp/src/backend/cloud.rs`, add the enum and change the struct + constructor + bearer resolution:
+```rust
+/// How a [`CloudBackend`] authenticates upstream.
+pub enum CloudAuth {
+    /// One configured token used for every call (stdio → cloud, single-tenant).
+    Static(String),
+    /// Every call must carry the caller's own bearer; no fallback (http multi-tenant).
+    PerCaller,
+}
+
+pub struct CloudBackend {
+    base_url: String,
+    auth: CloudAuth,
+    http: reqwest::Client,
+}
+
+impl CloudBackend {
+    pub fn new(base_url: impl Into<String>, auth: CloudAuth) -> Self {
+        Self {
+            base_url: base_url.into().trim_end_matches('/').to_owned(),
+            auth,
+            http: reqwest::Client::new(),
+        }
+    }
+
+    /// Resolve the bearer to send: the caller's wins; else the `Static` token;
+    /// `PerCaller` with no caller bearer is a (middleware-prevented) error.
+    fn resolve_bearer<'a>(&'a self, caller: &'a CallerAuth) -> Result<&'a str, BackendError> {
+        match (&self.auth, caller.bearer.as_deref()) {
+            (_, Some(b)) => Ok(b),
+            (CloudAuth::Static(t), None) => Ok(t),
+            (CloudAuth::PerCaller, None) => Err(BackendError::MissingCredential),
+        }
+    }
+}
+```
+Replace the private `bearer` helper usage: each method now resolves the bearer first and applies it. Change the `bearer` helper to:
+```rust
+    fn authed(&self, bearer: &str, rb: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        rb.bearer_auth(bearer)
+    }
+```
+And in each of the three methods, at the top:
+```rust
+        let bearer = self.resolve_bearer(caller)?;
+```
+then replace `self.bearer(caller, self.http.get(&url))` with `self.authed(bearer, self.http.get(&url))` (and likewise for the POST in `complete`).
+
+- [ ] **Step 4: Update the other cloud tests to the new constructor**
+
+Existing cloud tests call `CloudBackend::new(server.uri(), "brk_test")` / `"configured-tok"`. Change each to `CloudBackend::new(server.uri(), CloudAuth::Static("brk_test".into()))` (and the precedence test from Task 1 to `CloudAuth::Static("configured-tok".into())`). Add `CloudAuth` to the test `use super::*` scope (it's in `super`).
+
+- [ ] **Step 5: Update `build_backend` cloud arm in `mcp/src/server.rs`**
+
+For now keep `build_backend`'s signature; just construct `Static`:
+```rust
+        crate::BackendKind::Cloud => {
+            let token = cloud_token.ok_or_else(|| {
+                anyhow::anyhow!("cloud backend needs a bearer token (--token or BITROUTER_TOKEN)")
+            })?;
+            Ok(Arc::new(CloudBackend::new(cloud_url, crate::backend::cloud::CloudAuth::Static(token.to_owned()))))
+        }
+```
+(Transport-aware mode selection is Task 4.)
+
+- [ ] **Step 6: Verify**
+
+Run: `cargo nextest run -p bitrouter-mcp` → all pass (now 13). `cargo clippy -p bitrouter-mcp --all-targets` clean; `cargo fmt` + `--check` clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add mcp/src/backend/cloud.rs mcp/src/server.rs
+git commit -m "feat(mcp): CloudAuth mode enum (Static | PerCaller)"
+```
+
+---
+
+## Task 3: Extract the caller bearer from `RequestContext` in tools
+
+**Files:** `mcp/src/server.rs`
+
+- [ ] **Step 1: Write the failing test for `caller_from`**
+
+Add to `mcp/src/server.rs` `tests` (build a `RequestContext` is heavy; instead unit-test a pure helper that takes the extensions). Refactor extraction into a pure function over `&rmcp::model::Extensions` so it is testable:
+```rust
+#[test]
+fn caller_from_extensions_reads_bearer() {
+    use rmcp::model::Extensions;
+    let mut ext = Extensions::new();
+    let req = http::Request::builder()
+        .header(http::header::AUTHORIZATION, "Bearer xyz")
+        .body(())
+        .expect("req");
+    let (parts, _) = req.into_parts();
+    ext.insert(parts);
+    assert_eq!(caller_from_extensions(&ext).bearer.as_deref(), Some("xyz"));
+
+    let empty = Extensions::new();
+    assert_eq!(caller_from_extensions(&empty).bearer, None);
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo nextest run -p bitrouter-mcp caller_from_extensions_reads_bearer`
+Expected: FAIL (`caller_from_extensions` undefined). (`http` is already a transitive dep via rmcp/axum; if the test needs it directly, add `http = { workspace = true }` to `[dev-dependencies]` or `[dependencies]` of `mcp/Cargo.toml` — it is in the workspace deps.)
+
+- [ ] **Step 3: Implement `caller_from_extensions` + wire it into the tools**
+
+Add to `mcp/src/server.rs`:
+```rust
+use crate::backend::CallerAuth;
+
+/// Extract the caller's bearer from MCP request extensions (the streamable-HTTP
+/// transport injects `http::request::Parts`). Returns an empty `CallerAuth`
+/// over stdio (no parts) or when no/!Bearer `Authorization` is present.
+fn caller_from_extensions(ext: &rmcp::model::Extensions) -> CallerAuth {
+    let bearer = ext
+        .get::<http::request::Parts>()
+        .and_then(|p| p.headers.get(http::header::AUTHORIZATION))
+        .and_then(|h| h.to_str().ok())
+        .and_then(|s| s.strip_prefix("Bearer "))
+        .map(str::to_owned);
+    CallerAuth { bearer }
+}
+```
+Change the three tool methods to take `ctx: rmcp::service::RequestContext<rmcp::model::RoleServer>` as a parameter and use the real caller:
+```rust
+    #[tool(description = "Route a completion through BitRouter and return the full result.")]
+    async fn complete(
+        &self,
+        Parameters(args): Parameters<CompleteArgs>,
+        ctx: rmcp::service::RequestContext<rmcp::model::RoleServer>,
+    ) -> Result<CallToolResult, McpError> {
+        let caller = caller_from_extensions(&ctx.extensions);
+        // … self.backend.complete(&caller, req) …
+    }
+```
+`list_models` and `status` likewise gain `ctx: RequestContext<RoleServer>` and call `caller_from_extensions(&ctx.extensions)`, replacing the `&CallerAuth::default()` placeholders from Task 1. Import `RoleServer` / `RequestContext` at the top (e.g. `use rmcp::model::RoleServer; use rmcp::service::RequestContext;`) to keep signatures tidy.
+
+> If the `#[tool]` macro rejects the combined `Parameters<…>` + `RequestContext<…>` signature (it should not — both are `FromContextPart` extractors), report the exact error; do not work around it silently.
+
+- [ ] **Step 4: Verify**
+
+Run: `cargo nextest run -p bitrouter-mcp` → all pass (incl. `caller_from_extensions_reads_bearer`, and the existing `handler_constructs_with_three_tools` and `stdio_lists_three_tools` still green — proving stdio still works with the new tool signatures). `cargo clippy` clean; `cargo fmt`/`--check` clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp/src/server.rs mcp/Cargo.toml
+git commit -m "feat(mcp): forward caller bearer from request context"
+```
+
+---
+
+## Task 4: Make `build_backend` transport-aware (mode selection)
+
+**Files:** `mcp/src/server.rs`, `mcp/src/lib.rs`
+
+- [ ] **Step 1: Change `build_backend` to take `Transport` and pick the mode**
+
+Replace `build_backend` in `mcp/src/server.rs`:
+```rust
+/// Build the backend. The cloud auth mode depends on transport:
+/// stdio→cloud uses the configured token (Static); http→cloud is multi-tenant
+/// (PerCaller — each request must carry its own bearer).
+pub fn build_backend(
+    kind: crate::BackendKind,
+    transport: crate::Transport,
+    local_url: &str,
+    cloud_url: &str,
+    cloud_token: Option<&str>,
+) -> anyhow::Result<Arc<dyn Backend>> {
+    use crate::backend::cloud::CloudAuth;
+    match kind {
+        crate::BackendKind::Local => Ok(Arc::new(LocalBackend::new(local_url))),
+        crate::BackendKind::Cloud => {
+            let auth = match transport {
+                crate::Transport::Http => CloudAuth::PerCaller,
+                crate::Transport::Stdio => {
+                    let token = cloud_token.ok_or_else(|| {
+                        anyhow::anyhow!("stdio cloud backend needs a token (--token or BITROUTER_TOKEN)")
+                    })?;
+                    CloudAuth::Static(token.to_owned())
+                }
+            };
+            Ok(Arc::new(CloudBackend::new(cloud_url, auth)))
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Update the `serve()` call site in `mcp/src/lib.rs`**
+
+In `serve()`, pass `opts.transport` into `build_backend`:
+```rust
+    let backend = server::build_backend(
+        opts.backend,
+        opts.transport,
+        &opts.local_url,
+        &opts.cloud_url,
+        opts.cloud_token.as_deref(),
+    )?;
+```
+
+- [ ] **Step 3: Verify**
+
+Run: `cargo build -p bitrouter-mcp` and `cargo nextest run -p bitrouter-mcp` → green. `cargo clippy` clean; fmt clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mcp/src/server.rs mcp/src/lib.rs
+git commit -m "feat(mcp): select CloudAuth mode by transport"
+```
+
+---
+
+## Task 5: Pre-auth edge middleware on the HTTP cloud route
+
+**Files:** `mcp/src/server.rs`, `mcp/src/lib.rs`
+
+- [ ] **Step 1: Write the failing middleware test**
+
+Add a test module to `mcp/src/server.rs` (or a new `mcp/tests/edge_auth.rs`). Test the pure middleware predicate by extracting it:
+```rust
+#[test]
+fn require_bearer_predicate() {
+    assert!(has_bearer(Some("Bearer abc")));
+    assert!(!has_bearer(Some("Basic abc")));
+    assert!(!has_bearer(None));
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo nextest run -p bitrouter-mcp require_bearer_predicate`
+Expected: FAIL (`has_bearer` undefined).
+
+- [ ] **Step 3: Implement the predicate + middleware, install it in `serve_http` for cloud**
+
+Add to `mcp/src/server.rs`:
+```rust
+/// Whether an `Authorization` header value is a Bearer token.
+fn has_bearer(value: Option<&str>) -> bool {
+    value.is_some_and(|v| v.starts_with("Bearer "))
+}
+
+async fn require_bearer(
+    headers: axum::http::HeaderMap,
+    request: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    let present = has_bearer(
+        headers
+            .get(axum::http::header::AUTHORIZATION)
+            .and_then(|h| h.to_str().ok()),
+    );
+    if present {
+        next.run(request).await
+    } else {
+        axum::http::StatusCode::UNAUTHORIZED.into_response()
+    }
+}
+```
+Add `use axum::response::IntoResponse;` for `.into_response()`. Change `serve_http` to accept a `require_auth: bool` and conditionally layer the middleware:
+```rust
+pub async fn serve_http(backend: Arc<dyn Backend>, bind: &str, require_auth: bool) -> anyhow::Result<()> {
+    // … build `service` as today …
+    let mut router = axum::Router::new().nest_service("/mcp-control", service);
+    if require_auth {
+        router = router.layer(axum::middleware::from_fn(require_bearer));
+    }
+    // … bind + serve as today …
+}
+```
+
+- [ ] **Step 4: Update the `serve()` call site in `mcp/src/lib.rs`**
+
+```rust
+        Transport::Http => {
+            let require_auth = matches!(opts.backend, BackendKind::Cloud);
+            server::serve_http(backend, &opts.bind, require_auth).await
+        }
+```
+
+- [ ] **Step 5: Verify**
+
+Run: `cargo nextest run -p bitrouter-mcp` → green (incl. `require_bearer_predicate`). `cargo clippy` clean; fmt clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mcp/src/server.rs mcp/src/lib.rs
+git commit -m "feat(mcp): pre-auth edge middleware for http cloud"
+```
+
+---
+
+## Task 6: Multi-tenant HTTP integration test
+
+**Files:** `mcp/tests/multitenant_http.rs` (new)
+
+Proves two different callers' bearers are each forwarded verbatim to the (mock) cloud.
+
+- [ ] **Step 1: Write the integration test**
+
+Create `mcp/tests/multitenant_http.rs`:
+```rust
+//! End-to-end: two MCP clients with different bearers each get their own bearer
+//! forwarded to the (mock) cloud. Proof of multi-tenancy.
+use std::sync::Arc;
+use std::time::Duration;
+
+use bitrouter_mcp::backend::cloud::{CloudAuth, CloudBackend};
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+async fn call_list_models(base: &str, bearer: &str) {
+    // Drive the streamable-HTTP MCP endpoint with initialize + tools/call.
+    let http = reqwest::Client::new();
+    // initialize
+    let init = http.post(format!("{base}/mcp-control"))
+        .header("authorization", format!("Bearer {bearer}"))
+        .header("content-type", "application/json")
+        .header("accept", "application/json, text/event-stream")
+        .body(r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"t","version":"0"}}}"#)
+        .send().await.expect("init send");
+    let session = init.headers().get("mcp-session-id").and_then(|h| h.to_str().ok()).map(str::to_owned);
+    // tools/call list_models
+    let mut req = http.post(format!("{base}/mcp-control"))
+        .header("authorization", format!("Bearer {bearer}"))
+        .header("content-type", "application/json")
+        .header("accept", "application/json, text/event-stream")
+        .body(r#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"list_models","arguments":{}}}"#);
+    if let Some(s) = session { req = req.header("mcp-session-id", s); }
+    let _ = req.send().await.expect("call send");
+}
+
+#[tokio::test]
+async fn two_callers_forward_distinct_bearers() {
+    // Mock cloud: assert each bearer is seen on /v1/models.
+    let cloud = MockServer::start().await;
+    for tok in ["aaa", "bbb"] {
+        Mock::given(method("GET"))
+            .and(path("/v1/models"))
+            .and(header("authorization", format!("Bearer {tok}").as_str()))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"object":"list","data":[]})))
+            .expect(1)
+            .mount(&cloud)
+            .await;
+    }
+
+    // Serve the MCP HTTP server (PerCaller) pointed at the mock cloud, on an ephemeral port.
+    let backend: Arc<dyn bitrouter_mcp::backend::Backend> =
+        Arc::new(CloudBackend::new(cloud.uri(), CloudAuth::PerCaller));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    let server = tokio::spawn(async move {
+        bitrouter_mcp::server::serve_http_on(backend, listener, true).await
+    });
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let base = format!("http://{addr}");
+    call_list_models(&base, "aaa").await;
+    call_list_models(&base, "bbb").await;
+
+    // wiremock `.expect(1)` per bearer verifies on drop that each was forwarded exactly once.
+    drop(cloud);
+    server.abort();
+}
+```
+
+- [ ] **Step 2: Add a `serve_http_on` variant that accepts a pre-bound listener**
+
+The test needs an ephemeral port and to start serving without `ctrl_c`-only shutdown. In `mcp/src/server.rs`, factor the router-building out and add:
+```rust
+/// Like `serve_http`, but serves on an already-bound listener and shuts down
+/// when the listener's task is aborted (used by tests). No ctrl_c handler.
+pub async fn serve_http_on(
+    backend: Arc<dyn Backend>,
+    listener: tokio::net::TcpListener,
+    require_auth: bool,
+) -> anyhow::Result<()> {
+    let router = build_http_router(backend, require_auth);
+    axum::serve(listener, router).await?;
+    Ok(())
+}
+```
+Refactor the shared router construction into `fn build_http_router(backend: Arc<dyn Backend>, require_auth: bool) -> axum::Router` and have `serve_http` call it (so `serve_http` keeps its ctrl_c graceful shutdown, and `serve_http_on` reuses the router). Keep the `StreamableHttpServerConfig` cancellation wiring inside `build_http_router` or `serve_http` as today.
+
+> Note: this exposes `serve_http_on` as `pub` solely for integration testing of real multi-tenant forwarding. It is a thin, documented wrapper — acceptable. If the team prefers not to widen the public surface, gate it behind `#[doc(hidden)]`.
+
+- [ ] **Step 3: Run the test**
+
+Run: `cargo nextest run -p bitrouter-mcp two_callers_forward_distinct_bearers`
+Expected: PASS. If the streamable-HTTP request framing needs an `mcp-session-id` flow the test doesn't satisfy, adjust the request sequence per the server's responses (read the init response body/headers). The assertion that matters: each `Bearer` reached `/v1/models` exactly once.
+
+- [ ] **Step 4: Verify full crate + commit**
+
+Run: `cargo nextest run -p bitrouter-mcp` (all green), `cargo clippy -p bitrouter-mcp --all-targets` (clean), `cargo fmt`/`--check` (clean).
+```bash
+git add mcp/src/server.rs mcp/tests/multitenant_http.rs
+git commit -m "test(mcp): multi-tenant bearer forwarding integration test"
+```
+
+---
+
+## Task 7: Update the `/bitrouter` skill reference
+
+**Files:** `skills/bitrouter/references/mcp-server.md`
+
+- [ ] **Step 1: Document multi-tenant remote auth**
+
+Edit `skills/bitrouter/references/mcp-server.md` to state:
+- The remote HTTP server (`bitrouter mcp serve --transport http`) is **multi-tenant**: each MCP client sets its own `Authorization: Bearer <brk_… or access token>` in its remote-server config; the server forwards it per request to `api.bitrouter.ai`.
+- HTTP→cloud requires a `Bearer` (edge middleware returns `401` otherwise).
+- `--token`/`BITROUTER_TOKEN` is the **stdio→cloud** credential only; a multi-tenant HTTP host needs no token.
+- Native browser OAuth (Item B) remains deferred (cloud lacks Dynamic Client Registration; `/oauth/authorize` requires a `brk_` principal).
+
+Keep `skills/bitrouter/SKILL.md` unchanged unless a one-line tweak to the existing MCP section is warranted (it should already say "see references/mcp-server.md").
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add skills/bitrouter/references/mcp-server.md
+git commit -m "docs(skill): document multi-tenant remote MCP auth"
+```
+
+---
+
+## Task 8: Full verification
+
+- [ ] **Step 1: Whole-crate + workspace checks**
+
+Run: `cargo nextest run --all-features` → all pass (workspace; new crate ~16 tests).
+Run: `cargo clippy --all-features` → clean (no `#[allow]`).
+Run: `cargo fmt -- --check` → clean.
+
+- [ ] **Step 2: Manual smoke (help only — no live daemon/cloud)**
+
+Run: `cargo run -p bitrouter -- mcp serve --help` → still lists flags (no flag changes expected).
+
+- [ ] **Step 3: Final commit if fmt/clippy adjusted anything**
+
+```bash
+git add -A && git commit -m "chore(mcp): clippy + fmt for per-caller auth"
+```
+
+---
+
+## Self-review notes (addressed)
+
+- **Spec coverage:** `CallerAuth` + trait threading (Task 1); `CloudAuth` enum + `MissingCredential` (Task 2); `caller_from` extraction + `RequestContext` tools (Task 3); transport→mode in `build_backend` (Task 4); edge middleware HTTP+cloud-only (Task 5); multi-tenant proof (Task 6); precedence tests (Tasks 1–2); skill docs (Task 7); verification (Task 8). Behaviour matrix rows all covered.
+- **Type consistency:** `CallerAuth { bearer: Option<String> }`, `CloudAuth::{Static(String), PerCaller}`, `BackendError::MissingCredential`, `build_backend(kind, transport, local_url, cloud_url, cloud_token)`, `serve_http(backend, bind, require_auth)`, `serve_http_on(backend, listener, require_auth)`, `caller_from_extensions(&Extensions) -> CallerAuth`, `has_bearer(Option<&str>) -> bool` — used consistently across tasks.
+- **Risk:** the only novel rmcp surface is a tool taking both `Parameters` + `RequestContext` (Task 3) — confirmed supported at the source level (`FromContextPart` for both); the step flags it to report rather than work around if it fails.

--- a/docs/superpowers/specs/2026-06-07-bitrouter-mcp-per-caller-auth-design.md
+++ b/docs/superpowers/specs/2026-06-07-bitrouter-mcp-per-caller-auth-design.md
@@ -1,6 +1,6 @@
 # BitRouter MCP — Per-Caller Bearer Forwarding (v1.x, Item A)
 
-- **Status:** Draft for review
+- **Status:** Draft for review (rev 2 — incorporates review feedback)
 - **Date:** 2026-06-07
 - **Builds on:** `2026-06-07-bitrouter-mcp-server-design.md` (v1, shipped in PR #530)
 - **Issue:** follow-up to #526
@@ -30,18 +30,18 @@ work and is not required once token-in-header multi-tenancy (A) works.
 ### Goals
 - The HTTP transport forwards each caller's `Authorization` bearer to the cloud,
   per request (true multi-tenant).
+- HTTP requests with no/!Bearer `Authorization` are rejected **at the edge**
+  (401) before reaching a tool, when serving the cloud backend.
 - stdio behaviour is **unchanged** (no HTTP request → no per-caller bearer →
-  existing configured-token / no-auth paths still apply).
+  the configured construction token applies).
 - The local daemon **never** receives a caller bearer.
-- A missing bearer (HTTP, no configured fallback) yields a **clear tool error**,
-  not an opaque upstream failure.
 
 ### Non-Goals
 - Native in-client browser OAuth / PRM / DCR (Item B — needs cloud changes).
-- Local token validation/introspection in the MCP server (the cloud validates;
-  we forward and surface its verdict).
-- TLS termination / hosting concerns (operator's responsibility; we keep the
-  default bind at `127.0.0.1` and forward to cloud over HTTPS).
+- Local token *validation*/introspection (the cloud validates; we forward and
+  surface its verdict). The edge middleware only checks **presence**, not validity.
+- TLS termination / hosting concerns (operator's responsibility; default bind
+  stays `127.0.0.1`, forwarding to cloud over HTTPS).
 
 ## 3. The mechanism (verified against rmcp 1.7.0)
 
@@ -61,59 +61,77 @@ let bearer = ctx
     .map(str::to_owned);
 ```
 
-The `RequestContext` form is chosen over the `Extension<Parts>` extractor
+The `RequestContext` form is chosen over the bare `Extension<Parts>` extractor
 because `ctx.extensions.get::<Parts>()` returns `Option` — `None` over stdio,
 where no HTTP parts exist — so the **same tool definition works on both
 transports**.
 
+**A `#[tool]` method may take both `Parameters<T>` and `RequestContext`.**
+Verified: both implement rmcp's `FromContextPart` extractor
+(`handler/server/tool.rs:181`, `handler/server/common.rs:114`), so the macro
+extracts each independently — the same axum-style multi-extractor model. (This
+was the one open implementation risk; it is resolved.)
+
 ## 4. Design
 
-### 4.1 Separate "what to call" from "who's calling"
+### 4.1 A minimal forwarded-credential type (and why not reuse `CallerContext`)
 
-A small per-call credential carrier, defined in `mcp/src/backend/mod.rs`:
+A small per-call carrier in `mcp/src/backend/mod.rs`:
 
 ```rust
-/// Per-call caller identity. Empty for stdio / unauthenticated local use.
+/// The caller's bearer to forward upstream, if the inbound request carried one.
+/// Empty for stdio (the backend's construction token applies instead).
 #[derive(Debug, Default, Clone)]
-pub struct Caller {
-    /// The caller's bearer token, if the inbound request carried one.
+pub struct CallerAuth {
     pub bearer: Option<String>,
 }
 ```
 
-The `Backend` trait threads it through every method:
+**Why a new type rather than `bitrouter-sdk::CallerContext`:** `CallerContext`
+is a *resolved-identity* type (`api_key_id`, `user_id`, `local`) — the **output**
+of authentication, deliberately storing "opaque identity," with **no raw
+credential**. We need the opposite: the raw bearer to **relay** to the cloud,
+which validates it. `CallerContext` also lives in `bitrouter-sdk`, which the
+thin mcp crate intentionally does not depend on (it would pull the whole SDK in
+for one struct that doesn't even carry a token). The distinct name `CallerAuth`
+avoids implying equivalence with the SDK's `CallerContext`.
+
+### 4.2 `Backend` trait threads the caller credential
 
 ```rust
 #[async_trait]
 pub trait Backend: Send + Sync {
-    async fn complete(&self, caller: &Caller, req: CompleteRequest) -> Result<CompleteResponse, BackendError>;
-    async fn list_models(&self, caller: &Caller) -> Result<Vec<ModelInfo>, BackendError>;
-    async fn status(&self, caller: &Caller) -> Result<StatusInfo, BackendError>;
+    async fn complete(&self, caller: &CallerAuth, req: CompleteRequest) -> Result<CompleteResponse, BackendError>;
+    async fn list_models(&self, caller: &CallerAuth) -> Result<Vec<ModelInfo>, BackendError>;
+    async fn status(&self, caller: &CallerAuth) -> Result<StatusInfo, BackendError>;
 }
 ```
-
-### 4.2 Backend behaviour
 
 - **`LocalBackend`** ignores `caller` entirely (the BYOK daemon is single-tenant
   and must never receive a third party's cloud bearer). Signatures change; bodies
   do not.
-- **`CloudBackend.token`** becomes `Option<String>` — a **fallback** for the
-  single-tenant stdio→cloud case. Each request authenticates with:
+- **`CloudBackend.token` stays a required `String`** set at construction
+  (`CloudBackend::new(base_url, token)` — unchanged signature). Per the design
+  decision, a cloud backend always has a token. Each request authenticates with
+  the per-caller bearer when present, else the construction token:
   ```rust
-  let bearer = caller.bearer.as_deref().or(self.token.as_deref());
+  let bearer = caller.bearer.as_deref().unwrap_or(&self.token);
   ```
-  - `Some(b)` → send `Authorization: Bearer b`.
-  - `None` → return `BackendError::MissingCredential` (new variant) with a clear
-    message: *"no bearer token — set Authorization on the MCP client or pass
-    --token"*. (Today `CloudBackend::new` requires a token; this relaxes it so a
-    hosted multi-tenant server can run with no default token and rely on
-    per-caller bearers.)
+  No new error variant: there is always a credential to send (caller's or the
+  construction fallback). Invalid tokens are the cloud's `401` →
+  `BackendError::Upstream { 401 }` (already handled).
+
+> For a pure multi-tenant HTTP host, the construction token is required but
+> effectively a backstop — the §4.5 edge middleware guarantees every HTTP
+> request that reaches a tool already carries a caller bearer, which overrides
+> it. The operator still supplies `--token`/`BITROUTER_TOKEN` (any valid bearer)
+> to build the backend.
 
 ### 4.3 Tool handlers
 
 Each of the three `#[tool]` methods in `mcp/src/server.rs` gains a
-`ctx: RequestContext<RoleServer>` parameter, extracts the bearer per §3, builds
-a `Caller`, and passes it to the backend:
+`ctx: RequestContext<RoleServer>` parameter alongside its existing params,
+extracts the bearer per §3 into a `CallerAuth`, and passes it to the backend:
 
 ```rust
 #[tool(description = "…")]
@@ -122,38 +140,53 @@ async fn complete(
     Parameters(args): Parameters<CompleteArgs>,
     ctx: RequestContext<RoleServer>,
 ) -> Result<CallToolResult, McpError> {
-    let caller = caller_from(&ctx);          // helper: extracts bearer (§3)
+    let caller = caller_from(&ctx);          // private helper, §3 extraction
     match self.backend.complete(&caller, args.into()).await { … }
 }
 ```
 
 `list_models` and `status` likewise gain `ctx` and pass `&caller`. A single
-private `caller_from(ctx: &RequestContext<RoleServer>) -> Caller` helper holds
-the extraction logic (one place, unit-tested).
-
-> Verify at implementation: the rmcp `#[tool]` macro accepts a method taking
-> both `Parameters<T>` and `RequestContext<RoleServer>`. rmcp's extractor model
-> supports multiple params; confirm by compile. If the combination is rejected,
-> fall back to the `Extension<http::request::Parts>` extractor guarded for the
-> stdio (no-parts) case.
+private `caller_from(ctx: &RequestContext<RoleServer>) -> CallerAuth` holds the
+extraction logic (one place, unit-tested).
 
 ### 4.4 CLI / serve wiring
 
-- `CloudBackend::new(base_url, token: Option<String>)` — token now optional.
-- `build_backend` (in `server.rs`) for the cloud kind: pass the configured
-  `--token`/`BITROUTER_TOKEN` as the **fallback** token (may be `None`). The
-  per-caller bearer (when present) overrides it inside the backend.
-- No new CLI flags. `--token` keeps its meaning (now: the *fallback* used when a
-  request carries no `Authorization`). For a pure multi-tenant host, omit it.
+- `CloudBackend::new(base_url, token)` — **unchanged** (token required).
+- `build_backend` cloud arm — unchanged: the configured `--token`/
+  `BITROUTER_TOKEN` becomes the construction token.
+- No new CLI flags. `--token` keeps its meaning (now also the stdio→cloud
+  credential and the HTTP backstop).
+
+### 4.5 Pre-auth edge middleware (HTTP + cloud backend only)
+
+`serve_http` installs a small axum middleware on the `/mcp-control` route **when
+the backend is `Cloud`**, rejecting requests whose `Authorization` is missing or
+not a `Bearer` token with `401 Unauthorized` before rmcp sees them. Modelled on
+rmcp's `simple_auth_streamhttp.rs` (`middleware::from_fn`). It checks
+**presence only** — token *validity* is the cloud's job.
+
+```rust
+// pseudo
+async fn require_bearer(headers: HeaderMap, req: Request, next: Next) -> Result<Response, StatusCode> {
+    match headers.get(AUTHORIZATION).and_then(|h| h.to_str().ok()) {
+        Some(v) if v.starts_with("Bearer ") => Ok(next.run(req).await),
+        _ => Err(StatusCode::UNAUTHORIZED),
+    }
+}
+```
+
+Not installed for `--backend local` over HTTP (the local daemon is
+unauthenticated, so requiring a bearer there would be wrong) — that unusual
+combo stays open, with the caller bearer ignored as in §4.2.
 
 ## 5. Behaviour matrix
 
 | Transport → backend | Credential used per call |
 |---|---|
 | stdio → local | none (caller ignored) — unchanged |
-| stdio → cloud | configured `--token`/`BITROUTER_TOKEN` (fallback; no HTTP parts) — unchanged |
-| http → local | caller bearer ignored (local never gets it); local stays unauthenticated/master_key |
-| **http → cloud** | **caller's `Authorization` bearer**; else fallback token; else `MissingCredential` error |
+| stdio → cloud | construction `--token`/`BITROUTER_TOKEN` (no HTTP parts) — unchanged |
+| http → local | caller bearer ignored; no edge middleware; local unauthenticated |
+| **http → cloud** | edge middleware requires a `Bearer`; the tool forwards that **caller bearer** to `api.bitrouter.ai` (overriding the construction token) |
 
 ## 6. Security
 
@@ -161,45 +194,52 @@ the extraction logic (one place, unit-tested).
   header).
 - The **local backend never** attaches a caller bearer — a caller's cloud
   credential cannot leak to the BYOK daemon.
+- **Edge middleware** rejects unauthenticated HTTP→cloud requests at the door
+  (401), shrinking what reaches rmcp.
 - Forwarding to `api.bitrouter.ai` stays over **HTTPS**; the cloud is the sole
-  validator (bad token → `401` → `Upstream { 401 }`).
+  validator of token *validity* (bad token → `401` → `Upstream { 401 }`).
 - HTTP bind default stays `127.0.0.1:4357`. Real multi-tenant hosting (operator
-  binds `0.0.0.0` behind TLS) is out of scope here but unblocked by this change.
-- `MissingCredential` returns a tool error, never panics.
+  binds `0.0.0.0` behind TLS) is out of scope here but unblocked.
 
 ## 7. Testing
 
-- **`caller_from` unit test** — given a `RequestContext` whose extensions carry
-  an `http::request::Parts` with `Authorization: Bearer xyz`, returns
-  `Caller { bearer: Some("xyz") }`; with no parts (stdio) returns
-  `Caller::default()`; with a malformed header returns `bearer: None`.
-- **CloudBackend precedence tests** — `caller.bearer` overrides the fallback
-  token (wiremock asserts the forwarded `Authorization` header equals the caller
-  bearer, not the fallback); with neither, `complete/list_models/status` return
-  `BackendError::MissingCredential`.
-- **Multi-tenant HTTP integration test** — stand up the streamable-HTTP server
-  pointed at a wiremock "cloud"; issue two `tools/call list_models` requests
-  with **different** `Authorization` bearers; assert the wiremock saw each bearer
-  forwarded verbatim on its respective call. This is the proof of multi-tenancy.
+- **`caller_from` unit test** — a `RequestContext` whose extensions carry an
+  `http::request::Parts` with `Authorization: Bearer xyz` →
+  `CallerAuth { bearer: Some("xyz") }`; no parts (stdio) → `CallerAuth::default()`;
+  malformed/non-Bearer header → `bearer: None`.
+- **CloudBackend precedence tests** — `caller.bearer` overrides the construction
+  token (wiremock asserts the forwarded `Authorization` equals the caller bearer,
+  not the construction token); with `CallerAuth::default()`, the construction
+  token is sent.
+- **Edge-middleware tests** — HTTP→cloud request with no `Authorization` → `401`;
+  with `Authorization: Bearer x` → passes through (reaches a tool). Confirm the
+  middleware is NOT applied for `--backend local`.
+- **Multi-tenant HTTP integration test** — streamable-HTTP server pointed at a
+  wiremock "cloud"; two `tools/call list_models` requests with **different**
+  `Authorization` bearers; assert wiremock saw each bearer forwarded verbatim on
+  its respective call. The proof of multi-tenancy.
 - **Regression** — existing v1 backend tests update to the new signatures
-  (`complete(&Caller::default(), req)` etc.); all must stay green. No `#[allow]`,
+  (`complete(&CallerAuth::default(), req)` etc.); all stay green. No `#[allow]`,
   no `.unwrap`/`.expect`/`panic!` in non-test code (CLAUDE.md).
 
 ## 8. Skill update (CLAUDE.md requirement)
 
-`skills/bitrouter/references/mcp-server.md`: document that the remote HTTP
-server is now **multi-tenant** — each MCP client supplies its own
-`Authorization: Bearer <brk_…>` header in its remote-server config, forwarded
-per request; `--token` is the optional single-tenant fallback. Note native
-browser OAuth (Item B) remains deferred and why (cloud-side DCR).
+`skills/bitrouter/references/mcp-server.md`: the remote HTTP server is now
+**multi-tenant** — each MCP client supplies its own `Authorization: Bearer
+<brk_…>` header (HTTP→cloud requires it; 401 otherwise), forwarded per request;
+`--token` is the stdio→cloud credential and HTTP construction backstop. Note
+native browser OAuth (Item B) remains deferred and why (cloud-side DCR).
 
-## 9. Open questions (carry into the plan)
+## 9. Resolved during design / remaining notes
 
-1. Confirm the rmcp `#[tool]` macro accepts `Parameters<T>` + `RequestContext<…>`
-   together (§4.3) — else use the `Extension<Parts>` fallback.
-2. Whether to also add a lightweight axum middleware that rejects HTTP requests
-   with *no* `Authorization` header up front (defense-in-depth). Leaning **no**
-   for this increment — the per-tool `MissingCredential` error is sufficient and
-   keeps stdio/HTTP symmetric; revisit if pre-auth rejection is wanted for hosting.
-3. `Caller` is intentionally minimal (just `bearer`). If Item B later needs a
-   resolved principal/claims, extend `Caller` then — not now (YAGNI).
+1. **(resolved)** rmcp `#[tool]` accepts `Parameters<T>` + `RequestContext`
+   together — both are `FromContextPart` extractors (§3).
+2. **(resolved)** Pre-auth middleware: **included** (§4.5), HTTP+cloud only.
+3. **(resolved)** No existing bitrouter mechanism fits; `CallerContext` is a
+   resolved-identity type without a raw bearer and lives in `bitrouter-sdk`
+   (§4.1). New minimal `CallerAuth` justified.
+4. **(decision)** Construction token stays **required** even for multi-tenant
+   HTTP (operator passes any valid bearer as the backstop; the edge middleware
+   makes per-call use of it moot on HTTP→cloud).
+5. **(YAGNI)** `CallerAuth` carries only `bearer`. If Item B later needs resolved
+   claims/principal, extend then — not now.

--- a/docs/superpowers/specs/2026-06-07-bitrouter-mcp-per-caller-auth-design.md
+++ b/docs/superpowers/specs/2026-06-07-bitrouter-mcp-per-caller-auth-design.md
@@ -110,22 +110,45 @@ pub trait Backend: Send + Sync {
 - **`LocalBackend`** ignores `caller` entirely (the BYOK daemon is single-tenant
   and must never receive a third party's cloud bearer). Signatures change; bodies
   do not.
-- **`CloudBackend.token` stays a required `String`** set at construction
-  (`CloudBackend::new(base_url, token)` — unchanged signature). Per the design
-  decision, a cloud backend always has a token. Each request authenticates with
-  the per-caller bearer when present, else the construction token:
+- **`CloudBackend` holds an explicit credential *mode*** rather than a single
+  token field, so the single-tenant and multi-tenant cases are distinct,
+  type-safe construction choices (no accidentally-tokenless backend, no
+  redundant token):
+
   ```rust
-  let bearer = caller.bearer.as_deref().unwrap_or(&self.token);
+  /// How a CloudBackend authenticates upstream.
+  pub enum CloudAuth {
+      /// One configured token used for every call. (stdio → cloud, single-tenant)
+      Static(String),
+      /// Every call must carry the caller's own bearer; no fallback. (http multi-tenant)
+      PerCaller,
+  }
+  // CloudBackend { base_url: String, http: reqwest::Client, auth: CloudAuth }
+  // CloudBackend::new(base_url, auth: CloudAuth)
   ```
-  No new error variant: there is always a credential to send (caller's or the
-  construction fallback). Invalid tokens are the cloud's `401` →
+
+  Per call, the caller's bearer always wins; the `Static` token is the stdio
+  fallback; `PerCaller` with no bearer is an (edge-middleware-prevented) error:
+
+  ```rust
+  let bearer = match (&self.auth, caller.bearer.as_deref()) {
+      (_, Some(b))                 => b,                                  // caller bearer wins
+      (CloudAuth::Static(t), None) => t,                                 // stdio fallback
+      (CloudAuth::PerCaller, None) => return Err(BackendError::MissingCredential),
+  };
+  ```
+
+  `MissingCredential` is a new `BackendError` variant used **only** as a
+  defense-in-depth guard for `PerCaller` with no bearer — unreachable in practice
+  because the §4.5 edge middleware rejects bearer-less HTTP→cloud requests at the
+  door. Invalid (present-but-wrong) tokens remain the cloud's `401` →
   `BackendError::Upstream { 401 }` (already handled).
 
-> For a pure multi-tenant HTTP host, the construction token is required but
-> effectively a backstop — the §4.5 edge middleware guarantees every HTTP
-> request that reaches a tool already carries a caller bearer, which overrides
-> it. The operator still supplies `--token`/`BITROUTER_TOKEN` (any valid bearer)
-> to build the backend.
+> Both `CloudAuth` variants are genuinely used (Static for stdio→cloud, PerCaller
+> for http→cloud) — no dead code. A pure multi-tenant HTTP host passes **no**
+> `--token`: the backend is built `PerCaller`. The earlier "always require a
+> construction token" tension is gone — the tokenless state (`PerCaller`) is a
+> deliberate, named mode, not an accidental `None`.
 
 ### 4.3 Tool handlers
 
@@ -151,11 +174,17 @@ extraction logic (one place, unit-tested).
 
 ### 4.4 CLI / serve wiring
 
-- `CloudBackend::new(base_url, token)` — **unchanged** (token required).
-- `build_backend` cloud arm — unchanged: the configured `--token`/
-  `BITROUTER_TOKEN` becomes the construction token.
-- No new CLI flags. `--token` keeps its meaning (now also the stdio→cloud
-  credential and the HTTP backstop).
+`build_backend` selects the `CloudAuth` mode from the transport:
+
+- **stdio → cloud** → `CloudAuth::Static(token)`. `--token`/`BITROUTER_TOKEN` is
+  **required** here (no per-request header exists); error clearly if absent.
+- **http → cloud** → `CloudAuth::PerCaller`. **No `--token` needed** (and it is
+  ignored if passed); the §4.5 edge middleware enforces a per-caller bearer.
+
+No new CLI flags. `--token`/`BITROUTER_TOKEN` now means specifically "the
+stdio→cloud credential." This requires `build_backend` to know the transport
+(it currently takes only the backend kind) — extend its signature to take
+`Transport` so it can pick the mode.
 
 ### 4.5 Pre-auth edge middleware (HTTP + cloud backend only)
 
@@ -184,9 +213,9 @@ combo stays open, with the caller bearer ignored as in §4.2.
 | Transport → backend | Credential used per call |
 |---|---|
 | stdio → local | none (caller ignored) — unchanged |
-| stdio → cloud | construction `--token`/`BITROUTER_TOKEN` (no HTTP parts) — unchanged |
+| stdio → cloud | `CloudAuth::Static(token)` from `--token`/`BITROUTER_TOKEN` (required; no HTTP parts) |
 | http → local | caller bearer ignored; no edge middleware; local unauthenticated |
-| **http → cloud** | edge middleware requires a `Bearer`; the tool forwards that **caller bearer** to `api.bitrouter.ai` (overriding the construction token) |
+| **http → cloud** | `CloudAuth::PerCaller`; edge middleware requires a `Bearer`; the tool forwards that **caller bearer** to `api.bitrouter.ai`. No `--token`. |
 
 ## 6. Security
 
@@ -207,10 +236,12 @@ combo stays open, with the caller bearer ignored as in §4.2.
   `http::request::Parts` with `Authorization: Bearer xyz` →
   `CallerAuth { bearer: Some("xyz") }`; no parts (stdio) → `CallerAuth::default()`;
   malformed/non-Bearer header → `bearer: None`.
-- **CloudBackend precedence tests** — `caller.bearer` overrides the construction
-  token (wiremock asserts the forwarded `Authorization` equals the caller bearer,
-  not the construction token); with `CallerAuth::default()`, the construction
-  token is sent.
+- **CloudBackend precedence tests** —
+  (a) `CloudAuth::Static("fallback")` + `caller.bearer = Some("caller")` →
+  wiremock asserts the forwarded `Authorization` is `Bearer caller` (caller
+  wins); (b) `Static("fallback")` + `CallerAuth::default()` → forwards `Bearer
+  fallback`; (c) `CloudAuth::PerCaller` + `CallerAuth::default()` →
+  `BackendError::MissingCredential` (no request sent).
 - **Edge-middleware tests** — HTTP→cloud request with no `Authorization` → `401`;
   with `Authorization: Bearer x` → passes through (reaches a tool). Confirm the
   middleware is NOT applied for `--backend local`.
@@ -227,7 +258,8 @@ combo stays open, with the caller bearer ignored as in §4.2.
 `skills/bitrouter/references/mcp-server.md`: the remote HTTP server is now
 **multi-tenant** — each MCP client supplies its own `Authorization: Bearer
 <brk_…>` header (HTTP→cloud requires it; 401 otherwise), forwarded per request;
-`--token` is the stdio→cloud credential and HTTP construction backstop. Note
+`--token`/`BITROUTER_TOKEN` is the **stdio→cloud** credential only (a
+multi-tenant HTTP host needs no token; the backend is built `PerCaller`). Note
 native browser OAuth (Item B) remains deferred and why (cloud-side DCR).
 
 ## 9. Resolved during design / remaining notes
@@ -238,8 +270,9 @@ native browser OAuth (Item B) remains deferred and why (cloud-side DCR).
 3. **(resolved)** No existing bitrouter mechanism fits; `CallerContext` is a
    resolved-identity type without a raw bearer and lives in `bitrouter-sdk`
    (§4.1). New minimal `CallerAuth` justified.
-4. **(decision)** Construction token stays **required** even for multi-tenant
-   HTTP (operator passes any valid bearer as the backstop; the edge middleware
-   makes per-call use of it moot on HTTP→cloud).
+4. **(decision)** Credential model is an explicit `CloudAuth` mode (Option C):
+   `Static(token)` for stdio→cloud (token required), `PerCaller` for http→cloud
+   (no token). This keeps the "no accidentally-tokenless backend" invariant while
+   removing the redundant multi-tenant token (§4.2, §4.4).
 5. **(YAGNI)** `CallerAuth` carries only `bearer`. If Item B later needs resolved
    claims/principal, extend then — not now.

--- a/docs/superpowers/specs/2026-06-07-bitrouter-mcp-per-caller-auth-design.md
+++ b/docs/superpowers/specs/2026-06-07-bitrouter-mcp-per-caller-auth-design.md
@@ -1,0 +1,205 @@
+# BitRouter MCP — Per-Caller Bearer Forwarding (v1.x, Item A)
+
+- **Status:** Draft for review
+- **Date:** 2026-06-07
+- **Builds on:** `2026-06-07-bitrouter-mcp-server-design.md` (v1, shipped in PR #530)
+- **Issue:** follow-up to #526
+- **Author:** Spikel (design discussion w/ Claude)
+
+## 1. Summary
+
+Make the remote (streamable-HTTP) MCP server **multi-tenant**: instead of the
+cloud backend using a single token configured at startup, each tool call
+forwards the **caller's own `Authorization` bearer** to `api.bitrouter.ai`. A
+hosted `bitrouter mcp serve --transport http` can then serve many users at
+once — each MCP client sets its own `Authorization: Bearer <brk_… or access
+token>` in its remote-server config (Claude Code and Cursor both support
+headers), and the server forwards that credential per request.
+
+**No `bitrouter-cloud` changes.** `brk_` keys and OAuth access tokens are
+already valid bearers on `api.bitrouter.ai/v1`; the cloud validates them and
+returns `401` on bad tokens (surfaced as `BackendError::Upstream { 401 }`).
+
+This is v1.x **Item A**. Native browser OAuth (PRM + Dynamic Client
+Registration) is **Item B**, deferred: the cloud AS today has no DCR endpoint
+and `/oauth/authorize` requires a `brk_` principal, so B needs cross-repo cloud
+work and is not required once token-in-header multi-tenancy (A) works.
+
+## 2. Goals / Non-Goals
+
+### Goals
+- The HTTP transport forwards each caller's `Authorization` bearer to the cloud,
+  per request (true multi-tenant).
+- stdio behaviour is **unchanged** (no HTTP request → no per-caller bearer →
+  existing configured-token / no-auth paths still apply).
+- The local daemon **never** receives a caller bearer.
+- A missing bearer (HTTP, no configured fallback) yields a **clear tool error**,
+  not an opaque upstream failure.
+
+### Non-Goals
+- Native in-client browser OAuth / PRM / DCR (Item B — needs cloud changes).
+- Local token validation/introspection in the MCP server (the cloud validates;
+  we forward and surface its verdict).
+- TLS termination / hosting concerns (operator's responsibility; we keep the
+  default bind at `127.0.0.1` and forward to cloud over HTTPS).
+
+## 3. The mechanism (verified against rmcp 1.7.0)
+
+rmcp's streamable-HTTP tower service injects the inbound `http::request::Parts`
+(headers included) into each MCP request's extensions
+(`transport/streamable_http_server/tower.rs:1039/1102/1179`), reachable from a
+tool's `RequestContext`. Confirmed by rmcp's own docs (`tower.rs:438–495`):
+
+```rust
+// inside a #[tool] method that also takes `ctx: RequestContext<RoleServer>`
+let bearer = ctx
+    .extensions
+    .get::<http::request::Parts>()                       // None over stdio
+    .and_then(|p| p.headers.get(http::header::AUTHORIZATION))
+    .and_then(|h| h.to_str().ok())
+    .and_then(|s| s.strip_prefix("Bearer "))
+    .map(str::to_owned);
+```
+
+The `RequestContext` form is chosen over the `Extension<Parts>` extractor
+because `ctx.extensions.get::<Parts>()` returns `Option` — `None` over stdio,
+where no HTTP parts exist — so the **same tool definition works on both
+transports**.
+
+## 4. Design
+
+### 4.1 Separate "what to call" from "who's calling"
+
+A small per-call credential carrier, defined in `mcp/src/backend/mod.rs`:
+
+```rust
+/// Per-call caller identity. Empty for stdio / unauthenticated local use.
+#[derive(Debug, Default, Clone)]
+pub struct Caller {
+    /// The caller's bearer token, if the inbound request carried one.
+    pub bearer: Option<String>,
+}
+```
+
+The `Backend` trait threads it through every method:
+
+```rust
+#[async_trait]
+pub trait Backend: Send + Sync {
+    async fn complete(&self, caller: &Caller, req: CompleteRequest) -> Result<CompleteResponse, BackendError>;
+    async fn list_models(&self, caller: &Caller) -> Result<Vec<ModelInfo>, BackendError>;
+    async fn status(&self, caller: &Caller) -> Result<StatusInfo, BackendError>;
+}
+```
+
+### 4.2 Backend behaviour
+
+- **`LocalBackend`** ignores `caller` entirely (the BYOK daemon is single-tenant
+  and must never receive a third party's cloud bearer). Signatures change; bodies
+  do not.
+- **`CloudBackend.token`** becomes `Option<String>` — a **fallback** for the
+  single-tenant stdio→cloud case. Each request authenticates with:
+  ```rust
+  let bearer = caller.bearer.as_deref().or(self.token.as_deref());
+  ```
+  - `Some(b)` → send `Authorization: Bearer b`.
+  - `None` → return `BackendError::MissingCredential` (new variant) with a clear
+    message: *"no bearer token — set Authorization on the MCP client or pass
+    --token"*. (Today `CloudBackend::new` requires a token; this relaxes it so a
+    hosted multi-tenant server can run with no default token and rely on
+    per-caller bearers.)
+
+### 4.3 Tool handlers
+
+Each of the three `#[tool]` methods in `mcp/src/server.rs` gains a
+`ctx: RequestContext<RoleServer>` parameter, extracts the bearer per §3, builds
+a `Caller`, and passes it to the backend:
+
+```rust
+#[tool(description = "…")]
+async fn complete(
+    &self,
+    Parameters(args): Parameters<CompleteArgs>,
+    ctx: RequestContext<RoleServer>,
+) -> Result<CallToolResult, McpError> {
+    let caller = caller_from(&ctx);          // helper: extracts bearer (§3)
+    match self.backend.complete(&caller, args.into()).await { … }
+}
+```
+
+`list_models` and `status` likewise gain `ctx` and pass `&caller`. A single
+private `caller_from(ctx: &RequestContext<RoleServer>) -> Caller` helper holds
+the extraction logic (one place, unit-tested).
+
+> Verify at implementation: the rmcp `#[tool]` macro accepts a method taking
+> both `Parameters<T>` and `RequestContext<RoleServer>`. rmcp's extractor model
+> supports multiple params; confirm by compile. If the combination is rejected,
+> fall back to the `Extension<http::request::Parts>` extractor guarded for the
+> stdio (no-parts) case.
+
+### 4.4 CLI / serve wiring
+
+- `CloudBackend::new(base_url, token: Option<String>)` — token now optional.
+- `build_backend` (in `server.rs`) for the cloud kind: pass the configured
+  `--token`/`BITROUTER_TOKEN` as the **fallback** token (may be `None`). The
+  per-caller bearer (when present) overrides it inside the backend.
+- No new CLI flags. `--token` keeps its meaning (now: the *fallback* used when a
+  request carries no `Authorization`). For a pure multi-tenant host, omit it.
+
+## 5. Behaviour matrix
+
+| Transport → backend | Credential used per call |
+|---|---|
+| stdio → local | none (caller ignored) — unchanged |
+| stdio → cloud | configured `--token`/`BITROUTER_TOKEN` (fallback; no HTTP parts) — unchanged |
+| http → local | caller bearer ignored (local never gets it); local stays unauthenticated/master_key |
+| **http → cloud** | **caller's `Authorization` bearer**; else fallback token; else `MissingCredential` error |
+
+## 6. Security
+
+- **Never log tokens** (no `tracing` of `caller.bearer` or the Authorization
+  header).
+- The **local backend never** attaches a caller bearer — a caller's cloud
+  credential cannot leak to the BYOK daemon.
+- Forwarding to `api.bitrouter.ai` stays over **HTTPS**; the cloud is the sole
+  validator (bad token → `401` → `Upstream { 401 }`).
+- HTTP bind default stays `127.0.0.1:4357`. Real multi-tenant hosting (operator
+  binds `0.0.0.0` behind TLS) is out of scope here but unblocked by this change.
+- `MissingCredential` returns a tool error, never panics.
+
+## 7. Testing
+
+- **`caller_from` unit test** — given a `RequestContext` whose extensions carry
+  an `http::request::Parts` with `Authorization: Bearer xyz`, returns
+  `Caller { bearer: Some("xyz") }`; with no parts (stdio) returns
+  `Caller::default()`; with a malformed header returns `bearer: None`.
+- **CloudBackend precedence tests** — `caller.bearer` overrides the fallback
+  token (wiremock asserts the forwarded `Authorization` header equals the caller
+  bearer, not the fallback); with neither, `complete/list_models/status` return
+  `BackendError::MissingCredential`.
+- **Multi-tenant HTTP integration test** — stand up the streamable-HTTP server
+  pointed at a wiremock "cloud"; issue two `tools/call list_models` requests
+  with **different** `Authorization` bearers; assert the wiremock saw each bearer
+  forwarded verbatim on its respective call. This is the proof of multi-tenancy.
+- **Regression** — existing v1 backend tests update to the new signatures
+  (`complete(&Caller::default(), req)` etc.); all must stay green. No `#[allow]`,
+  no `.unwrap`/`.expect`/`panic!` in non-test code (CLAUDE.md).
+
+## 8. Skill update (CLAUDE.md requirement)
+
+`skills/bitrouter/references/mcp-server.md`: document that the remote HTTP
+server is now **multi-tenant** — each MCP client supplies its own
+`Authorization: Bearer <brk_…>` header in its remote-server config, forwarded
+per request; `--token` is the optional single-tenant fallback. Note native
+browser OAuth (Item B) remains deferred and why (cloud-side DCR).
+
+## 9. Open questions (carry into the plan)
+
+1. Confirm the rmcp `#[tool]` macro accepts `Parameters<T>` + `RequestContext<…>`
+   together (§4.3) — else use the `Extension<Parts>` fallback.
+2. Whether to also add a lightweight axum middleware that rejects HTTP requests
+   with *no* `Authorization` header up front (defense-in-depth). Leaning **no**
+   for this increment — the per-tool `MissingCredential` error is sufficient and
+   keeps stdio/HTTP symmetric; revisit if pre-auth rejection is wanted for hosting.
+3. `Caller` is intentionally minimal (just `bearer`). If Item B later needs a
+   resolved principal/claims, extend `Caller` then — not now (YAGNI).

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -26,6 +26,7 @@ rmcp = { workspace = true, features = [
     "transport-streamable-http-server",
 ] }
 async-trait.workspace = true
+http = { workspace = true }
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/mcp/src/backend/cloud.rs
+++ b/mcp/src/backend/cloud.rs
@@ -5,8 +5,8 @@
 use async_trait::async_trait;
 
 use super::{
-    Backend, BackendError, CompleteRequest, CompleteResponse, ModelInfo, ModelsEnvelope,
-    StatusInfo, Usage,
+    Backend, BackendError, CallerAuth, CompleteRequest, CompleteResponse, ModelInfo,
+    ModelsEnvelope, StatusInfo, Usage,
 };
 
 pub struct CloudBackend {
@@ -24,8 +24,9 @@ impl CloudBackend {
         }
     }
 
-    fn bearer(&self, rb: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
-        rb.bearer_auth(&self.token)
+    fn bearer(&self, caller: &CallerAuth, rb: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        let token = caller.bearer.as_deref().unwrap_or(&self.token);
+        rb.bearer_auth(token)
     }
 }
 
@@ -38,10 +39,10 @@ struct Balance {
 
 #[async_trait]
 impl Backend for CloudBackend {
-    async fn list_models(&self) -> Result<Vec<ModelInfo>, BackendError> {
+    async fn list_models(&self, caller: &CallerAuth) -> Result<Vec<ModelInfo>, BackendError> {
         let url = format!("{}/v1/models", self.base_url);
         let resp = self
-            .bearer(self.http.get(&url))
+            .bearer(caller, self.http.get(&url))
             .send()
             .await
             .map_err(|e| BackendError::Transport(e.to_string()))?;
@@ -67,7 +68,11 @@ impl Backend for CloudBackend {
             .collect())
     }
 
-    async fn complete(&self, req: CompleteRequest) -> Result<CompleteResponse, BackendError> {
+    async fn complete(
+        &self,
+        caller: &CallerAuth,
+        req: CompleteRequest,
+    ) -> Result<CompleteResponse, BackendError> {
         let url = format!("{}/v1/chat/completions", self.base_url);
         let mut body = serde_json::json!({ "model": req.model, "messages": req.messages });
         if let Some(m) = req.max_tokens {
@@ -80,7 +85,7 @@ impl Backend for CloudBackend {
             body["system"] = s.into();
         }
         let resp = self
-            .bearer(self.http.post(&url).json(&body))
+            .bearer(caller, self.http.post(&url).json(&body))
             .send()
             .await
             .map_err(|e| BackendError::Transport(e.to_string()))?;
@@ -124,10 +129,10 @@ impl Backend for CloudBackend {
         })
     }
 
-    async fn status(&self) -> Result<StatusInfo, BackendError> {
+    async fn status(&self, caller: &CallerAuth) -> Result<StatusInfo, BackendError> {
         let url = format!("{}/v1/billing/balance", self.base_url);
         let resp = self
-            .bearer(self.http.get(&url))
+            .bearer(caller, self.http.get(&url))
             .send()
             .await
             .map_err(|e| BackendError::Transport(e.to_string()))?;
@@ -171,7 +176,11 @@ mod tests {
             .await;
 
         let backend = CloudBackend::new(server.uri(), "brk_test");
-        match backend.status().await.expect("status") {
+        match backend
+            .status(&CallerAuth::default())
+            .await
+            .expect("status")
+        {
             StatusInfo::Cloud {
                 available_micro_usd,
                 balance_micro_usd,
@@ -194,7 +203,7 @@ mod tests {
             .mount(&server)
             .await;
         let backend = CloudBackend::new(server.uri(), "brk_bad");
-        match backend.list_models().await {
+        match backend.list_models(&CallerAuth::default()).await {
             Err(BackendError::Upstream { status, .. }) => assert_eq!(status, 401),
             other => panic!("expected Upstream 401, got {other:?}"),
         }
@@ -214,7 +223,10 @@ mod tests {
             .await;
 
         let backend = CloudBackend::new(server.uri(), "brk_test");
-        let models = backend.list_models().await.expect("models");
+        let models = backend
+            .list_models(&CallerAuth::default())
+            .await
+            .expect("models");
         assert_eq!(
             models,
             vec![ModelInfo {
@@ -223,5 +235,23 @@ mod tests {
                 active: true,
             }]
         );
+    }
+
+    #[tokio::test]
+    async fn caller_bearer_overrides_configured_token() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/models"))
+            .and(header("authorization", "Bearer caller-tok"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "object": "list", "data": []
+            })))
+            .mount(&server)
+            .await;
+        let backend = CloudBackend::new(server.uri(), "configured-tok");
+        let caller = CallerAuth {
+            bearer: Some("caller-tok".into()),
+        };
+        backend.list_models(&caller).await.expect("list_models");
     }
 }

--- a/mcp/src/backend/cloud.rs
+++ b/mcp/src/backend/cloud.rs
@@ -9,24 +9,41 @@ use super::{
     ModelsEnvelope, StatusInfo, Usage,
 };
 
+/// How a [`CloudBackend`] authenticates upstream.
+pub enum CloudAuth {
+    /// One configured token used for every call (stdio → cloud, single-tenant).
+    Static(String),
+    /// Every call must carry the caller's own bearer; no fallback (http multi-tenant).
+    PerCaller,
+}
+
 pub struct CloudBackend {
     base_url: String,
-    token: String,
+    auth: CloudAuth,
     http: reqwest::Client,
 }
 
 impl CloudBackend {
-    pub fn new(base_url: impl Into<String>, token: impl Into<String>) -> Self {
+    pub fn new(base_url: impl Into<String>, auth: CloudAuth) -> Self {
         Self {
             base_url: base_url.into().trim_end_matches('/').to_owned(),
-            token: token.into(),
+            auth,
             http: reqwest::Client::new(),
         }
     }
 
-    fn bearer(&self, caller: &CallerAuth, rb: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
-        let token = caller.bearer.as_deref().unwrap_or(&self.token);
-        rb.bearer_auth(token)
+    /// Resolve the bearer to send: the caller's wins; else the `Static` token;
+    /// `PerCaller` with no caller bearer is a (middleware-prevented) error.
+    fn resolve_bearer<'a>(&'a self, caller: &'a CallerAuth) -> Result<&'a str, BackendError> {
+        match (&self.auth, caller.bearer.as_deref()) {
+            (_, Some(b)) => Ok(b),
+            (CloudAuth::Static(t), None) => Ok(t),
+            (CloudAuth::PerCaller, None) => Err(BackendError::MissingCredential),
+        }
+    }
+
+    fn authed(&self, bearer: &str, rb: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        rb.bearer_auth(bearer)
     }
 }
 
@@ -40,9 +57,10 @@ struct Balance {
 #[async_trait]
 impl Backend for CloudBackend {
     async fn list_models(&self, caller: &CallerAuth) -> Result<Vec<ModelInfo>, BackendError> {
+        let bearer = self.resolve_bearer(caller)?;
         let url = format!("{}/v1/models", self.base_url);
         let resp = self
-            .bearer(caller, self.http.get(&url))
+            .authed(bearer, self.http.get(&url))
             .send()
             .await
             .map_err(|e| BackendError::Transport(e.to_string()))?;
@@ -84,8 +102,9 @@ impl Backend for CloudBackend {
         if let Some(s) = req.system {
             body["system"] = s.into();
         }
+        let bearer = self.resolve_bearer(caller)?;
         let resp = self
-            .bearer(caller, self.http.post(&url).json(&body))
+            .authed(bearer, self.http.post(&url).json(&body))
             .send()
             .await
             .map_err(|e| BackendError::Transport(e.to_string()))?;
@@ -130,9 +149,10 @@ impl Backend for CloudBackend {
     }
 
     async fn status(&self, caller: &CallerAuth) -> Result<StatusInfo, BackendError> {
+        let bearer = self.resolve_bearer(caller)?;
         let url = format!("{}/v1/billing/balance", self.base_url);
         let resp = self
-            .bearer(caller, self.http.get(&url))
+            .authed(bearer, self.http.get(&url))
             .send()
             .await
             .map_err(|e| BackendError::Transport(e.to_string()))?;
@@ -175,7 +195,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        let backend = CloudBackend::new(server.uri(), "brk_test");
+        let backend = CloudBackend::new(server.uri(), CloudAuth::Static("brk_test".into()));
         match backend
             .status(&CallerAuth::default())
             .await
@@ -202,7 +222,7 @@ mod tests {
             .respond_with(ResponseTemplate::new(401).set_body_string("unauthorized"))
             .mount(&server)
             .await;
-        let backend = CloudBackend::new(server.uri(), "brk_bad");
+        let backend = CloudBackend::new(server.uri(), CloudAuth::Static("brk_bad".into()));
         match backend.list_models(&CallerAuth::default()).await {
             Err(BackendError::Upstream { status, .. }) => assert_eq!(status, 401),
             other => panic!("expected Upstream 401, got {other:?}"),
@@ -222,7 +242,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        let backend = CloudBackend::new(server.uri(), "brk_test");
+        let backend = CloudBackend::new(server.uri(), CloudAuth::Static("brk_test".into()));
         let models = backend
             .list_models(&CallerAuth::default())
             .await
@@ -238,6 +258,16 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn per_caller_without_bearer_errors() {
+        let backend = CloudBackend::new("https://api.bitrouter.ai", CloudAuth::PerCaller);
+        let err = backend
+            .list_models(&CallerAuth::default())
+            .await
+            .expect_err("should error");
+        assert!(matches!(err, BackendError::MissingCredential));
+    }
+
+    #[tokio::test]
     async fn caller_bearer_overrides_configured_token() {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
@@ -248,7 +278,7 @@ mod tests {
             })))
             .mount(&server)
             .await;
-        let backend = CloudBackend::new(server.uri(), "configured-tok");
+        let backend = CloudBackend::new(server.uri(), CloudAuth::Static("configured-tok".into()));
         let caller = CallerAuth {
             bearer: Some("caller-tok".into()),
         };

--- a/mcp/src/backend/local.rs
+++ b/mcp/src/backend/local.rs
@@ -5,8 +5,8 @@
 use async_trait::async_trait;
 
 use super::{
-    Backend, BackendError, CompleteRequest, CompleteResponse, ModelInfo, ModelsEnvelope,
-    ProviderStatus, StatusInfo, Usage,
+    Backend, BackendError, CallerAuth, CompleteRequest, CompleteResponse, ModelInfo,
+    ModelsEnvelope, ProviderStatus, StatusInfo, Usage,
 };
 
 /// Routes tool calls to the local daemon's `/v1/*` HTTP API.
@@ -27,7 +27,7 @@ impl LocalBackend {
 
 #[async_trait]
 impl Backend for LocalBackend {
-    async fn list_models(&self) -> Result<Vec<ModelInfo>, BackendError> {
+    async fn list_models(&self, _caller: &CallerAuth) -> Result<Vec<ModelInfo>, BackendError> {
         let url = format!("{}/v1/models", self.base_url);
         let resp = self
             .http
@@ -57,7 +57,11 @@ impl Backend for LocalBackend {
             .collect())
     }
 
-    async fn complete(&self, req: CompleteRequest) -> Result<CompleteResponse, BackendError> {
+    async fn complete(
+        &self,
+        _caller: &CallerAuth,
+        req: CompleteRequest,
+    ) -> Result<CompleteResponse, BackendError> {
         let url = format!("{}/v1/chat/completions", self.base_url);
         let mut body = serde_json::json!({
             "model": req.model,
@@ -119,7 +123,7 @@ impl Backend for LocalBackend {
         })
     }
 
-    async fn status(&self) -> Result<StatusInfo, BackendError> {
+    async fn status(&self, _caller: &CallerAuth) -> Result<StatusInfo, BackendError> {
         let url = format!("{}/v1/models", self.base_url);
         let resp = self
             .http
@@ -199,13 +203,16 @@ mod tests {
 
         let backend = LocalBackend::new(server.uri());
         let out = backend
-            .complete(CompleteRequest {
-                model: "openai/gpt-4o".into(),
-                messages: vec![serde_json::json!({ "role": "user", "content": "hi" })],
-                max_tokens: Some(64),
-                temperature: None,
-                system: None,
-            })
+            .complete(
+                &CallerAuth::default(),
+                CompleteRequest {
+                    model: "openai/gpt-4o".into(),
+                    messages: vec![serde_json::json!({ "role": "user", "content": "hi" })],
+                    max_tokens: Some(64),
+                    temperature: None,
+                    system: None,
+                },
+            )
             .await
             .expect("complete");
 
@@ -230,7 +237,7 @@ mod tests {
             .mount(&server)
             .await;
         let backend = LocalBackend::new(server.uri());
-        match backend.status().await {
+        match backend.status(&CallerAuth::default()).await {
             Err(BackendError::Upstream { status, .. }) => assert_eq!(status, 500),
             other => panic!("expected Upstream 500, got {other:?}"),
         }
@@ -253,7 +260,11 @@ mod tests {
             .await;
 
         let backend = LocalBackend::new(server.uri());
-        match backend.status().await.expect("status") {
+        match backend
+            .status(&CallerAuth::default())
+            .await
+            .expect("status")
+        {
             StatusInfo::Local {
                 running,
                 models,
@@ -297,7 +308,10 @@ mod tests {
             .await;
 
         let backend = LocalBackend::new(server.uri());
-        let models = backend.list_models().await.expect("list_models");
+        let models = backend
+            .list_models(&CallerAuth::default())
+            .await
+            .expect("list_models");
 
         assert_eq!(
             models,

--- a/mcp/src/backend/mod.rs
+++ b/mcp/src/backend/mod.rs
@@ -83,6 +83,13 @@ pub(super) struct ModelEntry {
     pub(super) providers: Vec<String>,
 }
 
+/// The caller's bearer to forward upstream, if the inbound request carried one.
+/// Empty for stdio (the cloud backend's configured credential applies instead).
+#[derive(Debug, Default, Clone)]
+pub struct CallerAuth {
+    pub bearer: Option<String>,
+}
+
 /// Errors surfaced to the MCP client as tool failures.
 #[derive(Debug, thiserror::Error)]
 pub enum BackendError {
@@ -94,12 +101,18 @@ pub enum BackendError {
     Transport(String),
     #[error("malformed upstream response: {0}")]
     Decode(String),
+    #[error("no bearer token: set Authorization on the MCP client")]
+    MissingCredential,
 }
 
 /// Where tool calls route. Object-safe so tools hold `Arc<dyn Backend>`.
 #[async_trait]
 pub trait Backend: Send + Sync {
-    async fn complete(&self, req: CompleteRequest) -> Result<CompleteResponse, BackendError>;
-    async fn list_models(&self) -> Result<Vec<ModelInfo>, BackendError>;
-    async fn status(&self) -> Result<StatusInfo, BackendError>;
+    async fn complete(
+        &self,
+        caller: &CallerAuth,
+        req: CompleteRequest,
+    ) -> Result<CompleteResponse, BackendError>;
+    async fn list_models(&self, caller: &CallerAuth) -> Result<Vec<ModelInfo>, BackendError>;
+    async fn status(&self, caller: &CallerAuth) -> Result<StatusInfo, BackendError>;
 }

--- a/mcp/src/lib.rs
+++ b/mcp/src/lib.rs
@@ -84,6 +84,9 @@ pub async fn serve(opts: ServeOptions) -> anyhow::Result<()> {
     )?;
     match opts.transport {
         Transport::Stdio => server::serve_stdio(backend).await,
-        Transport::Http => server::serve_http(backend, &opts.bind).await,
+        Transport::Http => {
+            let require_auth = matches!(opts.backend, BackendKind::Cloud);
+            server::serve_http(backend, &opts.bind, require_auth).await
+        }
     }
 }

--- a/mcp/src/lib.rs
+++ b/mcp/src/lib.rs
@@ -77,6 +77,7 @@ pub struct ServeOptions {
 pub async fn serve(opts: ServeOptions) -> anyhow::Result<()> {
     let backend = server::build_backend(
         opts.backend,
+        opts.transport,
         &opts.local_url,
         &opts.cloud_url,
         opts.cloud_token.as_deref(),

--- a/mcp/src/server.rs
+++ b/mcp/src/server.rs
@@ -159,23 +159,32 @@ pub async fn serve_http(backend: Arc<dyn Backend>, bind: &str) -> anyhow::Result
     Ok(())
 }
 
-/// Build the backend for a given kind from connection params.
+/// Build the backend. The cloud auth mode depends on transport:
+/// stdio→cloud uses the configured token (Static); http→cloud is multi-tenant
+/// (PerCaller — each request must carry its own bearer).
 pub fn build_backend(
     kind: crate::BackendKind,
+    transport: crate::Transport,
     local_url: &str,
     cloud_url: &str,
     cloud_token: Option<&str>,
 ) -> anyhow::Result<Arc<dyn Backend>> {
+    use crate::backend::cloud::CloudAuth;
     match kind {
         crate::BackendKind::Local => Ok(Arc::new(LocalBackend::new(local_url))),
         crate::BackendKind::Cloud => {
-            let token = cloud_token.ok_or_else(|| {
-                anyhow::anyhow!("cloud backend needs a bearer token (--token or BITROUTER_TOKEN)")
-            })?;
-            Ok(Arc::new(CloudBackend::new(
-                cloud_url,
-                crate::backend::cloud::CloudAuth::Static(token.to_owned()),
-            )))
+            let auth = match transport {
+                crate::Transport::Http => CloudAuth::PerCaller,
+                crate::Transport::Stdio => {
+                    let token = cloud_token.ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "stdio cloud backend needs a token (--token or BITROUTER_TOKEN)"
+                        )
+                    })?;
+                    CloudAuth::Static(token.to_owned())
+                }
+            };
+            Ok(Arc::new(CloudBackend::new(cloud_url, auth)))
         }
     }
 }

--- a/mcp/src/server.rs
+++ b/mcp/src/server.rs
@@ -150,14 +150,18 @@ async fn require_bearer(
 
 /// Build the `/mcp-control` axum router for `backend`, optionally gated by the
 /// pre-auth bearer middleware.
-fn build_http_router(backend: Arc<dyn Backend>, require_auth: bool) -> axum::Router {
+fn build_http_router(
+    backend: Arc<dyn Backend>,
+    require_auth: bool,
+    config: rmcp::transport::streamable_http_server::StreamableHttpServerConfig,
+) -> axum::Router {
     use rmcp::transport::streamable_http_server::{
-        StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
+        StreamableHttpService, session::local::LocalSessionManager,
     };
     let service = StreamableHttpService::new(
         move || Ok(BitrouterMcp::new(backend.clone())),
         LocalSessionManager::default().into(),
-        StreamableHttpServerConfig::default(),
+        config,
     );
     let mut router = axum::Router::new().nest_service("/mcp-control", service);
     if require_auth {
@@ -174,7 +178,12 @@ pub async fn serve_http_on(
     listener: tokio::net::TcpListener,
     require_auth: bool,
 ) -> anyhow::Result<()> {
-    axum::serve(listener, build_http_router(backend, require_auth)).await?;
+    use rmcp::transport::streamable_http_server::StreamableHttpServerConfig;
+    axum::serve(
+        listener,
+        build_http_router(backend, require_auth, StreamableHttpServerConfig::default()),
+    )
+    .await?;
     Ok(())
 }
 
@@ -195,21 +204,10 @@ pub async fn serve_http(
     bind: &str,
     require_auth: bool,
 ) -> anyhow::Result<()> {
-    use rmcp::transport::streamable_http_server::{
-        StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
-    };
+    use rmcp::transport::streamable_http_server::StreamableHttpServerConfig;
     let ct = tokio_util::sync::CancellationToken::new();
     let mut config = StreamableHttpServerConfig::default();
     config.cancellation_token = ct.child_token();
-    let service = StreamableHttpService::new(
-        move || Ok(BitrouterMcp::new(backend.clone())),
-        LocalSessionManager::default().into(),
-        config,
-    );
-    let mut router = axum::Router::new().nest_service("/mcp-control", service);
-    if require_auth {
-        router = router.layer(axum::middleware::from_fn(require_bearer));
-    }
     let listener = tokio::net::TcpListener::bind(bind).await?;
     let shutdown = {
         let ct = ct.clone();
@@ -218,7 +216,7 @@ pub async fn serve_http(
             ct.cancel();
         }
     };
-    axum::serve(listener, router)
+    axum::serve(listener, build_http_router(backend, require_auth, config))
         .with_graceful_shutdown(shutdown)
         .await?;
     Ok(())

--- a/mcp/src/server.rs
+++ b/mcp/src/server.rs
@@ -148,6 +148,36 @@ async fn require_bearer(
     }
 }
 
+/// Build the `/mcp-control` axum router for `backend`, optionally gated by the
+/// pre-auth bearer middleware.
+fn build_http_router(backend: Arc<dyn Backend>, require_auth: bool) -> axum::Router {
+    use rmcp::transport::streamable_http_server::{
+        StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
+    };
+    let service = StreamableHttpService::new(
+        move || Ok(BitrouterMcp::new(backend.clone())),
+        LocalSessionManager::default().into(),
+        StreamableHttpServerConfig::default(),
+    );
+    let mut router = axum::Router::new().nest_service("/mcp-control", service);
+    if require_auth {
+        router = router.layer(axum::middleware::from_fn(require_bearer));
+    }
+    router
+}
+
+/// Serve streamable HTTP on an already-bound listener until the task is dropped.
+/// Exposed for integration tests of real multi-tenant forwarding.
+#[doc(hidden)]
+pub async fn serve_http_on(
+    backend: Arc<dyn Backend>,
+    listener: tokio::net::TcpListener,
+    require_auth: bool,
+) -> anyhow::Result<()> {
+    axum::serve(listener, build_http_router(backend, require_auth)).await?;
+    Ok(())
+}
+
 /// Serve over stdio until the client disconnects.
 pub async fn serve_stdio(backend: Arc<dyn Backend>) -> anyhow::Result<()> {
     use rmcp::{ServiceExt, transport::stdio};

--- a/mcp/src/server.rs
+++ b/mcp/src/server.rs
@@ -151,7 +151,10 @@ pub fn build_backend(
             let token = cloud_token.ok_or_else(|| {
                 anyhow::anyhow!("cloud backend needs a bearer token (--token or BITROUTER_TOKEN)")
             })?;
-            Ok(Arc::new(CloudBackend::new(cloud_url, token)))
+            Ok(Arc::new(CloudBackend::new(
+                cloud_url,
+                crate::backend::cloud::CloudAuth::Static(token.to_owned()),
+            )))
         }
     }
 }

--- a/mcp/src/server.rs
+++ b/mcp/src/server.rs
@@ -123,6 +123,31 @@ impl ServerHandler for BitrouterMcp {
 use crate::backend::cloud::CloudBackend;
 use crate::backend::local::LocalBackend;
 
+/// Whether an `Authorization` header value is a Bearer token.
+fn has_bearer(value: Option<&str>) -> bool {
+    value.is_some_and(|v| v.starts_with("Bearer "))
+}
+
+/// Reject requests without a `Bearer` Authorization header (presence only;
+/// the cloud validates the token's validity).
+async fn require_bearer(
+    headers: axum::http::HeaderMap,
+    request: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    use axum::response::IntoResponse;
+    let present = has_bearer(
+        headers
+            .get(axum::http::header::AUTHORIZATION)
+            .and_then(|h| h.to_str().ok()),
+    );
+    if present {
+        next.run(request).await
+    } else {
+        axum::http::StatusCode::UNAUTHORIZED.into_response()
+    }
+}
+
 /// Serve over stdio until the client disconnects.
 pub async fn serve_stdio(backend: Arc<dyn Backend>) -> anyhow::Result<()> {
     use rmcp::{ServiceExt, transport::stdio};
@@ -132,7 +157,14 @@ pub async fn serve_stdio(backend: Arc<dyn Backend>) -> anyhow::Result<()> {
 }
 
 /// Serve streamable HTTP at `/mcp-control` on `bind` until Ctrl-C.
-pub async fn serve_http(backend: Arc<dyn Backend>, bind: &str) -> anyhow::Result<()> {
+///
+/// When `require_auth` is `true`, requests without a `Bearer` Authorization
+/// header are rejected with `401 Unauthorized` before reaching the MCP handler.
+pub async fn serve_http(
+    backend: Arc<dyn Backend>,
+    bind: &str,
+    require_auth: bool,
+) -> anyhow::Result<()> {
     use rmcp::transport::streamable_http_server::{
         StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
     };
@@ -144,7 +176,10 @@ pub async fn serve_http(backend: Arc<dyn Backend>, bind: &str) -> anyhow::Result
         LocalSessionManager::default().into(),
         config,
     );
-    let router = axum::Router::new().nest_service("/mcp-control", service);
+    let mut router = axum::Router::new().nest_service("/mcp-control", service);
+    if require_auth {
+        router = router.layer(axum::middleware::from_fn(require_bearer));
+    }
     let listener = tokio::net::TcpListener::bind(bind).await?;
     let shutdown = {
         let ct = ct.clone();
@@ -195,6 +230,13 @@ mod tests {
     use crate::backend::{
         BackendError, CallerAuth, CompleteResponse, ModelInfo, StatusInfo, Usage,
     };
+
+    #[test]
+    fn require_bearer_predicate() {
+        assert!(has_bearer(Some("Bearer abc")));
+        assert!(!has_bearer(Some("Basic abc")));
+        assert!(!has_bearer(None));
+    }
 
     struct StubBackend;
     #[async_trait::async_trait]

--- a/mcp/src/server.rs
+++ b/mcp/src/server.rs
@@ -8,7 +8,7 @@ use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::{CallToolResult, Content, ServerCapabilities, ServerInfo};
 use rmcp::{ErrorData as McpError, ServerHandler, tool, tool_handler, tool_router};
 
-use crate::backend::{Backend, CompleteRequest};
+use crate::backend::{Backend, CallerAuth, CompleteRequest};
 
 #[derive(Clone)]
 pub struct BitrouterMcp {
@@ -48,7 +48,7 @@ impl BitrouterMcp {
             temperature: args.temperature,
             system: args.system,
         };
-        match self.backend.complete(req).await {
+        match self.backend.complete(&CallerAuth::default(), req).await {
             Ok(r) => match serde_json::to_string(&r) {
                 Ok(json) => Ok(CallToolResult::success(vec![Content::text(json)])),
                 Err(e) => Ok(CallToolResult::error(vec![Content::text(format!(
@@ -61,7 +61,7 @@ impl BitrouterMcp {
 
     #[tool(description = "List models routable through BitRouter.")]
     async fn list_models(&self) -> Result<CallToolResult, McpError> {
-        match self.backend.list_models().await {
+        match self.backend.list_models(&CallerAuth::default()).await {
             Ok(m) => match serde_json::to_string(&m) {
                 Ok(json) => Ok(CallToolResult::success(vec![Content::text(json)])),
                 Err(e) => Ok(CallToolResult::error(vec![Content::text(format!(
@@ -76,7 +76,7 @@ impl BitrouterMcp {
         description = "Report BitRouter status (local: liveness/models/providers; cloud: credit balance)."
     )]
     async fn status(&self) -> Result<CallToolResult, McpError> {
-        match self.backend.status().await {
+        match self.backend.status(&CallerAuth::default()).await {
             Ok(s) => match serde_json::to_string(&s) {
                 Ok(json) => Ok(CallToolResult::success(vec![Content::text(json)])),
                 Err(e) => Ok(CallToolResult::error(vec![Content::text(format!(
@@ -159,12 +159,18 @@ pub fn build_backend(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::backend::{BackendError, CompleteResponse, ModelInfo, StatusInfo, Usage};
+    use crate::backend::{
+        BackendError, CallerAuth, CompleteResponse, ModelInfo, StatusInfo, Usage,
+    };
 
     struct StubBackend;
     #[async_trait::async_trait]
     impl Backend for StubBackend {
-        async fn complete(&self, _: CompleteRequest) -> Result<CompleteResponse, BackendError> {
+        async fn complete(
+            &self,
+            _: &CallerAuth,
+            _: CompleteRequest,
+        ) -> Result<CompleteResponse, BackendError> {
             Ok(CompleteResponse {
                 content: "ok".into(),
                 model: "m".into(),
@@ -175,10 +181,10 @@ mod tests {
                 finish_reason: "stop".into(),
             })
         }
-        async fn list_models(&self) -> Result<Vec<ModelInfo>, BackendError> {
+        async fn list_models(&self, _: &CallerAuth) -> Result<Vec<ModelInfo>, BackendError> {
             Ok(vec![])
         }
-        async fn status(&self) -> Result<StatusInfo, BackendError> {
+        async fn status(&self, _: &CallerAuth) -> Result<StatusInfo, BackendError> {
             Ok(StatusInfo::Cloud {
                 available_micro_usd: 1,
                 balance_micro_usd: 1,

--- a/mcp/src/server.rs
+++ b/mcp/src/server.rs
@@ -6,9 +6,23 @@ use std::sync::Arc;
 use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::{CallToolResult, Content, ServerCapabilities, ServerInfo};
-use rmcp::{ErrorData as McpError, ServerHandler, tool, tool_handler, tool_router};
+use rmcp::service::RequestContext;
+use rmcp::{ErrorData as McpError, RoleServer, ServerHandler, tool, tool_handler, tool_router};
 
 use crate::backend::{Backend, CallerAuth, CompleteRequest};
+
+/// Extract the caller's bearer from MCP request extensions. The streamable-HTTP
+/// transport injects `http::request::Parts`; returns an empty `CallerAuth` over
+/// stdio (no parts) or when no/!Bearer `Authorization` is present.
+fn caller_from_extensions(ext: &rmcp::model::Extensions) -> CallerAuth {
+    let bearer = ext
+        .get::<http::request::Parts>()
+        .and_then(|p| p.headers.get(http::header::AUTHORIZATION))
+        .and_then(|h| h.to_str().ok())
+        .and_then(|s| s.strip_prefix("Bearer "))
+        .map(str::to_owned);
+    CallerAuth { bearer }
+}
 
 #[derive(Clone)]
 pub struct BitrouterMcp {
@@ -40,7 +54,9 @@ impl BitrouterMcp {
     async fn complete(
         &self,
         Parameters(args): Parameters<CompleteArgs>,
+        ctx: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, McpError> {
+        let caller = caller_from_extensions(&ctx.extensions);
         let req = CompleteRequest {
             model: args.model,
             messages: args.messages,
@@ -48,7 +64,7 @@ impl BitrouterMcp {
             temperature: args.temperature,
             system: args.system,
         };
-        match self.backend.complete(&CallerAuth::default(), req).await {
+        match self.backend.complete(&caller, req).await {
             Ok(r) => match serde_json::to_string(&r) {
                 Ok(json) => Ok(CallToolResult::success(vec![Content::text(json)])),
                 Err(e) => Ok(CallToolResult::error(vec![Content::text(format!(
@@ -60,8 +76,12 @@ impl BitrouterMcp {
     }
 
     #[tool(description = "List models routable through BitRouter.")]
-    async fn list_models(&self) -> Result<CallToolResult, McpError> {
-        match self.backend.list_models(&CallerAuth::default()).await {
+    async fn list_models(
+        &self,
+        ctx: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, McpError> {
+        let caller = caller_from_extensions(&ctx.extensions);
+        match self.backend.list_models(&caller).await {
             Ok(m) => match serde_json::to_string(&m) {
                 Ok(json) => Ok(CallToolResult::success(vec![Content::text(json)])),
                 Err(e) => Ok(CallToolResult::error(vec![Content::text(format!(
@@ -75,8 +95,9 @@ impl BitrouterMcp {
     #[tool(
         description = "Report BitRouter status (local: liveness/models/providers; cloud: credit balance)."
     )]
-    async fn status(&self) -> Result<CallToolResult, McpError> {
-        match self.backend.status(&CallerAuth::default()).await {
+    async fn status(&self, ctx: RequestContext<RoleServer>) -> Result<CallToolResult, McpError> {
+        let caller = caller_from_extensions(&ctx.extensions);
+        match self.backend.status(&caller).await {
             Ok(s) => match serde_json::to_string(&s) {
                 Ok(json) => Ok(CallToolResult::success(vec![Content::text(json)])),
                 Err(e) => Ok(CallToolResult::error(vec![Content::text(format!(
@@ -200,5 +221,31 @@ mod tests {
     fn handler_constructs_with_three_tools() {
         let h = BitrouterMcp::new(Arc::new(StubBackend));
         assert_eq!(h.tool_router.list_all().len(), 3);
+    }
+
+    #[test]
+    fn caller_from_extensions_reads_bearer() {
+        use rmcp::model::Extensions;
+        let mut ext = Extensions::new();
+        let req = http::Request::builder()
+            .header(http::header::AUTHORIZATION, "Bearer xyz")
+            .body(())
+            .expect("req");
+        let (parts, _) = req.into_parts();
+        ext.insert(parts);
+        assert_eq!(caller_from_extensions(&ext).bearer.as_deref(), Some("xyz"));
+
+        let empty = Extensions::new();
+        assert_eq!(caller_from_extensions(&empty).bearer, None);
+
+        // non-Bearer scheme → None
+        let mut ext2 = Extensions::new();
+        let req2 = http::Request::builder()
+            .header(http::header::AUTHORIZATION, "Basic abc")
+            .body(())
+            .expect("req2");
+        let (parts2, _) = req2.into_parts();
+        ext2.insert(parts2);
+        assert_eq!(caller_from_extensions(&ext2).bearer, None);
     }
 }

--- a/mcp/tests/multitenant_http.rs
+++ b/mcp/tests/multitenant_http.rs
@@ -1,0 +1,90 @@
+//! End-to-end: two MCP clients with different bearers each get their own bearer
+//! forwarded to the (mock) cloud. Proof of multi-tenancy.
+use std::sync::Arc;
+use std::time::Duration;
+
+use bitrouter_mcp::backend::Backend;
+use bitrouter_mcp::backend::cloud::{CloudAuth, CloudBackend};
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// Drive the streamable-HTTP MCP endpoint: initialize (capture session id),
+/// send `notifications/initialized`, then `tools/call list_models`.
+async fn call_list_models(base: &str, bearer: &str) {
+    let http = reqwest::Client::new();
+    let auth = format!("Bearer {bearer}");
+
+    let init = http
+        .post(format!("{base}/mcp-control"))
+        .header("authorization", &auth)
+        .header("content-type", "application/json")
+        .header("accept", "application/json, text/event-stream")
+        .body(r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"t","version":"0"}}}"#)
+        .send().await.expect("init send");
+    let session = init
+        .headers()
+        .get("mcp-session-id")
+        .and_then(|h| h.to_str().ok())
+        .map(str::to_owned);
+    let _ = init.text().await;
+
+    if let Some(s) = &session {
+        let _ = http
+            .post(format!("{base}/mcp-control"))
+            .header("authorization", &auth)
+            .header("content-type", "application/json")
+            .header("accept", "application/json, text/event-stream")
+            .header("mcp-session-id", s)
+            .body(r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#)
+            .send()
+            .await
+            .expect("initialized send");
+    }
+
+    let mut call = http
+        .post(format!("{base}/mcp-control"))
+        .header("authorization", &auth)
+        .header("content-type", "application/json")
+        .header("accept", "application/json, text/event-stream")
+        .body(r#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"list_models","arguments":{}}}"#);
+    if let Some(s) = &session {
+        call = call.header("mcp-session-id", s);
+    }
+    let resp = call.send().await.expect("call send");
+    let _ = resp.text().await;
+}
+
+#[tokio::test]
+async fn two_callers_forward_distinct_bearers() {
+    let cloud = MockServer::start().await;
+    for tok in ["aaa", "bbb"] {
+        Mock::given(method("GET"))
+            .and(path("/v1/models"))
+            .and(header("authorization", format!("Bearer {tok}").as_str()))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"object":"list","data":[]})),
+            )
+            .expect(1)
+            .mount(&cloud)
+            .await;
+    }
+
+    let backend: Arc<dyn Backend> = Arc::new(CloudBackend::new(cloud.uri(), CloudAuth::PerCaller));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    let server = tokio::spawn(async move {
+        let _ = bitrouter_mcp::server::serve_http_on(backend, listener, true).await;
+    });
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    let base = format!("http://{addr}");
+    call_list_models(&base, "aaa").await;
+    call_list_models(&base, "bbb").await;
+
+    // wiremock `.expect(1)` per bearer is verified on drop: each bearer forwarded once.
+    drop(cloud);
+    server.abort();
+}

--- a/mcp/tests/multitenant_http.rs
+++ b/mcp/tests/multitenant_http.rs
@@ -88,3 +88,34 @@ async fn two_callers_forward_distinct_bearers() {
     drop(cloud);
     server.abort();
 }
+
+#[tokio::test]
+async fn missing_bearer_is_rejected_401() {
+    // PerCaller cloud backend (the cloud URL is never reached — the edge
+    // middleware rejects before any tool runs).
+    let backend: Arc<dyn Backend> = Arc::new(CloudBackend::new(
+        "https://api.bitrouter.ai",
+        CloudAuth::PerCaller,
+    ));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    let server = tokio::spawn(async move {
+        let _ = bitrouter_mcp::server::serve_http_on(backend, listener, true).await;
+    });
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    // POST with NO Authorization header → 401 from the edge middleware.
+    let resp = reqwest::Client::new()
+        .post(format!("http://{addr}/mcp-control"))
+        .header("content-type", "application/json")
+        .header("accept", "application/json, text/event-stream")
+        .body(r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"t","version":"0"}}}"#)
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status().as_u16(), 401);
+
+    server.abort();
+}

--- a/skills/bitrouter/SKILL.md
+++ b/skills/bitrouter/SKILL.md
@@ -137,9 +137,9 @@ BitRouter exposes its own tools (`complete`, `list_models`, `status`) over MCP. 
 # stdio (default): talks to the local daemon at 127.0.0.1:4356
 bitrouter mcp serve
 
-# streamable HTTP: cloud backend, mounts at /mcp-control on 127.0.0.1:4357
-bitrouter mcp serve --transport http --token brk_...
-# or: export BITROUTER_TOKEN=brk_...; bitrouter mcp serve --transport http
+# streamable HTTP: cloud backend, multi-tenant — clients supply their own Bearer header
+# no --token on the server side; each MCP client sets "Authorization: Bearer brk_..." in its remote config
+bitrouter mcp serve --transport http
 
 # print the Claude/Cursor mcpServers config block
 bitrouter mcp install --client claude
@@ -148,7 +148,7 @@ bitrouter mcp install --client claude
 bitrouter mcp install --client claude --config ~/Library/Application\ Support/Claude/claude_desktop_config.json
 ```
 
-Transport↔backend defaults: `stdio` → local daemon at `127.0.0.1:4356`; `http` → cloud at `api.bitrouter.ai` (requires a token). HTTP server binds at `127.0.0.1:4357` and mounts at `/mcp-control`.
+Transport↔backend defaults: `stdio` → local daemon at `127.0.0.1:4356`; `http` → cloud at `api.bitrouter.ai` (multi-tenant: each client sends its own `Authorization: Bearer` header; no server-side `--token` needed). HTTP server binds at `127.0.0.1:4357` and mounts at `/mcp-control`. For stdio→cloud, pass `--token brk_...` or `BITROUTER_TOKEN` (single-tenant).
 
 See `references/mcp-server.md` for all flags, tool JSON shapes, and deferred roadmap items.
 

--- a/skills/bitrouter/references/mcp-server.md
+++ b/skills/bitrouter/references/mcp-server.md
@@ -21,7 +21,7 @@ Starts the origin MCP server.
 | `--backend` | *(derived)* | `local` or `cloud`. Omit to auto-derive: `stdio`→`local`, `http`→`cloud` |
 | `--local-url` | `http://127.0.0.1:4356` | Root URL of the local BitRouter daemon |
 | `--cloud-url` | `https://api.bitrouter.ai` | Root URL of BitRouter Cloud |
-| `--token` | *(env fallback)* | Cloud bearer token; falls back to `BITROUTER_TOKEN` env var |
+| `--token` | *(env fallback)* | Cloud bearer token for **stdio→cloud only**; falls back to `BITROUTER_TOKEN` env var. Ignored when `--transport http` (multi-tenant PerCaller mode). |
 | `--bind` | `127.0.0.1:4357` | HTTP bind address (ignored for stdio) |
 
 **Examples:**
@@ -30,15 +30,14 @@ Starts the origin MCP server.
 # stdio — local daemon, no auth needed
 bitrouter mcp serve
 
-# HTTP — cloud backend, bearer token
-bitrouter mcp serve --transport http --token brk_...
+# stdio — cloud backend, single token (--token / BITROUTER_TOKEN required)
+bitrouter mcp serve --backend cloud --token brk_...
 
-# HTTP — local backend override
-bitrouter mcp serve --transport http --backend local --local-url http://127.0.0.1:4356
-
-# token from env
-export BITROUTER_TOKEN=brk_...
+# HTTP — cloud backend, multi-tenant (clients supply their own Bearer header; no --token on the server)
 bitrouter mcp serve --transport http
+
+# HTTP — local backend override (no auth middleware)
+bitrouter mcp serve --transport http --backend local --local-url http://127.0.0.1:4356
 ```
 
 ### `bitrouter mcp install`
@@ -149,31 +148,68 @@ Report BitRouter's health and credit state. The shape differs by backend.
 
 ## Transport ↔ Backend pairing
 
-| Transport | Default backend | Auth needed? | MCP endpoint |
+| Transport | Default backend | Auth mode | MCP endpoint |
 |---|---|---|---|
-| `stdio` | local | no (daemon uses `skip_auth`) | n/a — stdin/stdout |
-| `http` | cloud | yes — bearer token | `http://<bind>/mcp-control` |
+| `stdio` | local | none (daemon uses `skip_auth`) | n/a — stdin/stdout |
+| `http` | cloud | **PerCaller** — each request carries its own `Bearer` | `http://<bind>/mcp-control` |
 
 You can override the default backend with `--backend local|cloud`. The HTTP transport always mounts at `/mcp-control` (not `/mcp`, which is the gateway route).
 
 ---
 
-## Cloud auth (v1)
+## Cloud auth
 
-v1 uses a bearer token the user already holds, either:
+### stdio → cloud (single-tenant)
+
+When running with `--transport stdio --backend cloud`, a single bearer token is used for every request. Supply it via `--token <value>` or the `BITROUTER_TOKEN` environment variable:
 
 - A `brk_*` API key minted on the dashboard, or
 - The access token written by `bitrouter auth login` (RFC 8628 device flow).
 
-Pass the token via `--token <value>` or the `BITROUTER_TOKEN` environment variable. In-client browser OAuth (so an MCP client can mint its own token without a pre-existing credential) is deferred to a later release.
+```bash
+# stdio — cloud backend, single token
+bitrouter mcp serve --backend cloud --token brk_...
+# or: export BITROUTER_TOKEN=brk_...; bitrouter mcp serve --backend cloud
+```
+
+### http → cloud (multi-tenant, PerCaller)
+
+When running `--transport http --backend cloud` (the default for HTTP), the server is **multi-tenant**: each MCP client supplies its own `Authorization: Bearer` header, which is forwarded per-request to `api.bitrouter.ai/v1`. The server itself holds **no** token — `--token`/`BITROUTER_TOKEN` is ignored in this mode.
+
+An edge middleware rejects any request that lacks a `Bearer` Authorization header with `401 Unauthorized` before it reaches the MCP handler. The cloud backend validates the token's validity; the server only checks presence.
+
+```bash
+# HTTP multi-tenant — no --token needed on the server side
+bitrouter mcp serve --transport http
+```
+
+Each client configures its own credential in its remote-server block. Example for Claude Code / Cursor:
+
+```json
+{
+  "mcpServers": {
+    "bitrouter": {
+      "url": "http://127.0.0.1:4357/mcp-control",
+      "headers": {
+        "Authorization": "Bearer brk_..."
+      }
+    }
+  }
+}
+```
+
+Different clients can use different `brk_*` keys (or their own `bitrouter auth login` access tokens) against the same running server instance.
+
+### http → local
+
+When the local backend is forced (`--backend local`), no auth middleware is applied — the local daemon's own `skip_auth` setting governs access.
 
 ---
 
 ## Deferred / roadmap
 
-The following are explicitly **not** in v1:
+The following are explicitly **not** in the current release:
 
-- **Admin / mutating tools** — e.g. key rotation, provider toggle, policy edit. v1 is read/inference only.
+- **Admin / mutating tools** — e.g. key rotation, provider toggle, policy edit. Current release is read/inference only.
 - **Tier allowlist filter** — restricting `list_models` output to models within a user's plan tier.
-- **Native in-client OAuth** — today the user must mint a `brk_*` key or run `bitrouter auth login` before the MCP server starts.
-- **Per-caller multi-tenant bearer forwarding** — a single-tenant token is forwarded; per-caller isolation is deferred.
+- **Native in-client browser OAuth (Item B)** — MCP-native browser OAuth (RFC 8414 Authorization Server Metadata + RFC 7591 Dynamic Client Registration) is deferred. BitRouter Cloud's authorization server has no DCR endpoint, and its `/oauth/authorize` flow requires a `brk_*` principal. Enabling native browser OAuth requires cross-repo cloud work before the MCP server can participate. In the meantime, clients use pre-minted `brk_*` keys or device-flow tokens in the `Authorization: Bearer` header as shown above.


### PR DESCRIPTION
## Summary

Makes the BitRouter origin MCP server's **remote (streamable-HTTP) transport multi-tenant**: each MCP client sets its own `Authorization: Bearer <brk_… or access token>` header, and the server forwards that bearer **per request** to `api.bitrouter.ai`. Builds on the v1 origin server (#530); **stacked on `feat/mcp-server`** (retarget to `main` once #530 merges).

- **`CallerAuth`** threaded through the `Backend` trait (`LocalBackend` ignores it — a caller bearer never reaches the BYOK daemon).
- **`CloudAuth` mode enum** replaces the single token: `Static(token)` for stdio→cloud (single-tenant, `--token` required), `PerCaller` for http→cloud (multi-tenant, **no server token**). No accidentally-tokenless backend; no redundant token.
- Tools read the caller's bearer from rmcp `RequestContext`'s injected `http::request::Parts` (`None` over stdio, so stdio is unchanged).
- **Pre-auth edge middleware** returns `401` to bearer-less HTTP→cloud requests (presence-only; the cloud validates the token).
- `--token`/`BITROUTER_TOKEN` is now **stdio→cloud only**; CLI warns if passed with `--transport http`.

No `bitrouter-cloud` changes — `brk_` keys / access tokens are already valid bearers on `api.bitrouter.ai/v1`. Native browser OAuth (Item B) remains deferred (cloud lacks Dynamic Client Registration; `/oauth/authorize` requires a `brk_` principal).

Design spec + implementation plan included under `docs/superpowers/`.

## Test Plan

- [x] `cargo nextest run --all-features` — 678/678 pass (mcp crate: 17, incl. multi-tenant + 401 integration tests)
- [x] `cargo clippy --all-features` — clean (no `#[allow]`, no panics in non-test code)
- [x] `cargo fmt -- --check` — clean
- [x] `two_callers_forward_distinct_bearers` — proves each caller's bearer is forwarded verbatim (load-bearing: negative control verified)
- [x] `missing_bearer_is_rejected_401` — edge middleware rejects bearer-less requests
- [ ] Manual: point two MCP clients with different `Authorization` headers at a hosted `bitrouter mcp serve --transport http`

## Security notes for reviewers

- Bearer never logged (zero `tracing` of credentials); only `CloudBackend` ever attaches a caller bearer — it cannot reach `127.0.0.1:4356`.
- `PerCaller` + no bearer → `BackendError::MissingCredential` (tool error, not panic); belt-and-suspenders with the edge middleware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)