### PR TITLE
feat(sdk): surface MCP upstream 401/403 auth challenges (UpstreamAuth)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -864,6 +864,7 @@ dependencies = [
  "pin-project-lite",
  "regex",
  "reqwest 0.12.28",
+ "reqwest 0.13.3",
  "rmcp",
  "schemars",
  "serde",

--- a/crates/bitrouter-sdk/Cargo.toml
+++ b/crates/bitrouter-sdk/Cargo.toml
@@ -45,6 +45,11 @@ serde-saphyr = { workspace = true, optional = true }
 # <https://github.com/modelcontextprotocol/rust-sdk>
 rmcp = { workspace = true, optional = true }
 
+# Used ONLY to name rmcp 1.7's transport error type
+# (StreamableHttpError<reqwest::Error>) in the MCP auth-error downcast —
+# rmcp pins reqwest 0.13 while our own client stays on 0.12.
+rmcp-reqwest = { package = "reqwest", version = "0.13", default-features = false, optional = true }
+
 [features]
 default = []
 # axum HTTP server + SSE handlers + admin endpoints
@@ -55,7 +60,7 @@ config_file = ["dep:serde-saphyr", "tokio/fs"]
 # pure-routing pipeline. Without this feature the SDK still exposes
 # `mcp::Pipeline`, hook traits, and the `McpTransport` enum, so a consumer
 # can plug in a custom Executor without pulling rmcp.
-mcp = ["dep:rmcp", "tokio/process"]
+mcp = ["dep:rmcp", "dep:rmcp-reqwest", "tokio/process"]
 # Bundled `AcpStdioExecutor` + `ConfigAcpRoutingTable` for the `acp`
 # pure-routing pipeline. The executor implements newline-delimited JSON-RPC
 # over the subprocess stdio per the ACP spec; without this feature the SDK

--- a/crates/bitrouter-sdk/src/error.rs
+++ b/crates/bitrouter-sdk/src/error.rs
@@ -59,6 +59,21 @@ pub enum BitrouterError {
         message: String,
     },
 
+    /// 401 / 403 — upstream MCP server demanded authorization. Distinct from
+    /// [`Upstream`](Self::Upstream) (a generic 502) because the cloud needs the
+    /// real status, the `WWW-Authenticate` challenge, and the parsed required
+    /// scope to drive OAuth token refresh (401) and step-up (403).
+    #[error("upstream auth required ({status})")]
+    UpstreamAuth {
+        /// The upstream HTTP status — `401` or `403`.
+        status: u16,
+        /// The verbatim `WWW-Authenticate` header, when present.
+        www_authenticate: Option<String>,
+        /// The scope the upstream says is required (403 `insufficient_scope`
+        /// only); `None` when not named.
+        required_scope: Option<String>,
+    },
+
     /// 504 — upstream timed out.
     #[error("upstream timeout")]
     UpstreamTimeout,
@@ -79,6 +94,7 @@ impl BitrouterError {
             Self::NotFound(_) => 404,
             Self::RateLimited { .. } => 429,
             Self::Upstream { .. } => 502,
+            Self::UpstreamAuth { status, .. } => *status,
             Self::UpstreamTimeout => 504,
             Self::Internal(_) => 500,
         }
@@ -94,6 +110,8 @@ impl BitrouterError {
             Self::NotFound(_) => "not_found_error",
             Self::RateLimited { .. } => "rate_limit_error",
             Self::Upstream { .. } | Self::UpstreamTimeout => "upstream_error",
+            Self::UpstreamAuth { status: 403, .. } => "permission_error",
+            Self::UpstreamAuth { .. } => "authentication_error",
             Self::Internal(_) => "internal_error",
         }
     }
@@ -108,5 +126,31 @@ impl BitrouterError {
     /// Convenience constructor for [`BitrouterError::Internal`].
     pub fn internal(message: impl fmt::Display) -> Self {
         Self::Internal(message.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn upstream_auth_status_and_type() {
+        let unauth = BitrouterError::UpstreamAuth {
+            status: 401,
+            www_authenticate: Some("Bearer resource_metadata=\"https://x/.well-known\"".into()),
+            required_scope: None,
+        };
+        assert_eq!(unauth.status(), 401);
+        assert_eq!(unauth.error_type(), "authentication_error");
+
+        let insufficient = BitrouterError::UpstreamAuth {
+            status: 403,
+            www_authenticate: Some(
+                "Bearer error=\"insufficient_scope\", scope=\"read:files\"".into(),
+            ),
+            required_scope: Some("read:files".into()),
+        };
+        assert_eq!(insufficient.status(), 403);
+        assert_eq!(insufficient.error_type(), "permission_error");
     }
 }

--- a/crates/bitrouter-sdk/src/mcp/rmcp_executor.rs
+++ b/crates/bitrouter-sdk/src/mcp/rmcp_executor.rs
@@ -327,7 +327,7 @@ async fn connect(
             client
                 .serve(transport)
                 .await
-                .map_err(|e| upstream(server_name, format!("HTTP connect: {e}")))
+                .map_err(|e| map_initialize_error(server_name, e))
         }
         McpTransport::Stdio { command, args, env } => {
             // stdio child-process transport per the MCP spec
@@ -342,7 +342,7 @@ async fn connect(
             client
                 .serve(transport)
                 .await
-                .map_err(|e| upstream(server_name, format!("stdio connect: {e}")))
+                .map_err(|e| map_initialize_error(server_name, e))
         }
     }
 }
@@ -363,7 +363,6 @@ fn bad_params(server: &str, method: &str, msg: impl std::fmt::Display) -> Bitrou
 /// [`BitrouterError::UpstreamAuth`] for `401`/`403` so the cloud can drive
 /// token refresh / OAuth step-up; `None` for any other transport error
 /// (the caller then falls back to the generic 502 `upstream(...)`).
-#[allow(dead_code)] // wired up in the next task
 fn classify_transport_auth_error(
     dte: &rmcp::transport::DynamicTransportError,
 ) -> Option<BitrouterError> {
@@ -384,6 +383,18 @@ fn classify_transport_auth_error(
         }),
         _ => None,
     }
+}
+
+/// Map a connect/initialize failure to a `BitrouterError`, preferring a typed
+/// `UpstreamAuth` when the underlying transport error is an auth challenge,
+/// else the generic 502.
+fn map_initialize_error(server: &str, err: rmcp::service::ClientInitializeError) -> BitrouterError {
+    if let rmcp::service::ClientInitializeError::TransportError { error, .. } = &err
+        && let Some(auth) = classify_transport_auth_error(error)
+    {
+        return auth;
+    }
+    upstream(server, format!("connect: {err}"))
 }
 
 #[async_trait]
@@ -760,5 +771,33 @@ mod tests {
             Box::new(inner),
         );
         assert!(classify_transport_auth_error(&dte).is_none());
+    }
+
+    #[test]
+    fn initialize_transport_auth_maps_to_upstream_auth() {
+        use rmcp::service::ClientInitializeError;
+        use rmcp::transport::DynamicTransportError;
+        use rmcp::transport::streamable_http_client::{
+            InsufficientScopeError, StreamableHttpError,
+        };
+
+        let inner: StreamableHttpError<reqwest::Error> =
+            StreamableHttpError::InsufficientScope(InsufficientScopeError::new(
+                "Bearer error=\"insufficient_scope\", scope=\"a\"".into(),
+                Some("a".into()),
+            ));
+        let init_err = ClientInitializeError::TransportError {
+            error: DynamicTransportError::from_parts(
+                "test",
+                std::any::TypeId::of::<()>(),
+                Box::new(inner),
+            ),
+            context: "send initialize request".into(),
+        };
+        let mapped = map_initialize_error("srv", init_err);
+        assert!(matches!(
+            mapped,
+            BitrouterError::UpstreamAuth { status: 403, .. }
+        ));
     }
 }

--- a/crates/bitrouter-sdk/src/mcp/rmcp_executor.rs
+++ b/crates/bitrouter-sdk/src/mcp/rmcp_executor.rs
@@ -385,6 +385,22 @@ fn classify_transport_auth_error(
     }
 }
 
+/// Map a `ServiceError` from a live MCP call to a `BitrouterError`, preferring
+/// a typed `UpstreamAuth` when the transport error is an auth challenge, else
+/// the generic 502.
+fn map_service_error(
+    server: &str,
+    method: &str,
+    err: rmcp::service::ServiceError,
+) -> BitrouterError {
+    if let rmcp::service::ServiceError::TransportSend(dte) = &err
+        && let Some(auth) = classify_transport_auth_error(dte)
+    {
+        return auth;
+    }
+    upstream(server, format!("{method}: {err}"))
+}
+
 /// Map a connect/initialize failure to a `BitrouterError`, preferring a typed
 /// `UpstreamAuth` when the underlying transport error is an auth challenge,
 /// else the generic 502.
@@ -554,7 +570,7 @@ async fn dispatch(
             let tools = peer
                 .list_all_tools()
                 .await
-                .map_err(|e| upstream(server, format!("tools/list: {e}")))?;
+                .map_err(|e| map_service_error(server, method, e))?;
             Ok(serde_json::json!({ "tools": tools }))
         }
         "tools/call" => {
@@ -563,7 +579,7 @@ async fn dispatch(
             let result = peer
                 .call_tool(params)
                 .await
-                .map_err(|e| upstream(server, format!("tools/call: {e}")))?;
+                .map_err(|e| map_service_error(server, method, e))?;
             serde_json::to_value(&result).map_err(|e| {
                 BitrouterError::internal(format!("mcp '{server}' tools/call serialise: {e}"))
             })
@@ -572,7 +588,7 @@ async fn dispatch(
             let resources = peer
                 .list_all_resources()
                 .await
-                .map_err(|e| upstream(server, format!("resources/list: {e}")))?;
+                .map_err(|e| map_service_error(server, method, e))?;
             Ok(serde_json::json!({ "resources": resources }))
         }
         "resources/read" => {
@@ -581,7 +597,7 @@ async fn dispatch(
             let result = peer
                 .read_resource(params)
                 .await
-                .map_err(|e| upstream(server, format!("resources/read: {e}")))?;
+                .map_err(|e| map_service_error(server, method, e))?;
             serde_json::to_value(&result).map_err(|e| {
                 BitrouterError::internal(format!("mcp '{server}' resources/read serialise: {e}"))
             })
@@ -590,14 +606,14 @@ async fn dispatch(
             let templates = peer
                 .list_all_resource_templates()
                 .await
-                .map_err(|e| upstream(server, format!("resources/templates/list: {e}")))?;
+                .map_err(|e| map_service_error(server, method, e))?;
             Ok(serde_json::json!({ "resourceTemplates": templates }))
         }
         "prompts/list" => {
             let prompts = peer
                 .list_all_prompts()
                 .await
-                .map_err(|e| upstream(server, format!("prompts/list: {e}")))?;
+                .map_err(|e| map_service_error(server, method, e))?;
             Ok(serde_json::json!({ "prompts": prompts }))
         }
         "prompts/get" => {
@@ -606,7 +622,7 @@ async fn dispatch(
             let result = peer
                 .get_prompt(params)
                 .await
-                .map_err(|e| upstream(server, format!("prompts/get: {e}")))?;
+                .map_err(|e| map_service_error(server, method, e))?;
             serde_json::to_value(&result).map_err(|e| {
                 BitrouterError::internal(format!("mcp '{server}' prompts/get serialise: {e}"))
             })
@@ -771,6 +787,35 @@ mod tests {
             Box::new(inner),
         );
         assert!(classify_transport_auth_error(&dte).is_none());
+    }
+
+    #[test]
+    fn service_transport_send_auth_maps_to_upstream_auth() {
+        use rmcp::service::ServiceError;
+        use rmcp::transport::DynamicTransportError;
+        use rmcp::transport::streamable_http_client::{
+            InsufficientScopeError, StreamableHttpError,
+        };
+
+        let inner: StreamableHttpError<reqwest::Error> =
+            StreamableHttpError::InsufficientScope(InsufficientScopeError::new(
+                "Bearer error=\"insufficient_scope\", scope=\"x\"".into(),
+                Some("x".into()),
+            ));
+        let svc_err = ServiceError::TransportSend(DynamicTransportError::from_parts(
+            "test",
+            std::any::TypeId::of::<()>(),
+            Box::new(inner),
+        ));
+        let mapped = map_service_error("srv", "tools/call", svc_err);
+        assert!(matches!(
+            mapped,
+            BitrouterError::UpstreamAuth {
+                status: 403,
+                required_scope: Some(_),
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/crates/bitrouter-sdk/src/mcp/rmcp_executor.rs
+++ b/crates/bitrouter-sdk/src/mcp/rmcp_executor.rs
@@ -367,9 +367,13 @@ fn classify_transport_auth_error(
     dte: &rmcp::transport::DynamicTransportError,
 ) -> Option<BitrouterError> {
     use rmcp::transport::streamable_http_client::StreamableHttpError;
+    // regression: rmcp uses reqwest 0.13; downcast must name that type
+    // (rmcp_reqwest = reqwest 0.13). Our own client is reqwest 0.12 — a
+    // distinct, separately-compiled crate with a different TypeId, so naming
+    // bare `reqwest::Error` here would make this downcast silently never match.
     let err = dte
         .error
-        .downcast_ref::<StreamableHttpError<reqwest::Error>>()?;
+        .downcast_ref::<StreamableHttpError<rmcp_reqwest::Error>>()?;
     match err {
         StreamableHttpError::AuthRequired(e) => Some(BitrouterError::UpstreamAuth {
             status: 401,
@@ -732,7 +736,7 @@ mod tests {
             InsufficientScopeError, StreamableHttpError,
         };
 
-        let inner: StreamableHttpError<reqwest::Error> =
+        let inner: StreamableHttpError<rmcp_reqwest::Error> =
             StreamableHttpError::InsufficientScope(InsufficientScopeError::new(
                 "Bearer error=\"insufficient_scope\", scope=\"read:files\"".to_string(),
                 Some("read:files".to_string()),
@@ -762,7 +766,7 @@ mod tests {
         use rmcp::transport::DynamicTransportError;
         use rmcp::transport::streamable_http_client::{AuthRequiredError, StreamableHttpError};
 
-        let inner: StreamableHttpError<reqwest::Error> =
+        let inner: StreamableHttpError<rmcp_reqwest::Error> =
             StreamableHttpError::AuthRequired(AuthRequiredError::new("Bearer".to_string()));
         let dte = DynamicTransportError::from_parts(
             "test",
@@ -780,7 +784,8 @@ mod tests {
     fn non_auth_transport_error_is_not_classified() {
         use rmcp::transport::DynamicTransportError;
         use rmcp::transport::streamable_http_client::StreamableHttpError;
-        let inner: StreamableHttpError<reqwest::Error> = StreamableHttpError::UnexpectedEndOfStream;
+        let inner: StreamableHttpError<rmcp_reqwest::Error> =
+            StreamableHttpError::UnexpectedEndOfStream;
         let dte = DynamicTransportError::from_parts(
             "test",
             std::any::TypeId::of::<()>(),
@@ -797,7 +802,7 @@ mod tests {
             InsufficientScopeError, StreamableHttpError,
         };
 
-        let inner: StreamableHttpError<reqwest::Error> =
+        let inner: StreamableHttpError<rmcp_reqwest::Error> =
             StreamableHttpError::InsufficientScope(InsufficientScopeError::new(
                 "Bearer error=\"insufficient_scope\", scope=\"x\"".into(),
                 Some("x".into()),
@@ -826,7 +831,7 @@ mod tests {
             InsufficientScopeError, StreamableHttpError,
         };
 
-        let inner: StreamableHttpError<reqwest::Error> =
+        let inner: StreamableHttpError<rmcp_reqwest::Error> =
             StreamableHttpError::InsufficientScope(InsufficientScopeError::new(
                 "Bearer error=\"insufficient_scope\", scope=\"a\"".into(),
                 Some("a".into()),

--- a/crates/bitrouter-sdk/src/mcp/rmcp_executor.rs
+++ b/crates/bitrouter-sdk/src/mcp/rmcp_executor.rs
@@ -358,6 +358,34 @@ fn bad_params(server: &str, method: &str, msg: impl std::fmt::Display) -> Bitrou
     BitrouterError::bad_request(format!("mcp '{server}' {method}: {msg}"))
 }
 
+/// Inspect a transport error for an upstream auth challenge (rmcp 1.7
+/// classifies these as typed variants). Returns a status-bearing
+/// [`BitrouterError::UpstreamAuth`] for `401`/`403` so the cloud can drive
+/// token refresh / OAuth step-up; `None` for any other transport error
+/// (the caller then falls back to the generic 502 `upstream(...)`).
+#[allow(dead_code)] // wired up in the next task
+fn classify_transport_auth_error(
+    dte: &rmcp::transport::DynamicTransportError,
+) -> Option<BitrouterError> {
+    use rmcp::transport::streamable_http_client::StreamableHttpError;
+    let err = dte
+        .error
+        .downcast_ref::<StreamableHttpError<reqwest::Error>>()?;
+    match err {
+        StreamableHttpError::AuthRequired(e) => Some(BitrouterError::UpstreamAuth {
+            status: 401,
+            www_authenticate: Some(e.www_authenticate_header.clone()),
+            required_scope: None,
+        }),
+        StreamableHttpError::InsufficientScope(e) => Some(BitrouterError::UpstreamAuth {
+            status: 403,
+            www_authenticate: Some(e.www_authenticate_header.clone()),
+            required_scope: e.required_scope.clone(),
+        }),
+        _ => None,
+    }
+}
+
 #[async_trait]
 impl Executor for RmcpExecutor {
     async fn execute(&self, target: &McpTarget, request: &McpRequest) -> Result<McpResponse> {
@@ -668,5 +696,69 @@ mod tests {
         // Internal — RmcpExecutor without an AggregatingExecutor wrapper is
         // a programming bug, not a transport failure.
         assert_eq!(err.status(), 500, "unexpected error: {err}");
+    }
+
+    #[test]
+    fn classifies_insufficient_scope_transport_error() {
+        use rmcp::transport::DynamicTransportError;
+        use rmcp::transport::streamable_http_client::{
+            InsufficientScopeError, StreamableHttpError,
+        };
+
+        let inner: StreamableHttpError<reqwest::Error> =
+            StreamableHttpError::InsufficientScope(InsufficientScopeError::new(
+                "Bearer error=\"insufficient_scope\", scope=\"read:files\"".to_string(),
+                Some("read:files".to_string()),
+            ));
+        let dte = DynamicTransportError::from_parts(
+            "test",
+            std::any::TypeId::of::<()>(),
+            Box::new(inner),
+        );
+
+        let classified = classify_transport_auth_error(&dte).expect("should classify");
+        match classified {
+            BitrouterError::UpstreamAuth {
+                status,
+                required_scope,
+                ..
+            } => {
+                assert_eq!(status, 403);
+                assert_eq!(required_scope.as_deref(), Some("read:files"));
+            }
+            other => panic!("expected UpstreamAuth, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classifies_auth_required_transport_error() {
+        use rmcp::transport::DynamicTransportError;
+        use rmcp::transport::streamable_http_client::{AuthRequiredError, StreamableHttpError};
+
+        let inner: StreamableHttpError<reqwest::Error> =
+            StreamableHttpError::AuthRequired(AuthRequiredError::new("Bearer".to_string()));
+        let dte = DynamicTransportError::from_parts(
+            "test",
+            std::any::TypeId::of::<()>(),
+            Box::new(inner),
+        );
+        let classified = classify_transport_auth_error(&dte).expect("should classify");
+        assert!(matches!(
+            classified,
+            BitrouterError::UpstreamAuth { status: 401, .. }
+        ));
+    }
+
+    #[test]
+    fn non_auth_transport_error_is_not_classified() {
+        use rmcp::transport::DynamicTransportError;
+        use rmcp::transport::streamable_http_client::StreamableHttpError;
+        let inner: StreamableHttpError<reqwest::Error> = StreamableHttpError::UnexpectedEndOfStream;
+        let dte = DynamicTransportError::from_parts(
+            "test",
+            std::any::TypeId::of::<()>(),
+            Box::new(inner),
+        );
+        assert!(classify_transport_auth_error(&dte).is_none());
     }
 }


### PR DESCRIPTION
## Summary

The SDK's outbound-MCP path flattened **every** upstream error to `BitrouterError::Upstream { status: 502 }` (`rmcp_executor.rs` `fn upstream()`), discarding the real HTTP status, body, and `WWW-Authenticate`. That made it impossible for a downstream consumer (bitrouter-cloud's MCP gateway) to drive OAuth token refresh on a 401 or step-up on a 403 — and it meant the existing 401 token-refresh decorator was latently dead against real upstreams.

This PR threads the real challenge through:

- **New `BitrouterError::UpstreamAuth { status, www_authenticate, required_scope }`** variant — `status()` returns 401/403, `error_type()` maps 403→`permission_error` else `authentication_error`. The `WWW-Authenticate` header is deliberately kept out of the `Display`/response body.
- **`classify_transport_auth_error`** downcasts `rmcp 1.7`'s typed `StreamableHttpError::{AuthRequired, InsufficientScope}` (the latter already parses `required_scope`) out of `DynamicTransportError`.
- Wired at **both** error paths: connect/initialize (`ClientInitializeError::TransportError` → `map_initialize_error`) and live-call dispatch (`ServiceError::TransportSend` → `map_service_error`).
- **Critical fix:** the downcast must name rmcp's **reqwest 0.13** type, not the SDK's own reqwest 0.12 (distinct `TypeId`s — the downcast otherwise always returns `None` at runtime). Added an aliased `rmcp-reqwest` (package = `reqwest`, 0.13, `default-features = false`, gated behind `mcp`) and aligned the tests to that type so the binding is guarded.

Non-streaming `dispatch` is fully covered; the `execute_streaming` path is deliberately left for a follow-up (no current production caller uses it — the cloud's aggregating/caching executors go through `dispatch`).

Unblocks bitrouter-cloud's outbound-MCP OAuth authorization-code flow (separate repo, Plan B).

## Test Plan
- [x] `cargo nextest run -p bitrouter-sdk --features "mcp config_file"` — 233 passed
- [x] `cargo nextest run --workspace --all-features` — 670 passed
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Revert-proof: reverting the downcast to the 0.12 type makes 4/5 classification tests fail (confirms the tests genuinely bind to rmcp's 0.13 type, not a tautology)
- [ ] Follow-up: add a live-transport (real 401) regression test when an HTTP test-server dev-dep is available
- [ ] Release: publish next alpha (alpha.10) so bitrouter-cloud can consume from crates.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)