### PR TITLE
fix(stream): bill prompt tokens on client disconnect

### DIFF
--- a/crates/bitrouter-sdk/src/language_model/context.rs
+++ b/crates/bitrouter-sdk/src/language_model/context.rs
@@ -12,7 +12,7 @@ use crate::event::{EventBus, PipelineEvent};
 use crate::language_model::settlement::SettlementContext;
 use crate::language_model::stream::UsageAccumulator;
 use crate::language_model::types::{
-    ExecutionResult, PipelineRequest, PipelineResponse, Prompt, RoutingTarget, Usage,
+    Content, ExecutionResult, PipelineRequest, PipelineResponse, Prompt, RoutingTarget, Usage,
 };
 use crate::plugin::PluginId;
 
@@ -243,6 +243,28 @@ impl PipelineContext {
         &self.events
     }
 
+    /// Rough `char` count of the request prompt's text — system instruction
+    /// plus every message's text / reasoning content. Used to seed the
+    /// [`UsageAccumulator`] so a client disconnect *before* the upstream usage
+    /// frame can still estimate prompt tokens. Non-text parts (tool calls,
+    /// tool results) are skipped; they carry no user-visible prose and the
+    /// estimate only needs to beat `0` until the authoritative frame arrives.
+    fn prompt_text_chars(&self) -> u64 {
+        let prompt = self.prompt();
+        let mut chars = prompt
+            .system
+            .as_ref()
+            .map_or(0u64, |s| s.chars().count() as u64);
+        for message in &prompt.messages {
+            for content in &message.content {
+                if let Content::Text { text } | Content::Reasoning { text } = content {
+                    chars = chars.saturating_add(text.chars().count() as u64);
+                }
+            }
+        }
+        chars
+    }
+
     /// Borrow a `StreamContext` for the StreamHook stage.
     pub fn stream_context(&self) -> StreamContext {
         let target = self.route_chain.as_ref().and_then(|c| c.first()).cloned();
@@ -250,7 +272,7 @@ impl PipelineContext {
             request_id: self.request_id.clone(),
             caller: self.caller.clone(),
             target,
-            accumulated_usage: UsageAccumulator::new(),
+            accumulated_usage: UsageAccumulator::with_prompt_chars(self.prompt_text_chars()),
             parts_emitted: 0,
             final_usage: None,
             events: EventBus::new(),
@@ -378,6 +400,8 @@ impl StreamContext {
 mod tests {
     use super::*;
     use crate::config::PromptOverrides;
+    use crate::language_model::stream::{StreamOutcome, StreamProcessor};
+    use crate::language_model::types::StreamPart;
     use crate::language_model::{Message, PipelineRequest, Role};
 
     fn ctx_from_prompt(prompt: Prompt) -> PipelineContext {
@@ -458,5 +482,141 @@ mod tests {
         ctx.apply_preset_overrides(&PromptOverrides::default());
         assert!(ctx.prompt().system.is_none());
         assert!(ctx.prompt().params.extra.is_empty());
+    }
+
+    fn prompt_with_text(system: Option<&str>, user_text: &str) -> Prompt {
+        Prompt {
+            model: "gpt-5".into(),
+            system: system.map(str::to_string),
+            messages: vec![Message {
+                role: Role::User,
+                content: vec![Content::Text {
+                    text: user_text.to_string(),
+                }],
+            }],
+            tools: vec![],
+            params: Default::default(),
+            response_format: None,
+            stream: true,
+        }
+    }
+
+    // Mirrors the private `UsageAccumulator::CHARS_PER_TOKEN_ESTIMATE`.
+    const CHARS_PER_TOKEN: u64 = 4;
+
+    #[test]
+    fn stream_context_seeds_prompt_token_estimate() {
+        let system = "You are a careful assistant.";
+        let user = "Summarize the meeting notes in three concise bullet points.";
+        let ctx = ctx_from_prompt(prompt_with_text(Some(system), user));
+
+        let chars = (system.chars().count() + user.chars().count()) as u64;
+        let sc = ctx.stream_context();
+        assert_eq!(
+            sc.accumulated_usage.estimated_prompt_tokens(),
+            chars.div_ceil(CHARS_PER_TOKEN),
+        );
+        // No deltas observed yet → no output estimate.
+        assert_eq!(sc.accumulated_usage.estimated_output_tokens(), 0);
+    }
+
+    #[test]
+    fn prompt_token_estimate_ignores_non_text_content() {
+        // Only the system instruction is prose; the message's tool-call JSON
+        // args must not inflate the prompt-token estimate.
+        let system = "sys";
+        let prompt = Prompt {
+            model: "gpt-5".into(),
+            system: Some(system.into()),
+            messages: vec![Message {
+                role: Role::Assistant,
+                content: vec![Content::ToolCall {
+                    id: "call_1".into(),
+                    name: "get_weather".into(),
+                    arguments: "{\"city\":\"a deliberately long value to be ignored\"}".into(),
+                }],
+            }],
+            tools: vec![],
+            params: Default::default(),
+            response_format: None,
+            stream: true,
+        };
+        let ctx = ctx_from_prompt(prompt);
+        let sc = ctx.stream_context();
+        assert_eq!(
+            sc.accumulated_usage.estimated_prompt_tokens(),
+            (system.chars().count() as u64).div_ceil(CHARS_PER_TOKEN),
+        );
+    }
+
+    #[tokio::test]
+    async fn disconnect_bills_prompt_tokens_without_output() {
+        let user = "Generate a long essay about distributed systems.";
+        let ctx = ctx_from_prompt(prompt_with_text(None, user));
+        let expected_prompt = (user.chars().count() as u64).div_ceil(CHARS_PER_TOKEN);
+
+        // Client hangs up before any delta or usage frame arrives.
+        let mut proc = StreamProcessor::new(vec![], vec![], ctx.stream_context());
+        proc.finish(StreamOutcome::ClientDisconnected).await;
+
+        let usage = proc
+            .context()
+            .final_usage
+            .expect("disconnect with a non-empty prompt must still bill input tokens");
+        assert_eq!(usage.prompt_tokens, expected_prompt);
+        assert_eq!(usage.completion_tokens, 0);
+    }
+
+    #[tokio::test]
+    async fn disconnect_bills_prompt_and_estimated_output() {
+        let user = "hi";
+        let ctx = ctx_from_prompt(prompt_with_text(None, user));
+        let mut proc = StreamProcessor::new(vec![], vec![], ctx.stream_context());
+
+        // Drain some output, then disconnect before the trailing usage frame.
+        let delta = "The answer is forty-two, and here is some more text.";
+        proc.process_part(StreamPart::TextDelta { text: delta.into() })
+            .await
+            .expect("text delta passes through with no hooks");
+        proc.finish(StreamOutcome::ClientDisconnected).await;
+
+        let usage = proc.context().final_usage.expect("billed on disconnect");
+        assert_eq!(
+            usage.prompt_tokens,
+            (user.chars().count() as u64).div_ceil(CHARS_PER_TOKEN),
+        );
+        assert_eq!(
+            usage.completion_tokens,
+            (delta.chars().count() as u64).div_ceil(CHARS_PER_TOKEN),
+        );
+    }
+
+    #[tokio::test]
+    async fn authoritative_usage_overrides_disconnect_estimate() {
+        // A real upstream usage frame must win over the disconnect estimate,
+        // even when the stream then ends as a client disconnect.
+        let ctx = ctx_from_prompt(prompt_with_text(Some("system"), "user question"));
+        let mut proc = StreamProcessor::new(vec![], vec![], ctx.stream_context());
+
+        proc.process_part(StreamPart::Usage {
+            usage: Usage {
+                prompt_tokens: 11,
+                completion_tokens: 22,
+                ..Default::default()
+            },
+        })
+        .await
+        .unwrap();
+        proc.finish(StreamOutcome::ClientDisconnected).await;
+
+        let usage = proc
+            .context()
+            .final_usage
+            .expect("authoritative usage billed");
+        assert_eq!(
+            usage.prompt_tokens, 11,
+            "real prompt tokens, not the estimate"
+        );
+        assert_eq!(usage.completion_tokens, 22);
     }
 }

--- a/crates/bitrouter-sdk/src/language_model/stream.rs
+++ b/crates/bitrouter-sdk/src/language_model/stream.rs
@@ -233,6 +233,10 @@ pub struct UsageAccumulator {
     seen: bool,
     /// Total `char` count of `TextDelta` + `ReasoningDelta` text observed.
     delta_chars: u64,
+    /// `char` count of the request prompt's text, seeded at stream start. Lets a
+    /// client disconnect *before* the upstream usage frame still estimate the
+    /// prompt tokens the provider bills regardless of disconnect.
+    prompt_chars: u64,
 }
 
 impl UsageAccumulator {
@@ -240,9 +244,14 @@ impl UsageAccumulator {
     /// Conservative-ish: too small bills extra, too large bills less.
     const CHARS_PER_TOKEN_ESTIMATE: u64 = 4;
 
-    /// A fresh, empty accumulator.
-    pub fn new() -> Self {
-        Self::default()
+    /// A fresh accumulator seeded with the request prompt's `char` count, so a
+    /// disconnect before the upstream usage frame can still estimate prompt
+    /// tokens. Pass `0` when no prompt-token estimate is wanted.
+    pub fn with_prompt_chars(prompt_chars: u64) -> Self {
+        Self {
+            prompt_chars,
+            ..Default::default()
+        }
     }
 
     /// Observe a part; updates the running usage from a `Usage` part or from a
@@ -274,6 +283,13 @@ impl UsageAccumulator {
     /// observed.
     pub fn estimated_output_tokens(&self) -> u64 {
         self.delta_chars.div_ceil(Self::CHARS_PER_TOKEN_ESTIMATE)
+    }
+
+    /// Estimated prompt-token count from the seeded prompt char count, for the
+    /// disconnect-billing fallback. Returns `0` when the accumulator was not
+    /// seeded with a prompt char count.
+    pub fn estimated_prompt_tokens(&self) -> u64 {
+        self.prompt_chars.div_ceil(Self::CHARS_PER_TOKEN_ESTIMATE)
     }
 }
 
@@ -363,15 +379,17 @@ impl StreamProcessor {
     ///   wins — covers both clean termination and disconnect *after* the
     ///   usage chunk.
     /// - If the stream ended via [`StreamOutcome::ClientDisconnected`] before
-    ///   any `Usage` was seen but delta text *was* observed, synthesise a
-    ///   usage with `completion_tokens` estimated from the text length so
-    ///   the request still bills. Without this, a client could drain a long
-    ///   generation, hang up just before the trailing usage frame, and pay
-    ///   $0. Prompt tokens stay at `0` in the estimate (the prompt isn't
-    ///   plumbed through `StreamContext` — known gap, mirrors the v0 fix).
-    /// - Otherwise (clean error with no usage, or disconnect with no
-    ///   deltas), leave `final_usage` empty; settlement records the request
-    ///   as un-billable.
+    ///   any `Usage` was seen, synthesise a usage from the disconnect
+    ///   estimate: `prompt_tokens` from the request prompt's char count
+    ///   (seeded into the accumulator at stream start) and `completion_tokens`
+    ///   from the observed delta text. The provider bills input tokens the
+    ///   moment it accepts the request, so prompt tokens are charged even when
+    ///   no output streamed before the hang-up; output is added when deltas
+    ///   were seen. Without this, a client could drain a long generation, hang
+    ///   up just before the trailing usage frame, and pay $0.
+    /// - Otherwise (clean error with no usage, or disconnect with neither a
+    ///   seeded prompt nor deltas), leave `final_usage` empty; settlement
+    ///   records the request as un-billable.
     pub async fn finish(&mut self, outcome: StreamOutcome) -> &StreamContext {
         if self.ended {
             return &self.ctx;
@@ -385,15 +403,18 @@ impl StreamProcessor {
         if let Some(usage) = self.ctx.accumulated_usage.finalized() {
             self.ctx.final_usage = Some(usage);
         } else if matches!(outcome, StreamOutcome::ClientDisconnected) {
-            let estimated = self.ctx.accumulated_usage.estimated_output_tokens();
-            if estimated > 0 {
+            let prompt_tokens = self.ctx.accumulated_usage.estimated_prompt_tokens();
+            let completion_tokens = self.ctx.accumulated_usage.estimated_output_tokens();
+            if prompt_tokens > 0 || completion_tokens > 0 {
                 tracing::warn!(
                     request_id = %self.ctx.request_id,
-                    estimated_output_tokens = estimated,
-                    "client disconnected mid-stream before upstream usage frame; billing estimated output"
+                    estimated_prompt_tokens = prompt_tokens,
+                    estimated_output_tokens = completion_tokens,
+                    "client disconnected mid-stream before upstream usage frame; billing estimated usage"
                 );
                 self.ctx.final_usage = Some(Usage {
-                    completion_tokens: estimated,
+                    prompt_tokens,
+                    completion_tokens,
                     ..Default::default()
                 });
             }

--- a/crates/bitrouter-sdk/src/language_model/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/tests.rs
@@ -614,8 +614,10 @@ async fn disconnect_before_usage_bills_estimated_output() {
     let entries = captured.lock().unwrap().clone();
     assert_eq!(entries.len(), 1, "exactly one settlement recorded");
     let (prompt, completion) = entries[0];
-    // Prompt-tokens not plumbed through StreamContext yet — known gap.
-    assert_eq!(prompt, 0, "prompt-token estimate is the documented gap");
+    // Prompt tokens are now seeded into the `StreamContext` and billed on
+    // disconnect even though the upstream usage frame never arrived: the
+    // request prompt is `"hi"` (2 chars), so ceil(2/4) = 1 token.
+    assert_eq!(prompt, 1, "prompt-token estimate billed on disconnect");
     assert!(
         completion >= 1,
         "completion-token estimate must be non-zero ({completion}); ~31 chars / 4 ≈ 8 tokens"


### PR DESCRIPTION
## Problem

When a client disconnects mid-stream **before** the upstream `usage` frame arrives, settlement billed only an estimated *completion*-token count (chars/4 of observed text deltas) and left `prompt_tokens` at `0` — the prompt was never plumbed into `StreamContext`. Providers bill input tokens the moment they accept a request, so every disconnected stream was under-billed by the full prompt cost, and a client that hung up before the first delta was billed **nothing at all**.

## Fix

- `UsageAccumulator` gains a `prompt_chars` field; `new()` is replaced by `with_prompt_chars(prompt_chars)` and a new `estimated_prompt_tokens()` (`prompt_chars.div_ceil(4)`), mirroring the existing output estimate.
- `PipelineContext::stream_context()` seeds the accumulator from `prompt_text_chars()` — system instruction + each message's `Text`/`Reasoning` content. Non-text parts (`ToolCall`/`ToolResult`) are skipped so base64/JSON payloads don't inflate the estimate.
- `StreamProcessor::finish()`'s `ClientDisconnected` branch now bills both estimated prompt and completion tokens (whichever are `> 0`). An authoritative upstream `usage` frame still takes precedence when present, and non-disconnect outcomes (clean completion, upstream error, hook abort) are unaffected.

## Tests

5 new tests in `context.rs` (estimate seeding, non-text exclusion, prompt-only disconnect billing, prompt+output disconnect billing, authoritative-usage precedence) plus the pre-existing disconnect integration test updated to assert the now-billed prompt tokens. `cargo test/clippy/fmt --all-features` all green; reviewed by an independent agent (PASS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)