### PR TITLE
fix(pipeline): run non-streaming requests to completion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4423,6 +4423,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/crates/bitrouter-sdk/Cargo.toml
+++ b/crates/bitrouter-sdk/Cargo.toml
@@ -17,7 +17,9 @@ futures.workspace = true
 futures-core.workspace = true
 tokio = { workspace = true, features = ["sync", "rt", "macros", "time"] }
 tokio-stream.workspace = true
-tokio-util.workspace = true
+# `rt` feature: `tokio_util::task::TaskTracker`, used to run non-streaming
+# requests to completion after a client disconnect (see `Pipeline::execute_detached`).
+tokio-util = { workspace = true, features = ["rt"] }
 tracing.workspace = true
 http.workspace = true
 bytes.workspace = true

--- a/crates/bitrouter-sdk/src/language_model/builder.rs
+++ b/crates/bitrouter-sdk/src/language_model/builder.rs
@@ -142,6 +142,7 @@ impl PipelineBuilder {
             executor,
             keepalive_interval: self.keepalive_interval,
             pending_settlements: Arc::new(std::sync::Mutex::new(tokio::task::JoinSet::new())),
+            detached_executions: tokio_util::task::TaskTracker::new(),
         })
     }
 }

--- a/crates/bitrouter-sdk/src/language_model/pipeline.rs
+++ b/crates/bitrouter-sdk/src/language_model/pipeline.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 
 use futures::{FutureExt, StreamExt};
 use futures_core::Stream;
+use tracing::Instrument;
 
 use crate::error::{BitrouterError, Result};
 use crate::language_model::context::PipelineContext;
@@ -44,6 +45,13 @@ pub struct Pipeline {
     /// settlement). [`Pipeline::drain_pending_settlements`] awaits them all
     /// on graceful shutdown so the process doesn't exit mid-settlement.
     pub(crate) pending_settlements: Arc<std::sync::Mutex<tokio::task::JoinSet<()>>>,
+    /// Detached **non-streaming** executions ([`Pipeline::execute_detached`]).
+    /// A `TaskTracker` (not the `JoinSet` above) because *every* non-streaming
+    /// request runs here, so completed tasks must be reaped automatically
+    /// rather than retained until shutdown. `drain_pending_settlements` closes
+    /// and awaits it on graceful shutdown so a SIGTERM can't cut a request that
+    /// the upstream is still billing us for.
+    pub(crate) detached_executions: tokio_util::task::TaskTracker,
 }
 
 impl Pipeline {
@@ -83,7 +91,56 @@ impl Pipeline {
         while taken.join_next().await.is_some() {
             drained += 1;
         }
+
+        // Also wait for every in-flight detached non-streaming execution
+        // (`execute_detached`). `close()` only stops the tracker from blocking
+        // `wait()` on tasks spawned *after* this point — already-spawned tasks
+        // are still awaited. axum drains in-flight handlers before this runs,
+        // so every detached execution has already been spawned.
+        drained += self.detached_executions.len();
+        self.detached_executions.close();
+        self.detached_executions.wait().await;
+
         drained
+    }
+
+    /// Execute a non-streaming request that **always runs to completion**, even
+    /// if the caller (an HTTP request handler) is dropped because the client
+    /// disconnected.
+    ///
+    /// axum/hyper drops the request-handler future the instant the client
+    /// disconnects, which would otherwise cancel the in-flight upstream call
+    /// mid-prefill and skip Stage-4 settlement — the client pays nothing while
+    /// the upstream still bills us for the request it accepted. This mirrors
+    /// OpenRouter's documented behaviour: for non-streaming requests the model
+    /// "will continue processing and you will be billed for the complete
+    /// response" (<https://openrouter.ai/docs/api/reference/streaming>).
+    ///
+    /// The work is spawned onto a shutdown-tracked task, so dropping the
+    /// returned future no longer cancels it. The connected caller still awaits
+    /// the task's `JoinHandle` and gets the real response. Streaming requests
+    /// keep their own cancel-on-disconnect path ([`Pipeline::execute_stream`]).
+    pub async fn execute_detached(
+        self: Arc<Self>,
+        req: PipelineRequest,
+    ) -> Result<PipelineResponse> {
+        let pipeline = Arc::clone(&self);
+        // `tokio::spawn` does not propagate the current tracing span, so attach
+        // it explicitly — otherwise the whole request's logs would detach from
+        // the handler's request span / trace context.
+        let span = tracing::Span::current();
+        let handle = self
+            .detached_executions
+            .spawn(async move { pipeline.execute(req).await }.instrument(span));
+        match handle.await {
+            Ok(result) => result,
+            // The task panicked or was aborted (it is never aborted by us). The
+            // settlement inside `execute` already ran or the panic precluded it;
+            // surface a clean internal error to the still-connected caller.
+            Err(join_err) => Err(BitrouterError::internal(format!(
+                "non-streaming execution task failed to complete: {join_err}"
+            ))),
+        }
     }
 
     /// Execute a non-streaming request: the four stages, in order.

--- a/crates/bitrouter-sdk/src/language_model/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/tests.rs
@@ -934,3 +934,114 @@ async fn executor_rejects_response_format_on_unsupported_outbound() {
         other => panic!("expected BadRequest, got {other:?}"),
     }
 }
+
+// ===== non-streaming client-disconnect billing (OpenRouter parity) =====
+
+/// An executor whose `execute` blocks on a gate until the test releases it, so
+/// the test can deterministically drop the request future *while the upstream
+/// call is still in flight* — the exact shape of a mid-request client
+/// disconnect.
+struct GatedExecutor {
+    gate: Arc<tokio::sync::Notify>,
+    usage: (u64, u64),
+}
+#[async_trait]
+impl Executor for GatedExecutor {
+    async fn execute(
+        &self,
+        target: &RoutingTarget,
+        _prompt: &Prompt,
+        _ctx: &PipelineContext,
+    ) -> Result<ExecutionResult> {
+        self.gate.notified().await;
+        let (prompt_tokens, completion_tokens) = self.usage;
+        Ok(ExecutionResult {
+            provider_id: target.provider_name.clone(),
+            model_id: target.service_id.clone(),
+            account_label: target.account_label.clone(),
+            result: GenerateResult {
+                content: vec![Content::Text {
+                    text: "done".into(),
+                }],
+                usage: Some(Usage {
+                    prompt_tokens,
+                    completion_tokens,
+                    ..Default::default()
+                }),
+                finish_reason: Some(FinishReason::Stop),
+                response_id: None,
+                stop_details: None,
+            },
+            latency_ms: 1,
+            generation_time_ms: 1,
+        })
+    }
+    async fn execute_stream(
+        &self,
+        _target: &RoutingTarget,
+        _prompt: &Prompt,
+        _ctx: &PipelineContext,
+    ) -> Result<StreamPartStream> {
+        Err(BitrouterError::internal(
+            "GatedExecutor: streaming not used",
+        ))
+    }
+}
+
+#[tokio::test]
+async fn nonstream_execute_detached_returns_full_usage_when_connected() {
+    let captured = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let pipeline = pipeline_with(
+        routing_table(&["openai"]),
+        Arc::new(MockExecutor::always_text("hello")),
+        |b| {
+            b.settlement_recorder(UsageCapturingRecorder(captured.clone()));
+        },
+    );
+
+    let resp = pipeline
+        .clone()
+        .execute_detached(request())
+        .await
+        .expect("connected request succeeds");
+    assert_eq!(resp.result.content.len(), 1);
+    // `always_text` reports usage (prompt=10, completion=5).
+    assert_eq!(captured.lock().unwrap().clone(), vec![(10, 5)]);
+}
+
+#[tokio::test]
+async fn nonstream_disconnect_still_runs_to_completion_and_bills_full() {
+    let captured = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let gate = Arc::new(tokio::sync::Notify::new());
+    let pipeline = pipeline_with(
+        routing_table(&["openai"]),
+        Arc::new(GatedExecutor {
+            gate: gate.clone(),
+            usage: (7, 11),
+        }),
+        |b| {
+            b.settlement_recorder(UsageCapturingRecorder(captured.clone()));
+        },
+    );
+
+    // Start the request, then drop the handler future before it resolves —
+    // exactly what axum does to the handler when the client disconnects. The
+    // upstream call is gated, so the detached task cannot have finished yet.
+    let mut fut = Box::pin(pipeline.clone().execute_detached(request()));
+    assert!(
+        futures::poll!(fut.as_mut()).is_pending(),
+        "detached task spawned but gated; handler future still pending"
+    );
+    drop(fut); // client disconnected
+
+    // The request must still run to completion and settle the real full usage.
+    gate.notify_one();
+    let drained = pipeline.drain_pending_settlements().await;
+    assert!(drained >= 1, "the detached execution was awaited on drain");
+
+    assert_eq!(
+        captured.lock().unwrap().clone(),
+        vec![(7, 11)],
+        "non-stream disconnect bills the full upstream usage, not zero"
+    );
+}

--- a/crates/bitrouter-sdk/src/server.rs
+++ b/crates/bitrouter-sdk/src/server.rs
@@ -95,12 +95,13 @@ impl App {
             .await
             .map_err(|e| BitrouterError::internal(format!("serve: {e}")))?;
         // After the HTTP server drains, also wait for every detached client-
-        // disconnect settlement task (StreamSettlementGuard::drop). Without
-        // this, SIGTERM during heavy streaming traffic could drop the
-        // detached tasks mid-await and lose receipts.
+        // disconnect settlement task (StreamSettlementGuard::drop) and every
+        // detached non-streaming execution (Pipeline::execute_detached).
+        // Without this, SIGTERM during heavy traffic could drop those tasks
+        // mid-await and lose receipts.
         let drained = drain_pipeline.drain_pending_settlements().await;
         if drained > 0 {
-            tracing::info!(drained, "drained pending streaming settlements on shutdown");
+            tracing::info!(drained, "drained pending settlements on shutdown");
         }
         Ok(())
     }
@@ -610,7 +611,11 @@ async fn handle(
             &prompt.model,
         )
     } else {
-        match state.language_model.execute(req).await {
+        // `execute_detached`, not `execute`: a non-streaming request must run to
+        // completion and settle even if the client disconnects (axum drops this
+        // handler future on disconnect). The upstream bills us for the accepted
+        // request regardless, so the customer must be billed too.
+        match state.language_model.clone().execute_detached(req).await {
             Ok(resp) => match adapter.render_response(&resp.result, &prompt, &resp.request_id) {
                 Ok(json) => Json(json).into_response(),
                 Err(e) => e.into_response(),


### PR DESCRIPTION
## Problem

axum/hyper **drops the request-handler future the instant the client disconnects** ([axum maintainers confirm this](https://github.com/tokio-rs/axum/discussions/2811): "to survive a client disconnection you need `tokio::spawn` inside the handler"). For a non-streaming request that means the in-flight upstream call is cancelled mid-prefill and **Stage-4 settlement never runs** — the client pays $0 while the upstream still bills us for the request it accepted.

## Fix (OpenRouter parity)

OpenRouter: for non-streaming requests the model *"will continue processing and you will be billed for the complete response"* (<https://openrouter.ai/docs/api/reference/streaming>). We match that:

- New **`Pipeline::execute_detached(self: Arc<Self>, req)`** spawns `execute()` onto a shutdown-tracked `tokio_util::task::TaskTracker` and awaits the `JoinHandle`. Dropping the returned future (the handler, on disconnect) drops the handle but **does not abort** the tokio task, so the request runs to completion and settles the **real upstream usage**. The connected caller still gets the real response, unchanged.
- A `TaskTracker` (not the existing `Mutex<JoinSet>`) because *every* non-streaming request runs here — it auto-reaps completed tasks (no unbounded growth) and adds only one spawn + one atomic per request, no lock contention.
- `drain_pending_settlements()` now also `close()`s + `wait()`s the tracker so a SIGTERM can't cut an in-flight detached execution.
- The server's non-streaming handler calls `execute_detached`. **Streaming is unchanged** (keeps its existing cancel-on-disconnect path).

Per the locked decision: upstream cancellability is assumed (not probed); non-streaming always runs to completion; token estimation is untouched.

## Tests

A gated executor + two tests: (1) connected request returns the full real usage `(10,5)`; (2) client disconnect mid-request (drop the handler future after the first poll) still runs to completion and settles the **full real usage `(7,11)`, not zero**. `cargo test/clippy/fmt --all-features` green; reviewed by an independent agent (PASS, core claim verified against tokio-util source).

## Out of scope

The MCP `tools/call` handler (`mcp::Pipeline`) has the same disconnect-cancellation behavior but its settlement is separate from LLM billing — not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)