### PR TITLE
docs(readme): reposition for agent-native audience

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,21 @@
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Twitter](https://img.shields.io/badge/Twitter-black?logo=x&logoColor=white)](https://x.com/BitRouterAI)
 [![Discord](https://img.shields.io/badge/Discord-5865F2?logo=discord&logoColor=white)](https://discord.gg/G3zVrZDa5C)
+[![Telegram](https://img.shields.io/badge/Telegram-26A5E4?logo=telegram&logoColor=white)](https://t.me/bitrouterai)
 [![Docs](https://img.shields.io/badge/Docs-bitrouter.ai-green)](https://bitrouter.ai)
 
 Agent-native LLM router that optimizes your agent with every run. Zero harness changes — every model call reliable, traceable, secure, and cost-effective.
+
+## What it does
+
+BitRouter is a local proxy that sits between your agent and every upstream LLM provider. Point your agent at `http://localhost:4356` instead of a provider URL — your agent code stays unchanged while BitRouter handles routing, failover, cross-protocol translation, guardrails, and cost tracking.
+
+```diff
+- OPENAI_BASE_URL=https://api.openai.com/v1   # hardwired to one provider, no fallback
++ OPENAI_BASE_URL=http://localhost:4356        # all providers, automatic failover
+```
+
+That one env-var change is the only harness modification required. BitRouter auto-detects every API key in your environment and makes those providers immediately routable — no config file needed to get started.
 
 ## Install
 
@@ -63,37 +75,6 @@ bitrouter start         # `bitrouter` provider auto-enables once signed in
 
 Manage keys, usage, billing, policies, and BYOK from the same CLI — see `bitrouter cloud --help` or [`CLI.md`](CLI.md#cloud-account-management).
 
-## Features
-
-- **Multi-provider routing** — unified access to OpenAI, Anthropic, Google, OpenRouter, OpenCode Zen / Go, BitRouter Cloud, GitHub Copilot, ChatGPT Codex, and Amazon Bedrock; configure multiple accounts per provider with failover or round-robin load-balancing ([`sdk`](crates/bitrouter-sdk/) · [`providers`](crates/bitrouter-providers/))
-- **Cross-protocol routing** — any client protocol (Chat Completions, Responses, Messages, Generate Content) against any upstream; BitRouter translates transparently ([`sdk`](crates/bitrouter-sdk/))
-- **Zero-config** — auto-detects providers from environment variables; no config file needed to get started ([`providers`](crates/bitrouter-providers/))
-- **MCP gateway** — proxy for MCP servers; agents discover and call tools across hosts ([`sdk`](crates/bitrouter-sdk/))
-- **ACP integration** — manage coding agent sessions (Claude Code, OpenAI Codex, Gemini CLI) via the CLI ([`sdk`](crates/bitrouter-sdk/))
-- **Agent guardrails** — inspect, redact, or block risky content at the proxy layer ([`guardrails`](plugins/bitrouter-guardrails/))
-- **Observability** — per-request spend tracking, Prometheus metrics, and OTLP export ([`observe`](plugins/bitrouter-observe/))
-- **Virtual keys** — mint scoped `brvk_` API keys with `bitrouter key sign`, persisted to SQLite, PostgreSQL, or MySQL
-- **Custom providers** — add any OpenAI-compatible or Anthropic-compatible upstream via config
-
-## Supported Providers
-
-| Provider        | Status | Notes                                                          |
-| --------------- | ------ | -------------------------------------------------------------- |
-| OpenAI          | ✅     | Chat Completions + Responses API                               |
-| Anthropic       | ✅     | Messages API + Claude Pro/Max subscription (PKCE)              |
-| Google          | ✅     | Generative AI API                                              |
-| Amazon Bedrock  | ✅     | Via AWS SDK (opt-in)                                           |
-| OpenRouter      | ✅     | Chat Completions + Responses API                               |
-| OpenCode Zen    | ✅     | Curated models across Chat Completions, Messages, and Generate Content protocols      |
-| OpenCode Go     | ✅     | Low-cost subscription for open coding models                   |
-| BitRouter Cloud | ✅     | OAuth sign-in (`bitrouter auth login`); cloud-managed routing  |
-| GitHub Copilot  | ✅     | GitHub OAuth device flow (`bitrouter login github-copilot`)    |
-| ChatGPT Codex   | ✅     | ChatGPT subscription PKCE (`bitrouter login openai-codex`)     |
-
-Want to see another provider? [Open an issue](https://github.com/bitrouter/bitrouter/issues) or submit a PR. If you're a provider interested in first-party integration, reach out on [Discord](https://discord.gg/G3zVrZDa5C).
-
-Any agent runtime that supports a custom OpenAI or Anthropic base URL works with BitRouter out of the box — point it at `http://localhost:4356`. **Building an agent runtime?** We partner with teams on native integrations — email [contact@bitrouter.ai](mailto:contact@bitrouter.ai) or [book a meeting with the founder](https://cal.com/kelsenliu/founder-meeting).
-
 ## Comparison
 
 |                           | **BitRouter**                               | **OpenRouter**            | **LiteLLM**                    |
@@ -112,22 +93,69 @@ Any agent runtime that supports a custom OpenAI or Anthropic base URL works with
 
 **TL;DR** — OpenRouter is a cloud API marketplace for humans picking models. LiteLLM is a Python proxy for unifying provider SDKs. BitRouter is a Rust-native proxy purpose-built for autonomous agents — with cross-protocol routing, MCP and ACP support, and guardrails out of the box.
 
+## Features
+
+BitRouter is purpose-built for autonomous agents — every feature is designed for unattended, multi-step execution rather than human-in-the-loop API access.
+
+### Reliability
+
+When an agent runs unattended, a provider outage or rate-limit doesn't get a human retry — it just fails. BitRouter routes each call through a configurable fallback chain: if the primary provider fails, the next takes over automatically. Configure multiple accounts per provider for round-robin load-balancing, or let cross-protocol routing send OpenAI-format requests to an Anthropic or Google upstream when it's the better option.
+
+### Observability
+
+Every model call is recorded with provider, model, latency, and cost — queryable from the CLI without reaching for a dashboard. Export to Prometheus or any OTLP-compatible backend for fleet-level visibility. Use `bitrouter route <model>` to trace exactly how a model name resolves before it reaches the upstream.
+
+### Security
+
+Guardrails run at the proxy layer — before requests leave your network and before responses reach your agent. Inspect and redact sensitive content, block policy-violating output, or abort streams mid-flight when a rule triggers. Virtual keys (`brvk_`) let you issue scoped credentials per agent or user so no agent ever holds an upstream API key directly. MCP tool calls route through the same layer, keeping tool access under one control point.
+
+### Efficiency
+
+BitRouter is written in Rust and adds ~10ms of overhead — well under the latency of any upstream model. No Python workers, no GIL, no warm-up time. Per-request cost tracking makes model spend visible immediately, without waiting for a provider invoice. ACP integration means you can manage coding agent sessions (Claude Code, Codex, Gemini CLI) from the same CLI, without extra tooling.
+
+## Supported Providers
+
+| Provider        | Status | Notes                                                          |
+| --------------- | ------ | -------------------------------------------------------------- |
+| OpenAI          | ✅     | Chat Completions + Responses API                               |
+| Anthropic       | ✅     | Messages API + Claude Pro/Max subscription (PKCE)              |
+| Google          | ✅     | Generative AI API                                              |
+| Amazon Bedrock  | ✅     | Via AWS SDK (opt-in)                                           |
+| OpenRouter      | ✅     | Chat Completions + Responses API                               |
+| OpenCode Zen    | ✅     | Curated models across Chat Completions, Messages, and Generate Content protocols      |
+| OpenCode Go     | ✅     | Low-cost subscription for open coding models                   |
+| BitRouter Cloud | ✅     | OAuth sign-in (`bitrouter auth login`); cloud-managed routing  |
+| GitHub Copilot  | ✅     | GitHub OAuth device flow (`bitrouter login github-copilot`)    |
+| ChatGPT Codex   | ✅     | ChatGPT subscription PKCE (`bitrouter login openai-codex`)     |
+
+Want to see another provider? [Open an issue](https://github.com/bitrouter/bitrouter/issues) or submit a PR. If you're a provider interested in first-party integration, reach out on [Discord](https://discord.gg/G3zVrZDa5C).
+
+## Supported Harnesses
+
+Any agent runtime that speaks OpenAI or Anthropic APIs works with BitRouter out of the box — set `OPENAI_BASE_URL=http://localhost:4356` and you're done. The following harnesses are tested and supported:
+
+| Harness        | Status |
+| -------------- | ------ |
+| Claude Code    | ✅     |
+| OpenAI Codex   | ✅     |
+| OpenCode       | ✅     |
+| Hermes Agent   | ✅     |
+| Openclaw       | ✅     |
+| Pi-Agent       | ✅     |
+
+**Building an agent runtime?** We partner with teams on native integrations — email [contact@bitrouter.ai](mailto:contact@bitrouter.ai) or [book a meeting with the founder](https://cal.com/kelsenliu/founder-meeting).
+
+The full provider and harness catalog lives at [github.com/bitrouter/provider-registry](https://github.com/bitrouter/provider-registry).
+
 ## CLI
 
 ```bash
-bitrouter start / stop / restart / reload      # daemon lifecycle
-bitrouter status                               # pid, listen address, active models
+bitrouter start / stop / restart               # daemon lifecycle
 bitrouter route <model>                        # trace how a model name resolves
-bitrouter models [--provider <id>]            # list routable models
-bitrouter providers list                       # list configured providers
-bitrouter tools list / status / discover       # MCP server introspection
 bitrouter agents list / check / install        # ACP agent management
 bitrouter key sign --user <id>                 # mint a scoped brvk_ API key
-bitrouter policy create <id>                   # scaffold a routing policy
-bitrouter init                                 # scaffold bitrouter.yaml
-bitrouter login <provider>                     # upstream-provider OAuth (anthropic, openai-codex, github-copilot, …)
-bitrouter auth login / logout / whoami         # BitRouter Cloud sign-in (RFC 8628 device flow)
-bitrouter cloud keys / usage / billing / …     # manage keys, usage, billing, policies, BYOK against BitRouter Cloud
+bitrouter auth login / logout / whoami         # BitRouter Cloud sign-in
+bitrouter cloud keys / usage / billing         # manage cloud account
 ```
 
 See [`CLI.md`](CLI.md) for flags, config resolution, and examples.


### PR DESCRIPTION
## Summary

- Adds a **"What it does"** section with a before/after `OPENAI_BASE_URL` diff to deliver the zero-harness-changes pitch before Install
- Moves the **Comparison** table above Features so readers hit the decision context earlier
- Rewrites **Features** as four agent-native pillars (Reliability, Observability, Security, Efficiency) — removes internal crate links that read as dev noise
- Adds **Supported Harnesses** section (Claude Code, Codex, OpenCode, Hermes Agent, Openclaw, Pi-Agent) with a link to the provider-registry for the full catalog
- Trims **CLI** from 13 lines to 6 representative commands
- Adds **Telegram** badge

## Test plan

- [ ] Verify badge renders correctly on GitHub (Telegram `#26A5E4`)
- [ ] Verify `diff` code block renders correctly in the "What it does" section
- [ ] Spot-check provider-registry link resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)