### PR TITLE
fix(mcp): add package description for crates.io publish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -807,7 +807,7 @@ dependencies = [
 
 [[package]]
 name = "bitrouter-mcp"
-version = "1.0.0-alpha.9"
+version = "1.0.0-alpha.11"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "bitrouter-mcp"
+description = "BitRouter origin MCP server: exposes complete/list_models/status over stdio and streamable HTTP."
 version.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary

The release workflow's `cargo publish` failed for `bitrouter-mcp`:

```
missing or empty metadata fields: description
```

`bitrouter-mcp` (added in #530) was the only publishable workspace crate without a `description` field, which crates.io requires. This adds one, matching the per-crate `description` convention used by the other crates (`bitrouter-sdk`, `bitrouter-cloud-sdk`, etc.).

## Test Plan

- `cargo publish --dry-run --no-verify -p bitrouter-mcp` now packages and reaches the upload step with no metadata error (previously failed on the missing `description`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)