### PR TITLE
feat(observe)!: forward cloud span attrs + content capture

### DIFF
--- a/apps/bitrouter/src/metering/recorder.rs
+++ b/apps/bitrouter/src/metering/recorder.rs
@@ -63,7 +63,7 @@ impl MeteringRecorder {
 
 #[async_trait]
 impl SettlementRecorder for MeteringRecorder {
-    async fn record(&self, ctx: &SettlementContext) -> Result<()> {
+    async fn record(&self, ctx: &mut SettlementContext) -> Result<()> {
         let (estimated_charge_micro_usd, missing_pricing) = self.estimate_charge(ctx);
         if missing_pricing {
             // Demoted from `warn` to `debug` — the per-request "finished"

--- a/apps/bitrouter/src/metering/tests.rs
+++ b/apps/bitrouter/src/metering/tests.rs
@@ -51,7 +51,7 @@ async fn recorder_writes_estimated_charge_from_pricing() -> Result<()> {
     let store = MeteringStore::new(pool.clone());
     let recorder = MeteringRecorder::new(store.clone(), pricing());
     // 10 prompt × 2 + 5 completion × 10 = 70 µ$
-    recorder.record(&ctx("k1", 10, 5)).await?;
+    recorder.record(&mut ctx("k1", 10, 5)).await?;
     let spend = store.get_spend("k1", TimeWindow::ThisMonth).await?;
     assert_eq!(spend, 70);
     Ok(())
@@ -63,7 +63,7 @@ async fn recorder_writes_zero_when_pricing_missing() -> Result<()> {
     let store = MeteringStore::new(pool.clone());
     let empty = Arc::new(PricingTable::new());
     let recorder = MeteringRecorder::new(store.clone(), empty);
-    recorder.record(&ctx("k1", 10, 5)).await?;
+    recorder.record(&mut ctx("k1", 10, 5)).await?;
     let spend = store.get_spend("k1", TimeWindow::ThisMonth).await?;
     assert_eq!(spend, 0);
     // The row was still written — count is 1.
@@ -77,9 +77,9 @@ async fn spend_aggregates_across_requests() -> Result<()> {
     let pool = pool().await;
     let store = MeteringStore::new(pool.clone());
     let recorder = MeteringRecorder::new(store.clone(), pricing());
-    recorder.record(&ctx("k1", 10, 5)).await?; // 70
-    recorder.record(&ctx("k1", 100, 0)).await?; // 200
-    recorder.record(&ctx("k1", 0, 50)).await?; // 500
+    recorder.record(&mut ctx("k1", 10, 5)).await?; // 70
+    recorder.record(&mut ctx("k1", 100, 0)).await?; // 200
+    recorder.record(&mut ctx("k1", 0, 50)).await?; // 500
     let spend = store.get_spend("k1", TimeWindow::ThisMonth).await?;
     assert_eq!(spend, 70 + 200 + 500);
     Ok(())
@@ -90,8 +90,8 @@ async fn spend_isolates_by_api_key() -> Result<()> {
     let pool = pool().await;
     let store = MeteringStore::new(pool.clone());
     let recorder = MeteringRecorder::new(store.clone(), pricing());
-    recorder.record(&ctx("k1", 10, 5)).await?;
-    recorder.record(&ctx("k2", 100, 0)).await?;
+    recorder.record(&mut ctx("k1", 10, 5)).await?;
+    recorder.record(&mut ctx("k2", 100, 0)).await?;
     assert_eq!(store.get_spend("k1", TimeWindow::ThisMonth).await?, 70);
     assert_eq!(store.get_spend("k2", TimeWindow::ThisMonth).await?, 200);
     Ok(())
@@ -163,7 +163,7 @@ async fn failed_request_still_records_with_error() -> Result<()> {
     let recorder = MeteringRecorder::new(store.clone(), pricing());
     let mut c = ctx("k1", 5, 0);
     c.error = Some(bitrouter_sdk::BitrouterError::internal("boom"));
-    recorder.record(&c).await?;
+    recorder.record(&mut c).await?;
     let count = store.get_request_count("k1", TimeWindow::ThisMonth).await?;
     assert_eq!(count, 1, "failed requests still get a metering row");
     Ok(())

--- a/crates/bitrouter-sdk/src/language_model/pipeline.rs
+++ b/crates/bitrouter-sdk/src/language_model/pipeline.rs
@@ -414,7 +414,7 @@ impl Pipeline {
         log_request_finished(&settle);
 
         for recorder in &self.settlement_recorders {
-            if let Err(e) = recorder.record(&settle).await {
+            if let Err(e) = recorder.record(&mut settle).await {
                 tracing::error!(error = %e, "SettlementRecorder failed");
             }
         }

--- a/crates/bitrouter-sdk/src/language_model/settlement.rs
+++ b/crates/bitrouter-sdk/src/language_model/settlement.rs
@@ -2,10 +2,10 @@
 //! [`SettlementRecorder`] list.
 //!
 //! The SDK is opinionated only about *pipeline data correctness*: a recorder
-//! receives the final, immutable token / latency / model / error data
-//! the pipeline observed. What a recorder does with that data
-//! (metering, charging, signed receipts, blockchain anchoring, …) is
-//! deployment-specific and lives outside the SDK.
+//! receives the final token / latency / model / error data the pipeline
+//! observed, and may emit events forward for later stages / observe hooks.
+//! What a recorder does with that data (metering, charging, signed receipts,
+//! blockchain anchoring, …) is deployment-specific and lives outside the SDK.
 
 use async_trait::async_trait;
 
@@ -94,5 +94,12 @@ impl SettlementContext {
 #[async_trait]
 pub trait SettlementRecorder: Send + Sync {
     /// Record the request outcome.
-    async fn record(&self, ctx: &SettlementContext) -> Result<()>;
+    ///
+    /// `ctx` is `&mut` so a recorder may also [`SettlementContext::emit`]
+    /// events forward (e.g. cloud-computed span attributes) for later stages
+    /// and observe hooks: [`PipelineContext::absorb_settlement`] folds the
+    /// settlement bus back into the request bus before `on_request_end`.
+    ///
+    /// [`PipelineContext::absorb_settlement`]: crate::language_model::PipelineContext::absorb_settlement
+    async fn record(&self, ctx: &mut SettlementContext) -> Result<()>;
 }

--- a/crates/bitrouter-sdk/src/language_model/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/tests.rs
@@ -100,7 +100,7 @@ impl RouteHook for EmitRouteHook {
 struct CountingRecorder(Arc<AtomicUsize>);
 #[async_trait]
 impl SettlementRecorder for CountingRecorder {
-    async fn record(&self, _ctx: &SettlementContext) -> Result<()> {
+    async fn record(&self, _ctx: &mut SettlementContext) -> Result<()> {
         self.0.fetch_add(1, Ordering::SeqCst);
         Ok(())
     }
@@ -111,7 +111,7 @@ impl SettlementRecorder for CountingRecorder {
 struct UsageCapturingRecorder(Arc<std::sync::Mutex<Vec<(u64, u64)>>>);
 #[async_trait]
 impl SettlementRecorder for UsageCapturingRecorder {
-    async fn record(&self, ctx: &SettlementContext) -> Result<()> {
+    async fn record(&self, ctx: &mut SettlementContext) -> Result<()> {
         self.0
             .lock()
             .unwrap()
@@ -263,7 +263,7 @@ async fn settlement_recorders_run_in_registration_order() {
     }
     #[async_trait]
     impl SettlementRecorder for LabelledRecorder {
-        async fn record(&self, _ctx: &SettlementContext) -> Result<()> {
+        async fn record(&self, _ctx: &mut SettlementContext) -> Result<()> {
             self.log.lock().unwrap().push(self.label);
             Ok(())
         }
@@ -760,7 +760,7 @@ async fn route_hook_event_is_visible_downstream() {
     struct EventAssertRecorder;
     #[async_trait]
     impl SettlementRecorder for EventAssertRecorder {
-        async fn record(&self, ctx: &SettlementContext) -> Result<()> {
+        async fn record(&self, ctx: &mut SettlementContext) -> Result<()> {
             assert!(
                 ctx.has_event::<TestRouteEvent>(),
                 "route-stage event reached settlement"
@@ -778,6 +778,58 @@ async fn route_hook_event_is_visible_downstream() {
         },
     );
     pipeline.execute(request()).await.expect("ok");
+}
+
+#[tokio::test]
+async fn settlement_recorder_can_emit_event_for_later_recorders() {
+    // Option A (#529): `record(&mut ctx)` lets a recorder emit events that a
+    // later-registered recorder — and, via `absorb_settlement`, downstream
+    // observe hooks — can read.
+    #[derive(Serialize)]
+    struct SettleEmit {
+        tag: u32,
+    }
+    impl PipelineEvent for SettleEmit {
+        fn event_name(&self) -> &'static str {
+            "test.settle_emit"
+        }
+    }
+
+    struct EmitRecorder;
+    #[async_trait]
+    impl SettlementRecorder for EmitRecorder {
+        async fn record(&self, ctx: &mut SettlementContext) -> Result<()> {
+            ctx.emit(SettleEmit { tag: 42 });
+            Ok(())
+        }
+    }
+
+    let seen = Arc::new(AtomicUsize::new(0));
+    struct AssertRecorder(Arc<AtomicUsize>);
+    #[async_trait]
+    impl SettlementRecorder for AssertRecorder {
+        async fn record(&self, ctx: &mut SettlementContext) -> Result<()> {
+            if let Some(e) = ctx.get_event::<SettleEmit>() {
+                self.0.store(e.tag as usize, Ordering::SeqCst);
+            }
+            Ok(())
+        }
+    }
+
+    let pipeline = pipeline_with(
+        routing_table(&["openai"]),
+        Arc::new(MockExecutor::always_text("x")),
+        |b| {
+            b.settlement_recorder(EmitRecorder)
+                .settlement_recorder(AssertRecorder(seen.clone()));
+        },
+    );
+    pipeline.execute(request()).await.expect("ok");
+    assert_eq!(
+        seen.load(Ordering::SeqCst),
+        42,
+        "a later settlement recorder sees the event emitted by an earlier one"
+    );
 }
 
 #[tokio::test]

--- a/plugins/bitrouter-observe/src/otel/config.rs
+++ b/plugins/bitrouter-observe/src/otel/config.rs
@@ -44,6 +44,11 @@ pub struct OtelConfig {
 
     /// Metrics configuration.
     pub metrics: MetricsConfig,
+
+    /// Whether to capture prompt / response message content onto spans.
+    /// Default [`ContentCaptureMode::Off`] — no message bodies leave the
+    /// process. Override with `BITROUTER_OBSERVE_CONTENT_CAPTURE=full`.
+    pub content_capture: ContentCaptureMode,
 }
 
 /// Subset of OTel-spec sampler kinds the SDK actually supports. The default
@@ -62,6 +67,24 @@ pub enum SamplerKind {
     ParentBasedAlwaysOff,
     #[serde(rename = "parentbased_traceidratio")]
     ParentBasedTraceIdRatio,
+}
+
+/// Whether the exporter copies prompt / response message content onto spans.
+///
+/// `Off` (default) keeps all message bodies out of telemetry — only metadata
+/// (tokens, model, latency, finish reason, cloud-forwarded attributes) is
+/// exported. `Full` serializes the prompt messages onto `gen_ai.input.messages`
+/// and the response content onto `gen_ai.output.messages`. Redaction is a
+/// caller policy, not done here; downstream pipelines decide whether to forward
+/// the content (e.g. a collector that strips it from a third-party export).
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ContentCaptureMode {
+    /// Never copy message content onto spans (privacy-preserving default).
+    #[default]
+    Off,
+    /// Serialize prompt + response message content onto the span.
+    Full,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -110,6 +133,7 @@ impl Default for OtelConfig {
             sampler_arg: None,
             traces: TraceConfig::default(),
             metrics: MetricsConfig::default(),
+            content_capture: ContentCaptureMode::Off,
         }
     }
 }
@@ -182,6 +206,11 @@ impl OtelConfig {
         {
             self.sampler_arg = Some(ratio);
         }
+        if let Some(s) = lookup("BITROUTER_OBSERVE_CONTENT_CAPTURE")
+            && let Some(mode) = parse_content_capture(&s)
+        {
+            self.content_capture = mode;
+        }
         self
     }
 }
@@ -194,6 +223,14 @@ fn parse_sampler(s: &str) -> Option<SamplerKind> {
         "parentbased_always_on" => Some(SamplerKind::ParentBasedAlwaysOn),
         "parentbased_always_off" => Some(SamplerKind::ParentBasedAlwaysOff),
         "parentbased_traceidratio" => Some(SamplerKind::ParentBasedTraceIdRatio),
+        _ => None,
+    }
+}
+
+fn parse_content_capture(s: &str) -> Option<ContentCaptureMode> {
+    match s.to_ascii_lowercase().as_str() {
+        "off" => Some(ContentCaptureMode::Off),
+        "full" => Some(ContentCaptureMode::Full),
         _ => None,
     }
 }
@@ -256,5 +293,20 @@ mod tests {
             Some("secret")
         );
         assert_eq!(cfg.headers.get("x-team").map(String::as_str), Some("infra"));
+    }
+
+    #[test]
+    fn content_capture_defaults_off_and_env_overrides_to_full() {
+        assert_eq!(
+            OtelConfig::default().content_capture,
+            ContentCaptureMode::Off
+        );
+        let cfg = OtelConfig::default()
+            .with_env_from(env(&[("BITROUTER_OBSERVE_CONTENT_CAPTURE", "full")]));
+        assert_eq!(cfg.content_capture, ContentCaptureMode::Full);
+        // Unknown value leaves the default untouched.
+        let cfg = OtelConfig::default()
+            .with_env_from(env(&[("BITROUTER_OBSERVE_CONTENT_CAPTURE", "bogus")]));
+        assert_eq!(cfg.content_capture, ContentCaptureMode::Off);
     }
 }

--- a/plugins/bitrouter-observe/src/otel/exporter.rs
+++ b/plugins/bitrouter-observe/src/otel/exporter.rs
@@ -55,7 +55,8 @@ use bitrouter_sdk::language_model::{
 };
 
 use crate::otel::cardinality::CardinalityLimiter;
-use crate::otel::config::{OtelConfig, SamplerKind};
+use crate::otel::config::{ContentCaptureMode, OtelConfig, SamplerKind};
+use crate::otel::span_attributes::SpanAttributes;
 
 /// HTTP header extractor for W3C trace context propagation
 /// (<https://www.w3.org/TR/trace-context/>). Used on inbound headers.
@@ -718,6 +719,51 @@ impl ObserveHook for OtelExporter {
                 }
             }
 
+            // Cloud-forwarded attributes (cost / namespace / routing / …). A
+            // `SettlementRecorder` may emit `SpanAttributes`;
+            // `PipelineContext::absorb_settlement` folds the settlement bus
+            // back into `ctx` before this hook runs, so they're visible here.
+            // Generic by design — the emitter names the keys, we just stamp.
+            if let Some(extra) = ctx.get_event::<SpanAttributes>() {
+                for (key, value) in &extra.0 {
+                    match value {
+                        serde_json::Value::String(s) => {
+                            span.set_attribute(KeyValue::new(key.clone(), s.clone()));
+                        }
+                        serde_json::Value::Bool(b) => {
+                            span.set_attribute(KeyValue::new(key.clone(), *b));
+                        }
+                        serde_json::Value::Number(n) => {
+                            if let Some(i) = n.as_i64() {
+                                span.set_attribute(KeyValue::new(key.clone(), i));
+                            } else if let Some(f) = n.as_f64() {
+                                span.set_attribute(KeyValue::new(key.clone(), f));
+                            }
+                        }
+                        // null / array / object: not a scalar OTel value — skip.
+                        _ => {}
+                    }
+                }
+            }
+
+            // Optional prompt / response content capture (off by default).
+            if self.config.content_capture == ContentCaptureMode::Full {
+                if let Ok(json) = serde_json::to_string(&ctx.prompt().messages) {
+                    span.set_attribute(KeyValue::new(
+                        "gen_ai.input.messages",
+                        truncate_utf8(json, CONTENT_ATTR_MAX_BYTES),
+                    ));
+                }
+                if let Some(result) = &ctx.execution_result
+                    && let Ok(json) = serde_json::to_string(&result.result.content)
+                {
+                    span.set_attribute(KeyValue::new(
+                        "gen_ai.output.messages",
+                        truncate_utf8(json, CONTENT_ATTR_MAX_BYTES),
+                    ));
+                }
+            }
+
             match outcome {
                 RequestOutcome::Completed => {
                     span.set_status(Status::Ok);
@@ -754,6 +800,27 @@ impl ObserveHook for OtelExporter {
             metrics.record_request(ctx, outcome);
         }
     }
+}
+
+/// Maximum byte length for a single captured content attribute
+/// (`gen_ai.input.messages` / `gen_ai.output.messages`). A conservative cap so
+/// a pathological prompt or response can't produce an oversized span the
+/// collector or backend would reject. Only consulted under
+/// [`ContentCaptureMode::Full`].
+const CONTENT_ATTR_MAX_BYTES: usize = 128 * 1024;
+
+/// Truncate a `String` to at most `max` bytes, backing off to the nearest
+/// UTF-8 char boundary so the result is always valid UTF-8.
+fn truncate_utf8(mut s: String, max: usize) -> String {
+    if s.len() <= max {
+        return s;
+    }
+    let mut end = max;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    s.truncate(end);
+    s
 }
 
 fn build_resource(config: &OtelConfig) -> Resource {
@@ -994,6 +1061,10 @@ mod hop_tests {
     /// endpoint) by constructing the struct directly — possible here
     /// because the test lives in the same module and sees private fields.
     fn make_test_exporter() -> (OtelExporter, Arc<Mutex<Vec<SpanData>>>) {
+        make_test_exporter_with(OtelConfig::default())
+    }
+
+    fn make_test_exporter_with(config: OtelConfig) -> (OtelExporter, Arc<Mutex<Vec<SpanData>>>) {
         let captured = Arc::new(Mutex::new(Vec::new()));
         let processor = CapturingProcessor {
             captured: captured.clone(),
@@ -1012,7 +1083,7 @@ mod hop_tests {
             tracer,
             provider,
             metrics: None,
-            config: OtelConfig::default(),
+            config,
             api_key_limiter: Arc::new(CardinalityLimiter::new(100)),
             user_id_limiter: Arc::new(CardinalityLimiter::new(100)),
             active_spans: Arc::new(DashMap::new()),
@@ -1093,6 +1164,26 @@ mod hop_tests {
             .find(|kv| kv.key.as_str() == key)
             .and_then(|kv| match kv.value {
                 Value::I64(v) => Some(v),
+                _ => None,
+            })
+    }
+
+    fn f64_attr(span: &SpanData, key: &str) -> Option<f64> {
+        span.attributes
+            .iter()
+            .find(|kv| kv.key.as_str() == key)
+            .and_then(|kv| match kv.value {
+                Value::F64(v) => Some(v),
+                _ => None,
+            })
+    }
+
+    fn bool_attr(span: &SpanData, key: &str) -> Option<bool> {
+        span.attributes
+            .iter()
+            .find(|kv| kv.key.as_str() == key)
+            .and_then(|kv| match kv.value {
+                Value::Bool(v) => Some(v),
                 _ => None,
             })
     }
@@ -1196,6 +1287,95 @@ mod hop_tests {
         );
         assert_eq!(i64_attr(hop_chat, "gen_ai.usage.input_tokens"), Some(11));
         assert_eq!(i64_attr(hop_chat, "gen_ai.usage.output_tokens"), Some(7));
+    }
+
+    #[tokio::test]
+    async fn on_request_end_stamps_forwarded_span_attributes() {
+        // A SettlementRecorder forwards cloud-computed attributes via a
+        // `SpanAttributes` event (#529); `absorb_settlement` makes them visible
+        // on the PipelineContext, and `on_request_end` stamps each entry — by
+        // JSON type — onto the root `chat` span.
+        let (exporter, captured) = make_test_exporter();
+        let mut ctx = PipelineContext::new(fresh_request());
+
+        exporter.after_phase(Phase::PreRequest, &ctx).await;
+
+        let mut attrs = serde_json::Map::new();
+        attrs.insert("$ai_total_cost_usd".into(), serde_json::json!(0.00123456));
+        attrs.insert("namespace".into(), serde_json::json!("acme"));
+        attrs.insert("fallback".into(), serde_json::json!(true));
+        attrs.insert("bitrouter.retry_count".into(), serde_json::json!(2));
+        // Null / nested values are skipped (not representable as a scalar attr).
+        attrs.insert("skipped_null".into(), serde_json::Value::Null);
+        ctx.emit(SpanAttributes(attrs));
+
+        exporter
+            .on_request_end(&ctx, &RequestOutcome::Completed)
+            .await;
+        exporter.provider.force_flush();
+
+        let spans = captured.lock().unwrap().clone();
+        let root_chat = spans
+            .iter()
+            .find(|s| s.name == "chat test-model" && s.span_kind == SpanKind::Internal)
+            .expect("root chat INTERNAL span");
+
+        assert_eq!(str_attr(root_chat, "namespace"), Some("acme"));
+        assert_eq!(f64_attr(root_chat, "$ai_total_cost_usd"), Some(0.00123456));
+        assert_eq!(bool_attr(root_chat, "fallback"), Some(true));
+        assert_eq!(i64_attr(root_chat, "bitrouter.retry_count"), Some(2));
+        assert!(
+            root_chat
+                .attributes
+                .iter()
+                .all(|kv| kv.key.as_str() != "skipped_null"),
+            "null values are not stamped onto the span"
+        );
+    }
+
+    #[tokio::test]
+    async fn content_capture_off_omits_messages_full_records_them() {
+        let target = fresh_target("openai");
+
+        // Off (default): no message bodies on the span.
+        let (exporter, captured) = make_test_exporter();
+        let mut ctx = PipelineContext::new(fresh_request());
+        ctx.execution_result = Some(fresh_result(&target));
+        exporter.after_phase(Phase::PreRequest, &ctx).await;
+        exporter
+            .on_request_end(&ctx, &RequestOutcome::Completed)
+            .await;
+        exporter.provider.force_flush();
+        let spans = captured.lock().unwrap().clone();
+        let root = spans
+            .iter()
+            .find(|s| s.name == "chat test-model" && s.span_kind == SpanKind::Internal)
+            .expect("root chat INTERNAL span");
+        assert_eq!(str_attr(root, "gen_ai.input.messages"), None);
+        assert_eq!(str_attr(root, "gen_ai.output.messages"), None);
+
+        // Full: prompt + response content serialized onto the span.
+        let cfg = OtelConfig {
+            content_capture: ContentCaptureMode::Full,
+            ..OtelConfig::default()
+        };
+        let (exporter, captured) = make_test_exporter_with(cfg);
+        let mut ctx = PipelineContext::new(fresh_request());
+        ctx.execution_result = Some(fresh_result(&target));
+        exporter.after_phase(Phase::PreRequest, &ctx).await;
+        exporter
+            .on_request_end(&ctx, &RequestOutcome::Completed)
+            .await;
+        exporter.provider.force_flush();
+        let spans = captured.lock().unwrap().clone();
+        let root = spans
+            .iter()
+            .find(|s| s.name == "chat test-model" && s.span_kind == SpanKind::Internal)
+            .expect("root chat INTERNAL span");
+        let input = str_attr(root, "gen_ai.input.messages").expect("input messages captured");
+        assert!(input.contains("hi"), "prompt text serialized: {input}");
+        let output = str_attr(root, "gen_ai.output.messages").expect("output messages captured");
+        assert!(output.contains("ok"), "response text serialized: {output}");
     }
 
     #[tokio::test]

--- a/plugins/bitrouter-observe/src/otel/mod.rs
+++ b/plugins/bitrouter-observe/src/otel/mod.rs
@@ -16,8 +16,12 @@ mod config;
 mod exporter;
 pub mod http_layer;
 mod metrics;
+mod span_attributes;
 mod transport;
 
 pub use cardinality::CardinalityLimiter;
-pub use config::{BatchConfig, MetricsConfig, OtelConfig, SamplerKind, TraceConfig};
+pub use config::{
+    BatchConfig, ContentCaptureMode, MetricsConfig, OtelConfig, SamplerKind, TraceConfig,
+};
 pub use exporter::{OtelExporter, OtelObserveHook, OtelStatus};
+pub use span_attributes::SpanAttributes;

--- a/plugins/bitrouter-observe/src/otel/span_attributes.rs
+++ b/plugins/bitrouter-observe/src/otel/span_attributes.rs
@@ -1,0 +1,29 @@
+//! [`SpanAttributes`] — a generic, serialize-only pipeline event that carries
+//! extra span attributes forward to the OTel exporter's `on_request_end`.
+//!
+//! A deployment (e.g. `bitrouter-cloud`) that computes attributes the SDK does
+//! not know about — request cost, namespace, routing profile — emits a
+//! `SpanAttributes` from its [`SettlementRecorder`]; the exporter stamps every
+//! entry onto the request's root `chat` span. Keeping it a plain
+//! `serde_json::Map` means no backend concept (billing, tenancy, …) leaks into
+//! the SDK or this plugin: every future attribute rides for free, named by the
+//! emitter (e.g. PostHog's `$ai_total_cost_usd`).
+//!
+//! [`SettlementRecorder`]: bitrouter_sdk::language_model::SettlementRecorder
+
+use bitrouter_sdk::PipelineEvent;
+use serde::Serialize;
+use serde_json::{Map, Value};
+
+/// Extra span attributes forwarded from a settlement recorder to the OTel
+/// exporter. The map's keys are used verbatim as span-attribute keys; values
+/// are stamped by JSON type (string / bool / integer / float). Null and nested
+/// JSON (array / object) are skipped — OTel attribute values are scalar.
+#[derive(Debug, Clone, Serialize)]
+pub struct SpanAttributes(pub Map<String, Value>);
+
+impl PipelineEvent for SpanAttributes {
+    fn event_name(&self) -> &'static str {
+        "observe.span_attributes"
+    }
+}


### PR DESCRIPTION
## What & why

Phase B/C of the PostHog LLM-analytics work. `bitrouter-cloud` exports the
`gen_ai`-semconv spans `bitrouter-observe` already emits to PostHog. Phase B/C
need those spans to carry data **only the cloud knows** (request cost,
namespace, routing profile) plus **optional message content**. Today the seam
is blocked: `SettlementRecorder::record(&self, ctx: &SettlementContext)` is
immutable, so a recorder can read events but not emit.

Closes #529 (see the issue for the full design + the live PostHog verification
that a span attribute named `$ai_total_cost_usd` overrides auto-pricing).

## Changes

1. **Write-seam — Option A.** `SettlementRecorder::record` now takes
   `&mut SettlementContext`. `PipelineContext::absorb_settlement` already folds
   the settlement bus back into the request bus *before* `on_request_end`, so
   anything a recorder emits is visible to the observe hook. One call site
   (`pipeline.rs`) + 5 impls updated (signature only).
2. **Generic `SpanAttributes` event** (`bitrouter-observe`): a serialize-only
   `PipelineEvent` wrapping `serde_json::Map<String, Value>`. The emitter (e.g.
   the cloud's settlement recorder) fills it with backend-named keys; the
   exporter stamps each entry onto the **root `chat`** span in `on_request_end`,
   by JSON type (string / bool / i64 / f64; null & nested skipped). No
   billing/tenancy concept leaks into the SDK — every future attribute rides for
   free.
3. **`ContentCaptureMode { Off, Full }`** on `OtelConfig` (default **Off**, env
   `BITROUTER_OBSERVE_CONTENT_CAPTURE=full`). `Full` serializes prompt →
   `gen_ai.input.messages` and response → `gen_ai.output.messages`, each capped
   at 128 KiB (UTF-8-safe) to avoid oversized-span rejection. Redaction is a
   caller policy; downstream pipelines (the cloud collector) strip content from
   third-party exports by default.

## Breaking change

`SettlementRecorder::record` takes `&mut SettlementContext` instead of
`&SettlementContext`. Implementors just update the signature; no behavior change
unless they choose to emit. Pre-1.0, so no major bump.

## Tests

- SDK: a recorder emits an event a later recorder sees (proves the `&mut` seam).
- observe exporter: forwarded attrs land on the root span by JSON type; null
  skipped; content `Off` omits message bodies, `Full` records them.
- observe config: `BITROUTER_OBSERVE_CONTENT_CAPTURE` env override + default.
- `cargo fmt --check`, `cargo clippy --all-features --all-targets` (clean),
  `cargo nextest run --all-features` → **678 passed, 0 skipped**.

## Release

Merging rolls into the open `release-plz` PR #522 (`v1.0.0-alpha.10`);
publishing that makes the new API available to `bitrouter-cloud` on crates.io.

🤖 Generated with [Claude Code](https://claude.com/claude-code)