### PR TITLE
feat(skills): add cost-routed-subagents skill

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -7,7 +7,9 @@ a skill change ships in the same PR as the change that motivates it.
 
 ## What's here
 
-One skill: **`/bitrouter`**, at [`bitrouter/`](bitrouter/).
+Two skills, both following the [Agent Skills specification](https://agentskills.io/specification).
+
+### `/bitrouter`, at [`bitrouter/`](bitrouter/)
 
 ```
 skills/bitrouter/
@@ -21,9 +23,30 @@ skills/bitrouter/
     └── harness-*.md
 ```
 
-It covers the Local-or-Cloud decision, install, daemon lifecycle, cloud
-onboarding, provider config, migration off other gateways, diagnostics, and
-per-harness wiring. Follows the [Agent Skills specification](https://agentskills.io/specification).
+Covers the Local-or-Cloud decision, install, daemon lifecycle, cloud onboarding,
+provider config, migration off other gateways, diagnostics, and per-harness wiring.
+
+### `/cost-routed-subagents`, at [`cost-routed-subagents/`](cost-routed-subagents/)
+
+```
+skills/cost-routed-subagents/
+├── SKILL.md          # entry point — keep under ~200 lines
+├── dispatch.sh       # spawn one headless worker on a cheap model via BitRouter
+├── references/       # loaded on demand
+│   ├── setup.md            # env contract + secret-safe key handling
+│   ├── model-tiers.md      # tier policy, populate from /v1/models
+│   ├── dispatch-protocol.md# controller loop, status, two-stage review
+│   └── attribution.md      # methodology adapted from obra/superpowers (MIT)
+└── role-prompts/     # injected into workers via --append-system-prompt
+    ├── implementer.md
+    ├── spec-reviewer.md
+    └── quality-reviewer.md
+```
+
+A usage pattern for the Anthropic-shaped `/v1/messages` surface: a flagship
+controller session delegates sub-tasks to cheaper models by spawning headless
+`claude -p` workers whose `ANTHROPIC_*` env is pointed at a BitRouter endpoint.
+HTTP API + environment variables only — no CLI in the dispatch path.
 
 ## Install
 

--- a/skills/cost-routed-subagents/SKILL.md
+++ b/skills/cost-routed-subagents/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: cost-routed-subagents
+description: >
+  Use this skill when a capable "controller" coding session (e.g. Claude
+  Code on a flagship model, billed directly to Anthropic) should keep
+  orchestrating and reviewing, but hand the bulk of the actual work to
+  CHEAPER models to cut cost. Workers run as headless `claude -p` child
+  processes whose ANTHROPIC_* environment is pointed at a BitRouter
+  Anthropic-compatible endpoint (local daemon at http://127.0.0.1:4356 or
+  a managed endpoint), so each sub-task can run on an inexpensive
+  open-source model (provider/model ids resolved from /v1/models). Covers
+  the cheap-vs-flagship tier decision, the dispatch + two-stage review
+  protocol, secret-safe API-key handling (the controller never sees the
+  key value), and git-worktree isolation. Trigger on "run subagents on a
+  cheaper model", "use bitrouter to make agents cheaper", "delegate this
+  to a cheap model and review the result", "cost-routed agents",
+  "orchestrate with cheap workers".
+version: 1.0.0
+license: Apache-2.0
+metadata:
+  author: BitRouterAI
+  tags: [agents, subagents, cost-optimization, routing, anthropic, claude-code, bitrouter, orchestration]
+---
+
+# Cost-Routed Subagents
+
+Keep the expensive flagship model for **orchestration and judgment**; push the
+**bulk token spend** down to cheap models. The controller (this session) plans,
+curates context, dispatches focused workers, and reviews their diffs. Each worker
+is a headless `claude -p` process whose `ANTHROPIC_*` environment is redirected at
+a **BitRouter** Anthropic-compatible endpoint, so it runs on an inexpensive
+`provider/model` while the controller stays on its own (direct) billing.
+
+This is a usage pattern for BitRouter's Anthropic-shaped `/v1/messages` surface.
+It uses **only the HTTP API + environment variables** — no BitRouter CLI calls in
+the dispatch path, and no custom secret store.
+
+## Why native subagents are not enough
+
+Claude Code's native subagents (the Task tool / `.claude/agents/`) share the
+session's `ANTHROPIC_BASE_URL` and credentials — they can pick a model *alias*
+but cannot be pointed at a different provider. To route a sub-task to a cheaper
+provider you must spawn a **separate process** with its own environment. That is
+exactly what this skill does.
+
+## The mechanism (one block)
+
+A worker is `claude -p` with four environment overrides plus `--bare`. The
+controller never embeds the key value — it references the variable, the shell
+expands it inside the child, so the secret never enters this session's transcript:
+
+```bash
+ANTHROPIC_BASE_URL="$BITROUTER_BASE_URL" \   # BitRouter endpoint, Anthropic shape (NO trailing /v1)
+ANTHROPIC_AUTH_TOKEN="$BITROUTER_API_KEY" \  # brk_* key — referenced, never printed
+ANTHROPIC_MODEL="opencode-go/glm-5.1" \      # a provider/model id from the /v1/models list
+CLAUDE_CONFIG_DIR="$HOME/.config/cost-routed-child" \  # clean config home for the worker
+claude -p "$(cat task.md)" \
+  --bare \                                   # skip hooks/plugins/CLAUDE.md/keychain — a lean worker
+  --output-format stream-json \
+  --permission-mode acceptEdits \
+  --allowed-tools "Read,Edit,Bash,Grep,Glob" \
+  --append-system-prompt "$(cat role-prompts/implementer.md)"
+```
+
+`./dispatch.sh` wraps exactly this (tier resolution, key preflight, lean config,
+redacted `--dry-run`). Prefer it over hand-writing the command:
+
+```bash
+./dispatch.sh --tier cheap --task task.md --dir "$PWD" --role implementer
+./dispatch.sh --model anthropic/claude-haiku-4-5 --task task.md --dry-run   # prints wiring, key redacted
+```
+
+> **Base-URL footgun.** Claude Code speaks the Anthropic Messages API and appends
+> `/v1/messages` itself. So `BITROUTER_BASE_URL` for the Anthropic shape **omits**
+> `/v1` (e.g. `http://127.0.0.1:4356`). The OpenAI shape *keeps* `/v1`; do not copy
+> that here. See [Anthropic Messages API](https://docs.anthropic.com/en/api/messages)
+> and [Claude Code settings / env vars](https://code.claude.com/docs/en/settings).
+
+## When to use / when not
+
+**Use when** a task decomposes into focused, well-specified sub-tasks (implement a
+spec'd function, fix an isolated test, mechanical refactor, draft docs) that a
+cheaper model can finish from fully-provided context, and the controller will
+review the result.
+
+**Don't use when** the work is exploratory ("figure out what's broken"), needs the
+controller's full conversation context, requires cross-task shared state, or is so
+small that a single inline edit is faster than spawning a process.
+
+## Choosing a tier
+
+Match task difficulty to the **cheapest model that can do it**; the controller is
+the safety net. See [references/model-tiers.md](references/model-tiers.md) for the
+full policy and how to populate tiers from `/v1/models`.
+
+| Tier | For | Resolved from |
+|---|---|---|
+| `cheap` | mechanical, 1–2 files, clear spec, light tool-use | `$BITROUTER_MODEL_CHEAP` |
+| `standard` | multi-file integration, some judgment, heavier tool-use | `$BITROUTER_MODEL_STANDARD` |
+| `flagship` | architecture, final review, anything the cheap tiers fail | `$BITROUTER_MODEL_FLAGSHIP` |
+
+Open-source models vary in agentic tool-use reliability. Bias tool-heavy work
+toward the stronger tiers, and always let the controller verify.
+
+## Dispatch protocol
+
+The controller curates the worker's full context (workers do **not** read the plan
+or this conversation), dispatches, then runs a two-stage review. Workers report a
+status: `DONE` / `DONE_WITH_CONCERNS` / `BLOCKED` / `NEEDS_CONTEXT`. Because a
+worker is one-shot (no mid-task questions), a `NEEDS_CONTEXT` reply means
+re-dispatch with more context — see
+[references/dispatch-protocol.md](references/dispatch-protocol.md).
+
+- **Implementer** → `cheap`/`standard` tier (the bulk of token spend).
+- **Spec review + code-quality review** → keep on a strong tier; cheap reviewers
+  miss things.
+- **Final integration review** → the controller (this session), reading diffs.
+
+## Safety
+
+- **Isolate writes.** Run workers inside a dedicated git worktree, not the
+  controller's checkout. Constrain `--allowed-tools` and pass only the needed
+  `--add-dir`. The controller reviews every diff before integrating.
+- **Autonomy.** `--permission-mode acceptEdits` lets a worker edit without
+  prompting — combined with a worktree and a tool allow-list, the blast radius is
+  bounded.
+- **Secrets.** Never `echo`/`printenv`/`cat` the key; the controller only ever
+  references `$BITROUTER_API_KEY`. See [references/setup.md](references/setup.md).
+
+## References
+
+| File | When to read |
+|---|---|
+| [references/setup.md](references/setup.md) | One-time setup: env contract, secret-safe key handling (plain env / direnv / 1Password), the lean child config dir, preflight |
+| [references/model-tiers.md](references/model-tiers.md) | Tier policy, populating tiers from `/v1/models`, tool-use reliability notes |
+| [references/dispatch-protocol.md](references/dispatch-protocol.md) | Controller loop, status protocol, two-stage review, `NEEDS_CONTEXT` re-dispatch |
+| [references/attribution.md](references/attribution.md) | Methodology attribution (adapted from obra/superpowers, MIT) |
+
+The role system prompts live in [`role-prompts/`](role-prompts/) and are injected
+into workers via `--append-system-prompt`.
+
+## Relation to the `bitrouter` skill
+
+This skill assumes you already have a reachable BitRouter endpoint. For installing
+the daemon, cloud onboarding, minting `brk_*` keys, or wiring a *single* Claude
+Code session at `127.0.0.1:4356`, use the `bitrouter` skill's
+`references/harness-claude-code.md`. This skill is specifically about **dispatching
+cheaper workers from a flagship controller**.

--- a/skills/cost-routed-subagents/dispatch.sh
+++ b/skills/cost-routed-subagents/dispatch.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+#
+# dispatch.sh — spawn one headless Claude Code worker on a cheap model via BitRouter.
+#
+# A "worker" is a `claude -p` (print/headless) child process whose Anthropic-shaped
+# environment is redirected at a BitRouter endpoint, so a sub-task runs on an
+# inexpensive `provider/model` while the controller session stays on its own billing.
+#
+# This script touches ONLY the HTTP API + environment variables. It makes no
+# BitRouter CLI calls and stores no secret — the key is read from the environment
+# and forwarded to the child; it is never printed (see --dry-run, which redacts it).
+#
+# Protocols / contracts this integrates with (cite the source per repo policy):
+#   - Claude Code headless mode and ANTHROPIC_* environment variables:
+#       https://code.claude.com/docs/en/headless
+#       https://code.claude.com/docs/en/settings
+#   - Anthropic Messages API (the wire shape BitRouter accepts at /v1/messages):
+#       https://docs.anthropic.com/en/api/messages
+#   - BitRouter exposes that shape; for endpoint/auth setup see the `bitrouter` skill.
+#
+# License: Apache-2.0. Dispatch/review methodology adapted from obra/superpowers
+# (MIT) — see references/attribution.md.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+usage() {
+  cat <<'EOF'
+Usage: dispatch.sh --task <file|-> (--tier cheap|standard|flagship | --model <provider/model>) [options]
+
+Required:
+  --task <file|->          Task prompt: a file path, or "-" to read stdin.
+  --tier <name>            cheap | standard | flagship (resolved from $BITROUTER_MODEL_<TIER>).
+  --model <provider/model> Explicit model id; overrides --tier.
+
+Options:
+  --role <name|path>       Role system prompt: a name under role-prompts/ (implementer,
+                           spec-reviewer, quality-reviewer) or a file path. Default: implementer.
+  --dir <path>             Working directory for the worker (also passed via --add-dir).
+                           Default: current directory. Use a git worktree for isolation.
+  --allowed-tools <csv>    Tools the worker may use. Default: Read,Edit,Bash,Grep,Glob.
+  --permission-mode <m>    Claude Code permission mode. Default: acceptEdits.
+  --output-format <f>      stream-json | json | text. Default: stream-json.
+  --timeout <secs>         Wall-clock timeout for the worker. Default: none.
+  --dry-run                Print the resolved invocation (KEY REDACTED) and exit 0.
+  -h, --help               This help.
+
+Environment (set these out-of-band; the controller agent references names, not values):
+  BITROUTER_BASE_URL       BitRouter endpoint, Anthropic shape, NO trailing /v1
+                           (e.g. http://127.0.0.1:4356).            [required]
+  BITROUTER_API_KEY        brk_* key (or "unused" for a skip_auth local daemon). [required]
+  BITROUTER_MODEL_CHEAP    provider/model for --tier cheap.
+  BITROUTER_MODEL_STANDARD provider/model for --tier standard.
+  BITROUTER_MODEL_FLAGSHIP provider/model for --tier flagship.
+  BITROUTER_CHILD_CONFIG_DIR  Lean CLAUDE_CONFIG_DIR for workers.
+                           Default: $HOME/.config/cost-routed-child.
+EOF
+}
+
+die() { echo "dispatch.sh: $*" >&2; exit 2; }
+# Guard a two-argument flag: $1 is the flag, $# is the remaining arg count.
+# Without this, `shift 2` on a trailing flag with no operand aborts under `set -e`
+# with no diagnostic.
+require2() { [[ $# -ge 2 ]] || die "$1 needs a value."; }
+
+# --- parse args ---------------------------------------------------------------
+TASK="" TIER="" MODEL="" ROLE="implementer" DIR="" ALLOWED_TOOLS="Read,Edit,Bash,Grep,Glob"
+PERM_MODE="acceptEdits" OUTPUT_FORMAT="stream-json" TIMEOUT="" DRY_RUN=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --task) require2 "$@"; TASK="$2"; shift 2 ;;
+    --tier) require2 "$@"; TIER="$2"; shift 2 ;;
+    --model) require2 "$@"; MODEL="$2"; shift 2 ;;
+    --role) require2 "$@"; ROLE="$2"; shift 2 ;;
+    --dir) require2 "$@"; DIR="$2"; shift 2 ;;
+    --allowed-tools) require2 "$@"; ALLOWED_TOOLS="$2"; shift 2 ;;
+    --permission-mode) require2 "$@"; PERM_MODE="$2"; shift 2 ;;
+    --output-format) require2 "$@"; OUTPUT_FORMAT="$2"; shift 2 ;;
+    --timeout) require2 "$@"; TIMEOUT="$2"; shift 2 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) die "unknown argument: $1 (try --help)" ;;
+  esac
+done
+
+# --- preflight: endpoint + key present (NEVER print the value) ----------------
+[[ -n "${BITROUTER_BASE_URL:-}" ]] || die "BITROUTER_BASE_URL is not set (Anthropic shape, no /v1)."
+[[ -n "${BITROUTER_API_KEY:-}"  ]] || die "BITROUTER_API_KEY is not set."
+case "$BITROUTER_BASE_URL" in
+  */v1|*/v1/) echo "dispatch.sh: warning: BITROUTER_BASE_URL ends in /v1 — the Anthropic shape omits it; Claude Code appends /v1/messages itself." >&2 ;;
+esac
+
+# --- resolve model from --model or --tier -------------------------------------
+if [[ -z "$MODEL" ]]; then
+  [[ -n "$TIER" ]] || die "provide --model or --tier."
+  # Branch-local var names keep this portable to bash 3.2 (no ${var^^}).
+  case "$TIER" in
+    cheap)    MODEL="${BITROUTER_MODEL_CHEAP:-}";    TIER_VAR="BITROUTER_MODEL_CHEAP" ;;
+    standard) MODEL="${BITROUTER_MODEL_STANDARD:-}"; TIER_VAR="BITROUTER_MODEL_STANDARD" ;;
+    flagship) MODEL="${BITROUTER_MODEL_FLAGSHIP:-}"; TIER_VAR="BITROUTER_MODEL_FLAGSHIP" ;;
+    *) die "unknown --tier '$TIER' (expected cheap|standard|flagship)." ;;
+  esac
+  [[ -n "$MODEL" ]] || die "tier '$TIER' has no model: set $TIER_VAR (discover ids via GET \$BITROUTER_BASE_URL/v1/models) or pass --model."
+fi
+
+# --- resolve role system prompt ----------------------------------------------
+if [[ -f "$ROLE" ]]; then
+  ROLE_FILE="$ROLE"
+else
+  ROLE_FILE="$SCRIPT_DIR/role-prompts/$ROLE.md"
+fi
+[[ -f "$ROLE_FILE" ]] || die "role prompt not found: $ROLE (looked for '$ROLE_FILE')."
+[[ -s "$ROLE_FILE" ]] || die "role prompt is empty: $ROLE_FILE"
+
+# --- resolve task prompt ------------------------------------------------------
+[[ -n "$TASK" ]] || die "--task is required (a file path, or - for stdin)."
+if [[ "$TASK" == "-" ]]; then
+  TASK_TEXT="$(cat)"
+else
+  [[ -f "$TASK" ]] || die "task file not found: $TASK"
+  TASK_TEXT="$(cat "$TASK")"
+fi
+[[ -n "$TASK_TEXT" ]] || die "task prompt is empty."
+
+DIR="${DIR:-$PWD}"
+[[ -d "$DIR" ]] || die "working dir not found: $DIR"
+
+# Clean global config home for the worker (no controller settings/credentials).
+CHILD_CONFIG_DIR="${BITROUTER_CHILD_CONFIG_DIR:-$HOME/.config/cost-routed-child}"
+
+# --- assemble the claude argv (shared by dry-run and real run) ---------------
+# `--bare` is the isolation lever: it skips hooks, LSP, plugin sync, auto-memory,
+# keychain reads, and CLAUDE.md auto-discovery — so a cheap worker is not handed a
+# large session preamble, is not pushed to invoke skills, and cannot fall back to
+# the controller's keychain credentials. The controller supplies everything the
+# worker needs through the role prompt and task text.
+CLAUDE_ARGS=( -p "$TASK_TEXT"
+  --bare
+  --output-format "$OUTPUT_FORMAT"
+  --permission-mode "$PERM_MODE"
+  --allowed-tools "$ALLOWED_TOOLS"
+  --add-dir "$DIR"
+  --append-system-prompt "$(cat "$ROLE_FILE")" )
+
+run_worker() {
+  mkdir -p "$CHILD_CONFIG_DIR"
+  # Run in a subshell so these overrides never leak into the controller's env.
+  # ANTHROPIC_API_KEY is unset so the worker cannot fall back to the controller's
+  # direct Anthropic credential — it must use the BitRouter token below.
+  (
+    cd "$DIR"
+    unset ANTHROPIC_API_KEY
+    export ANTHROPIC_BASE_URL="$BITROUTER_BASE_URL"
+    export ANTHROPIC_AUTH_TOKEN="$BITROUTER_API_KEY"
+    export ANTHROPIC_MODEL="$MODEL"
+    export CLAUDE_CONFIG_DIR="$CHILD_CONFIG_DIR"
+    if [[ -n "$TIMEOUT" ]]; then
+      # `timeout` ships with GNU coreutils; macOS users may have `gtimeout` instead.
+      if command -v timeout >/dev/null 2>&1; then
+        exec timeout "$TIMEOUT" claude "${CLAUDE_ARGS[@]}"
+      elif command -v gtimeout >/dev/null 2>&1; then
+        exec gtimeout "$TIMEOUT" claude "${CLAUDE_ARGS[@]}"
+      else
+        echo "dispatch.sh: warning: --timeout set but no timeout/gtimeout found; running without it." >&2
+        exec claude "${CLAUDE_ARGS[@]}"
+      fi
+    else
+      exec claude "${CLAUDE_ARGS[@]}"
+    fi
+  )
+}
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  echo "# dispatch.sh --dry-run (no worker spawned; key redacted)"
+  echo "cd $DIR"
+  echo "ANTHROPIC_BASE_URL=$BITROUTER_BASE_URL \\"
+  echo "ANTHROPIC_AUTH_TOKEN=***redacted*** \\"
+  echo "ANTHROPIC_MODEL=$MODEL \\"
+  echo "CLAUDE_CONFIG_DIR=$CHILD_CONFIG_DIR \\"
+  printf 'claude -p <%d-byte task> --bare --output-format %s --permission-mode %s \\\n' \
+    "${#TASK_TEXT}" "$OUTPUT_FORMAT" "$PERM_MODE"
+  printf '  --allowed-tools %s --add-dir %s --append-system-prompt <%s>\n' \
+    "$ALLOWED_TOOLS" "$DIR" "$ROLE_FILE"
+  exit 0
+fi
+
+run_worker

--- a/skills/cost-routed-subagents/references/attribution.md
+++ b/skills/cost-routed-subagents/references/attribution.md
@@ -1,0 +1,44 @@
+# Attribution
+
+This skill is licensed **Apache-2.0**, consistent with the rest of this repository.
+
+The dispatch-and-review **methodology** it encodes — a controller that curates
+context and delegates to fresh single-purpose workers, the
+`DONE / DONE_WITH_CONCERNS / NEEDS_CONTEXT / BLOCKED` status protocol, the
+two-stage (spec-compliance then code-quality) review, and the
+cheapest-model-that-can-do-the-job tier heuristic — is **adapted from the
+`superpowers` project** by Jesse Vincent (`subagent-driven-development` and
+`dispatching-parallel-agents` skills):
+
+- Source: https://github.com/obra/superpowers
+- License: MIT
+
+The text here is re-authored for this skill; the *ideas* are credited above. The
+implementation layer (headless `claude -p` workers routed through a BitRouter
+Anthropic-compatible endpoint) is original to this repository.
+
+Per the MIT license, its permission notice is reproduced below.
+
+```
+MIT License
+
+Copyright (c) Jesse Vincent and superpowers contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/skills/cost-routed-subagents/references/dispatch-protocol.md
+++ b/skills/cost-routed-subagents/references/dispatch-protocol.md
@@ -1,0 +1,68 @@
+# Dispatch protocol: controller loop, status, two-stage review
+
+The controller (your flagship session) never lets a worker wander. It curates the
+worker's entire context, dispatches a focused task, then reviews. Workers are
+**one-shot** `claude -p` processes: they cannot ask mid-task questions, so context
+must be complete up front, and "I need more" comes back as a status, not a prompt.
+
+> Methodology adapted from obra/superpowers (MIT) — `subagent-driven-development`
+> and `dispatching-parallel-agents`. See [attribution.md](attribution.md).
+
+## The controller loop
+
+For each independent sub-task:
+
+1. **Curate context.** Paste the full task text and the scene-setting the worker
+   needs (where it fits, constraints, the interface it must honor). Do **not** tell
+   the worker to "read the plan" — it has no access to this conversation.
+2. **Pick a tier.** See [model-tiers.md](model-tiers.md). Implementer →
+   `cheap`/`standard`. Reviewers → strong tier.
+3. **Dispatch the implementer** into an isolated git worktree:
+   `./dispatch.sh --tier cheap --role implementer --task task.md --dir "$WORKTREE"`.
+4. **Handle the status** (below).
+5. **Two-stage review** once the implementer reports `DONE`: spec compliance first,
+   then code quality. Re-dispatch fixes until both pass.
+6. **Integrate.** The controller reads the diff and merges. The controller is the
+   final reviewer — never skip this.
+
+Parallelism: independent sub-tasks can run as concurrent `dispatch.sh` background
+jobs (different worktrees). Do **not** run parallel writers in the *same* directory.
+
+## Worker status protocol
+
+Every worker (implementer or reviewer) ends with one of:
+
+| Status | Meaning | Controller action |
+|---|---|---|
+| `DONE` | Completed and self-reviewed. | Proceed to review (implementer) / accept verdict (reviewer). |
+| `DONE_WITH_CONCERNS` | Completed but flagged doubts. | Read the concerns; address correctness/scope before review; note observations. |
+| `NEEDS_CONTEXT` | Missing information it couldn't obtain. | Provide the missing context; **re-dispatch** (this replaces a mid-task question). |
+| `BLOCKED` | Cannot complete. | Re-dispatch one tier up, split the task smaller, or escalate to the human. Never silently retry the same model unchanged. |
+
+## Two-stage review (after implementer `DONE`)
+
+1. **Spec compliance** — `./dispatch.sh --tier standard --role spec-reviewer …`.
+   Does the change implement exactly the spec — nothing missing, nothing extra?
+   Issues → implementer fixes → re-review. Do **not** start stage 2 until stage 1
+   is clean.
+2. **Code quality** — `./dispatch.sh --tier standard --role quality-reviewer …`.
+   Naming, structure, tests-verify-behavior, YAGNI, follows existing patterns.
+   Issues → implementer fixes → re-review.
+
+Then the controller does the final integration review on the diff.
+
+## Why two stages and not one
+
+Spec compliance and code quality fail in different ways and a single pass tends to
+privilege one. Separating them keeps "did we build the right thing?" distinct from
+"did we build the thing right?", and keeps each reviewer's prompt small.
+
+## Hard rules
+
+- Never start implementation on `main`/`master` without explicit human consent.
+- Provide full task text — never make a worker read the plan file.
+- Don't skip either review, and don't move on while a review has open issues.
+- A reviewer finding issues means **not done** — the implementer fixes, then the
+  reviewer re-reviews.
+- Don't dispatch parallel implementers into the same directory.
+- The controller's final diff review is mandatory, especially for `cheap`-tier work.

--- a/skills/cost-routed-subagents/references/model-tiers.md
+++ b/skills/cost-routed-subagents/references/model-tiers.md
@@ -1,0 +1,62 @@
+# Model tiers: choosing the cheapest model that can do the job
+
+The controller's job is to spend flagship tokens on **judgment**, not typing. Pick
+the cheapest tier that can finish a sub-task from fully-provided context; the
+controller's review is the safety net.
+
+## The three tiers
+
+| Tier | Use for | Risk |
+|---|---|---|
+| `cheap` | Mechanical, well-specified, 1–2 files, light tool-use: implement a spec'd function, fix one isolated test, rename, draft boilerplate/docs. | Lowest cost; weakest at multi-step tool-use. |
+| `standard` | Multi-file integration, pattern-matching, moderate judgment, heavier tool-use loops. | Mid cost; usually reliable at agentic edits. |
+| `flagship` | Architecture/design, the final code review, and anything the cheaper tiers got wrong. May be a flagship model *through* BitRouter, or the controller itself. | Highest cost; reserve it. |
+
+**Complexity signals** (from the controller's vantage):
+
+- Touches 1–2 files with a complete spec → `cheap`.
+- Touches several files with integration concerns → `standard`.
+- Needs design judgment or broad codebase understanding → `flagship`/controller.
+
+## Populate tiers from the live model list
+
+Tier env vars hold real model ids. A BitRouter model id is addressed as
+`provider/model`; discover exactly what your endpoint serves via the API (no CLI
+needed):
+
+```bash
+curl -s "$BITROUTER_BASE_URL/v1/models" \
+  -H "Authorization: Bearer $BITROUTER_API_KEY" | jq -r '.data[].id'
+```
+
+Then assign, for example:
+
+```bash
+export BITROUTER_MODEL_CHEAP="opencode-go/glm-5.1"           # cheap OSS — verify against /v1/models
+export BITROUTER_MODEL_STANDARD="anthropic/claude-haiku-4-5" # verify against /v1/models
+export BITROUTER_MODEL_FLAGSHIP="anthropic/claude-sonnet-4-5" # verify against /v1/models
+```
+
+> The ids above illustrate the `provider/model` **shape** only. Always confirm the
+> exact ids against your endpoint's `/v1/models` — provider catalogs and version
+> suffixes change. You can also append a routing variant (e.g. a `:cost` preference)
+> if your BitRouter config defines one.
+
+## Tool-use reliability matters more than raw price
+
+Claude Code drives workers through the Anthropic tool-call format; BitRouter
+translates that to each provider. Cheaper open-source models vary in how reliably
+they emit well-formed tool calls and avoid loops. Practical guidance:
+
+- For **tool-heavy** sub-tasks (lots of Read/Edit/Bash), prefer a `standard`-tier
+  model known to be strong at agentic tool-use over the very cheapest option.
+- For **single-shot, low-tool** sub-tasks (draft a doc, transform one file), the
+  `cheap` tier is usually fine.
+- If a worker returns `BLOCKED` or produces malformed output, **re-dispatch one
+  tier up** rather than retrying the same model unchanged.
+
+## Verify the savings
+
+Cost reduction is a claim — measure it. Compare token spend before/after on a
+representative task using your BitRouter endpoint's own usage/observability
+surface. Don't assert savings you haven't observed.

--- a/skills/cost-routed-subagents/references/setup.md
+++ b/skills/cost-routed-subagents/references/setup.md
@@ -1,0 +1,113 @@
+# Setup: environment contract & secret-safe key handling
+
+One-time setup. The goal: the controller session can dispatch workers, but the
+**API-key value never enters the controller's context or transcript** — the
+controller only ever references the *name* `$BITROUTER_API_KEY`, and the shell
+expands it inside the child process.
+
+## 1. The environment contract
+
+Workers read these. Set them in the shell that launches your controller session so
+they are inherited by the controller and by every `Bash`/`dispatch.sh` subprocess.
+
+| Variable | Meaning | Example |
+|---|---|---|
+| `BITROUTER_BASE_URL` | BitRouter endpoint, **Anthropic shape, no trailing `/v1`** | `http://127.0.0.1:4356` |
+| `BITROUTER_API_KEY` | `brk_*` key, or `unused` for a `skip_auth` local daemon | `brk_…` |
+| `BITROUTER_MODEL_CHEAP` | `provider/model` for `--tier cheap` | see [model-tiers.md](model-tiers.md) |
+| `BITROUTER_MODEL_STANDARD` | `provider/model` for `--tier standard` | — |
+| `BITROUTER_MODEL_FLAGSHIP` | `provider/model` for `--tier flagship` | — |
+| `BITROUTER_CHILD_CONFIG_DIR` | Lean `CLAUDE_CONFIG_DIR` for workers | `~/.config/cost-routed-child` |
+
+> **Anthropic-shape base URL.** Claude Code appends `/v1/messages` itself, so the
+> base URL omits `/v1`. With a local daemon that is `http://127.0.0.1:4356`; for a
+> managed endpoint it is the host with **no** `/v1`. (The OpenAI shape keeps `/v1`
+> — don't reuse that value here.)
+>
+> **Do not export `ANTHROPIC_BASE_URL` globally.** That would redirect the
+> controller itself onto BitRouter. Keep the `BITROUTER_*` namespace separate; the
+> mapping to `ANTHROPIC_*` happens only inside the worker (see `dispatch.sh`).
+
+## 2. Pasting the key — pick one (no custom tooling required)
+
+### Option A — plain env file (zero dependencies, recommended baseline)
+
+Put the secret in a file the shell sources, **not** committed to git:
+
+```bash
+# ~/.config/cost-routed-subagents/env   (chmod 600; add the path to .gitignore)
+export BITROUTER_BASE_URL="http://127.0.0.1:4356"
+export BITROUTER_API_KEY="brk_…"
+export BITROUTER_MODEL_CHEAP="…"
+export BITROUTER_MODEL_STANDARD="…"
+export BITROUTER_MODEL_FLAGSHIP="…"
+```
+
+```bash
+# in ~/.zshrc or ~/.bashrc, or run before launching the controller:
+[ -f ~/.config/cost-routed-subagents/env ] && . ~/.config/cost-routed-subagents/env
+```
+
+The controller agent never reads this file and never prints `$BITROUTER_API_KEY`.
+
+### Option B — direnv (reusable, auto-loads per directory)
+
+```bash
+# .envrc  (direnv; add .envrc to .gitignore)
+export BITROUTER_BASE_URL="http://127.0.0.1:4356"
+export BITROUTER_API_KEY="brk_…"
+```
+
+`direnv allow` once; entering the directory loads the env. No custom code.
+
+### Option C — 1Password `op run` (strongest: secret never touches disk)
+
+Store the key in a vault and inject it at launch, so it exists only in process
+memory:
+
+```bash
+# .env.tpl  (committed; contains references, not secrets)
+BITROUTER_BASE_URL=http://127.0.0.1:4356
+BITROUTER_API_KEY=op://Private/bitrouter/api_key
+
+op run --env-file=.env.tpl -- claude        # launch the controller
+```
+
+## 3. Worker isolation: `--bare` + a clean config home
+
+The isolation that keeps a cheap worker focused comes from **`--bare`**, which
+`dispatch.sh` always passes. Per its own help, `--bare` skips hooks, LSP, plugin
+sync, auto-memory, background prefetches, keychain reads, and CLAUDE.md
+auto-discovery — so the worker is not handed a large session preamble, is not
+pushed to invoke skills, and cannot fall back to the controller's keychain
+credentials.
+
+`CLAUDE_CONFIG_DIR` then points the worker's **global** config home at a fresh
+directory, so it does not read the controller's global `settings.json` or stored
+`.credentials.json` either:
+
+```bash
+mkdir -p ~/.config/cost-routed-child   # empty is fine; dispatch.sh creates it too
+```
+
+Note the scope: `CLAUDE_CONFIG_DIR` only relocates the global `~/.claude` tree.
+Project-level `CLAUDE.md`/`.claude/` inside the worktree are governed by `--bare`
+(skipped). If you ever drop `--bare`, the worktree's own project config would load —
+usually fine, since a worker editing the repo should follow the repo's conventions,
+but it means a cheap model would also pick up whatever the project injects.
+
+## 4. Preflight (no value printed)
+
+Confirm wiring without revealing the key or spending tokens:
+
+```bash
+# presence only — prints "ok", never the value
+[ -n "$BITROUTER_API_KEY" ] && [ -n "$BITROUTER_BASE_URL" ] && echo "env ok" || echo "MISSING env"
+
+# full resolved invocation, key redacted, nothing spawned
+# (--task - reads stdin; --model takes a literal so no tier env is needed)
+./dispatch.sh --model demo:model --task - --dry-run <<<'demo task'
+```
+
+For a live smoke test that does spend a few tokens, dispatch a trivial task on the
+`cheap` tier in a throwaway directory and confirm the worker returns `DONE`.

--- a/skills/cost-routed-subagents/role-prompts/implementer.md
+++ b/skills/cost-routed-subagents/role-prompts/implementer.md
@@ -1,0 +1,35 @@
+You are an implementer worker dispatched by a controller agent. You run once,
+non-interactively: you cannot ask questions mid-task, and no human will reply. Work
+only from the task and context given to you in the user message — do not assume
+access to any plan, conversation history, or files beyond your working directory.
+
+Your job:
+1. Implement exactly what the task specifies — nothing missing, nothing extra (YAGNI).
+2. If the task calls for tests, write tests that verify real behavior, not mocks.
+3. Run the relevant tests/build and confirm your change works.
+4. Keep each file focused on one responsibility; follow existing patterns in the
+   codebase you are editing. Improve code you touch the way a careful engineer
+   would, but do not restructure things outside your task.
+5. Commit your work if the task asks you to; otherwise leave a clean diff.
+6. Self-review with fresh eyes before reporting: completeness, correct/clear names,
+   no overbuilding, tests actually verify behavior. Fix what you find.
+
+Write all code and comments in English.
+
+When you cannot proceed, stop and say so — bad work is worse than no work, and you
+will not be penalized for escalating. Escalate when the task needs an architectural
+decision with multiple valid approaches, requires understanding you cannot obtain
+from the provided context, or asks you to restructure code in ways the task did not
+anticipate.
+
+End your reply with a report in exactly this form:
+
+    STATUS: DONE | DONE_WITH_CONCERNS | BLOCKED | NEEDS_CONTEXT
+    SUMMARY: <what you implemented, or attempted if blocked>
+    TESTS: <what you ran and the result>
+    FILES: <files created/changed>
+    CONCERNS: <doubts, missing context, or what you are blocked on — omit if none>
+
+Use DONE_WITH_CONCERNS if you finished but have doubts about correctness. Use
+NEEDS_CONTEXT if information you needed was not provided. Use BLOCKED if you cannot
+complete the task. Never silently produce work you are unsure about.

--- a/skills/cost-routed-subagents/role-prompts/quality-reviewer.md
+++ b/skills/cost-routed-subagents/role-prompts/quality-reviewer.md
@@ -1,0 +1,25 @@
+You are a code-quality reviewer dispatched by a controller agent. You run once,
+non-interactively. Review only the diff or files given to you. Assume spec
+compliance has already been confirmed in a separate stage — do not re-check whether
+the right thing was built; check whether it was built **well**.
+
+Evaluate:
+- **Naming** — names describe what things do, not how; no misleading names.
+- **Structure** — focused files/functions, clear interfaces, no needless coupling;
+  follows existing patterns in the surrounding codebase.
+- **Tests** — verify real behavior rather than mocks; cover the meaningful cases.
+- **Simplicity** — no dead code, no overbuilding, no premature abstraction.
+- **Correctness smells** — obvious edge cases, error handling, resource leaks.
+
+Distinguish severity: Blocking (must fix) vs. Important vs. Nit. Be concrete — cite
+file and line, and say what to change. Write your review in English.
+
+End your reply with a report in exactly this form:
+
+    STATUS: APPROVED | CHANGES_REQUESTED
+    BLOCKING: <issues that must be fixed — omit if none>
+    IMPORTANT: <issues that should be fixed — omit if none>
+    NITS: <minor suggestions — omit if none>
+
+APPROVED only if there are no Blocking issues. Otherwise CHANGES_REQUESTED; the
+implementer will fix and you will review again.

--- a/skills/cost-routed-subagents/role-prompts/spec-reviewer.md
+++ b/skills/cost-routed-subagents/role-prompts/spec-reviewer.md
@@ -1,0 +1,27 @@
+You are a spec-compliance reviewer dispatched by a controller agent. You run once,
+non-interactively. Review only against the task/spec and the diff or files given to
+you — do not assume access to any plan or conversation history.
+
+Your single question: **does the change implement exactly the spec — nothing
+missing, nothing extra?**
+
+Check:
+- Every required behavior in the spec is present and correct.
+- Nothing was added that the spec did not ask for (no scope creep, no extra flags,
+  no speculative features).
+- Acceptance criteria, if stated, are met.
+
+Do NOT review code style, naming, or structure here — that is a separate review
+stage. Stay strictly on spec compliance.
+
+Write your review in English. Be concrete: name the requirement and the file/line.
+
+End your reply with a report in exactly this form:
+
+    STATUS: PASS | FAIL
+    MISSING: <required behavior not implemented — omit if none>
+    EXTRA: <implemented but not requested — omit if none>
+    NOTES: <anything the controller should know — omit if none>
+
+PASS only if there is nothing missing and nothing extra. Any gap means FAIL; the
+implementer will fix and you will review again.


### PR DESCRIPTION
## What

Adds a second bundled skill, **`cost-routed-subagents`**, at
`skills/cost-routed-subagents/`. It's a usage pattern for BitRouter's
Anthropic-shaped `/v1/messages` surface: a capable **controller** session (e.g.
Claude Code on a flagship model, billed directly) keeps orchestrating and
reviewing, but delegates the **bulk token spend** to cheaper models. Each worker
is a headless `claude -p` child process whose `ANTHROPIC_*` environment is
redirected at a BitRouter endpoint, so a sub-task runs on an inexpensive
`provider/model` while the controller stays on its own billing.

## Why this approach

Native Claude Code subagents share the session's `ANTHROPIC_BASE_URL` and
credentials — they can pick a model *alias* but cannot be pointed at a different
provider. Routing a sub-task to a cheaper provider therefore requires spawning a
**separate process** with its own environment. The skill is **HTTP API + env vars
only** — no BitRouter CLI in the dispatch path, and no custom secret store.

## Contents

- **`SKILL.md`** (≤200 lines) — when to use, the dispatch mechanism, the
  cheap/standard/flagship tier table, secret-safe key handling, safety.
- **`dispatch.sh`** — spawn one worker. Maps `BITROUTER_*` → `ANTHROPIC_*` inside a
  child subshell only (never leaks into the controller), unsets the controller's
  `ANTHROPIC_API_KEY`, runs `--bare` for worker isolation, supports a redacted
  `--dry-run`. Portable to bash 3.2 (macOS). Cites Claude Code headless docs + the
  Anthropic Messages API per repo policy.
- **`references/`** — `setup.md` (env contract + secret-safe key handling via plain
  env / direnv / 1Password `op run`, so the controller never sees the key value),
  `model-tiers.md` (tier policy, populate from `/v1/models`), `dispatch-protocol.md`
  (controller loop, `DONE`/`DONE_WITH_CONCERNS`/`NEEDS_CONTEXT`/`BLOCKED` status,
  two-stage review), `attribution.md`.
- **`role-prompts/`** — implementer + two-stage reviewer system prompts injected via
  `--append-system-prompt`.
- Registers the second skill in `skills/README.md`.

## Key UX (the controller never touches the secret)

The API key lives only in the **process environment**; the controller references
`$BITROUTER_API_KEY` by name and the shell expands it inside the child, so the
value never enters the session transcript. `--dry-run` redacts the token.

## Notes for review

- **Model-id form:** uses the slash form `provider/model` to match the existing
  `bitrouter` skill's docs; example ids are marked "verify against `/v1/models`",
  which is the authoritative source.
- **Base-URL footgun:** the Anthropic shape omits `/v1` (Claude Code appends
  `/v1/messages`); `dispatch.sh` warns if `BITROUTER_BASE_URL` ends in `/v1`.
- **Attribution:** dispatch/review methodology adapted from
  [obra/superpowers](https://github.com/obra/superpowers) (MIT); the MIT notice is
  reproduced in `references/attribution.md`.

## Testing

Validated offline under bash 3.2.57: syntax, `--help`, preflight (missing env →
clean error), tier resolution, the trailing-flag guard, empty-role rejection, the
`/v1` warning, and `--dry-run` with a `brk_` canary confirming the key is never
printed.

Also smoke-tested **live** against a BitRouter endpoint:
- Bare `GET /v1/models` → 200 (confirms the slash `provider/model` id form) and
  `POST /v1/messages` (Anthropic shape, `Authorization: Bearer` + `anthropic-version`)
  → 200 with a well-formed Anthropic response.
- A real `dispatch.sh` worker on `deepseek/deepseek-v4-pro` (an id Anthropic's API
  would reject — so this proves it routed through BitRouter, not direct Anthropic)
  ran with `--bare`, created and executed a file, and returned the implementer
  status protocol (`STATUS: DONE`). Exit 0.

Not wired into CI (requires a live endpoint + key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
