### PR TITLE
feat(language-model): LanguageModelV3 parity for the canonical IR

### DIFF
--- a/apps/bitrouter/src/auth/tests.rs
+++ b/apps/bitrouter/src/auth/tests.rs
@@ -26,6 +26,7 @@ fn prompt() -> Prompt {
     Prompt {
         model: "m".to_string(),
         system: None,
+        system_provider_metadata: Default::default(),
         messages: vec![Message::text(Role::User, "hi")],
         tools: Vec::new(),
         params: GenerationParams::default(),

--- a/apps/bitrouter/src/policy/hook.rs
+++ b/apps/bitrouter/src/policy/hook.rs
@@ -67,7 +67,7 @@ impl PreRequestHook for PolicyHook {
 
         // 3. tool-access rules — checked against the request's declared tools
         if effective.has_tool_restriction() {
-            let tools = ctx.prompt().tools.iter().map(|t| t.name.as_str());
+            let tools = ctx.prompt().tools.iter().map(|t| t.name());
             if let Err(violation) = effective.check_tools(tools) {
                 return Ok(HookDecision::Deny(DenyReason::Forbidden(
                     violation.to_string(),

--- a/apps/bitrouter/src/policy/tests.rs
+++ b/apps/bitrouter/src/policy/tests.rs
@@ -17,6 +17,7 @@ fn ctx(model: &str, policy_id: Option<&str>) -> PipelineContext {
     let prompt = Prompt {
         model: model.to_string(),
         system: None,
+        system_provider_metadata: Default::default(),
         messages: vec![Message::text(Role::User, "hi")],
         tools: Vec::new(),
         params: GenerationParams::default(),
@@ -40,6 +41,7 @@ fn ctx_with_tools(tools: &[&str], policy_id: Option<&str>) -> PipelineContext {
     let prompt = Prompt {
         model: "m".to_string(),
         system: None,
+        system_provider_metadata: Default::default(),
         messages: vec![Message::text(Role::User, "hi")],
         tools: tools
             .iter()

--- a/apps/bitrouter/src/policy/tests.rs
+++ b/apps/bitrouter/src/policy/tests.rs
@@ -48,6 +48,7 @@ fn ctx_with_tools(tools: &[&str], policy_id: Option<&str>) -> PipelineContext {
                 description: None,
                 parameters: serde_json::json!({}),
                 strict: None,
+                provider_metadata: Default::default(),
             })
             .collect(),
         params: GenerationParams::default(),

--- a/apps/bitrouter/src/policy/tests.rs
+++ b/apps/bitrouter/src/policy/tests.rs
@@ -43,10 +43,11 @@ fn ctx_with_tools(tools: &[&str], policy_id: Option<&str>) -> PipelineContext {
         messages: vec![Message::text(Role::User, "hi")],
         tools: tools
             .iter()
-            .map(|name| Tool {
+            .map(|name| Tool::Function {
                 name: name.to_string(),
                 description: None,
                 parameters: serde_json::json!({}),
+                strict: None,
             })
             .collect(),
         params: GenerationParams::default(),

--- a/apps/bitrouter/tests/e2e.rs
+++ b/apps/bitrouter/tests/e2e.rs
@@ -75,6 +75,7 @@ fn chat_prompt() -> Prompt {
     Prompt {
         model: "test-model".to_string(),
         system: None,
+        system_provider_metadata: Default::default(),
         messages: vec![Message::text(Role::User, "hello")],
         tools: Vec::new(),
         params: GenerationParams::default(),

--- a/apps/bitrouter/tests/e2e.rs
+++ b/apps/bitrouter/tests/e2e.rs
@@ -107,7 +107,7 @@ async fn e2e_assembled_pipeline_routes_to_mock_provider() {
         .content
         .iter()
         .filter_map(|c| match c {
-            bitrouter_sdk::language_model::Content::Text { text } => Some(text.as_str()),
+            bitrouter_sdk::language_model::Content::Text { text, .. } => Some(text.as_str()),
             _ => None,
         })
         .collect();

--- a/crates/bitrouter-bedrock/src/lib.rs
+++ b/crates/bitrouter-bedrock/src/lib.rs
@@ -83,8 +83,8 @@ use aws_sdk_bedrockruntime::types::{
     ContentBlock, ContentBlockDelta, ContentBlockDeltaEvent, ContentBlockStart,
     ContentBlockStartEvent, ConversationRole, ConverseOutput, ConverseStreamMetadataEvent,
     ConverseStreamOutput, InferenceConfiguration, Message as BedrockMessage, MessageStopEvent,
-    StopReason, SystemContentBlock, ToolResultBlock, ToolResultContentBlock, ToolUseBlock,
-    ToolUseBlockStart,
+    StopReason, SystemContentBlock, ToolResultBlock, ToolResultContentBlock, ToolResultStatus,
+    ToolUseBlock, ToolUseBlockStart,
 };
 use aws_smithy_types::Document;
 use aws_smithy_types::event_stream::RawMessage;
@@ -92,7 +92,8 @@ use bedrock::error::SdkError;
 
 use bitrouter_sdk::language_model::{
     Content, ExecutionResult, Executor, FinishReason, GenerateResult, PipelineContext, Prompt,
-    Role, RoutingTarget, StreamPart, StreamPartStream, Usage,
+    Role, RoutingTarget, StreamPart, StreamPartStream, ToolResultContentPart, ToolResultOutput,
+    Usage,
 };
 use bitrouter_sdk::{BitrouterError, Result};
 
@@ -309,14 +310,25 @@ fn canonical_content_to_bedrock(blocks: &[Content]) -> Result<Vec<ContentBlock>>
                     })?;
                 out.push(ContentBlock::ToolUse(tool_use));
             }
-            Content::ToolResult { call_id, content } => {
-                let tool_result = ToolResultBlock::builder()
-                    .tool_use_id(call_id.clone())
-                    .content(ToolResultContentBlock::Text(content.clone()))
-                    .build()
-                    .map_err(|e| {
-                        BitrouterError::internal(format!("building Bedrock ToolResultBlock: {e}"))
-                    })?;
+            Content::ToolResult {
+                call_id, output, ..
+            } => {
+                // Bedrock Converse `ToolResultBlock`: a content-block list plus a
+                // `status` (success/error). Map the typed output faithfully —
+                // text/JSON go to `Text` / `Json` content blocks, and the error
+                // variants set `status = error`. Bedrock has no tool-name field,
+                // so `tool_name` is dropped.
+                // https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolResultBlock.html
+                let mut builder = ToolResultBlock::builder().tool_use_id(call_id.clone());
+                if output.is_error() {
+                    builder = builder.status(ToolResultStatus::Error);
+                }
+                for block in render_tool_result_blocks(output) {
+                    builder = builder.content(block);
+                }
+                let tool_result = builder.build().map_err(|e| {
+                    BitrouterError::internal(format!("building Bedrock ToolResultBlock: {e}"))
+                })?;
                 out.push(ContentBlock::ToolResult(tool_result));
             }
             Content::Reasoning { .. } => {
@@ -324,9 +336,44 @@ fn canonical_content_to_bedrock(blocks: &[Content]) -> Result<Vec<ContentBlock>>
                 // Bedrock Converse input schema — they appear only on the
                 // *response* side (under `reasoningContent`). Skipping.
             }
+            Content::File { .. } => {
+                // Multimodal request input (Bedrock `image` / `document` content
+                // blocks) is not yet wired onto the canonical IR here, mirroring
+                // the response side, which also skips non-text/tool blocks.
+                // Skipping keeps the request faithful for the text/tool path.
+                // https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ContentBlock.html
+            }
         }
     }
     Ok(out)
+}
+
+/// Render a canonical [`ToolResultOutput`] into Bedrock `ToolResultContentBlock`s.
+/// Text / error-text → a `Text` block; JSON / error-json → a `Json` block; a
+/// multimodal `Content` output contributes one block per part, with text parts
+/// becoming `Text` blocks and media parts skipped (the faithful router does not
+/// decode bytes into Bedrock's structured `Image` / `Document` blocks).
+/// https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolResultContentBlock.html
+fn render_tool_result_blocks(output: &ToolResultOutput) -> Vec<ToolResultContentBlock> {
+    match output {
+        ToolResultOutput::Text { value } | ToolResultOutput::ErrorText { value } => {
+            vec![ToolResultContentBlock::Text(value.clone())]
+        }
+        ToolResultOutput::Json { value } | ToolResultOutput::ErrorJson { value } => {
+            vec![ToolResultContentBlock::Json(json_value_to_document(
+                value.clone(),
+            ))]
+        }
+        ToolResultOutput::Content { value } => value
+            .iter()
+            .filter_map(|part| match part {
+                ToolResultContentPart::Text { text } => {
+                    Some(ToolResultContentBlock::Text(text.clone()))
+                }
+                ToolResultContentPart::Media { .. } => None,
+            })
+            .collect(),
+    }
 }
 
 fn build_inference_config(prompt: &Prompt) -> InferenceConfiguration {
@@ -395,18 +442,40 @@ fn bedrock_content_to_canonical(blocks: &[ContentBlock]) -> Vec<Content> {
                 });
             }
             ContentBlock::ToolResult(tr) => {
-                // Concatenate any text-shaped tool_result fragments.
-                let text: String = tr
-                    .content()
-                    .iter()
-                    .filter_map(|c| match c {
-                        ToolResultContentBlock::Text(s) => Some(s.as_str()),
-                        _ => None,
-                    })
-                    .collect();
+                // Bedrock carries a `status` (success/error) and a content-block
+                // list. A lone `Json` block maps to a structured Json output;
+                // otherwise the text fragments are concatenated. The error
+                // status promotes to the matching error variant. Bedrock has no
+                // tool-name field, so `tool_name` is `None`.
+                // https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolResultBlock.html
+                let is_error = tr.status() == Some(&ToolResultStatus::Error);
+                let json_block = match tr.content() {
+                    [ToolResultContentBlock::Json(doc)] => Some(document_to_json(doc)),
+                    _ => None,
+                };
+                let output = match json_block {
+                    Some(value) if is_error => ToolResultOutput::ErrorJson { value },
+                    Some(value) => ToolResultOutput::Json { value },
+                    None => {
+                        let text: String = tr
+                            .content()
+                            .iter()
+                            .filter_map(|c| match c {
+                                ToolResultContentBlock::Text(s) => Some(s.as_str()),
+                                _ => None,
+                            })
+                            .collect();
+                        if is_error {
+                            ToolResultOutput::ErrorText { value: text }
+                        } else {
+                            ToolResultOutput::Text { value: text }
+                        }
+                    }
+                };
                 out.push(Content::ToolResult {
                     call_id: tr.tool_use_id().to_string(),
-                    content: text,
+                    tool_name: None,
+                    output,
                 });
             }
             _ => {
@@ -569,5 +638,102 @@ fn map_stream_err(
     BitrouterError::Upstream {
         status: 502,
         message: format!("Bedrock stream recv error: {e:?}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bitrouter_sdk::language_model::DataContent;
+
+    /// Render a single canonical tool result through Bedrock and parse it back,
+    /// returning the canonical output that survived the round trip.
+    fn round_trip_tool_output(output: ToolResultOutput) -> ToolResultOutput {
+        let blocks = canonical_content_to_bedrock(&[Content::ToolResult {
+            call_id: "call_1".to_string(),
+            tool_name: None,
+            output,
+        }])
+        .expect("render to Bedrock content blocks");
+        let back = bedrock_content_to_canonical(&blocks);
+        match back.into_iter().next() {
+            Some(Content::ToolResult { output, .. }) => output,
+            other => panic!("expected a tool result, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn bedrock_tool_result_text_round_trips() {
+        let output = ToolResultOutput::Text {
+            value: "the answer is 42".to_string(),
+        };
+        assert_eq!(round_trip_tool_output(output.clone()), output);
+    }
+
+    #[test]
+    fn bedrock_tool_result_json_round_trips_via_json_block() {
+        // A Json output renders to a Bedrock `Json` content block and parses back
+        // structured (not stringified).
+        let output = ToolResultOutput::Json {
+            value: serde_json::json!({ "celsius": 21, "unit": "C" }),
+        };
+        assert_eq!(round_trip_tool_output(output.clone()), output);
+    }
+
+    #[test]
+    fn bedrock_tool_result_error_text_sets_and_recovers_status() {
+        // The error flag rides Bedrock's `status` field, so ErrorText round-trips
+        // (Bedrock has a native error status, unlike the OpenAI tool wires).
+        let output = ToolResultOutput::ErrorText {
+            value: "tool blew up".to_string(),
+        };
+        let blocks = canonical_content_to_bedrock(&[Content::ToolResult {
+            call_id: "c1".to_string(),
+            tool_name: None,
+            output: output.clone(),
+        }])
+        .unwrap();
+        // The rendered block carries `status = error`.
+        match &blocks[0] {
+            ContentBlock::ToolResult(tr) => {
+                assert_eq!(tr.status(), Some(&ToolResultStatus::Error));
+            }
+            other => panic!("expected a tool_result block, got {other:?}"),
+        }
+        assert_eq!(round_trip_tool_output(output.clone()), output);
+    }
+
+    #[test]
+    fn bedrock_tool_result_error_json_round_trips() {
+        let output = ToolResultOutput::ErrorJson {
+            value: serde_json::json!({ "code": "E_BOOM" }),
+        };
+        assert_eq!(round_trip_tool_output(output.clone()), output);
+    }
+
+    #[test]
+    fn bedrock_tool_result_content_keeps_text_drops_media() {
+        // A multimodal Content output renders its text parts as Text blocks; the
+        // media part is dropped (faithful router does not decode bytes into
+        // Bedrock's structured Image/Document blocks), so it re-parses as Text.
+        let output = ToolResultOutput::Content {
+            value: vec![
+                ToolResultContentPart::Text {
+                    text: "see this".to_string(),
+                },
+                ToolResultContentPart::Media {
+                    media_type: "image/png".to_string(),
+                    data: DataContent::Base64 {
+                        data: "AAAA".to_string(),
+                    },
+                },
+            ],
+        };
+        assert_eq!(
+            round_trip_tool_output(output),
+            ToolResultOutput::Text {
+                value: "see this".to_string()
+            }
+        );
     }
 }

--- a/crates/bitrouter-bedrock/src/lib.rs
+++ b/crates/bitrouter-bedrock/src/lib.rs
@@ -347,6 +347,13 @@ fn canonical_content_to_bedrock(blocks: &[Content]) -> Result<Vec<ContentBlock>>
                 // Skipping keeps the request faithful for the text/tool path.
                 // https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ContentBlock.html
             }
+            Content::Source { .. } => {
+                // Citation sources are response-side metadata only — they never
+                // appear in a request, so there is nothing to render here.
+                // (Bedrock surfaces its own citations under a response
+                // `citationsContent` block, which the response parser would map;
+                // the request path simply skips.)
+            }
         }
     }
     Ok(out)

--- a/crates/bitrouter-bedrock/src/lib.rs
+++ b/crates/bitrouter-bedrock/src/lib.rs
@@ -370,7 +370,10 @@ fn render_tool_result_blocks(output: &ToolResultOutput) -> Vec<ToolResultContent
                 ToolResultContentPart::Text { text } => {
                     Some(ToolResultContentBlock::Text(text.clone()))
                 }
-                ToolResultContentPart::Media { .. } => None,
+                // A faithful router does not decode bytes into Bedrock's
+                // structured Image/Document blocks, and Bedrock has no field for a
+                // foreign provider's `file_id`; both drop here.
+                ToolResultContentPart::Media { .. } | ToolResultContentPart::FileId { .. } => None,
             })
             .collect(),
     }
@@ -447,6 +450,14 @@ fn bedrock_content_to_canonical(blocks: &[ContentBlock]) -> Vec<Content> {
                 // otherwise the text fragments are concatenated. The error
                 // status promotes to the matching error variant. Bedrock has no
                 // tool-name field, so `tool_name` is `None`.
+                //
+                // Known asymmetry: this lone-`[Json]` recovery currently only
+                // fires for results that the renderer above emitted from a `Json` /
+                // `ErrorJson` output, because the `Content` render path drops media
+                // and never produces a standalone Json block. The recovery is kept
+                // general (it would also rebuild a Json output from an
+                // externally-authored Bedrock request) rather than narrowed to the
+                // shapes this SDK happens to emit today.
                 // https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolResultBlock.html
                 let is_error = tr.status() == Some(&ToolResultStatus::Error);
                 let json_block = match tr.content() {

--- a/crates/bitrouter-bedrock/src/lib.rs
+++ b/crates/bitrouter-bedrock/src/lib.rs
@@ -200,6 +200,9 @@ impl Executor for BedrockExecutor {
                 // <https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ConverseOutput.html>
                 response_id: None,
                 stop_details: None,
+                // Bedrock Converse exposes no result-level field that lacks a
+                // dedicated canonical slot, so no provider metadata is carried.
+                provider_metadata: Default::default(),
             },
             latency_ms: elapsed,
             generation_time_ms: elapsed,
@@ -293,7 +296,7 @@ fn canonical_content_to_bedrock(blocks: &[Content]) -> Result<Vec<ContentBlock>>
     let mut out = Vec::with_capacity(blocks.len());
     for c in blocks {
         match c {
-            Content::Text { text } => out.push(ContentBlock::Text(text.clone())),
+            Content::Text { text, .. } => out.push(ContentBlock::Text(text.clone())),
             // The Bedrock Converse content model has no provider-executed
             // server-tool block, so a `provider_executed` call degrades to a
             // plain `toolUse` block (the flag is dropped) — `..` ignores it.
@@ -446,7 +449,10 @@ fn bedrock_content_to_canonical(blocks: &[ContentBlock]) -> Vec<Content> {
     let mut out = Vec::with_capacity(blocks.len());
     for b in blocks {
         match b {
-            ContentBlock::Text(t) => out.push(Content::Text { text: t.clone() }),
+            ContentBlock::Text(t) => out.push(Content::Text {
+                text: t.clone(),
+                provider_metadata: Default::default(),
+            }),
             ContentBlock::ToolUse(tu) => {
                 let arguments = document_to_json(tu.input()).to_string();
                 out.push(Content::ToolCall {
@@ -456,6 +462,7 @@ fn bedrock_content_to_canonical(blocks: &[ContentBlock]) -> Vec<Content> {
                     // Bedrock `toolUse` blocks are client tool calls; the
                     // Converse content model has no provider-executed marker.
                     provider_executed: false,
+                    provider_metadata: Default::default(),
                 });
             }
             ContentBlock::ToolResult(tr) => {
@@ -501,6 +508,7 @@ fn bedrock_content_to_canonical(blocks: &[ContentBlock]) -> Vec<Content> {
                     call_id: tr.tool_use_id().to_string(),
                     tool_name: None,
                     output,
+                    provider_metadata: Default::default(),
                 });
             }
             _ => {
@@ -678,6 +686,7 @@ mod tests {
             call_id: "call_1".to_string(),
             tool_name: None,
             output,
+            provider_metadata: Default::default(),
         }])
         .expect("render to Bedrock content blocks");
         let back = bedrock_content_to_canonical(&blocks);
@@ -716,6 +725,7 @@ mod tests {
             call_id: "c1".to_string(),
             tool_name: None,
             output: output.clone(),
+            provider_metadata: Default::default(),
         }])
         .unwrap();
         // The rendered block carries `status = error`.

--- a/crates/bitrouter-bedrock/src/lib.rs
+++ b/crates/bitrouter-bedrock/src/lib.rs
@@ -294,10 +294,14 @@ fn canonical_content_to_bedrock(blocks: &[Content]) -> Result<Vec<ContentBlock>>
     for c in blocks {
         match c {
             Content::Text { text } => out.push(ContentBlock::Text(text.clone())),
+            // The Bedrock Converse content model has no provider-executed
+            // server-tool block, so a `provider_executed` call degrades to a
+            // plain `toolUse` block (the flag is dropped) — `..` ignores it.
             Content::ToolCall {
                 id,
                 name,
                 arguments,
+                ..
             } => {
                 let args_doc = json_to_document(arguments)?;
                 let tool_use = ToolUseBlock::builder()
@@ -442,6 +446,9 @@ fn bedrock_content_to_canonical(blocks: &[ContentBlock]) -> Vec<Content> {
                     id: tu.tool_use_id().to_string(),
                     name: tu.name().to_string(),
                     arguments,
+                    // Bedrock `toolUse` blocks are client tool calls; the
+                    // Converse content model has no provider-executed marker.
+                    provider_executed: false,
                 });
             }
             ContentBlock::ToolResult(tr) => {

--- a/crates/bitrouter-bedrock/src/lib.rs
+++ b/crates/bitrouter-bedrock/src/lib.rs
@@ -357,6 +357,14 @@ fn canonical_content_to_bedrock(blocks: &[Content]) -> Result<Vec<ContentBlock>>
                 // `citationsContent` block, which the response parser would map;
                 // the request path simply skips.)
             }
+            Content::ToolApprovalRequest { .. } | Content::ToolApprovalResponse { .. } => {
+                // The Bedrock Converse content model has no tool-approval
+                // handshake block (`mcp_approval_request` / `mcp_approval_response`
+                // are OpenAI-Responses-only), so both approval parts are skipped.
+                // A denied execution still degrades to a plain `toolResult` text
+                // block via the `ToolResult` arm (`render_tool_result_blocks`).
+                // https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ContentBlock.html
+            }
         }
     }
     Ok(out)
@@ -390,6 +398,14 @@ fn render_tool_result_blocks(output: &ToolResultOutput) -> Vec<ToolResultContent
                 ToolResultContentPart::Media { .. } | ToolResultContentPart::FileId { .. } => None,
             })
             .collect(),
+        // Bedrock Converse has no `execution-denied` tool-result shape, so a
+        // denied execution degrades to a plain `Text` block carrying the reason
+        // (or the default denial string), mirroring the string degrade on the
+        // other non-Responses wires.
+        // https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolResultContentBlock.html
+        ToolResultOutput::ExecutionDenied { .. } => {
+            vec![ToolResultContentBlock::Text(output.to_provider_string())]
+        }
     }
 }
 

--- a/crates/bitrouter-bedrock/src/lib.rs
+++ b/crates/bitrouter-bedrock/src/lib.rs
@@ -476,8 +476,10 @@ fn bedrock_content_to_canonical(blocks: &[ContentBlock]) -> Vec<Content> {
                     name: tu.name().to_string(),
                     arguments,
                     // Bedrock `toolUse` blocks are client tool calls; the
-                    // Converse content model has no provider-executed marker.
+                    // Converse content model has no provider-executed marker, and
+                    // no provider-executed MCP (`dynamic`) call envelope.
                     provider_executed: false,
+                    dynamic: false,
                     provider_metadata: Default::default(),
                 });
             }
@@ -524,6 +526,8 @@ fn bedrock_content_to_canonical(blocks: &[ContentBlock]) -> Vec<Content> {
                     call_id: tr.tool_use_id().to_string(),
                     tool_name: None,
                     output,
+                    // Bedrock Converse has no MCP tool-result wire.
+                    dynamic: false,
                     provider_metadata: Default::default(),
                 });
             }
@@ -702,6 +706,7 @@ mod tests {
             call_id: "call_1".to_string(),
             tool_name: None,
             output,
+            dynamic: false,
             provider_metadata: Default::default(),
         }])
         .expect("render to Bedrock content blocks");
@@ -741,6 +746,7 @@ mod tests {
             call_id: "c1".to_string(),
             tool_name: None,
             output: output.clone(),
+            dynamic: false,
             provider_metadata: Default::default(),
         }])
         .unwrap();

--- a/crates/bitrouter-sdk/src/language_model/context.rs
+++ b/crates/bitrouter-sdk/src/language_model/context.rs
@@ -312,6 +312,7 @@ impl PipelineContext {
                 finish_reason: None,
                 response_id: None,
                 stop_details: None,
+                provider_metadata: Default::default(),
             },
         );
         PipelineResponse {
@@ -398,6 +399,7 @@ mod tests {
             messages: vec![Message {
                 role: Role::User,
                 content: vec![],
+                provider_metadata: Default::default(),
             }],
             tools: vec![],
             params: Default::default(),

--- a/crates/bitrouter-sdk/src/language_model/context.rs
+++ b/crates/bitrouter-sdk/src/language_model/context.rs
@@ -396,10 +396,10 @@ mod tests {
         Prompt {
             model: "gpt-5".into(),
             system: None,
+            system_provider_metadata: Default::default(),
             messages: vec![Message {
                 role: Role::User,
                 content: vec![],
-                provider_metadata: Default::default(),
             }],
             tools: vec![],
             params: Default::default(),

--- a/crates/bitrouter-sdk/src/language_model/executor.rs
+++ b/crates/bitrouter-sdk/src/language_model/executor.rs
@@ -78,7 +78,10 @@ impl MockExecutor {
     pub fn always_text(text: impl Into<String>) -> Self {
         use crate::language_model::types::{Content, FinishReason, Usage};
         let result = GenerateResult {
-            content: vec![Content::Text { text: text.into() }],
+            content: vec![Content::Text {
+                text: text.into(),
+                provider_metadata: Default::default(),
+            }],
             usage: Some(Usage {
                 prompt_tokens: 10,
                 completion_tokens: 5,
@@ -87,6 +90,7 @@ impl MockExecutor {
             finish_reason: Some(FinishReason::Stop),
             response_id: None,
             stop_details: None,
+            provider_metadata: Default::default(),
         };
         Self::new(vec![MockResponse::Generate(result)])
     }

--- a/crates/bitrouter-sdk/src/language_model/mod.rs
+++ b/crates/bitrouter-sdk/src/language_model/mod.rs
@@ -100,6 +100,7 @@ pub use stream::{
 };
 pub use types::{
     ApiProtocol, Capability, Content, DataContent, ExecutionResult, FinishReason, GenerateResult,
-    GenerationParams, Message, PipelineRequest, PipelineResponse, Prompt, Role, RoutingTarget,
-    Source, StreamPart, Tool, ToolChoice, ToolResultContentPart, ToolResultOutput, Usage,
+    GenerationParams, Message, PipelineRequest, PipelineResponse, Prompt, ProviderMetadata, Role,
+    RoutingTarget, Source, StreamPart, Tool, ToolChoice, ToolResultContentPart, ToolResultOutput,
+    Usage,
 };

--- a/crates/bitrouter-sdk/src/language_model/mod.rs
+++ b/crates/bitrouter-sdk/src/language_model/mod.rs
@@ -101,5 +101,5 @@ pub use stream::{
 pub use types::{
     ApiProtocol, Capability, Content, DataContent, ExecutionResult, FinishReason, GenerateResult,
     GenerationParams, Message, PipelineRequest, PipelineResponse, Prompt, Role, RoutingTarget,
-    StreamPart, Tool, ToolChoice, ToolResultContentPart, ToolResultOutput, Usage,
+    Source, StreamPart, Tool, ToolChoice, ToolResultContentPart, ToolResultOutput, Usage,
 };

--- a/crates/bitrouter-sdk/src/language_model/mod.rs
+++ b/crates/bitrouter-sdk/src/language_model/mod.rs
@@ -99,7 +99,7 @@ pub use stream::{
     UsageAccumulator,
 };
 pub use types::{
-    ApiProtocol, Capability, Content, ExecutionResult, FinishReason, GenerateResult,
+    ApiProtocol, Capability, Content, DataContent, ExecutionResult, FinishReason, GenerateResult,
     GenerationParams, Message, PipelineRequest, PipelineResponse, Prompt, Role, RoutingTarget,
-    StreamPart, Tool, Usage,
+    StreamPart, Tool, ToolResultContentPart, ToolResultOutput, Usage,
 };

--- a/crates/bitrouter-sdk/src/language_model/mod.rs
+++ b/crates/bitrouter-sdk/src/language_model/mod.rs
@@ -101,5 +101,5 @@ pub use stream::{
 pub use types::{
     ApiProtocol, Capability, Content, DataContent, ExecutionResult, FinishReason, GenerateResult,
     GenerationParams, Message, PipelineRequest, PipelineResponse, Prompt, Role, RoutingTarget,
-    StreamPart, Tool, ToolResultContentPart, ToolResultOutput, Usage,
+    StreamPart, Tool, ToolChoice, ToolResultContentPart, ToolResultOutput, Usage,
 };

--- a/crates/bitrouter-sdk/src/language_model/pipeline.rs
+++ b/crates/bitrouter-sdk/src/language_model/pipeline.rs
@@ -176,6 +176,7 @@ impl Pipeline {
                     finish_reason: None,
                     response_id: None,
                     stop_details: None,
+                    provider_metadata: Default::default(),
                 },
                 latency_ms: 0,
                 generation_time_ms: 0,

--- a/crates/bitrouter-sdk/src/language_model/protocol/chat_completions.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/chat_completions.rs
@@ -20,7 +20,7 @@ use crate::language_model::protocol::{
 use crate::language_model::stream::SseFrame;
 use crate::language_model::types::{
     ApiProtocol, Content, DataContent, FinishReason, GenerateResult, GenerationParams, Message,
-    Prompt, ResponseFormat, Role, RoutingTarget, StreamPart, Usage,
+    Modality, Prompt, ResponseFormat, Role, RoutingTarget, StreamPart, Usage,
 };
 
 /// The Chat Completions inbound + outbound protocol adapter.
@@ -365,6 +365,14 @@ impl InboundAdapter for ChatCompletionsAdapter {
             None => None,
         };
 
+        // Output modalities (OpenAI `modalities`, e.g. ["text","audio"]). Promote
+        // to the typed slot so capability detection sees them; remove from extra
+        // so they are not double-rendered.
+        let response_modalities = extra
+            .remove("modalities")
+            .and_then(|v| serde_json::from_value::<Vec<Modality>>(v).ok())
+            .unwrap_or_default();
+
         Ok(Prompt {
             model: req.model,
             system,
@@ -375,7 +383,7 @@ impl InboundAdapter for ChatCompletionsAdapter {
                 top_p: req.top_p,
                 max_tokens: req.max_tokens.or(req.max_completion_tokens),
                 reasoning_effort: req.reasoning_effort,
-                response_modalities: Vec::new(),
+                response_modalities,
                 // Every Chat Completions field without a typed slot — tool_choice,
                 // stop / stop_sequences, seed, n, presence/frequency_penalty,
                 // logit_bias, … — rides in `extra` and is splatted back on render.
@@ -522,6 +530,12 @@ impl OutboundAdapter for ChatCompletionsAdapter {
         // other params are handled).
         if let Some(rf) = &prompt.response_format {
             req.insert("response_format".into(), render_chat_response_format(rf));
+        }
+        // Output modalities -> OpenAI `modalities`.
+        if !prompt.params.response_modalities.is_empty()
+            && let Ok(value) = serde_json::to_value(&prompt.params.response_modalities)
+        {
+            req.insert("modalities".into(), value);
         }
         // Splat the extras back into the outbound request — this is how
         // `tool_choice`, `stop`, `seed`, etc. survive the round trip. Typed

--- a/crates/bitrouter-sdk/src/language_model/protocol/chat_completions.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/chat_completions.rs
@@ -851,7 +851,8 @@ fn render_tool_result_content(output: &ToolResultOutput) -> serde_json::Value {
         ToolResultOutput::Content { value } => {
             let parts: Vec<serde_json::Value> = value
                 .iter()
-                .filter_map(|p| render_input_part(&tool_result_part_to_content(p)))
+                .filter_map(tool_result_part_to_content)
+                .filter_map(|c| render_input_part(&c))
                 .collect();
             parts.into()
         }
@@ -861,15 +862,21 @@ fn render_tool_result_content(output: &ToolResultOutput) -> serde_json::Value {
 
 /// Lift a [`ToolResultContentPart`] into a canonical [`Content`] so the shared
 /// [`render_input_part`] media renderer can be reused for tool-result content.
-fn tool_result_part_to_content(part: &ToolResultContentPart) -> Content {
+/// Returns `None` for a provider file reference: the OpenAI Chat Completions
+/// `content` parts (`text` / `image_url` / `input_audio` / `file{file_data}`)
+/// have no bare-`file_id` form, so a [`ToolResultContentPart::FileId`] has no
+/// faithful representation here and is dropped rather than fabricated.
+/// <https://platform.openai.com/docs/api-reference/chat/create#chat-create-messages>
+fn tool_result_part_to_content(part: &ToolResultContentPart) -> Option<Content> {
     match part {
-        ToolResultContentPart::Text { text } => Content::Text { text: text.clone() },
-        ToolResultContentPart::Media { media_type, data } => Content::File {
+        ToolResultContentPart::Text { text } => Some(Content::Text { text: text.clone() }),
+        ToolResultContentPart::Media { media_type, data } => Some(Content::File {
             media_type: media_type.clone(),
             data: data.clone(),
             filename: None,
             extra: Default::default(),
-        },
+        }),
+        ToolResultContentPart::FileId { .. } => None,
     }
 }
 

--- a/crates/bitrouter-sdk/src/language_model/protocol/chat_completions.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/chat_completions.rs
@@ -20,7 +20,7 @@ use crate::language_model::protocol::{
 use crate::language_model::stream::SseFrame;
 use crate::language_model::types::{
     ApiProtocol, Content, DataContent, FinishReason, GenerateResult, GenerationParams, Message,
-    Modality, Prompt, ResponseFormat, Role, RoutingTarget, StreamPart, Tool, ToolChoice,
+    Modality, Prompt, ResponseFormat, Role, RoutingTarget, Source, StreamPart, Tool, ToolChoice,
     ToolResultContentPart, ToolResultOutput, Usage,
 };
 
@@ -327,6 +327,75 @@ fn parse_chat_part(part: &serde_json::Value) -> Option<Content> {
     }
 }
 
+/// Parse an OpenAI Chat `message.annotations[]` array into canonical
+/// [`Content::Source`] parts. Only `url_citation` entries
+/// (`{type:"url_citation", url_citation:{url, title?}}`) are mapped — the only
+/// annotation kind Chat Completions emits for web search. The citation id is
+/// synthesized from the url + index (the wire carries none); the `start_index`/
+/// `end_index` text offsets are dropped (no canonical slot). Mirrors the AI SDK
+/// OpenAI chat mapping.
+/// <https://github.com/vercel/ai/blob/main/packages/openai/src/chat/openai-chat-language-model.ts>
+fn parse_chat_annotations(annotations: Option<&serde_json::Value>) -> Vec<Content> {
+    let Some(arr) = annotations.and_then(|a| a.as_array()) else {
+        return Vec::new();
+    };
+    arr.iter()
+        .enumerate()
+        .filter_map(|(i, ann)| {
+            if ann.get("type").and_then(|t| t.as_str()) != Some("url_citation") {
+                return None;
+            }
+            let cite = ann.get("url_citation")?;
+            let url = cite.get("url").and_then(|u| u.as_str())?.to_string();
+            let title = cite
+                .get("title")
+                .and_then(|t| t.as_str())
+                .map(str::to_string);
+            Some(Content::Source {
+                source: Source::Url {
+                    id: Source::synthesize_id(&url, i),
+                    url,
+                    title,
+                },
+            })
+        })
+        .collect()
+}
+
+/// Render canonical [`Content::Source`] parts back into OpenAI Chat
+/// `message.annotations[]` `url_citation` entries. Only [`Source::Url`] has a
+/// Chat representation; a [`Source::Document`] citation (which only OpenAI
+/// Responses / Anthropic documents produce) has no `url_citation` shape on this
+/// wire and is dropped — documented cross-protocol loss. Returns an empty Vec
+/// when the result carries no URL sources.
+/// <https://platform.openai.com/docs/api-reference/chat/object> (`annotations`)
+fn render_chat_annotations(result: &GenerateResult) -> Vec<serde_json::Value> {
+    result
+        .content
+        .iter()
+        .filter_map(|c| match c {
+            Content::Source {
+                source: Source::Url { url, title, .. },
+            } => {
+                let mut cite = serde_json::Map::new();
+                cite.insert("url".into(), url.clone().into());
+                if let Some(title) = title {
+                    cite.insert("title".into(), title.clone().into());
+                }
+                Some(serde_json::json!({
+                    "type": "url_citation",
+                    "url_citation": serde_json::Value::Object(cite),
+                }))
+            }
+            // Document citations have no `url_citation` form on the Chat wire.
+            Content::Source {
+                source: Source::Document { .. },
+            } => None,
+            _ => None,
+        })
+        .collect()
+}
+
 impl InboundAdapter for ChatCompletionsAdapter {
     fn protocol(&self) -> ApiProtocol {
         ApiProtocol::ChatCompletions
@@ -544,6 +613,16 @@ impl InboundAdapter for ChatCompletionsAdapter {
             message.insert("tool_calls".into(), tool_calls.into());
         }
 
+        // Re-attach web-search citations as `message.annotations[]`
+        // `url_citation` entries — the same location `parse_response` lifts them
+        // from. Collected from the result's `Content::Source` parts rather than
+        // rendered per-part (citations are response annotations, not content).
+        // <https://platform.openai.com/docs/api-reference/chat/object> (`annotations`)
+        let annotations = render_chat_annotations(result);
+        if !annotations.is_empty() {
+            message.insert("annotations".into(), annotations.into());
+        }
+
         let mut response = serde_json::Map::new();
         response.insert("id".into(), request_id.into());
         response.insert("object".into(), "chat.completion".into());
@@ -736,6 +815,14 @@ impl OutboundAdapter for ChatCompletionsAdapter {
                 });
             }
         }
+        // Web-search citations ride `message.annotations[]` as `url_citation`
+        // entries `{type:"url_citation", url_citation:{url, title, ...}}`. Lift
+        // each into a canonical `Content::Source` (URL) so it is not dropped.
+        // The wire carries no citation id, so synthesize a stable one from the
+        // url + index. `start_index`/`end_index` (the text offsets) have no slot
+        // on the canonical `Source` and are dropped — see [`Source`].
+        // <https://platform.openai.com/docs/api-reference/chat/object> (`annotations`)
+        content.extend(parse_chat_annotations(message.get("annotations")));
 
         let finish_reason = choice
             .get("finish_reason")
@@ -1237,6 +1324,16 @@ impl StreamDecoder for ChatStreamDecoder {
                         });
                     }
                 }
+                // Streamed web-search citations arrive on `delta.annotations`
+                // (same `url_citation` shape as the non-streaming response).
+                // Each becomes one whole `StreamPart::Source`; the id is
+                // synthesized from the url + this chunk's annotation index.
+                // <https://github.com/vercel/ai/blob/main/packages/openai/src/chat/openai-chat-language-model.ts>
+                for content in parse_chat_annotations(delta.get("annotations")) {
+                    if let Content::Source { source } = content {
+                        parts.push(StreamPart::Source { source });
+                    }
+                }
             }
             if let Some(reason) = choice
                 .get("finish_reason")
@@ -1356,6 +1453,29 @@ impl StreamEncoder for ChatStreamEncoder {
                 // Chat Completions streaming has no native file-output frame
                 // (image generation is a separate API), so a generated file is
                 // surfaced only on the non-streaming path. Documented limitation.
+            }
+            StreamPart::Source { source } => {
+                // Re-attach a streamed citation as a `delta.annotations[]`
+                // `url_citation` chunk — the location the decoder reads. Only a
+                // URL source has a Chat representation; a document citation is
+                // dropped here (no `url_citation` form on this wire).
+                // <https://github.com/vercel/ai/blob/main/packages/openai/src/chat/openai-chat-language-model.ts>
+                if let Source::Url { url, title, .. } = source {
+                    let mut cite = serde_json::Map::new();
+                    cite.insert("url".into(), url.clone().into());
+                    if let Some(title) = title {
+                        cite.insert("title".into(), title.clone().into());
+                    }
+                    let mut delta = self.open_delta();
+                    delta.insert(
+                        "annotations".into(),
+                        serde_json::json!([{
+                            "type": "url_citation",
+                            "url_citation": serde_json::Value::Object(cite),
+                        }]),
+                    );
+                    frames.push(self.chunk(serde_json::Value::Object(delta), None));
+                }
             }
             StreamPart::ResponseStarted { .. } => {
                 // Observability-only metadata (upstream response id); not

--- a/crates/bitrouter-sdk/src/language_model/protocol/chat_completions.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/chat_completions.rs
@@ -403,16 +403,33 @@ impl InboundAdapter for ChatCompletionsAdapter {
         let mut message = serde_json::Map::new();
         message.insert("role".into(), "assistant".into());
 
-        let text: String = result
+        // `content` is a plain string for text-only replies; when the reply
+        // carries a generated file (e.g. an image), emit a parts array — the same
+        // shape OpenAI uses for input media. Non-standard for a chat *response*,
+        // but it preserves the data rather than dropping it.
+        if result
             .content
             .iter()
-            .filter_map(|c| match c {
-                Content::Text { text } => Some(text.as_str()),
-                _ => None,
-            })
-            .collect();
-        // `content` is always present (possibly an empty string) — never null.
-        message.insert("content".into(), text.into());
+            .any(|c| matches!(c, Content::File { .. }))
+        {
+            let parts: Vec<serde_json::Value> = result
+                .content
+                .iter()
+                .filter_map(render_input_part)
+                .collect();
+            message.insert("content".into(), parts.into());
+        } else {
+            let text: String = result
+                .content
+                .iter()
+                .filter_map(|c| match c {
+                    Content::Text { text } => Some(text.as_str()),
+                    _ => None,
+                })
+                .collect();
+            // `content` is always present (possibly an empty string) — never null.
+            message.insert("content".into(), text.into());
+        }
 
         let reasoning: String = result
             .content
@@ -1111,6 +1128,11 @@ impl StreamEncoder for ChatStreamEncoder {
             }
             StreamPart::Usage { .. } => {
                 // usage is attached to the Finish chunk below; nothing here.
+            }
+            StreamPart::File { .. } => {
+                // Chat Completions streaming has no native file-output frame
+                // (image generation is a separate API), so a generated file is
+                // surfaced only on the non-streaming path. Documented limitation.
             }
             StreamPart::ResponseStarted { .. } => {
                 // Observability-only metadata (upstream response id); not

--- a/crates/bitrouter-sdk/src/language_model/protocol/chat_completions.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/chat_completions.rs
@@ -206,6 +206,79 @@ fn content_text(value: &serde_json::Value) -> String {
     }
 }
 
+/// Parse an OpenAI `content` value (string, or array of content parts) into
+/// ordered canonical content. Text + media parts are preserved in order; other
+/// part shapes are skipped.
+fn parse_chat_content(value: &serde_json::Value) -> Vec<Content> {
+    match value {
+        serde_json::Value::String(s) if !s.is_empty() => vec![Content::Text { text: s.clone() }],
+        serde_json::Value::Array(parts) => parts.iter().filter_map(parse_chat_part).collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// Parse one OpenAI content part into canonical content.
+fn parse_chat_part(part: &serde_json::Value) -> Option<Content> {
+    match part.get("type").and_then(|t| t.as_str())? {
+        "text" => {
+            let text = part.get("text").and_then(|t| t.as_str())?.to_string();
+            (!text.is_empty()).then_some(Content::Text { text })
+        }
+        // <https://platform.openai.com/docs/guides/vision>
+        "image_url" => {
+            let url = part
+                .get("image_url")
+                .and_then(|i| i.get("url"))
+                .and_then(|u| u.as_str())?;
+            let (media_type, data) = DataContent::from_url(url);
+            Some(Content::File {
+                media_type: media_type.unwrap_or_else(|| "image/*".to_string()),
+                data,
+                filename: None,
+                extra: Default::default(),
+            })
+        }
+        // <https://platform.openai.com/docs/guides/audio>
+        "input_audio" => {
+            let audio = part.get("input_audio")?;
+            let format = audio
+                .get("format")
+                .and_then(|f| f.as_str())
+                .unwrap_or("mp3");
+            let data = if let Some(d) = audio.get("data").and_then(|d| d.as_str()) {
+                DataContent::Base64 {
+                    data: d.to_string(),
+                }
+            } else {
+                DataContent::Url {
+                    url: audio.get("url").and_then(|u| u.as_str())?.to_string(),
+                }
+            };
+            Some(Content::File {
+                media_type: format!("audio/{format}"),
+                data,
+                filename: None,
+                extra: Default::default(),
+            })
+        }
+        "file" => {
+            let file = part.get("file")?;
+            let file_data = file.get("file_data").and_then(|d| d.as_str())?;
+            let (media_type, data) = DataContent::from_url(file_data);
+            Some(Content::File {
+                media_type: media_type.unwrap_or_else(|| "application/octet-stream".to_string()),
+                data,
+                filename: file
+                    .get("filename")
+                    .and_then(|f| f.as_str())
+                    .map(str::to_string),
+                extra: Default::default(),
+            })
+        }
+        _ => None,
+    }
+}
+
 impl InboundAdapter for ChatCompletionsAdapter {
     fn protocol(&self) -> ApiProtocol {
         ApiProtocol::ChatCompletions
@@ -246,11 +319,8 @@ impl InboundAdapter for ChatCompletionsAdapter {
                     content: result,
                 });
             } else {
-                if let Some(text) = &m.content {
-                    let text = content_text(text);
-                    if !text.is_empty() {
-                        content.push(Content::Text { text });
-                    }
+                if let Some(value) = &m.content {
+                    content.extend(parse_chat_content(value));
                 }
                 for tc in m.tool_calls {
                     content.push(Content::ToolCall {

--- a/crates/bitrouter-sdk/src/language_model/protocol/chat_completions.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/chat_completions.rs
@@ -14,14 +14,15 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::{BitrouterError, Result};
 use crate::language_model::protocol::{
-    InboundAdapter, OutboundAdapter, SseEvent, StreamDecoder, StreamEncoder, Transport,
-    describe_deser_error,
+    InboundAdapter, OutboundAdapter, PROVIDER_ID_OPENAI, SseEvent, StreamDecoder, StreamEncoder,
+    Transport, describe_deser_error,
 };
 use crate::language_model::stream::SseFrame;
 use crate::language_model::types::{
     ApiProtocol, Content, DataContent, FinishReason, GenerateResult, GenerationParams, Message,
-    Modality, Prompt, ResponseFormat, Role, RoutingTarget, Source, StreamPart, Tool, ToolChoice,
-    ToolResultContentPart, ToolResultOutput, Usage,
+    Modality, Prompt, ProviderMetadata, ResponseFormat, Role, RoutingTarget, Source, StreamPart,
+    Tool, ToolChoice, ToolResultContentPart, ToolResultOutput, Usage, provider_namespace,
+    set_provider_metadata,
 };
 
 /// The Chat Completions inbound + outbound protocol adapter.
@@ -246,7 +247,7 @@ fn parse_tool_result_output(value: &serde_json::Value) -> ToolResultOutput {
 /// other content kind yields `None`.
 fn content_to_tool_result_part(c: Content) -> Option<ToolResultContentPart> {
     match c {
-        Content::Text { text } => Some(ToolResultContentPart::Text { text }),
+        Content::Text { text, .. } => Some(ToolResultContentPart::Text { text }),
         Content::File {
             media_type, data, ..
         } => Some(ToolResultContentPart::Media { media_type, data }),
@@ -259,7 +260,10 @@ fn content_to_tool_result_part(c: Content) -> Option<ToolResultContentPart> {
 /// part shapes are skipped.
 fn parse_chat_content(value: &serde_json::Value) -> Vec<Content> {
     match value {
-        serde_json::Value::String(s) if !s.is_empty() => vec![Content::Text { text: s.clone() }],
+        serde_json::Value::String(s) if !s.is_empty() => vec![Content::Text {
+            text: s.clone(),
+            provider_metadata: ProviderMetadata::new(),
+        }],
         serde_json::Value::Array(parts) => parts.iter().filter_map(parse_chat_part).collect(),
         _ => Vec::new(),
     }
@@ -270,20 +274,35 @@ fn parse_chat_part(part: &serde_json::Value) -> Option<Content> {
     match part.get("type").and_then(|t| t.as_str())? {
         "text" => {
             let text = part.get("text").and_then(|t| t.as_str())?.to_string();
-            (!text.is_empty()).then_some(Content::Text { text })
+            (!text.is_empty()).then_some(Content::Text {
+                text,
+                provider_metadata: ProviderMetadata::new(),
+            })
         }
         // <https://platform.openai.com/docs/guides/vision>
         "image_url" => {
-            let url = part
-                .get("image_url")
-                .and_then(|i| i.get("url"))
-                .and_then(|u| u.as_str())?;
+            let image_url = part.get("image_url")?;
+            let url = image_url.get("url").and_then(|u| u.as_str())?;
             let (media_type, data) = DataContent::from_url(url);
+            // The OpenAI image `detail` hint (`auto` | `low` | `high`) is
+            // provider metadata, not a payload field — preserve it under the
+            // `openai` namespace so it survives a round-trip (and is ignored,
+            // not leaked, on a non-OpenAI upstream).
+            // <https://platform.openai.com/docs/guides/vision>
+            let mut provider_metadata = ProviderMetadata::new();
+            if let Some(detail) = image_url.get("detail") {
+                set_provider_metadata(
+                    &mut provider_metadata,
+                    PROVIDER_ID_OPENAI,
+                    "detail",
+                    detail.clone(),
+                );
+            }
             Some(Content::File {
                 media_type: media_type.unwrap_or_else(|| "image/*".to_string()),
                 data,
                 filename: None,
-                extra: Default::default(),
+                provider_metadata,
             })
         }
         // <https://platform.openai.com/docs/guides/audio>
@@ -306,7 +325,7 @@ fn parse_chat_part(part: &serde_json::Value) -> Option<Content> {
                 media_type: format!("audio/{format}"),
                 data,
                 filename: None,
-                extra: Default::default(),
+                provider_metadata: ProviderMetadata::new(),
             })
         }
         "file" => {
@@ -320,7 +339,7 @@ fn parse_chat_part(part: &serde_json::Value) -> Option<Content> {
                     .get("filename")
                     .and_then(|f| f.as_str())
                     .map(str::to_string),
-                extra: Default::default(),
+                provider_metadata: ProviderMetadata::new(),
             })
         }
         _ => None,
@@ -357,6 +376,7 @@ fn parse_chat_annotations(annotations: Option<&serde_json::Value>) -> Vec<Conten
                     url,
                     title,
                 },
+                provider_metadata: ProviderMetadata::new(),
             })
         })
         .collect()
@@ -376,6 +396,7 @@ fn render_chat_annotations(result: &GenerateResult) -> Vec<serde_json::Value> {
         .filter_map(|c| match c {
             Content::Source {
                 source: Source::Url { url, title, .. },
+                ..
             } => {
                 let mut cite = serde_json::Map::new();
                 cite.insert("url".into(), url.clone().into());
@@ -390,6 +411,7 @@ fn render_chat_annotations(result: &GenerateResult) -> Vec<serde_json::Value> {
             // Document citations have no `url_citation` form on the Chat wire.
             Content::Source {
                 source: Source::Document { .. },
+                ..
             } => None,
             _ => None,
         })
@@ -424,7 +446,10 @@ impl InboundAdapter for ChatCompletionsAdapter {
             if let Some(reasoning) = m.reasoning_content
                 && !reasoning.is_empty()
             {
-                content.push(Content::Reasoning { text: reasoning });
+                content.push(Content::Reasoning {
+                    text: reasoning,
+                    provider_metadata: ProviderMetadata::new(),
+                });
             }
             if role == Role::Tool {
                 // OpenAI tool messages carry `{role:"tool", tool_call_id, content}`;
@@ -447,6 +472,7 @@ impl InboundAdapter for ChatCompletionsAdapter {
                     call_id,
                     tool_name: None,
                     output,
+                    provider_metadata: ProviderMetadata::new(),
                 });
             } else {
                 if let Some(value) = &m.content {
@@ -460,10 +486,15 @@ impl InboundAdapter for ChatCompletionsAdapter {
                         // Chat Completions `tool_calls` are always client tools —
                         // there is no server-tool slot on this wire.
                         provider_executed: false,
+                        provider_metadata: ProviderMetadata::new(),
                     });
                 }
             }
-            messages.push(Message { role, content });
+            messages.push(Message {
+                role,
+                content,
+                provider_metadata: ProviderMetadata::new(),
+            });
         }
 
         // Chat Completions is function-only on the wire — there is no
@@ -479,6 +510,9 @@ impl InboundAdapter for ChatCompletionsAdapter {
                 description: t.function.description,
                 parameters: t.function.parameters,
                 strict: t.function.strict,
+                // Chat Completions has no per-tool `cache_control`; no provider
+                // metadata to lift here.
+                provider_metadata: ProviderMetadata::new(),
             })
             .collect();
 
@@ -569,7 +603,7 @@ impl InboundAdapter for ChatCompletionsAdapter {
                 .content
                 .iter()
                 .filter_map(|c| match c {
-                    Content::Text { text } => Some(text.as_str()),
+                    Content::Text { text, .. } => Some(text.as_str()),
                     _ => None,
                 })
                 .collect();
@@ -581,7 +615,7 @@ impl InboundAdapter for ChatCompletionsAdapter {
             .content
             .iter()
             .filter_map(|c| match c {
-                Content::Reasoning { text } => Some(text.as_str()),
+                Content::Reasoning { text, .. } => Some(text.as_str()),
                 _ => None,
             })
             .collect();
@@ -637,6 +671,15 @@ impl InboundAdapter for ChatCompletionsAdapter {
         );
         if let Some(usage) = result.usage {
             response.insert("usage".into(), render_usage(&usage));
+        }
+        // Restore the OpenAI `system_fingerprint` from result-level provider
+        // metadata when present (only ever set by this protocol's
+        // `parse_response`), so a same-protocol round-trip reproduces it.
+        // <https://platform.openai.com/docs/api-reference/chat/object>
+        if let Some(fp) = provider_namespace(&result.provider_metadata, PROVIDER_ID_OPENAI)
+            .and_then(|o| o.get("systemFingerprint"))
+        {
+            response.insert("system_fingerprint".into(), fp.clone());
         }
         Ok(serde_json::Value::Object(response))
     }
@@ -764,6 +807,7 @@ impl OutboundAdapter for ChatCompletionsAdapter {
         {
             content.push(Content::Reasoning {
                 text: reasoning.to_string(),
+                provider_metadata: ProviderMetadata::new(),
             });
         }
         if let Some(text) = message
@@ -772,7 +816,10 @@ impl OutboundAdapter for ChatCompletionsAdapter {
             .map(content_text)
             .filter(|s| !s.is_empty())
         {
-            content.push(Content::Text { text });
+            content.push(Content::Text {
+                text,
+                provider_metadata: ProviderMetadata::new(),
+            });
         }
         // Chat Completions' `message.refusal` (when non-empty) is the model's
         // declined-response text. Carry it through so the caller sees the
@@ -786,6 +833,7 @@ impl OutboundAdapter for ChatCompletionsAdapter {
         {
             content.push(Content::Text {
                 text: refusal.to_string(),
+                provider_metadata: ProviderMetadata::new(),
             });
             refusal_seen = true;
         }
@@ -812,6 +860,7 @@ impl OutboundAdapter for ChatCompletionsAdapter {
                     // The Chat Completions response wire has no server-tool item;
                     // every `tool_calls` entry is a client tool call.
                     provider_executed: false,
+                    provider_metadata: ProviderMetadata::new(),
                 });
             }
         }
@@ -844,6 +893,19 @@ impl OutboundAdapter for ChatCompletionsAdapter {
             .get("id")
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
+        // OpenAI's `system_fingerprint` identifies the backend config the
+        // response was produced with — it has no dedicated canonical field, so
+        // carry it at result level under the `openai` namespace.
+        // <https://platform.openai.com/docs/api-reference/chat/object>
+        let mut provider_metadata = ProviderMetadata::new();
+        if let Some(fp) = body.get("system_fingerprint").filter(|v| !v.is_null()) {
+            set_provider_metadata(
+                &mut provider_metadata,
+                PROVIDER_ID_OPENAI,
+                "systemFingerprint",
+                fp.clone(),
+            );
+        }
 
         Ok(GenerateResult {
             content,
@@ -851,6 +913,7 @@ impl OutboundAdapter for ChatCompletionsAdapter {
             finish_reason,
             response_id,
             stop_details: None,
+            provider_metadata,
         })
     }
 
@@ -884,6 +947,7 @@ fn render_chat_tool(tool: &Tool) -> serde_json::Value {
             description,
             parameters,
             strict,
+            ..
         } => {
             let mut function = serde_json::Map::new();
             function.insert("name".into(), name.clone().into());
@@ -901,7 +965,9 @@ fn render_chat_tool(tool: &Tool) -> serde_json::Value {
             }
             serde_json::json!({ "type": "function", "function": function })
         }
-        Tool::ProviderDefined { id, name, args } => super::provider_defined_native(id, name, args),
+        Tool::ProviderDefined { id, name, args, .. } => {
+            super::provider_defined_native(id, name, args)
+        }
     }
 }
 
@@ -1010,17 +1076,28 @@ impl Transport for ChatCompletionsTransport {
 /// array, so they yield `None` here.
 fn render_input_part(c: &Content) -> Option<serde_json::Value> {
     match c {
-        Content::Text { text } => Some(serde_json::json!({ "type": "text", "text": text })),
+        Content::Text { text, .. } => Some(serde_json::json!({ "type": "text", "text": text })),
         Content::File {
             media_type,
             data,
             filename,
-            ..
+            provider_metadata,
         } => Some(if media_type.starts_with("image/") {
             // <https://platform.openai.com/docs/guides/vision>
+            let mut image_url = serde_json::Map::new();
+            image_url.insert("url".into(), data.to_url(media_type).into());
+            // Restore the OpenAI `detail` hint from the `openai` namespace when
+            // it round-tripped through `provider_metadata` (set by this
+            // protocol's `parse_chat_part`).
+            // <https://platform.openai.com/docs/guides/vision>
+            if let Some(detail) = provider_namespace(provider_metadata, PROVIDER_ID_OPENAI)
+                .and_then(|o| o.get("detail"))
+            {
+                image_url.insert("detail".into(), detail.clone());
+            }
             serde_json::json!({
                 "type": "image_url",
-                "image_url": { "url": data.to_url(media_type) }
+                "image_url": serde_json::Value::Object(image_url),
             })
         } else if let Some(format) = media_type.strip_prefix("audio/") {
             // <https://platform.openai.com/docs/guides/audio>
@@ -1072,12 +1149,15 @@ fn render_tool_result_content(output: &ToolResultOutput) -> serde_json::Value {
 /// <https://platform.openai.com/docs/api-reference/chat/create#chat-create-messages>
 fn tool_result_part_to_content(part: &ToolResultContentPart) -> Option<Content> {
     match part {
-        ToolResultContentPart::Text { text } => Some(Content::Text { text: text.clone() }),
+        ToolResultContentPart::Text { text } => Some(Content::Text {
+            text: text.clone(),
+            provider_metadata: ProviderMetadata::new(),
+        }),
         ToolResultContentPart::Media { media_type, data } => Some(Content::File {
             media_type: media_type.clone(),
             data: data.clone(),
             filename: None,
-            extra: Default::default(),
+            provider_metadata: ProviderMetadata::new(),
         }),
         ToolResultContentPart::FileId { .. } => None,
     }
@@ -1116,7 +1196,7 @@ fn render_message(m: &Message) -> serde_json::Value {
             .content
             .iter()
             .filter_map(|c| match c {
-                Content::Text { text } => Some(text.as_str()),
+                Content::Text { text, .. } => Some(text.as_str()),
                 _ => None,
             })
             .collect();
@@ -1127,7 +1207,7 @@ fn render_message(m: &Message) -> serde_json::Value {
         .content
         .iter()
         .filter_map(|c| match c {
-            Content::Reasoning { text } => Some(text.as_str()),
+            Content::Reasoning { text, .. } => Some(text.as_str()),
             _ => None,
         })
         .collect();
@@ -1330,7 +1410,7 @@ impl StreamDecoder for ChatStreamDecoder {
                 // synthesized from the url + this chunk's annotation index.
                 // <https://github.com/vercel/ai/blob/main/packages/openai/src/chat/openai-chat-language-model.ts>
                 for content in parse_chat_annotations(delta.get("annotations")) {
-                    if let Content::Source { source } = content {
+                    if let Content::Source { source, .. } = content {
                         parts.push(StreamPart::Source { source });
                     }
                 }

--- a/crates/bitrouter-sdk/src/language_model/protocol/chat_completions.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/chat_completions.rs
@@ -377,7 +377,7 @@ fn parse_chat_part(part: &serde_json::Value) -> Option<Content> {
 /// synthesized from the url + index (the wire carries none); the `start_index`/
 /// `end_index` text offsets are dropped (no canonical slot). Mirrors the AI SDK
 /// OpenAI chat mapping.
-/// <https://github.com/vercel/ai/blob/main/packages/openai/src/chat/openai-chat-language-model.ts>
+/// <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/openai/src/chat/openai-chat-language-model.ts>
 fn parse_chat_annotations(annotations: Option<&serde_json::Value>) -> Vec<Content> {
     let Some(arr) = annotations.and_then(|a| a.as_array()) else {
         return Vec::new();
@@ -1500,7 +1500,7 @@ impl StreamDecoder for ChatStreamDecoder {
                 // (same `url_citation` shape as the non-streaming response).
                 // Each becomes one whole `StreamPart::Source`; the id is
                 // synthesized from the url + this chunk's annotation index.
-                // <https://github.com/vercel/ai/blob/main/packages/openai/src/chat/openai-chat-language-model.ts>
+                // <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/openai/src/chat/openai-chat-language-model.ts>
                 for content in parse_chat_annotations(delta.get("annotations")) {
                     if let Content::Source { source, .. } = content {
                         parts.push(StreamPart::Source { source });
@@ -1639,7 +1639,7 @@ impl StreamEncoder for ChatStreamEncoder {
                 // `url_citation` chunk — the location the decoder reads. Only a
                 // URL source has a Chat representation; a document citation is
                 // dropped here (no `url_citation` form on this wire).
-                // <https://github.com/vercel/ai/blob/main/packages/openai/src/chat/openai-chat-language-model.ts>
+                // <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/openai/src/chat/openai-chat-language-model.ts>
                 if let Source::Url { url, title, .. } = source {
                     let mut cite = serde_json::Map::new();
                     cite.insert("url".into(), url.clone().into());

--- a/crates/bitrouter-sdk/src/language_model/protocol/chat_completions.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/chat_completions.rs
@@ -62,10 +62,29 @@ pub struct ChatRequest {
     /// <https://platform.openai.com/docs/guides/structured-outputs>
     #[serde(default)]
     response_format: Option<ChatResponseFormat>,
+    /// Deterministic-sampling seed. Promoted to the canonical `seed` slot so it
+    /// translates across protocols (e.g. to a Gemini upstream's
+    /// `generationConfig.seed`) instead of no-op'ing as a top-level key on a
+    /// nested-config wire.
+    /// <https://platform.openai.com/docs/api-reference/chat/create#chat-create-seed>
+    #[serde(default)]
+    seed: Option<i64>,
+    /// Stop sequences — a single string or an array of up to four. Promoted to
+    /// the canonical `stop` slot.
+    /// <https://platform.openai.com/docs/api-reference/chat/create#chat-create-stop>
+    #[serde(default)]
+    stop: Option<serde_json::Value>,
+    /// Presence penalty. Promoted to the canonical `presence_penalty` slot.
+    /// <https://platform.openai.com/docs/api-reference/chat/create#chat-create-presence_penalty>
+    #[serde(default)]
+    presence_penalty: Option<f64>,
+    /// Frequency penalty. Promoted to the canonical `frequency_penalty` slot.
+    /// <https://platform.openai.com/docs/api-reference/chat/create#chat-create-frequency_penalty>
+    #[serde(default)]
+    frequency_penalty: Option<f64>,
     #[serde(default)]
     stream: bool,
-    /// Every other field — `tool_choice`, `stop` / `stop_sequences`, `seed`,
-    /// `n`, `presence_penalty`, `frequency_penalty`, `logit_bias`, `logprobs`,
+    /// Every other field — `tool_choice`, `n`, `logit_bias`, `logprobs`,
     /// `top_logprobs`, `user`, `stream_options`, `parallel_tool_calls`, … —
     /// survives parse/render via `extra`. v0 passed these through; v1 must too.
     /// Skipped from the published schema so the documented contract is the set
@@ -568,9 +587,15 @@ impl InboundAdapter for ChatCompletionsAdapter {
                 reasoning_effort: req.reasoning_effort,
                 response_modalities,
                 tool_choice,
+                // Chat Completions carries no top-k.
+                top_k: None,
+                seed: req.seed,
+                stop: parse_chat_stop(req.stop),
+                presence_penalty: req.presence_penalty,
+                frequency_penalty: req.frequency_penalty,
                 // Every remaining Chat Completions field without a typed slot —
-                // stop / stop_sequences, seed, n, presence/frequency_penalty,
-                // logit_bias, … — rides in `extra` and is splatted back on render.
+                // n, logit_bias, … — rides in `extra` and is splatted back on
+                // render.
                 extra,
             },
             response_format,
@@ -761,9 +786,26 @@ impl OutboundAdapter for ChatCompletionsAdapter {
         if let Some(tc) = &prompt.params.tool_choice {
             req.insert("tool_choice".into(), render_chat_tool_choice(tc));
         }
+        // Render the typed sampling slots into their Chat Completions wire names.
+        // Chat Completions carries no top-k, so `top_k` is intentionally not
+        // rendered here (it reaches Anthropic/Gemini upstreams instead). `stop`
+        // renders as an array, which the API accepts for any count.
+        // <https://platform.openai.com/docs/api-reference/chat/create>
+        if let Some(seed) = prompt.params.seed {
+            req.insert("seed".into(), seed.into());
+        }
+        if !prompt.params.stop.is_empty() {
+            req.insert("stop".into(), prompt.params.stop.clone().into());
+        }
+        if let Some(pp) = prompt.params.presence_penalty {
+            req.insert("presence_penalty".into(), pp.into());
+        }
+        if let Some(fp) = prompt.params.frequency_penalty {
+            req.insert("frequency_penalty".into(), fp.into());
+        }
         // Splat the extras back into the outbound request — this is how
-        // `stop`, `seed`, etc. survive the round trip. Typed fields above win
-        // over any same-named extra.
+        // remaining untyped fields survive the round trip. Typed fields above
+        // win over any same-named extra.
         for (k, v) in &prompt.params.extra {
             req.entry(k.clone()).or_insert_with(|| v.clone());
         }
@@ -1022,6 +1064,26 @@ fn render_chat_response_format(rf: &ResponseFormat) -> serde_json::Value {
     }
     js.insert("schema".into(), schema.clone());
     serde_json::json!({ "type": "json_schema", "json_schema": serde_json::Value::Object(js) })
+}
+
+/// Normalize a Chat Completions `stop` value into the canonical stop-sequence
+/// list. The wire accepts either a single string or an array of strings;
+/// non-string array members and any other JSON shape are ignored (the canonical
+/// slot is string-only, matching Anthropic's `stop_sequences` and Gemini's
+/// `stopSequences`). `None`/empty yields an empty list, which renders nothing.
+/// <https://platform.openai.com/docs/api-reference/chat/create#chat-create-stop>
+fn parse_chat_stop(value: Option<serde_json::Value>) -> Vec<String> {
+    match value {
+        Some(serde_json::Value::String(s)) => vec![s],
+        Some(serde_json::Value::Array(items)) => items
+            .into_iter()
+            .filter_map(|v| match v {
+                serde_json::Value::String(s) => Some(s),
+                _ => None,
+            })
+            .collect(),
+        _ => Vec::new(),
+    }
 }
 
 /// Parse a Chat Completions `tool_choice` value into the canonical [`ToolChoice`].

--- a/crates/bitrouter-sdk/src/language_model/protocol/chat_completions.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/chat_completions.rs
@@ -20,7 +20,8 @@ use crate::language_model::protocol::{
 use crate::language_model::stream::SseFrame;
 use crate::language_model::types::{
     ApiProtocol, Content, DataContent, FinishReason, GenerateResult, GenerationParams, Message,
-    Modality, Prompt, ResponseFormat, Role, RoutingTarget, StreamPart, Usage,
+    Modality, Prompt, ResponseFormat, Role, RoutingTarget, StreamPart, ToolResultContentPart,
+    ToolResultOutput, Usage,
 };
 
 /// The Chat Completions inbound + outbound protocol adapter.
@@ -206,6 +207,48 @@ fn content_text(value: &serde_json::Value) -> String {
     }
 }
 
+/// Parse an OpenAI `tool` message `content` value into a canonical
+/// [`ToolResultOutput`]. A string → [`ToolResultOutput::Text`]. A content-part
+/// array that carries any media part → [`ToolResultOutput::Content`] (text +
+/// media, in order); a text-only array collapses to `Text` so a trivial
+/// `[{type:text}]` does not gratuitously promote to the multimodal variant. Any
+/// other JSON value → [`ToolResultOutput::Json`].
+/// <https://platform.openai.com/docs/api-reference/chat/create#chat-create-messages>
+fn parse_tool_result_output(value: &serde_json::Value) -> ToolResultOutput {
+    match value {
+        serde_json::Value::String(s) => ToolResultOutput::Text { value: s.clone() },
+        serde_json::Value::Array(parts) => {
+            let canonical: Vec<Content> = parts.iter().filter_map(parse_chat_part).collect();
+            let has_media = canonical.iter().any(|c| matches!(c, Content::File { .. }));
+            if has_media {
+                let value = canonical
+                    .into_iter()
+                    .filter_map(content_to_tool_result_part)
+                    .collect();
+                ToolResultOutput::Content { value }
+            } else {
+                ToolResultOutput::Text {
+                    value: content_text(value),
+                }
+            }
+        }
+        other => ToolResultOutput::from_untyped_value(other),
+    }
+}
+
+/// Map a canonical text/file [`Content`] into a [`ToolResultContentPart`].
+/// Only text and media parts have a tool-result-content representation; any
+/// other content kind yields `None`.
+fn content_to_tool_result_part(c: Content) -> Option<ToolResultContentPart> {
+    match c {
+        Content::Text { text } => Some(ToolResultContentPart::Text { text }),
+        Content::File {
+            media_type, data, ..
+        } => Some(ToolResultContentPart::Media { media_type, data }),
+        _ => None,
+    }
+}
+
 /// Parse an OpenAI `content` value (string, or array of content parts) into
 /// ordered canonical content. Text + media parts are preserved in order; other
 /// part shapes are skipped.
@@ -310,13 +353,26 @@ impl InboundAdapter for ChatCompletionsAdapter {
                 content.push(Content::Reasoning { text: reasoning });
             }
             if role == Role::Tool {
-                let result = m.content.as_ref().map(content_text).unwrap_or_default();
+                // OpenAI tool messages carry `{role:"tool", tool_call_id, content}`;
+                // `content` is a string or a content-part array, with no tool
+                // name and no error flag on the wire. A string → Text, a part
+                // array carrying media → Content, any other structured value →
+                // Json.
+                // <https://platform.openai.com/docs/api-reference/chat/create#chat-create-messages>
+                let output = m
+                    .content
+                    .as_ref()
+                    .map(parse_tool_result_output)
+                    .unwrap_or_else(|| ToolResultOutput::Text {
+                        value: String::new(),
+                    });
                 let call_id = m.tool_call_id.ok_or_else(|| {
                     BitrouterError::bad_request("tool message missing 'tool_call_id'")
                 })?;
                 content.push(Content::ToolResult {
                     call_id,
-                    content: result,
+                    tool_name: None,
+                    output,
                 });
             } else {
                 if let Some(value) = &m.content {
@@ -784,16 +840,56 @@ fn render_input_part(c: &Content) -> Option<serde_json::Value> {
     }
 }
 
+/// Render a [`ToolResultOutput`] into the value of an OpenAI tool message's
+/// `content` field. A multimodal [`ToolResultOutput::Content`] becomes a
+/// content-part array (reusing [`render_input_part`]); every other variant
+/// collapses to a plain string (the error variants lose their flag, which the
+/// OpenAI tool wire cannot represent).
+/// <https://platform.openai.com/docs/api-reference/chat/create#chat-create-messages>
+fn render_tool_result_content(output: &ToolResultOutput) -> serde_json::Value {
+    match output {
+        ToolResultOutput::Content { value } => {
+            let parts: Vec<serde_json::Value> = value
+                .iter()
+                .filter_map(|p| render_input_part(&tool_result_part_to_content(p)))
+                .collect();
+            parts.into()
+        }
+        other => other.to_provider_string().into(),
+    }
+}
+
+/// Lift a [`ToolResultContentPart`] into a canonical [`Content`] so the shared
+/// [`render_input_part`] media renderer can be reused for tool-result content.
+fn tool_result_part_to_content(part: &ToolResultContentPart) -> Content {
+    match part {
+        ToolResultContentPart::Text { text } => Content::Text { text: text.clone() },
+        ToolResultContentPart::Media { media_type, data } => Content::File {
+            media_type: media_type.clone(),
+            data: data.clone(),
+            filename: None,
+            extra: Default::default(),
+        },
+    }
+}
+
 fn render_message(m: &Message) -> serde_json::Value {
     let mut obj = serde_json::Map::new();
     obj.insert("role".into(), role_str(m.role).into());
 
     if m.role == Role::Tool {
-        // tool messages carry a tool_call_id + flat string content
+        // OpenAI tool messages carry `{tool_call_id, content}`. `content` is a
+        // string, or a content-part array when the result is multimodal. The
+        // wire has no error flag and no tool-name field, so an error output
+        // degrades to its text/JSON string and `tool_name` is dropped.
+        // <https://platform.openai.com/docs/api-reference/chat/create#chat-create-messages>
         for c in &m.content {
-            if let Content::ToolResult { call_id, content } = c {
+            if let Content::ToolResult {
+                call_id, output, ..
+            } = c
+            {
                 obj.insert("tool_call_id".into(), call_id.clone().into());
-                obj.insert("content".into(), content.clone().into());
+                obj.insert("content".into(), render_tool_result_content(output));
             }
         }
         return serde_json::Value::Object(obj);

--- a/crates/bitrouter-sdk/src/language_model/protocol/chat_completions.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/chat_completions.rs
@@ -490,11 +490,7 @@ impl InboundAdapter for ChatCompletionsAdapter {
                     });
                 }
             }
-            messages.push(Message {
-                role,
-                content,
-                provider_metadata: ProviderMetadata::new(),
-            });
+            messages.push(Message { role, content });
         }
 
         // Chat Completions is function-only on the wire — there is no
@@ -555,6 +551,8 @@ impl InboundAdapter for ChatCompletionsAdapter {
         Ok(Prompt {
             model: req.model,
             system,
+            // Chat Completions has no system-level `cache_control` on its wire.
+            system_provider_metadata: ProviderMetadata::new(),
             messages,
             tools,
             params: GenerationParams {

--- a/crates/bitrouter-sdk/src/language_model/protocol/chat_completions.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/chat_completions.rs
@@ -496,6 +496,8 @@ impl InboundAdapter for ChatCompletionsAdapter {
                     call_id,
                     tool_name: None,
                     output,
+                    // Chat Completions has no MCP tool-result wire.
+                    dynamic: false,
                     provider_metadata: ProviderMetadata::new(),
                 });
             } else {
@@ -510,6 +512,8 @@ impl InboundAdapter for ChatCompletionsAdapter {
                         // Chat Completions `tool_calls` are always client tools —
                         // there is no server-tool slot on this wire.
                         provider_executed: false,
+                        // …and no provider-executed MCP (`dynamic`) call envelope.
+                        dynamic: false,
                         provider_metadata: ProviderMetadata::new(),
                     });
                 }
@@ -909,6 +913,8 @@ impl OutboundAdapter for ChatCompletionsAdapter {
                     // The Chat Completions response wire has no server-tool item;
                     // every `tool_calls` entry is a client tool call.
                     provider_executed: false,
+                    // …and no provider-executed MCP (`dynamic`) call envelope.
+                    dynamic: false,
                     provider_metadata: ProviderMetadata::new(),
                 });
             }

--- a/crates/bitrouter-sdk/src/language_model/protocol/chat_completions.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/chat_completions.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 use crate::error::{BitrouterError, Result};
 use crate::language_model::protocol::{
     InboundAdapter, OutboundAdapter, PROVIDER_ID_OPENAI, SseEvent, StreamDecoder, StreamEncoder,
-    Transport, describe_deser_error,
+    Transport, describe_deser_error, rendered_finish_reason, stash_raw_finish_reason,
 };
 use crate::language_model::stream::SseFrame;
 use crate::language_model::types::{
@@ -97,6 +97,11 @@ pub enum ChatResponseFormat {
 pub struct ChatJsonSchema {
     /// Schema name (OpenAI requires it).
     name: String,
+    /// Optional schema description — extra LLM guidance OpenAI passes through to
+    /// the model. Promoted to the canonical `response_format` description.
+    /// <https://platform.openai.com/docs/guides/structured-outputs>
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
     /// Strict-mode flag.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     strict: Option<bool>,
@@ -521,6 +526,7 @@ impl InboundAdapter for ChatCompletionsAdapter {
             Some(ChatResponseFormat::JsonSchema { json_schema }) => {
                 Some(ResponseFormat::JsonSchema {
                     name: Some(json_schema.name),
+                    description: json_schema.description,
                     strict: json_schema.strict,
                     schema: json_schema.schema,
                 })
@@ -664,7 +670,10 @@ impl InboundAdapter for ChatCompletionsAdapter {
             serde_json::json!([{
                 "index": 0,
                 "message": serde_json::Value::Object(message),
-                "finish_reason": result.finish_reason.as_ref().map(finish_reason_str),
+                // Prefer the stashed raw finish reason (e.g. `function_call`)
+                // over the unified-enum mapping so a same-protocol round-trip
+                // reproduces the exact native value.
+                "finish_reason": rendered_finish_reason(result, PROVIDER_ID_OPENAI, finish_reason_str),
             }]),
         );
         if let Some(usage) = result.usage {
@@ -871,9 +880,12 @@ impl OutboundAdapter for ChatCompletionsAdapter {
         // <https://platform.openai.com/docs/api-reference/chat/object> (`annotations`)
         content.extend(parse_chat_annotations(message.get("annotations")));
 
-        let finish_reason = choice
+        let raw_finish = choice
             .get("finish_reason")
             .and_then(|f| f.as_str())
+            .map(str::to_string);
+        let finish_reason = raw_finish
+            .as_deref()
             .and_then(parse_finish_reason)
             // A `refusal` field signals content-filter regardless of what
             // `finish_reason` claims, so the caller can surface the refusal.
@@ -904,6 +916,19 @@ impl OutboundAdapter for ChatCompletionsAdapter {
                 fp.clone(),
             );
         }
+        // Preserve the raw `finish_reason` when the unified enum would not
+        // re-render it verbatim — e.g. `function_call` (→ `tool_calls`) or an
+        // Anthropic-flavoured `end_turn` / `max_tokens` accepted here. A refusal
+        // override also diverges from the wire string. Stash it under the
+        // `openai` namespace so `render_response` reproduces the exact native
+        // value on a same-protocol hop.
+        stash_raw_finish_reason(
+            &mut provider_metadata,
+            PROVIDER_ID_OPENAI,
+            raw_finish.as_deref(),
+            finish_reason.as_ref(),
+            finish_reason_str,
+        );
 
         Ok(GenerateResult {
             content,
@@ -970,11 +995,15 @@ fn render_chat_tool(tool: &Tool) -> serde_json::Value {
 }
 
 /// Render a canonical [`ResponseFormat`] into Chat Completions' native
-/// `{ type: "json_schema", json_schema: { name, strict, schema } }`. OpenAI
-/// requires `name`; supply a stable default when the caller didn't set one.
+/// `{ type: "json_schema", json_schema: { name, description?, strict?, schema } }`.
+/// OpenAI requires `name`; supply a stable default when the caller didn't set
+/// one. `description` is emitted only when the canonical slot carries it (the
+/// OpenAI family is the only wire that transmits a schema description).
+/// <https://platform.openai.com/docs/guides/structured-outputs>
 fn render_chat_response_format(rf: &ResponseFormat) -> serde_json::Value {
     let ResponseFormat::JsonSchema {
         name,
+        description,
         strict,
         schema,
     } = rf;
@@ -985,6 +1014,9 @@ fn render_chat_response_format(rf: &ResponseFormat) -> serde_json::Value {
             .unwrap_or_else(|| "response".to_string())
             .into(),
     );
+    if let Some(description) = description {
+        js.insert("description".into(), description.clone().into());
+    }
     if let Some(strict) = strict {
         js.insert("strict".into(), (*strict).into());
     }

--- a/crates/bitrouter-sdk/src/language_model/protocol/chat_completions.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/chat_completions.rs
@@ -20,7 +20,7 @@ use crate::language_model::protocol::{
 use crate::language_model::stream::SseFrame;
 use crate::language_model::types::{
     ApiProtocol, Content, DataContent, FinishReason, GenerateResult, GenerationParams, Message,
-    Modality, Prompt, ResponseFormat, Role, RoutingTarget, StreamPart, ToolChoice,
+    Modality, Prompt, ResponseFormat, Role, RoutingTarget, StreamPart, Tool, ToolChoice,
     ToolResultContentPart, ToolResultOutput, Usage,
 };
 
@@ -152,7 +152,8 @@ pub struct ChatTool {
 }
 
 /// The `function` payload of a [`ChatTool`]: name + description + JSON-Schema
-/// parameters.
+/// parameters + optional `strict` flag.
+/// <https://platform.openai.com/docs/guides/function-calling#strict-mode>
 #[derive(Debug, Default, Deserialize, JsonSchema)]
 pub struct ChatToolFunction {
     name: String,
@@ -160,6 +161,10 @@ pub struct ChatToolFunction {
     description: Option<String>,
     #[serde(default)]
     parameters: serde_json::Value,
+    /// OpenAI strict-mode flag (V3 `strict`). Captured so it is not lost across
+    /// the canonical boundary.
+    #[serde(default)]
+    strict: Option<bool>,
 }
 
 // ===== role mapping (total — v0 #454-4) =====
@@ -392,13 +397,19 @@ impl InboundAdapter for ChatCompletionsAdapter {
             messages.push(Message { role, content });
         }
 
+        // Chat Completions is function-only on the wire — there is no
+        // provider-defined ("server") tool envelope, so every entry parses to a
+        // `Tool::Function`. The `strict` flag is captured into the canonical slot
+        // (previously dropped here).
+        // <https://platform.openai.com/docs/api-reference/chat/create#chat-create-tools>
         let tools = req
             .tools
             .into_iter()
-            .map(|t| crate::language_model::types::Tool {
+            .map(|t| crate::language_model::types::Tool::Function {
                 name: t.function.name,
                 description: t.function.description,
                 parameters: t.function.parameters,
+                strict: t.function.strict,
             })
             .collect();
 
@@ -584,16 +595,7 @@ impl OutboundAdapter for ChatCompletionsAdapter {
                 prompt
                     .tools
                     .iter()
-                    .map(|t| {
-                        serde_json::json!({
-                            "type": "function",
-                            "function": {
-                                "name": t.name,
-                                "description": t.description,
-                                "parameters": t.parameters,
-                            }
-                        })
-                    })
+                    .map(render_chat_tool)
                     .collect::<Vec<_>>()
                     .into(),
             );
@@ -771,6 +773,48 @@ impl OutboundAdapter for ChatCompletionsAdapter {
 
     fn supports_response_format(&self) -> bool {
         true
+    }
+}
+
+/// Render one canonical [`Tool`] into a Chat Completions `tools` entry.
+///
+/// A [`Tool::Function`] becomes `{type:"function", function:{name, description,
+/// parameters, strict?}}`; the `strict` flag is emitted when set (previously it
+/// was always dropped).
+/// <https://platform.openai.com/docs/api-reference/chat/create#chat-create-tools>
+///
+/// Chat Completions has **no** provider-defined ("server") tool envelope on the
+/// wire, so a [`Tool::ProviderDefined`] only reaches here on a cross-protocol
+/// route (a client targeting another provider's server tool, routed to an
+/// OpenAI-compatible upstream). Per the faithful-passthrough rule it is
+/// preserved verbatim in its source-native shape so the upstream decides; the
+/// object is splatted directly into the `tools` array rather than dropped or
+/// lossily mapped.
+fn render_chat_tool(tool: &Tool) -> serde_json::Value {
+    match tool {
+        Tool::Function {
+            name,
+            description,
+            parameters,
+            strict,
+        } => {
+            let mut function = serde_json::Map::new();
+            function.insert("name".into(), name.clone().into());
+            // `description` rides through as JSON null when absent for parity with
+            // the prior render; callers tolerate it.
+            function.insert(
+                "description".into(),
+                description
+                    .clone()
+                    .map_or(serde_json::Value::Null, serde_json::Value::String),
+            );
+            function.insert("parameters".into(), parameters.clone());
+            if let Some(strict) = strict {
+                function.insert("strict".into(), (*strict).into());
+            }
+            serde_json::json!({ "type": "function", "function": function })
+        }
+        Tool::ProviderDefined { id, name, args } => super::provider_defined_native(id, name, args),
     }
 }
 

--- a/crates/bitrouter-sdk/src/language_model/protocol/chat_completions.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/chat_completions.rs
@@ -20,8 +20,8 @@ use crate::language_model::protocol::{
 use crate::language_model::stream::SseFrame;
 use crate::language_model::types::{
     ApiProtocol, Content, DataContent, FinishReason, GenerateResult, GenerationParams, Message,
-    Modality, Prompt, ResponseFormat, Role, RoutingTarget, StreamPart, ToolResultContentPart,
-    ToolResultOutput, Usage,
+    Modality, Prompt, ResponseFormat, Role, RoutingTarget, StreamPart, ToolChoice,
+    ToolResultContentPart, ToolResultOutput, Usage,
 };
 
 /// The Chat Completions inbound + outbound protocol adapter.
@@ -383,6 +383,9 @@ impl InboundAdapter for ChatCompletionsAdapter {
                         id: tc.id,
                         name: tc.function.name,
                         arguments: tc.function.arguments,
+                        // Chat Completions `tool_calls` are always client tools —
+                        // there is no server-tool slot on this wire.
+                        provider_executed: false,
                     });
                 }
             }
@@ -429,6 +432,12 @@ impl InboundAdapter for ChatCompletionsAdapter {
             .and_then(|v| serde_json::from_value::<Vec<Modality>>(v).ok())
             .unwrap_or_default();
 
+        // `tool_choice` is a typed field. Promote it into the canonical slot so
+        // cross-protocol routing renders it natively for the target provider, and
+        // remove it from `extra` so it is not also splatted back verbatim (which
+        // would forward an OpenAI-shaped choice into a non-OpenAI upstream).
+        let tool_choice = extra.remove("tool_choice").map(parse_chat_tool_choice);
+
         Ok(Prompt {
             model: req.model,
             system,
@@ -440,7 +449,8 @@ impl InboundAdapter for ChatCompletionsAdapter {
                 max_tokens: req.max_tokens.or(req.max_completion_tokens),
                 reasoning_effort: req.reasoning_effort,
                 response_modalities,
-                // Every Chat Completions field without a typed slot — tool_choice,
+                tool_choice,
+                // Every remaining Chat Completions field without a typed slot —
                 // stop / stop_sequences, seed, n, presence/frequency_penalty,
                 // logit_bias, … — rides in `extra` and is splatted back on render.
                 extra,
@@ -499,6 +509,9 @@ impl InboundAdapter for ChatCompletionsAdapter {
             message.insert("reasoning_content".into(), reasoning.into());
         }
 
+        // Chat Completions has no provider-executed server-tool slot, so a
+        // `provider_executed` call degrades to a plain `tool_calls` entry here
+        // (the flag is dropped) — `..` ignores it deliberately.
         let tool_calls: Vec<_> = result
             .content
             .iter()
@@ -507,6 +520,7 @@ impl InboundAdapter for ChatCompletionsAdapter {
                     id,
                     name,
                     arguments,
+                    ..
                 } => Some(serde_json::json!({
                     "id": id,
                     "type": "function",
@@ -610,9 +624,15 @@ impl OutboundAdapter for ChatCompletionsAdapter {
         {
             req.insert("modalities".into(), value);
         }
+        // Render the canonical tool_choice into Chat Completions' native shape,
+        // before the extras splat so the typed slot wins over any stale
+        // `tool_choice` left in extras.
+        if let Some(tc) = &prompt.params.tool_choice {
+            req.insert("tool_choice".into(), render_chat_tool_choice(tc));
+        }
         // Splat the extras back into the outbound request — this is how
-        // `tool_choice`, `stop`, `seed`, etc. survive the round trip. Typed
-        // fields above win over any same-named extra.
+        // `stop`, `seed`, etc. survive the round trip. Typed fields above win
+        // over any same-named extra.
         for (k, v) in &prompt.params.extra {
             req.entry(k.clone()).or_insert_with(|| v.clone());
         }
@@ -708,6 +728,9 @@ impl OutboundAdapter for ChatCompletionsAdapter {
                         .and_then(|a| a.as_str())
                         .unwrap_or_default()
                         .to_string(),
+                    // The Chat Completions response wire has no server-tool item;
+                    // every `tool_calls` entry is a client tool call.
+                    provider_executed: false,
                 });
             }
         }
@@ -772,6 +795,55 @@ fn render_chat_response_format(rf: &ResponseFormat) -> serde_json::Value {
     }
     js.insert("schema".into(), schema.clone());
     serde_json::json!({ "type": "json_schema", "json_schema": serde_json::Value::Object(js) })
+}
+
+/// Parse a Chat Completions `tool_choice` value into the canonical [`ToolChoice`].
+/// The wire is either a string (`"auto"|"none"|"required"`) or an object
+/// `{type:"function",function:{name}}`. Anything else (e.g. the legacy
+/// `{type:"none"}` object form, or a provider extension) is preserved verbatim
+/// via [`ToolChoice::Other`] so it round-trips losslessly.
+/// <https://platform.openai.com/docs/api-reference/chat/create#chat-create-tool_choice>
+fn parse_chat_tool_choice(value: serde_json::Value) -> ToolChoice {
+    match &value {
+        serde_json::Value::String(s) => match s.as_str() {
+            "auto" => ToolChoice::Auto,
+            "none" => ToolChoice::None,
+            "required" => ToolChoice::Required,
+            _ => ToolChoice::Other { value },
+        },
+        serde_json::Value::Object(obj)
+            if obj.get("type").and_then(|t| t.as_str()) == Some("function") =>
+        {
+            match obj
+                .get("function")
+                .and_then(|f| f.get("name"))
+                .and_then(|n| n.as_str())
+            {
+                Some(name) => ToolChoice::Tool {
+                    name: name.to_string(),
+                },
+                None => ToolChoice::Other { value },
+            }
+        }
+        _ => ToolChoice::Other { value },
+    }
+}
+
+/// Render a canonical [`ToolChoice`] into Chat Completions' native shape:
+/// `"auto"|"none"|"required"` for the simple variants, `{type:"function",
+/// function:{name}}` for a specific tool, and the preserved raw value for
+/// [`ToolChoice::Other`].
+/// <https://platform.openai.com/docs/api-reference/chat/create#chat-create-tool_choice>
+fn render_chat_tool_choice(choice: &ToolChoice) -> serde_json::Value {
+    match choice {
+        ToolChoice::Auto => "auto".into(),
+        ToolChoice::None => "none".into(),
+        ToolChoice::Required => "required".into(),
+        ToolChoice::Tool { name } => {
+            serde_json::json!({ "type": "function", "function": { "name": name } })
+        }
+        ToolChoice::Other { value } => value.clone(),
+    }
 }
 
 #[async_trait]
@@ -932,6 +1004,9 @@ fn render_message(m: &Message) -> serde_json::Value {
         obj.insert("reasoning_content".into(), reasoning.into());
     }
 
+    // Chat Completions has no provider-executed server-tool slot, so a
+    // `provider_executed` call degrades to a plain `tool_calls` entry here (the
+    // flag is dropped) — `..` ignores it deliberately.
     let tool_calls: Vec<_> = m
         .content
         .iter()
@@ -940,6 +1015,7 @@ fn render_message(m: &Message) -> serde_json::Value {
                 id,
                 name,
                 arguments,
+                ..
             } => Some(serde_json::json!({
                 "id": id,
                 "type": "function",

--- a/crates/bitrouter-sdk/src/language_model/protocol/chat_completions.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/chat_completions.rs
@@ -19,8 +19,8 @@ use crate::language_model::protocol::{
 };
 use crate::language_model::stream::SseFrame;
 use crate::language_model::types::{
-    ApiProtocol, Content, FinishReason, GenerateResult, GenerationParams, Message, Prompt,
-    ResponseFormat, Role, RoutingTarget, StreamPart, Usage,
+    ApiProtocol, Content, DataContent, FinishReason, GenerateResult, GenerationParams, Message,
+    Prompt, ResponseFormat, Role, RoutingTarget, StreamPart, Usage,
 };
 
 /// The Chat Completions inbound + outbound protocol adapter.
@@ -305,6 +305,7 @@ impl InboundAdapter for ChatCompletionsAdapter {
                 top_p: req.top_p,
                 max_tokens: req.max_tokens.or(req.max_completion_tokens),
                 reasoning_effort: req.reasoning_effort,
+                response_modalities: Vec::new(),
                 // Every Chat Completions field without a typed slot — tool_choice,
                 // stop / stop_sequences, seed, n, presence/frequency_penalty,
                 // logit_bias, … — rides in `extra` and is splatted back on render.
@@ -644,6 +645,44 @@ impl Transport for ChatCompletionsTransport {
     }
 }
 
+/// Render one canonical content part into an OpenAI content-array element
+/// (text + media). Reasoning / tool calls ride sibling fields, not the content
+/// array, so they yield `None` here.
+fn render_input_part(c: &Content) -> Option<serde_json::Value> {
+    match c {
+        Content::Text { text } => Some(serde_json::json!({ "type": "text", "text": text })),
+        Content::File {
+            media_type,
+            data,
+            filename,
+            ..
+        } => Some(if media_type.starts_with("image/") {
+            // <https://platform.openai.com/docs/guides/vision>
+            serde_json::json!({
+                "type": "image_url",
+                "image_url": { "url": data.to_url(media_type) }
+            })
+        } else if let Some(format) = media_type.strip_prefix("audio/") {
+            // <https://platform.openai.com/docs/guides/audio>
+            let audio = match data {
+                DataContent::Base64 { data } => {
+                    serde_json::json!({ "data": data, "format": format })
+                }
+                DataContent::Url { url } => serde_json::json!({ "url": url, "format": format }),
+            };
+            serde_json::json!({ "type": "input_audio", "input_audio": audio })
+        } else {
+            // Documents (PDF, …) — OpenAI `file` part.
+            let mut file = serde_json::json!({ "file_data": data.to_url(media_type) });
+            if let Some(name) = filename {
+                file["filename"] = serde_json::Value::String(name.clone());
+            }
+            serde_json::json!({ "type": "file", "file": file })
+        }),
+        _ => None,
+    }
+}
+
 fn render_message(m: &Message) -> serde_json::Value {
     let mut obj = serde_json::Map::new();
     obj.insert("role".into(), role_str(m.role).into());
@@ -659,15 +698,23 @@ fn render_message(m: &Message) -> serde_json::Value {
         return serde_json::Value::Object(obj);
     }
 
-    let text: String = m
-        .content
-        .iter()
-        .filter_map(|c| match c {
-            Content::Text { text } => Some(text.as_str()),
-            _ => None,
-        })
-        .collect();
-    obj.insert("content".into(), text.into());
+    // `content` is a plain string for text-only messages (back-compat) or an
+    // ordered parts array when the message carries media.
+    if m.content.iter().any(|c| matches!(c, Content::File { .. })) {
+        let parts: Vec<serde_json::Value> =
+            m.content.iter().filter_map(render_input_part).collect();
+        obj.insert("content".into(), parts.into());
+    } else {
+        let text: String = m
+            .content
+            .iter()
+            .filter_map(|c| match c {
+                Content::Text { text } => Some(text.as_str()),
+                _ => None,
+            })
+            .collect();
+        obj.insert("content".into(), text.into());
+    }
 
     let reasoning: String = m
         .content

--- a/crates/bitrouter-sdk/src/language_model/protocol/chat_completions.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/chat_completions.rs
@@ -1564,6 +1564,14 @@ impl StreamEncoder for ChatStreamEncoder {
                 // (image generation is a separate API), so a generated file is
                 // surfaced only on the non-streaming path. Documented limitation.
             }
+            StreamPart::TextStart { .. }
+            | StreamPart::TextEnd { .. }
+            | StreamPart::ReasoningStart { .. }
+            | StreamPart::ReasoningEnd { .. } => {
+                // Coarse wire: Chat Completions frames no content blocks (deltas
+                // are a flat run on one `choices[0].delta`), so block-lifecycle
+                // markers have no native frame and re-encode to nothing.
+            }
             StreamPart::Source { source } => {
                 // Re-attach a streamed citation as a `delta.annotations[]`
                 // `url_citation` chunk — the location the decoder reads. Only a

--- a/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
@@ -641,6 +641,14 @@ fn render_part(c: &Content) -> Option<serde_json::Value> {
         // `tool_name` (Gemini keys results by name), falling back to `call_id`;
         // `id` rides along when it differs from the name. A non-object output
         // degrades losslessly under a `result` key.
+        //
+        // Known degrade: a multimodal `Content` output collapses to
+        // `{ result: <concatenated text> }` here — its media and provider
+        // file-reference parts are dropped. The V3 `FunctionResponse.parts[]`
+        // array (which CAN carry inline media alongside the response) is left
+        // unused; modeling it is deferred until a consumer needs Gemini-side tool
+        // media, since today no other request wire round-trips media *out* of a
+        // tool result into Gemini.
         // <https://ai.google.dev/api/caching#FunctionResponse>
         Content::ToolResult {
             call_id,

--- a/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
@@ -20,7 +20,7 @@ use crate::language_model::protocol::{
 use crate::language_model::stream::SseFrame;
 use crate::language_model::types::{
     ApiProtocol, Content, DataContent, FinishReason, GenerateResult, GenerationParams, Message,
-    Modality, Prompt, ResponseFormat, Role, RoutingTarget, StreamPart, Usage,
+    Modality, Prompt, ResponseFormat, Role, RoutingTarget, StreamPart, ToolResultOutput, Usage,
 };
 
 /// The Generate Content protocol adapter.
@@ -215,16 +215,33 @@ fn parse_parts(parts: &[serde_json::Value]) -> Vec<Content> {
                     .unwrap_or_else(|| "{}".to_string()),
             });
         } else if let Some(fr) = part.get("functionResponse") {
+            // Gemini `functionResponse {id?, name, response}`: `name` is the tool
+            // name (required), the optional `id` correlates the originating call,
+            // and `response` is a JSON object. Map `name` → tool_name, `id` →
+            // call_id (falling back to `name` when the wire omits the id, since
+            // the canonical call_id must not be empty), and the JSON `response`
+            // → a structured Json output.
+            // <https://ai.google.dev/api/caching#FunctionResponse>
+            let name = fr
+                .get("name")
+                .and_then(|n| n.as_str())
+                .unwrap_or_default()
+                .to_string();
+            let call_id = fr
+                .get("id")
+                .and_then(|i| i.as_str())
+                .map(str::to_string)
+                .unwrap_or_else(|| name.clone());
+            let output = fr
+                .get("response")
+                .map(ToolResultOutput::from_untyped_value)
+                .unwrap_or_else(|| ToolResultOutput::Json {
+                    value: serde_json::json!({}),
+                });
             out.push(Content::ToolResult {
-                call_id: fr
-                    .get("name")
-                    .and_then(|n| n.as_str())
-                    .unwrap_or_default()
-                    .to_string(),
-                content: fr
-                    .get("response")
-                    .map(|r| r.to_string())
-                    .unwrap_or_default(),
+                call_id,
+                tool_name: (!name.is_empty()).then_some(name),
+                output,
             });
         } else if let Some(inline) = part.get("inlineData") {
             // Inline base64 media. <https://ai.google.dev/gemini-api/docs/image-understanding>
@@ -619,12 +636,35 @@ fn render_part(c: &Content) -> Option<serde_json::Value> {
                 serde_json::from_str(arguments).unwrap_or(serde_json::json!({}));
             Some(serde_json::json!({ "functionCall": { "name": name, "args": args } }))
         }
-        Content::ToolResult { call_id, content } => {
-            let response: serde_json::Value =
-                serde_json::from_str(content).unwrap_or(serde_json::json!({ "result": content }));
-            Some(serde_json::json!({
-                "functionResponse": { "name": call_id, "response": response }
-            }))
+        // Gemini `functionResponse {id?, name, response}`: `response` must be a
+        // JSON object and there is no error flag or media slot. `name` comes from
+        // `tool_name` (Gemini keys results by name), falling back to `call_id`;
+        // `id` rides along when it differs from the name. A non-object output
+        // degrades losslessly under a `result` key.
+        // <https://ai.google.dev/api/caching#FunctionResponse>
+        Content::ToolResult {
+            call_id,
+            tool_name,
+            output,
+        } => {
+            let name = tool_name.as_deref().unwrap_or(call_id);
+            let response = match output {
+                ToolResultOutput::Json { value } | ToolResultOutput::ErrorJson { value }
+                    if value.is_object() =>
+                {
+                    value.clone()
+                }
+                ToolResultOutput::Json { value } | ToolResultOutput::ErrorJson { value } => {
+                    serde_json::json!({ "result": value })
+                }
+                other => serde_json::json!({ "result": other.to_provider_string() }),
+            };
+            let mut fr = serde_json::json!({ "name": name, "response": response });
+            // Carry the call id only when it adds information beyond the name.
+            if call_id != name && !call_id.is_empty() {
+                fr["id"] = serde_json::Value::String(call_id.clone());
+            }
+            Some(serde_json::json!({ "functionResponse": fr }))
         }
         // Inline bytes -> `inlineData`; a URL -> `fileData`. Gemini keys media by
         // `mimeType`. <https://ai.google.dev/gemini-api/docs/image-understanding>

--- a/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
@@ -199,37 +199,40 @@ fn take_gemini_modalities(
 /// `allowedFunctionNames`. `AUTO`→`Auto`, `NONE`→`None`, bare `ANY`→`Required`.
 /// `ANY` restricted to a single allowed name is rendered as `Tool` (a forced
 /// specific call); any richer constraint — `ANY` with multiple allowed names,
-/// the `VALIDATED` mode, or a `toolConfig` carrying sibling keys — has no V3
-/// equivalent and is preserved verbatim via [`ToolChoice::Other`] so it
-/// round-trips losslessly on the same wire.
+/// the `VALIDATED` mode, a `functionCallingConfig` that omits `mode` (e.g. one
+/// carrying only `allowedFunctionNames`), or a `toolConfig` carrying sibling
+/// keys — has no V3 equivalent and is preserved verbatim via
+/// [`ToolChoice::Other`] so it round-trips losslessly on the same wire. Like the
+/// other adapters' tool-choice parsers, this is infallible: anything it cannot
+/// reduce to a typed variant degrades to `Other`, never to a dropped value.
 /// <https://ai.google.dev/api/caching#FunctionCallingConfig>
-fn parse_gemini_tool_choice(tool_config: &serde_json::Value) -> Option<ToolChoice> {
-    let obj = tool_config.as_object()?;
-    let fcc = obj.get("functionCallingConfig")?.as_object()?;
-    let mode = fcc.get("mode").and_then(|m| m.as_str())?;
-    let allowed: Vec<&str> = fcc
-        .get("allowedFunctionNames")
-        .and_then(|a| a.as_array())
-        .map(|arr| arr.iter().filter_map(|n| n.as_str()).collect())
-        .unwrap_or_default();
-    // A `toolConfig` with extra sibling keys, or a `functionCallingConfig` with
-    // keys beyond mode/allowedFunctionNames, cannot be reconstructed from a bare
-    // typed variant — preserve the whole thing verbatim.
-    let only_known_siblings = obj.len() == 1
-        && fcc
-            .keys()
-            .all(|k| k == "mode" || k == "allowedFunctionNames");
-    match mode {
-        "AUTO" if only_known_siblings && allowed.is_empty() => Some(ToolChoice::Auto),
-        "NONE" if only_known_siblings && allowed.is_empty() => Some(ToolChoice::None),
-        "ANY" if only_known_siblings && allowed.is_empty() => Some(ToolChoice::Required),
-        "ANY" if only_known_siblings && allowed.len() == 1 => Some(ToolChoice::Tool {
-            name: allowed[0].to_string(),
-        }),
-        _ => Some(ToolChoice::Other {
-            value: tool_config.clone(),
-        }),
-    }
+fn parse_gemini_tool_choice(tool_config: serde_json::Value) -> ToolChoice {
+    let reduced = tool_config.as_object().and_then(|obj| {
+        let fcc = obj.get("functionCallingConfig")?.as_object()?;
+        let mode = fcc.get("mode").and_then(|m| m.as_str())?;
+        let allowed: Vec<&str> = fcc
+            .get("allowedFunctionNames")
+            .and_then(|a| a.as_array())
+            .map(|arr| arr.iter().filter_map(|n| n.as_str()).collect())
+            .unwrap_or_default();
+        // A `toolConfig` with extra sibling keys, or a `functionCallingConfig`
+        // with keys beyond mode/allowedFunctionNames, cannot be reconstructed
+        // from a bare typed variant — fall through to the verbatim `Other`.
+        let only_known_siblings = obj.len() == 1
+            && fcc
+                .keys()
+                .all(|k| k == "mode" || k == "allowedFunctionNames");
+        match mode {
+            "AUTO" if only_known_siblings && allowed.is_empty() => Some(ToolChoice::Auto),
+            "NONE" if only_known_siblings && allowed.is_empty() => Some(ToolChoice::None),
+            "ANY" if only_known_siblings && allowed.is_empty() => Some(ToolChoice::Required),
+            "ANY" if only_known_siblings && allowed.len() == 1 => Some(ToolChoice::Tool {
+                name: allowed[0].to_string(),
+            }),
+            _ => None,
+        }
+    });
+    reduced.unwrap_or(ToolChoice::Other { value: tool_config })
 }
 
 /// Render a canonical [`ToolChoice`] into Google's top-level `toolConfig` value.
@@ -485,13 +488,16 @@ impl InboundAdapter for GenerateContentAdapter {
             None => (GenerationParams::default(), None),
         };
         // `toolConfig` is a top-level Google field that carries tool choice. Lift
-        // its `functionCallingConfig` into the typed slot and remove `toolConfig`
-        // from the top-level extras so it is not also re-rendered verbatim (which
-        // would forward a Gemini-shaped choice into a non-Gemini upstream, and
-        // double-write it on a same-protocol round-trip).
+        // it into the typed slot — as a reduced `ToolChoice` when it maps onto a
+        // V3 variant, otherwise verbatim via `ToolChoice::Other` — and remove
+        // `toolConfig` from the top-level extras so it is not also re-rendered
+        // verbatim (which would forward a Gemini-shaped choice into a non-Gemini
+        // upstream, and double-write it on a same-protocol round-trip). The
+        // parser is infallible, so an exotic `toolConfig` (e.g. one whose
+        // `functionCallingConfig` omits `mode`) is preserved, never dropped.
         let mut top_level = req.extra;
         if let Some(tc) = top_level.remove("toolConfig") {
-            params.tool_choice = parse_gemini_tool_choice(&tc);
+            params.tool_choice = Some(parse_gemini_tool_choice(tc));
         }
         // Preserve the remaining top-level Google fields (`safetySettings`,
         // `cachedContent`, …) across the round-trip. They're namespaced so they

--- a/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
@@ -155,11 +155,33 @@ pub struct GenerateContentGenerationConfig {
     /// `response_mime_type: "application/json"`).
     #[serde(default)]
     response_schema: Option<serde_json::Value>,
-    /// `stopSequences`, `seed`, `topK`, `responseLogprobs`, `presencePenalty`,
-    /// `frequencyPenalty`, … — every generation-config knob without a typed
-    /// slot rides via `extra` and is splatted back into `generationConfig` on
-    /// render. v0 passed these through. Skipped from the published schema for
-    /// the same reason as the top-level `extra` on [`GenerateContentRequest`].
+    /// Top-k sampling. Promoted to the canonical `top_k` slot so it translates
+    /// across protocols (e.g. to an Anthropic upstream's `top_k`).
+    /// <https://ai.google.dev/api/generate-content#GenerationConfig>
+    #[serde(default)]
+    top_k: Option<u32>,
+    /// Deterministic-sampling seed. Promoted to the canonical `seed` slot.
+    /// <https://ai.google.dev/api/generate-content#GenerationConfig>
+    #[serde(default)]
+    seed: Option<i64>,
+    /// Stop sequences. Promoted to the canonical `stop` slot, so it can render
+    /// as a Chat Completions `stop` or an Anthropic `stop_sequences`.
+    /// <https://ai.google.dev/api/generate-content#GenerationConfig>
+    #[serde(default)]
+    stop_sequences: Option<Vec<String>>,
+    /// Presence penalty. Promoted to the canonical `presence_penalty` slot.
+    /// <https://ai.google.dev/api/generate-content#GenerationConfig>
+    #[serde(default)]
+    presence_penalty: Option<f64>,
+    /// Frequency penalty. Promoted to the canonical `frequency_penalty` slot.
+    /// <https://ai.google.dev/api/generate-content#GenerationConfig>
+    #[serde(default)]
+    frequency_penalty: Option<f64>,
+    /// `responseLogprobs`, `candidateCount`, `thinkingConfig`, … — every
+    /// generation-config knob without a typed slot rides via `extra` and is
+    /// splatted back into `generationConfig` on render. v0 passed these through.
+    /// Skipped from the published schema for the same reason as the top-level
+    /// `extra` on [`GenerateContentRequest`].
     #[serde(flatten)]
     #[schemars(skip)]
     extra: std::collections::HashMap<String, serde_json::Value>,
@@ -768,6 +790,11 @@ impl InboundAdapter for GenerateContentAdapter {
                     max_output_tokens,
                     response_mime_type,
                     response_schema,
+                    top_k,
+                    seed,
+                    stop_sequences,
+                    presence_penalty,
+                    frequency_penalty,
                     mut extra,
                 } = g;
                 let response_format = match (
@@ -800,6 +827,11 @@ impl InboundAdapter for GenerateContentAdapter {
                         reasoning_effort: None,
                         response_modalities,
                         tool_choice: None,
+                        top_k,
+                        seed,
+                        stop: stop_sequences.unwrap_or_default(),
+                        presence_penalty,
+                        frequency_penalty,
                         extra,
                     },
                     response_format,
@@ -940,9 +972,30 @@ impl OutboundAdapter for GenerateContentAdapter {
                 .collect();
             gen_config.insert("responseModalities".into(), tokens.into());
         }
-        // Splat Google generation-config extras (stopSequences, topK, seed, …)
-        // back into the outbound config. Typed fields above win over a same-named
-        // extra; the sentinel key carries top-level fields and is skipped here.
+        // Render the typed sampling slots into their nested `generationConfig`
+        // wire names. Gemini carries all five, so a `stop` authored on a Chat
+        // client reaches here as `stopSequences`, an Anthropic `top_k` as `topK`,
+        // and so on.
+        // <https://ai.google.dev/api/generate-content#GenerationConfig>
+        if let Some(top_k) = prompt.params.top_k {
+            gen_config.insert("topK".into(), top_k.into());
+        }
+        if let Some(seed) = prompt.params.seed {
+            gen_config.insert("seed".into(), seed.into());
+        }
+        if !prompt.params.stop.is_empty() {
+            gen_config.insert("stopSequences".into(), prompt.params.stop.clone().into());
+        }
+        if let Some(pp) = prompt.params.presence_penalty {
+            gen_config.insert("presencePenalty".into(), pp.into());
+        }
+        if let Some(fp) = prompt.params.frequency_penalty {
+            gen_config.insert("frequencyPenalty".into(), fp.into());
+        }
+        // Splat remaining Google generation-config extras (responseLogprobs,
+        // candidateCount, …) back into the outbound config. Typed fields above
+        // win over a same-named extra; the sentinel key carries top-level fields
+        // and is skipped here.
         for (k, v) in &prompt.params.extra {
             if k == GOOGLE_TOP_LEVEL_EXTRA_KEY {
                 continue;

--- a/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
@@ -20,7 +20,7 @@ use crate::language_model::protocol::{
 use crate::language_model::stream::SseFrame;
 use crate::language_model::types::{
     ApiProtocol, Content, DataContent, FinishReason, GenerateResult, GenerationParams, Message,
-    Modality, Prompt, ResponseFormat, Role, RoutingTarget, StreamPart, Tool, ToolChoice,
+    Modality, Prompt, ResponseFormat, Role, RoutingTarget, Source, StreamPart, Tool, ToolChoice,
     ToolResultOutput, Usage,
 };
 
@@ -451,6 +451,74 @@ fn parse_parts(parts: &[serde_json::Value]) -> Vec<Content> {
     out
 }
 
+/// Parse a Gemini `candidate.groundingMetadata` object into canonical
+/// [`Content::Source`] (URL) parts. Web search grounding surfaces as
+/// `groundingMetadata.groundingChunks[]`, each `{web:{uri, title?}}`; the
+/// model's own server-side Search tool emits these instead of any
+/// `functionCall`. The chunk carries no citation id, so synthesize a stable one
+/// from the uri + index. Non-`web` chunks (`retrievedContext` RAG sources) are
+/// not mapped here — they require document-source plumbing the response wire
+/// does not expose uniformly. Mirrors the AI SDK `extractSources`.
+/// <https://ai.google.dev/gemini-api/docs/grounding>
+/// <https://github.com/vercel/ai/blob/main/packages/google/src/google-language-model.ts>
+fn parse_grounding_sources(grounding: Option<&serde_json::Value>) -> Vec<Content> {
+    let Some(chunks) = grounding
+        .and_then(|g| g.get("groundingChunks"))
+        .and_then(|c| c.as_array())
+    else {
+        return Vec::new();
+    };
+    chunks
+        .iter()
+        .enumerate()
+        .filter_map(|(i, chunk)| {
+            let web = chunk.get("web")?;
+            let url = web.get("uri").and_then(|u| u.as_str())?.to_string();
+            let title = web
+                .get("title")
+                .and_then(|t| t.as_str())
+                .map(str::to_string);
+            Some(Content::Source {
+                source: Source::Url {
+                    id: Source::synthesize_id(&url, i),
+                    url,
+                    title,
+                },
+            })
+        })
+        .collect()
+}
+
+/// Render canonical [`Content::Source`] parts into a Gemini
+/// `groundingMetadata.groundingChunks[]` array (web chunks `{web:{uri, title}}`)
+/// — the location [`parse_grounding_sources`] reads. Only [`Source::Url`] maps;
+/// a [`Source::Document`] citation has no `groundingChunks.web` form and is
+/// dropped (documented cross-protocol loss). Returns an empty Vec when the
+/// result carries no URL sources.
+/// <https://ai.google.dev/api/generate-content#GroundingChunk>
+fn render_grounding_chunks(result: &GenerateResult) -> Vec<serde_json::Value> {
+    result
+        .content
+        .iter()
+        .filter_map(|c| match c {
+            Content::Source {
+                source: Source::Url { url, title, .. },
+            } => {
+                let mut web = serde_json::Map::new();
+                web.insert("uri".into(), url.clone().into());
+                if let Some(title) = title {
+                    web.insert("title".into(), title.clone().into());
+                }
+                Some(serde_json::json!({ "web": serde_json::Value::Object(web) }))
+            }
+            Content::Source {
+                source: Source::Document { .. },
+            } => None,
+            _ => None,
+        })
+        .collect()
+}
+
 fn finish_reason(s: &str) -> Option<FinishReason> {
     match s {
         "STOP" => Some(FinishReason::Stop),
@@ -617,16 +685,26 @@ impl InboundAdapter for GenerateContentAdapter {
     ) -> Result<serde_json::Value> {
         let parts: Vec<serde_json::Value> = result.content.iter().filter_map(render_part).collect();
         let usage = result.usage.unwrap_or_default();
+        let mut candidate = serde_json::json!({
+            "content": { "role": "model", "parts": parts },
+            "finishReason": result
+                .finish_reason
+                .as_ref()
+                .map(finish_reason_str)
+                .unwrap_or_else(|| "STOP".to_string()),
+            "index": 0,
+        });
+        // Re-attach web-search citations under `candidate.groundingMetadata`
+        // (the location `parse_response` lifts them from), collected from the
+        // result's `Content::Source` parts rather than rendered into `parts`
+        // (grounding is candidate metadata, not a content part).
+        // <https://ai.google.dev/gemini-api/docs/grounding>
+        let chunks = render_grounding_chunks(result);
+        if !chunks.is_empty() {
+            candidate["groundingMetadata"] = serde_json::json!({ "groundingChunks": chunks });
+        }
         Ok(serde_json::json!({
-            "candidates": [{
-                "content": { "role": "model", "parts": parts },
-                "finishReason": result
-                    .finish_reason
-                    .as_ref()
-                    .map(finish_reason_str)
-                    .unwrap_or_else(|| "STOP".to_string()),
-                "index": 0,
-            }],
+            "candidates": [candidate],
             "usageMetadata": {
                 "promptTokenCount": usage.prompt_tokens,
                 "candidatesTokenCount": usage.completion_tokens,
@@ -725,12 +803,17 @@ impl OutboundAdapter for GenerateContentAdapter {
             .ok_or_else(|| {
                 BitrouterError::bad_request("google response missing 'candidates[0]'")
             })?;
-        let parts = candidate
+        let mut parts = candidate
             .get("content")
             .and_then(|c| c.get("parts"))
             .and_then(|p| p.as_array())
             .map(|p| parse_parts(p))
             .unwrap_or_default();
+        // Web-search grounding rides `candidate.groundingMetadata`, separate
+        // from the content `parts`. Lift its `groundingChunks` into
+        // `Content::Source` parts appended after the content.
+        // <https://ai.google.dev/gemini-api/docs/grounding>
+        parts.extend(parse_grounding_sources(candidate.get("groundingMetadata")));
         let finish = candidate
             .get("finishReason")
             .and_then(|f| f.as_str())
@@ -851,6 +934,10 @@ fn render_part(c: &Content) -> Option<serde_json::Value> {
                 "fileData": { "mimeType": media_type, "fileUri": url }
             }),
         }),
+        // Sources are response-side citation metadata, never a request part —
+        // they are re-attached under `groundingMetadata` in `render_response`,
+        // not rendered as a content `part`. Skip on the request path.
+        Content::Source { .. } => None,
     }
 }
 
@@ -895,6 +982,12 @@ struct GenerateContentStreamDecoder {
     /// Whether the one-shot [`StreamPart::ResponseStarted`] has been emitted.
     /// Every chunk repeats `responseId`; we surface it only once.
     response_started_emitted: bool,
+    /// URLs of grounding sources already emitted as `StreamPart::Source`.
+    /// `streamGenerateContent` repeats the accumulating `groundingMetadata` on
+    /// successive chunks, so dedupe by URL to emit each citation once — matching
+    /// the AI SDK's `emittedSourceUrls` set.
+    /// <https://github.com/vercel/ai/blob/main/packages/google/src/google-language-model.ts>
+    emitted_source_urls: std::collections::HashSet<String>,
 }
 
 impl StreamDecoder for GenerateContentStreamDecoder {
@@ -958,7 +1051,26 @@ impl StreamDecoder for GenerateContentStreamDecoder {
                         Content::File {
                             media_type, data, ..
                         } => parts.push(StreamPart::File { media_type, data }),
+                        // `parse_parts` never produces `Source` (grounding is
+                        // candidate metadata, not a content part); it is decoded
+                        // from `groundingMetadata` below.
+                        Content::Source { .. } => {}
                     }
+                }
+            }
+            // Web-search grounding arrives on `candidate.groundingMetadata`,
+            // accumulating across chunks. Emit each new citation once as a whole
+            // `StreamPart::Source`, deduped by URL.
+            // <https://ai.google.dev/gemini-api/docs/grounding>
+            for content in parse_grounding_sources(candidate.get("groundingMetadata")) {
+                if let Content::Source {
+                    source: Source::Url { url, title, id },
+                } = content
+                    && self.emitted_source_urls.insert(url.clone())
+                {
+                    parts.push(StreamPart::Source {
+                        source: Source::Url { url, title, id },
+                    });
                 }
             }
             if let Some(reason) = candidate
@@ -1024,6 +1136,30 @@ impl StreamEncoder for GenerateContentStreamEncoder {
                     }] } }]
                 })
             }
+            // Re-attach a streamed citation as a one-chunk
+            // `candidate.groundingMetadata.groundingChunks` web entry — the
+            // location the decoder reads. Only a URL source maps; a document
+            // citation is dropped (no `groundingChunks.web` form on this wire).
+            // <https://ai.google.dev/api/generate-content#GroundingChunk>
+            StreamPart::Source { source } => match source {
+                Source::Url { url, title, .. } => {
+                    let mut web = serde_json::Map::new();
+                    web.insert("uri".into(), url.clone().into());
+                    if let Some(title) = title {
+                        web.insert("title".into(), title.clone().into());
+                    }
+                    serde_json::json!({
+                        "candidates": [{
+                            "content": { "role": "model", "parts": [] },
+                            "groundingMetadata": {
+                                "groundingChunks": [{ "web": serde_json::Value::Object(web) }]
+                            },
+                        }]
+                    })
+                }
+                // No `groundingChunks.web` form for a document citation.
+                Source::Document { .. } => return Ok(Vec::new()),
+            },
             StreamPart::Usage { usage } => serde_json::json!({
                 "usageMetadata": {
                     "promptTokenCount": usage.prompt_tokens,

--- a/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
@@ -188,6 +188,42 @@ fn parse_parts(parts: &[serde_json::Value]) -> Vec<Content> {
                     .map(|r| r.to_string())
                     .unwrap_or_default(),
             });
+        } else if let Some(inline) = part.get("inlineData") {
+            // Inline base64 media. <https://ai.google.dev/gemini-api/docs/image-understanding>
+            out.push(Content::File {
+                media_type: inline
+                    .get("mimeType")
+                    .and_then(|m| m.as_str())
+                    .unwrap_or_default()
+                    .to_string(),
+                data: DataContent::Base64 {
+                    data: inline
+                        .get("data")
+                        .and_then(|d| d.as_str())
+                        .unwrap_or_default()
+                        .to_string(),
+                },
+                filename: None,
+                extra: Default::default(),
+            });
+        } else if let Some(file) = part.get("fileData") {
+            // A URI the model fetches.
+            out.push(Content::File {
+                media_type: file
+                    .get("mimeType")
+                    .and_then(|m| m.as_str())
+                    .unwrap_or_default()
+                    .to_string(),
+                data: DataContent::Url {
+                    url: file
+                        .get("fileUri")
+                        .and_then(|u| u.as_str())
+                        .unwrap_or_default()
+                        .to_string(),
+                },
+                filename: None,
+                extra: Default::default(),
+            });
         } else if let Some(text) = part.get("text").and_then(|t| t.as_str()) {
             let is_thought = part
                 .get("thought")
@@ -203,7 +239,6 @@ fn parse_parts(parts: &[serde_json::Value]) -> Vec<Content> {
                 });
             }
         }
-        // parts of other shapes (inlineData, fileData…) are skipped for now
     }
     out
 }

--- a/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
@@ -20,9 +20,21 @@ use crate::language_model::protocol::{
 use crate::language_model::stream::SseFrame;
 use crate::language_model::types::{
     ApiProtocol, Content, DataContent, FinishReason, GenerateResult, GenerationParams, Message,
-    Modality, Prompt, ResponseFormat, Role, RoutingTarget, Source, StreamPart, Tool, ToolChoice,
-    ToolResultOutput, Usage,
+    Modality, Prompt, ProviderMetadata, ResponseFormat, Role, RoutingTarget, Source, StreamPart,
+    Tool, ToolChoice, ToolResultOutput, Usage, provider_namespace, set_provider_metadata,
 };
+
+/// The metadata key, within the `google` namespace, carrying a reasoning part's
+/// `thoughtSignature` — the continuity token Gemini emits on thinking parts so a
+/// follow-up turn can replay the reasoning. Matches the Vercel AI SDK's
+/// `providerMetadata.google.thoughtSignature`.
+/// <https://ai.google.dev/gemini-api/docs/thinking>
+const GOOGLE_THOUGHT_SIGNATURE: &str = "thoughtSignature";
+/// The metadata key, within the `google` namespace, carrying the response's
+/// `modelVersion` (the exact model build that served the response) at result
+/// level — it has no dedicated canonical field.
+/// <https://ai.google.dev/api/generate-content#GenerateContentResponse>
+const GOOGLE_MODEL_VERSION: &str = "modelVersion";
 
 /// The Generate Content protocol adapter.
 pub struct GenerateContentAdapter;
@@ -284,6 +296,8 @@ fn parse_generate_content_tool(t: GenerateContentTool) -> Vec<Tool> {
             parameters: f.parameters,
             // Google function declarations carry no `strict` slot.
             strict: None,
+            // Gemini has no per-tool `cache_control`; no metadata to lift.
+            provider_metadata: ProviderMetadata::new(),
         })
         .collect();
     for (key, value) in t.extra {
@@ -291,6 +305,7 @@ fn parse_generate_content_tool(t: GenerateContentTool) -> Vec<Tool> {
             id: format!("{PROVIDER_ID_GOOGLE}.{key}"),
             name: key,
             args: value,
+            provider_metadata: ProviderMetadata::new(),
         });
     }
     out
@@ -319,12 +334,13 @@ fn render_generate_content_tools(tools: &[Tool]) -> serde_json::Value {
                 description,
                 parameters,
                 strict: _,
+                ..
             } => function_declarations.push(serde_json::json!({
                 "name": name,
                 "description": description,
                 "parameters": parameters,
             })),
-            Tool::ProviderDefined { id, name, args } => {
+            Tool::ProviderDefined { id, name, args, .. } => {
                 entries.push(provider_defined_native(id, name, args));
             }
         }
@@ -337,6 +353,37 @@ fn render_generate_content_tools(tools: &[Tool]) -> serde_json::Value {
     }
     out.extend(entries);
     serde_json::Value::Array(out)
+}
+
+/// Lift a Gemini part's `thoughtSignature` into a [`ProviderMetadata`] under the
+/// `google` namespace. Gemini stamps this opaque token on thinking parts (and on
+/// the `functionCall` parts that continue a reasoning chain); it must round-trip
+/// or a follow-up turn replaying the reasoning is rejected. Returns an empty map
+/// when the part has none.
+/// <https://ai.google.dev/gemini-api/docs/thinking>
+fn parse_thought_signature(part: &serde_json::Value) -> ProviderMetadata {
+    let mut meta = ProviderMetadata::new();
+    if let Some(sig) = part.get("thoughtSignature").filter(|v| !v.is_null()) {
+        set_provider_metadata(
+            &mut meta,
+            PROVIDER_ID_GOOGLE,
+            GOOGLE_THOUGHT_SIGNATURE,
+            sig.clone(),
+        );
+    }
+    meta
+}
+
+/// Splat a Gemini `thoughtSignature` from `meta` onto an existing part JSON
+/// object (a no-op when there is none) — the inverse of
+/// [`parse_thought_signature`], used by the render path.
+fn apply_thought_signature(target: &mut serde_json::Value, meta: &ProviderMetadata) {
+    if let Some(sig) =
+        provider_namespace(meta, PROVIDER_ID_GOOGLE).and_then(|o| o.get(GOOGLE_THOUGHT_SIGNATURE))
+        && let Some(obj) = target.as_object_mut()
+    {
+        obj.insert("thoughtSignature".to_string(), sig.clone());
+    }
 }
 
 /// Parse one Google `parts[]` array into ordered canonical content. Order is
@@ -366,6 +413,11 @@ fn parse_parts(parts: &[serde_json::Value]) -> Vec<Content> {
                 // fields, never as a `functionCall`, so there is no
                 // provider-executed call to parse here.
                 provider_executed: false,
+                // A `functionCall` part may carry a `thoughtSignature` (it
+                // continues a reasoning chain); preserve it so a follow-up turn
+                // can replay the chain.
+                // <https://ai.google.dev/gemini-api/docs/thinking>
+                provider_metadata: parse_thought_signature(part),
             });
         } else if let Some(fr) = part.get("functionResponse") {
             // Gemini `functionResponse {id?, name, response}`: `name` is the tool
@@ -395,6 +447,7 @@ fn parse_parts(parts: &[serde_json::Value]) -> Vec<Content> {
                 call_id,
                 tool_name: (!name.is_empty()).then_some(name),
                 output,
+                provider_metadata: ProviderMetadata::new(),
             });
         } else if let Some(inline) = part.get("inlineData") {
             // Inline base64 media. <https://ai.google.dev/gemini-api/docs/image-understanding>
@@ -412,7 +465,7 @@ fn parse_parts(parts: &[serde_json::Value]) -> Vec<Content> {
                         .to_string(),
                 },
                 filename: None,
-                extra: Default::default(),
+                provider_metadata: ProviderMetadata::new(),
             });
         } else if let Some(file) = part.get("fileData") {
             // A URI the model fetches.
@@ -430,7 +483,7 @@ fn parse_parts(parts: &[serde_json::Value]) -> Vec<Content> {
                         .to_string(),
                 },
                 filename: None,
-                extra: Default::default(),
+                provider_metadata: ProviderMetadata::new(),
             });
         } else if let Some(text) = part.get("text").and_then(|t| t.as_str()) {
             let is_thought = part
@@ -440,10 +493,15 @@ fn parse_parts(parts: &[serde_json::Value]) -> Vec<Content> {
             if is_thought {
                 out.push(Content::Reasoning {
                     text: text.to_string(),
+                    // Preserve the thinking part's `thoughtSignature` continuity
+                    // token so reasoning round-trips into a follow-up turn.
+                    // <https://ai.google.dev/gemini-api/docs/thinking>
+                    provider_metadata: parse_thought_signature(part),
                 });
             } else {
                 out.push(Content::Text {
                     text: text.to_string(),
+                    provider_metadata: ProviderMetadata::new(),
                 });
             }
         }
@@ -510,6 +568,7 @@ fn parse_grounding_chunk(chunk: &serde_json::Value, index: usize) -> Option<Cont
             url,
             title,
         },
+        provider_metadata: ProviderMetadata::new(),
     };
     if let Some(web) = chunk.get("web") {
         let url = web.get("uri").and_then(|u| u.as_str())?.to_string();
@@ -537,6 +596,7 @@ fn parse_grounding_chunk(chunk: &serde_json::Value, index: usize) -> Option<Cont
                     title,
                     filename,
                 },
+                provider_metadata: ProviderMetadata::new(),
             });
         }
         // File Search format: a store id with no uri.
@@ -549,6 +609,7 @@ fn parse_grounding_chunk(chunk: &serde_json::Value, index: usize) -> Option<Cont
                     title,
                     filename: grounding_filename(store),
                 },
+                provider_metadata: ProviderMetadata::new(),
             });
         }
         return None;
@@ -602,6 +663,7 @@ fn render_grounding_chunks(result: &GenerateResult) -> Vec<serde_json::Value> {
         .filter_map(|c| match c {
             Content::Source {
                 source: Source::Url { url, title, .. },
+                ..
             } => {
                 let mut web = serde_json::Map::new();
                 web.insert("uri".into(), url.clone().into());
@@ -612,6 +674,7 @@ fn render_grounding_chunks(result: &GenerateResult) -> Vec<serde_json::Value> {
             }
             Content::Source {
                 source: Source::Document { .. },
+                ..
             } => None,
             _ => None,
         })
@@ -668,12 +731,14 @@ impl InboundAdapter for GenerateContentAdapter {
                 messages.push(Message {
                     role: Role::Tool,
                     content: tool_results,
+                    provider_metadata: ProviderMetadata::new(),
                 });
             }
             if !rest.is_empty() {
                 messages.push(Message {
                     role,
                     content: rest,
+                    provider_metadata: ProviderMetadata::new(),
                 });
             }
         }
@@ -802,7 +867,7 @@ impl InboundAdapter for GenerateContentAdapter {
         if !chunks.is_empty() {
             candidate["groundingMetadata"] = serde_json::json!({ "groundingChunks": chunks });
         }
-        Ok(serde_json::json!({
+        let mut body = serde_json::json!({
             "candidates": [candidate],
             "usageMetadata": {
                 "promptTokenCount": usage.prompt_tokens,
@@ -810,7 +875,16 @@ impl InboundAdapter for GenerateContentAdapter {
                 "totalTokenCount": usage.total(),
                 "thoughtsTokenCount": usage.reasoning_tokens,
             },
-        }))
+        });
+        // Restore the result-level `modelVersion` when it round-tripped (only
+        // ever set by this protocol's `parse_response`).
+        // <https://ai.google.dev/api/generate-content#GenerateContentResponse>
+        if let Some(mv) = provider_namespace(&result.provider_metadata, PROVIDER_ID_GOOGLE)
+            .and_then(|o| o.get(GOOGLE_MODEL_VERSION))
+        {
+            body["modelVersion"] = mv.clone();
+        }
+        Ok(body)
     }
 
     fn stream_encoder(&self, _request_id: &str, _model: &str) -> Box<dyn StreamEncoder> {
@@ -924,12 +998,26 @@ impl OutboundAdapter for GenerateContentAdapter {
             .get("responseId")
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
+        // Gemini's `modelVersion` (the exact model build that served the
+        // response) has no dedicated canonical field — carry it at result level
+        // under the `google` namespace.
+        // <https://ai.google.dev/api/generate-content#GenerateContentResponse>
+        let mut provider_metadata = ProviderMetadata::new();
+        if let Some(mv) = body.get("modelVersion").filter(|v| !v.is_null()) {
+            set_provider_metadata(
+                &mut provider_metadata,
+                PROVIDER_ID_GOOGLE,
+                GOOGLE_MODEL_VERSION,
+                mv.clone(),
+            );
+        }
         Ok(GenerateResult {
             content: parts,
             usage,
             finish_reason: finish,
             response_id,
             stop_details: None,
+            provider_metadata,
         })
     }
 
@@ -974,14 +1062,29 @@ impl Transport for GenerateContentTransport {
 
 fn render_part(c: &Content) -> Option<serde_json::Value> {
     match c {
-        Content::Text { text } => Some(serde_json::json!({ "text": text })),
-        Content::Reasoning { text } => Some(serde_json::json!({ "text": text, "thought": true })),
+        Content::Text { text, .. } => Some(serde_json::json!({ "text": text })),
+        Content::Reasoning {
+            text,
+            provider_metadata,
+        } => {
+            let mut part = serde_json::json!({ "text": text, "thought": true });
+            // Restore the thinking part's `thoughtSignature` continuity token.
+            apply_thought_signature(&mut part, provider_metadata);
+            Some(part)
+        }
         Content::ToolCall {
-            name, arguments, ..
+            name,
+            arguments,
+            provider_metadata,
+            ..
         } => {
             let args: serde_json::Value =
                 serde_json::from_str(arguments).unwrap_or(serde_json::json!({}));
-            Some(serde_json::json!({ "functionCall": { "name": name, "args": args } }))
+            let mut part = serde_json::json!({ "functionCall": { "name": name, "args": args } });
+            // A `functionCall` continuing a reasoning chain carries a
+            // `thoughtSignature`; restore it when it round-tripped.
+            apply_thought_signature(&mut part, provider_metadata);
+            Some(part)
         }
         // Gemini `functionResponse {id?, name, response}`: `response` must be a
         // JSON object and there is no error flag or media slot. `name` comes from
@@ -1001,6 +1104,7 @@ fn render_part(c: &Content) -> Option<serde_json::Value> {
             call_id,
             tool_name,
             output,
+            ..
         } => {
             let name = tool_name.as_deref().unwrap_or(call_id);
             let response = match output {
@@ -1126,8 +1230,8 @@ impl StreamDecoder for GenerateContentStreamDecoder {
             {
                 for content in parse_parts(content_parts) {
                     match content {
-                        Content::Text { text } => parts.push(StreamPart::TextDelta { text }),
-                        Content::Reasoning { text } => {
+                        Content::Text { text, .. } => parts.push(StreamPart::TextDelta { text }),
+                        Content::Reasoning { text, .. } => {
                             parts.push(StreamPart::ReasoningDelta { text })
                         }
                         // The streaming `ToolCallDelta` has no provider-executed
@@ -1166,7 +1270,7 @@ impl StreamDecoder for GenerateContentStreamDecoder {
             // dropped here.
             // <https://ai.google.dev/gemini-api/docs/grounding>
             for content in parse_grounding_sources(candidate.get("groundingMetadata")) {
-                if let Content::Source { source } = content {
+                if let Content::Source { source, .. } = content {
                     let key = match &source {
                         Source::Url { url, .. } => url.clone(),
                         Source::Document { id, .. } => id.clone(),

--- a/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
@@ -536,7 +536,7 @@ fn parse_parts(parts: &[serde_json::Value]) -> Vec<Content> {
 /// path's extension (e.g. a `gs://…/report.pdf` uri). Mirrors the AI SDK's
 /// extension table; an unrecognized extension falls back to
 /// `application/octet-stream`.
-/// <https://github.com/vercel/ai/blob/main/packages/google/src/google-language-model.ts>
+/// <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/google/src/google-generative-ai-language-model.ts>
 fn grounding_doc_media_type(uri: &str) -> &'static str {
     if uri.ends_with(".pdf") {
         "application/pdf"
@@ -578,7 +578,7 @@ fn grounding_filename(uri: &str) -> Option<String> {
 /// `maps`/`retrievedContext` chunk with neither uri nor store) — these are the
 /// only documented drops, and they carry nothing representable.
 /// <https://ai.google.dev/api/generate-content#GroundingChunk>
-/// <https://github.com/vercel/ai/blob/main/packages/google/src/google-language-model.ts>
+/// <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/google/src/google-generative-ai-language-model.ts>
 fn parse_grounding_chunk(chunk: &serde_json::Value, index: usize) -> Option<Content> {
     let title_of = |obj: &serde_json::Value| {
         obj.get("title")
@@ -657,7 +657,7 @@ fn parse_grounding_chunk(chunk: &serde_json::Value, index: usize) -> Option<Cont
 /// carries no citation id, so one is synthesized from the uri/filename + index.
 /// Mirrors the AI SDK `extractSources`.
 /// <https://ai.google.dev/gemini-api/docs/grounding>
-/// <https://github.com/vercel/ai/blob/main/packages/google/src/google-language-model.ts>
+/// <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/google/src/google-generative-ai-language-model.ts>
 fn parse_grounding_sources(grounding: Option<&serde_json::Value>) -> Vec<Content> {
     let Some(chunks) = grounding
         .and_then(|g| g.get("groundingChunks"))
@@ -1215,7 +1215,7 @@ fn render_part(c: &Content) -> Option<serde_json::Value> {
         // (`continue`), so both approval parts are skipped here. A denied
         // execution degrades to a `functionResponse {result: <denial string>}`
         // via the `ToolResult` arm above (`to_provider_string`).
-        // <https://github.com/vercel/ai/blob/main/packages/google/src/convert-to-google-messages.ts>
+        // <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/google/src/convert-to-google-generative-ai-messages.ts>
         Content::ToolApprovalRequest { .. } | Content::ToolApprovalResponse { .. } => None,
     }
 }
@@ -1266,7 +1266,7 @@ struct GenerateContentStreamDecoder {
     /// [`Source::Document`]. `streamGenerateContent` repeats the accumulating
     /// `groundingMetadata` on successive chunks, so dedupe to emit each citation
     /// once — matching the AI SDK's `emittedSourceUrls` set.
-    /// <https://github.com/vercel/ai/blob/main/packages/google/src/google-language-model.ts>
+    /// <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/google/src/google-generative-ai-language-model.ts>
     emitted_source_keys: std::collections::HashSet<String>,
 }
 

--- a/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
@@ -734,13 +734,12 @@ impl StreamDecoder for GenerateContentStreamDecoder {
                             arguments,
                         }),
                         Content::ToolResult { .. } => {}
-                        // Response-side file output (e.g. Gemini-generated images)
-                        // is the not-yet-implemented multimodal *output* surface:
-                        // no StreamPart here, and the non-streaming cross-protocol
-                        // render also drops it where the target protocol has no
-                        // native output-file shape (chat / responses). Request-side
-                        // files never reach this decoder.
-                        Content::File { .. } => {}
+                        // A generated file (e.g. an image) becomes one whole
+                        // `StreamPart::File`, matching the AI SDK V3 stream `file`
+                        // part. <https://ai.google.dev/gemini-api/docs/image-generation>
+                        Content::File {
+                            media_type, data, ..
+                        } => parts.push(StreamPart::File { media_type, data }),
                     }
                 }
             }
@@ -770,6 +769,21 @@ impl StreamEncoder for GenerateContentStreamEncoder {
             // Observability-only metadata (upstream response id) — never
             // forwarded to the Google-protocol client.
             StreamPart::ResponseStarted { .. } => return Ok(Vec::new()),
+            // A generated file -> an `inlineData` / `fileData` part in one chunk.
+            // <https://ai.google.dev/gemini-api/docs/image-generation>
+            StreamPart::File { media_type, data } => {
+                let file_part = match data {
+                    DataContent::Base64 { data } => serde_json::json!({
+                        "inlineData": { "mimeType": media_type, "data": data }
+                    }),
+                    DataContent::Url { url } => serde_json::json!({
+                        "fileData": { "mimeType": media_type, "fileUri": url }
+                    }),
+                };
+                serde_json::json!({
+                    "candidates": [{ "content": { "role": "model", "parts": [file_part] } }]
+                })
+            }
             StreamPart::TextDelta { text } => serde_json::json!({
                 "candidates": [{ "content": { "role": "model", "parts": [{ "text": text }] } }]
             }),

--- a/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
@@ -20,7 +20,7 @@ use crate::language_model::protocol::{
 use crate::language_model::stream::SseFrame;
 use crate::language_model::types::{
     ApiProtocol, Content, DataContent, FinishReason, GenerateResult, GenerationParams, Message,
-    Prompt, ResponseFormat, Role, RoutingTarget, StreamPart, Usage,
+    Modality, Prompt, ResponseFormat, Role, RoutingTarget, StreamPart, Usage,
 };
 
 /// The Generate Content protocol adapter.
@@ -152,6 +152,44 @@ fn role_str(role: Role) -> &'static str {
         // Generate Content has only user/model; tool results ride in a user turn.
         Role::User | Role::System | Role::Tool => "user",
     }
+}
+
+/// Map a Google `responseModalities` token (uppercase) to a canonical [`Modality`].
+fn modality_from_gemini(token: &str) -> Option<Modality> {
+    match token {
+        "TEXT" => Some(Modality::Text),
+        "IMAGE" => Some(Modality::Image),
+        "AUDIO" => Some(Modality::Audio),
+        _ => None,
+    }
+}
+
+/// The Google `responseModalities` token (uppercase) for a canonical [`Modality`].
+fn modality_to_gemini(modality: &Modality) -> &'static str {
+    match modality {
+        Modality::Text => "TEXT",
+        Modality::Image => "IMAGE",
+        Modality::Audio => "AUDIO",
+    }
+}
+
+/// Take `responseModalities` out of a generation-config extras map, mapping the
+/// uppercase Google tokens to canonical modalities.
+fn take_gemini_modalities(
+    extra: &mut std::collections::HashMap<String, serde_json::Value>,
+) -> Vec<Modality> {
+    extra
+        .remove("responseModalities")
+        .and_then(|v| {
+            v.as_array().map(|tokens| {
+                tokens
+                    .iter()
+                    .filter_map(|t| t.as_str())
+                    .filter_map(modality_from_gemini)
+                    .collect()
+            })
+        })
+        .unwrap_or_default()
 }
 
 /// Parse one Google `parts[]` array into ordered canonical content. Order is
@@ -349,13 +387,14 @@ impl InboundAdapter for GenerateContentAdapter {
                         None
                     }
                 };
+                let response_modalities = take_gemini_modalities(&mut extra);
                 (
                     GenerationParams {
                         temperature,
                         top_p,
                         max_tokens: max_output_tokens,
                         reasoning_effort: None,
-                        response_modalities: Vec::new(),
+                        response_modalities,
                         extra,
                     },
                     response_format,
@@ -461,6 +500,16 @@ impl OutboundAdapter for GenerateContentAdapter {
             let ResponseFormat::JsonSchema { schema, .. } = rf;
             gen_config.insert("responseMimeType".into(), "application/json".into());
             gen_config.insert("responseSchema".into(), schema.clone());
+        }
+        // Output modalities -> Google `responseModalities` (uppercase tokens).
+        if !prompt.params.response_modalities.is_empty() {
+            let tokens: Vec<serde_json::Value> = prompt
+                .params
+                .response_modalities
+                .iter()
+                .map(|m| modality_to_gemini(m).into())
+                .collect();
+            gen_config.insert("responseModalities".into(), tokens.into());
         }
         // Splat Google generation-config extras (stopSequences, topK, seed, …)
         // back into the outbound config. Typed fields above win over a same-named

--- a/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
@@ -731,14 +731,12 @@ impl InboundAdapter for GenerateContentAdapter {
                 messages.push(Message {
                     role: Role::Tool,
                     content: tool_results,
-                    provider_metadata: ProviderMetadata::new(),
                 });
             }
             if !rest.is_empty() {
                 messages.push(Message {
                     role,
                     content: rest,
-                    provider_metadata: ProviderMetadata::new(),
                 });
             }
         }
@@ -833,6 +831,8 @@ impl InboundAdapter for GenerateContentAdapter {
         Ok(Prompt {
             model: req.model,
             system: system.filter(|s| !s.is_empty()),
+            // Generate Content has no system-level `cache_control` on its wire.
+            system_provider_metadata: ProviderMetadata::new(),
             messages,
             tools,
             params,

--- a/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
@@ -15,7 +15,8 @@ use serde::Deserialize;
 use crate::error::{BitrouterError, Result};
 use crate::language_model::protocol::{
     InboundAdapter, OutboundAdapter, PROVIDER_ID_GOOGLE, SseEvent, StreamDecoder, StreamEncoder,
-    Transport, describe_deser_error, provider_defined_native,
+    Transport, describe_deser_error, provider_defined_native, rendered_finish_reason,
+    stash_raw_finish_reason,
 };
 use crate::language_model::stream::SseFrame;
 use crate::language_model::types::{
@@ -775,6 +776,7 @@ impl InboundAdapter for GenerateContentAdapter {
                 ) {
                     (true, Some(schema)) => Some(ResponseFormat::JsonSchema {
                         name: None,
+                        description: None,
                         strict: None,
                         schema,
                     }),
@@ -851,10 +853,10 @@ impl InboundAdapter for GenerateContentAdapter {
         let usage = result.usage.unwrap_or_default();
         let mut candidate = serde_json::json!({
             "content": { "role": "model", "parts": parts },
-            "finishReason": result
-                .finish_reason
-                .as_ref()
-                .map(finish_reason_str)
+            // Prefer the stashed raw `finishReason` (e.g. `RECITATION`) over the
+            // unified-enum mapping so a same-protocol round-trip is byte-faithful;
+            // default to `STOP` when the result carries no finish reason at all.
+            "finishReason": rendered_finish_reason(result, PROVIDER_ID_GOOGLE, finish_reason_str)
                 .unwrap_or_else(|| "STOP".to_string()),
             "index": 0,
         });
@@ -987,10 +989,11 @@ impl OutboundAdapter for GenerateContentAdapter {
         // `Content::Source` parts appended after the content.
         // <https://ai.google.dev/gemini-api/docs/grounding>
         parts.extend(parse_grounding_sources(candidate.get("groundingMetadata")));
-        let finish = candidate
+        let raw_finish = candidate
             .get("finishReason")
             .and_then(|f| f.as_str())
-            .and_then(finish_reason);
+            .map(str::to_string);
+        let finish = raw_finish.as_deref().and_then(finish_reason);
         let usage = body.get("usageMetadata").and_then(parse_usage);
         // Generate Content: top-level `responseId`.
         // <https://ai.google.dev/api/generate-content#GenerateContentResponse>
@@ -1011,6 +1014,18 @@ impl OutboundAdapter for GenerateContentAdapter {
                 mv.clone(),
             );
         }
+        // Preserve the raw `finishReason` when the unified enum can't reproduce
+        // it: the content-filter family (`RECITATION` / `BLOCKLIST` /
+        // `PROHIBITED_CONTENT`) all collapse to `ContentFilter`, which renders
+        // back as the canonical `SAFETY`, so the precise sub-reason would be
+        // lost without stashing it under the `google` namespace.
+        stash_raw_finish_reason(
+            &mut provider_metadata,
+            PROVIDER_ID_GOOGLE,
+            raw_finish.as_deref(),
+            finish.as_ref(),
+            finish_reason_str,
+        );
         Ok(GenerateResult {
             content: parts,
             usage,

--- a/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
@@ -436,6 +436,8 @@ fn parse_parts(parts: &[serde_json::Value]) -> Vec<Content> {
                 // fields, never as a `functionCall`, so there is no
                 // provider-executed call to parse here.
                 provider_executed: false,
+                // Gemini has no provider-executed MCP (`dynamic`) call envelope.
+                dynamic: false,
                 // A `functionCall` part may carry a `thoughtSignature` (it
                 // continues a reasoning chain); preserve it so a follow-up turn
                 // can replay the chain.
@@ -470,6 +472,8 @@ fn parse_parts(parts: &[serde_json::Value]) -> Vec<Content> {
                 call_id,
                 tool_name: (!name.is_empty()).then_some(name),
                 output,
+                // Gemini has no MCP tool-result wire.
+                dynamic: false,
                 provider_metadata: ProviderMetadata::new(),
             });
         } else if let Some(inline) = part.get("inlineData") {

--- a/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
@@ -734,9 +734,12 @@ impl StreamDecoder for GenerateContentStreamDecoder {
                             arguments,
                         }),
                         Content::ToolResult { .. } => {}
-                        // Response-side file output (e.g. generated images) is not
-                        // yet surfaced as a stream part; request files never reach
-                        // the decoder.
+                        // Response-side file output (e.g. Gemini-generated images)
+                        // is the not-yet-implemented multimodal *output* surface:
+                        // no StreamPart here, and the non-streaming cross-protocol
+                        // render also drops it where the target protocol has no
+                        // native output-file shape (chat / responses). Request-side
+                        // files never reach this decoder.
                         Content::File { .. } => {}
                     }
                 }

--- a/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
@@ -1333,6 +1333,13 @@ impl StreamEncoder for GenerateContentStreamEncoder {
             // Observability-only metadata (upstream response id) — never
             // forwarded to the Google-protocol client.
             StreamPart::ResponseStarted { .. } => return Ok(Vec::new()),
+            // Coarse wire: Generate Content frames no content blocks (text /
+            // reasoning are flat `parts` on one candidate), so block-lifecycle
+            // markers have no native chunk and re-encode to nothing.
+            StreamPart::TextStart { .. }
+            | StreamPart::TextEnd { .. }
+            | StreamPart::ReasoningStart { .. }
+            | StreamPart::ReasoningEnd { .. } => return Ok(Vec::new()),
             // A generated file -> an `inlineData` / `fileData` part in one chunk.
             // <https://ai.google.dev/gemini-api/docs/image-generation>
             StreamPart::File { media_type, data } => {

--- a/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
@@ -20,7 +20,8 @@ use crate::language_model::protocol::{
 use crate::language_model::stream::SseFrame;
 use crate::language_model::types::{
     ApiProtocol, Content, DataContent, FinishReason, GenerateResult, GenerationParams, Message,
-    Modality, Prompt, ResponseFormat, Role, RoutingTarget, StreamPart, ToolResultOutput, Usage,
+    Modality, Prompt, ResponseFormat, Role, RoutingTarget, StreamPart, ToolChoice,
+    ToolResultOutput, Usage,
 };
 
 /// The Generate Content protocol adapter.
@@ -192,6 +193,63 @@ fn take_gemini_modalities(
         .unwrap_or_default()
 }
 
+/// Parse Google's top-level `toolConfig` value into the canonical
+/// [`ToolChoice`]. Gemini expresses tool choice as
+/// `toolConfig.functionCallingConfig.mode` (`AUTO|NONE|ANY`) with an optional
+/// `allowedFunctionNames`. `AUTO`→`Auto`, `NONE`→`None`, bare `ANY`→`Required`.
+/// `ANY` restricted to a single allowed name is rendered as `Tool` (a forced
+/// specific call); any richer constraint — `ANY` with multiple allowed names,
+/// the `VALIDATED` mode, or a `toolConfig` carrying sibling keys — has no V3
+/// equivalent and is preserved verbatim via [`ToolChoice::Other`] so it
+/// round-trips losslessly on the same wire.
+/// <https://ai.google.dev/api/caching#FunctionCallingConfig>
+fn parse_gemini_tool_choice(tool_config: &serde_json::Value) -> Option<ToolChoice> {
+    let obj = tool_config.as_object()?;
+    let fcc = obj.get("functionCallingConfig")?.as_object()?;
+    let mode = fcc.get("mode").and_then(|m| m.as_str())?;
+    let allowed: Vec<&str> = fcc
+        .get("allowedFunctionNames")
+        .and_then(|a| a.as_array())
+        .map(|arr| arr.iter().filter_map(|n| n.as_str()).collect())
+        .unwrap_or_default();
+    // A `toolConfig` with extra sibling keys, or a `functionCallingConfig` with
+    // keys beyond mode/allowedFunctionNames, cannot be reconstructed from a bare
+    // typed variant — preserve the whole thing verbatim.
+    let only_known_siblings = obj.len() == 1
+        && fcc
+            .keys()
+            .all(|k| k == "mode" || k == "allowedFunctionNames");
+    match mode {
+        "AUTO" if only_known_siblings && allowed.is_empty() => Some(ToolChoice::Auto),
+        "NONE" if only_known_siblings && allowed.is_empty() => Some(ToolChoice::None),
+        "ANY" if only_known_siblings && allowed.is_empty() => Some(ToolChoice::Required),
+        "ANY" if only_known_siblings && allowed.len() == 1 => Some(ToolChoice::Tool {
+            name: allowed[0].to_string(),
+        }),
+        _ => Some(ToolChoice::Other {
+            value: tool_config.clone(),
+        }),
+    }
+}
+
+/// Render a canonical [`ToolChoice`] into Google's top-level `toolConfig` value.
+/// `Required`→`mode:"ANY"`, `Tool`→`mode:"ANY"` with a single-entry
+/// `allowedFunctionNames`. [`ToolChoice::Other`] is emitted verbatim (it already
+/// holds a Google-native `toolConfig`).
+/// <https://ai.google.dev/api/caching#FunctionCallingConfig>
+fn render_gemini_tool_choice(choice: &ToolChoice) -> serde_json::Value {
+    let fcc = match choice {
+        ToolChoice::Auto => serde_json::json!({ "mode": "AUTO" }),
+        ToolChoice::None => serde_json::json!({ "mode": "NONE" }),
+        ToolChoice::Required => serde_json::json!({ "mode": "ANY" }),
+        ToolChoice::Tool { name } => {
+            serde_json::json!({ "mode": "ANY", "allowedFunctionNames": [name] })
+        }
+        ToolChoice::Other { value } => return value.clone(),
+    };
+    serde_json::json!({ "functionCallingConfig": fcc })
+}
+
 /// Parse one Google `parts[]` array into ordered canonical content. Order is
 /// preserved (#416); `thought: true` parts become `Reasoning` (#454-1).
 fn parse_parts(parts: &[serde_json::Value]) -> Vec<Content> {
@@ -213,6 +271,12 @@ fn parse_parts(parts: &[serde_json::Value]) -> Vec<Content> {
                     .get("args")
                     .map(|a| a.to_string())
                     .unwrap_or_else(|| "{}".to_string()),
+                // Gemini `functionCall` parts are client tool calls. Google's
+                // own server-side tools (Search grounding, code execution)
+                // surface as separate `groundingMetadata` / `executableCode`
+                // fields, never as a `functionCall`, so there is no
+                // provider-executed call to parse here.
+                provider_executed: false,
             });
         } else if let Some(fr) = part.get("functionResponse") {
             // Gemini `functionResponse {id?, name, response}`: `name` is the tool
@@ -412,6 +476,7 @@ impl InboundAdapter for GenerateContentAdapter {
                         max_tokens: max_output_tokens,
                         reasoning_effort: None,
                         response_modalities,
+                        tool_choice: None,
                         extra,
                     },
                     response_format,
@@ -419,14 +484,23 @@ impl InboundAdapter for GenerateContentAdapter {
             }
             None => (GenerationParams::default(), None),
         };
-        // Preserve top-level Google fields (`toolConfig`, `safetySettings`,
+        // `toolConfig` is a top-level Google field that carries tool choice. Lift
+        // its `functionCallingConfig` into the typed slot and remove `toolConfig`
+        // from the top-level extras so it is not also re-rendered verbatim (which
+        // would forward a Gemini-shaped choice into a non-Gemini upstream, and
+        // double-write it on a same-protocol round-trip).
+        let mut top_level = req.extra;
+        if let Some(tc) = top_level.remove("toolConfig") {
+            params.tool_choice = parse_gemini_tool_choice(&tc);
+        }
+        // Preserve the remaining top-level Google fields (`safetySettings`,
         // `cachedContent`, …) across the round-trip. They're namespaced so they
         // don't collide with `generationConfig`-level extras above and only the
         // Generate Content `render_request` lifts them back to the top level.
-        if !req.extra.is_empty() {
+        if !top_level.is_empty() {
             params.extra.insert(
                 GOOGLE_TOP_LEVEL_EXTRA_KEY.to_string(),
-                serde_json::Value::Object(req.extra.into_iter().collect()),
+                serde_json::Value::Object(top_level.into_iter().collect()),
             );
         }
 
@@ -540,8 +614,14 @@ impl OutboundAdapter for GenerateContentAdapter {
         if !gen_config.is_empty() {
             req.insert("generationConfig".into(), gen_config.into());
         }
-        // Lift namespaced top-level extras (toolConfig / safetySettings /
-        // cachedContent / …) back to the request root.
+        // Render the canonical tool_choice into Google's top-level `toolConfig`,
+        // before the top-level-extras lift so the typed slot wins over any stale
+        // `toolConfig` that might linger in the sentinel.
+        if let Some(tc) = &prompt.params.tool_choice {
+            req.insert("toolConfig".into(), render_gemini_tool_choice(tc));
+        }
+        // Lift namespaced top-level extras (safetySettings / cachedContent / …)
+        // back to the request root.
         if let Some(serde_json::Value::Object(top)) =
             prompt.params.extra.get(GOOGLE_TOP_LEVEL_EXTRA_KEY)
         {
@@ -772,10 +852,15 @@ impl StreamDecoder for GenerateContentStreamDecoder {
                         Content::Reasoning { text } => {
                             parts.push(StreamPart::ReasoningDelta { text })
                         }
+                        // The streaming `ToolCallDelta` has no provider-executed
+                        // flag (Gemini streams only client `functionCall` parts),
+                        // so the server-tool marker is not carried here — `..`
+                        // ignores it deliberately.
                         Content::ToolCall {
                             id,
                             name,
                             arguments,
+                            ..
                         } => parts.push(StreamPart::ToolCallDelta {
                             id,
                             name: Some(name),

--- a/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
@@ -14,13 +14,13 @@ use serde::Deserialize;
 
 use crate::error::{BitrouterError, Result};
 use crate::language_model::protocol::{
-    InboundAdapter, OutboundAdapter, SseEvent, StreamDecoder, StreamEncoder, Transport,
-    describe_deser_error,
+    InboundAdapter, OutboundAdapter, PROVIDER_ID_GOOGLE, SseEvent, StreamDecoder, StreamEncoder,
+    Transport, describe_deser_error, provider_defined_native,
 };
 use crate::language_model::stream::SseFrame;
 use crate::language_model::types::{
     ApiProtocol, Content, DataContent, FinishReason, GenerateResult, GenerationParams, Message,
-    Modality, Prompt, ResponseFormat, Role, RoutingTarget, StreamPart, ToolChoice,
+    Modality, Prompt, ResponseFormat, Role, RoutingTarget, StreamPart, Tool, ToolChoice,
     ToolResultOutput, Usage,
 };
 
@@ -85,13 +85,30 @@ pub struct GenerateContentContent {
     parts: Vec<serde_json::Value>,
 }
 
-/// One element of [`GenerateContentRequest`]'s `tools` array — Google's
-/// `{ functionDeclarations: [...] }` envelope.
+/// One element of [`GenerateContentRequest`]'s `tools` array.
+///
+/// A single Google tool object may carry client function declarations
+/// (`functionDeclarations`) **and/or** one or more provider-defined ("built-in")
+/// tool keys on the same object — `googleSearch`, `codeExecution`,
+/// `googleSearchRetrieval`, `urlContext`. Function declarations parse to
+/// [`Tool::Function`]; every other key is a provider-defined tool namespaced
+/// `google.<key>`, its value preserved verbatim as `args`. The non-function keys
+/// ride in `extra`.
+/// <https://ai.google.dev/gemini-api/docs/function-calling>
+/// <https://ai.google.dev/gemini-api/docs/google-search>
+/// <https://ai.google.dev/gemini-api/docs/code-execution>
 #[derive(Debug, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct GenerateContentTool {
     #[serde(default)]
     function_declarations: Vec<GenerateContentFunctionDecl>,
+    /// Provider-defined (built-in) tool keys on this object — `googleSearch`,
+    /// `codeExecution`, `googleSearchRetrieval`, `urlContext`, … — each preserved
+    /// verbatim. Skipped from the published schema; the documented contract is
+    /// the typed `functionDeclarations` shape.
+    #[serde(flatten)]
+    #[schemars(skip)]
+    extra: std::collections::HashMap<String, serde_json::Value>,
 }
 
 /// One function declaration inside a [`GenerateContentTool`]: name + description +
@@ -251,6 +268,75 @@ fn render_gemini_tool_choice(choice: &ToolChoice) -> serde_json::Value {
         ToolChoice::Other { value } => return value.clone(),
     };
     serde_json::json!({ "functionCallingConfig": fcc })
+}
+
+/// Expand one Google `tools[]` object into canonical [`Tool`]s: each
+/// `functionDeclarations` entry → a [`Tool::Function`]; each other (built-in)
+/// key → a [`Tool::ProviderDefined`] namespaced `google.<key>`, value preserved
+/// verbatim as `args`.
+fn parse_generate_content_tool(t: GenerateContentTool) -> Vec<Tool> {
+    let mut out: Vec<Tool> = t
+        .function_declarations
+        .into_iter()
+        .map(|f| Tool::Function {
+            name: f.name,
+            description: f.description,
+            parameters: f.parameters,
+            // Google function declarations carry no `strict` slot.
+            strict: None,
+        })
+        .collect();
+    for (key, value) in t.extra {
+        out.push(Tool::ProviderDefined {
+            id: format!("{PROVIDER_ID_GOOGLE}.{key}"),
+            name: key,
+            args: value,
+        });
+    }
+    out
+}
+
+/// Render the canonical tool list into Google's `tools` value.
+///
+/// Google packs all client function tools into a single object's
+/// `functionDeclarations` array, while each provider-defined built-in tool is a
+/// distinct single-key object (`{googleSearch:{}}`, `{codeExecution:{}}`, …).
+/// Google's own function declarations have **no** `strict` slot, so
+/// [`Tool::Function::strict`] is intentionally dropped here (documented; mirrors
+/// the structured-output `strict` drop). A [`Tool::ProviderDefined`] renders to
+/// its source-native shape via [`provider_defined_native`]: a `google.*` id is a
+/// lossless same-protocol round-trip; a foreign-provider id is preserved verbatim
+/// (faithful passthrough) as its own tool-array element so the upstream decides.
+/// <https://ai.google.dev/gemini-api/docs/function-calling>
+/// <https://ai.google.dev/gemini-api/docs/google-search>
+fn render_generate_content_tools(tools: &[Tool]) -> serde_json::Value {
+    let mut function_declarations = Vec::new();
+    let mut entries = Vec::new();
+    for tool in tools {
+        match tool {
+            Tool::Function {
+                name,
+                description,
+                parameters,
+                strict: _,
+            } => function_declarations.push(serde_json::json!({
+                "name": name,
+                "description": description,
+                "parameters": parameters,
+            })),
+            Tool::ProviderDefined { id, name, args } => {
+                entries.push(provider_defined_native(id, name, args));
+            }
+        }
+    }
+    // The function-declarations object goes first when present, preserving the
+    // prior single-object render for the common (function-only) case.
+    let mut out = Vec::with_capacity(entries.len() + 1);
+    if !function_declarations.is_empty() {
+        out.push(serde_json::json!({ "functionDeclarations": function_declarations }));
+    }
+    out.extend(entries);
+    serde_json::Value::Array(out)
 }
 
 /// Parse one Google `parts[]` array into ordered canonical content. Order is
@@ -425,15 +511,17 @@ impl InboundAdapter for GenerateContentAdapter {
             }
         }
 
+        // A Google tool object may carry `functionDeclarations` (client function
+        // tools) and/or provider-defined built-in keys (`googleSearch`,
+        // `codeExecution`, `googleSearchRetrieval`, `urlContext`, …) on the same
+        // object. Expand each object into its function tools plus one
+        // `Tool::ProviderDefined` per built-in key, namespaced `google.<key>`,
+        // value preserved verbatim as `args`.
+        // <https://ai.google.dev/gemini-api/docs/function-calling>
         let tools = req
             .tools
             .into_iter()
-            .flat_map(|t| t.function_declarations)
-            .map(|f| crate::language_model::types::Tool {
-                name: f.name,
-                description: f.description,
-                parameters: f.parameters,
-            })
+            .flat_map(parse_generate_content_tool)
             .collect();
 
         // `responseMimeType` / `responseSchema` are typed fields now. Promote
@@ -569,16 +657,7 @@ impl OutboundAdapter for GenerateContentAdapter {
             );
         }
         if !prompt.tools.is_empty() {
-            req.insert(
-                "tools".into(),
-                serde_json::json!([{
-                    "functionDeclarations": prompt.tools.iter().map(|t| serde_json::json!({
-                        "name": t.name,
-                        "description": t.description,
-                        "parameters": t.parameters,
-                    })).collect::<Vec<_>>()
-                }]),
-            );
+            req.insert("tools".into(), render_generate_content_tools(&prompt.tools));
         }
         let mut gen_config = serde_json::Map::new();
         if let Some(t) = prompt.params.temperature {

--- a/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
@@ -1141,6 +1141,14 @@ fn render_part(c: &Content) -> Option<serde_json::Value> {
         // they are re-attached under `groundingMetadata` in `render_response`,
         // not rendered as a content `part`. Skip on the request path.
         Content::Source { .. } => None,
+        // The Gemini Generate Content wire has no tool-approval handshake: there
+        // is no `mcp_approval_request` / `mcp_approval_response` part. The AI
+        // SDK's Google converter drops a `tool-approval-response` part
+        // (`continue`), so both approval parts are skipped here. A denied
+        // execution degrades to a `functionResponse {result: <denial string>}`
+        // via the `ToolResult` arm above (`to_provider_string`).
+        // <https://github.com/vercel/ai/blob/main/packages/google/src/convert-to-google-messages.ts>
+        Content::ToolApprovalRequest { .. } | Content::ToolApprovalResponse { .. } => None,
     }
 }
 
@@ -1259,6 +1267,10 @@ impl StreamDecoder for GenerateContentStreamDecoder {
                         // candidate metadata, not a content part); it is decoded
                         // from `groundingMetadata` below.
                         Content::Source { .. } => {}
+                        // The Gemini wire carries no tool-approval handshake, so
+                        // `parse_parts` never yields these; nothing to stream.
+                        Content::ToolApprovalRequest { .. }
+                        | Content::ToolApprovalResponse { .. } => {}
                     }
                 }
             }

--- a/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
@@ -451,14 +451,127 @@ fn parse_parts(parts: &[serde_json::Value]) -> Vec<Content> {
     out
 }
 
+/// Infer a document IANA media type from a Gemini `retrievedContext` file
+/// path's extension (e.g. a `gs://…/report.pdf` uri). Mirrors the AI SDK's
+/// extension table; an unrecognized extension falls back to
+/// `application/octet-stream`.
+/// <https://github.com/vercel/ai/blob/main/packages/google/src/google-language-model.ts>
+fn grounding_doc_media_type(uri: &str) -> &'static str {
+    if uri.ends_with(".pdf") {
+        "application/pdf"
+    } else if uri.ends_with(".txt") {
+        "text/plain"
+    } else if uri.ends_with(".docx") {
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    } else if uri.ends_with(".doc") {
+        "application/msword"
+    } else if uri.ends_with(".md") || uri.ends_with(".markdown") {
+        "text/markdown"
+    } else {
+        "application/octet-stream"
+    }
+}
+
+/// The trailing path segment of a `gs://`/file-path uri, used as a document
+/// `filename` (mirrors the AI SDK's `uri.split('/').pop()`).
+fn grounding_filename(uri: &str) -> Option<String> {
+    uri.rsplit('/')
+        .next()
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
+/// Parse one Gemini grounding chunk into a canonical [`Content::Source`].
+/// Mirrors the AI SDK `extractSources`, handling every chunk kind:
+/// - `web` (`{uri, title?}`) → [`Source::Url`] — the server Search tool's hits;
+/// - `image` (`{sourceUri, title?}`) → [`Source::Url`] keyed by `sourceUri`
+///   (Google requires attribution to the source page, not the image bytes);
+/// - `retrievedContext` (`{uri?, title?, fileSearchStore?}`) — an `http(s)` uri
+///   → [`Source::Url`]; any other uri (e.g. `gs://`) → [`Source::Document`] with
+///   the media type/filename inferred from the path; a `fileSearchStore`-only
+///   chunk → [`Source::Document`] keyed by the store's trailing segment;
+/// - `maps` (`{uri?, title?}`) → [`Source::Url`] when it carries a `uri`.
+///
+/// The chunk carries no citation id, so one is synthesized from the
+/// url/filename + index. A chunk with no usable field yields `None` (e.g. a
+/// `maps`/`retrievedContext` chunk with neither uri nor store) — these are the
+/// only documented drops, and they carry nothing representable.
+/// <https://ai.google.dev/api/generate-content#GroundingChunk>
+/// <https://github.com/vercel/ai/blob/main/packages/google/src/google-language-model.ts>
+fn parse_grounding_chunk(chunk: &serde_json::Value, index: usize) -> Option<Content> {
+    let title_of = |obj: &serde_json::Value| {
+        obj.get("title")
+            .and_then(|t| t.as_str())
+            .map(str::to_string)
+    };
+    let url_source = |url: String, title: Option<String>| Content::Source {
+        source: Source::Url {
+            id: Source::synthesize_id(&url, index),
+            url,
+            title,
+        },
+    };
+    if let Some(web) = chunk.get("web") {
+        let url = web.get("uri").and_then(|u| u.as_str())?.to_string();
+        return Some(url_source(url, title_of(web)));
+    }
+    if let Some(image) = chunk.get("image") {
+        // Attribution uses the source page URI, not the raw `imageUri`.
+        let url = image.get("sourceUri").and_then(|u| u.as_str())?.to_string();
+        return Some(url_source(url, title_of(image)));
+    }
+    if let Some(ctx) = chunk.get("retrievedContext") {
+        let uri = ctx.get("uri").and_then(|u| u.as_str());
+        if let Some(uri) = uri {
+            // An http(s) RAG source is representable as a URL today; a
+            // file-path source (`gs://`, …) becomes a document citation.
+            if uri.starts_with("http://") || uri.starts_with("https://") {
+                return Some(url_source(uri.to_string(), title_of(ctx)));
+            }
+            let filename = grounding_filename(uri);
+            let title = title_of(ctx).unwrap_or_else(|| "Unknown Document".to_string());
+            return Some(Content::Source {
+                source: Source::Document {
+                    id: Source::synthesize_id(uri, index),
+                    media_type: grounding_doc_media_type(uri).to_string(),
+                    title,
+                    filename,
+                },
+            });
+        }
+        // File Search format: a store id with no uri.
+        if let Some(store) = ctx.get("fileSearchStore").and_then(|s| s.as_str()) {
+            let title = title_of(ctx).unwrap_or_else(|| "Unknown Document".to_string());
+            return Some(Content::Source {
+                source: Source::Document {
+                    id: Source::synthesize_id(store, index),
+                    media_type: "application/octet-stream".to_string(),
+                    title,
+                    filename: grounding_filename(store),
+                },
+            });
+        }
+        return None;
+    }
+    if let Some(maps) = chunk.get("maps") {
+        let url = maps.get("uri").and_then(|u| u.as_str())?.to_string();
+        return Some(url_source(url, title_of(maps)));
+    }
+    // An unrecognized, forward-compatible chunk kind carries no representable
+    // citation field. The only grounding chunk kinds Gemini documents are
+    // `web`, `image`, `retrievedContext`, and `maps` (all handled above); a new
+    // kind is skipped rather than silently mismapped.
+    // <https://ai.google.dev/api/generate-content#GroundingChunk>
+    None
+}
+
 /// Parse a Gemini `candidate.groundingMetadata` object into canonical
-/// [`Content::Source`] (URL) parts. Web search grounding surfaces as
-/// `groundingMetadata.groundingChunks[]`, each `{web:{uri, title?}}`; the
-/// model's own server-side Search tool emits these instead of any
-/// `functionCall`. The chunk carries no citation id, so synthesize a stable one
-/// from the uri + index. Non-`web` chunks (`retrievedContext` RAG sources) are
-/// not mapped here — they require document-source plumbing the response wire
-/// does not expose uniformly. Mirrors the AI SDK `extractSources`.
+/// [`Content::Source`] parts. Web search grounding surfaces as
+/// `groundingMetadata.groundingChunks[]`; the model's own server-side Search
+/// tool emits these instead of any `functionCall`. Each chunk is mapped by
+/// [`parse_grounding_chunk`] (every documented chunk kind is handled). The chunk
+/// carries no citation id, so one is synthesized from the uri/filename + index.
+/// Mirrors the AI SDK `extractSources`.
 /// <https://ai.google.dev/gemini-api/docs/grounding>
 /// <https://github.com/vercel/ai/blob/main/packages/google/src/google-language-model.ts>
 fn parse_grounding_sources(grounding: Option<&serde_json::Value>) -> Vec<Content> {
@@ -471,21 +584,7 @@ fn parse_grounding_sources(grounding: Option<&serde_json::Value>) -> Vec<Content
     chunks
         .iter()
         .enumerate()
-        .filter_map(|(i, chunk)| {
-            let web = chunk.get("web")?;
-            let url = web.get("uri").and_then(|u| u.as_str())?.to_string();
-            let title = web
-                .get("title")
-                .and_then(|t| t.as_str())
-                .map(str::to_string);
-            Some(Content::Source {
-                source: Source::Url {
-                    id: Source::synthesize_id(&url, i),
-                    url,
-                    title,
-                },
-            })
-        })
+        .filter_map(|(i, chunk)| parse_grounding_chunk(chunk, i))
         .collect()
 }
 
@@ -982,12 +1081,13 @@ struct GenerateContentStreamDecoder {
     /// Whether the one-shot [`StreamPart::ResponseStarted`] has been emitted.
     /// Every chunk repeats `responseId`; we surface it only once.
     response_started_emitted: bool,
-    /// URLs of grounding sources already emitted as `StreamPart::Source`.
-    /// `streamGenerateContent` repeats the accumulating `groundingMetadata` on
-    /// successive chunks, so dedupe by URL to emit each citation once — matching
-    /// the AI SDK's `emittedSourceUrls` set.
+    /// Dedup keys of grounding sources already emitted as `StreamPart::Source`
+    /// — the citation URL for a [`Source::Url`], the synthesized id for a
+    /// [`Source::Document`]. `streamGenerateContent` repeats the accumulating
+    /// `groundingMetadata` on successive chunks, so dedupe to emit each citation
+    /// once — matching the AI SDK's `emittedSourceUrls` set.
     /// <https://github.com/vercel/ai/blob/main/packages/google/src/google-language-model.ts>
-    emitted_source_urls: std::collections::HashSet<String>,
+    emitted_source_keys: std::collections::HashSet<String>,
 }
 
 impl StreamDecoder for GenerateContentStreamDecoder {
@@ -1060,17 +1160,20 @@ impl StreamDecoder for GenerateContentStreamDecoder {
             }
             // Web-search grounding arrives on `candidate.groundingMetadata`,
             // accumulating across chunks. Emit each new citation once as a whole
-            // `StreamPart::Source`, deduped by URL.
+            // `StreamPart::Source`, deduped by URL (or document id). Every
+            // grounding chunk kind `parse_grounding_sources` recognizes — URL
+            // and document sources alike — is forwarded; none is silently
+            // dropped here.
             // <https://ai.google.dev/gemini-api/docs/grounding>
             for content in parse_grounding_sources(candidate.get("groundingMetadata")) {
-                if let Content::Source {
-                    source: Source::Url { url, title, id },
-                } = content
-                    && self.emitted_source_urls.insert(url.clone())
-                {
-                    parts.push(StreamPart::Source {
-                        source: Source::Url { url, title, id },
-                    });
+                if let Content::Source { source } = content {
+                    let key = match &source {
+                        Source::Url { url, .. } => url.clone(),
+                        Source::Document { id, .. } => id.clone(),
+                    };
+                    if self.emitted_source_keys.insert(key) {
+                        parts.push(StreamPart::Source { source });
+                    }
                 }
             }
             if let Some(reason) = candidate

--- a/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
@@ -19,8 +19,8 @@ use crate::language_model::protocol::{
 };
 use crate::language_model::stream::SseFrame;
 use crate::language_model::types::{
-    ApiProtocol, Content, FinishReason, GenerateResult, GenerationParams, Message, Prompt,
-    ResponseFormat, Role, RoutingTarget, StreamPart, Usage,
+    ApiProtocol, Content, DataContent, FinishReason, GenerateResult, GenerationParams, Message,
+    Prompt, ResponseFormat, Role, RoutingTarget, StreamPart, Usage,
 };
 
 /// The Generate Content protocol adapter.
@@ -320,6 +320,7 @@ impl InboundAdapter for GenerateContentAdapter {
                         top_p,
                         max_tokens: max_output_tokens,
                         reasoning_effort: None,
+                        response_modalities: Vec::new(),
                         extra,
                     },
                     response_format,
@@ -541,6 +542,18 @@ fn render_part(c: &Content) -> Option<serde_json::Value> {
                 "functionResponse": { "name": call_id, "response": response }
             }))
         }
+        // Inline bytes -> `inlineData`; a URL -> `fileData`. Gemini keys media by
+        // `mimeType`. <https://ai.google.dev/gemini-api/docs/image-understanding>
+        Content::File {
+            media_type, data, ..
+        } => Some(match data {
+            DataContent::Base64 { data } => serde_json::json!({
+                "inlineData": { "mimeType": media_type, "data": data }
+            }),
+            DataContent::Url { url } => serde_json::json!({
+                "fileData": { "mimeType": media_type, "fileUri": url }
+            }),
+        }),
     }
 }
 
@@ -637,6 +650,10 @@ impl StreamDecoder for GenerateContentStreamDecoder {
                             arguments,
                         }),
                         Content::ToolResult { .. } => {}
+                        // Response-side file output (e.g. generated images) is not
+                        // yet surfaced as a stream part; request files never reach
+                        // the decoder.
+                        Content::File { .. } => {}
                     }
                 }
             }

--- a/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
@@ -132,16 +132,23 @@ fn parse_reasoning_metadata(block: &serde_json::Value, block_type: &str) -> Prov
 /// [`parse_reasoning_metadata`]. A `redactedThinking` flag re-emits a
 /// `redacted_thinking` block whose `data` is the preserved encrypted payload
 /// (falling back to `text` when absent); otherwise a `thinking` block, carrying
-/// its `signature` when one round-tripped. Any block-level `cache_control` is
-/// re-applied last.
+/// its `signature` when one round-tripped.
+///
+/// A `cache_control` breakpoint is intentionally **not** re-applied here:
+/// Anthropic rejects `cache_control` on `thinking` / `redacted_thinking` blocks
+/// (they are cached implicitly when they appear in a prior assistant turn), so
+/// the Vercel reference validates them with `canCache: false` and never emits
+/// the field. Any `cacheControl` that rode in `provider_metadata` is therefore
+/// dropped on render rather than producing a request the API would reject.
 /// <https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking>
+/// <https://github.com/vercel/ai/blob/main/packages/anthropic/src/convert-to-anthropic-prompt.ts>
 fn render_reasoning_block(text: &str, meta: &ProviderMetadata) -> serde_json::Value {
     let ns = provider_namespace(meta, PROVIDER_ID_ANTHROPIC);
     let is_redacted = ns
         .and_then(|o| o.get(ANTHROPIC_REDACTED))
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
-    let mut block = if is_redacted {
+    if is_redacted {
         // Prefer the preserved encrypted payload; the canonical `text` mirrors
         // it on parse, so it is the correct fallback if metadata was stripped.
         let data = ns
@@ -155,9 +162,7 @@ fn render_reasoning_block(text: &str, meta: &ProviderMetadata) -> serde_json::Va
             obj["signature"] = sig.clone();
         }
         obj
-    };
-    apply_cache_control(&mut block, meta);
-    block
+    }
 }
 
 /// The Messages inbound + outbound protocol adapter.
@@ -363,6 +368,26 @@ fn parse_system(value: &serde_json::Value) -> String {
             .collect::<Vec<_>>()
             .join("\n"),
         _ => String::new(),
+    }
+}
+
+/// Lift a `cache_control` breakpoint off Anthropic's `system` field into a
+/// [`ProviderMetadata`] under `anthropic.cacheControl`. The system prefix is the
+/// highest-value, most common prompt-cache breakpoint; a string system carries
+/// none, while an array system carries it on a `{type:"text", text,
+/// cache_control}` block. The last block that carries `cache_control` wins — the
+/// cache boundary is the cumulative prefix up to the final breakpoint.
+/// <https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching>
+fn parse_system_metadata(value: &serde_json::Value) -> ProviderMetadata {
+    match value {
+        serde_json::Value::Array(blocks) => blocks
+            .iter()
+            .rev()
+            .map(parse_cache_control)
+            .find(|m| !m.is_empty())
+            .unwrap_or_default(),
+        // A plain-string system has no place to carry `cache_control`.
+        _ => ProviderMetadata::new(),
     }
 }
 
@@ -732,6 +757,14 @@ impl InboundAdapter for MessagesAdapter {
             .as_ref()
             .map(parse_system)
             .filter(|s| !s.is_empty());
+        // Lift any system-block `cache_control` breakpoint into the parallel
+        // metadata slot so the highest-value prompt-cache point (the system
+        // prefix) survives — a bare `system: Option<String>` would flatten it.
+        let system_provider_metadata = req
+            .system
+            .as_ref()
+            .map(parse_system_metadata)
+            .unwrap_or_default();
 
         let mut messages = Vec::with_capacity(req.messages.len());
         for m in &req.messages {
@@ -746,14 +779,12 @@ impl InboundAdapter for MessagesAdapter {
                 messages.push(Message {
                     role: Role::Tool,
                     content: tool_results,
-                    provider_metadata: ProviderMetadata::new(),
                 });
             }
             if !rest.is_empty() {
                 messages.push(Message {
                     role,
                     content: rest,
-                    provider_metadata: ProviderMetadata::new(),
                 });
             }
         }
@@ -820,6 +851,7 @@ impl InboundAdapter for MessagesAdapter {
         Ok(Prompt {
             model: req.model,
             system,
+            system_provider_metadata,
             messages,
             tools,
             params: GenerationParams {
@@ -905,7 +937,27 @@ impl OutboundAdapter for MessagesAdapter {
         let mut req = serde_json::Map::new();
         req.insert("model".into(), prompt.model.clone().into());
         if let Some(system) = &prompt.system {
-            req.insert("system".into(), system.clone().into());
+            // When a system-prompt `cache_control` breakpoint round-tripped,
+            // re-render `system` as a cached `[{type:"text", text,
+            // cache_control}]` block (the Anthropic array form) rather than a
+            // bare string, so the highest-value cache point is preserved. With no
+            // breakpoint, the plain-string form is kept.
+            // <https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching>
+            match cache_control_value(&prompt.system_provider_metadata) {
+                Some(cc) => {
+                    req.insert(
+                        "system".into(),
+                        serde_json::json!([{
+                            "type": "text",
+                            "text": system,
+                            "cache_control": cc,
+                        }]),
+                    );
+                }
+                None => {
+                    req.insert("system".into(), system.clone().into());
+                }
+            }
         }
         req.insert("messages".into(), messages.into());
         if !prompt.tools.is_empty() {
@@ -1581,12 +1633,13 @@ fn render_message(m: &Message) -> serde_json::Value {
     };
     let blocks: Vec<serde_json::Value> =
         m.content.iter().filter_map(render_content_block).collect();
-    let mut out = serde_json::json!({ "role": role, "content": blocks });
-    // A message may also carry a turn-level `cache_control` breakpoint (Anthropic
-    // accepts `cache_control` on a message, not only its blocks).
-    // <https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching>
-    apply_cache_control(&mut out, &m.provider_metadata);
-    out
+    // No message-level `cache_control` is emitted: Anthropic rejects
+    // `cache_control` as a sibling of `role`/`content`. A turn-level cache
+    // breakpoint belongs on a content block, and the Vercel reference folds a
+    // message's `cacheControl` onto its last content block rather than the
+    // message object — so the per-block render above already covers caching.
+    // <https://github.com/vercel/ai/blob/main/packages/anthropic/src/convert-to-anthropic-prompt.ts>
+    serde_json::json!({ "role": role, "content": blocks })
 }
 
 fn parse_usage(value: &serde_json::Value) -> Option<Usage> {

--- a/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
@@ -142,7 +142,7 @@ fn parse_reasoning_metadata(block: &serde_json::Value, block_type: &str) -> Prov
 /// the field. Any `cacheControl` that rode in `provider_metadata` is therefore
 /// dropped on render rather than producing a request the API would reject.
 /// <https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking>
-/// <https://github.com/vercel/ai/blob/main/packages/anthropic/src/convert-to-anthropic-prompt.ts>
+/// <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts>
 fn render_reasoning_block(text: &str, meta: &ProviderMetadata) -> serde_json::Value {
     let ns = provider_namespace(meta, PROVIDER_ID_ANTHROPIC);
     let is_redacted = ns
@@ -1578,7 +1578,7 @@ fn render_content_block(c: &Content) -> Option<serde_json::Value> {
         // (`continue`), so both approval parts are skipped here. A denied
         // execution still degrades to a plain `tool_result` string on the
         // request side (`render_tool_result_content` via `to_provider_string`).
-        // <https://github.com/vercel/ai/blob/main/packages/anthropic/src/convert-to-anthropic-prompt.ts>
+        // <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts>
         Content::ToolApprovalRequest { .. } | Content::ToolApprovalResponse { .. } => None,
     }
 }
@@ -1687,7 +1687,7 @@ fn render_message(m: &Message) -> serde_json::Value {
     // breakpoint belongs on a content block, and the Vercel reference folds a
     // message's `cacheControl` onto its last content block rather than the
     // message object — so the per-block render above already covers caching.
-    // <https://github.com/vercel/ai/blob/main/packages/anthropic/src/convert-to-anthropic-prompt.ts>
+    // <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts>
     serde_json::json!({ "role": role, "content": blocks })
 }
 

--- a/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
@@ -23,7 +23,8 @@ use crate::language_model::protocol::{
 use crate::language_model::stream::SseFrame;
 use crate::language_model::types::{
     ApiProtocol, AuthScheme, Content, DataContent, FinishReason, GenerateResult, GenerationParams,
-    Message, Prompt, ResponseFormat, Role, RoutingTarget, StopDetails, StreamPart, Usage,
+    Message, Prompt, ResponseFormat, Role, RoutingTarget, StopDetails, StreamPart,
+    ToolResultContentPart, ToolResultOutput, Usage,
 };
 
 /// The Messages inbound + outbound protocol adapter.
@@ -131,7 +132,126 @@ fn parse_system(value: &serde_json::Value) -> String {
     }
 }
 
-/// Messages `tool_result.content` may be a string or an array of blocks (#364).
+/// Parse an Anthropic image/document `source` object into a canonical
+/// `(media_type, DataContent)`. A `base64` source carries an explicit
+/// `media_type`; a `url` source carries none, so the caller's fallback (derived
+/// from the block kind) is used.
+/// <https://docs.anthropic.com/en/docs/build-with-claude/vision>
+fn parse_anthropic_source(
+    source: Option<&serde_json::Value>,
+    media_type_fallback: &str,
+) -> (String, DataContent) {
+    let media_type = source
+        .and_then(|s| s.get("media_type"))
+        .and_then(|m| m.as_str())
+        .map(str::to_string)
+        .unwrap_or_else(|| media_type_fallback.to_string());
+    let data = if source.and_then(|s| s.get("type")).and_then(|t| t.as_str()) == Some("url") {
+        DataContent::Url {
+            url: source
+                .and_then(|s| s.get("url"))
+                .and_then(|u| u.as_str())
+                .unwrap_or_default()
+                .to_string(),
+        }
+    } else {
+        DataContent::Base64 {
+            data: source
+                .and_then(|s| s.get("data"))
+                .and_then(|d| d.as_str())
+                .unwrap_or_default()
+                .to_string(),
+        }
+    };
+    (media_type, data)
+}
+
+/// Parse the `content` of an Anthropic `tool_result` block into a canonical
+/// [`ToolResultOutput`], honoring the block's `is_error` flag.
+///
+/// `is_error` selects the error variants: a string error → [`ToolResultOutput::ErrorText`],
+/// a structured error → [`ToolResultOutput::ErrorJson`]. Without the flag, a
+/// string → [`ToolResultOutput::Text`], a block array carrying media →
+/// [`ToolResultOutput::Content`] (text + image parts in order), a text-only
+/// block array collapses to `Text`, and any other JSON value →
+/// [`ToolResultOutput::Json`].
+/// <https://docs.anthropic.com/en/docs/build-with-claude/tool-use#tool-result>
+fn parse_tool_result_output(
+    content: Option<&serde_json::Value>,
+    is_error: bool,
+) -> ToolResultOutput {
+    let Some(value) = content else {
+        // An absent body still carries the error flag faithfully.
+        return if is_error {
+            ToolResultOutput::ErrorText {
+                value: String::new(),
+            }
+        } else {
+            ToolResultOutput::Text {
+                value: String::new(),
+            }
+        };
+    };
+    if is_error {
+        return match value {
+            serde_json::Value::String(s) => ToolResultOutput::ErrorText { value: s.clone() },
+            serde_json::Value::Array(_) => ToolResultOutput::ErrorText {
+                value: tool_result_text(value),
+            },
+            other => ToolResultOutput::ErrorJson {
+                value: other.clone(),
+            },
+        };
+    }
+    match value {
+        serde_json::Value::String(s) => ToolResultOutput::Text { value: s.clone() },
+        serde_json::Value::Array(blocks) => {
+            let parts = parse_tool_result_blocks(blocks);
+            let has_media = parts
+                .iter()
+                .any(|p| matches!(p, ToolResultContentPart::Media { .. }));
+            if has_media {
+                ToolResultOutput::Content { value: parts }
+            } else {
+                ToolResultOutput::Text {
+                    value: tool_result_text(value),
+                }
+            }
+        }
+        other => ToolResultOutput::Json {
+            value: other.clone(),
+        },
+    }
+}
+
+/// Parse an Anthropic `tool_result` content-block array into ordered
+/// [`ToolResultContentPart`]s. `text` blocks become text parts; `image` blocks
+/// become media parts. Unknown block kinds are skipped (forward compatibility).
+/// <https://docs.anthropic.com/en/docs/build-with-claude/tool-use#tool-result>
+fn parse_tool_result_blocks(blocks: &[serde_json::Value]) -> Vec<ToolResultContentPart> {
+    blocks
+        .iter()
+        .filter_map(|b| match b.get("type").and_then(|t| t.as_str()) {
+            Some("text") => Some(ToolResultContentPart::Text {
+                text: b
+                    .get("text")
+                    .and_then(|t| t.as_str())
+                    .unwrap_or_default()
+                    .to_string(),
+            }),
+            Some("image") => {
+                let (media_type, data) = parse_anthropic_source(b.get("source"), "image/");
+                Some(ToolResultContentPart::Media { media_type, data })
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+/// Flatten the text of an Anthropic `tool_result` content value (string, or a
+/// block array) — used as the lossless string fallback for providers that
+/// cannot carry structure.
+/// <https://docs.anthropic.com/en/docs/build-with-claude/tool-use#tool-result>
 fn tool_result_text(value: &serde_json::Value) -> String {
     match value {
         serde_json::Value::String(s) => s.clone(),
@@ -188,54 +308,38 @@ fn parse_content(value: &serde_json::Value) -> Result<Vec<Content>> {
                             .map(|i| i.to_string())
                             .unwrap_or_else(|| "{}".to_string()),
                     }),
+                    // Anthropic `tool_result` block `{tool_use_id, content, is_error}`:
+                    // `content` is a string or a block array (text / image); the
+                    // optional `is_error` flag promotes the output to an error
+                    // variant. The wire carries no tool name → `tool_name: None`.
+                    // <https://docs.anthropic.com/en/docs/build-with-claude/tool-use#tool-result>
                     "tool_result" => out.push(Content::ToolResult {
                         call_id: block
                             .get("tool_use_id")
                             .and_then(|i| i.as_str())
                             .unwrap_or_default()
                             .to_string(),
-                        content: block
-                            .get("content")
-                            .map(tool_result_text)
-                            .unwrap_or_default(),
+                        tool_name: None,
+                        output: parse_tool_result_output(
+                            block.get("content"),
+                            block
+                                .get("is_error")
+                                .and_then(|e| e.as_bool())
+                                .unwrap_or(false),
+                        ),
                     }),
                     // image/* and documents (PDF, …) -> a canonical File part.
                     // <https://docs.anthropic.com/en/docs/build-with-claude/vision>
                     "image" | "document" => {
-                        let source = block.get("source");
-                        let media_type = source
-                            .and_then(|s| s.get("media_type"))
-                            .and_then(|m| m.as_str())
-                            .map(str::to_string)
-                            .unwrap_or_else(|| {
-                                // A `url` source carries no media type; derive a
-                                // prefix from the block kind so modality detection
-                                // still works.
-                                if block_type == "image" {
-                                    "image/".to_string()
-                                } else {
-                                    "application/".to_string()
-                                }
-                            });
-                        let data = if source.and_then(|s| s.get("type")).and_then(|t| t.as_str())
-                            == Some("url")
-                        {
-                            DataContent::Url {
-                                url: source
-                                    .and_then(|s| s.get("url"))
-                                    .and_then(|u| u.as_str())
-                                    .unwrap_or_default()
-                                    .to_string(),
-                            }
+                        // A `url` source carries no media type; derive a prefix
+                        // from the block kind so modality detection still works.
+                        let fallback = if block_type == "image" {
+                            "image/"
                         } else {
-                            DataContent::Base64 {
-                                data: source
-                                    .and_then(|s| s.get("data"))
-                                    .and_then(|d| d.as_str())
-                                    .unwrap_or_default()
-                                    .to_string(),
-                            }
+                            "application/"
                         };
+                        let (media_type, data) =
+                            parse_anthropic_source(block.get("source"), fallback);
                         out.push(Content::File {
                             media_type,
                             data,
@@ -788,19 +892,67 @@ fn render_content_block(c: &Content) -> Option<serde_json::Value> {
     }
 }
 
+/// Render one canonical [`ToolResultOutput`] into an Anthropic `tool_result`
+/// block body: `(content, is_error)`. A multimodal [`ToolResultOutput::Content`]
+/// becomes a block array (`text` + `image` blocks); every other variant becomes
+/// a string. The error variants set `is_error: true`; `ErrorJson` is stringified
+/// because the Anthropic wire's error body is a string, not structured JSON.
+/// <https://docs.anthropic.com/en/docs/build-with-claude/tool-use#tool-result>
+fn render_tool_result_content(output: &ToolResultOutput) -> (serde_json::Value, bool) {
+    let is_error = output.is_error();
+    let content = match output {
+        ToolResultOutput::Content { value } => {
+            let blocks: Vec<serde_json::Value> = value
+                .iter()
+                .map(|p| match p {
+                    ToolResultContentPart::Text { text } => {
+                        serde_json::json!({ "type": "text", "text": text })
+                    }
+                    ToolResultContentPart::Media { media_type, data } => {
+                        let source = match data {
+                            DataContent::Base64 { data } => serde_json::json!({
+                                "type": "base64", "media_type": media_type, "data": data
+                            }),
+                            DataContent::Url { url } => {
+                                serde_json::json!({ "type": "url", "url": url })
+                            }
+                        };
+                        serde_json::json!({ "type": "image", "source": source })
+                    }
+                })
+                .collect();
+            serde_json::Value::Array(blocks)
+        }
+        other => serde_json::Value::String(other.to_provider_string()),
+    };
+    (content, is_error)
+}
+
 fn render_message(m: &Message) -> serde_json::Value {
     // Canonical Tool-role messages become Anthropic user messages carrying
     // tool_result blocks.
+    // <https://docs.anthropic.com/en/docs/build-with-claude/tool-use#tool-result>
     if m.role == Role::Tool {
         let blocks: Vec<serde_json::Value> = m
             .content
             .iter()
             .filter_map(|c| match c {
-                Content::ToolResult { call_id, content } => Some(serde_json::json!({
-                    "type": "tool_result",
-                    "tool_use_id": call_id,
-                    "content": content,
-                })),
+                Content::ToolResult {
+                    call_id, output, ..
+                } => {
+                    let (content, is_error) = render_tool_result_content(output);
+                    let mut block = serde_json::json!({
+                        "type": "tool_result",
+                        "tool_use_id": call_id,
+                        "content": content,
+                    });
+                    // Only emit `is_error` when set — Anthropic treats its absence
+                    // as `false`, so omitting it keeps non-error results clean.
+                    if is_error {
+                        block["is_error"] = serde_json::Value::Bool(true);
+                    }
+                    Some(block)
+                }
                 _ => None,
             })
             .collect();

--- a/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
@@ -199,6 +199,50 @@ fn parse_content(value: &serde_json::Value) -> Result<Vec<Content>> {
                             .map(tool_result_text)
                             .unwrap_or_default(),
                     }),
+                    // image/* and documents (PDF, …) -> a canonical File part.
+                    // <https://docs.anthropic.com/en/docs/build-with-claude/vision>
+                    "image" | "document" => {
+                        let source = block.get("source");
+                        let media_type = source
+                            .and_then(|s| s.get("media_type"))
+                            .and_then(|m| m.as_str())
+                            .map(str::to_string)
+                            .unwrap_or_else(|| {
+                                // A `url` source carries no media type; derive a
+                                // prefix from the block kind so modality detection
+                                // still works.
+                                if block_type == "image" {
+                                    "image/".to_string()
+                                } else {
+                                    "application/".to_string()
+                                }
+                            });
+                        let data = if source.and_then(|s| s.get("type")).and_then(|t| t.as_str())
+                            == Some("url")
+                        {
+                            DataContent::Url {
+                                url: source
+                                    .and_then(|s| s.get("url"))
+                                    .and_then(|u| u.as_str())
+                                    .unwrap_or_default()
+                                    .to_string(),
+                            }
+                        } else {
+                            DataContent::Base64 {
+                                data: source
+                                    .and_then(|s| s.get("data"))
+                                    .and_then(|d| d.as_str())
+                                    .unwrap_or_default()
+                                    .to_string(),
+                            }
+                        };
+                        out.push(Content::File {
+                            media_type,
+                            data,
+                            filename: None,
+                            extra: Default::default(),
+                        });
+                    }
                     // Unknown block types are skipped, not fatal — forward
                     // compatibility (an explicit decision, not a catch-all bug).
                     other => {

--- a/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
@@ -202,13 +202,23 @@ pub struct MessagesRequest {
     /// <https://platform.claude.com/docs/en/build-with-claude/structured-outputs>
     #[serde(default)]
     output_config: Option<MessagesOutputConfig>,
+    /// Top-k sampling. Promoted to the canonical `top_k` slot so it translates
+    /// across protocols (e.g. to a Gemini upstream's `generationConfig.topK`).
+    /// <https://docs.anthropic.com/en/api/messages#body-top-k>
+    #[serde(default)]
+    top_k: Option<u32>,
+    /// Custom stop sequences. Promoted to the canonical `stop` slot, so it can
+    /// render as a Chat Completions `stop` or a Gemini `stopSequences`.
+    /// <https://docs.anthropic.com/en/api/messages#body-stop-sequences>
+    #[serde(default)]
+    stop_sequences: Option<Vec<String>>,
     #[serde(default)]
     stream: bool,
-    /// Every other field — `tool_choice`, `stop_sequences`, `top_k`, `metadata`,
-    /// `thinking`, the deprecated flat `output_format` alias, … — rides along
-    /// via `extra` and is splatted back on render. Skipped from the published
-    /// schema so the documented contract is the set of typed fields;
-    /// pass-through behavior is preserved at runtime.
+    /// Every other field — `tool_choice`, `metadata`, `thinking`, the deprecated
+    /// flat `output_format` alias, … — rides along via `extra` and is splatted
+    /// back on render. Skipped from the published schema so the documented
+    /// contract is the set of typed fields; pass-through behavior is preserved
+    /// at runtime.
     #[serde(flatten)]
     #[schemars(skip)]
     extra: std::collections::HashMap<String, serde_json::Value>,
@@ -863,6 +873,12 @@ impl InboundAdapter for MessagesAdapter {
                 reasoning_effort,
                 response_modalities: Vec::new(),
                 tool_choice,
+                top_k: req.top_k,
+                // Anthropic carries no seed or penalties on its wire.
+                seed: None,
+                stop: req.stop_sequences.unwrap_or_default(),
+                presence_penalty: None,
+                frequency_penalty: None,
                 extra,
             },
             response_format,
@@ -1018,8 +1034,18 @@ impl OutboundAdapter for MessagesAdapter {
         if let Some(tc) = &prompt.params.tool_choice {
             req.insert("tool_choice".into(), render_messages_tool_choice(tc));
         }
-        // Splat anthropic-specific extras (stop_sequences, top_k, …) back into
-        // the outbound request. Typed fields win over same-named extras.
+        // Render the typed sampling slots Anthropic carries: `top_k` and
+        // `stop_sequences`. Seed and presence/frequency penalties have no
+        // Messages wire field, so they are intentionally not rendered here.
+        // <https://docs.anthropic.com/en/api/messages>
+        if let Some(top_k) = prompt.params.top_k {
+            req.insert("top_k".into(), top_k.into());
+        }
+        if !prompt.params.stop.is_empty() {
+            req.insert("stop_sequences".into(), prompt.params.stop.clone().into());
+        }
+        // Splat anthropic-specific extras (metadata, thinking, …) back into the
+        // outbound request. Typed fields win over same-named extras.
         for (k, v) in &prompt.params.extra {
             req.entry(k.clone()).or_insert_with(|| v.clone());
         }

--- a/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
@@ -1236,6 +1236,10 @@ impl StreamEncoder for MessagesStreamEncoder {
         let mut frames = Vec::new();
         self.ensure_started(&mut frames);
         match part {
+            StreamPart::File { .. } => {
+                // Anthropic Messages streaming has no file-output content block;
+                // a generated file is surfaced only on the non-streaming path.
+            }
             StreamPart::TextDelta { text } => {
                 if self.ensure_block_open(&mut frames, EncoderBlockKind::Text) {
                     frames.push(Self::ev(

--- a/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
@@ -904,11 +904,20 @@ fn render_tool_result_content(output: &ToolResultOutput) -> (serde_json::Value, 
         ToolResultOutput::Content { value } => {
             let blocks: Vec<serde_json::Value> = value
                 .iter()
-                .map(|p| match p {
+                .filter_map(|p| match p {
                     ToolResultContentPart::Text { text } => {
-                        serde_json::json!({ "type": "text", "text": text })
+                        Some(serde_json::json!({ "type": "text", "text": text }))
                     }
-                    ToolResultContentPart::Media { media_type, data } => {
+                    // Anthropic `tool_result` content accepts only `text` and
+                    // `image` blocks — there is no `document`/audio block inside a
+                    // tool result. Emit an `image` block only for `image/*` media;
+                    // skip any other media type rather than mislabeling, say, a
+                    // PDF or audio clip as an image (which the API would reject or
+                    // misinterpret).
+                    // <https://docs.anthropic.com/en/docs/build-with-claude/tool-use#tool-result>
+                    ToolResultContentPart::Media { media_type, data }
+                        if media_type.starts_with("image/") =>
+                    {
                         let source = match data {
                             DataContent::Base64 { data } => serde_json::json!({
                                 "type": "base64", "media_type": media_type, "data": data
@@ -917,7 +926,12 @@ fn render_tool_result_content(output: &ToolResultOutput) -> (serde_json::Value, 
                                 serde_json::json!({ "type": "url", "url": url })
                             }
                         };
-                        serde_json::json!({ "type": "image", "source": source })
+                        Some(serde_json::json!({ "type": "image", "source": source }))
+                    }
+                    // Non-image media and provider file references have no
+                    // tool_result block on the Anthropic wire; drop them.
+                    ToolResultContentPart::Media { .. } | ToolResultContentPart::FileId { .. } => {
+                        None
                     }
                 })
                 .collect();

--- a/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
@@ -25,7 +25,7 @@ use crate::language_model::protocol::{
 use crate::language_model::stream::SseFrame;
 use crate::language_model::types::{
     ApiProtocol, AuthScheme, Content, DataContent, FinishReason, GenerateResult, GenerationParams,
-    Message, Prompt, ResponseFormat, Role, RoutingTarget, StopDetails, StreamPart, Tool,
+    Message, Prompt, ResponseFormat, Role, RoutingTarget, Source, StopDetails, StreamPart, Tool,
     ToolChoice, ToolResultContentPart, ToolResultOutput, Usage,
 };
 
@@ -666,11 +666,18 @@ impl InboundAdapter for MessagesAdapter {
         request_id: &str,
     ) -> Result<serde_json::Value> {
         // Content blocks keep their canonical order (#416).
-        let content: Vec<serde_json::Value> = result
+        let mut content: Vec<serde_json::Value> = result
             .content
             .iter()
             .filter_map(render_content_block)
             .collect();
+        // Re-attach web-search citations as one `web_search_tool_result` block
+        // (the faithful Anthropic citation location — see
+        // `render_web_search_result_block`). Appended after the answer blocks,
+        // matching the wire order (the result block follows the text it cites).
+        if let Some(block) = render_web_search_result_block(result) {
+            content.push(block);
+        }
         let usage = result.usage.unwrap_or_default();
         let stop_reason = result
             .finish_reason
@@ -793,15 +800,23 @@ impl OutboundAdapter for MessagesAdapter {
             .and_then(|c| c.as_array())
             .ok_or_else(|| BitrouterError::bad_request("anthropic response missing 'content'"))?;
         let mut content = Vec::with_capacity(content_blocks.len());
+        // Running citation counter so synthesized source ids stay unique across
+        // every text block / web_search_tool_result block in the reply.
+        let mut source_index = 0usize;
         for block in content_blocks {
             match block.get("type").and_then(|t| t.as_str()) {
-                Some("text") => content.push(Content::Text {
-                    text: block
-                        .get("text")
-                        .and_then(|t| t.as_str())
-                        .unwrap_or_default()
-                        .to_string(),
-                }),
+                Some("text") => {
+                    content.push(Content::Text {
+                        text: block
+                            .get("text")
+                            .and_then(|t| t.as_str())
+                            .unwrap_or_default()
+                            .to_string(),
+                    });
+                    // A text block may carry inline web-search citations; lift
+                    // them into `Content::Source` parts right after the text.
+                    content.extend(parse_messages_block_sources(block, &mut source_index));
+                }
                 Some("thinking") | Some("redacted_thinking") => content.push(Content::Reasoning {
                     text: block
                         .get("thinking")
@@ -835,6 +850,14 @@ impl OutboundAdapter for MessagesAdapter {
                         .unwrap_or_else(|| "{}".to_string()),
                     provider_executed: kind == "server_tool_use",
                 }),
+                // A `web_search_tool_result` block carries the raw search hits
+                // (`content[]` of `web_search_result`). Lift each into a
+                // `Content::Source`; the paired `server_tool_use` call block was
+                // already captured above as a provider-executed tool call.
+                // <https://platform.claude.com/docs/en/agents-and-tools/tool-use/web-search-tool>
+                Some("web_search_tool_result") => {
+                    content.extend(parse_messages_block_sources(block, &mut source_index));
+                }
                 _ => {}
             }
         }
@@ -981,6 +1004,110 @@ impl Transport for MessagesTransport {
     }
 }
 
+/// Lift Anthropic web-search citations out of a response `content` block into
+/// canonical [`Content::Source`] (URL) parts, with `next_index` tracking the
+/// running citation count so synthesized ids stay unique across blocks.
+///
+/// Two block shapes carry web-search citations:
+/// - a `text` block whose `citations[]` array holds
+///   `{type:"web_search_result_location", url, title, cited_text, encrypted_index}`
+///   entries (an inline citation linked to a span of the answer text), and
+/// - a `web_search_tool_result` block whose `content[]` array holds
+///   `{type:"web_search_result", url, title, page_age, ...}` entries (the raw
+///   search hits).
+///
+/// Both map to `Source::Url{url, title}`. The wire carries no citation id, so
+/// one is synthesized from the url + running index. The inline `cited_text` and
+/// the `encrypted_index`/`page_age` provider fields have no slot on the
+/// canonical `Source` and are dropped — see [`Source`] (the text-to-source
+/// linkage loss is inherent to the V3 parity target).
+/// <https://platform.claude.com/docs/en/agents-and-tools/tool-use/web-search-tool>
+fn parse_messages_block_sources(block: &serde_json::Value, next_index: &mut usize) -> Vec<Content> {
+    let entries = match block.get("type").and_then(|t| t.as_str()) {
+        Some("text") => block.get("citations").and_then(|c| c.as_array()),
+        Some("web_search_tool_result") => block.get("content").and_then(|c| c.as_array()),
+        _ => None,
+    };
+    let Some(entries) = entries else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for entry in entries {
+        // A text block's `citations[]` may also carry non-web citation kinds
+        // (`page_location` / `char_location` for document citations); only the
+        // URL web-search kind has a faithful `Source::Url` form today.
+        let kind = entry.get("type").and_then(|t| t.as_str());
+        if !matches!(
+            kind,
+            Some("web_search_result_location") | Some("web_search_result")
+        ) {
+            continue;
+        }
+        let Some(url) = entry.get("url").and_then(|u| u.as_str()) else {
+            continue;
+        };
+        let title = entry
+            .get("title")
+            .and_then(|t| t.as_str())
+            .map(str::to_string);
+        out.push(Content::Source {
+            source: Source::Url {
+                id: Source::synthesize_id(url, *next_index),
+                url: url.to_string(),
+                title,
+            },
+        });
+        *next_index += 1;
+    }
+    out
+}
+
+/// Render canonical [`Content::Source`] parts into a single Anthropic
+/// `web_search_tool_result` block whose `content[]` carries one
+/// `web_search_result` entry per URL source.
+///
+/// This is the chosen render location among the two Anthropic citation shapes.
+/// A `web_search_tool_result` block is the faithful form because it natively
+/// holds an array of `{url, title}` results with **no** required text linkage,
+/// so it reproduces url+title+id losslessly. The alternative — `citations[]` on
+/// a `text` block — would demand a `cited_text` span and char offsets that the
+/// canonical `Source` does not carry (and could not reconstruct), so emitting it
+/// would fabricate the very text-linkage data the parity target drops.
+/// [`Source::Document`] citations have no `web_search_result` form and are
+/// skipped here. Returns `None` when the result carries no URL sources.
+/// <https://platform.claude.com/docs/en/agents-and-tools/tool-use/web-search-tool>
+fn render_web_search_result_block(result: &GenerateResult) -> Option<serde_json::Value> {
+    let results: Vec<serde_json::Value> = result
+        .content
+        .iter()
+        .filter_map(|c| match c {
+            Content::Source {
+                source: Source::Url { url, title, .. },
+            } => {
+                let mut entry = serde_json::Map::new();
+                entry.insert("type".into(), "web_search_result".into());
+                entry.insert("url".into(), url.clone().into());
+                if let Some(title) = title {
+                    entry.insert("title".into(), title.clone().into());
+                }
+                Some(serde_json::Value::Object(entry))
+            }
+            _ => None,
+        })
+        .collect();
+    if results.is_empty() {
+        return None;
+    }
+    Some(serde_json::json!({
+        "type": "web_search_tool_result",
+        // The wire pairs this block with the originating `server_tool_use` id;
+        // the canonical `Source` does not carry it, so a synthetic placeholder
+        // is used. It is opaque to clients and only correlates the result block.
+        "tool_use_id": "srvtoolu_citations",
+        "content": results,
+    }))
+}
+
 fn render_content_block(c: &Content) -> Option<serde_json::Value> {
     match c {
         Content::Text { text } => Some(serde_json::json!({ "type": "text", "text": text })),
@@ -1035,6 +1162,10 @@ fn render_content_block(c: &Content) -> Option<serde_json::Value> {
             };
             Some(serde_json::json!({ "type": block_type, "source": source }))
         }
+        // Citations are not a per-block render: they are collected across the
+        // whole reply and re-attached as one `web_search_tool_result` block by
+        // `render_response` (see `render_web_search_result_block`). Skip here.
+        Content::Source { .. } => None,
     }
 }
 
@@ -1250,6 +1381,27 @@ impl StreamDecoder for MessagesStreamDecoder {
             "content_block_start" => {
                 let index = json.get("index").and_then(|i| i.as_u64()).unwrap_or(0) as usize;
                 let block = json.get("content_block");
+                // A streamed `web_search_tool_result` block carries its full
+                // `content[]` result array up-front on the start frame (it is
+                // not chunked), so lift each hit into a whole `StreamPart::Source`
+                // here — no buffering needed. The companion `citations_delta`
+                // path (inline citations linked to text spans) is **not** wired:
+                // it would require buffering citations against an open text block
+                // and carries the `cited_text` char-range linkage the canonical
+                // `Source` drops anyway — documented gap, parsed only on the
+                // non-streaming path.
+                // <https://platform.claude.com/docs/en/agents-and-tools/tool-use/web-search-tool>
+                if let Some(block) = block
+                    && block.get("type").and_then(|t| t.as_str()) == Some("web_search_tool_result")
+                {
+                    let mut idx = 0usize;
+                    for content in parse_messages_block_sources(block, &mut idx) {
+                        if let Content::Source { source } = content {
+                            parts.push(StreamPart::Source { source });
+                        }
+                    }
+                    return Ok(parts);
+                }
                 let kind = match block.and_then(|b| b.get("type")).and_then(|t| t.as_str()) {
                     Some("thinking") | Some("redacted_thinking") => BlockKind::Thinking,
                     Some("tool_use") => BlockKind::ToolUse,
@@ -1621,6 +1773,43 @@ impl StreamEncoder for MessagesStreamEncoder {
                             "delta": { "type": "input_json_delta", "partial_json": arguments },
                         }),
                     ));
+                }
+            }
+            StreamPart::Source { source } => {
+                // Re-attach a streamed citation as its own
+                // `web_search_tool_result` content block (the decode path's
+                // mirror): close any open block, emit a `content_block_start`
+                // carrying a one-entry `content[]` result array, then close it.
+                // Only a URL source has a `web_search_result` form; a document
+                // citation is dropped here (no such block on this wire).
+                // <https://platform.claude.com/docs/en/agents-and-tools/tool-use/web-search-tool>
+                if let Source::Url { url, title, .. } = source {
+                    self.close_block(&mut frames);
+                    let mut entry = serde_json::Map::new();
+                    entry.insert("type".into(), "web_search_result".into());
+                    entry.insert("url".into(), url.clone().into());
+                    if let Some(title) = title {
+                        entry.insert("title".into(), title.clone().into());
+                    }
+                    frames.push(Self::ev(
+                        "content_block_start",
+                        serde_json::json!({
+                            "type": "content_block_start",
+                            "index": self.block_index,
+                            "content_block": {
+                                "type": "web_search_tool_result",
+                                "tool_use_id": "srvtoolu_citations",
+                                "content": [serde_json::Value::Object(entry)],
+                            },
+                        }),
+                    ));
+                    frames.push(Self::ev(
+                        "content_block_stop",
+                        serde_json::json!({
+                            "type": "content_block_stop", "index": self.block_index,
+                        }),
+                    ));
+                    self.block_index += 1;
                 }
             }
             StreamPart::Usage { .. } => {}

--- a/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
@@ -25,9 +25,140 @@ use crate::language_model::protocol::{
 use crate::language_model::stream::SseFrame;
 use crate::language_model::types::{
     ApiProtocol, AuthScheme, Content, DataContent, FinishReason, GenerateResult, GenerationParams,
-    Message, Prompt, ResponseFormat, Role, RoutingTarget, Source, StopDetails, StreamPart, Tool,
-    ToolChoice, ToolResultContentPart, ToolResultOutput, Usage,
+    Message, Prompt, ProviderMetadata, ResponseFormat, Role, RoutingTarget, Source, StopDetails,
+    StreamPart, Tool, ToolChoice, ToolResultContentPart, ToolResultOutput, Usage,
+    provider_namespace, set_provider_metadata,
 };
+
+/// The metadata key, within the `anthropic` namespace, under which a block /
+/// tool / message / system `cache_control` object rides. Matches the Vercel AI
+/// SDK's `providerOptions.anthropic.cacheControl` naming.
+/// <https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching>
+const ANTHROPIC_CACHE_CONTROL: &str = "cacheControl";
+/// The metadata key carrying an Anthropic thinking block's `signature` — the
+/// opaque token that lets a thinking block be replayed on a follow-up turn.
+/// <https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking>
+const ANTHROPIC_SIGNATURE: &str = "signature";
+/// The metadata key marking a `redacted_thinking` block, whose encrypted body
+/// rides under [`ANTHROPIC_REDACTED_DATA`]. A bare boolean `true`.
+const ANTHROPIC_REDACTED: &str = "redactedThinking";
+/// The metadata key carrying a `redacted_thinking` block's encrypted `data`
+/// payload, so the block round-trips byte-for-byte.
+const ANTHROPIC_REDACTED_DATA: &str = "redactedData";
+/// The metadata key carrying the originating `server_tool_use` `tool_use_id`
+/// that a `web_search_tool_result` block paired with, so the render path can
+/// restore the exact pairing id instead of reusing one by position.
+/// <https://platform.claude.com/docs/en/agents-and-tools/tool-use/web-search-tool>
+const ANTHROPIC_TOOL_USE_ID: &str = "toolUseId";
+
+/// Lift an Anthropic block/tool's `cache_control` object into a fresh
+/// [`ProviderMetadata`] under `anthropic.cacheControl`. Anthropic's prompt
+/// caching marks a cache breakpoint with `"cache_control":{"type":"ephemeral"}`
+/// on a content block, a tool, or the system prompt; the object is preserved
+/// verbatim so a same-protocol round-trip reproduces it exactly and a
+/// cross-protocol route carries it (namespaced, ignored by other providers).
+/// Returns an empty map when the value carries no `cache_control`.
+/// <https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching>
+fn parse_cache_control(value: &serde_json::Value) -> ProviderMetadata {
+    let mut meta = ProviderMetadata::new();
+    if let Some(cc) = value.get("cache_control").filter(|v| !v.is_null()) {
+        set_provider_metadata(
+            &mut meta,
+            PROVIDER_ID_ANTHROPIC,
+            ANTHROPIC_CACHE_CONTROL,
+            cc.clone(),
+        );
+    }
+    meta
+}
+
+/// The Anthropic `cache_control` object carried in `provider_metadata`, if any —
+/// the inverse of [`parse_cache_control`]. Used by the render paths to splat
+/// `cache_control` back onto the block/tool/system it belongs to.
+fn cache_control_value(meta: &ProviderMetadata) -> Option<serde_json::Value> {
+    provider_namespace(meta, PROVIDER_ID_ANTHROPIC)
+        .and_then(|o| o.get(ANTHROPIC_CACHE_CONTROL))
+        .cloned()
+}
+
+/// Splat the Anthropic `cache_control` object from `meta` onto an existing block
+/// / tool / system JSON object (a no-op when there is none). Mutates in place so
+/// the render sites can build the block first and stamp caching last.
+fn apply_cache_control(target: &mut serde_json::Value, meta: &ProviderMetadata) {
+    if let Some(cc) = cache_control_value(meta)
+        && let Some(obj) = target.as_object_mut()
+    {
+        obj.insert("cache_control".to_string(), cc);
+    }
+}
+
+/// Lift an Anthropic `thinking` / `redacted_thinking` block's continuity fields
+/// into a [`ProviderMetadata`] under the `anthropic` namespace, alongside any
+/// block-level `cache_control`. A `thinking` block carries a `signature`; a
+/// `redacted_thinking` block carries an encrypted `data` payload and is marked
+/// with a `redactedThinking: true` flag so the render path re-emits the correct
+/// block type. Without this the signature is lost and Anthropic rejects a
+/// follow-up turn that replays the (now-unsigned) thinking block.
+/// <https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking>
+fn parse_reasoning_metadata(block: &serde_json::Value, block_type: &str) -> ProviderMetadata {
+    let mut meta = parse_cache_control(block);
+    if block_type == "redacted_thinking" {
+        set_provider_metadata(
+            &mut meta,
+            PROVIDER_ID_ANTHROPIC,
+            ANTHROPIC_REDACTED,
+            serde_json::Value::Bool(true),
+        );
+        if let Some(data) = block.get("data") {
+            set_provider_metadata(
+                &mut meta,
+                PROVIDER_ID_ANTHROPIC,
+                ANTHROPIC_REDACTED_DATA,
+                data.clone(),
+            );
+        }
+    } else if let Some(sig) = block.get("signature").filter(|v| !v.is_null()) {
+        set_provider_metadata(
+            &mut meta,
+            PROVIDER_ID_ANTHROPIC,
+            ANTHROPIC_SIGNATURE,
+            sig.clone(),
+        );
+    }
+    meta
+}
+
+/// Render a canonical reasoning part back into its Anthropic block, inverting
+/// [`parse_reasoning_metadata`]. A `redactedThinking` flag re-emits a
+/// `redacted_thinking` block whose `data` is the preserved encrypted payload
+/// (falling back to `text` when absent); otherwise a `thinking` block, carrying
+/// its `signature` when one round-tripped. Any block-level `cache_control` is
+/// re-applied last.
+/// <https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking>
+fn render_reasoning_block(text: &str, meta: &ProviderMetadata) -> serde_json::Value {
+    let ns = provider_namespace(meta, PROVIDER_ID_ANTHROPIC);
+    let is_redacted = ns
+        .and_then(|o| o.get(ANTHROPIC_REDACTED))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let mut block = if is_redacted {
+        // Prefer the preserved encrypted payload; the canonical `text` mirrors
+        // it on parse, so it is the correct fallback if metadata was stripped.
+        let data = ns
+            .and_then(|o| o.get(ANTHROPIC_REDACTED_DATA))
+            .cloned()
+            .unwrap_or_else(|| serde_json::Value::String(text.to_string()));
+        serde_json::json!({ "type": "redacted_thinking", "data": data })
+    } else {
+        let mut obj = serde_json::json!({ "type": "thinking", "thinking": text });
+        if let Some(sig) = ns.and_then(|o| o.get(ANTHROPIC_SIGNATURE)) {
+            obj["signature"] = sig.clone();
+        }
+        obj
+    };
+    apply_cache_control(&mut block, meta);
+    block
+}
 
 /// The Messages inbound + outbound protocol adapter.
 pub struct MessagesAdapter;
@@ -147,13 +278,27 @@ pub struct MessagesTool {
 /// config keys preserved verbatim as `args`); a typeless entry is a client
 /// function tool (`{name, description?, input_schema}`). An entry with neither a
 /// `type` nor a `name` is dropped — there is nothing to forward.
-fn parse_messages_tool(t: MessagesTool) -> Option<Tool> {
+fn parse_messages_tool(mut t: MessagesTool) -> Option<Tool> {
+    // `cache_control` on a tool is a prompt-caching breakpoint, not a config
+    // key — lift it out of `extra` (for both tool kinds) into the canonical
+    // metadata slot so it round-trips and is not re-rendered as opaque `args`.
+    // <https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching>
+    let mut provider_metadata = ProviderMetadata::new();
+    if let Some(cc) = t.extra.remove("cache_control") {
+        set_provider_metadata(
+            &mut provider_metadata,
+            PROVIDER_ID_ANTHROPIC,
+            ANTHROPIC_CACHE_CONTROL,
+            cc,
+        );
+    }
     if let Some(kind) = t.kind {
         // Server tool: `{type:"web_search_20250305", name:"web_search", …config}`.
         return Some(Tool::ProviderDefined {
             id: format!("{PROVIDER_ID_ANTHROPIC}.{kind}"),
             name: t.name.unwrap_or_else(|| kind.clone()),
             args: serde_json::Value::Object(t.extra.into_iter().collect()),
+            provider_metadata,
         });
     }
     Some(Tool::Function {
@@ -162,6 +307,7 @@ fn parse_messages_tool(t: MessagesTool) -> Option<Tool> {
         parameters: t.input_schema,
         // Anthropic client tools carry no `strict` slot.
         strict: None,
+        provider_metadata,
     })
 }
 
@@ -183,14 +329,27 @@ fn render_messages_tool(tool: &Tool) -> serde_json::Value {
             description,
             parameters,
             strict: _,
+            provider_metadata,
         } => {
-            serde_json::json!({
+            let mut obj = serde_json::json!({
                 "name": name,
                 "description": description,
                 "input_schema": parameters,
-            })
+            });
+            // Restore a tool-level `cache_control` breakpoint when it round-tripped.
+            apply_cache_control(&mut obj, provider_metadata);
+            obj
         }
-        Tool::ProviderDefined { id, name, args } => provider_defined_native(id, name, args),
+        Tool::ProviderDefined {
+            id,
+            name,
+            args,
+            provider_metadata,
+        } => {
+            let mut obj = provider_defined_native(id, name, args);
+            apply_cache_control(&mut obj, provider_metadata);
+            obj
+        }
     }
 }
 
@@ -343,7 +502,10 @@ fn tool_result_text(value: &serde_json::Value) -> String {
 /// canonical [`Content`]. Block order is preserved (#416).
 fn parse_content(value: &serde_json::Value) -> Result<Vec<Content>> {
     match value {
-        serde_json::Value::String(s) => Ok(vec![Content::Text { text: s.clone() }]),
+        serde_json::Value::String(s) => Ok(vec![Content::Text {
+            text: s.clone(),
+            provider_metadata: ProviderMetadata::new(),
+        }]),
         serde_json::Value::Array(blocks) => {
             let mut out = Vec::with_capacity(blocks.len());
             for block in blocks {
@@ -357,8 +519,15 @@ fn parse_content(value: &serde_json::Value) -> Result<Vec<Content>> {
                             .and_then(|t| t.as_str())
                             .unwrap_or_default()
                             .to_string(),
+                        // Preserve a block-level `cache_control` breakpoint.
+                        provider_metadata: parse_cache_control(block),
                     }),
-                    // both `thinking` and `redacted_thinking` map to Reasoning
+                    // both `thinking` and `redacted_thinking` map to Reasoning.
+                    // The `signature` (thinking) and encrypted `data`
+                    // (redacted_thinking) are continuity tokens with no canonical
+                    // field — carry them in `provider_metadata` so a thinking
+                    // block can be replayed on a follow-up turn.
+                    // <https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking>
                     "thinking" | "redacted_thinking" => out.push(Content::Reasoning {
                         text: block
                             .get("thinking")
@@ -366,6 +535,7 @@ fn parse_content(value: &serde_json::Value) -> Result<Vec<Content>> {
                             .and_then(|t| t.as_str())
                             .unwrap_or_default()
                             .to_string(),
+                        provider_metadata: parse_reasoning_metadata(block, block_type),
                     }),
                     // A client `tool_use` block, or a provider-executed
                     // `server_tool_use` block (web search, code execution, …).
@@ -389,6 +559,8 @@ fn parse_content(value: &serde_json::Value) -> Result<Vec<Content>> {
                             .map(|i| i.to_string())
                             .unwrap_or_else(|| "{}".to_string()),
                         provider_executed: block_type == "server_tool_use",
+                        // Preserve a block-level `cache_control` breakpoint.
+                        provider_metadata: parse_cache_control(block),
                     }),
                     // Anthropic `tool_result` block `{tool_use_id, content, is_error}`:
                     // `content` is a string or a block array (text / image); the
@@ -409,6 +581,8 @@ fn parse_content(value: &serde_json::Value) -> Result<Vec<Content>> {
                                 .and_then(|e| e.as_bool())
                                 .unwrap_or(false),
                         ),
+                        // Preserve a block-level `cache_control` breakpoint.
+                        provider_metadata: parse_cache_control(block),
                     }),
                     // image/* and documents (PDF, …) -> a canonical File part.
                     // <https://docs.anthropic.com/en/docs/build-with-claude/vision>
@@ -426,7 +600,8 @@ fn parse_content(value: &serde_json::Value) -> Result<Vec<Content>> {
                             media_type,
                             data,
                             filename: None,
-                            extra: Default::default(),
+                            // Preserve a block-level `cache_control` breakpoint.
+                            provider_metadata: parse_cache_control(block),
                         });
                     }
                     // Unknown block types are skipped, not fatal — forward
@@ -571,12 +746,14 @@ impl InboundAdapter for MessagesAdapter {
                 messages.push(Message {
                     role: Role::Tool,
                     content: tool_results,
+                    provider_metadata: ProviderMetadata::new(),
                 });
             }
             if !rest.is_empty() {
                 messages.push(Message {
                     role,
                     content: rest,
+                    provider_metadata: ProviderMetadata::new(),
                 });
             }
         }
@@ -814,19 +991,25 @@ impl OutboundAdapter for MessagesAdapter {
                             .and_then(|t| t.as_str())
                             .unwrap_or_default()
                             .to_string(),
+                        provider_metadata: parse_cache_control(block),
                     });
                     // A text block may carry inline web-search citations; lift
                     // them into `Content::Source` parts right after the text.
                     content.extend(parse_messages_block_sources(block, &mut source_index));
                 }
-                Some("thinking") | Some("redacted_thinking") => content.push(Content::Reasoning {
-                    text: block
-                        .get("thinking")
-                        .or_else(|| block.get("data"))
-                        .and_then(|t| t.as_str())
-                        .unwrap_or_default()
-                        .to_string(),
-                }),
+                Some(thinking @ ("thinking" | "redacted_thinking")) => {
+                    content.push(Content::Reasoning {
+                        text: block
+                            .get("thinking")
+                            .or_else(|| block.get("data"))
+                            .and_then(|t| t.as_str())
+                            .unwrap_or_default()
+                            .to_string(),
+                        // Carry the thinking `signature` / redacted `data` so the
+                        // reasoning block can be replayed on a follow-up turn.
+                        provider_metadata: parse_reasoning_metadata(block, thinking),
+                    });
+                }
                 // A client `tool_use` block, or a provider-executed
                 // `server_tool_use` block. Anthropic runs server tools (e.g.
                 // `web_search`) itself and emits a `server_tool_use` block with
@@ -851,6 +1034,7 @@ impl OutboundAdapter for MessagesAdapter {
                         .map(|i| i.to_string())
                         .unwrap_or_else(|| "{}".to_string()),
                     provider_executed: kind == "server_tool_use",
+                    provider_metadata: parse_cache_control(block),
                 }),
                 // A `web_search_tool_result` block carries the raw search hits
                 // (`content[]` of `web_search_result`). Lift each into a
@@ -886,6 +1070,12 @@ impl OutboundAdapter for MessagesAdapter {
             finish_reason,
             response_id,
             stop_details,
+            // Anthropic's Messages response carries no result-level metadata
+            // field without a dedicated canonical slot (unlike OpenAI's
+            // `system_fingerprint` or Gemini's `modelVersion`); the per-block
+            // signature / cache_control above are where its provider metadata
+            // lives. Left empty rather than inventing an unconstructed slot.
+            provider_metadata: ProviderMetadata::new(),
         })
     }
 
@@ -1033,6 +1223,14 @@ fn parse_messages_block_sources(block: &serde_json::Value, next_index: &mut usiz
     let Some(entries) = entries else {
         return Vec::new();
     };
+    // A `web_search_tool_result` block carries the originating `server_tool_use`
+    // id that paired it on the wire; preserve it so the render path restores the
+    // EXACT pairing id rather than reusing one by position.
+    // <https://platform.claude.com/docs/en/agents-and-tools/tool-use/web-search-tool>
+    let tool_use_id = block
+        .get("tool_use_id")
+        .and_then(|i| i.as_str())
+        .filter(|s| !s.is_empty());
     let mut out = Vec::new();
     for entry in entries {
         // A text block's `citations[]` may also carry non-web citation kinds
@@ -1052,12 +1250,22 @@ fn parse_messages_block_sources(block: &serde_json::Value, next_index: &mut usiz
             .get("title")
             .and_then(|t| t.as_str())
             .map(str::to_string);
+        let mut provider_metadata = ProviderMetadata::new();
+        if let Some(id) = tool_use_id {
+            set_provider_metadata(
+                &mut provider_metadata,
+                PROVIDER_ID_ANTHROPIC,
+                ANTHROPIC_TOOL_USE_ID,
+                serde_json::Value::String(id.to_string()),
+            );
+        }
         out.push(Content::Source {
             source: Source::Url {
                 id: Source::synthesize_id(url, *next_index),
                 url: url.to_string(),
                 title,
             },
+            provider_metadata,
         });
         *next_index += 1;
     }
@@ -1107,22 +1315,26 @@ fn is_web_search_call(c: &Content) -> bool {
 /// [`Source::Document`] citations have no `web_search_result` form and are
 /// skipped here. Returns an empty Vec when the result carries no URL sources.
 ///
-/// **Pairing strategy (correlate by order).** On the Anthropic wire a
-/// `web_search_tool_result` is invalid on its own: it must pair with a
-/// `server_tool_use` block sharing one `tool_use_id`, or a client echoing the
-/// assistant turn into a follow-up triggers `invalid_request_error`.
-/// - Same-protocol: the upstream `server_tool_use` parsed to a
-///   `ToolCall{provider_executed:true, name:"web_search"}` and is re-rendered as
-///   a real `server_tool_use` by [`render_content_block`]. Here we detect that
-///   preceding call and **reuse its id** as `tool_use_id` (real pairing; no
-///   second `server_tool_use` is emitted), so `srvtoolu_…` ids correlate.
-/// - Cross-protocol (no such call, e.g. Gemini grounding → Anthropic client):
-///   we **synthesize** a matching `server_tool_use{id, name:"web_search",
-///   input:{}}` immediately before the result block so the pair is still valid.
+/// **Pairing strategy.** On the Anthropic wire a `web_search_tool_result` is
+/// invalid on its own: it must pair with a `server_tool_use` block sharing one
+/// `tool_use_id`, or a client echoing the assistant turn into a follow-up
+/// triggers `invalid_request_error`. The `tool_use_id` is resolved in priority
+/// order:
+/// 1. **Real call present** — the upstream `server_tool_use` parsed to a
+///    `ToolCall{provider_executed:true, name:"web_search"}` and is re-rendered as
+///    a real `server_tool_use` by [`render_content_block`]. Reuse its id as
+///    `tool_use_id` (real pairing; no second `server_tool_use` is emitted).
+/// 2. **Exact id preserved** — no originating call survived (e.g. a cross-protocol
+///    route, or a result that carried only the citations), but the `Source`'s
+///    `provider_metadata["anthropic"]["toolUseId"]` preserved the *exact*
+///    originating id from parse. Synthesize a `server_tool_use` carrying that
+///    exact id, so the pair reproduces the original `tool_use_id` byte-for-byte.
+/// 3. **Fallback** — no id at all (a genuinely foreign source, e.g. Gemini
+///    grounding): synthesize a `server_tool_use` with a stable placeholder id so
+///    the emitted pair is at least valid.
 ///
-/// Preserving the *exact* original id across a full canonical round-trip is
-/// deferred to provider-metadata plumbing; the emitted wire must never be
-/// invalid in the meantime.
+/// [`Source::Document`] citations have no `web_search_result` form and are
+/// skipped here.
 /// <https://platform.claude.com/docs/en/agents-and-tools/tool-use/web-search-tool>
 fn render_web_search_result_blocks(result: &GenerateResult) -> Vec<serde_json::Value> {
     let results: Vec<serde_json::Value> = result
@@ -1131,6 +1343,7 @@ fn render_web_search_result_blocks(result: &GenerateResult) -> Vec<serde_json::V
         .filter_map(|c| match c {
             Content::Source {
                 source: Source::Url { url, title, .. },
+                ..
             } => {
                 let mut entry = serde_json::Map::new();
                 entry.insert("type".into(), "web_search_result".into());
@@ -1146,57 +1359,71 @@ fn render_web_search_result_blocks(result: &GenerateResult) -> Vec<serde_json::V
     if results.is_empty() {
         return Vec::new();
     }
-    // Correlate by order: borrow the id of the originating provider-executed
-    // `web_search` call. All URL sources collapse into one result block, and
-    // Anthropic emits one web-search call per result block, so the last such
-    // call in the content is the originator. That call is already re-rendered as
-    // a real `server_tool_use` by `render_content_block`, so reusing its id
-    // keeps the pair correlated without emitting a duplicate call block — and
-    // crucially without leaving that real call orphaned (the bug the synthetic
-    // `srvtoolu_citations` placeholder used to cause). Scanning the whole
-    // content (not just before the first source) covers the wire shape where an
-    // inline-cited text block's `Source` precedes the `server_tool_use`.
-    let paired_id = result.content.iter().rev().find_map(|c| match c {
+    // (1) Borrow the id of the originating provider-executed `web_search` call.
+    // All URL sources collapse into one result block, and Anthropic emits one
+    // web-search call per result block, so the last such call in the content is
+    // the originator. That call is already re-rendered as a real
+    // `server_tool_use` by `render_content_block`, so reusing its id keeps the
+    // pair correlated without emitting a duplicate (or orphaning the real call).
+    let call_id = result.content.iter().rev().find_map(|c| match c {
         Content::ToolCall { id, .. } if is_web_search_call(c) => Some(id.clone()),
         _ => None,
     });
-    match paired_id {
-        // Real pairing: the originating `server_tool_use` already rendered with
-        // this id; only the result block is added, sharing that id.
-        Some(id) => vec![serde_json::json!({
+    if let Some(id) = call_id {
+        return vec![serde_json::json!({
             "type": "web_search_tool_result",
             "tool_use_id": id,
             "content": results,
-        })],
-        // No originating call (cross-protocol): synthesize the `server_tool_use`
-        // so the emitted pair is valid, both blocks sharing one synthetic id.
-        None => vec![
-            serde_json::json!({
-                "type": "server_tool_use",
-                "id": SYNTHETIC_WEB_SEARCH_ID,
-                "name": ANTHROPIC_WEB_SEARCH_TOOL,
-                "input": {},
-            }),
-            serde_json::json!({
-                "type": "web_search_tool_result",
-                "tool_use_id": SYNTHETIC_WEB_SEARCH_ID,
-                "content": results,
-            }),
-        ],
+        })];
     }
+    // (2) No surviving call — fall back to the EXACT originating `tool_use_id`
+    // preserved on a `Source`'s provider metadata, if any, so the pair restores
+    // the original id rather than the placeholder. (3) Otherwise the placeholder.
+    let preserved_id = result.content.iter().find_map(|c| match c {
+        Content::Source {
+            provider_metadata, ..
+        } => provider_namespace(provider_metadata, PROVIDER_ID_ANTHROPIC)
+            .and_then(|o| o.get(ANTHROPIC_TOOL_USE_ID))
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+        _ => None,
+    });
+    let tool_use_id = preserved_id.unwrap_or_else(|| SYNTHETIC_WEB_SEARCH_ID.to_string());
+    vec![
+        serde_json::json!({
+            "type": "server_tool_use",
+            "id": tool_use_id,
+            "name": ANTHROPIC_WEB_SEARCH_TOOL,
+            "input": {},
+        }),
+        serde_json::json!({
+            "type": "web_search_tool_result",
+            "tool_use_id": tool_use_id,
+            "content": results,
+        }),
+    ]
 }
 
 fn render_content_block(c: &Content) -> Option<serde_json::Value> {
     match c {
-        Content::Text { text } => Some(serde_json::json!({ "type": "text", "text": text })),
-        Content::Reasoning { text } => {
-            Some(serde_json::json!({ "type": "thinking", "thinking": text }))
+        Content::Text {
+            text,
+            provider_metadata,
+        } => {
+            let mut block = serde_json::json!({ "type": "text", "text": text });
+            apply_cache_control(&mut block, provider_metadata);
+            Some(block)
         }
+        Content::Reasoning {
+            text,
+            provider_metadata,
+        } => Some(render_reasoning_block(text, provider_metadata)),
         Content::ToolCall {
             id,
             name,
             arguments,
             provider_executed,
+            provider_metadata,
         } => {
             let input: serde_json::Value =
                 serde_json::from_str(arguments).unwrap_or(serde_json::json!({}));
@@ -1211,9 +1438,11 @@ fn render_content_block(c: &Content) -> Option<serde_json::Value> {
             } else {
                 "tool_use"
             };
-            Some(serde_json::json!({
+            let mut block = serde_json::json!({
                 "type": block_type, "id": id, "name": name, "input": input,
-            }))
+            });
+            apply_cache_control(&mut block, provider_metadata);
+            Some(block)
         }
         // tool results are request-side only; not part of an assistant reply
         Content::ToolResult { .. } => None,
@@ -1221,7 +1450,10 @@ fn render_content_block(c: &Content) -> Option<serde_json::Value> {
         // Source is `{type:base64,media_type,data}` or `{type:url,url}`.
         // <https://docs.anthropic.com/en/docs/build-with-claude/vision>
         Content::File {
-            media_type, data, ..
+            media_type,
+            data,
+            provider_metadata,
+            ..
         } => {
             let source = match data {
                 DataContent::Base64 { data } => serde_json::json!({
@@ -1238,7 +1470,9 @@ fn render_content_block(c: &Content) -> Option<serde_json::Value> {
             } else {
                 "document"
             };
-            Some(serde_json::json!({ "type": block_type, "source": source }))
+            let mut block = serde_json::json!({ "type": block_type, "source": source });
+            apply_cache_control(&mut block, provider_metadata);
+            Some(block)
         }
         // Citations are not a per-block render: they are collected across the
         // whole reply and re-attached as a `server_tool_use` ↔
@@ -1308,7 +1542,10 @@ fn render_message(m: &Message) -> serde_json::Value {
             .iter()
             .filter_map(|c| match c {
                 Content::ToolResult {
-                    call_id, output, ..
+                    call_id,
+                    output,
+                    provider_metadata,
+                    ..
                 } => {
                     let (content, is_error) = render_tool_result_content(output);
                     let mut block = serde_json::json!({
@@ -1321,6 +1558,8 @@ fn render_message(m: &Message) -> serde_json::Value {
                     if is_error {
                         block["is_error"] = serde_json::Value::Bool(true);
                     }
+                    // Restore a `tool_result`-level `cache_control` breakpoint.
+                    apply_cache_control(&mut block, provider_metadata);
                     Some(block)
                 }
                 _ => None,
@@ -1342,7 +1581,12 @@ fn render_message(m: &Message) -> serde_json::Value {
     };
     let blocks: Vec<serde_json::Value> =
         m.content.iter().filter_map(render_content_block).collect();
-    serde_json::json!({ "role": role, "content": blocks })
+    let mut out = serde_json::json!({ "role": role, "content": blocks });
+    // A message may also carry a turn-level `cache_control` breakpoint (Anthropic
+    // accepts `cache_control` on a message, not only its blocks).
+    // <https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching>
+    apply_cache_control(&mut out, &m.provider_metadata);
+    out
 }
 
 fn parse_usage(value: &serde_json::Value) -> Option<Usage> {
@@ -1475,7 +1719,7 @@ impl StreamDecoder for MessagesStreamDecoder {
                 {
                     let mut idx = 0usize;
                     for content in parse_messages_block_sources(block, &mut idx) {
-                        if let Content::Source { source } = content {
+                        if let Content::Source { source, .. } = content {
                             parts.push(StreamPart::Source { source });
                         }
                     }

--- a/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
@@ -2069,6 +2069,18 @@ impl StreamDecoder for MessagesStreamDecoder {
                     }
                     return Ok(parts);
                 }
+                // Streaming MCP gap: a streamed `mcp_tool_use` block (a
+                // provider-executed remote MCP call) and its companion
+                // `mcp_tool_result` are not recognised here and fall to
+                // `BlockKind::Text`, so they are mishandled on this delta path —
+                // the streaming counterpart of the `web_search` `citations_delta`
+                // gap documented above. Surfacing them faithfully would require
+                // new cross-protocol `StreamPart` plumbing (the other encoders
+                // have no streaming MCP frame to target). The non-streaming
+                // handshake (`parse_response` / `render_response`) is the
+                // complete, faithful round trip; the streamed blocks are a
+                // deferred gap, not yet wired.
+                // <https://platform.claude.com/docs/en/agents-and-tools/mcp-connector>
                 let kind = match block.and_then(|b| b.get("type")).and_then(|t| t.as_str()) {
                     Some("thinking") | Some("redacted_thinking") => BlockKind::Thinking,
                     Some("tool_use") => BlockKind::ToolUse,

--- a/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
@@ -1531,6 +1531,14 @@ fn render_content_block(c: &Content) -> Option<serde_json::Value> {
         // `web_search_tool_result` pair by `render_response` (see
         // `render_web_search_result_blocks`). Skip here.
         Content::Source { .. } => None,
+        // The Anthropic Messages wire has no tool-approval handshake: it carries
+        // no `mcp_approval_request` / `mcp_approval_response` block. The AI SDK's
+        // Anthropic converter likewise drops a `tool-approval-response` part
+        // (`continue`), so both approval parts are skipped here. A denied
+        // execution still degrades to a plain `tool_result` string on the
+        // request side (`render_tool_result_content` via `to_provider_string`).
+        // <https://github.com/vercel/ai/blob/main/packages/anthropic/src/convert-to-anthropic-prompt.ts>
+        Content::ToolApprovalRequest { .. } | Content::ToolApprovalResponse { .. } => None,
     }
 }
 

--- a/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
@@ -23,7 +23,7 @@ use crate::language_model::protocol::{
 use crate::language_model::stream::SseFrame;
 use crate::language_model::types::{
     ApiProtocol, AuthScheme, Content, DataContent, FinishReason, GenerateResult, GenerationParams,
-    Message, Prompt, ResponseFormat, Role, RoutingTarget, StopDetails, StreamPart,
+    Message, Prompt, ResponseFormat, Role, RoutingTarget, StopDetails, StreamPart, ToolChoice,
     ToolResultContentPart, ToolResultOutput, Usage,
 };
 
@@ -292,7 +292,13 @@ fn parse_content(value: &serde_json::Value) -> Result<Vec<Content>> {
                             .unwrap_or_default()
                             .to_string(),
                     }),
-                    "tool_use" => out.push(Content::ToolCall {
+                    // A client `tool_use` block, or a provider-executed
+                    // `server_tool_use` block (web search, code execution, …).
+                    // They share the same `{id, name, input}` shape and differ
+                    // only by the block `type`; the latter sets
+                    // `provider_executed` so it is not re-sent as a client call.
+                    // <https://platform.claude.com/docs/en/agents-and-tools/tool-use/web-search-tool>
+                    "tool_use" | "server_tool_use" => out.push(Content::ToolCall {
                         id: block
                             .get("id")
                             .and_then(|i| i.as_str())
@@ -307,6 +313,7 @@ fn parse_content(value: &serde_json::Value) -> Result<Vec<Content>> {
                             .get("input")
                             .map(|i| i.to_string())
                             .unwrap_or_else(|| "{}".to_string()),
+                        provider_executed: block_type == "server_tool_use",
                     }),
                     // Anthropic `tool_result` block `{tool_use_id, content, is_error}`:
                     // `content` is a string or a block array (text / image); the
@@ -550,6 +557,11 @@ impl InboundAdapter for MessagesAdapter {
             response_format = Some(rf);
         }
 
+        // Promote `tool_choice` into the typed slot and drop it from `extra` so it
+        // is not also splatted back verbatim — otherwise an Anthropic-shaped
+        // choice would leak into a non-Anthropic upstream.
+        let tool_choice = extra.remove("tool_choice").map(parse_messages_tool_choice);
+
         Ok(Prompt {
             model: req.model,
             system,
@@ -561,6 +573,7 @@ impl InboundAdapter for MessagesAdapter {
                 max_tokens: req.max_tokens,
                 reasoning_effort,
                 response_modalities: Vec::new(),
+                tool_choice,
                 extra,
             },
             response_format,
@@ -688,8 +701,13 @@ impl OutboundAdapter for MessagesAdapter {
                 serde_json::Value::Object(output_config),
             );
         }
-        // Splat anthropic-specific extras (tool_choice, stop_sequences, …) back
-        // into the outbound request. Typed fields win over same-named extras.
+        // Render the canonical tool_choice into Anthropic's native shape, before
+        // the extras splat so the typed slot wins over any stale `tool_choice`.
+        if let Some(tc) = &prompt.params.tool_choice {
+            req.insert("tool_choice".into(), render_messages_tool_choice(tc));
+        }
+        // Splat anthropic-specific extras (stop_sequences, top_k, …) back into
+        // the outbound request. Typed fields win over same-named extras.
         for (k, v) in &prompt.params.extra {
             req.entry(k.clone()).or_insert_with(|| v.clone());
         }
@@ -720,7 +738,15 @@ impl OutboundAdapter for MessagesAdapter {
                         .unwrap_or_default()
                         .to_string(),
                 }),
-                Some("tool_use") => content.push(Content::ToolCall {
+                // A client `tool_use` block, or a provider-executed
+                // `server_tool_use` block. Anthropic runs server tools (e.g.
+                // `web_search`) itself and emits a `server_tool_use` block with
+                // an `srvtoolu_…` id followed by a `*_tool_result` block; mark
+                // it `provider_executed` so a follow-up turn does not re-issue it
+                // as a client call. The paired result block is consumed
+                // separately and is not a tool *call*.
+                // <https://platform.claude.com/docs/en/agents-and-tools/tool-use/web-search-tool>
+                Some(kind @ ("tool_use" | "server_tool_use")) => content.push(Content::ToolCall {
                     id: block
                         .get("id")
                         .and_then(|i| i.as_str())
@@ -735,6 +761,7 @@ impl OutboundAdapter for MessagesAdapter {
                         .get("input")
                         .map(|i| i.to_string())
                         .unwrap_or_else(|| "{}".to_string()),
+                    provider_executed: kind == "server_tool_use",
                 }),
                 _ => {}
             }
@@ -801,6 +828,41 @@ fn render_messages_response_format(rf: &ResponseFormat) -> serde_json::Value {
     serde_json::json!({ "type": "json_schema", "schema": schema })
 }
 
+/// Parse Anthropic's `tool_choice` object into the canonical [`ToolChoice`].
+/// Anthropic uses `{type:"auto"|"any"|"tool"|"none", name?}`: `any` is "must
+/// call some tool" (canonical `Required`), `tool` names a specific tool. An
+/// unrecognised shape is preserved verbatim via [`ToolChoice::Other`].
+/// <https://platform.claude.com/docs/en/agents-and-tools/tool-use/implement-tool-use#controlling-claudes-output>
+fn parse_messages_tool_choice(value: serde_json::Value) -> ToolChoice {
+    match value.get("type").and_then(|t| t.as_str()) {
+        Some("auto") => ToolChoice::Auto,
+        Some("none") => ToolChoice::None,
+        Some("any") => ToolChoice::Required,
+        Some("tool") => match value.get("name").and_then(|n| n.as_str()) {
+            Some(name) => ToolChoice::Tool {
+                name: name.to_string(),
+            },
+            None => ToolChoice::Other { value },
+        },
+        _ => ToolChoice::Other { value },
+    }
+}
+
+/// Render a canonical [`ToolChoice`] into Anthropic's native `tool_choice`
+/// object. `Required` maps to `{type:"any"}`; `Tool` to `{type:"tool",name}`.
+/// Anthropic natively supports `{type:"none"}`, so `None` round-trips faithfully
+/// (rather than the AI SDK's drop-the-tools workaround).
+/// <https://platform.claude.com/docs/en/agents-and-tools/tool-use/implement-tool-use#controlling-claudes-output>
+fn render_messages_tool_choice(choice: &ToolChoice) -> serde_json::Value {
+    match choice {
+        ToolChoice::Auto => serde_json::json!({ "type": "auto" }),
+        ToolChoice::None => serde_json::json!({ "type": "none" }),
+        ToolChoice::Required => serde_json::json!({ "type": "any" }),
+        ToolChoice::Tool { name } => serde_json::json!({ "type": "tool", "name": name }),
+        ToolChoice::Other { value } => value.clone(),
+    }
+}
+
 #[async_trait]
 impl Transport for MessagesTransport {
     fn protocol(&self) -> ApiProtocol {
@@ -857,11 +919,23 @@ fn render_content_block(c: &Content) -> Option<serde_json::Value> {
             id,
             name,
             arguments,
+            provider_executed,
         } => {
             let input: serde_json::Value =
                 serde_json::from_str(arguments).unwrap_or(serde_json::json!({}));
+            // Reproduce the server-tool block shape on the same wire: a
+            // provider-executed call (e.g. web search) renders as
+            // `server_tool_use`, a client call as `tool_use`. Both carry the
+            // identical `{id, name, input}` payload — only the block type
+            // differs.
+            // <https://platform.claude.com/docs/en/agents-and-tools/tool-use/web-search-tool>
+            let block_type = if *provider_executed {
+                "server_tool_use"
+            } else {
+                "tool_use"
+            };
             Some(serde_json::json!({
-                "type": "tool_use", "id": id, "name": name, "input": input,
+                "type": block_type, "id": id, "name": name, "input": input,
             }))
         }
         // tool results are request-side only; not part of an assistant reply

--- a/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
@@ -51,6 +51,21 @@ const ANTHROPIC_REDACTED_DATA: &str = "redactedData";
 /// restore the exact pairing id instead of reusing one by position.
 /// <https://platform.claude.com/docs/en/agents-and-tools/tool-use/web-search-tool>
 const ANTHROPIC_TOOL_USE_ID: &str = "toolUseId";
+/// The metadata key tagging a [`Content::ToolCall`] / [`Content::ToolResult`] as
+/// an Anthropic **MCP** block. Set to the marker [`ANTHROPIC_MCP_TOOL_USE`] so
+/// the render path re-emits `mcp_tool_use` / `mcp_tool_result` rather than a
+/// plain `tool_use` / `tool_result`, mirroring the AI SDK's
+/// `providerOptions.anthropic.type === 'mcp-tool-use'` gate.
+/// <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts>
+const ANTHROPIC_MCP_TYPE: &str = "type";
+/// The [`ANTHROPIC_MCP_TYPE`] marker value identifying an MCP tool-use block.
+const ANTHROPIC_MCP_TOOL_USE: &str = "mcp-tool-use";
+/// The metadata key carrying an MCP tool call's remote **server identifier**
+/// (`mcp_tool_use.server_name`). Required by the wire — Anthropic rejects an
+/// `mcp_tool_use` block without it — so it is preserved under the `anthropic`
+/// namespace and restored on render.
+/// <https://platform.claude.com/docs/en/agents-and-tools/mcp-connector>
+const ANTHROPIC_MCP_SERVER_NAME: &str = "serverName";
 
 /// Lift an Anthropic block/tool's `cache_control` object into a fresh
 /// [`ProviderMetadata`] under `anthropic.cacheControl`. Anthropic's prompt
@@ -163,6 +178,74 @@ fn render_reasoning_block(text: &str, meta: &ProviderMetadata) -> serde_json::Va
             obj["signature"] = sig.clone();
         }
         obj
+    }
+}
+
+/// Build the `provider_metadata` for an Anthropic `mcp_tool_use` block: the MCP
+/// marker (`type: "mcp-tool-use"`) plus the remote `server_name`, alongside any
+/// block-level `cache_control`. The pair lets the render path reproduce the exact
+/// `mcp_tool_use` block — and any non-Anthropic wire ignores the namespace.
+/// <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/anthropic/src/anthropic-messages-language-model.ts>
+fn parse_mcp_tool_use_metadata(block: &serde_json::Value) -> ProviderMetadata {
+    let mut meta = parse_cache_control(block);
+    set_provider_metadata(
+        &mut meta,
+        PROVIDER_ID_ANTHROPIC,
+        ANTHROPIC_MCP_TYPE,
+        serde_json::Value::String(ANTHROPIC_MCP_TOOL_USE.to_string()),
+    );
+    if let Some(server) = block.get("server_name") {
+        set_provider_metadata(
+            &mut meta,
+            PROVIDER_ID_ANTHROPIC,
+            ANTHROPIC_MCP_SERVER_NAME,
+            server.clone(),
+        );
+    }
+    meta
+}
+
+/// The MCP `server_name` carried in `provider_metadata` (set by
+/// [`parse_mcp_tool_use_metadata`]), if this part was tagged as an Anthropic MCP
+/// tool-use. `None` means the part is not a renderable `mcp_tool_use` — either it
+/// is an ordinary call, or it is a `dynamic` MCP call that arrived on a *different*
+/// wire (e.g. an OpenAI `mcp_call`) and so has no Anthropic server name; such a
+/// call degrades to a plain `tool_use` block, dropping the foreign server id.
+fn mcp_server_name(meta: &ProviderMetadata) -> Option<String> {
+    let ns = provider_namespace(meta, PROVIDER_ID_ANTHROPIC)?;
+    let is_mcp = ns
+        .get(ANTHROPIC_MCP_TYPE)
+        .and_then(|v| v.as_str())
+        .is_some_and(|t| t == ANTHROPIC_MCP_TOOL_USE);
+    if !is_mcp {
+        return None;
+    }
+    ns.get(ANTHROPIC_MCP_SERVER_NAME)
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+}
+
+/// Parse an Anthropic `mcp_tool_result` block's body into a [`ToolResultOutput`].
+/// The wire `content` is the raw MCP result (a string or a `[{type:"text",
+/// text}]` array); it is kept as a structured JSON value — `Json`, or `ErrorJson`
+/// when `is_error` is set — so a same-protocol render re-emits the exact
+/// `content`. (The AI SDK reference carries `result: part.content` and its render
+/// only re-accepts a `json` / `error-json` body, which this mirrors.) A missing
+/// `content` defaults to JSON `null`, the faithful empty value.
+/// <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts>
+fn parse_mcp_tool_result_output(block: &serde_json::Value) -> ToolResultOutput {
+    let value = block
+        .get("content")
+        .cloned()
+        .unwrap_or(serde_json::Value::Null);
+    let is_error = block
+        .get("is_error")
+        .and_then(|e| e.as_bool())
+        .unwrap_or(false);
+    if is_error {
+        ToolResultOutput::ErrorJson { value }
+    } else {
+        ToolResultOutput::Json { value }
     }
 }
 
@@ -595,8 +678,38 @@ fn parse_content(value: &serde_json::Value) -> Result<Vec<Content>> {
                             .map(|i| i.to_string())
                             .unwrap_or_else(|| "{}".to_string()),
                         provider_executed: block_type == "server_tool_use",
+                        // Neither block is a runtime MCP (`dynamic`) tool call.
+                        dynamic: false,
                         // Preserve a block-level `cache_control` breakpoint.
                         provider_metadata: parse_cache_control(block),
+                    }),
+                    // Anthropic `mcp_tool_use` block `{id, name, input, server_name}`
+                    // — a provider-executed remote MCP tool call (the beta MCP
+                    // connector). It maps to a `dynamic`, provider-executed
+                    // `ToolCall`; the load-bearing `server_name` has no core field
+                    // and rides in `provider_metadata["anthropic"]` (with the
+                    // `type: "mcp-tool-use"` marker) so the render reproduces the
+                    // exact block. Mirrors the AI SDK reference mapping.
+                    // <https://platform.claude.com/docs/en/agents-and-tools/mcp-connector>
+                    // <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/anthropic/src/anthropic-messages-language-model.ts>
+                    "mcp_tool_use" => out.push(Content::ToolCall {
+                        id: block
+                            .get("id")
+                            .and_then(|i| i.as_str())
+                            .unwrap_or_default()
+                            .to_string(),
+                        name: block
+                            .get("name")
+                            .and_then(|n| n.as_str())
+                            .unwrap_or_default()
+                            .to_string(),
+                        arguments: block
+                            .get("input")
+                            .map(|i| i.to_string())
+                            .unwrap_or_else(|| "{}".to_string()),
+                        provider_executed: true,
+                        dynamic: true,
+                        provider_metadata: parse_mcp_tool_use_metadata(block),
                     }),
                     // Anthropic `tool_result` block `{tool_use_id, content, is_error}`:
                     // `content` is a string or a block array (text / image); the
@@ -617,7 +730,29 @@ fn parse_content(value: &serde_json::Value) -> Result<Vec<Content>> {
                                 .and_then(|e| e.as_bool())
                                 .unwrap_or(false),
                         ),
+                        // An ordinary `tool_result` is not an MCP inline result.
+                        dynamic: false,
                         // Preserve a block-level `cache_control` breakpoint.
+                        provider_metadata: parse_cache_control(block),
+                    }),
+                    // Anthropic `mcp_tool_result` block `{tool_use_id, content,
+                    // is_error}` — the inline result of an `mcp_tool_use` call. It
+                    // maps to a `dynamic` `ToolResult` whose body is the raw MCP
+                    // `content` (a JSON value), kept as `Json` / `ErrorJson` so the
+                    // render re-emits it verbatim; the AI SDK reference likewise
+                    // carries `result: part.content` and only accepts a JSON body
+                    // back. The `cache_control` breakpoint is preserved.
+                    // <https://platform.claude.com/docs/en/agents-and-tools/mcp-connector>
+                    // <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/anthropic/src/anthropic-messages-language-model.ts>
+                    "mcp_tool_result" => out.push(Content::ToolResult {
+                        call_id: block
+                            .get("tool_use_id")
+                            .and_then(|i| i.as_str())
+                            .unwrap_or_default()
+                            .to_string(),
+                        tool_name: None,
+                        output: parse_mcp_tool_result_output(block),
+                        dynamic: true,
                         provider_metadata: parse_cache_control(block),
                     }),
                     // image/* and documents (PDF, …) -> a canonical File part.
@@ -780,12 +915,17 @@ impl InboundAdapter for MessagesAdapter {
         let mut messages = Vec::with_capacity(req.messages.len());
         for m in &req.messages {
             let role = parse_role(&m.role)?;
-            // A user-role message may carry tool_result blocks — split those
-            // into a canonical Tool-role message so the IR stays clean.
+            // A user-role message may carry client `tool_result` blocks — split
+            // those into a canonical Tool-role message so the IR stays clean. A
+            // `dynamic` MCP result (an `mcp_tool_result`), however, is part of the
+            // assistant turn — it pairs with its `mcp_tool_use` call — so it is
+            // kept in place (NOT partitioned out), and re-renders as an
+            // `mcp_tool_result` block rather than a request-side `tool_result`.
+            // <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts>
             let parsed = parse_content(&m.content)?;
             let (tool_results, rest): (Vec<_>, Vec<_>) = parsed
                 .into_iter()
-                .partition(|c| matches!(c, Content::ToolResult { .. }));
+                .partition(|c| matches!(c, Content::ToolResult { dynamic: false, .. }));
             if !tool_results.is_empty() {
                 messages.push(Message {
                     role: Role::Tool,
@@ -1114,6 +1254,48 @@ impl OutboundAdapter for MessagesAdapter {
                         .map(|i| i.to_string())
                         .unwrap_or_else(|| "{}".to_string()),
                     provider_executed: kind == "server_tool_use",
+                    // Neither block is a runtime MCP (`dynamic`) tool call.
+                    dynamic: false,
+                    provider_metadata: parse_cache_control(block),
+                }),
+                // An `mcp_tool_use` block — a provider-executed remote MCP tool
+                // call on the response side; same mapping as the request parse
+                // above (`dynamic`, provider-executed, server identity in
+                // `provider_metadata["anthropic"]`).
+                // <https://platform.claude.com/docs/en/agents-and-tools/mcp-connector>
+                Some("mcp_tool_use") => content.push(Content::ToolCall {
+                    id: block
+                        .get("id")
+                        .and_then(|i| i.as_str())
+                        .unwrap_or_default()
+                        .to_string(),
+                    name: block
+                        .get("name")
+                        .and_then(|n| n.as_str())
+                        .unwrap_or_default()
+                        .to_string(),
+                    arguments: block
+                        .get("input")
+                        .map(|i| i.to_string())
+                        .unwrap_or_else(|| "{}".to_string()),
+                    provider_executed: true,
+                    dynamic: true,
+                    provider_metadata: parse_mcp_tool_use_metadata(block),
+                }),
+                // An `mcp_tool_result` block — the inline result of an
+                // `mcp_tool_use` call, emitted in the assistant turn right after
+                // the call. Mapped to a `dynamic` `ToolResult` carrying the raw MCP
+                // `content`, paired by `tool_use_id`.
+                // <https://platform.claude.com/docs/en/agents-and-tools/mcp-connector>
+                Some("mcp_tool_result") => content.push(Content::ToolResult {
+                    call_id: block
+                        .get("tool_use_id")
+                        .and_then(|i| i.as_str())
+                        .unwrap_or_default()
+                        .to_string(),
+                    tool_name: None,
+                    output: parse_mcp_tool_result_output(block),
+                    dynamic: true,
                     provider_metadata: parse_cache_control(block),
                 }),
                 // A `web_search_tool_result` block carries the raw search hits
@@ -1516,10 +1698,34 @@ fn render_content_block(c: &Content) -> Option<serde_json::Value> {
             name,
             arguments,
             provider_executed,
+            dynamic,
             provider_metadata,
         } => {
             let input: serde_json::Value =
                 serde_json::from_str(arguments).unwrap_or(serde_json::json!({}));
+            // A `dynamic` provider-executed MCP call that carries an Anthropic
+            // `server_name` (the `mcp-tool-use` metadata marker) reproduces its
+            // native `mcp_tool_use` block, restoring the load-bearing server id.
+            // The AI SDK gates the same way on `providerOptions.anthropic.type ===
+            // 'mcp-tool-use'` and warns/drops when the server name is missing; here
+            // a dynamic call WITHOUT an Anthropic server name (e.g. one routed in
+            // from an OpenAI `mcp_call`) simply degrades to a plain `tool_use`,
+            // dropping the foreign server identity.
+            // <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts>
+            if *dynamic
+                && *provider_executed
+                && let Some(server_name) = mcp_server_name(provider_metadata)
+            {
+                let mut block = serde_json::json!({
+                    "type": "mcp_tool_use",
+                    "id": id,
+                    "name": name,
+                    "input": input,
+                    "server_name": server_name,
+                });
+                apply_cache_control(&mut block, provider_metadata);
+                return Some(block);
+            }
             // Reproduce the server-tool block shape on the same wire: a
             // provider-executed call (e.g. web search) renders as
             // `server_tool_use`, a client call as `tool_use`. Both carry the
@@ -1537,7 +1743,38 @@ fn render_content_block(c: &Content) -> Option<serde_json::Value> {
             apply_cache_control(&mut block, provider_metadata);
             Some(block)
         }
-        // tool results are request-side only; not part of an assistant reply
+        // A `dynamic` MCP tool result is part of the assistant turn — it follows
+        // its `mcp_tool_use` call as an `mcp_tool_result` block (rather than a
+        // request-side `tool_result`). Re-emit that block, carrying the raw MCP
+        // `content` back from the structured output and the `is_error` flag. The
+        // AI SDK reference only round-trips a JSON-bodied MCP result, so a
+        // non-`Json`/`ErrorJson` output (only reachable from a hand-built value or
+        // a cross-protocol route) has no faithful `mcp_tool_result` form and is
+        // dropped here — exactly as the reference warns-and-skips it.
+        // <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts>
+        Content::ToolResult {
+            call_id,
+            output,
+            dynamic,
+            provider_metadata,
+            ..
+        } if *dynamic => {
+            let (value, is_error) = match output {
+                ToolResultOutput::Json { value } => (value.clone(), false),
+                ToolResultOutput::ErrorJson { value } => (value.clone(), true),
+                _ => return None,
+            };
+            let mut block = serde_json::json!({
+                "type": "mcp_tool_result",
+                "tool_use_id": call_id,
+                "is_error": is_error,
+                "content": value,
+            });
+            apply_cache_control(&mut block, provider_metadata);
+            Some(block)
+        }
+        // Ordinary tool results are request-side only; not part of an assistant
+        // reply (they ride a Tool-role message rendered by `render_message`).
         Content::ToolResult { .. } => None,
         // image/* -> an `image` block, everything else -> a `document` block.
         // Source is `{type:base64,media_type,data}` or `{type:url,url}`.

--- a/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
@@ -10,6 +10,8 @@
 //! - #416: mixed text + tool_use blocks keep their order and never 502.
 //! - #422: inbound `ping` events are ignored, not treated as errors.
 
+use std::collections::HashMap;
+
 use schemars::JsonSchema;
 use serde::Deserialize;
 
@@ -17,14 +19,14 @@ use async_trait::async_trait;
 
 use crate::error::{BitrouterError, Result};
 use crate::language_model::protocol::{
-    InboundAdapter, OutboundAdapter, SseEvent, StreamDecoder, StreamEncoder, Transport,
-    describe_deser_error,
+    InboundAdapter, OutboundAdapter, PROVIDER_ID_ANTHROPIC, SseEvent, StreamDecoder, StreamEncoder,
+    Transport, describe_deser_error, provider_defined_native,
 };
 use crate::language_model::stream::SseFrame;
 use crate::language_model::types::{
     ApiProtocol, AuthScheme, Content, DataContent, FinishReason, GenerateResult, GenerationParams,
-    Message, Prompt, ResponseFormat, Role, RoutingTarget, StopDetails, StreamPart, ToolChoice,
-    ToolResultContentPart, ToolResultOutput, Usage,
+    Message, Prompt, ResponseFormat, Role, RoutingTarget, StopDetails, StreamPart, Tool,
+    ToolChoice, ToolResultContentPart, ToolResultOutput, Usage,
 };
 
 /// The Messages inbound + outbound protocol adapter.
@@ -109,14 +111,87 @@ pub struct MessagesMessage {
     content: serde_json::Value,
 }
 
-/// One element of [`MessagesRequest`]'s `tools` array — Anthropic's tool definition shape.
+/// One element of [`MessagesRequest`]'s `tools` array.
+///
+/// Anthropic uses one array for both kinds of tool:
+/// - a **client (function) tool** — `{name, description?, input_schema}` (no `type`);
+/// - a **provider-defined (server) tool** — `{type:"web_search_20250305"|…, name, …config}`
+///   (web search, code execution, computer use, bash, text editor), where `type`
+///   is the dated tool version and `name` is the stable tool name.
+///
+/// A versioned `type` discriminates a server tool; its config keys ride in
+/// `extra` so they are preserved verbatim into `Tool::ProviderDefined.args`.
+/// <https://docs.claude.com/en/docs/agents-and-tools/tool-use/overview>
+/// <https://docs.claude.com/en/docs/agents-and-tools/tool-use/web-search-tool>
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct MessagesTool {
-    name: String,
+    #[serde(default, rename = "type")]
+    kind: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
     #[serde(default)]
     description: Option<String>,
     #[serde(default)]
     input_schema: serde_json::Value,
+    /// Server-tool configuration keys (e.g. `max_uses`, `allowed_domains`,
+    /// `display_width_px`) for a provider-defined tool. Preserved verbatim.
+    /// Skipped from the published schema — the documented contract is the typed
+    /// client-tool shape.
+    #[serde(flatten)]
+    #[schemars(skip)]
+    extra: HashMap<String, serde_json::Value>,
+}
+
+/// Parse one Anthropic `tools` entry into a canonical [`Tool`]. A versioned
+/// `type` marks a provider-defined server tool (namespaced `anthropic.<type>`,
+/// config keys preserved verbatim as `args`); a typeless entry is a client
+/// function tool (`{name, description?, input_schema}`). An entry with neither a
+/// `type` nor a `name` is dropped — there is nothing to forward.
+fn parse_messages_tool(t: MessagesTool) -> Option<Tool> {
+    if let Some(kind) = t.kind {
+        // Server tool: `{type:"web_search_20250305", name:"web_search", …config}`.
+        return Some(Tool::ProviderDefined {
+            id: format!("{PROVIDER_ID_ANTHROPIC}.{kind}"),
+            name: t.name.unwrap_or_else(|| kind.clone()),
+            args: serde_json::Value::Object(t.extra.into_iter().collect()),
+        });
+    }
+    Some(Tool::Function {
+        name: t.name?,
+        description: t.description,
+        parameters: t.input_schema,
+        // Anthropic client tools carry no `strict` slot.
+        strict: None,
+    })
+}
+
+/// Render one canonical [`Tool`] into an Anthropic `tools` entry.
+///
+/// A [`Tool::Function`] becomes `{name, description?, input_schema}`. Anthropic
+/// has **no** `strict` slot, so [`Tool::Function::strict`] is intentionally
+/// dropped here (documented; the same drop applies to structured-output
+/// `strict`). A [`Tool::ProviderDefined`] renders to its source-native shape via
+/// [`provider_defined_native`]: an `anthropic.*` id reproduces the exact server
+/// tool (`{type:<version>, name, …args}`) for a lossless same-protocol
+/// round-trip; a foreign-provider id is preserved verbatim (faithful
+/// passthrough) so the upstream decides.
+/// <https://docs.claude.com/en/docs/agents-and-tools/tool-use/overview>
+fn render_messages_tool(tool: &Tool) -> serde_json::Value {
+    match tool {
+        Tool::Function {
+            name,
+            description,
+            parameters,
+            strict: _,
+        } => {
+            serde_json::json!({
+                "name": name,
+                "description": description,
+                "input_schema": parameters,
+            })
+        }
+        Tool::ProviderDefined { id, name, args } => provider_defined_native(id, name, args),
+    }
 }
 
 /// Collapse Anthropic's `system` (string or content-block array) into plain text.
@@ -506,14 +581,17 @@ impl InboundAdapter for MessagesAdapter {
             }
         }
 
+        // Anthropic mixes client (function) tools and provider-defined (server)
+        // tools in one array. A versioned `type` (`web_search_20250305`,
+        // `code_execution_20250522`, `computer_20250124`, `bash_20250124`,
+        // `text_editor_20250124`, …) marks a server tool — namespaced
+        // `anthropic.<type>`, with its config keys preserved verbatim as `args`.
+        // A typeless entry is a client tool (`{name, description?, input_schema}`).
+        // <https://docs.claude.com/en/docs/agents-and-tools/tool-use/overview>
         let tools = req
             .tools
             .into_iter()
-            .map(|t| crate::language_model::types::Tool {
-                name: t.name,
-                description: t.description,
-                parameters: t.input_schema,
-            })
+            .filter_map(parse_messages_tool)
             .collect();
 
         // Messages' GA structured outputs are typed under `output_config`
@@ -650,13 +728,7 @@ impl OutboundAdapter for MessagesAdapter {
                 prompt
                     .tools
                     .iter()
-                    .map(|t| {
-                        serde_json::json!({
-                            "name": t.name,
-                            "description": t.description,
-                            "input_schema": t.parameters,
-                        })
-                    })
+                    .map(render_messages_tool)
                     .collect::<Vec<_>>()
                     .into(),
             );

--- a/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
@@ -671,13 +671,14 @@ impl InboundAdapter for MessagesAdapter {
             .iter()
             .filter_map(render_content_block)
             .collect();
-        // Re-attach web-search citations as one `web_search_tool_result` block
-        // (the faithful Anthropic citation location — see
-        // `render_web_search_result_block`). Appended after the answer blocks,
-        // matching the wire order (the result block follows the text it cites).
-        if let Some(block) = render_web_search_result_block(result) {
-            content.push(block);
-        }
+        // Re-attach web-search citations as a valid `server_tool_use` ↔
+        // `web_search_tool_result` pair (the faithful Anthropic citation
+        // location — see `render_web_search_result_blocks`). Appended after the
+        // answer blocks, matching the wire order (the result follows the text it
+        // cites). When the originating provider-executed call is already present
+        // among the answer blocks, only the result block is appended and it
+        // reuses that call's id; otherwise a synthetic call block is prepended.
+        content.extend(render_web_search_result_blocks(result));
         let usage = result.usage.unwrap_or_default();
         let stop_reason = result
             .finish_reason
@@ -709,6 +710,7 @@ impl InboundAdapter for MessagesAdapter {
             block_open: false,
             block_kind: None,
             block_index: 0,
+            pending_sources: Vec::new(),
         })
     }
 }
@@ -1062,21 +1064,67 @@ fn parse_messages_block_sources(block: &serde_json::Value, next_index: &mut usiz
     out
 }
 
-/// Render canonical [`Content::Source`] parts into a single Anthropic
-/// `web_search_tool_result` block whose `content[]` carries one
-/// `web_search_result` entry per URL source.
-///
-/// This is the chosen render location among the two Anthropic citation shapes.
-/// A `web_search_tool_result` block is the faithful form because it natively
-/// holds an array of `{url, title}` results with **no** required text linkage,
-/// so it reproduces url+title+id losslessly. The alternative — `citations[]` on
-/// a `text` block — would demand a `cited_text` span and char offsets that the
-/// canonical `Source` does not carry (and could not reconstruct), so emitting it
-/// would fabricate the very text-linkage data the parity target drops.
-/// [`Source::Document`] citations have no `web_search_result` form and are
-/// skipped here. Returns `None` when the result carries no URL sources.
+/// Synthetic `server_tool_use` id used to pair a synthesized web-search
+/// call with its `web_search_tool_result` when the canonical content has no
+/// originating provider-executed call to borrow a real id from (cross-protocol,
+/// e.g. a Gemini grounding response rendered to an Anthropic client). It is
+/// opaque to clients and only correlates the two blocks on the wire.
+const SYNTHETIC_WEB_SEARCH_ID: &str = "srvtoolu_citations";
+
+/// Anthropic's server `web_search` tool name, used on a synthesized
+/// `server_tool_use` block so the emitted pair is a valid web-search call.
 /// <https://platform.claude.com/docs/en/agents-and-tools/tool-use/web-search-tool>
-fn render_web_search_result_block(result: &GenerateResult) -> Option<serde_json::Value> {
+const ANTHROPIC_WEB_SEARCH_TOOL: &str = "web_search";
+
+/// True when a canonical [`Content::ToolCall`] is a provider-executed web-search
+/// call — the originating block of a `web_search_tool_result`. Anthropic's
+/// server web search emits a `server_tool_use{name:"web_search"}` block paired
+/// with its result by a shared `tool_use_id`; on parse that block becomes a
+/// `ToolCall{provider_executed:true, name:"web_search"}`, so the render path
+/// recognizes it here to reuse its real id when re-pairing.
+/// <https://platform.claude.com/docs/en/agents-and-tools/tool-use/web-search-tool>
+fn is_web_search_call(c: &Content) -> bool {
+    matches!(
+        c,
+        Content::ToolCall {
+            provider_executed: true,
+            name,
+            ..
+        } if name == ANTHROPIC_WEB_SEARCH_TOOL
+    )
+}
+
+/// Render canonical [`Content::Source`] parts into a valid Anthropic
+/// `server_tool_use` ↔ `web_search_tool_result` pair. The result block's
+/// `content[]` carries one `web_search_result` entry per URL source.
+///
+/// A `web_search_tool_result` block is the faithful render location among the
+/// two Anthropic citation shapes: it natively holds an array of `{url, title}`
+/// results with **no** required text linkage, so it reproduces url+title+id
+/// losslessly. The alternative — `citations[]` on a `text` block — would demand
+/// a `cited_text` span and char offsets the canonical `Source` cannot
+/// reconstruct, fabricating the very text-linkage data the parity target drops.
+/// [`Source::Document`] citations have no `web_search_result` form and are
+/// skipped here. Returns an empty Vec when the result carries no URL sources.
+///
+/// **Pairing strategy (correlate by order).** On the Anthropic wire a
+/// `web_search_tool_result` is invalid on its own: it must pair with a
+/// `server_tool_use` block sharing one `tool_use_id`, or a client echoing the
+/// assistant turn into a follow-up triggers `invalid_request_error`.
+/// - Same-protocol: the upstream `server_tool_use` parsed to a
+///   `ToolCall{provider_executed:true, name:"web_search"}` and is re-rendered as
+///   a real `server_tool_use` by [`render_content_block`]. Here we detect that
+///   preceding call and **reuse its id** as `tool_use_id` (real pairing; no
+///   second `server_tool_use` is emitted), so `srvtoolu_…` ids correlate.
+/// - Cross-protocol (no such call, e.g. Gemini grounding → Anthropic client):
+///   we **synthesize** a matching `server_tool_use{id, name:"web_search",
+///   input:{}}` immediately before the result block so the pair is still valid.
+///
+/// Preserving the *exact* original id across a full canonical round-trip is
+/// deferred to provider-metadata plumbing; the emitted wire must never be
+/// invalid in the meantime.
+/// <https://platform.claude.com/docs/en/agents-and-tools/tool-use/web-search-tool>
+fn render_web_search_result_blocks(result: &GenerateResult) -> Vec<serde_json::Value> {
     let results: Vec<serde_json::Value> = result
         .content
         .iter()
@@ -1096,16 +1144,46 @@ fn render_web_search_result_block(result: &GenerateResult) -> Option<serde_json:
         })
         .collect();
     if results.is_empty() {
-        return None;
+        return Vec::new();
     }
-    Some(serde_json::json!({
-        "type": "web_search_tool_result",
-        // The wire pairs this block with the originating `server_tool_use` id;
-        // the canonical `Source` does not carry it, so a synthetic placeholder
-        // is used. It is opaque to clients and only correlates the result block.
-        "tool_use_id": "srvtoolu_citations",
-        "content": results,
-    }))
+    // Correlate by order: borrow the id of the originating provider-executed
+    // `web_search` call. All URL sources collapse into one result block, and
+    // Anthropic emits one web-search call per result block, so the last such
+    // call in the content is the originator. That call is already re-rendered as
+    // a real `server_tool_use` by `render_content_block`, so reusing its id
+    // keeps the pair correlated without emitting a duplicate call block — and
+    // crucially without leaving that real call orphaned (the bug the synthetic
+    // `srvtoolu_citations` placeholder used to cause). Scanning the whole
+    // content (not just before the first source) covers the wire shape where an
+    // inline-cited text block's `Source` precedes the `server_tool_use`.
+    let paired_id = result.content.iter().rev().find_map(|c| match c {
+        Content::ToolCall { id, .. } if is_web_search_call(c) => Some(id.clone()),
+        _ => None,
+    });
+    match paired_id {
+        // Real pairing: the originating `server_tool_use` already rendered with
+        // this id; only the result block is added, sharing that id.
+        Some(id) => vec![serde_json::json!({
+            "type": "web_search_tool_result",
+            "tool_use_id": id,
+            "content": results,
+        })],
+        // No originating call (cross-protocol): synthesize the `server_tool_use`
+        // so the emitted pair is valid, both blocks sharing one synthetic id.
+        None => vec![
+            serde_json::json!({
+                "type": "server_tool_use",
+                "id": SYNTHETIC_WEB_SEARCH_ID,
+                "name": ANTHROPIC_WEB_SEARCH_TOOL,
+                "input": {},
+            }),
+            serde_json::json!({
+                "type": "web_search_tool_result",
+                "tool_use_id": SYNTHETIC_WEB_SEARCH_ID,
+                "content": results,
+            }),
+        ],
+    }
 }
 
 fn render_content_block(c: &Content) -> Option<serde_json::Value> {
@@ -1163,8 +1241,9 @@ fn render_content_block(c: &Content) -> Option<serde_json::Value> {
             Some(serde_json::json!({ "type": block_type, "source": source }))
         }
         // Citations are not a per-block render: they are collected across the
-        // whole reply and re-attached as one `web_search_tool_result` block by
-        // `render_response` (see `render_web_search_result_block`). Skip here.
+        // whole reply and re-attached as a `server_tool_use` ↔
+        // `web_search_tool_result` pair by `render_response` (see
+        // `render_web_search_result_blocks`). Skip here.
         Content::Source { .. } => None,
     }
 }
@@ -1573,6 +1652,12 @@ struct MessagesStreamEncoder {
     /// Meaningful only when `block_open == true`.
     block_kind: Option<EncoderBlockKind>,
     block_index: usize,
+    /// `web_search_result` entries buffered from streamed `StreamPart::Source`
+    /// parts, flushed as one collapsed `server_tool_use` ↔
+    /// `web_search_tool_result` pair (see `flush_pending_sources`). Buffered
+    /// rather than emitted per-source so the streamed wire matches the
+    /// non-streaming render (one block) and stays a valid pair.
+    pending_sources: Vec<serde_json::Value>,
 }
 
 impl MessagesStreamEncoder {
@@ -1616,6 +1701,60 @@ impl MessagesStreamEncoder {
         }
     }
 
+    /// Flush any buffered streamed citations as one collapsed
+    /// `server_tool_use` ↔ `web_search_tool_result` pair. `StreamPart` carries
+    /// no provider-executed flag, so the stream never reconstructs the
+    /// originating call — the pair is always synthesized (both blocks sharing
+    /// one synthetic `tool_use_id`) so a client echoing the turn into a
+    /// follow-up request does not see an orphan result block
+    /// (`invalid_request_error`). Each block opens and closes as a whole
+    /// `content_block`, mirroring the non-streaming render
+    /// (`render_web_search_result_blocks`).
+    /// <https://platform.claude.com/docs/en/agents-and-tools/tool-use/web-search-tool>
+    fn flush_pending_sources(&mut self, frames: &mut Vec<SseFrame>) {
+        if self.pending_sources.is_empty() {
+            return;
+        }
+        let results = std::mem::take(&mut self.pending_sources);
+        self.close_block(frames);
+        // Synthesized originating call, so the result block is a valid pair.
+        frames.push(Self::ev(
+            "content_block_start",
+            serde_json::json!({
+                "type": "content_block_start",
+                "index": self.block_index,
+                "content_block": {
+                    "type": "server_tool_use",
+                    "id": SYNTHETIC_WEB_SEARCH_ID,
+                    "name": ANTHROPIC_WEB_SEARCH_TOOL,
+                    "input": {},
+                },
+            }),
+        ));
+        frames.push(Self::ev(
+            "content_block_stop",
+            serde_json::json!({ "type": "content_block_stop", "index": self.block_index }),
+        ));
+        self.block_index += 1;
+        frames.push(Self::ev(
+            "content_block_start",
+            serde_json::json!({
+                "type": "content_block_start",
+                "index": self.block_index,
+                "content_block": {
+                    "type": "web_search_tool_result",
+                    "tool_use_id": SYNTHETIC_WEB_SEARCH_ID,
+                    "content": results,
+                },
+            }),
+        ));
+        frames.push(Self::ev(
+            "content_block_stop",
+            serde_json::json!({ "type": "content_block_stop", "index": self.block_index }),
+        ));
+        self.block_index += 1;
+    }
+
     /// If a block of a different kind is currently open, close it; then ensure
     /// a block of `wanted` is open. Returns whether a *new* block was opened
     /// this call so the caller can append the right `content_block_start`.
@@ -1643,6 +1782,9 @@ impl MessagesStreamEncoder {
         stop_reason: &str,
         usage: Option<Usage>,
     ) {
+        // Collapse all buffered citations into one pair just before the
+        // terminal frames, matching the non-streaming render's tail placement.
+        self.flush_pending_sources(frames);
         self.close_block(frames);
         let u = usage.unwrap_or_default();
         frames.push(Self::ev(
@@ -1776,40 +1918,22 @@ impl StreamEncoder for MessagesStreamEncoder {
                 }
             }
             StreamPart::Source { source } => {
-                // Re-attach a streamed citation as its own
-                // `web_search_tool_result` content block (the decode path's
-                // mirror): close any open block, emit a `content_block_start`
-                // carrying a one-entry `content[]` result array, then close it.
-                // Only a URL source has a `web_search_result` form; a document
-                // citation is dropped here (no such block on this wire).
+                // Buffer a streamed citation as a `web_search_result` entry; all
+                // entries flush together as one collapsed `server_tool_use` ↔
+                // `web_search_tool_result` pair at terminal
+                // (`flush_pending_sources`), matching the non-streaming render's
+                // single-block shape. Only a URL source has a `web_search_result`
+                // form; a document citation is dropped here (no such block on
+                // this wire).
                 // <https://platform.claude.com/docs/en/agents-and-tools/tool-use/web-search-tool>
                 if let Source::Url { url, title, .. } = source {
-                    self.close_block(&mut frames);
                     let mut entry = serde_json::Map::new();
                     entry.insert("type".into(), "web_search_result".into());
                     entry.insert("url".into(), url.clone().into());
                     if let Some(title) = title {
                         entry.insert("title".into(), title.clone().into());
                     }
-                    frames.push(Self::ev(
-                        "content_block_start",
-                        serde_json::json!({
-                            "type": "content_block_start",
-                            "index": self.block_index,
-                            "content_block": {
-                                "type": "web_search_tool_result",
-                                "tool_use_id": "srvtoolu_citations",
-                                "content": [serde_json::Value::Object(entry)],
-                            },
-                        }),
-                    ));
-                    frames.push(Self::ev(
-                        "content_block_stop",
-                        serde_json::json!({
-                            "type": "content_block_stop", "index": self.block_index,
-                        }),
-                    ));
-                    self.block_index += 1;
+                    self.pending_sources.push(serde_json::Value::Object(entry));
                 }
             }
             StreamPart::Usage { .. } => {}

--- a/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
@@ -20,7 +20,8 @@ use async_trait::async_trait;
 use crate::error::{BitrouterError, Result};
 use crate::language_model::protocol::{
     InboundAdapter, OutboundAdapter, PROVIDER_ID_ANTHROPIC, SseEvent, StreamDecoder, StreamEncoder,
-    Transport, describe_deser_error, provider_defined_native,
+    Transport, describe_deser_error, provider_defined_native, rendered_finish_reason,
+    stash_raw_finish_reason,
 };
 use crate::language_model::stream::SseFrame;
 use crate::language_model::types::{
@@ -819,9 +820,10 @@ impl InboundAdapter for MessagesAdapter {
             } = oc;
             reasoning_effort = effort;
             if let Some(MessagesOutputFormat::JsonSchema { schema }) = format {
-                // Anthropic's GA format carries no name / strict.
+                // Anthropic's GA format carries no name / description / strict.
                 response_format = Some(ResponseFormat::JsonSchema {
                     name: None,
+                    description: None,
                     strict: None,
                     schema,
                 });
@@ -889,11 +891,11 @@ impl InboundAdapter for MessagesAdapter {
         // reuses that call's id; otherwise a synthetic call block is prepended.
         content.extend(render_web_search_result_blocks(result));
         let usage = result.usage.unwrap_or_default();
-        let stop_reason = result
-            .finish_reason
-            .as_ref()
-            .map(finish_to_stop_reason)
-            .map_or(serde_json::Value::Null, serde_json::Value::String);
+        // Prefer the stashed raw `stop_reason` (e.g. `stop_sequence`) over the
+        // unified-enum mapping so a same-protocol round-trip is byte-faithful.
+        let stop_reason =
+            rendered_finish_reason(result, PROVIDER_ID_ANTHROPIC, finish_to_stop_reason)
+                .map_or(serde_json::Value::Null, serde_json::Value::String);
         let mut body = serde_json::Map::new();
         body.insert("id".into(), request_id.into());
         body.insert("type".into(), "message".into());
@@ -1099,10 +1101,11 @@ impl OutboundAdapter for MessagesAdapter {
                 _ => {}
             }
         }
-        let finish_reason = body
+        let raw_stop = body
             .get("stop_reason")
             .and_then(|s| s.as_str())
-            .and_then(stop_reason_to_finish);
+            .map(str::to_string);
+        let finish_reason = raw_stop.as_deref().and_then(stop_reason_to_finish);
         let usage = body.get("usage").and_then(parse_usage);
         // Messages: top-level `id` (`msg_...`).
         // <https://docs.anthropic.com/en/api/messages>
@@ -1116,18 +1119,29 @@ impl OutboundAdapter for MessagesAdapter {
         // non-refusal stop reason.
         // <https://platform.claude.com/docs/en/build-with-claude/handling-stop-reasons#refusal-categories>
         let stop_details = body.get("stop_details").and_then(parse_stop_details);
+        // Anthropic's Messages response carries no result-level metadata field
+        // without a dedicated canonical slot (unlike OpenAI's
+        // `system_fingerprint` or Gemini's `modelVersion`); the per-block
+        // signature / cache_control above are where its provider metadata lives.
+        // The one result-level value we preserve is the raw `stop_reason` when
+        // the unified enum can't reproduce it — `stop_sequence` (→ `Stop`, which
+        // renders `end_turn`) and `refusal` are the lossy cases — so a
+        // same-protocol render restores the exact native reason.
+        let mut provider_metadata = ProviderMetadata::new();
+        stash_raw_finish_reason(
+            &mut provider_metadata,
+            PROVIDER_ID_ANTHROPIC,
+            raw_stop.as_deref(),
+            finish_reason.as_ref(),
+            finish_to_stop_reason,
+        );
         Ok(GenerateResult {
             content,
             usage,
             finish_reason,
             response_id,
             stop_details,
-            // Anthropic's Messages response carries no result-level metadata
-            // field without a dedicated canonical slot (unlike OpenAI's
-            // `system_fingerprint` or Gemini's `modelVersion`); the per-block
-            // signature / cache_control above are where its provider metadata
-            // lives. Left empty rather than inventing an unconstructed slot.
-            provider_metadata: ProviderMetadata::new(),
+            provider_metadata,
         })
     }
 
@@ -1155,6 +1169,7 @@ fn json_schema_from(format: &serde_json::Value) -> Option<ResponseFormat> {
     }
     Some(ResponseFormat::JsonSchema {
         name: None,
+        description: None,
         strict: None,
         schema: format.get("schema")?.clone(),
     })

--- a/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
@@ -772,6 +772,10 @@ fn render_content_block(c: &Content) -> Option<serde_json::Value> {
                 DataContent::Base64 { data } => serde_json::json!({
                     "type": "base64", "media_type": media_type, "data": data
                 }),
+                // Anthropic's `url` source carries no media_type, so an
+                // `image/png` + Url loses its subtype on a round-trip — the kind
+                // (image vs document) is recovered from the block type on parse,
+                // so modality detection still survives.
                 DataContent::Url { url } => serde_json::json!({ "type": "url", "url": url }),
             };
             let block_type = if media_type.starts_with("image/") {

--- a/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
@@ -1732,6 +1732,11 @@ struct MessagesStreamDecoder {
     /// per content-block index → tool id (empty string for non-tool blocks),
     /// so an `input_json_delta` knows which canonical tool call it belongs to.
     block_tool_ids: Vec<String>,
+    /// per content-block index → its canonical kind, so `content_block_stop`
+    /// can emit the matching [`StreamPart::TextEnd`] / [`StreamPart::ReasoningEnd`]
+    /// for the block that just closed. `None` for an index never opened or for a
+    /// block kind that carries no lifecycle marker (tool / web-search results).
+    block_kinds: Vec<Option<BlockKind>>,
     usage: Usage,
 }
 
@@ -1815,17 +1820,36 @@ impl StreamDecoder for MessagesStreamDecoder {
                     self.block_tool_ids.push(String::new());
                 }
                 self.block_tool_ids[index] = tool_id.clone();
-                if kind == BlockKind::ToolUse {
-                    // emit an opening ToolCallDelta carrying the tool name
-                    let name = block
-                        .and_then(|b| b.get("name"))
-                        .and_then(|n| n.as_str())
-                        .map(|s| s.to_string());
-                    parts.push(StreamPart::ToolCallDelta {
-                        id: tool_id,
-                        name,
-                        arguments: String::new(),
-                    });
+                while self.block_kinds.len() <= index {
+                    self.block_kinds.push(None);
+                }
+                self.block_kinds[index] = Some(kind);
+                match kind {
+                    // Text / thinking blocks carry an explicit lifecycle on this
+                    // wire; surface the open as a canonical start marker so a
+                    // framing client encoder reopens a fresh block (the
+                    // merged-block fix). The block id is Anthropic's numeric
+                    // index rendered as a string.
+                    BlockKind::Text => parts.push(StreamPart::TextStart {
+                        id: index.to_string(),
+                    }),
+                    BlockKind::Thinking => parts.push(StreamPart::ReasoningStart {
+                        id: index.to_string(),
+                    }),
+                    BlockKind::ToolUse => {
+                        // A tool block's open already frames itself via the
+                        // `name`-bearing `ToolCallDelta` below — no separate
+                        // start marker (see the `StreamPart` enum docs).
+                        let name = block
+                            .and_then(|b| b.get("name"))
+                            .and_then(|n| n.as_str())
+                            .map(|s| s.to_string());
+                        parts.push(StreamPart::ToolCallDelta {
+                            id: tool_id,
+                            name,
+                            arguments: String::new(),
+                        });
+                    }
                 }
             }
             "content_block_delta" => {
@@ -1868,7 +1892,22 @@ impl StreamDecoder for MessagesStreamDecoder {
                     _ => {}
                 }
             }
-            "content_block_stop" => {}
+            "content_block_stop" => {
+                // Close the matching text / reasoning block so the boundary
+                // survives re-encoding. Tool / web-search blocks carry no end
+                // marker (their framing is the `name`-bearing delta on open and
+                // the next block / terminal on close).
+                let index = json.get("index").and_then(|i| i.as_u64()).unwrap_or(0) as usize;
+                match self.block_kinds.get(index).copied().flatten() {
+                    Some(BlockKind::Text) => parts.push(StreamPart::TextEnd {
+                        id: index.to_string(),
+                    }),
+                    Some(BlockKind::Thinking) => parts.push(StreamPart::ReasoningEnd {
+                        id: index.to_string(),
+                    }),
+                    _ => {}
+                }
+            }
             "message_delta" => {
                 // `message_delta.usage` carries the cumulative final counts
                 // (<https://docs.anthropic.com/en/api/messages-streaming>).
@@ -2091,6 +2130,39 @@ impl MessagesStreamEncoder {
         }
     }
 
+    /// Force-open a *fresh* text / thinking block, emitting its
+    /// `content_block_start`. Unlike [`Self::ensure_block_open`] this always
+    /// closes any currently-open block first, so an explicit canonical
+    /// [`StreamPart::TextStart`] / [`StreamPart::ReasoningStart`] starts a new
+    /// content block at the next index even when one of the same kind was
+    /// already open — this is the merged-block fix on this wire. A `text` block
+    /// opens with an empty `text`, a `thinking` block with empty `thinking`,
+    /// matching `content_block_start` on each kind.
+    /// <https://docs.anthropic.com/en/api/messages-streaming>
+    fn open_fresh_block(&mut self, frames: &mut Vec<SseFrame>, kind: EncoderBlockKind) {
+        self.close_block(frames);
+        self.block_kind = Some(kind);
+        self.block_open = true;
+        let content_block = match kind {
+            EncoderBlockKind::Text => serde_json::json!({ "type": "text", "text": "" }),
+            EncoderBlockKind::Thinking => serde_json::json!({ "type": "thinking", "thinking": "" }),
+            // Tool blocks frame themselves via the `name`-bearing `ToolCallDelta`
+            // arm, never through a start marker; keep the payload self-consistent
+            // if a future caller routes one here.
+            EncoderBlockKind::ToolUse => {
+                serde_json::json!({ "type": "tool_use", "id": "", "name": "", "input": {} })
+            }
+        };
+        frames.push(Self::ev(
+            "content_block_start",
+            serde_json::json!({
+                "type": "content_block_start",
+                "index": self.block_index,
+                "content_block": content_block,
+            }),
+        ));
+    }
+
     /// Emit the terminal `message_delta` + `message_stop` frames. Shared by the
     /// `Finish` and `ResponseCompleted` encode arms. Anthropic's
     /// `message_delta.usage` carries `output_tokens`, `input_tokens`, and the
@@ -2165,6 +2237,20 @@ impl StreamEncoder for MessagesStreamEncoder {
             StreamPart::File { .. } => {
                 // Anthropic Messages streaming has no file-output content block;
                 // a generated file is surfaced only on the non-streaming path.
+            }
+            StreamPart::TextStart { .. } => {
+                // Explicit block boundary from a block-framed upstream — open a
+                // *fresh* text content block so two distinct upstream text blocks
+                // re-encode as two `content_block_start`s, not one merged block.
+                self.open_fresh_block(&mut frames, EncoderBlockKind::Text);
+            }
+            StreamPart::ReasoningStart { .. } => {
+                self.open_fresh_block(&mut frames, EncoderBlockKind::Thinking);
+            }
+            StreamPart::TextEnd { .. } | StreamPart::ReasoningEnd { .. } => {
+                // Close the block the matching start opened; `close_block` is a
+                // no-op if nothing is open, so a stray end is harmless.
+                self.close_block(&mut frames);
             }
             StreamPart::TextDelta { text } => {
                 if self.ensure_block_open(&mut frames, EncoderBlockKind::Text) {

--- a/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
@@ -22,8 +22,8 @@ use crate::language_model::protocol::{
 };
 use crate::language_model::stream::SseFrame;
 use crate::language_model::types::{
-    ApiProtocol, AuthScheme, Content, FinishReason, GenerateResult, GenerationParams, Message,
-    Prompt, ResponseFormat, Role, RoutingTarget, StopDetails, StreamPart, Usage,
+    ApiProtocol, AuthScheme, Content, DataContent, FinishReason, GenerateResult, GenerationParams,
+    Message, Prompt, ResponseFormat, Role, RoutingTarget, StopDetails, StreamPart, Usage,
 };
 
 /// The Messages inbound + outbound protocol adapter.
@@ -412,6 +412,7 @@ impl InboundAdapter for MessagesAdapter {
                 top_p: req.top_p,
                 max_tokens: req.max_tokens,
                 reasoning_effort,
+                response_modalities: Vec::new(),
                 extra,
             },
             response_format,
@@ -717,6 +718,25 @@ fn render_content_block(c: &Content) -> Option<serde_json::Value> {
         }
         // tool results are request-side only; not part of an assistant reply
         Content::ToolResult { .. } => None,
+        // image/* -> an `image` block, everything else -> a `document` block.
+        // Source is `{type:base64,media_type,data}` or `{type:url,url}`.
+        // <https://docs.anthropic.com/en/docs/build-with-claude/vision>
+        Content::File {
+            media_type, data, ..
+        } => {
+            let source = match data {
+                DataContent::Base64 { data } => serde_json::json!({
+                    "type": "base64", "media_type": media_type, "data": data
+                }),
+                DataContent::Url { url } => serde_json::json!({ "type": "url", "url": url }),
+            };
+            let block_type = if media_type.starts_with("image/") {
+                "image"
+            } else {
+                "document"
+            };
+            Some(serde_json::json!({ "type": block_type, "source": source }))
+        }
     }
 }
 

--- a/crates/bitrouter-sdk/src/language_model/protocol/mod.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/mod.rs
@@ -84,6 +84,88 @@ pub mod responses;
 #[cfg(test)]
 mod tests;
 
+/// Provider-id prefix for OpenAI tools (Responses wire): `openai.<tool>`.
+pub(crate) const PROVIDER_ID_OPENAI: &str = "openai";
+/// Provider-id prefix for Anthropic tools (Messages wire): `anthropic.<tool>`.
+pub(crate) const PROVIDER_ID_ANTHROPIC: &str = "anthropic";
+/// Provider-id prefix for Google tools (Generate Content wire): `google.<tool>`.
+pub(crate) const PROVIDER_ID_GOOGLE: &str = "google";
+
+/// Split a provider-namespaced tool id (`<provider-id>.<tool-name>`, e.g.
+/// `openai.web_search_preview`) into `(provider_id, tool_name)`. If the id has
+/// no `.` separator the whole string is treated as the tool name with an empty
+/// provider id, so a malformed id never panics — the caller renders it verbatim.
+pub(crate) fn split_provider_id(id: &str) -> (&str, &str) {
+    match id.split_once('.') {
+        Some((provider, tool)) => (provider, tool),
+        None => ("", id),
+    }
+}
+
+/// Reconstruct a provider-defined tool's **source-native** wire object from its
+/// canonical `(id, name, args)`, as the originating provider serializes it.
+///
+/// This is the single source of truth for both directions of provider-defined
+/// tools:
+///
+/// - **Same-protocol render** (the tool's `id` prefix matches the target wire):
+///   the output is exactly the native shape the provider expects, so a
+///   provider-defined tool round-trips losslessly.
+/// - **Cross-protocol render** (foreign `id` prefix): bitrouter does not have a
+///   faithful 1:1 equivalent on a different provider's wire (V3 namespaces these
+///   tools by provider for exactly this reason), so the *faithful* behavior is to
+///   preserve the tool **verbatim** in its source-native shape and let the
+///   upstream decide — the same rule as
+///   [`ToolChoice::Other`](crate::language_model::types::ToolChoice::Other). The
+///   caller splats this object into the target request's tool list unchanged.
+///
+/// Native shapes (one comment-linked doc per provider lives at each adapter's
+/// tool render site):
+/// - OpenAI / Responses — a flat object `{type:<tool>, …args}`.
+/// - Anthropic / Messages — `{type:<tool>, name, …args}` (versioned `type` + a
+///   stable `name`).
+/// - Google / Generate Content — a single-key object `{<toolKey>: args}` (the
+///   `args` already carry the camelCase tool key's value).
+///
+/// `args` must be a JSON object; a non-object `args` (only reachable from a
+/// hand-built canonical value) is treated as empty so this never panics.
+pub(crate) fn provider_defined_native(
+    id: &str,
+    name: &str,
+    args: &serde_json::Value,
+) -> serde_json::Value {
+    let (provider, tool) = split_provider_id(id);
+    let arg_fields = args.as_object().cloned().unwrap_or_default();
+    match provider {
+        PROVIDER_ID_ANTHROPIC => {
+            // Anthropic server tools: `{type:"web_search_20250305", name:"web_search", …args}`.
+            let mut obj = serde_json::Map::new();
+            obj.insert("type".into(), tool.into());
+            obj.insert("name".into(), name.into());
+            obj.extend(arg_fields);
+            serde_json::Value::Object(obj)
+        }
+        PROVIDER_ID_GOOGLE => {
+            // Google tools live as a single camelCase key on the tool object:
+            // `{googleSearch:{}}`, `{codeExecution:{}}`, `{urlContext:{}}`, …
+            // The key is the tool name; its value is the (possibly empty) args.
+            let value = args.as_object().map_or_else(
+                || serde_json::json!({}),
+                |m| serde_json::Value::Object(m.clone()),
+            );
+            serde_json::json!({ tool: value })
+        }
+        // OpenAI / Responses (and any other provider id) — a flat `{type, …args}`
+        // object, which is also the most faithful generic verbatim form.
+        _ => {
+            let mut obj = serde_json::Map::new();
+            obj.insert("type".into(), tool.into());
+            obj.extend(arg_fields);
+            serde_json::Value::Object(obj)
+        }
+    }
+}
+
 /// A parsed Server-Sent-Events event from an upstream stream.
 #[derive(Debug, Clone, Default)]
 pub struct SseEvent {

--- a/crates/bitrouter-sdk/src/language_model/protocol/mod.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/mod.rs
@@ -73,8 +73,67 @@ use async_trait::async_trait;
 use crate::error::Result;
 use crate::language_model::stream::SseFrame;
 use crate::language_model::types::{
-    ApiProtocol, GenerateResult, Prompt, RoutingTarget, StreamPart,
+    ApiProtocol, FinishReason, GenerateResult, Prompt, ProviderMetadata, RoutingTarget, StreamPart,
+    provider_namespace, set_provider_metadata,
 };
+
+/// The provider-metadata key under which a lossy finish-reason mapping stashes
+/// the **raw** provider finish reason. The canonical [`FinishReason`] enum maps
+/// several distinct native reasons onto one variant (Anthropic `stop_sequence`
+/// and `end_turn` both → `Stop`; Gemini `RECITATION` / `BLOCKLIST` /
+/// `PROHIBITED_CONTENT` and `SAFETY` all → `ContentFilter`; Chat Completions
+/// `function_call` → `ToolCalls`), so re-rendering from the enum alone would
+/// lose the exact native string on a same-protocol round-trip. Adapters stash
+/// the raw string here under their own provider id when (and only when) the
+/// mapping is lossy, and read it back on render.
+pub(crate) const RAW_FINISH_REASON: &str = "rawFinishReason";
+
+/// Record the raw provider finish-reason string under
+/// `meta[provider_id]["rawFinishReason"]` **iff** re-rendering the unified
+/// `finish` through `render` would not reproduce `raw` verbatim. Reasons that
+/// already round-trip losslessly (e.g. Chat Completions `stop`, Gemini `STOP`)
+/// store nothing, keeping the metadata map empty in the common case.
+///
+/// This is the single source of truth every adapter's `parse_response` uses to
+/// avoid the documented cross-mapping loss; the matching read is
+/// [`rendered_finish_reason`].
+pub(crate) fn stash_raw_finish_reason(
+    meta: &mut ProviderMetadata,
+    provider_id: &str,
+    raw: Option<&str>,
+    finish: Option<&FinishReason>,
+    render: impl Fn(&FinishReason) -> String,
+) {
+    if let (Some(raw), Some(finish)) = (raw, finish)
+        && render(finish) != raw
+    {
+        set_provider_metadata(
+            meta,
+            provider_id,
+            RAW_FINISH_REASON,
+            serde_json::Value::String(raw.to_string()),
+        );
+    }
+}
+
+/// Render a result's finish reason to its native wire string, preferring a
+/// stashed [`RAW_FINISH_REASON`] (under `provider_id`) over the enum mapping so
+/// a lossy parse round-trips byte-for-byte. Falls back to `render(finish)` when
+/// no raw was stashed (the lossless case) and to `None` when the result carries
+/// no finish reason at all.
+///
+/// The matching write is [`stash_raw_finish_reason`].
+pub(crate) fn rendered_finish_reason(
+    result: &GenerateResult,
+    provider_id: &str,
+    render: impl Fn(&FinishReason) -> String,
+) -> Option<String> {
+    let finish = result.finish_reason.as_ref()?;
+    let raw = provider_namespace(&result.provider_metadata, provider_id)
+        .and_then(|o| o.get(RAW_FINISH_REASON))
+        .and_then(|v| v.as_str());
+    Some(raw.map_or_else(|| render(finish), str::to_string))
+}
 
 pub mod chat_completions;
 pub mod generate_content;

--- a/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
@@ -29,7 +29,8 @@ use crate::language_model::protocol::{
 use crate::language_model::stream::SseFrame;
 use crate::language_model::types::{
     ApiProtocol, Content, DataContent, FinishReason, GenerateResult, GenerationParams, Message,
-    Prompt, ResponseFormat, Role, RoutingTarget, StreamPart, ToolResultOutput, Usage,
+    Prompt, ResponseFormat, Role, RoutingTarget, StreamPart, ToolResultContentPart,
+    ToolResultOutput, Usage,
 };
 
 /// The Responses protocol adapter.
@@ -252,14 +253,15 @@ fn parse_input(value: &serde_json::Value) -> Result<Vec<Message>> {
                         });
                     }
                     // OpenAI Responses `function_call_output {call_id, output}`:
-                    // `output` is a string or structured JSON, with no tool name
-                    // and no error flag on the wire. A string → Text, any other
+                    // `output` is a string, a content-part array, or (loosely) a
+                    // bare JSON value, with no tool name and no error flag on the
+                    // wire. A string → Text, a part array → Content, any other
                     // value → Json.
                     // <https://platform.openai.com/docs/api-reference/responses/create>
                     Some("function_call_output") => {
                         let output = item
                             .get("output")
-                            .map(ToolResultOutput::from_untyped_value)
+                            .map(parse_responses_tool_output)
                             .unwrap_or_else(|| ToolResultOutput::Text {
                                 value: String::new(),
                             });
@@ -728,10 +730,10 @@ fn render_message_items(m: &Message) -> Vec<serde_json::Value> {
                 };
                 text_parts.push(part);
             }
-            // Responses `function_call_output {call_id, output}`. `output` carries
-            // no error flag and no tool name, so an error output degrades to its
-            // value and `tool_name` is dropped. `Json` / `ErrorJson` preserve
-            // their structured value; the text/content variants stringify.
+            // Responses `function_call_output {call_id, output}`. `output` is a
+            // string or content-part array, with no error flag and no tool name,
+            // so an error output degrades to its value and `tool_name` is dropped.
+            // `Json` / `ErrorJson` stringify; `Content` becomes a part array.
             // <https://platform.openai.com/docs/api-reference/responses/create>
             Content::ToolResult {
                 call_id, output, ..
@@ -759,14 +761,130 @@ fn render_message_items(m: &Message) -> Vec<serde_json::Value> {
 }
 
 /// Render a [`ToolResultOutput`] into a Responses `function_call_output.output`
-/// value. Structured `Json` / `ErrorJson` keep their value (Responses accepts a
-/// structured output); the text and multimodal variants stringify (the wire has
-/// no media slot for tool output here).
+/// value. The wire's `output` is `string | content-part-array`, never a bare
+/// JSON-value slot: `Text` / `ErrorText` pass through as a string, `Json` /
+/// `ErrorJson` are **stringified** (the reference does `JSON.stringify`), and a
+/// multimodal `Content` becomes a part array of `input_text` / `input_image` /
+/// `input_file` — the same wire shapes a user message uses, so media survives
+/// rather than being flattened to text. The error flag and tool name have no
+/// slot here and are dropped.
 /// <https://platform.openai.com/docs/api-reference/responses/create>
+/// <https://github.com/vercel/ai/blob/main/packages/openai/src/responses/convert-to-openai-responses-input.ts>
 fn render_responses_tool_output(output: &ToolResultOutput) -> serde_json::Value {
     match output {
-        ToolResultOutput::Json { value } | ToolResultOutput::ErrorJson { value } => value.clone(),
+        // `output` is a string slot, not a JSON-value slot: stringify the value
+        // (matching the reference's `JSON.stringify(output.value)`) rather than
+        // emitting a bare object the wire would reject.
+        ToolResultOutput::Json { value } | ToolResultOutput::ErrorJson { value } => {
+            serde_json::Value::String(value.to_string())
+        }
+        ToolResultOutput::Content { value } => serde_json::Value::Array(
+            value
+                .iter()
+                .map(render_responses_tool_output_part)
+                .collect(),
+        ),
         other => serde_json::Value::String(other.to_provider_string()),
+    }
+}
+
+/// Render one [`ToolResultContentPart`] into a Responses tool-output content
+/// part. `text` → `input_text`; `image/*` media or an image file reference →
+/// `input_image`; any other media or file reference → `input_file`. Media bytes
+/// ride as a `data:` URL or a plain URL; a provider file reference rides as
+/// `file_id`.
+/// <https://github.com/vercel/ai/blob/main/packages/openai/src/responses/convert-to-openai-responses-input.ts>
+fn render_responses_tool_output_part(part: &ToolResultContentPart) -> serde_json::Value {
+    match part {
+        ToolResultContentPart::Text { text } => {
+            serde_json::json!({ "type": "input_text", "text": text })
+        }
+        ToolResultContentPart::Media { media_type, data } => {
+            if media_type.starts_with("image/") {
+                serde_json::json!({
+                    "type": "input_image", "image_url": data.to_url(media_type)
+                })
+            } else {
+                // The reference renders a `url`-form file as `file_url` and a
+                // `data`-form file as `file_data`; `to_url` already collapses
+                // inline bytes into a `data:` URL, so both land in `file_data`
+                // here — a value the Responses wire accepts for either form.
+                serde_json::json!({
+                    "type": "input_file", "file_data": data.to_url(media_type)
+                })
+            }
+        }
+        ToolResultContentPart::FileId { media_type, id } => {
+            let kind = match media_type {
+                Some(mt) if mt.starts_with("image/") => "input_image",
+                _ => "input_file",
+            };
+            serde_json::json!({ "type": kind, "file_id": id })
+        }
+    }
+}
+
+/// Parse a Responses `function_call_output.output` value into a canonical
+/// [`ToolResultOutput`]. A string or bare JSON value uses the untyped mapping
+/// (string → `Text`, else `Json`); a content-part array becomes the multimodal
+/// `Content` variant, inverting [`render_responses_tool_output`].
+/// <https://platform.openai.com/docs/api-reference/responses/create>
+fn parse_responses_tool_output(value: &serde_json::Value) -> ToolResultOutput {
+    match value {
+        serde_json::Value::Array(parts) => ToolResultOutput::Content {
+            value: parts
+                .iter()
+                .filter_map(parse_responses_tool_output_part)
+                .collect(),
+        },
+        other => ToolResultOutput::from_untyped_value(other),
+    }
+}
+
+/// Parse one Responses tool-output content part into a [`ToolResultContentPart`].
+/// `input_text` → text; `input_image` / `input_file` carry either a `file_id`
+/// (→ [`ToolResultContentPart::FileId`]) or an inline/URL payload
+/// (→ [`ToolResultContentPart::Media`]).
+/// <https://github.com/vercel/ai/blob/main/packages/openai/src/responses/convert-to-openai-responses-input.ts>
+fn parse_responses_tool_output_part(part: &serde_json::Value) -> Option<ToolResultContentPart> {
+    match part.get("type").and_then(|t| t.as_str())? {
+        "input_text" | "text" => Some(ToolResultContentPart::Text {
+            text: part.get("text").and_then(|t| t.as_str())?.to_string(),
+        }),
+        "input_image" => {
+            if let Some(id) = part.get("file_id").and_then(|f| f.as_str()) {
+                return Some(ToolResultContentPart::FileId {
+                    media_type: Some("image/*".to_string()),
+                    id: id.to_string(),
+                });
+            }
+            let url = part.get("image_url").and_then(|u| u.as_str())?;
+            let (media_type, data) = DataContent::from_url(url);
+            Some(ToolResultContentPart::Media {
+                media_type: media_type.unwrap_or_else(|| "image/*".to_string()),
+                data,
+            })
+        }
+        "input_file" => {
+            if let Some(id) = part.get("file_id").and_then(|f| f.as_str()) {
+                return Some(ToolResultContentPart::FileId {
+                    media_type: None,
+                    id: id.to_string(),
+                });
+            }
+            // The data form carries `file_data` (a `data:` URL); the url form
+            // carries `file_url`. Either resolves through the shared parser.
+            let payload = part
+                .get("file_data")
+                .or_else(|| part.get("file_url"))
+                .and_then(|d| d.as_str())?;
+            let (media_type, data) = DataContent::from_url(payload);
+            Some(ToolResultContentPart::Media {
+                media_type: media_type.unwrap_or_else(|| "application/octet-stream".to_string()),
+                data,
+            })
+        }
+        _ => None,
     }
 }
 

--- a/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
@@ -29,7 +29,7 @@ use crate::language_model::protocol::{
 use crate::language_model::stream::SseFrame;
 use crate::language_model::types::{
     ApiProtocol, Content, DataContent, FinishReason, GenerateResult, GenerationParams, Message,
-    Prompt, ResponseFormat, Role, RoutingTarget, StreamPart, Tool, ToolChoice,
+    Prompt, ResponseFormat, Role, RoutingTarget, Source, StreamPart, Tool, ToolChoice,
     ToolResultContentPart, ToolResultOutput, Usage,
 };
 
@@ -227,6 +227,119 @@ fn parse_responses_part(part: &serde_json::Value) -> Option<Content> {
         }
         _ => None,
     }
+}
+
+/// Parse a Responses `output_text` part's `annotations[]` into canonical
+/// [`Content::Source`] parts, with `next_index` tracking the running citation
+/// count so synthesized ids stay unique across parts/items. Mirrors the AI SDK
+/// OpenAI Responses mapping:
+/// - `url_citation` (`{url, title}`) → [`Source::Url`];
+/// - `file_citation` / `container_file_citation` (`{filename, file_id}`) →
+///   [`Source::Document`] with `media_type: text/plain`, `title`/`filename` from
+///   `filename`;
+/// - `file_path` (`{file_id}`) → [`Source::Document`] with
+///   `media_type: application/octet-stream`, `title`/`filename` from `file_id`.
+///
+/// The wire carries no citation id, so one is synthesized (from the url, or from
+/// `file_id`/`filename` for documents) + index. The `index`/`start_index` text
+/// offsets and the `file_id`/`container_id` provider fields have no canonical
+/// slot and are dropped — see [`Source`].
+/// <https://github.com/vercel/ai/blob/main/packages/openai/src/responses/openai-responses-language-model.ts>
+fn parse_responses_annotations(
+    annotations: Option<&serde_json::Value>,
+    next_index: &mut usize,
+) -> Vec<Content> {
+    let Some(arr) = annotations.and_then(|a| a.as_array()) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for ann in arr {
+        let source = match ann.get("type").and_then(|t| t.as_str()) {
+            Some("url_citation") => {
+                let Some(url) = ann.get("url").and_then(|u| u.as_str()) else {
+                    continue;
+                };
+                Source::Url {
+                    id: Source::synthesize_id(url, *next_index),
+                    url: url.to_string(),
+                    title: ann
+                        .get("title")
+                        .and_then(|t| t.as_str())
+                        .map(str::to_string),
+                }
+            }
+            Some("file_citation") | Some("container_file_citation") => {
+                let filename = ann
+                    .get("filename")
+                    .and_then(|f| f.as_str())
+                    .unwrap_or_default()
+                    .to_string();
+                Source::Document {
+                    id: Source::synthesize_id(&filename, *next_index),
+                    media_type: "text/plain".to_string(),
+                    title: filename.clone(),
+                    filename: (!filename.is_empty()).then_some(filename),
+                }
+            }
+            Some("file_path") => {
+                let file_id = ann
+                    .get("file_id")
+                    .and_then(|f| f.as_str())
+                    .unwrap_or_default()
+                    .to_string();
+                Source::Document {
+                    id: Source::synthesize_id(&file_id, *next_index),
+                    media_type: "application/octet-stream".to_string(),
+                    title: file_id.clone(),
+                    filename: (!file_id.is_empty()).then_some(file_id),
+                }
+            }
+            _ => continue,
+        };
+        out.push(Content::Source { source });
+        *next_index += 1;
+    }
+    out
+}
+
+/// Render canonical [`Content::Source`] parts into a Responses `annotations[]`
+/// array for an `output_text` part — the location [`parse_responses_annotations`]
+/// reads. [`Source::Url`] → `url_citation`; [`Source::Document`] →
+/// `file_citation` (keyed by `filename`). The `file_id`/`container_id` provider
+/// fields cannot be reconstructed from the canonical `Source` and are omitted on
+/// the document path (documented loss). Returns an empty Vec when the result
+/// carries no sources.
+/// <https://platform.openai.com/docs/api-reference/responses/object> (`annotations`)
+fn render_responses_annotations(result: &GenerateResult) -> Vec<serde_json::Value> {
+    result
+        .content
+        .iter()
+        .filter_map(|c| match c {
+            Content::Source {
+                source: Source::Url { url, title, .. },
+            } => {
+                let mut ann = serde_json::Map::new();
+                ann.insert("type".into(), "url_citation".into());
+                ann.insert("url".into(), url.clone().into());
+                if let Some(title) = title {
+                    ann.insert("title".into(), title.clone().into());
+                }
+                Some(serde_json::Value::Object(ann))
+            }
+            Content::Source {
+                source: Source::Document {
+                    title, filename, ..
+                },
+            } => {
+                let name = filename.clone().unwrap_or_else(|| title.clone());
+                Some(serde_json::json!({
+                    "type": "file_citation",
+                    "filename": name,
+                }))
+            }
+            _ => None,
+        })
+        .collect()
 }
 
 /// Parse the Responses `input` field — a string or a heterogeneous item array.
@@ -574,6 +687,9 @@ impl OutboundAdapter for ResponsesAdapter {
             .and_then(|o| o.as_array())
             .ok_or_else(|| BitrouterError::bad_request("responses response missing 'output'"))?;
         let mut content = Vec::new();
+        // Running citation counter so synthesized source ids stay unique across
+        // every annotated output_text part in the response.
+        let mut source_index = 0usize;
         for item in output {
             match item.get("type").and_then(|t| t.as_str()) {
                 Some("message") => {
@@ -584,6 +700,13 @@ impl OutboundAdapter for ResponsesAdapter {
                                     text: text.to_string(),
                                 });
                             }
+                            // An `output_text` part may carry web-search / file
+                            // citations on `annotations[]`; lift them into
+                            // `Content::Source` parts right after the text.
+                            content.extend(parse_responses_annotations(
+                                part.get("annotations"),
+                                &mut source_index,
+                            ));
                         }
                     }
                 }
@@ -971,6 +1094,9 @@ fn render_message_items(m: &Message) -> Vec<serde_json::Value> {
                     "output": output_value,
                 }));
             }
+            // Citation sources are response-side metadata only; they are never
+            // re-sent as a request input item, so the request path skips them.
+            Content::Source { .. } => {}
         }
     }
     if !text_parts.is_empty() {
@@ -1140,10 +1266,20 @@ fn render_output_items(result: &GenerateResult) -> Vec<serde_json::Value> {
         })
         .collect();
     if !text.is_empty() {
+        // Re-attach citations as the `output_text` part's `annotations[]` (the
+        // location `parse_response` lifts them from), collected from the result's
+        // `Content::Source` parts rather than rendered per-part. The key is
+        // omitted entirely when there are no sources (#454-5: never emit null /
+        // gratuitous empty fields).
+        let mut part = serde_json::json!({ "type": "output_text", "text": text });
+        let annotations = render_responses_annotations(result);
+        if !annotations.is_empty() {
+            part["annotations"] = annotations.into();
+        }
         items.push(serde_json::json!({
             "type": "message",
             "role": "assistant",
-            "content": [{ "type": "output_text", "text": text }],
+            "content": [part],
         }));
     }
     for c in &result.content {
@@ -1875,6 +2011,18 @@ impl StreamEncoder for ResponsesStreamEncoder {
                         }),
                     ));
                 }
+            }
+            StreamPart::Source { .. } => {
+                // Streaming citations are NOT re-encoded onto the Responses wire.
+                // On this protocol a citation is a `response.output_text.annotation.added`
+                // event that mutates an already-open `output_text` item's
+                // `annotations[]`; a cross-protocol `StreamPart::Source` arrives
+                // with no guaranteed open text item to attach to, and faithfully
+                // re-emitting the `*.annotation.added` lifecycle would require
+                // buffering against the text item-state machine. Documented gap:
+                // the citation survives the non-streaming Responses render
+                // (`render_output_items`) but is dropped on the streamed path.
+                // <https://platform.openai.com/docs/api-reference/responses-streaming/response/output_text/annotation_added>
             }
             StreamPart::Usage { .. } => {}
             StreamPart::ResponseStarted { .. } => {

--- a/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
@@ -28,8 +28,8 @@ use crate::language_model::protocol::{
 };
 use crate::language_model::stream::SseFrame;
 use crate::language_model::types::{
-    ApiProtocol, Content, FinishReason, GenerateResult, GenerationParams, Message, Prompt,
-    ResponseFormat, Role, RoutingTarget, StreamPart, Usage,
+    ApiProtocol, Content, DataContent, FinishReason, GenerateResult, GenerationParams, Message,
+    Prompt, ResponseFormat, Role, RoutingTarget, StreamPart, Usage,
 };
 
 /// The Responses protocol adapter.
@@ -162,17 +162,49 @@ fn role_str(role: Role) -> &'static str {
     }
 }
 
-/// Extract text from a Responses `content` value: a string, or an array of
-/// `{type:"input_text"|"output_text"|"text", text}` parts.
-fn content_text(value: &serde_json::Value) -> String {
+/// Parse a Responses `content` value (string or array of content parts) into
+/// ordered canonical content.
+fn parse_responses_content(value: Option<&serde_json::Value>) -> Vec<Content> {
     match value {
-        serde_json::Value::String(s) => s.clone(),
-        serde_json::Value::Array(parts) => parts
-            .iter()
-            .filter_map(|p| p.get("text").and_then(|t| t.as_str()))
-            .collect::<Vec<_>>()
-            .join(""),
-        _ => String::new(),
+        Some(serde_json::Value::String(s)) => vec![Content::Text { text: s.clone() }],
+        Some(serde_json::Value::Array(parts)) => {
+            parts.iter().filter_map(parse_responses_part).collect()
+        }
+        _ => Vec::new(),
+    }
+}
+
+/// Parse one Responses content part into canonical content.
+/// <https://platform.openai.com/docs/api-reference/responses/create>
+fn parse_responses_part(part: &serde_json::Value) -> Option<Content> {
+    match part.get("type").and_then(|t| t.as_str())? {
+        "input_text" | "output_text" | "text" => Some(Content::Text {
+            text: part.get("text").and_then(|t| t.as_str())?.to_string(),
+        }),
+        "input_image" => {
+            let url = part.get("image_url").and_then(|u| u.as_str())?;
+            let (media_type, data) = DataContent::from_url(url);
+            Some(Content::File {
+                media_type: media_type.unwrap_or_else(|| "image/*".to_string()),
+                data,
+                filename: None,
+                extra: Default::default(),
+            })
+        }
+        "input_file" => {
+            let file_data = part.get("file_data").and_then(|d| d.as_str())?;
+            let (media_type, data) = DataContent::from_url(file_data);
+            Some(Content::File {
+                media_type: media_type.unwrap_or_else(|| "application/octet-stream".to_string()),
+                data,
+                filename: part
+                    .get("filename")
+                    .and_then(|f| f.as_str())
+                    .map(str::to_string),
+                extra: Default::default(),
+            })
+        }
+        _ => None,
     }
 }
 
@@ -191,13 +223,14 @@ fn parse_input(value: &serde_json::Value) -> Result<Vec<Message>> {
                     Some("message") | None => {
                         if let Some(role) = item.get("role").and_then(|r| r.as_str()) {
                             let role = parse_role(role)?;
-                            let text = item.get("content").map(content_text).unwrap_or_default();
-                            messages.push(Message::text(role, text));
+                            let content = parse_responses_content(item.get("content"));
+                            messages.push(Message { role, content });
                         }
                     }
                     Some("function_call") => {
                         messages.push(Message {
                             role: Role::Assistant,
+                            // tool calls are single-part assistant turns
                             content: vec![Content::ToolCall {
                                 id: item
                                     .get("call_id")

--- a/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
@@ -29,8 +29,8 @@ use crate::language_model::protocol::{
 use crate::language_model::stream::SseFrame;
 use crate::language_model::types::{
     ApiProtocol, Content, DataContent, FinishReason, GenerateResult, GenerationParams, Message,
-    Prompt, ResponseFormat, Role, RoutingTarget, Source, StreamPart, Tool, ToolChoice,
-    ToolResultContentPart, ToolResultOutput, Usage,
+    Prompt, ProviderMetadata, ResponseFormat, Role, RoutingTarget, Source, StreamPart, Tool,
+    ToolChoice, ToolResultContentPart, ToolResultOutput, Usage,
 };
 
 /// The Responses protocol adapter.
@@ -187,7 +187,10 @@ fn role_str(role: Role) -> &'static str {
 /// ordered canonical content.
 fn parse_responses_content(value: Option<&serde_json::Value>) -> Vec<Content> {
     match value {
-        Some(serde_json::Value::String(s)) => vec![Content::Text { text: s.clone() }],
+        Some(serde_json::Value::String(s)) => vec![Content::Text {
+            text: s.clone(),
+            provider_metadata: ProviderMetadata::new(),
+        }],
         Some(serde_json::Value::Array(parts)) => {
             parts.iter().filter_map(parse_responses_part).collect()
         }
@@ -201,6 +204,7 @@ fn parse_responses_part(part: &serde_json::Value) -> Option<Content> {
     match part.get("type").and_then(|t| t.as_str())? {
         "input_text" | "output_text" | "text" => Some(Content::Text {
             text: part.get("text").and_then(|t| t.as_str())?.to_string(),
+            provider_metadata: ProviderMetadata::new(),
         }),
         "input_image" => {
             let url = part.get("image_url").and_then(|u| u.as_str())?;
@@ -209,7 +213,7 @@ fn parse_responses_part(part: &serde_json::Value) -> Option<Content> {
                 media_type: media_type.unwrap_or_else(|| "image/*".to_string()),
                 data,
                 filename: None,
-                extra: Default::default(),
+                provider_metadata: ProviderMetadata::new(),
             })
         }
         "input_file" => {
@@ -222,7 +226,7 @@ fn parse_responses_part(part: &serde_json::Value) -> Option<Content> {
                     .get("filename")
                     .and_then(|f| f.as_str())
                     .map(str::to_string),
-                extra: Default::default(),
+                provider_metadata: ProviderMetadata::new(),
             })
         }
         _ => None,
@@ -296,7 +300,10 @@ fn parse_responses_annotations(
             }
             _ => continue,
         };
-        out.push(Content::Source { source });
+        out.push(Content::Source {
+            source,
+            provider_metadata: ProviderMetadata::new(),
+        });
         *next_index += 1;
     }
     out
@@ -315,7 +322,7 @@ fn render_responses_annotations(result: &GenerateResult) -> Vec<serde_json::Valu
         .content
         .iter()
         .filter_map(|c| match c {
-            Content::Source { source } => Some(render_source_annotation(source)),
+            Content::Source { source, .. } => Some(render_source_annotation(source)),
             _ => None,
         })
         .collect()
@@ -368,7 +375,11 @@ fn parse_input(value: &serde_json::Value) -> Result<Vec<Message>> {
                         if let Some(role) = item.get("role").and_then(|r| r.as_str()) {
                             let role = parse_role(role)?;
                             let content = parse_responses_content(item.get("content"));
-                            messages.push(Message { role, content });
+                            messages.push(Message {
+                                role,
+                                content,
+                                provider_metadata: ProviderMetadata::new(),
+                            });
                         }
                     }
                     Some("function_call") => {
@@ -397,7 +408,9 @@ fn parse_input(value: &serde_json::Value) -> Result<Vec<Message>> {
                                 // (`web_search_call`, …) are never re-sent as
                                 // input items.
                                 provider_executed: false,
+                                provider_metadata: ProviderMetadata::new(),
                             }],
+                            provider_metadata: ProviderMetadata::new(),
                         });
                     }
                     // OpenAI Responses `function_call_output {call_id, output}`:
@@ -423,7 +436,9 @@ fn parse_input(value: &serde_json::Value) -> Result<Vec<Message>> {
                                     .to_string(),
                                 tool_name: None,
                                 output,
+                                provider_metadata: ProviderMetadata::new(),
                             }],
+                            provider_metadata: ProviderMetadata::new(),
                         });
                     }
                     Some("reasoning") => {
@@ -440,7 +455,11 @@ fn parse_input(value: &serde_json::Value) -> Result<Vec<Message>> {
                         if !text.is_empty() {
                             messages.push(Message {
                                 role: Role::Assistant,
-                                content: vec![Content::Reasoning { text }],
+                                content: vec![Content::Reasoning {
+                                    text,
+                                    provider_metadata: ProviderMetadata::new(),
+                                }],
+                                provider_metadata: ProviderMetadata::new(),
                             });
                         }
                     }
@@ -709,6 +728,7 @@ impl OutboundAdapter for ResponsesAdapter {
                             if let Some(text) = part.get("text").and_then(|t| t.as_str()) {
                                 content.push(Content::Text {
                                     text: text.to_string(),
+                                    provider_metadata: ProviderMetadata::new(),
                                 });
                             }
                             // An `output_text` part may carry web-search / file
@@ -733,7 +753,10 @@ impl OutboundAdapter for ResponsesAdapter {
                         })
                         .unwrap_or_default();
                     if !text.is_empty() {
-                        content.push(Content::Reasoning { text });
+                        content.push(Content::Reasoning {
+                            text,
+                            provider_metadata: ProviderMetadata::new(),
+                        });
                     }
                 }
                 Some("function_call") => {
@@ -755,6 +778,7 @@ impl OutboundAdapter for ResponsesAdapter {
                             .to_string(),
                         // A `function_call` output item is a client tool call.
                         provider_executed: false,
+                        provider_metadata: ProviderMetadata::new(),
                     });
                 }
                 // OpenAI Responses built-in (server-side) tools surface as their
@@ -791,6 +815,7 @@ impl OutboundAdapter for ResponsesAdapter {
                         // emits an empty input object.
                         arguments: "{}".to_string(),
                         provider_executed: true,
+                        provider_metadata: ProviderMetadata::new(),
                     });
                 }
                 Some("code_interpreter_call") => {
@@ -813,6 +838,7 @@ impl OutboundAdapter for ResponsesAdapter {
                         name: "code_interpreter".to_string(),
                         arguments: serde_json::Value::Object(input).to_string(),
                         provider_executed: true,
+                        provider_metadata: ProviderMetadata::new(),
                     });
                 }
                 // Deferred output-item types — intentionally skipped, not parsed,
@@ -853,6 +879,10 @@ impl OutboundAdapter for ResponsesAdapter {
             finish_reason,
             response_id,
             stop_details: None,
+            // The Responses object carries no result-level field that lacks a
+            // dedicated canonical slot (no `system_fingerprint`, unlike Chat
+            // Completions), so result-level provider metadata is empty here.
+            provider_metadata: ProviderMetadata::new(),
         })
     }
 
@@ -883,6 +913,7 @@ fn parse_responses_tool(t: ResponsesTool) -> Option<Tool> {
                 t.parameters
             },
             strict: t.strict,
+            provider_metadata: ProviderMetadata::new(),
         });
     }
     // Provider-defined server tool. `type` is the tool kind (and the tool name);
@@ -893,6 +924,7 @@ fn parse_responses_tool(t: ResponsesTool) -> Option<Tool> {
         id: format!("{PROVIDER_ID_OPENAI}.{kind}"),
         name: t.name.unwrap_or_else(|| kind.clone()),
         args: serde_json::Value::Object(t.extra.into_iter().collect()),
+        provider_metadata: ProviderMetadata::new(),
     })
 }
 
@@ -913,6 +945,7 @@ fn render_responses_tool(tool: &Tool) -> serde_json::Value {
             description,
             parameters,
             strict,
+            ..
         } => {
             let mut obj = serde_json::Map::new();
             obj.insert("type".into(), "function".into());
@@ -929,7 +962,7 @@ fn render_responses_tool(tool: &Tool) -> serde_json::Value {
             }
             serde_json::Value::Object(obj)
         }
-        Tool::ProviderDefined { id, name, args } => provider_defined_native(id, name, args),
+        Tool::ProviderDefined { id, name, args, .. } => provider_defined_native(id, name, args),
     }
 }
 
@@ -1034,7 +1067,7 @@ fn render_message_items(m: &Message) -> Vec<serde_json::Value> {
     let mut text_parts = Vec::new();
     for c in &m.content {
         match c {
-            Content::Text { text } => {
+            Content::Text { text, .. } => {
                 let kind = if m.role == Role::Assistant {
                     "output_text"
                 } else {
@@ -1050,6 +1083,7 @@ fn render_message_items(m: &Message) -> Vec<serde_json::Value> {
                 name,
                 arguments,
                 provider_executed,
+                ..
             } => {
                 // A provider-executed server-tool call is NOT re-sent as a client
                 // `function_call` input item — the provider already ran it, and
@@ -1258,7 +1292,7 @@ fn render_output_items(result: &GenerateResult) -> Vec<serde_json::Value> {
         .content
         .iter()
         .filter_map(|c| match c {
-            Content::Reasoning { text } => Some(text.as_str()),
+            Content::Reasoning { text, .. } => Some(text.as_str()),
             _ => None,
         })
         .collect();
@@ -1272,7 +1306,7 @@ fn render_output_items(result: &GenerateResult) -> Vec<serde_json::Value> {
         .content
         .iter()
         .filter_map(|c| match c {
-            Content::Text { text } => Some(text.as_str()),
+            Content::Text { text, .. } => Some(text.as_str()),
             _ => None,
         })
         .collect();
@@ -1299,6 +1333,7 @@ fn render_output_items(result: &GenerateResult) -> Vec<serde_json::Value> {
             name,
             arguments,
             provider_executed,
+            ..
         } = c
         {
             if *provider_executed {
@@ -1495,7 +1530,7 @@ impl StreamDecoder for ResponsesStreamDecoder {
                 if let Some(annotation) = json.get("annotation") {
                     let arr = serde_json::Value::Array(vec![annotation.clone()]);
                     for content in parse_responses_annotations(Some(&arr), &mut self.source_index) {
-                        if let Content::Source { source } = content {
+                        if let Content::Source { source, .. } = content {
                             parts.push(StreamPart::Source { source });
                         }
                     }

--- a/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
@@ -29,7 +29,7 @@ use crate::language_model::protocol::{
 use crate::language_model::stream::SseFrame;
 use crate::language_model::types::{
     ApiProtocol, Content, DataContent, FinishReason, GenerateResult, GenerationParams, Message,
-    Prompt, ResponseFormat, Role, RoutingTarget, StreamPart, Usage,
+    Prompt, ResponseFormat, Role, RoutingTarget, StreamPart, ToolResultOutput, Usage,
 };
 
 /// The Responses protocol adapter.
@@ -251,7 +251,18 @@ fn parse_input(value: &serde_json::Value) -> Result<Vec<Message>> {
                             }],
                         });
                     }
+                    // OpenAI Responses `function_call_output {call_id, output}`:
+                    // `output` is a string or structured JSON, with no tool name
+                    // and no error flag on the wire. A string → Text, any other
+                    // value → Json.
+                    // <https://platform.openai.com/docs/api-reference/responses/create>
                     Some("function_call_output") => {
+                        let output = item
+                            .get("output")
+                            .map(ToolResultOutput::from_untyped_value)
+                            .unwrap_or_else(|| ToolResultOutput::Text {
+                                value: String::new(),
+                            });
                         messages.push(Message {
                             role: Role::Tool,
                             content: vec![Content::ToolResult {
@@ -260,13 +271,8 @@ fn parse_input(value: &serde_json::Value) -> Result<Vec<Message>> {
                                     .and_then(|i| i.as_str())
                                     .unwrap_or_default()
                                     .to_string(),
-                                content: item
-                                    .get("output")
-                                    .map(|o| match o {
-                                        serde_json::Value::String(s) => s.clone(),
-                                        other => other.to_string(),
-                                    })
-                                    .unwrap_or_default(),
+                                tool_name: None,
+                                output,
                             }],
                         });
                     }
@@ -722,11 +728,19 @@ fn render_message_items(m: &Message) -> Vec<serde_json::Value> {
                 };
                 text_parts.push(part);
             }
-            Content::ToolResult { call_id, content } => {
+            // Responses `function_call_output {call_id, output}`. `output` carries
+            // no error flag and no tool name, so an error output degrades to its
+            // value and `tool_name` is dropped. `Json` / `ErrorJson` preserve
+            // their structured value; the text/content variants stringify.
+            // <https://platform.openai.com/docs/api-reference/responses/create>
+            Content::ToolResult {
+                call_id, output, ..
+            } => {
+                let output_value = render_responses_tool_output(output);
                 items.push(serde_json::json!({
                     "type": "function_call_output",
                     "call_id": call_id,
-                    "output": content,
+                    "output": output_value,
                 }));
             }
         }
@@ -742,6 +756,18 @@ fn render_message_items(m: &Message) -> Vec<serde_json::Value> {
         );
     }
     items
+}
+
+/// Render a [`ToolResultOutput`] into a Responses `function_call_output.output`
+/// value. Structured `Json` / `ErrorJson` keep their value (Responses accepts a
+/// structured output); the text and multimodal variants stringify (the wire has
+/// no media slot for tool output here).
+/// <https://platform.openai.com/docs/api-reference/responses/create>
+fn render_responses_tool_output(output: &ToolResultOutput) -> serde_json::Value {
+    match output {
+        ToolResultOutput::Json { value } | ToolResultOutput::ErrorJson { value } => value.clone(),
+        other => serde_json::Value::String(other.to_provider_string()),
+    }
 }
 
 /// Render a canonical result into Responses `output` items.

--- a/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
@@ -791,6 +791,20 @@ fn render_output_items(result: &GenerateResult) -> Vec<serde_json::Value> {
             }));
         }
     }
+    // Best-effort: a generated file becomes an image message item. The Responses
+    // API has no standard output-image item, so this preserves the data rather
+    // than dropping it. <https://platform.openai.com/docs/api-reference/responses>
+    for c in &result.content {
+        if let Content::File {
+            media_type, data, ..
+        } = c
+        {
+            items.push(serde_json::json!({
+                "type": "message", "role": "assistant",
+                "content": [{ "type": "output_image", "image_url": data.to_url(media_type) }],
+            }));
+        }
+    }
     items
 }
 
@@ -1395,6 +1409,10 @@ impl StreamEncoder for ResponsesStreamEncoder {
         let mut frames = Vec::new();
         self.ensure_created(&mut frames);
         match part {
+            StreamPart::File { .. } => {
+                // Responses streaming surfaces generated files on the
+                // non-streaming path; no inline file-output delta is emitted here.
+            }
             StreamPart::TextDelta { text } => {
                 // `open_text_item` closes any open reasoning / tool item
                 // first — items never interleave their deltas.

--- a/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
@@ -616,9 +616,22 @@ impl OutboundAdapter for ResponsesAdapter {
                 // `id`, with a synthetic tool name and the call's distinguishing
                 // input, matching the AI SDK reference mapping. These must be
                 // marked `provider_executed` so they are not re-sent as client
-                // `function_call` items on a later turn.
+                // `function_call` items on a later turn. `image_generation_call`
+                // and `computer_call` join the no-echoed-input group: the AI SDK
+                // emits an empty input for both (`'{}'` and `''` respectively)
+                // and surfaces their payload only via a *separate* tool-result
+                // (the generated image / the computer-use status). The flat
+                // `ToolCall` cannot carry that result, so — exactly as for
+                // `web_search_call`/`file_search_call` — only the call itself is
+                // modeled here; it round-trips via `render_output_items`, which
+                // re-emits `<name>_call` keyed by `id`.
                 // <https://github.com/vercel/ai/blob/main/packages/openai/src/responses/openai-responses-language-model.ts>
-                Some(server_tool @ ("web_search_call" | "file_search_call")) => {
+                Some(
+                    server_tool @ ("web_search_call"
+                    | "file_search_call"
+                    | "image_generation_call"
+                    | "computer_call"),
+                ) => {
                     content.push(Content::ToolCall {
                         id: item
                             .get("id")
@@ -655,6 +668,24 @@ impl OutboundAdapter for ResponsesAdapter {
                         provider_executed: true,
                     });
                 }
+                // Deferred output-item types — intentionally skipped, not parsed,
+                // and documented here so the omission is explicit rather than a
+                // silent drop:
+                //   - `mcp_call`: the AI SDK models this as a provider-executed
+                //     `mcp.<name>` call *plus* a separate tool-result carrying the
+                //     remote MCP tool's `output`/`error`. The flat `ToolCall`
+                //     cannot hold that result, so faithfully representing it needs
+                //     a richer content shape than exists today.
+                //   - `local_shell_call`: a *client*-executed call (the AI SDK
+                //     leaves `providerExecuted` unset and keys it by `call_id`),
+                //     which must round-trip its `action` payload and be paired
+                //     with a `local_shell_call_output`. That is a distinct client
+                //     tool-call shape, not the provider-executed `<name>_call`
+                //     reproduction path used above, so it is deferred too.
+                //   - any other unknown item type is skipped for forward
+                //     compatibility (mirrors the input-side `Some(_) => {}`),
+                //     rather than failing the whole response.
+                // <https://github.com/vercel/ai/blob/main/packages/openai/src/responses/openai-responses-language-model.ts>
                 _ => {}
             }
         }

--- a/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
@@ -722,8 +722,12 @@ fn parse_input(value: &serde_json::Value) -> Result<Vec<Message>> {
                     // An `mcp_call` echoed back into the request `input[]` (a
                     // stateless client replaying the assistant turn) is lowered to
                     // the same `dynamic` `ToolCall` + inline `ToolResult` pair as
-                    // on the response side, carried as one assistant message so a
-                    // same-protocol round-trip is symmetric.
+                    // on the response side, carried as one assistant message. This
+                    // is symmetric in IR-lowering only: `render_request` then drops
+                    // the dynamic pair (a provider-executed call is not replayed on
+                    // the input wire, mirroring the AI SDK), so the pair survives a
+                    // request→response re-render, not a request→request one.
+                    // <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/openai/src/responses/convert-to-openai-responses-input.ts>
                     Some("mcp_call") => {
                         messages.push(Message {
                             role: Role::Assistant,
@@ -1855,9 +1859,12 @@ fn render_output_items(result: &GenerateResult) -> Vec<serde_json::Value> {
             // A `dynamic` provider-executed MCP call recombines with its inline
             // result — the same-id `ToolResult` carrying the `{type:'call', …}`
             // body — back into ONE `mcp_call` item, so the inline output/error
-            // round-trips. If no such paired result is present (e.g. the call was
-            // routed in from a non-Responses wire), fall through and degrade the
-            // call to a plain `function_call`.
+            // round-trips. If no such paired result is present (e.g. an upstream
+            // truncated the response after the call but before its inline result,
+            // or the call was routed in from a non-Responses wire), the call is
+            // degraded to a plain `function_call` below — it must NOT fall into
+            // the `{name}_call` server-tool branch, which would emit an invalid
+            // `mcp.<name>_call` item the Responses API does not define.
             if *dynamic
                 && *provider_executed
                 && let Some(item) = result
@@ -1891,12 +1898,16 @@ fn render_output_items(result: &GenerateResult) -> Vec<serde_json::Value> {
                 items.push(item);
                 continue;
             }
-            if *provider_executed {
+            if *provider_executed && !*dynamic {
                 // Reproduce the provider-executed server-tool output item on the
                 // same wire. The Responses API names these items `<tool>_call`
                 // (e.g. `web_search_call`) and keys them by item `id` rather than
                 // `call_id`. `code_interpreter_call` carries its `code` /
                 // `container_id` back out; the others have no echoed input.
+                // A `dynamic` MCP call is deliberately excluded here: its native
+                // shape is `mcp_call` (emitted only when its inline result is
+                // paired, above), and `mcp.<name>_call` is not a valid Responses
+                // item type — an unpaired one degrades to `function_call` instead.
                 // <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/openai/src/responses/openai-responses-language-model.ts>
                 let mut item = serde_json::Map::new();
                 item.insert("type".into(), format!("{name}_call").into());
@@ -1914,6 +1925,10 @@ fn render_output_items(result: &GenerateResult) -> Vec<serde_json::Value> {
                 }
                 items.push(serde_json::Value::Object(item));
             } else {
+                // A client `function_call`, or a `dynamic` MCP call whose inline
+                // result was not paired (handled above): both render as a valid
+                // `function_call` item. The MCP tool name keeps its `mcp.` prefix
+                // so a downstream consumer can still recover the bare tool name.
                 items.push(serde_json::json!({
                     "type": "function_call",
                     "call_id": id,
@@ -2152,6 +2167,19 @@ impl StreamDecoder for ResponsesStreamDecoder {
                                 arguments: String::new(),
                             });
                         }
+                        // Streaming MCP gap: a streamed `mcp_call` item (a
+                        // provider-executed remote MCP call with its inline
+                        // result) is currently dropped on this delta path — like
+                        // the `mcp_approval_request` gap documented above, it has
+                        // no `StreamPart` variant to carry the call+inline-result
+                        // pair, and surfacing it would require new cross-protocol
+                        // `StreamPart` plumbing the other encoders cannot yet
+                        // target. The non-streaming handshake (`parse_response` /
+                        // `render_output_items`) is the complete, faithful round
+                        // trip; a streamed `mcp_call` is simply not emitted as a
+                        // delta here. Deferred, not lost.
+                        // <https://platform.openai.com/docs/api-reference/responses-streaming>
+                        "mcp_call" => {}
                         _ => {}
                     }
                 }

--- a/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
@@ -30,7 +30,8 @@ use crate::language_model::stream::SseFrame;
 use crate::language_model::types::{
     ApiProtocol, Content, DataContent, FinishReason, GenerateResult, GenerationParams, Message,
     Prompt, ProviderMetadata, ResponseFormat, Role, RoutingTarget, Source, StreamPart, Tool,
-    ToolChoice, ToolResultContentPart, ToolResultOutput, Usage,
+    ToolChoice, ToolResultContentPart, ToolResultOutput, Usage, provider_namespace,
+    set_provider_metadata,
 };
 
 /// The Responses protocol adapter.
@@ -209,11 +210,26 @@ fn parse_responses_part(part: &serde_json::Value) -> Option<Content> {
         "input_image" => {
             let url = part.get("image_url").and_then(|u| u.as_str())?;
             let (media_type, data) = DataContent::from_url(url);
+            // The Responses `input_image` carries the same `detail` hint
+            // (`auto` | `low` | `high`) as Chat Completions' `image_url`; it is
+            // provider metadata, not a payload field. Preserve it under the
+            // `openai` namespace so it round-trips on a Responses request and
+            // survives a hop from a Chat Completions client (same namespace).
+            // <https://platform.openai.com/docs/api-reference/responses/create>
+            let mut provider_metadata = ProviderMetadata::new();
+            if let Some(detail) = part.get("detail").filter(|v| !v.is_null()) {
+                set_provider_metadata(
+                    &mut provider_metadata,
+                    PROVIDER_ID_OPENAI,
+                    "detail",
+                    detail.clone(),
+                );
+            }
             Some(Content::File {
                 media_type: media_type.unwrap_or_else(|| "image/*".to_string()),
                 data,
                 filename: None,
-                provider_metadata: ProviderMetadata::new(),
+                provider_metadata,
             })
         }
         "input_file" => {
@@ -375,11 +391,7 @@ fn parse_input(value: &serde_json::Value) -> Result<Vec<Message>> {
                         if let Some(role) = item.get("role").and_then(|r| r.as_str()) {
                             let role = parse_role(role)?;
                             let content = parse_responses_content(item.get("content"));
-                            messages.push(Message {
-                                role,
-                                content,
-                                provider_metadata: ProviderMetadata::new(),
-                            });
+                            messages.push(Message { role, content });
                         }
                     }
                     Some("function_call") => {
@@ -410,7 +422,6 @@ fn parse_input(value: &serde_json::Value) -> Result<Vec<Message>> {
                                 provider_executed: false,
                                 provider_metadata: ProviderMetadata::new(),
                             }],
-                            provider_metadata: ProviderMetadata::new(),
                         });
                     }
                     // OpenAI Responses `function_call_output {call_id, output}`:
@@ -438,7 +449,6 @@ fn parse_input(value: &serde_json::Value) -> Result<Vec<Message>> {
                                 output,
                                 provider_metadata: ProviderMetadata::new(),
                             }],
-                            provider_metadata: ProviderMetadata::new(),
                         });
                     }
                     Some("reasoning") => {
@@ -459,7 +469,6 @@ fn parse_input(value: &serde_json::Value) -> Result<Vec<Message>> {
                                     text,
                                     provider_metadata: ProviderMetadata::new(),
                                 }],
-                                provider_metadata: ProviderMetadata::new(),
                             });
                         }
                     }
@@ -581,6 +590,8 @@ impl InboundAdapter for ResponsesAdapter {
         Ok(Prompt {
             model: req.model,
             system,
+            // Responses carries no system-level `cache_control` on its wire.
+            system_provider_metadata: ProviderMetadata::new(),
             messages,
             tools,
             params: GenerationParams {
@@ -1107,12 +1118,24 @@ fn render_message_items(m: &Message) -> Vec<serde_json::Value> {
                 media_type,
                 data,
                 filename,
-                ..
+                provider_metadata,
             } => {
                 let part = if media_type.starts_with("image/") {
-                    serde_json::json!({
+                    let mut image = serde_json::json!({
                         "type": "input_image", "image_url": data.to_url(media_type)
-                    })
+                    });
+                    // Restore the OpenAI `detail` hint from the `openai`
+                    // namespace when it round-tripped through `provider_metadata`
+                    // (set by this protocol's parse path, or by Chat Completions'
+                    // image_url parse — same namespace).
+                    // <https://platform.openai.com/docs/api-reference/responses/create>
+                    if let Some(detail) = provider_namespace(provider_metadata, PROVIDER_ID_OPENAI)
+                        .and_then(|o| o.get("detail"))
+                        && let Some(obj) = image.as_object_mut()
+                    {
+                        obj.insert("detail".into(), detail.clone());
+                    }
+                    image
                 } else {
                     let mut file = serde_json::json!({
                         "type": "input_file", "file_data": data.to_url(media_type)

--- a/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
@@ -675,6 +675,17 @@ impl InboundAdapter for ResponsesAdapter {
                 reasoning_effort: req.reasoning.and_then(|r| r.effort),
                 response_modalities: Vec::new(),
                 tool_choice,
+                // The Responses API has no top-level top_k / seed / stop /
+                // presence_penalty / frequency_penalty — they are unsupported on
+                // this wire and dropped by the reference implementation, so the
+                // canonical slots stay empty here and the outbound adapter
+                // renders none of them.
+                // <https://github.com/vercel/ai/blob/main/packages/openai/src/responses/openai-responses-language-model.ts>
+                top_k: None,
+                seed: None,
+                stop: Vec::new(),
+                presence_penalty: None,
+                frequency_penalty: None,
                 // Splat every remaining Responses-API field without a typed slot
                 // — parallel_tool_calls, max_tool_calls, metadata, include[],
                 // previous_response_id, store, stream_options, … — into `extra`

--- a/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
@@ -40,7 +40,7 @@ use crate::language_model::types::{
 /// `ToolApprovalRequest` requires one (the AI SDK generates a fresh id here);
 /// deriving it deterministically from the approval id (`approval:<id>`) keeps a
 /// same-protocol round-trip stable without fabricating provider-side identity.
-/// <https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v3/language-model-v3-tool-approval-request.ts>
+/// <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/provider/src/language-model/v3/language-model-v3-tool-approval-request.ts>
 fn synthesize_approval_tool_call_id(approval_id: &str) -> String {
     format!("approval:{approval_id}")
 }
@@ -280,7 +280,7 @@ fn parse_responses_part(part: &serde_json::Value) -> Option<Content> {
 /// `file_id`/`filename` for documents) + index. The `index`/`start_index` text
 /// offsets and the `file_id`/`container_id` provider fields have no canonical
 /// slot and are dropped — see [`Source`].
-/// <https://github.com/vercel/ai/blob/main/packages/openai/src/responses/openai-responses-language-model.ts>
+/// <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/openai/src/responses/openai-responses-language-model.ts>
 fn parse_responses_annotations(
     annotations: Option<&serde_json::Value>,
     next_index: &mut usize,
@@ -478,7 +478,7 @@ fn parse_input(value: &serde_json::Value) -> Result<Vec<Message>> {
                     // approval item and skips re-emitting it as a string — matching
                     // the AI SDK's `execution-denied` skip rule.
                     // <https://platform.openai.com/docs/api-reference/responses/object>
-                    // <https://github.com/vercel/ai/blob/main/packages/openai/src/responses/convert-to-openai-responses-input.ts>
+                    // <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/openai/src/responses/convert-to-openai-responses-input.ts>
                     Some("mcp_approval_response") => {
                         let approval_id = item
                             .get("approval_request_id")
@@ -680,7 +680,7 @@ impl InboundAdapter for ResponsesAdapter {
                 // this wire and dropped by the reference implementation, so the
                 // canonical slots stay empty here and the outbound adapter
                 // renders none of them.
-                // <https://github.com/vercel/ai/blob/main/packages/openai/src/responses/openai-responses-language-model.ts>
+                // <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/openai/src/responses/openai-responses-language-model.ts>
                 top_k: None,
                 seed: None,
                 stop: Vec::new(),
@@ -892,7 +892,7 @@ impl OutboundAdapter for ResponsesAdapter {
                 // `web_search_call`/`file_search_call` — only the call itself is
                 // modeled here; it round-trips via `render_output_items`, which
                 // re-emits `<name>_call` keyed by `id`.
-                // <https://github.com/vercel/ai/blob/main/packages/openai/src/responses/openai-responses-language-model.ts>
+                // <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/openai/src/responses/openai-responses-language-model.ts>
                 Some(
                     server_tool @ ("web_search_call"
                     | "file_search_call"
@@ -938,22 +938,34 @@ impl OutboundAdapter for ResponsesAdapter {
                     });
                 }
                 // OpenAI Responses `mcp_approval_request {id, server_label, name,
-                // arguments}` — a provider-executed MCP tool call paused for
-                // human approval. It becomes a `Content::ToolApprovalRequest`. The
-                // MCP server identity (`server_label` / `name` / `arguments`) has
-                // no slot on the flat content shape, so it rides in
-                // `provider_metadata["openai"]` to reproduce the exact item on
-                // render. `approval_id` is the item's `approval_request_id`,
-                // falling back to its `id`; `tool_call_id` is synthesized from it
-                // (the wire carries no separate tool-call id), mirroring the AI
-                // SDK reference which generates a fresh id here.
+                // arguments, approval_request_id?}` — a provider-executed MCP tool
+                // call paused for human approval. It becomes a
+                // `Content::ToolApprovalRequest`. The MCP server identity
+                // (`server_label` / `name` / `arguments`) has no slot on the flat
+                // content shape, so it rides in `provider_metadata["openai"]` to
+                // reproduce the exact item on render.
+                //
+                // The wire carries TWO ids that can differ: the item `id` and the
+                // optional `approval_request_id` (the correlation key the later
+                // `mcp_approval_response.approval_request_id` and any `mcp_call`
+                // reference). `approval_id` takes the correlation key —
+                // `approval_request_id`, falling back to `id` — matching the AI SDK
+                // reference (`approval_request_id ?? id`). When the item ALSO had a
+                // distinct `id`, that raw item id would otherwise be lost on a
+                // same-protocol round-trip (render keys the item by `approval_id`),
+                // so it is preserved under `provider_metadata["openai"]["itemId"]`
+                // — the same key the AI SDK uses for the OpenAI item id — and
+                // restored on render. `tool_call_id` is synthesized from
+                // `approval_id` (the wire carries no separate tool-call id),
+                // mirroring the AI SDK reference which generates a fresh id here.
                 // <https://platform.openai.com/docs/api-reference/responses/object>
-                // <https://github.com/vercel/ai/blob/main/packages/openai/src/responses/openai-responses-language-model.ts>
+                // <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/openai/src/responses/openai-responses-language-model.ts>
                 Some("mcp_approval_request") => {
+                    let item_id = item.get("id").and_then(|i| i.as_str());
                     let approval_id = item
                         .get("approval_request_id")
-                        .or_else(|| item.get("id"))
                         .and_then(|i| i.as_str())
+                        .or(item_id)
                         .unwrap_or_default()
                         .to_string();
                     let mut meta = ProviderMetadata::new();
@@ -974,20 +986,47 @@ impl OutboundAdapter for ResponsesAdapter {
                             );
                         }
                     }
+                    // Preserve the raw item `id` only when it differs from the
+                    // chosen `approval_id`, so it round-trips without bloating the
+                    // common case (where the two coincide and `id` is recoverable).
+                    if let Some(id) = item_id
+                        && id != approval_id
+                    {
+                        set_provider_metadata(
+                            &mut meta,
+                            PROVIDER_ID_OPENAI,
+                            "itemId",
+                            serde_json::Value::String(id.to_string()),
+                        );
+                    }
                     content.push(Content::ToolApprovalRequest {
                         tool_call_id: synthesize_approval_tool_call_id(&approval_id),
                         approval_id,
                         provider_metadata: meta,
                     });
                 }
-                // Deferred output-item types — intentionally skipped, not parsed,
-                // and documented here so the omission is explicit rather than a
-                // silent drop:
-                //   - `mcp_call`: the AI SDK models this as a provider-executed
-                //     `mcp.<name>` call *plus* a separate tool-result carrying the
-                //     remote MCP tool's `output`/`error`. The flat `ToolCall`
-                //     cannot hold that result, so faithfully representing it needs
-                //     a richer content shape than exists today.
+                // KNOWN LIMITATION — these output items are dropped on parse,
+                // which is a fidelity gap (not a clean N/A) honestly recorded
+                // here. Carrying them faithfully needs a content-shape change
+                // that is deliberately out of scope for this change:
+                //   - `mcp_call`: a provider-executed remote MCP tool call whose
+                //     *result* is carried **inline** on the same item
+                //     (`{ server_label, name, arguments, output?, error? }`). The
+                //     AI SDK reference lowers it to a provider-executed tool-call
+                //     PLUS a separate tool-result whose body is an MCP-specific
+                //     `{ type: 'call', serverLabel, name, arguments, output?,
+                //     error? }` structure. bitrouter's flat `ToolCall` has no
+                //     server-identifier slot and its `ToolResult` renders only as
+                //     a *separate* `function_call_output` input item — so there is
+                //     no shape today that re-emits a single `mcp_call` item with
+                //     its inline output. Mapping `output`/`error` onto a paired
+                //     `ToolResult`/`ExecutionDenied` would NOT round-trip (it
+                //     would split one wire item into two, and `ExecutionDenied`
+                //     means *approval-denied*, not a tool error), so it is left
+                //     uncarried rather than mis-modeled — the same deferral as the
+                //     `Content::ToolCall` `dynamic` flag and Anthropic
+                //     `mcp_tool_use`. **Result: Responses MCP tool-call results
+                //     are not yet carried; this is a deferred gap.**
                 //   - `local_shell_call`: a *client*-executed call (the AI SDK
                 //     leaves `providerExecuted` unset and keys it by `call_id`),
                 //     which must round-trip its `action` payload and be paired
@@ -997,7 +1036,7 @@ impl OutboundAdapter for ResponsesAdapter {
                 //   - any other unknown item type is skipped for forward
                 //     compatibility (mirrors the input-side `Some(_) => {}`),
                 //     rather than failing the whole response.
-                // <https://github.com/vercel/ai/blob/main/packages/openai/src/responses/openai-responses-language-model.ts>
+                // <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/openai/src/responses/openai-responses-language-model.ts>
                 _ => {}
             }
         }
@@ -1235,7 +1274,7 @@ fn render_message_items(m: &Message) -> Vec<serde_json::Value> {
                 // the Responses input wire has no slot to replay a server-tool
                 // call (the AI SDK reference drops it / emits an item_reference).
                 // Only client tool calls round-trip as `function_call`.
-                // <https://github.com/vercel/ai/blob/main/packages/openai/src/responses/convert-to-openai-responses-input.ts>
+                // <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/openai/src/responses/convert-to-openai-responses-input.ts>
                 if !provider_executed {
                     items.push(serde_json::json!({
                         "type": "function_call",
@@ -1293,7 +1332,7 @@ fn render_message_items(m: &Message) -> Vec<serde_json::Value> {
             // `function_call_output` too would duplicate it. An *unpaired* denial
             // (no approval id) falls through and degrades to the denial string.
             // <https://platform.openai.com/docs/api-reference/responses/create>
-            // <https://github.com/vercel/ai/blob/main/packages/openai/src/responses/convert-to-openai-responses-input.ts>
+            // <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/openai/src/responses/convert-to-openai-responses-input.ts>
             Content::ToolResult {
                 call_id,
                 output,
@@ -1318,7 +1357,7 @@ fn render_message_items(m: &Message) -> Vec<serde_json::Value> {
             // the input wire. The optional canonical `reason` has no slot on this
             // item and is dropped (the wire carries none).
             // <https://platform.openai.com/docs/api-reference/responses/object>
-            // <https://github.com/vercel/ai/blob/main/packages/openai/src/responses/convert-to-openai-responses-input.ts>
+            // <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/openai/src/responses/convert-to-openai-responses-input.ts>
             Content::ToolApprovalResponse {
                 approval_id,
                 approved,
@@ -1362,7 +1401,7 @@ fn render_message_items(m: &Message) -> Vec<serde_json::Value> {
 /// rather than being flattened to text. The error flag and tool name have no
 /// slot here and are dropped.
 /// <https://platform.openai.com/docs/api-reference/responses/create>
-/// <https://github.com/vercel/ai/blob/main/packages/openai/src/responses/convert-to-openai-responses-input.ts>
+/// <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/openai/src/responses/convert-to-openai-responses-input.ts>
 fn render_responses_tool_output(output: &ToolResultOutput) -> serde_json::Value {
     match output {
         // `output` is a string slot, not a JSON-value slot: stringify the value
@@ -1386,7 +1425,7 @@ fn render_responses_tool_output(output: &ToolResultOutput) -> serde_json::Value 
 /// `input_image`; any other media or file reference → `input_file`. Media bytes
 /// ride as a `data:` URL or a plain URL; a provider file reference rides as
 /// `file_id`.
-/// <https://github.com/vercel/ai/blob/main/packages/openai/src/responses/convert-to-openai-responses-input.ts>
+/// <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/openai/src/responses/convert-to-openai-responses-input.ts>
 fn render_responses_tool_output_part(part: &ToolResultContentPart) -> serde_json::Value {
     match part {
         ToolResultContentPart::Text { text } => {
@@ -1438,7 +1477,7 @@ fn parse_responses_tool_output(value: &serde_json::Value) -> ToolResultOutput {
 /// `input_text` → text; `input_image` / `input_file` carry either a `file_id`
 /// (→ [`ToolResultContentPart::FileId`]) or an inline/URL payload
 /// (→ [`ToolResultContentPart::Media`]).
-/// <https://github.com/vercel/ai/blob/main/packages/openai/src/responses/convert-to-openai-responses-input.ts>
+/// <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/openai/src/responses/convert-to-openai-responses-input.ts>
 fn parse_responses_tool_output_part(part: &serde_json::Value) -> Option<ToolResultContentPart> {
     match part.get("type").and_then(|t| t.as_str())? {
         "input_text" | "text" => Some(ToolResultContentPart::Text {
@@ -1538,7 +1577,7 @@ fn render_output_items(result: &GenerateResult) -> Vec<serde_json::Value> {
                 // (e.g. `web_search_call`) and keys them by item `id` rather than
                 // `call_id`. `code_interpreter_call` carries its `code` /
                 // `container_id` back out; the others have no echoed input.
-                // <https://github.com/vercel/ai/blob/main/packages/openai/src/responses/openai-responses-language-model.ts>
+                // <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/openai/src/responses/openai-responses-language-model.ts>
                 let mut item = serde_json::Map::new();
                 item.insert("type".into(), format!("{name}_call").into());
                 item.insert("id".into(), id.clone().into());
@@ -1566,9 +1605,12 @@ fn render_output_items(result: &GenerateResult) -> Vec<serde_json::Value> {
     }
     // Reproduce a `mcp_approval_request` output item from each
     // `Content::ToolApprovalRequest`. The MCP server identity (`server_label` /
-    // `name` / `arguments`) is restored from `provider_metadata["openai"]`; the
-    // item is keyed by the approval id, matching the wire shape the parse path
-    // reads. <https://platform.openai.com/docs/api-reference/responses/object>
+    // `name` / `arguments`) is restored from `provider_metadata["openai"]`. The
+    // item `id` is the preserved raw `itemId` when the source carried one distinct
+    // from the correlation key; otherwise it falls back to `approval_id`. When a
+    // distinct `itemId` was preserved, `approval_request_id` is emitted alongside
+    // (= `approval_id`) so the original two-id item round-trips byte-faithfully —
+    // inverting the parse path. <https://platform.openai.com/docs/api-reference/responses/object>
     for c in &result.content {
         if let Content::ToolApprovalRequest {
             approval_id,
@@ -1578,8 +1620,18 @@ fn render_output_items(result: &GenerateResult) -> Vec<serde_json::Value> {
         {
             let mut item = serde_json::Map::new();
             item.insert("type".into(), "mcp_approval_request".into());
-            item.insert("id".into(), approval_id.clone().into());
-            if let Some(openai) = provider_namespace(provider_metadata, PROVIDER_ID_OPENAI) {
+            let openai = provider_namespace(provider_metadata, PROVIDER_ID_OPENAI);
+            let item_id = openai
+                .and_then(|o| o.get("itemId"))
+                .and_then(|v| v.as_str());
+            item.insert("id".into(), item_id.unwrap_or(approval_id).into());
+            // The correlation key is carried separately only when it differs from
+            // the item id (i.e. the source had both); otherwise `id` alone conveys
+            // it, matching the single-id items the parse path also accepts.
+            if item_id.is_some() {
+                item.insert("approval_request_id".into(), approval_id.clone().into());
+            }
+            if let Some(openai) = openai {
                 if let Some(label) = openai.get("serverLabel") {
                     item.insert("server_label".into(), label.clone());
                 }

--- a/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
@@ -29,7 +29,7 @@ use crate::language_model::protocol::{
 use crate::language_model::stream::SseFrame;
 use crate::language_model::types::{
     ApiProtocol, Content, DataContent, FinishReason, GenerateResult, GenerationParams, Message,
-    Prompt, ResponseFormat, Role, RoutingTarget, StreamPart, ToolResultContentPart,
+    Prompt, ResponseFormat, Role, RoutingTarget, StreamPart, ToolChoice, ToolResultContentPart,
     ToolResultOutput, Usage,
 };
 
@@ -249,6 +249,11 @@ fn parse_input(value: &serde_json::Value) -> Result<Vec<Message>> {
                                     .and_then(|a| a.as_str())
                                     .unwrap_or_default()
                                     .to_string(),
+                                // A `function_call` input item is always a client
+                                // tool call; provider-executed server-tool calls
+                                // (`web_search_call`, …) are never re-sent as
+                                // input items.
+                                provider_executed: false,
                             }],
                         });
                     }
@@ -406,6 +411,11 @@ impl InboundAdapter for ResponsesAdapter {
             None => None,
         };
 
+        // Promote `tool_choice` into the typed slot and drop it from `extra` so
+        // it is not also splatted back verbatim into a (possibly non-OpenAI)
+        // upstream.
+        let tool_choice = extra.remove("tool_choice").map(parse_responses_tool_choice);
+
         Ok(Prompt {
             model: req.model,
             system,
@@ -417,10 +427,11 @@ impl InboundAdapter for ResponsesAdapter {
                 max_tokens: req.max_output_tokens,
                 reasoning_effort: req.reasoning.and_then(|r| r.effort),
                 response_modalities: Vec::new(),
-                // Splat every Responses-API field without a typed slot —
-                // tool_choice, parallel_tool_calls, max_tool_calls, metadata,
-                // include[], previous_response_id, store, stream_options, … —
-                // into `extra` so render_request can put them back.
+                tool_choice,
+                // Splat every remaining Responses-API field without a typed slot
+                // — parallel_tool_calls, max_tool_calls, metadata, include[],
+                // previous_response_id, store, stream_options, … — into `extra`
+                // so render_request can put them back.
                 extra,
             },
             response_format,
@@ -530,9 +541,13 @@ impl OutboundAdapter for ResponsesAdapter {
             text.insert("format".into(), render_responses_response_format(rf));
             req.insert("text".into(), serde_json::Value::Object(text));
         }
-        // Splat Responses-API extras (tool_choice, parallel_tool_calls,
-        // metadata, include, …) back onto the outbound request. Typed fields
-        // win.
+        // Render the canonical tool_choice into the Responses native shape,
+        // before the extras splat so the typed slot wins.
+        if let Some(tc) = &prompt.params.tool_choice {
+            req.insert("tool_choice".into(), render_responses_tool_choice(tc));
+        }
+        // Splat remaining Responses-API extras (parallel_tool_calls, metadata,
+        // include, …) back onto the outbound request. Typed fields win.
         for (k, v) in &prompt.params.extra {
             req.entry(k.clone()).or_insert_with(|| v.clone());
         }
@@ -591,6 +606,53 @@ impl OutboundAdapter for ResponsesAdapter {
                             .and_then(|a| a.as_str())
                             .unwrap_or_default()
                             .to_string(),
+                        // A `function_call` output item is a client tool call.
+                        provider_executed: false,
+                    });
+                }
+                // OpenAI Responses built-in (server-side) tools surface as their
+                // own output-item types rather than `function_call`. The SDK
+                // exposes each as a provider-executed tool call keyed by item
+                // `id`, with a synthetic tool name and the call's distinguishing
+                // input, matching the AI SDK reference mapping. These must be
+                // marked `provider_executed` so they are not re-sent as client
+                // `function_call` items on a later turn.
+                // <https://github.com/vercel/ai/blob/main/packages/openai/src/responses/openai-responses-language-model.ts>
+                Some(server_tool @ ("web_search_call" | "file_search_call")) => {
+                    content.push(Content::ToolCall {
+                        id: item
+                            .get("id")
+                            .and_then(|i| i.as_str())
+                            .unwrap_or_default()
+                            .to_string(),
+                        name: server_tool.trim_end_matches("_call").to_string(),
+                        // The Responses API does not echo these tools' query
+                        // arguments on the output item, so the SDK reference
+                        // emits an empty input object.
+                        arguments: "{}".to_string(),
+                        provider_executed: true,
+                    });
+                }
+                Some("code_interpreter_call") => {
+                    // `code_interpreter_call` does carry its `code` and
+                    // `container_id`; preserve them as the call input (matching
+                    // the AI SDK `{ code, containerId }` shape).
+                    let mut input = serde_json::Map::new();
+                    if let Some(code) = item.get("code").and_then(|c| c.as_str()) {
+                        input.insert("code".into(), code.into());
+                    }
+                    if let Some(container) = item.get("container_id").and_then(|c| c.as_str()) {
+                        input.insert("containerId".into(), container.into());
+                    }
+                    content.push(Content::ToolCall {
+                        id: item
+                            .get("id")
+                            .and_then(|i| i.as_str())
+                            .unwrap_or_default()
+                            .to_string(),
+                        name: "code_interpreter".to_string(),
+                        arguments: serde_json::Value::Object(input).to_string(),
+                        provider_executed: true,
                     });
                 }
                 _ => {}
@@ -649,6 +711,49 @@ fn render_responses_response_format(rf: &ResponseFormat) -> serde_json::Value {
     serde_json::Value::Object(obj)
 }
 
+/// Parse a Responses `tool_choice` value into the canonical [`ToolChoice`]. The
+/// wire is a string (`"auto"|"none"|"required"`) or an object — `{type:
+/// "function", name}` forces a specific function (note: the name is flat, unlike
+/// Chat Completions' nested `function.name`). Built-in-tool choices
+/// (`{type:"web_search"|…}`), `allowed_tools`, and any other shape are preserved
+/// verbatim via [`ToolChoice::Other`].
+/// <https://platform.openai.com/docs/api-reference/responses/create#responses-create-tool_choice>
+fn parse_responses_tool_choice(value: serde_json::Value) -> ToolChoice {
+    match &value {
+        serde_json::Value::String(s) => match s.as_str() {
+            "auto" => ToolChoice::Auto,
+            "none" => ToolChoice::None,
+            "required" => ToolChoice::Required,
+            _ => ToolChoice::Other { value },
+        },
+        serde_json::Value::Object(obj)
+            if obj.get("type").and_then(|t| t.as_str()) == Some("function") =>
+        {
+            match obj.get("name").and_then(|n| n.as_str()) {
+                Some(name) => ToolChoice::Tool {
+                    name: name.to_string(),
+                },
+                None => ToolChoice::Other { value },
+            }
+        }
+        _ => ToolChoice::Other { value },
+    }
+}
+
+/// Render a canonical [`ToolChoice`] into the Responses native shape:
+/// `"auto"|"none"|"required"` strings, `{type:"function",name}` for a specific
+/// tool (flat `name`), and the preserved raw value for [`ToolChoice::Other`].
+/// <https://platform.openai.com/docs/api-reference/responses/create#responses-create-tool_choice>
+fn render_responses_tool_choice(choice: &ToolChoice) -> serde_json::Value {
+    match choice {
+        ToolChoice::Auto => "auto".into(),
+        ToolChoice::None => "none".into(),
+        ToolChoice::Required => "required".into(),
+        ToolChoice::Tool { name } => serde_json::json!({ "type": "function", "name": name }),
+        ToolChoice::Other { value } => value.clone(),
+    }
+}
+
 #[async_trait]
 impl Transport for ResponsesTransport {
     fn protocol(&self) -> ApiProtocol {
@@ -698,13 +803,22 @@ fn render_message_items(m: &Message) -> Vec<serde_json::Value> {
                 id,
                 name,
                 arguments,
+                provider_executed,
             } => {
-                items.push(serde_json::json!({
-                    "type": "function_call",
-                    "call_id": id,
-                    "name": name,
-                    "arguments": arguments,
-                }));
+                // A provider-executed server-tool call is NOT re-sent as a client
+                // `function_call` input item — the provider already ran it, and
+                // the Responses input wire has no slot to replay a server-tool
+                // call (the AI SDK reference drops it / emits an item_reference).
+                // Only client tool calls round-trip as `function_call`.
+                // <https://github.com/vercel/ai/blob/main/packages/openai/src/responses/convert-to-openai-responses-input.ts>
+                if !provider_executed {
+                    items.push(serde_json::json!({
+                        "type": "function_call",
+                        "call_id": id,
+                        "name": name,
+                        "arguments": arguments,
+                    }));
+                }
             }
             // image/* -> `input_image`, other media -> `input_file`; the payload
             // is a URL or `data:` URI via the shared helper.
@@ -925,14 +1039,39 @@ fn render_output_items(result: &GenerateResult) -> Vec<serde_json::Value> {
             id,
             name,
             arguments,
+            provider_executed,
         } = c
         {
-            items.push(serde_json::json!({
-                "type": "function_call",
-                "call_id": id,
-                "name": name,
-                "arguments": arguments,
-            }));
+            if *provider_executed {
+                // Reproduce the provider-executed server-tool output item on the
+                // same wire. The Responses API names these items `<tool>_call`
+                // (e.g. `web_search_call`) and keys them by item `id` rather than
+                // `call_id`. `code_interpreter_call` carries its `code` /
+                // `container_id` back out; the others have no echoed input.
+                // <https://github.com/vercel/ai/blob/main/packages/openai/src/responses/openai-responses-language-model.ts>
+                let mut item = serde_json::Map::new();
+                item.insert("type".into(), format!("{name}_call").into());
+                item.insert("id".into(), id.clone().into());
+                if name == "code_interpreter"
+                    && let Ok(serde_json::Value::Object(input)) =
+                        serde_json::from_str::<serde_json::Value>(arguments)
+                {
+                    if let Some(code) = input.get("code") {
+                        item.insert("code".into(), code.clone());
+                    }
+                    if let Some(container) = input.get("containerId") {
+                        item.insert("container_id".into(), container.clone());
+                    }
+                }
+                items.push(serde_json::Value::Object(item));
+            } else {
+                items.push(serde_json::json!({
+                    "type": "function_call",
+                    "call_id": id,
+                    "name": name,
+                    "arguments": arguments,
+                }));
+            }
         }
     }
     // Best-effort: a generated file becomes an image message item. The Responses

--- a/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
@@ -375,6 +375,7 @@ impl InboundAdapter for ResponsesAdapter {
                 top_p: req.top_p,
                 max_tokens: req.max_output_tokens,
                 reasoning_effort: req.reasoning.and_then(|r| r.effort),
+                response_modalities: Vec::new(),
                 // Splat every Responses-API field without a typed slot —
                 // tool_choice, parallel_tool_calls, max_tool_calls, metadata,
                 // include[], previous_response_id, store, stream_options, … —
@@ -663,6 +664,30 @@ fn render_message_items(m: &Message) -> Vec<serde_json::Value> {
                     "name": name,
                     "arguments": arguments,
                 }));
+            }
+            // image/* -> `input_image`, other media -> `input_file`; the payload
+            // is a URL or `data:` URI via the shared helper.
+            // <https://platform.openai.com/docs/api-reference/responses/create>
+            Content::File {
+                media_type,
+                data,
+                filename,
+                ..
+            } => {
+                let part = if media_type.starts_with("image/") {
+                    serde_json::json!({
+                        "type": "input_image", "image_url": data.to_url(media_type)
+                    })
+                } else {
+                    let mut file = serde_json::json!({
+                        "type": "input_file", "file_data": data.to_url(media_type)
+                    });
+                    if let Some(name) = filename {
+                        file["filename"] = serde_json::Value::String(name.clone());
+                    }
+                    file
+                };
+                text_parts.push(part);
             }
             Content::ToolResult { call_id, content } => {
                 items.push(serde_json::json!({

--- a/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
@@ -45,6 +45,181 @@ fn synthesize_approval_tool_call_id(approval_id: &str) -> String {
     format!("approval:{approval_id}")
 }
 
+/// The tool-name prefix the AI SDK gives a remote MCP tool surfaced from an
+/// `mcp_call` item (`mcp.<name>`). bitrouter keeps the same prefix so the tool
+/// name round-trips and the render can recover the bare MCP tool name.
+/// <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/openai/src/responses/openai-responses-language-model.ts>
+const RESPONSES_MCP_TOOL_PREFIX: &str = "mcp.";
+/// The synthetic tool name for an OpenAI Responses `local_shell_call` — a
+/// client-executed shell tool keyed by `call_id`. Matches the AI SDK's custom
+/// tool name so the input `action` payload round-trips.
+/// <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/openai/src/tool/local-shell.ts>
+const RESPONSES_LOCAL_SHELL_TOOL: &str = "local_shell";
+/// The `provider_metadata["openai"]` key holding a Responses output item's `id`,
+/// distinct from its `call_id`. Restored on render so a same-protocol round-trip
+/// reproduces the original item id (mirrors the AI SDK `itemId` key).
+/// <https://platform.openai.com/docs/api-reference/responses/object>
+const RESPONSES_ITEM_ID: &str = "itemId";
+/// The discriminator the AI SDK stamps on an `mcp_call`'s lowered tool-result
+/// body (`{ type: 'call', serverLabel, name, arguments, output?, error? }`). The
+/// Responses encoder recognises it to recombine a dynamic `ToolCall` + its
+/// same-id `ToolResult` back into a single `mcp_call` item.
+/// <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/openai/src/tool/mcp.ts>
+const RESPONSES_MCP_CALL_TAG: &str = "call";
+
+/// Lower an OpenAI Responses `mcp_call` item — a provider-executed remote MCP
+/// tool call whose result is carried **inline** — into the canonical pair the
+/// AI SDK reference produces: a `dynamic`, provider-executed [`Content::ToolCall`]
+/// plus a paired [`Content::ToolResult`] whose body is the MCP-specific
+/// `{ type: 'call', serverLabel, name, arguments, output?, error? }` JSON object.
+/// Keeping the result as that exact structure (rather than splitting `output`
+/// onto a bare string) lets [`render_output_items`] recombine the two parts into
+/// one `mcp_call` item, so the inline result round-trips same-protocol exactly.
+/// The item `id` correlates the pair and is preserved under
+/// `provider_metadata["openai"]["itemId"]`.
+/// <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/openai/src/responses/openai-responses-language-model.ts>
+fn parse_mcp_call(item: &serde_json::Value) -> Vec<Content> {
+    let id = item
+        .get("id")
+        .and_then(|i| i.as_str())
+        .unwrap_or_default()
+        .to_string();
+    let name = item
+        .get("name")
+        .and_then(|n| n.as_str())
+        .unwrap_or_default()
+        .to_string();
+    let arguments = item
+        .get("arguments")
+        .and_then(|a| a.as_str())
+        .unwrap_or_default()
+        .to_string();
+    // Build the MCP result body, mirroring the AI SDK `mcpOutputSchema`:
+    // `{type:'call', serverLabel, name, arguments, output?, error?}`. `output`
+    // and `error` are only present when the wire carried them.
+    let mut result = serde_json::Map::new();
+    result.insert("type".into(), RESPONSES_MCP_CALL_TAG.into());
+    if let Some(label) = item.get("server_label") {
+        result.insert("serverLabel".into(), label.clone());
+    }
+    result.insert("name".into(), name.clone().into());
+    result.insert("arguments".into(), arguments.clone().into());
+    if let Some(output) = item.get("output").filter(|v| !v.is_null()) {
+        result.insert("output".into(), output.clone());
+    }
+    if let Some(error) = item.get("error").filter(|v| !v.is_null()) {
+        result.insert("error".into(), error.clone());
+    }
+    let mut meta = ProviderMetadata::new();
+    set_provider_metadata(
+        &mut meta,
+        PROVIDER_ID_OPENAI,
+        RESPONSES_ITEM_ID,
+        serde_json::Value::String(id.clone()),
+    );
+    vec![
+        Content::ToolCall {
+            id: id.clone(),
+            name: format!("{RESPONSES_MCP_TOOL_PREFIX}{name}"),
+            arguments,
+            provider_executed: true,
+            dynamic: true,
+            provider_metadata: ProviderMetadata::new(),
+        },
+        Content::ToolResult {
+            call_id: id,
+            tool_name: Some(format!("{RESPONSES_MCP_TOOL_PREFIX}{name}")),
+            output: ToolResultOutput::Json {
+                value: serde_json::Value::Object(result),
+            },
+            dynamic: true,
+            provider_metadata: meta,
+        },
+    ]
+}
+
+/// The OpenAI `itemId` preserved in `provider_metadata`, if any.
+fn responses_item_id(meta: &ProviderMetadata) -> Option<String> {
+    provider_namespace(meta, PROVIDER_ID_OPENAI)
+        .and_then(|o| o.get(RESPONSES_ITEM_ID))
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+}
+
+/// Recombine a `dynamic` provider-executed MCP [`Content::ToolCall`] with its
+/// inline result — the [`Content::ToolResult`] whose `output` is the
+/// `{type:'call', …}` body lowered by [`parse_mcp_call`] — back into a single
+/// Responses `mcp_call` output item, inverting the parse split. Returns `None`
+/// when `result_output` is not such an MCP-call body (so a dynamic call routed in
+/// from a different wire, with no matching MCP result, is not mis-recombined).
+/// The emitted item restores `id`, `server_label`, `name`, `arguments`, and the
+/// inline `output`/`error`.
+/// <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/openai/src/tool/mcp.ts>
+fn render_mcp_call_item(
+    call_id: &str,
+    result_meta: &ProviderMetadata,
+    result_output: &ToolResultOutput,
+) -> Option<serde_json::Value> {
+    let body = match result_output {
+        ToolResultOutput::Json { value } => value.as_object()?,
+        _ => return None,
+    };
+    if body.get("type").and_then(|t| t.as_str()) != Some(RESPONSES_MCP_CALL_TAG) {
+        return None;
+    }
+    let mut item = serde_json::Map::new();
+    item.insert("type".into(), "mcp_call".into());
+    // Prefer the preserved item id; fall back to the correlating call id.
+    let item_id = responses_item_id(result_meta).unwrap_or_else(|| call_id.to_string());
+    item.insert("id".into(), item_id.into());
+    if let Some(label) = body.get("serverLabel") {
+        item.insert("server_label".into(), label.clone());
+    }
+    if let Some(name) = body.get("name") {
+        item.insert("name".into(), name.clone());
+    }
+    if let Some(arguments) = body.get("arguments") {
+        item.insert("arguments".into(), arguments.clone());
+    }
+    if let Some(output) = body.get("output") {
+        item.insert("output".into(), output.clone());
+    }
+    if let Some(error) = body.get("error") {
+        item.insert("error".into(), error.clone());
+    }
+    Some(serde_json::Value::Object(item))
+}
+
+/// Reconstruct a Responses `local_shell_call` output item from a client
+/// `local_shell` [`Content::ToolCall`], inverting the `local_shell_call` parse.
+/// The `action` is carried verbatim in the call's `{action}` input (so a
+/// same-protocol round-trip is byte-faithful), `call_id` is the call id, and the
+/// item `id` is restored from `provider_metadata["openai"]["itemId"]`. Returns
+/// `None` when the input is not the expected `{action}` object.
+/// <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/openai/src/responses/openai-responses-language-model.ts>
+fn render_local_shell_call_item(c: &Content) -> Option<serde_json::Value> {
+    let Content::ToolCall {
+        id,
+        arguments,
+        provider_metadata,
+        ..
+    } = c
+    else {
+        return None;
+    };
+    let input: serde_json::Value = serde_json::from_str(arguments).ok()?;
+    let action = input.get("action")?.clone();
+    let mut item = serde_json::Map::new();
+    item.insert("type".into(), "local_shell_call".into());
+    item.insert("call_id".into(), id.clone().into());
+    // The item `id` is distinct from `call_id` on this wire; restore it when it
+    // round-tripped, else fall back to the call id so the item is still valid.
+    let item_id = responses_item_id(provider_metadata).unwrap_or_else(|| id.clone());
+    item.insert("id".into(), item_id.into());
+    item.insert("action".into(), action);
+    Some(serde_json::Value::Object(item))
+}
+
 /// The Responses protocol adapter.
 pub struct ResponsesAdapter;
 
@@ -436,6 +611,9 @@ fn parse_input(value: &serde_json::Value) -> Result<Vec<Message>> {
                                 // (`web_search_call`, …) are never re-sent as
                                 // input items.
                                 provider_executed: false,
+                                // …nor is it a provider-executed MCP (`dynamic`)
+                                // call (those arrive as `mcp_call` items).
+                                dynamic: false,
                                 provider_metadata: ProviderMetadata::new(),
                             }],
                         });
@@ -463,6 +641,9 @@ fn parse_input(value: &serde_json::Value) -> Result<Vec<Message>> {
                                     .to_string(),
                                 tool_name: None,
                                 output,
+                                // A `function_call_output` is a plain client
+                                // tool-result item, never an inline MCP result.
+                                dynamic: false,
                                 provider_metadata: ProviderMetadata::new(),
                             }],
                         });
@@ -507,6 +688,8 @@ fn parse_input(value: &serde_json::Value) -> Result<Vec<Message>> {
                                 call_id: approval_id,
                                 tool_name: None,
                                 output: ToolResultOutput::ExecutionDenied { reason: None },
+                                // An approval denial is not an MCP inline result.
+                                dynamic: false,
                                 provider_metadata: denial_meta,
                             });
                         }
@@ -535,6 +718,48 @@ fn parse_input(value: &serde_json::Value) -> Result<Vec<Message>> {
                                 }],
                             });
                         }
+                    }
+                    // An `mcp_call` echoed back into the request `input[]` (a
+                    // stateless client replaying the assistant turn) is lowered to
+                    // the same `dynamic` `ToolCall` + inline `ToolResult` pair as
+                    // on the response side, carried as one assistant message so a
+                    // same-protocol round-trip is symmetric.
+                    Some("mcp_call") => {
+                        messages.push(Message {
+                            role: Role::Assistant,
+                            content: parse_mcp_call(item),
+                        });
+                    }
+                    // A `local_shell_call` input item — a client shell call replayed
+                    // into the request. Mapped to the same client `local_shell`
+                    // `ToolCall` as the response parse, as an assistant message.
+                    Some("local_shell_call") => {
+                        let call_id = item
+                            .get("call_id")
+                            .and_then(|i| i.as_str())
+                            .unwrap_or_default()
+                            .to_string();
+                        let action = item.get("action").cloned().unwrap_or(serde_json::json!({}));
+                        let mut meta = ProviderMetadata::new();
+                        if let Some(id) = item.get("id").and_then(|i| i.as_str()) {
+                            set_provider_metadata(
+                                &mut meta,
+                                PROVIDER_ID_OPENAI,
+                                RESPONSES_ITEM_ID,
+                                serde_json::Value::String(id.to_string()),
+                            );
+                        }
+                        messages.push(Message {
+                            role: Role::Assistant,
+                            content: vec![Content::ToolCall {
+                                id: call_id,
+                                name: RESPONSES_LOCAL_SHELL_TOOL.to_string(),
+                                arguments: serde_json::json!({ "action": action }).to_string(),
+                                provider_executed: false,
+                                dynamic: false,
+                                provider_metadata: meta,
+                            }],
+                        });
                     }
                     // forward-compatible: unknown item types are skipped, not fatal
                     Some(_) => {}
@@ -874,6 +1099,7 @@ impl OutboundAdapter for ResponsesAdapter {
                             .to_string(),
                         // A `function_call` output item is a client tool call.
                         provider_executed: false,
+                        dynamic: false,
                         provider_metadata: ProviderMetadata::new(),
                     });
                 }
@@ -911,6 +1137,8 @@ impl OutboundAdapter for ResponsesAdapter {
                         // emits an empty input object.
                         arguments: "{}".to_string(),
                         provider_executed: true,
+                        // OpenAI's built-in server tools are not runtime MCP tools.
+                        dynamic: false,
                         provider_metadata: ProviderMetadata::new(),
                     });
                 }
@@ -934,6 +1162,8 @@ impl OutboundAdapter for ResponsesAdapter {
                         name: "code_interpreter".to_string(),
                         arguments: serde_json::Value::Object(input).to_string(),
                         provider_executed: true,
+                        // `code_interpreter` is a built-in server tool, not MCP.
+                        dynamic: false,
                         provider_metadata: ProviderMetadata::new(),
                     });
                 }
@@ -1005,38 +1235,70 @@ impl OutboundAdapter for ResponsesAdapter {
                         provider_metadata: meta,
                     });
                 }
-                // KNOWN LIMITATION — these output items are dropped on parse,
-                // which is a fidelity gap (not a clean N/A) honestly recorded
-                // here. Carrying them faithfully needs a content-shape change
-                // that is deliberately out of scope for this change:
-                //   - `mcp_call`: a provider-executed remote MCP tool call whose
-                //     *result* is carried **inline** on the same item
-                //     (`{ server_label, name, arguments, output?, error? }`). The
-                //     AI SDK reference lowers it to a provider-executed tool-call
-                //     PLUS a separate tool-result whose body is an MCP-specific
-                //     `{ type: 'call', serverLabel, name, arguments, output?,
-                //     error? }` structure. bitrouter's flat `ToolCall` has no
-                //     server-identifier slot and its `ToolResult` renders only as
-                //     a *separate* `function_call_output` input item — so there is
-                //     no shape today that re-emits a single `mcp_call` item with
-                //     its inline output. Mapping `output`/`error` onto a paired
-                //     `ToolResult`/`ExecutionDenied` would NOT round-trip (it
-                //     would split one wire item into two, and `ExecutionDenied`
-                //     means *approval-denied*, not a tool error), so it is left
-                //     uncarried rather than mis-modeled — the same deferral as the
-                //     `Content::ToolCall` `dynamic` flag and Anthropic
-                //     `mcp_tool_use`. **Result: Responses MCP tool-call results
-                //     are not yet carried; this is a deferred gap.**
-                //   - `local_shell_call`: a *client*-executed call (the AI SDK
-                //     leaves `providerExecuted` unset and keys it by `call_id`),
-                //     which must round-trip its `action` payload and be paired
-                //     with a `local_shell_call_output`. That is a distinct client
-                //     tool-call shape, not the provider-executed `<name>_call`
-                //     reproduction path used above, so it is deferred too.
-                //   - any other unknown item type is skipped for forward
-                //     compatibility (mirrors the input-side `Some(_) => {}`),
-                //     rather than failing the whole response.
+                // `mcp_call` — a provider-executed remote MCP tool call whose
+                // *result* is carried **inline** on the same item
+                // (`{ server_label, name, arguments, output?, error? }`). It is
+                // lowered (mirroring the AI SDK reference) to a `dynamic`,
+                // provider-executed `ToolCall` PLUS a paired `ToolResult` whose
+                // body is the MCP-specific `{ type: 'call', serverLabel, name,
+                // arguments, output?, error? }` structure. `render_output_items`
+                // recombines the two back into a single `mcp_call` item, so the
+                // inline result round-trips same-protocol exactly.
                 // <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/openai/src/responses/openai-responses-language-model.ts>
+                Some("mcp_call") => content.extend(parse_mcp_call(item)),
+                // `mcp_list_tools` — the catalogue of tools a remote MCP server
+                // advertised. The AI SDK reference skips it (it is neither a call
+                // nor a result the model acts on), and so does bitrouter; there is
+                // no canonical content part for a tool catalogue.
+                // <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/openai/src/responses/openai-responses-language-model.ts>
+                Some("mcp_list_tools") => {}
+                // `local_shell_call` — a *client*-executed shell tool call (the AI
+                // SDK leaves `providerExecuted` unset and keys it by `call_id`),
+                // carrying an `action` payload. It maps to an ordinary client
+                // `ToolCall` named `local_shell` whose input is `{action}` (the
+                // wire action preserved verbatim); `render_output_items`
+                // reconstructs the `local_shell_call` item from the same name, so
+                // the call round-trips same-protocol. The item `id` (distinct from
+                // `call_id`) rides in `provider_metadata["openai"]["itemId"]`.
+                //
+                // Residual gap: the paired `local_shell_call_output` is a
+                // *client*-supplied result on a follow-up **request**. bitrouter's
+                // `ToolResult` does not carry the tool name on the Responses wire
+                // (which keys results purely by `call_id`), so the request render
+                // cannot distinguish a `local_shell` result from an ordinary
+                // `function_call_output`; the output therefore degrades to
+                // `function_call_output` rather than `local_shell_call_output`.
+                // <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/openai/src/tool/local-shell.ts>
+                Some("local_shell_call") => {
+                    let call_id = item
+                        .get("call_id")
+                        .and_then(|i| i.as_str())
+                        .unwrap_or_default()
+                        .to_string();
+                    let action = item.get("action").cloned().unwrap_or(serde_json::json!({}));
+                    let mut meta = ProviderMetadata::new();
+                    if let Some(id) = item.get("id").and_then(|i| i.as_str()) {
+                        set_provider_metadata(
+                            &mut meta,
+                            PROVIDER_ID_OPENAI,
+                            RESPONSES_ITEM_ID,
+                            serde_json::Value::String(id.to_string()),
+                        );
+                    }
+                    content.push(Content::ToolCall {
+                        id: call_id,
+                        name: RESPONSES_LOCAL_SHELL_TOOL.to_string(),
+                        arguments: serde_json::json!({ "action": action }).to_string(),
+                        // A `local_shell_call` is a client tool call (the client
+                        // runs the shell), not a provider-executed or MCP call.
+                        provider_executed: false,
+                        dynamic: false,
+                        provider_metadata: meta,
+                    });
+                }
+                // Any other unknown item type is skipped for forward
+                // compatibility (mirrors the input-side `Some(_) => {}`), rather
+                // than failing the whole response.
                 _ => {}
             }
         }
@@ -1273,15 +1535,25 @@ fn render_message_items(m: &Message) -> Vec<serde_json::Value> {
                 // `function_call` input item — the provider already ran it, and
                 // the Responses input wire has no slot to replay a server-tool
                 // call (the AI SDK reference drops it / emits an item_reference).
-                // Only client tool calls round-trip as `function_call`.
+                // This also covers a `dynamic` provider-executed MCP call.
+                // Only client tool calls round-trip as input items.
                 // <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/openai/src/responses/convert-to-openai-responses-input.ts>
                 if !provider_executed {
-                    items.push(serde_json::json!({
-                        "type": "function_call",
-                        "call_id": id,
-                        "name": name,
-                        "arguments": arguments,
-                    }));
+                    // A client `local_shell` call reproduces its `local_shell_call`
+                    // input item (with the `action` payload), matching the AI SDK;
+                    // every other client call is a `function_call`.
+                    if name == RESPONSES_LOCAL_SHELL_TOOL
+                        && let Some(item) = render_local_shell_call_item(c)
+                    {
+                        items.push(item);
+                    } else {
+                        items.push(serde_json::json!({
+                            "type": "function_call",
+                            "call_id": id,
+                            "name": name,
+                            "arguments": arguments,
+                        }));
+                    }
                 }
             }
             // image/* -> `input_image`, other media -> `input_file`; the payload
@@ -1336,14 +1608,22 @@ fn render_message_items(m: &Message) -> Vec<serde_json::Value> {
             Content::ToolResult {
                 call_id,
                 output,
+                dynamic,
                 provider_metadata,
                 ..
             } => {
+                // A `dynamic` MCP result is the inline result of a
+                // provider-executed `mcp_call`; the provider already ran it, so it
+                // is NOT re-sent as a client `function_call_output` (the AI SDK
+                // reference likewise does not replay provider-executed results on
+                // the input wire). It rides the response path instead, where the
+                // `mcp_call` item recombines its call and inline result.
+                // <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/openai/src/responses/convert-to-openai-responses-input.ts>
                 let denial_paired_with_approval =
                     matches!(output, ToolResultOutput::ExecutionDenied { .. })
                         && provider_namespace(provider_metadata, PROVIDER_ID_OPENAI)
                             .is_some_and(|o| o.contains_key("approvalId"));
-                if !denial_paired_with_approval {
+                if !*dynamic && !denial_paired_with_approval {
                     let output_value = render_responses_tool_output(output);
                     items.push(serde_json::json!({
                         "type": "function_call_output",
@@ -1568,9 +1848,49 @@ fn render_output_items(result: &GenerateResult) -> Vec<serde_json::Value> {
             name,
             arguments,
             provider_executed,
+            dynamic,
             ..
         } = c
         {
+            // A `dynamic` provider-executed MCP call recombines with its inline
+            // result — the same-id `ToolResult` carrying the `{type:'call', …}`
+            // body — back into ONE `mcp_call` item, so the inline output/error
+            // round-trips. If no such paired result is present (e.g. the call was
+            // routed in from a non-Responses wire), fall through and degrade the
+            // call to a plain `function_call`.
+            if *dynamic
+                && *provider_executed
+                && let Some(item) = result
+                    .content
+                    .iter()
+                    .filter_map(|r| match r {
+                        Content::ToolResult {
+                            call_id,
+                            output,
+                            dynamic: result_dynamic,
+                            provider_metadata,
+                            ..
+                        } if *result_dynamic && call_id == id => {
+                            render_mcp_call_item(call_id, provider_metadata, output)
+                        }
+                        _ => None,
+                    })
+                    .next()
+            {
+                items.push(item);
+                continue;
+            }
+            // A client `local_shell` call reproduces its `local_shell_call` output
+            // item, keyed by `call_id`, restoring the `action` payload and the
+            // item `id` from `provider_metadata["openai"]["itemId"]`.
+            // <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/openai/src/responses/openai-responses-language-model.ts>
+            if !*provider_executed
+                && name == RESPONSES_LOCAL_SHELL_TOOL
+                && let Some(item) = render_local_shell_call_item(c)
+            {
+                items.push(item);
+                continue;
+            }
             if *provider_executed {
                 // Reproduce the provider-executed server-tool output item on the
                 // same wire. The Responses API names these items `<tool>_call`

--- a/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
@@ -23,14 +23,14 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::{BitrouterError, Result};
 use crate::language_model::protocol::{
-    InboundAdapter, OutboundAdapter, SseEvent, StreamDecoder, StreamEncoder, Transport,
-    describe_deser_error,
+    InboundAdapter, OutboundAdapter, PROVIDER_ID_OPENAI, SseEvent, StreamDecoder, StreamEncoder,
+    Transport, describe_deser_error, provider_defined_native,
 };
 use crate::language_model::stream::SseFrame;
 use crate::language_model::types::{
     ApiProtocol, Content, DataContent, FinishReason, GenerateResult, GenerationParams, Message,
-    Prompt, ResponseFormat, Role, RoutingTarget, StreamPart, ToolChoice, ToolResultContentPart,
-    ToolResultOutput, Usage,
+    Prompt, ResponseFormat, Role, RoutingTarget, StreamPart, Tool, ToolChoice,
+    ToolResultContentPart, ToolResultOutput, Usage,
 };
 
 /// The Responses protocol adapter.
@@ -120,8 +120,17 @@ pub enum ResponsesTextFormat {
     },
 }
 
-/// One element of [`ResponsesRequest`]'s `tools` array — the Responses-flavoured
-/// flat tool definition (`{ type: "function", name, description, parameters }`).
+/// One element of [`ResponsesRequest`]'s `tools` array.
+///
+/// Responses uses one flat array for both kinds of tool:
+/// - a **function** tool — `{type:"function", name, description?, parameters, strict?}`;
+/// - a **provider-defined** server tool — `{type:"web_search_preview"|…, …config}`
+///   (`code_interpreter`, `file_search`, `image_generation`, `computer_use_preview`).
+///
+/// `kind` (`type`) discriminates the two; for a server tool the configuration
+/// keys ride in `extra` so they are preserved verbatim into the canonical
+/// `Tool::ProviderDefined.args`.
+/// <https://platform.openai.com/docs/api-reference/responses/create#responses-create-tools>
 #[derive(Debug, Default, Deserialize, JsonSchema)]
 pub struct ResponsesTool {
     #[serde(default, rename = "type")]
@@ -132,6 +141,17 @@ pub struct ResponsesTool {
     description: Option<String>,
     #[serde(default)]
     parameters: serde_json::Value,
+    /// OpenAI strict-mode flag (V3 `strict`) on a function tool. Captured so it
+    /// is not lost across the canonical boundary.
+    #[serde(default)]
+    strict: Option<bool>,
+    /// Server-tool configuration keys (e.g. `search_context_size`,
+    /// `container`, `vector_store_ids`) for a provider-defined tool. Preserved
+    /// verbatim. Skipped from the published schema — the documented contract is
+    /// the typed function-tool shape.
+    #[serde(flatten)]
+    #[schemars(skip)]
+    extra: HashMap<String, serde_json::Value>,
 }
 
 /// `reasoning` knob on [`ResponsesRequest`] — only `effort` is read; other
@@ -353,19 +373,19 @@ impl InboundAdapter for ResponsesAdapter {
         let messages = parse_input(&req.input)?;
         let system = req.instructions.filter(|s| !s.is_empty());
 
+        // Responses packs function tools and provider-defined ("server") tools
+        // into one flat array, discriminated by `type`. `type:"function"` (or a
+        // typeless entry that still carries a `name`, tolerated for lenient
+        // clients) becomes a `Tool::Function`; every other `type`
+        // (`web_search_preview`, `code_interpreter`, `file_search`,
+        // `image_generation`, `computer_use_preview`, …) is a provider-defined
+        // tool whose config keys ride in `extra` and are preserved verbatim under
+        // an `openai.<type>` id.
+        // <https://platform.openai.com/docs/api-reference/responses/create#responses-create-tools>
         let tools = req
             .tools
             .into_iter()
-            .filter(|t| t.kind.as_deref() == Some("function") || t.name.is_some())
-            .map(|t| crate::language_model::types::Tool {
-                name: t.name.unwrap_or_default(),
-                description: t.description,
-                parameters: if t.parameters.is_null() {
-                    serde_json::json!({})
-                } else {
-                    t.parameters
-                },
-            })
+            .filter_map(parse_responses_tool)
             .collect();
 
         // `text` is a typed field. Promote `text.format: json_schema` into the
@@ -504,14 +524,7 @@ impl OutboundAdapter for ResponsesAdapter {
                 prompt
                     .tools
                     .iter()
-                    .map(|t| {
-                        serde_json::json!({
-                            "type": "function",
-                            "name": t.name,
-                            "description": t.description,
-                            "parameters": t.parameters,
-                        })
-                    })
+                    .map(render_responses_tool)
                     .collect::<Vec<_>>()
                     .into(),
             );
@@ -715,6 +728,74 @@ impl OutboundAdapter for ResponsesAdapter {
 
     fn supports_response_format(&self) -> bool {
         true
+    }
+}
+
+/// Parse one Responses `tools` entry into a canonical [`Tool`]. A
+/// `type:"function"` entry (or a typeless one that still has a `name`) is a
+/// [`Tool::Function`]; anything else is a provider-defined server tool keyed by
+/// its `type`, namespaced `openai.<type>`, with its config keys preserved
+/// verbatim as `args`. An entry that is neither (no `type`, no `name`) is
+/// dropped — there is nothing to forward.
+fn parse_responses_tool(t: ResponsesTool) -> Option<Tool> {
+    let is_function = t.kind.as_deref() == Some("function");
+    if is_function || (t.kind.is_none() && t.name.is_some()) {
+        return Some(Tool::Function {
+            name: t.name.unwrap_or_default(),
+            description: t.description,
+            parameters: if t.parameters.is_null() {
+                serde_json::json!({})
+            } else {
+                t.parameters
+            },
+            strict: t.strict,
+        });
+    }
+    // Provider-defined server tool. `type` is the tool kind (and the tool name);
+    // config keys live in `extra`. A few server tools (`file_search`) accept a
+    // distinct `name`; default to the kind when absent.
+    let kind = t.kind?;
+    Some(Tool::ProviderDefined {
+        id: format!("{PROVIDER_ID_OPENAI}.{kind}"),
+        name: t.name.unwrap_or_else(|| kind.clone()),
+        args: serde_json::Value::Object(t.extra.into_iter().collect()),
+    })
+}
+
+/// Render one canonical [`Tool`] into a Responses `tools` entry.
+///
+/// A [`Tool::Function`] becomes the flat `{type:"function", name, description?,
+/// parameters, strict?}` shape; `strict` is emitted when set (previously always
+/// dropped). A [`Tool::ProviderDefined`] is rendered to its source-native shape
+/// via [`provider_defined_native`]: for an `openai.*` id this is the exact
+/// Responses server-tool object (`{type:<tool>, …args}`), a lossless
+/// same-protocol round-trip; a foreign-provider id is preserved verbatim
+/// (faithful passthrough) so the upstream decides.
+/// <https://platform.openai.com/docs/api-reference/responses/create#responses-create-tools>
+fn render_responses_tool(tool: &Tool) -> serde_json::Value {
+    match tool {
+        Tool::Function {
+            name,
+            description,
+            parameters,
+            strict,
+        } => {
+            let mut obj = serde_json::Map::new();
+            obj.insert("type".into(), "function".into());
+            obj.insert("name".into(), name.clone().into());
+            obj.insert(
+                "description".into(),
+                description
+                    .clone()
+                    .map_or(serde_json::Value::Null, serde_json::Value::String),
+            );
+            obj.insert("parameters".into(), parameters.clone());
+            if let Some(strict) = strict {
+                obj.insert("strict".into(), (*strict).into());
+            }
+            serde_json::Value::Object(obj)
+        }
+        Tool::ProviderDefined { id, name, args } => provider_defined_native(id, name, args),
     }
 }
 

--- a/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
@@ -34,6 +34,17 @@ use crate::language_model::types::{
     set_provider_metadata,
 };
 
+/// Synthesize a stable `tool_call_id` for a [`Content::ToolApprovalRequest`]
+/// parsed from a Responses `mcp_approval_request`. That item transmits an
+/// `approval_request_id` but no separate tool-call id, and V3's
+/// `ToolApprovalRequest` requires one (the AI SDK generates a fresh id here);
+/// deriving it deterministically from the approval id (`approval:<id>`) keeps a
+/// same-protocol round-trip stable without fabricating provider-side identity.
+/// <https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v3/language-model-v3-tool-approval-request.ts>
+fn synthesize_approval_tool_call_id(approval_id: &str) -> String {
+    format!("approval:{approval_id}")
+}
+
 /// The Responses protocol adapter.
 pub struct ResponsesAdapter;
 
@@ -451,6 +462,54 @@ fn parse_input(value: &serde_json::Value) -> Result<Vec<Message>> {
                             }],
                         });
                     }
+                    // OpenAI Responses `mcp_approval_response {approval_request_id,
+                    // approve}` — the human-in-the-loop grant/deny for a
+                    // provider-executed MCP tool call. It becomes a
+                    // `Content::ToolApprovalResponse` (a `tool`-role part). A
+                    // **denial** (`approve == false`) additionally yields a paired
+                    // `ToolResult` whose output is `ExecutionDenied`, carrying the
+                    // approval id under `provider_metadata["openai"]["approvalId"]`
+                    // so render knows the denial was already conveyed by the
+                    // approval item and skips re-emitting it as a string — matching
+                    // the AI SDK's `execution-denied` skip rule.
+                    // <https://platform.openai.com/docs/api-reference/responses/object>
+                    // <https://github.com/vercel/ai/blob/main/packages/openai/src/responses/convert-to-openai-responses-input.ts>
+                    Some("mcp_approval_response") => {
+                        let approval_id = item
+                            .get("approval_request_id")
+                            .and_then(|i| i.as_str())
+                            .unwrap_or_default()
+                            .to_string();
+                        let approved = item
+                            .get("approve")
+                            .and_then(|a| a.as_bool())
+                            .unwrap_or(false);
+                        let mut content = vec![Content::ToolApprovalResponse {
+                            approval_id: approval_id.clone(),
+                            approved,
+                            reason: None,
+                            provider_metadata: ProviderMetadata::new(),
+                        }];
+                        if !approved {
+                            let mut denial_meta = ProviderMetadata::new();
+                            set_provider_metadata(
+                                &mut denial_meta,
+                                PROVIDER_ID_OPENAI,
+                                "approvalId",
+                                approval_id.clone().into(),
+                            );
+                            content.push(Content::ToolResult {
+                                call_id: approval_id,
+                                tool_name: None,
+                                output: ToolResultOutput::ExecutionDenied { reason: None },
+                                provider_metadata: denial_meta,
+                            });
+                        }
+                        messages.push(Message {
+                            role: Role::Tool,
+                            content,
+                        });
+                    }
                     Some("reasoning") => {
                         let text = item
                             .get("summary")
@@ -852,6 +911,49 @@ impl OutboundAdapter for ResponsesAdapter {
                         provider_metadata: ProviderMetadata::new(),
                     });
                 }
+                // OpenAI Responses `mcp_approval_request {id, server_label, name,
+                // arguments}` — a provider-executed MCP tool call paused for
+                // human approval. It becomes a `Content::ToolApprovalRequest`. The
+                // MCP server identity (`server_label` / `name` / `arguments`) has
+                // no slot on the flat content shape, so it rides in
+                // `provider_metadata["openai"]` to reproduce the exact item on
+                // render. `approval_id` is the item's `approval_request_id`,
+                // falling back to its `id`; `tool_call_id` is synthesized from it
+                // (the wire carries no separate tool-call id), mirroring the AI
+                // SDK reference which generates a fresh id here.
+                // <https://platform.openai.com/docs/api-reference/responses/object>
+                // <https://github.com/vercel/ai/blob/main/packages/openai/src/responses/openai-responses-language-model.ts>
+                Some("mcp_approval_request") => {
+                    let approval_id = item
+                        .get("approval_request_id")
+                        .or_else(|| item.get("id"))
+                        .and_then(|i| i.as_str())
+                        .unwrap_or_default()
+                        .to_string();
+                    let mut meta = ProviderMetadata::new();
+                    for key in ["server_label", "name", "arguments"] {
+                        if let Some(v) = item.get(key) {
+                            // Store under the camelCase form the AI SDK uses for
+                            // the OpenAI namespace (`serverLabel`).
+                            let meta_key = if key == "server_label" {
+                                "serverLabel"
+                            } else {
+                                key
+                            };
+                            set_provider_metadata(
+                                &mut meta,
+                                PROVIDER_ID_OPENAI,
+                                meta_key,
+                                v.clone(),
+                            );
+                        }
+                    }
+                    content.push(Content::ToolApprovalRequest {
+                        tool_call_id: synthesize_approval_tool_call_id(&approval_id),
+                        approval_id,
+                        provider_metadata: meta,
+                    });
+                }
                 // Deferred output-item types — intentionally skipped, not parsed,
                 // and documented here so the omission is explicit rather than a
                 // silent drop:
@@ -1151,17 +1253,56 @@ fn render_message_items(m: &Message) -> Vec<serde_json::Value> {
             // string or content-part array, with no error flag and no tool name,
             // so an error output degrades to its value and `tool_name` is dropped.
             // `Json` / `ErrorJson` stringify; `Content` becomes a part array.
+            //
+            // An `ExecutionDenied` output paired with an approval (its approval id
+            // rides in `provider_metadata["openai"]["approvalId"]`) is **skipped**
+            // here: the sibling `ToolApprovalResponse` already re-emits the
+            // `mcp_approval_response` that conveys the denial, so emitting a
+            // `function_call_output` too would duplicate it. An *unpaired* denial
+            // (no approval id) falls through and degrades to the denial string.
             // <https://platform.openai.com/docs/api-reference/responses/create>
+            // <https://github.com/vercel/ai/blob/main/packages/openai/src/responses/convert-to-openai-responses-input.ts>
             Content::ToolResult {
-                call_id, output, ..
+                call_id,
+                output,
+                provider_metadata,
+                ..
             } => {
-                let output_value = render_responses_tool_output(output);
+                let denial_paired_with_approval =
+                    matches!(output, ToolResultOutput::ExecutionDenied { .. })
+                        && provider_namespace(provider_metadata, PROVIDER_ID_OPENAI)
+                            .is_some_and(|o| o.contains_key("approvalId"));
+                if !denial_paired_with_approval {
+                    let output_value = render_responses_tool_output(output);
+                    items.push(serde_json::json!({
+                        "type": "function_call_output",
+                        "call_id": call_id,
+                        "output": output_value,
+                    }));
+                }
+            }
+            // Responses `mcp_approval_response {approval_request_id, approve}` —
+            // the grant/deny for a provider-executed MCP tool call, re-emitted on
+            // the input wire. The optional canonical `reason` has no slot on this
+            // item and is dropped (the wire carries none).
+            // <https://platform.openai.com/docs/api-reference/responses/object>
+            // <https://github.com/vercel/ai/blob/main/packages/openai/src/responses/convert-to-openai-responses-input.ts>
+            Content::ToolApprovalResponse {
+                approval_id,
+                approved,
+                ..
+            } => {
                 items.push(serde_json::json!({
-                    "type": "function_call_output",
-                    "call_id": call_id,
-                    "output": output_value,
+                    "type": "mcp_approval_response",
+                    "approval_request_id": approval_id,
+                    "approve": approved,
                 }));
             }
+            // A `mcp_approval_request` is an *output* item (an assistant reply), so
+            // it never appears in a request `input` array — the request render
+            // skips it. It round-trips via the response path
+            // (`render_output_items`).
+            Content::ToolApprovalRequest { .. } => {}
             // Citation sources are response-side metadata only; they are never
             // re-sent as a request input item, so the request path skips them.
             Content::Source { .. } => {}
@@ -1391,6 +1532,35 @@ fn render_output_items(result: &GenerateResult) -> Vec<serde_json::Value> {
             }
         }
     }
+    // Reproduce a `mcp_approval_request` output item from each
+    // `Content::ToolApprovalRequest`. The MCP server identity (`server_label` /
+    // `name` / `arguments`) is restored from `provider_metadata["openai"]`; the
+    // item is keyed by the approval id, matching the wire shape the parse path
+    // reads. <https://platform.openai.com/docs/api-reference/responses/object>
+    for c in &result.content {
+        if let Content::ToolApprovalRequest {
+            approval_id,
+            provider_metadata,
+            ..
+        } = c
+        {
+            let mut item = serde_json::Map::new();
+            item.insert("type".into(), "mcp_approval_request".into());
+            item.insert("id".into(), approval_id.clone().into());
+            if let Some(openai) = provider_namespace(provider_metadata, PROVIDER_ID_OPENAI) {
+                if let Some(label) = openai.get("serverLabel") {
+                    item.insert("server_label".into(), label.clone());
+                }
+                if let Some(name) = openai.get("name") {
+                    item.insert("name".into(), name.clone());
+                }
+                if let Some(arguments) = openai.get("arguments") {
+                    item.insert("arguments".into(), arguments.clone());
+                }
+            }
+            items.push(serde_json::Value::Object(item));
+        }
+    }
     // Best-effort: a generated file becomes an image message item. The Responses
     // API has no standard output-image item, so this preserves the data rather
     // than dropping it. <https://platform.openai.com/docs/api-reference/responses>
@@ -1507,6 +1677,14 @@ impl StreamDecoder for ResponsesStreamDecoder {
             | "response.output_text.done"
             | "response.reasoning_summary_text.done" => {}
             "response.output_item.added" => {
+                // Streaming approval gap: a streamed `mcp_approval_request` item
+                // would need a dedicated `StreamPart` variant to surface, but no
+                // outbound encoder has a target for it (the other three protocols
+                // carry no streaming approval frame), so adding one would be
+                // unconstructed dead code. The non-streaming handshake
+                // (`parse_response` / `render_output_items`) is the complete,
+                // faithful round trip; a streamed approval item is simply not
+                // emitted as a delta here. <https://platform.openai.com/docs/api-reference/responses-streaming>
                 if let Some(item) = json.get("item")
                     && item.get("type").and_then(|t| t.as_str()) == Some("function_call")
                 {

--- a/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
@@ -1667,6 +1667,23 @@ impl ResponsesStreamDecoder {
     }
 }
 
+/// Derive the block id for a [`StreamPart::TextStart`] / [`StreamPart::TextEnd`]
+/// (and reasoning counterpart) from an `output_item.added` / `output_item.done`
+/// event: prefer the upstream `item.id`, falling back to the event's
+/// `output_index` when an upstream omits it. The id is used only to correlate a
+/// start with its matching end; outbound encoders generate their own item ids,
+/// so an exact value is not required for fidelity.
+fn block_marker_id(item: &serde_json::Value, event: &serde_json::Value) -> String {
+    if let Some(id) = item.get("id").and_then(|i| i.as_str()) {
+        return id.to_string();
+    }
+    event
+        .get("output_index")
+        .and_then(|i| i.as_u64())
+        .map(|i| i.to_string())
+        .unwrap_or_default()
+}
+
 impl StreamDecoder for ResponsesStreamDecoder {
     fn decode(&mut self, event: &SseEvent) -> Result<Vec<StreamPart>> {
         let data = event.data.trim();
@@ -1706,31 +1723,54 @@ impl StreamDecoder for ResponsesStreamDecoder {
                 // (`parse_response` / `render_output_items`) is the complete,
                 // faithful round trip; a streamed approval item is simply not
                 // emitted as a delta here. <https://platform.openai.com/docs/api-reference/responses-streaming>
-                if let Some(item) = json.get("item")
-                    && item.get("type").and_then(|t| t.as_str()) == Some("function_call")
-                {
-                    let item_id = item
-                        .get("id")
-                        .and_then(|i| i.as_str())
-                        .unwrap_or_default()
-                        .to_string();
-                    let call_id = item
-                        .get("call_id")
-                        .and_then(|i| i.as_str())
-                        .unwrap_or(&item_id)
-                        .to_string();
-                    let name = item
-                        .get("name")
-                        .and_then(|n| n.as_str())
-                        .unwrap_or_default()
-                        .to_string();
-                    self.function_items
-                        .push((item_id, call_id.clone(), name.clone()));
-                    parts.push(StreamPart::ToolCallDelta {
-                        id: call_id,
-                        name: Some(name),
-                        arguments: String::new(),
-                    });
+                if let Some(item) = json.get("item") {
+                    let item_type = item
+                        .get("type")
+                        .and_then(|t| t.as_str())
+                        .unwrap_or_default();
+                    let item_id = block_marker_id(item, &json);
+                    match item_type {
+                        // A `message` / `reasoning` item open is an explicit
+                        // block boundary on this wire — surface it as a canonical
+                        // start marker so a framing client encoder opens a fresh
+                        // block (the merged-block fix: two distinct message items
+                        // re-encode as two blocks, not one). The block id is the
+                        // upstream item id, falling back to `output_index` if the
+                        // upstream omitted it (used only for marker correlation).
+                        "message" => parts.push(StreamPart::TextStart { id: item_id }),
+                        "reasoning" => parts.push(StreamPart::ReasoningStart { id: item_id }),
+                        "function_call" => {
+                            // A function-call item frames itself via the
+                            // `name`-bearing `ToolCallDelta` below — no separate
+                            // start marker (see the `StreamPart` enum docs).
+                            // Track the *real* upstream `item.id` (not the marker
+                            // fallback) so `function_call_arguments.delta` — which
+                            // carries `item_id` — correlates to this call (#434).
+                            let real_item_id = item
+                                .get("id")
+                                .and_then(|i| i.as_str())
+                                .unwrap_or_default()
+                                .to_string();
+                            let call_id = item
+                                .get("call_id")
+                                .and_then(|i| i.as_str())
+                                .unwrap_or(&real_item_id)
+                                .to_string();
+                            let name = item
+                                .get("name")
+                                .and_then(|n| n.as_str())
+                                .unwrap_or_default()
+                                .to_string();
+                            self.function_items
+                                .push((real_item_id, call_id.clone(), name.clone()));
+                            parts.push(StreamPart::ToolCallDelta {
+                                id: call_id,
+                                name: Some(name),
+                                arguments: String::new(),
+                            });
+                        }
+                        _ => {}
+                    }
                 }
             }
             "response.output_text.delta" => {
@@ -1783,7 +1823,25 @@ impl StreamDecoder for ResponsesStreamDecoder {
             }
             // the `.done` event repeats the full arguments — do NOT re-emit
             // them (would duplicate, #434).
-            "response.function_call_arguments.done" | "response.output_item.done" => {}
+            "response.function_call_arguments.done" => {}
+            "response.output_item.done" => {
+                // Close the matching text / reasoning block so the boundary
+                // survives re-encoding (the merged-block fix). A `function_call`
+                // item carries no end marker (its framing is the `name`-bearing
+                // delta on open and the next item / terminal on close).
+                if let Some(item) = json.get("item") {
+                    let item_type = item
+                        .get("type")
+                        .and_then(|t| t.as_str())
+                        .unwrap_or_default();
+                    let item_id = block_marker_id(item, &json);
+                    match item_type {
+                        "message" => parts.push(StreamPart::TextEnd { id: item_id }),
+                        "reasoning" => parts.push(StreamPart::ReasoningEnd { id: item_id }),
+                        _ => {}
+                    }
+                }
+            }
             "response.completed" | "response.incomplete" => {
                 // #454-2: the full `response` object is carried here..3:
                 // map `response.completed` to the dedicated `ResponseCompleted`
@@ -2041,6 +2099,19 @@ impl ResponsesStreamEncoder {
         self.completed_items.push(item);
     }
 
+    /// Force-open a *fresh* reasoning item for an explicit
+    /// [`StreamPart::ReasoningStart`]. Unlike [`Self::open_reasoning_item`] this
+    /// first closes any reasoning item already open, so two distinct upstream
+    /// `reasoning` items re-encode as two `output_item.added`s rather than one
+    /// merged block (the merged-block fix on this wire). Closing the prior item
+    /// before reopening also re-runs the cross-kind close inside
+    /// `open_reasoning_item`, so message / tool items never interleave.
+    /// <https://platform.openai.com/docs/api-reference/responses-streaming>
+    fn open_fresh_reasoning_item(&mut self, frames: &mut Vec<SseFrame>) {
+        self.close_reasoning_item(frames);
+        self.open_reasoning_item(frames);
+    }
+
     /// Open a message item: `output_item.added` (type=message) +
     /// `content_part.added` (type=output_text). Idempotent — closes any
     /// open reasoning / tool item first so items never interleave.
@@ -2121,6 +2192,19 @@ impl ResponsesStreamEncoder {
             }),
         ));
         self.completed_items.push(item);
+    }
+
+    /// Force-open a *fresh* message item for an explicit
+    /// [`StreamPart::TextStart`]. Unlike [`Self::open_text_item`] this first
+    /// closes any message item already open, so two distinct upstream `message`
+    /// items re-encode as two `output_item.added`s rather than one merged block
+    /// (the merged-block fix on this wire). Closing the prior item before
+    /// reopening also re-runs the cross-kind close inside `open_text_item`, so
+    /// reasoning / tool items never interleave.
+    /// <https://platform.openai.com/docs/api-reference/responses-streaming>
+    fn open_fresh_text_item(&mut self, frames: &mut Vec<SseFrame>) {
+        self.close_text_item(frames);
+        self.open_text_item(frames);
     }
 
     /// Open a function-call item: `output_item.added` (type=function_call).
@@ -2237,6 +2321,26 @@ impl StreamEncoder for ResponsesStreamEncoder {
             StreamPart::File { .. } => {
                 // Responses streaming surfaces generated files on the
                 // non-streaming path; no inline file-output delta is emitted here.
+            }
+            StreamPart::TextStart { .. } => {
+                // Explicit block boundary from a block-framed upstream — open a
+                // *fresh* message item so two distinct upstream text blocks
+                // re-encode as two `output_item.added`s, not one merged block.
+                self.open_fresh_text_item(&mut frames);
+            }
+            StreamPart::ReasoningStart { .. } => {
+                self.open_fresh_reasoning_item(&mut frames);
+            }
+            StreamPart::TextEnd { .. } => {
+                // Close the message item the matching start opened, emitting its
+                // `output_text.done` + `content_part.done` + `output_item.done`.
+                // A no-op if nothing is open, so a stray end is harmless.
+                self.close_text_item(&mut frames);
+            }
+            StreamPart::ReasoningEnd { .. } => {
+                // Close the reasoning item the matching start opened (its
+                // `reasoning_text.done` + `content_part.done` + `output_item.done`).
+                self.close_reasoning_item(&mut frames);
             }
             StreamPart::TextDelta { text } => {
                 // `open_text_item` closes any open reasoning / tool item

--- a/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
@@ -124,6 +124,11 @@ pub enum ResponsesTextFormat {
     JsonSchema {
         /// Schema name (OpenAI requires it).
         name: String,
+        /// Optional schema description — extra LLM guidance OpenAI passes to the
+        /// model. Promoted to the canonical `response_format` description.
+        /// <https://platform.openai.com/docs/api-reference/responses/create>
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        description: Option<String>,
         /// Strict-mode flag.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         strict: Option<bool>,
@@ -559,6 +564,14 @@ fn openai_error_status(err_type: &str) -> u16 {
     }
 }
 
+// Responses has no native finish-reason *string* to preserve: its terminal
+// signal is the response `status` (`completed` / `incomplete` / `failed`), a
+// small closed set that the unified [`FinishReason`] enum reproduces exactly on
+// render (`Length` → `incomplete`, `Error` → `failed`, else `completed`). There
+// is therefore no lossy mapping to stash a raw value for — unlike the
+// Messages / Chat Completions / Generate Content adapters, which collapse
+// several distinct native reasons onto one variant and so stash
+// `rawFinishReason`. Hence this adapter writes no raw finish reason.
 fn finish_from_status(status: &str) -> Option<FinishReason> {
     match status {
         "completed" => Some(FinishReason::Stop),
@@ -609,6 +622,7 @@ impl InboundAdapter for ResponsesAdapter {
             }) => match format {
                 Some(ResponsesTextFormat::JsonSchema {
                     name,
+                    description,
                     strict,
                     schema,
                 }) => {
@@ -620,6 +634,7 @@ impl InboundAdapter for ResponsesAdapter {
                     }
                     Some(ResponseFormat::JsonSchema {
                         name: Some(name),
+                        description,
                         strict,
                         schema,
                     })
@@ -1080,11 +1095,14 @@ fn render_responses_tool(tool: &Tool) -> serde_json::Value {
 }
 
 /// Render a canonical [`ResponseFormat`] into Responses' native
-/// `{ type: "json_schema", name, strict, schema }` body that sits under
-/// `text.format`. OpenAI requires `name`; default it.
+/// `{ type: "json_schema", name, description?, strict?, schema }` body that sits
+/// under `text.format`. OpenAI requires `name`; default it. `description` is
+/// emitted only when the canonical slot carries it.
+/// <https://platform.openai.com/docs/api-reference/responses/create>
 fn render_responses_response_format(rf: &ResponseFormat) -> serde_json::Value {
     let ResponseFormat::JsonSchema {
         name,
+        description,
         strict,
         schema,
     } = rf;
@@ -1096,6 +1114,9 @@ fn render_responses_response_format(rf: &ResponseFormat) -> serde_json::Value {
             .unwrap_or_else(|| "response".to_string())
             .into(),
     );
+    if let Some(description) = description {
+        obj.insert("description".into(), description.clone().into());
+    }
     if let Some(strict) = strict {
         obj.insert("strict".into(), (*strict).into());
     }

--- a/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
@@ -315,31 +315,41 @@ fn render_responses_annotations(result: &GenerateResult) -> Vec<serde_json::Valu
         .content
         .iter()
         .filter_map(|c| match c {
-            Content::Source {
-                source: Source::Url { url, title, .. },
-            } => {
-                let mut ann = serde_json::Map::new();
-                ann.insert("type".into(), "url_citation".into());
-                ann.insert("url".into(), url.clone().into());
-                if let Some(title) = title {
-                    ann.insert("title".into(), title.clone().into());
-                }
-                Some(serde_json::Value::Object(ann))
-            }
-            Content::Source {
-                source: Source::Document {
-                    title, filename, ..
-                },
-            } => {
-                let name = filename.clone().unwrap_or_else(|| title.clone());
-                Some(serde_json::json!({
-                    "type": "file_citation",
-                    "filename": name,
-                }))
-            }
+            Content::Source { source } => Some(render_source_annotation(source)),
             _ => None,
         })
         .collect()
+}
+
+/// Render one canonical [`Source`] into a Responses `annotations[]` entry —
+/// shared by the non-streaming [`render_responses_annotations`] and the
+/// streaming `response.output_text.annotation.added` encode path.
+/// [`Source::Url`] → `url_citation`; [`Source::Document`] → `file_citation`
+/// (keyed by `filename`). The `file_id`/`container_id` provider fields cannot be
+/// reconstructed from the canonical `Source` and are omitted on the document
+/// path (documented loss).
+/// <https://platform.openai.com/docs/api-reference/responses/object> (`annotations`)
+fn render_source_annotation(source: &Source) -> serde_json::Value {
+    match source {
+        Source::Url { url, title, .. } => {
+            let mut ann = serde_json::Map::new();
+            ann.insert("type".into(), "url_citation".into());
+            ann.insert("url".into(), url.clone().into());
+            if let Some(title) = title {
+                ann.insert("title".into(), title.clone().into());
+            }
+            serde_json::Value::Object(ann)
+        }
+        Source::Document {
+            title, filename, ..
+        } => {
+            let name = filename.clone().unwrap_or_else(|| title.clone());
+            serde_json::json!({
+                "type": "file_citation",
+                "filename": name,
+            })
+        }
+    }
 }
 
 /// Parse the Responses `input` field — a string or a heterogeneous item array.
@@ -611,6 +621,7 @@ impl InboundAdapter for ResponsesAdapter {
             text_item: None,
             tool_item: None,
             completed_items: Vec::new(),
+            annotation_index: 0,
         })
     }
 }
@@ -1392,6 +1403,10 @@ fn parse_usage(value: &serde_json::Value) -> Option<Usage> {
 struct ResponsesStreamDecoder {
     /// item_id → (call_id, tool_name) for in-flight function-call items.
     function_items: Vec<(String, String, String)>,
+    /// Running citation count across `response.output_text.annotation.added`
+    /// events, so synthesized [`Source`] ids stay unique within the stream
+    /// (mirrors `next_index` on the non-streaming `parse_responses_annotations`).
+    source_index: usize,
 }
 
 impl ResponsesStreamDecoder {
@@ -1466,6 +1481,24 @@ impl StreamDecoder for ResponsesStreamDecoder {
                     parts.push(StreamPart::TextDelta {
                         text: delta.to_string(),
                     });
+                }
+            }
+            "response.output_text.annotation.added" => {
+                // A streamed citation mutates an open `output_text` item: the
+                // single new annotation rides on the `annotation` field with the
+                // same shape `parse_responses_annotations` reads. Lift it into a
+                // `StreamPart::Source` (the client-side encoder re-attaches it at
+                // the protocol's native citation location). Wrapped in a
+                // one-element array to reuse the array parser; `source_index`
+                // keeps synthesized ids unique across the stream.
+                // <https://platform.openai.com/docs/api-reference/responses-streaming/response/output_text/annotation_added>
+                if let Some(annotation) = json.get("annotation") {
+                    let arr = serde_json::Value::Array(vec![annotation.clone()]);
+                    for content in parse_responses_annotations(Some(&arr), &mut self.source_index) {
+                        if let Content::Source { source } = content {
+                            parts.push(StreamPart::Source { source });
+                        }
+                    }
                 }
             }
             "response.reasoning_summary_text.delta" | "response.reasoning_text.delta" => {
@@ -1595,6 +1628,10 @@ struct ResponsesStreamEncoder {
     /// Codex CLI reconstructs the assistant turn from this array, so an
     /// empty `output` renders as a blank turn (the symptom this fixes).
     completed_items: Vec<serde_json::Value>,
+    /// Running count of `response.output_text.annotation.added` events emitted,
+    /// supplying the monotonically increasing `annotation_index` each event
+    /// carries.
+    annotation_index: u64,
 }
 
 /// Tracking state for one open message / reasoning item.
@@ -2012,17 +2049,31 @@ impl StreamEncoder for ResponsesStreamEncoder {
                     ));
                 }
             }
-            StreamPart::Source { .. } => {
-                // Streaming citations are NOT re-encoded onto the Responses wire.
-                // On this protocol a citation is a `response.output_text.annotation.added`
-                // event that mutates an already-open `output_text` item's
-                // `annotations[]`; a cross-protocol `StreamPart::Source` arrives
-                // with no guaranteed open text item to attach to, and faithfully
-                // re-emitting the `*.annotation.added` lifecycle would require
-                // buffering against the text item-state machine. Documented gap:
-                // the citation survives the non-streaming Responses render
-                // (`render_output_items`) but is dropped on the streamed path.
+            StreamPart::Source { source } => {
+                // A citation is a `response.output_text.annotation.added` event
+                // that mutates an `output_text` item. Ensure a text item is open
+                // (a cross-protocol source may arrive before any text delta), so
+                // the annotation has a valid item to attach to, then emit it
+                // referencing that item. This mirrors the decode arm above and
+                // the non-streaming `render_responses_annotations`.
                 // <https://platform.openai.com/docs/api-reference/responses-streaming/response/output_text/annotation_added>
+                self.open_text_item(&mut frames);
+                if let Some(state) = self.text_item.as_ref() {
+                    let (item_id, output_index) = (state.item_id.clone(), state.output_index);
+                    let annotation_index = self.annotation_index;
+                    self.annotation_index += 1;
+                    let annotation = render_source_annotation(source);
+                    frames.push(self.ev(
+                        "response.output_text.annotation.added",
+                        serde_json::json!({
+                            "item_id": item_id,
+                            "output_index": output_index,
+                            "content_index": 0,
+                            "annotation_index": annotation_index,
+                            "annotation": annotation,
+                        }),
+                    ));
+                }
             }
             StreamPart::Usage { .. } => {}
             StreamPart::ResponseStarted { .. } => {

--- a/crates/bitrouter-sdk/src/language_model/protocol/snapshots/chat_completions_request.json
+++ b/crates/bitrouter-sdk/src/language_model/protocol/snapshots/chat_completions_request.json
@@ -4,6 +4,15 @@
   "description": "Chat Completions request body\n(<https://platform.openai.com/docs/api-reference/chat/create>).\n\n`pub` so downstream crates (notably `bitrouter-cloud`) can derive an\nOpenAPI schema from the canonical wire shape without redeclaring it.",
   "type": "object",
   "properties": {
+    "frequency_penalty": {
+      "description": "Frequency penalty. Promoted to the canonical `frequency_penalty` slot.\n<https://platform.openai.com/docs/api-reference/chat/create#chat-create-frequency_penalty>",
+      "type": [
+        "number",
+        "null"
+      ],
+      "format": "double",
+      "default": null
+    },
     "max_completion_tokens": {
       "type": [
         "integer",
@@ -31,6 +40,15 @@
     "model": {
       "type": "string"
     },
+    "presence_penalty": {
+      "description": "Presence penalty. Promoted to the canonical `presence_penalty` slot.\n<https://platform.openai.com/docs/api-reference/chat/create#chat-create-presence_penalty>",
+      "type": [
+        "number",
+        "null"
+      ],
+      "format": "double",
+      "default": null
+    },
     "reasoning_effort": {
       "type": [
         "string",
@@ -48,6 +66,19 @@
           "type": "null"
         }
       ],
+      "default": null
+    },
+    "seed": {
+      "description": "Deterministic-sampling seed. Promoted to the canonical `seed` slot so it\ntranslates across protocols (e.g. to a Gemini upstream's\n`generationConfig.seed`) instead of no-op'ing as a top-level key on a\nnested-config wire.\n<https://platform.openai.com/docs/api-reference/chat/create#chat-create-seed>",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "int64",
+      "default": null
+    },
+    "stop": {
+      "description": "Stop sequences — a single string or an array of up to four. Promoted to\nthe canonical `stop` slot.\n<https://platform.openai.com/docs/api-reference/chat/create#chat-create-stop>",
       "default": null
     },
     "stream": {

--- a/crates/bitrouter-sdk/src/language_model/protocol/snapshots/chat_completions_request.json
+++ b/crates/bitrouter-sdk/src/language_model/protocol/snapshots/chat_completions_request.json
@@ -231,7 +231,7 @@
       ]
     },
     "ChatToolFunction": {
-      "description": "The `function` payload of a [`ChatTool`]: name + description + JSON-Schema\nparameters.",
+      "description": "The `function` payload of a [`ChatTool`]: name + description + JSON-Schema\nparameters + optional `strict` flag.\n<https://platform.openai.com/docs/guides/function-calling#strict-mode>",
       "type": "object",
       "properties": {
         "description": {
@@ -245,6 +245,14 @@
           "type": "string"
         },
         "parameters": {
+          "default": null
+        },
+        "strict": {
+          "description": "OpenAI strict-mode flag (V3 `strict`). Captured so it is not lost across\nthe canonical boundary.",
+          "type": [
+            "boolean",
+            "null"
+          ],
           "default": null
         }
       },

--- a/crates/bitrouter-sdk/src/language_model/protocol/snapshots/chat_completions_request.json
+++ b/crates/bitrouter-sdk/src/language_model/protocol/snapshots/chat_completions_request.json
@@ -100,6 +100,13 @@
       "description": "The `json_schema` payload of [`ChatResponseFormat::JsonSchema`].",
       "type": "object",
       "properties": {
+        "description": {
+          "description": "Optional schema description — extra LLM guidance OpenAI passes through to\nthe model. Promoted to the canonical `response_format` description.\n<https://platform.openai.com/docs/guides/structured-outputs>",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "name": {
           "description": "Schema name (OpenAI requires it).",
           "type": "string"

--- a/crates/bitrouter-sdk/src/language_model/protocol/snapshots/generate_content_request.json
+++ b/crates/bitrouter-sdk/src/language_model/protocol/snapshots/generate_content_request.json
@@ -95,6 +95,15 @@
       "description": "`generationConfig` knobs on a [`GenerateContentRequest`].",
       "type": "object",
       "properties": {
+        "frequencyPenalty": {
+          "description": "Frequency penalty. Promoted to the canonical `frequency_penalty` slot.\n<https://ai.google.dev/api/generate-content#GenerationConfig>",
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double",
+          "default": null
+        },
         "maxOutputTokens": {
           "type": [
             "integer",
@@ -103,6 +112,15 @@
           "format": "uint32",
           "default": null,
           "minimum": 0
+        },
+        "presencePenalty": {
+          "description": "Presence penalty. Promoted to the canonical `presence_penalty` slot.\n<https://ai.google.dev/api/generate-content#GenerationConfig>",
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double",
+          "default": null
         },
         "responseMimeType": {
           "description": "Response MIME type. `application/json` paired with `response_schema` is\nthe structured-output contract; other values (e.g. `text/x.enum`) pass\nthrough opaquely.\n<https://ai.google.dev/gemini-api/docs/structured-output>",
@@ -116,6 +134,26 @@
           "description": "JSON Schema constraining the response (with\n`response_mime_type: \"application/json\"`).",
           "default": null
         },
+        "seed": {
+          "description": "Deterministic-sampling seed. Promoted to the canonical `seed` slot.\n<https://ai.google.dev/api/generate-content#GenerationConfig>",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int64",
+          "default": null
+        },
+        "stopSequences": {
+          "description": "Stop sequences. Promoted to the canonical `stop` slot, so it can render\nas a Chat Completions `stop` or an Anthropic `stop_sequences`.\n<https://ai.google.dev/api/generate-content#GenerationConfig>",
+          "type": [
+            "array",
+            "null"
+          ],
+          "default": null,
+          "items": {
+            "type": "string"
+          }
+        },
         "temperature": {
           "type": [
             "number",
@@ -123,6 +161,16 @@
           ],
           "format": "double",
           "default": null
+        },
+        "topK": {
+          "description": "Top-k sampling. Promoted to the canonical `top_k` slot so it translates\nacross protocols (e.g. to an Anthropic upstream's `top_k`).\n<https://ai.google.dev/api/generate-content#GenerationConfig>",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "default": null,
+          "minimum": 0
         },
         "topP": {
           "type": [

--- a/crates/bitrouter-sdk/src/language_model/protocol/snapshots/generate_content_request.json
+++ b/crates/bitrouter-sdk/src/language_model/protocol/snapshots/generate_content_request.json
@@ -135,7 +135,7 @@
       }
     },
     "GenerateContentTool": {
-      "description": "One element of [`GenerateContentRequest`]'s `tools` array — Google's\n`{ functionDeclarations: [...] }` envelope.",
+      "description": "One element of [`GenerateContentRequest`]'s `tools` array.\n\nA single Google tool object may carry client function declarations\n(`functionDeclarations`) **and/or** one or more provider-defined (\"built-in\")\ntool keys on the same object — `googleSearch`, `codeExecution`,\n`googleSearchRetrieval`, `urlContext`. Function declarations parse to\n[`Tool::Function`]; every other key is a provider-defined tool namespaced\n`google.<key>`, its value preserved verbatim as `args`. The non-function keys\nride in `extra`.\n<https://ai.google.dev/gemini-api/docs/function-calling>\n<https://ai.google.dev/gemini-api/docs/google-search>\n<https://ai.google.dev/gemini-api/docs/code-execution>",
       "type": "object",
       "properties": {
         "functionDeclarations": {

--- a/crates/bitrouter-sdk/src/language_model/protocol/snapshots/messages_request.json
+++ b/crates/bitrouter-sdk/src/language_model/protocol/snapshots/messages_request.json
@@ -33,6 +33,17 @@
         }
       ]
     },
+    "stop_sequences": {
+      "description": "Custom stop sequences. Promoted to the canonical `stop` slot, so it can\nrender as a Chat Completions `stop` or a Gemini `stopSequences`.\n<https://docs.anthropic.com/en/api/messages#body-stop-sequences>",
+      "type": [
+        "array",
+        "null"
+      ],
+      "default": null,
+      "items": {
+        "type": "string"
+      }
+    },
     "stream": {
       "type": "boolean",
       "default": false
@@ -54,6 +65,16 @@
       "items": {
         "$ref": "#/$defs/MessagesTool"
       }
+    },
+    "top_k": {
+      "description": "Top-k sampling. Promoted to the canonical `top_k` slot so it translates\nacross protocols (e.g. to a Gemini upstream's `generationConfig.topK`).\n<https://docs.anthropic.com/en/api/messages#body-top-k>",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "uint32",
+      "default": null,
+      "minimum": 0
     },
     "top_p": {
       "type": [

--- a/crates/bitrouter-sdk/src/language_model/protocol/snapshots/messages_request.json
+++ b/crates/bitrouter-sdk/src/language_model/protocol/snapshots/messages_request.json
@@ -132,7 +132,7 @@
       ]
     },
     "MessagesTool": {
-      "description": "One element of [`MessagesRequest`]'s `tools` array — Anthropic's tool definition shape.",
+      "description": "One element of [`MessagesRequest`]'s `tools` array.\n\nAnthropic uses one array for both kinds of tool:\n- a **client (function) tool** — `{name, description?, input_schema}` (no `type`);\n- a **provider-defined (server) tool** — `{type:\"web_search_20250305\"|…, name, …config}`\n  (web search, code execution, computer use, bash, text editor), where `type`\n  is the dated tool version and `name` is the stable tool name.\n\nA versioned `type` discriminates a server tool; its config keys ride in\n`extra` so they are preserved verbatim into `Tool::ProviderDefined.args`.\n<https://docs.claude.com/en/docs/agents-and-tools/tool-use/overview>\n<https://docs.claude.com/en/docs/agents-and-tools/tool-use/web-search-tool>",
       "type": "object",
       "properties": {
         "description": {
@@ -146,12 +146,20 @@
           "default": null
         },
         "name": {
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
+        "type": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
         }
-      },
-      "required": [
-        "name"
-      ]
+      }
     }
   }
 }

--- a/crates/bitrouter-sdk/src/language_model/protocol/snapshots/responses_request.json
+++ b/crates/bitrouter-sdk/src/language_model/protocol/snapshots/responses_request.json
@@ -168,7 +168,7 @@
       ]
     },
     "ResponsesTool": {
-      "description": "One element of [`ResponsesRequest`]'s `tools` array — the Responses-flavoured\nflat tool definition (`{ type: \"function\", name, description, parameters }`).",
+      "description": "One element of [`ResponsesRequest`]'s `tools` array.\n\nResponses uses one flat array for both kinds of tool:\n- a **function** tool — `{type:\"function\", name, description?, parameters, strict?}`;\n- a **provider-defined** server tool — `{type:\"web_search_preview\"|…, …config}`\n  (`code_interpreter`, `file_search`, `image_generation`, `computer_use_preview`).\n\n`kind` (`type`) discriminates the two; for a server tool the configuration\nkeys ride in `extra` so they are preserved verbatim into the canonical\n`Tool::ProviderDefined.args`.\n<https://platform.openai.com/docs/api-reference/responses/create#responses-create-tools>",
       "type": "object",
       "properties": {
         "description": {
@@ -186,6 +186,14 @@
           "default": null
         },
         "parameters": {
+          "default": null
+        },
+        "strict": {
+          "description": "OpenAI strict-mode flag (V3 `strict`) on a function tool. Captured so it\nis not lost across the canonical boundary.",
+          "type": [
+            "boolean",
+            "null"
+          ],
           "default": null
         },
         "type": {

--- a/crates/bitrouter-sdk/src/language_model/protocol/snapshots/responses_request.json
+++ b/crates/bitrouter-sdk/src/language_model/protocol/snapshots/responses_request.json
@@ -140,6 +140,13 @@
           "description": "JSON constrained to a schema.",
           "type": "object",
           "properties": {
+            "description": {
+              "description": "Optional schema description — extra LLM guidance OpenAI passes to the\nmodel. Promoted to the canonical `response_format` description.\n<https://platform.openai.com/docs/api-reference/responses/create>",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "name": {
               "description": "Schema name (OpenAI requires it).",
               "type": "string"

--- a/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
@@ -3008,3 +3008,105 @@ fn response_modalities_round_trip_through_generate_content() {
         serde_json::json!(["TEXT", "IMAGE"])
     );
 }
+
+#[test]
+fn generated_image_round_trips_through_generate_content_stream() {
+    // A generated image survives the canonical stream `File` part through the
+    // Gemini encoder (inlineData chunk) and back through its decoder.
+    let outbound = adapter_for(ApiProtocol::GenerateContent);
+    let part = StreamPart::File {
+        media_type: "image/png".to_string(),
+        data: DataContent::Base64 {
+            data: IMG_B64.to_string(),
+        },
+    };
+    let mut encoder = outbound.stream_encoder("resp_s", "test-model");
+    let mut frames = encoder.encode(&part).unwrap();
+    frames.extend(encoder.finish().unwrap());
+
+    let mut decoder = outbound.stream_decoder();
+    let mut decoded = Vec::new();
+    for frame in &frames {
+        if let SseFrame::Event { event, data } = frame {
+            decoded.extend(
+                decoder
+                    .decode(&SseEvent {
+                        event: event.clone(),
+                        data: data.clone(),
+                    })
+                    .unwrap(),
+            );
+        }
+    }
+    decoded.extend(decoder.finish().unwrap());
+
+    let expected = DataContent::Base64 {
+        data: IMG_B64.to_string(),
+    };
+    let file = decoded.iter().find_map(|p| match p {
+        StreamPart::File { media_type, data } => Some((media_type.as_str(), data)),
+        _ => None,
+    });
+    assert_eq!(file, Some(("image/png", &expected)));
+}
+
+#[test]
+fn generated_image_round_trips_through_generate_content_response() {
+    let adapter = adapter_for(ApiProtocol::GenerateContent);
+    let body = serde_json::json!({
+        "candidates": [{
+            "content": { "role": "model", "parts": [
+                { "inlineData": { "mimeType": "image/png", "data": IMG_B64 } }
+            ]},
+            "finishReason": "STOP"
+        }]
+    });
+    let result = adapter.parse_response(body).unwrap();
+    let expected = DataContent::Base64 {
+        data: IMG_B64.to_string(),
+    };
+    let file = result.content.iter().find_map(|c| match c {
+        Content::File {
+            media_type, data, ..
+        } => Some((media_type.as_str(), data)),
+        _ => None,
+    });
+    assert_eq!(file, Some(("image/png", &expected)));
+
+    let rendered = adapter
+        .render_response(&result, &sample_prompt(), "id")
+        .unwrap();
+    let s = serde_json::to_string(&rendered).unwrap();
+    assert!(
+        s.contains("inlineData") && s.contains(IMG_B64),
+        "rendered response should carry the generated image: {s}"
+    );
+}
+
+#[test]
+fn generated_image_renders_into_chat_response_best_effort() {
+    let adapter = adapter_for(ApiProtocol::ChatCompletions);
+    let result = GenerateResult {
+        content: vec![Content::File {
+            media_type: "image/png".to_string(),
+            data: DataContent::Base64 {
+                data: IMG_B64.to_string(),
+            },
+            filename: None,
+            extra: Default::default(),
+        }],
+        usage: None,
+        finish_reason: Some(FinishReason::Stop),
+        response_id: None,
+        stop_details: None,
+    };
+    let rendered = adapter
+        .render_response(&result, &sample_prompt(), "id")
+        .unwrap();
+    let part = &rendered["choices"][0]["message"]["content"][0];
+    assert_eq!(part["type"], "image_url");
+    assert_eq!(
+        part["image_url"]["url"],
+        format!("data:image/png;base64,{IMG_B64}")
+    );
+}

--- a/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
@@ -3803,7 +3803,7 @@ fn tool_result_json_degrades_to_text_on_string_wires() {
     // stringified and re-parses as Text (a lossless degrade). The Responses case
     // is the audit-proven fix: `output` is `JSON.stringify`d, never a raw object.
     // <https://platform.openai.com/docs/api-reference/chat/create#chat-create-messages>
-    // <https://github.com/vercel/ai/blob/main/packages/openai/src/responses/convert-to-openai-responses-input.ts>
+    // <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/openai/src/responses/convert-to-openai-responses-input.ts>
     let output = ToolResultOutput::Json {
         value: serde_json::json!({ "celsius": 21, "unit": "C" }),
     };
@@ -4037,7 +4037,7 @@ fn tool_result_json_renders_responses_output_as_string() {
     // must be emitted as a *stringified* JSON value (the reference does
     // `JSON.stringify(output.value)`), never as a raw object — otherwise the
     // OpenAI wire rejects it.
-    // <https://github.com/vercel/ai/blob/main/packages/openai/src/responses/convert-to-openai-responses-input.ts>
+    // <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/openai/src/responses/convert-to-openai-responses-input.ts>
     let value = serde_json::json!({ "celsius": 21, "unit": "C" });
     for output in [
         ToolResultOutput::Json {
@@ -4143,7 +4143,7 @@ fn tool_result_content_renders_responses_part_array() {
     // The rendered Responses wire carries the multimodal result as a part array:
     // text → input_text, image/* → input_image (image_url), other media →
     // input_file (file_data). It must NOT collapse to a string.
-    // <https://github.com/vercel/ai/blob/main/packages/openai/src/responses/convert-to-openai-responses-input.ts>
+    // <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/openai/src/responses/convert-to-openai-responses-input.ts>
     let output = ToolResultOutput::Content {
         value: vec![
             ToolResultContentPart::Text {
@@ -4194,7 +4194,7 @@ fn tool_result_content_file_id_round_trips_through_responses() {
     // `file_id`. It round-trips as a `FileId` content part. This is the only wire
     // that carries the construct, so the variant is constructed (parse) and
     // consumed (render) here in non-test code.
-    // <https://github.com/vercel/ai/blob/main/packages/openai/src/responses/convert-to-openai-responses-input.ts>
+    // <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/openai/src/responses/convert-to-openai-responses-input.ts>
     let output = ToolResultOutput::Content {
         value: vec![
             ToolResultContentPart::FileId {
@@ -5122,6 +5122,76 @@ fn sampling_params_translate_gemini_and_anthropic_to_others() {
         .render_request(&anthropic_in)
         .unwrap()["generationConfig"];
     assert_eq!(gc["topK"], 64);
+}
+
+/// Cross-protocol no-leak, Gemini/Anthropic → Responses: the Responses API has no
+/// wire field for `top_k` / `seed` / `stop` / `presence_penalty` /
+/// `frequency_penalty`, so a source request carrying any of them must render to
+/// Responses with NONE of those values present — in neither the native (snake)
+/// nor the source-wire (camel) spelling, and not leaked through the `extra`
+/// splat. The params Responses *does* support (`temperature`, `top_p`,
+/// `max_output_tokens`) still survive. Locks in the "Responses carries none"
+/// contract the [`GenerationParams`] field docs assert.
+#[test]
+fn sampling_params_do_not_leak_to_responses() {
+    let responses = adapter_for(ApiProtocol::Responses);
+
+    // Gemini source: all five generationConfig knobs, plus supported params.
+    let gemini = adapter_for(ApiProtocol::GenerateContent)
+        .parse_request(serde_json::json!({
+            "model": "gemini-2.0-flash",
+            "contents": [{"role": "user", "parts": [{"text": "hi"}]}],
+            "generationConfig": {
+                "temperature": 0.5,
+                "topP": 0.9,
+                "maxOutputTokens": 32,
+                "topK": 40,
+                "seed": 7,
+                "stopSequences": ["END"],
+                "presencePenalty": 0.1,
+                "frequencyPenalty": -0.1
+            }
+        }))
+        .unwrap();
+    let from_gemini = responses.render_request(&gemini).unwrap();
+    // None of the unsupported five appears in any spelling.
+    for key in [
+        "top_k",
+        "topK",
+        "seed",
+        "stop",
+        "stop_sequences",
+        "stopSequences",
+        "presence_penalty",
+        "presencePenalty",
+        "frequency_penalty",
+        "frequencyPenalty",
+    ] {
+        assert!(
+            from_gemini.get(key).is_none(),
+            "Responses must not carry `{key}` from a Gemini source: {from_gemini}"
+        );
+    }
+    // The supported params survive the route.
+    assert_eq!(from_gemini["temperature"], 0.5);
+    assert_eq!(from_gemini["top_p"], 0.9);
+    assert_eq!(from_gemini["max_output_tokens"], 32);
+
+    // Anthropic source: `top_k` must not reach Responses in any form.
+    let anthropic = adapter_for(ApiProtocol::Messages)
+        .parse_request(serde_json::json!({
+            "model": "claude-opus-4-8",
+            "max_tokens": 16,
+            "messages": [{"role": "user", "content": "hi"}],
+            "top_k": 64
+        }))
+        .unwrap();
+    assert_eq!(anthropic.params.top_k, Some(64));
+    let from_anthropic = responses.render_request(&anthropic).unwrap();
+    assert!(
+        from_anthropic.get("top_k").is_none() && from_anthropic.get("topK").is_none(),
+        "Responses must not carry top-k from an Anthropic source: {from_anthropic}"
+    );
 }
 
 /// A parsed sampling param must NOT also remain in the raw `extra` passthrough —
@@ -7687,10 +7757,24 @@ fn responses_mcp_approval_request_round_trips() {
     assert_eq!(item["server_label"], "dmcp");
     assert_eq!(item["name"], "roll");
     assert_eq!(item["arguments"], "{\"diceRollExpression\":\"2d4 + 1\"}");
+    // Single-id source: no distinct `itemId` was stored, so the render must NOT
+    // add a redundant `approval_request_id` (the `id` alone conveys it).
+    assert!(
+        item.get("approval_request_id").is_none(),
+        "single-id approval item must not gain a redundant approval_request_id: {item}"
+    );
+    let openai = meta.get("openai").and_then(|o| o.as_object()).unwrap();
+    assert!(
+        !openai.contains_key("itemId"),
+        "coinciding id must not be stored as itemId: {openai:?}"
+    );
 }
 
-/// A Responses `mcp_approval_request` with no `approval_request_id` falls back to
-/// the item `id` for the approval id (mirroring the AI SDK reference).
+/// A Responses `mcp_approval_request` with an `approval_request_id` *distinct*
+/// from its item `id` uses the former as the approval/correlation id, preserves
+/// the latter under `provider_metadata["openai"]["itemId"]`, and re-emits BOTH on
+/// render so the two-id form round-trips losslessly (mirroring the AI SDK
+/// reference's `approval_request_id ?? id` choice while not dropping the raw id).
 #[test]
 fn responses_mcp_approval_request_prefers_approval_request_id() {
     let adapter = adapter_for(ApiProtocol::Responses);
@@ -7708,16 +7792,39 @@ fn responses_mcp_approval_request_prefers_approval_request_id() {
         ]
     });
     let result = adapter.parse_response(body).unwrap();
-    let approval_id = result
+    let (approval_id, meta) = result
         .content
         .iter()
         .find_map(|c| match c {
-            Content::ToolApprovalRequest { approval_id, .. } => Some(approval_id.as_str()),
+            Content::ToolApprovalRequest {
+                approval_id,
+                provider_metadata,
+                ..
+            } => Some((approval_id.as_str(), provider_metadata)),
             _ => None,
         })
         .unwrap();
-    // `approval_request_id` wins over the item `id`.
+    // `approval_request_id` wins over the item `id` as the correlation key.
     assert_eq!(approval_id, "mcpr_real");
+    // The distinct raw item id is preserved, not dropped.
+    let openai = meta.get("openai").and_then(|o| o.as_object()).unwrap();
+    assert_eq!(openai["itemId"], "item_xyz");
+
+    // Render back: both ids reappear on the item (`id` = raw item id,
+    // `approval_request_id` = correlation key), so the original round-trips.
+    let rendered = adapter
+        .render_response(&result, &sample_prompt(), "resp_1")
+        .unwrap();
+    let item = rendered["output"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|i| i["type"] == "mcp_approval_request")
+        .expect("mcp_approval_request re-emitted");
+    assert_eq!(item["id"], "item_xyz");
+    assert_eq!(item["approval_request_id"], "mcpr_real");
+    assert_eq!(item["server_label"], "dmcp");
+    assert_eq!(item["name"], "roll");
 }
 
 /// An approved `mcp_approval_response` input item round-trips through Responses as

--- a/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
@@ -3245,39 +3245,43 @@ fn tool_result_text_degrades_to_json_result_on_gemini() {
 }
 
 #[test]
-fn tool_result_json_round_trips_through_structured_protocols() {
-    // Responses (`function_call_output.output`) and Generate Content
-    // (`functionResponse.response`) both carry a structured tool-result body, so
-    // a Json *object* output survives intact.
+fn tool_result_json_round_trips_through_generate_content() {
+    // Generate Content (`functionResponse.response`) is the only request wire
+    // whose tool-result body is a structured JSON *object* slot, so a Json object
+    // output survives intact there. (Responses' `output` is a string slot — see
+    // `tool_result_json_degrades_to_text_on_string_wires`.)
     let output = ToolResultOutput::Json {
         value: serde_json::json!({ "celsius": 21, "unit": "C" }),
     };
-    for protocol in [ApiProtocol::Responses, ApiProtocol::GenerateContent] {
-        assert_eq!(
-            round_trip_tool_output(protocol.clone(), output.clone()),
-            output,
-            "{protocol:?} lost a Json tool result"
-        );
-    }
+    assert_eq!(
+        round_trip_tool_output(ApiProtocol::GenerateContent, output.clone()),
+        output,
+        "Generate Content lost a Json tool result"
+    );
 }
 
 #[test]
-fn tool_result_json_degrades_to_text_on_chat_completions() {
-    // OpenAI Chat Completions' `tool` message `content` is a string (or a
-    // text/media part array) — there is no slot for a bare JSON value, so a Json
-    // output is stringified and re-parses as Text (a lossless degrade).
+fn tool_result_json_degrades_to_text_on_string_wires() {
+    // Neither OpenAI Chat Completions (`tool` message `content`) nor OpenAI
+    // Responses (`function_call_output.output`) has a slot for a bare JSON value —
+    // both are string (or part-array) slots. A Json output is therefore
+    // stringified and re-parses as Text (a lossless degrade). The Responses case
+    // is the audit-proven fix: `output` is `JSON.stringify`d, never a raw object.
     // <https://platform.openai.com/docs/api-reference/chat/create#chat-create-messages>
+    // <https://github.com/vercel/ai/blob/main/packages/openai/src/responses/convert-to-openai-responses-input.ts>
     let output = ToolResultOutput::Json {
         value: serde_json::json!({ "celsius": 21, "unit": "C" }),
     };
-    let back = round_trip_tool_output(ApiProtocol::ChatCompletions, output.clone());
-    assert_eq!(
-        back,
-        ToolResultOutput::Text {
-            value: output.to_provider_string(),
-        },
-        "Chat Completions Json tool result degrades to a stringified Text output"
-    );
+    for protocol in [ApiProtocol::ChatCompletions, ApiProtocol::Responses] {
+        let back = round_trip_tool_output(protocol.clone(), output.clone());
+        assert_eq!(
+            back,
+            ToolResultOutput::Text {
+                value: output.to_provider_string(),
+            },
+            "{protocol:?} Json tool result must degrade to a stringified Text output"
+        );
+    }
 }
 
 #[test]
@@ -3416,6 +3420,58 @@ fn tool_result_content_renders_anthropic_image_block() {
 }
 
 #[test]
+fn tool_result_content_skips_non_image_media_on_anthropic() {
+    // Anthropic `tool_result` content accepts only `text` and `image` blocks.
+    // A non-image media part (e.g. a PDF) must be skipped, NOT emitted as an
+    // `image` block with a non-image media_type.
+    // <https://docs.anthropic.com/en/docs/build-with-claude/tool-use#tool-result>
+    let output = ToolResultOutput::Content {
+        value: vec![
+            ToolResultContentPart::Text {
+                text: "report".to_string(),
+            },
+            ToolResultContentPart::Media {
+                media_type: "application/pdf".to_string(),
+                data: DataContent::Base64 {
+                    data: IMG_B64.to_string(),
+                },
+            },
+            ToolResultContentPart::Media {
+                media_type: "image/png".to_string(),
+                data: DataContent::Base64 {
+                    data: IMG_B64.to_string(),
+                },
+            },
+        ],
+    };
+    let req = adapter_for(ApiProtocol::Messages)
+        .render_request(&tool_result_prompt("t1", None, output))
+        .unwrap();
+    let blocks = req["messages"][0]["content"][0]["content"]
+        .as_array()
+        .expect("tool_result content is a block array");
+    // Only the text block and the single image block survive; the PDF is dropped.
+    assert_eq!(
+        blocks.len(),
+        2,
+        "non-image media must be skipped: {blocks:?}"
+    );
+    assert_eq!(blocks[0]["type"], "text");
+    assert_eq!(blocks[1]["type"], "image");
+    assert_eq!(blocks[1]["source"]["media_type"], "image/png");
+    // No block may carry a non-image media type under an `image` type tag.
+    for b in blocks {
+        if b["type"] == "image" {
+            let mt = b["source"]["media_type"].as_str().unwrap_or("");
+            assert!(
+                mt.is_empty() || mt.starts_with("image/"),
+                "an image block must not carry a non-image media_type: {mt}"
+            );
+        }
+    }
+}
+
+#[test]
 fn tool_result_content_round_trips_through_chat_completions() {
     // OpenAI Chat Completions carries a multimodal tool result as a content-part
     // array (text + image_url), so a Content output survives there too.
@@ -3436,6 +3492,209 @@ fn tool_result_content_round_trips_through_chat_completions() {
         round_trip_tool_output(ApiProtocol::ChatCompletions, output.clone()),
         output,
         "Chat Completions lost a multimodal Content tool result"
+    );
+}
+
+#[test]
+fn tool_result_json_renders_responses_output_as_string() {
+    // Regression: the Responses `function_call_output.output` field is a
+    // `string | content-part-array`, not a bare JSON-value slot. A Json output
+    // must be emitted as a *stringified* JSON value (the reference does
+    // `JSON.stringify(output.value)`), never as a raw object — otherwise the
+    // OpenAI wire rejects it.
+    // <https://github.com/vercel/ai/blob/main/packages/openai/src/responses/convert-to-openai-responses-input.ts>
+    let value = serde_json::json!({ "celsius": 21, "unit": "C" });
+    for output in [
+        ToolResultOutput::Json {
+            value: value.clone(),
+        },
+        ToolResultOutput::ErrorJson {
+            value: value.clone(),
+        },
+    ] {
+        let req = adapter_for(ApiProtocol::Responses)
+            .render_request(&tool_result_prompt("c1", None, output.clone()))
+            .unwrap();
+        // Find the function_call_output item in the rendered input array.
+        let wire_output = req["input"]
+            .as_array()
+            .expect("input is an array")
+            .iter()
+            .find(|i| i["type"] == "function_call_output")
+            .expect("a function_call_output item")["output"]
+            .clone();
+        assert!(
+            wire_output.is_string(),
+            "Responses `output` must be a JSON string, not a bare {:?}: {wire_output:?}",
+            output
+        );
+        // And the string must be the JSON serialization of the value.
+        assert_eq!(
+            wire_output.as_str().unwrap(),
+            value.to_string(),
+            "Responses `output` string must be the stringified JSON value"
+        );
+    }
+}
+
+#[test]
+fn tool_result_content_round_trips_through_responses() {
+    // A multimodal Content tool result (text + inline image + inline non-image
+    // file) survives a round trip through the Responses
+    // `function_call_output.output` part array. The wire has a real multimodal
+    // slot here (`input_text` / `input_image` / `input_file`), so media is
+    // preserved rather than flattened to text. Inline `data:` payloads carry the
+    // media type so it round-trips exactly (a plain `input_file` URL, by
+    // contrast, has no media-type hint — the same subtype loss the Anthropic
+    // URL-source path documents).
+    let output = ToolResultOutput::Content {
+        value: vec![
+            ToolResultContentPart::Text {
+                text: "see attachments".to_string(),
+            },
+            ToolResultContentPart::Media {
+                media_type: "image/png".to_string(),
+                data: DataContent::Base64 {
+                    data: IMG_B64.to_string(),
+                },
+            },
+            ToolResultContentPart::Media {
+                media_type: "application/pdf".to_string(),
+                data: DataContent::Base64 {
+                    data: IMG_B64.to_string(),
+                },
+            },
+        ],
+    };
+    assert_eq!(
+        round_trip_tool_output(ApiProtocol::Responses, output.clone()),
+        output,
+        "Responses lost a multimodal Content tool result"
+    );
+}
+
+#[test]
+fn tool_result_content_responses_file_url_round_trips_as_url() {
+    // A non-image file delivered by URL renders as `input_file.file_data` =
+    // the URL, and re-parses as a URL-form Media part. The media subtype is not
+    // carried on the wire (a bare URL has no type hint), so it degrades to the
+    // generic `application/octet-stream` — the type still round-trips, only the
+    // subtype is lost, which is the faithful behavior for an untyped URL slot.
+    let output = ToolResultOutput::Content {
+        value: vec![ToolResultContentPart::Media {
+            media_type: "application/pdf".to_string(),
+            data: DataContent::Url {
+                url: "https://example.invalid/report.pdf".to_string(),
+            },
+        }],
+    };
+    let back = round_trip_tool_output(ApiProtocol::Responses, output);
+    assert_eq!(
+        back,
+        ToolResultOutput::Content {
+            value: vec![ToolResultContentPart::Media {
+                media_type: "application/octet-stream".to_string(),
+                data: DataContent::Url {
+                    url: "https://example.invalid/report.pdf".to_string(),
+                },
+            }],
+        },
+        "a URL-form file part round-trips as a URL, degrading only its subtype"
+    );
+}
+
+#[test]
+fn tool_result_content_renders_responses_part_array() {
+    // The rendered Responses wire carries the multimodal result as a part array:
+    // text → input_text, image/* → input_image (image_url), other media →
+    // input_file (file_data). It must NOT collapse to a string.
+    // <https://github.com/vercel/ai/blob/main/packages/openai/src/responses/convert-to-openai-responses-input.ts>
+    let output = ToolResultOutput::Content {
+        value: vec![
+            ToolResultContentPart::Text {
+                text: "look".to_string(),
+            },
+            ToolResultContentPart::Media {
+                media_type: "image/png".to_string(),
+                data: DataContent::Base64 {
+                    data: IMG_B64.to_string(),
+                },
+            },
+            ToolResultContentPart::Media {
+                media_type: "application/pdf".to_string(),
+                data: DataContent::Url {
+                    url: "https://example.invalid/a.pdf".to_string(),
+                },
+            },
+        ],
+    };
+    let req = adapter_for(ApiProtocol::Responses)
+        .render_request(&tool_result_prompt("c1", None, output))
+        .unwrap();
+    let wire_output = req["input"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|i| i["type"] == "function_call_output")
+        .unwrap()["output"]
+        .clone();
+    let parts = wire_output
+        .as_array()
+        .expect("Responses Content output must be a part array, not a string");
+    assert_eq!(parts[0]["type"], "input_text");
+    assert_eq!(parts[0]["text"], "look");
+    assert_eq!(parts[1]["type"], "input_image");
+    assert_eq!(
+        parts[1]["image_url"],
+        format!("data:image/png;base64,{IMG_B64}")
+    );
+    assert_eq!(parts[2]["type"], "input_file");
+    assert_eq!(parts[2]["file_data"], "https://example.invalid/a.pdf");
+}
+
+#[test]
+fn tool_result_content_file_id_round_trips_through_responses() {
+    // A provider file reference (V3 `file-id` / `image-file-id`) rides the
+    // Responses wire as an `input_image` / `input_file` part whose payload is
+    // `file_id`. It round-trips as a `FileId` content part. This is the only wire
+    // that carries the construct, so the variant is constructed (parse) and
+    // consumed (render) here in non-test code.
+    // <https://github.com/vercel/ai/blob/main/packages/openai/src/responses/convert-to-openai-responses-input.ts>
+    let output = ToolResultOutput::Content {
+        value: vec![
+            ToolResultContentPart::FileId {
+                media_type: Some("image/*".to_string()),
+                id: "file-img-123".to_string(),
+            },
+            ToolResultContentPart::FileId {
+                media_type: None,
+                id: "file-doc-456".to_string(),
+            },
+        ],
+    };
+    // Assert the wire shape first.
+    let req = adapter_for(ApiProtocol::Responses)
+        .render_request(&tool_result_prompt("c1", None, output.clone()))
+        .unwrap();
+    let parts = req["input"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|i| i["type"] == "function_call_output")
+        .unwrap()["output"]
+        .as_array()
+        .expect("FileId parts render as a part array")
+        .clone();
+    assert_eq!(parts[0]["type"], "input_image");
+    assert_eq!(parts[0]["file_id"], "file-img-123");
+    assert_eq!(parts[1]["type"], "input_file");
+    assert_eq!(parts[1]["file_id"], "file-doc-456");
+
+    // Then the full round trip.
+    assert_eq!(
+        round_trip_tool_output(ApiProtocol::Responses, output.clone()),
+        output,
+        "Responses lost a FileId tool-result content part"
     );
 }
 

--- a/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
@@ -4794,6 +4794,241 @@ fn responses_mcp_call_round_trips_inline_error() {
     );
 }
 
+/// A `dynamic` provider-executed MCP `ToolCall` that reaches the Responses render
+/// WITHOUT its paired inline `ToolResult` (e.g. an upstream truncated the response
+/// after the call but before its inline result, then routed to a Responses client)
+/// must degrade to a VALID `function_call` item — never to an `mcp.<name>_call` /
+/// `<name>_call` item, which is not a Responses output item type.
+#[test]
+fn responses_unpaired_dynamic_mcp_call_degrades_to_function_call() {
+    let adapter = adapter_for(ApiProtocol::Responses);
+    let result = GenerateResult {
+        content: vec![Content::ToolCall {
+            // The `mcp.` prefix is what `parse_mcp_call` stamps on an MCP tool
+            // name; if this leaked into the `<name>_call` branch it would emit
+            // the invalid `mcp.search_docs_call`.
+            id: "mcp_1".to_string(),
+            name: "mcp.search_docs".to_string(),
+            arguments: "{\"q\":\"x\"}".to_string(),
+            provider_executed: true,
+            dynamic: true,
+            provider_metadata: Default::default(),
+        }],
+        usage: None,
+        finish_reason: Some(FinishReason::Length),
+        response_id: None,
+        stop_details: None,
+        provider_metadata: Default::default(),
+    };
+    let rendered = adapter
+        .render_response(&result, &sample_prompt(), "resp_1")
+        .unwrap();
+    let output = rendered["output"].as_array().unwrap();
+    // Exactly one item, and it is a valid `function_call` — not `<name>_call`.
+    assert_eq!(output.len(), 1, "the lone unpaired call yields one item");
+    let item = &output[0];
+    assert_eq!(
+        item["type"], "function_call",
+        "an unpaired dynamic MCP call must degrade to a valid function_call"
+    );
+    assert_eq!(item["call_id"], "mcp_1");
+    assert_eq!(item["name"], "mcp.search_docs");
+    assert_eq!(item["arguments"], "{\"q\":\"x\"}");
+    // The bug being closed: no invalid `<name>_call` / `mcp_call` item is emitted.
+    assert!(
+        output.iter().all(|i| i["type"] != "search_docs_call"
+            && i["type"] != "mcp.search_docs_call"
+            && i["type"] != "mcp_call"),
+        "no invalid `<name>_call` (or `mcp_call`) item for an unpaired dynamic MCP call"
+    );
+}
+
+/// Multiple `mcp_call`s interleaved with a regular `function_call` in one Responses
+/// response: each MCP call recombines with ITS OWN inline result by `call_id` (no
+/// cross-contamination, none dropped or duplicated), and the regular `function_call`
+/// renders independently alongside (the response wire carries no
+/// `function_call_output` — that is an input item, exercised by the request-side
+/// test below).
+#[test]
+fn responses_interleaved_mcp_calls_recombine_per_call_id() {
+    let adapter = adapter_for(ApiProtocol::Responses);
+    let body = serde_json::json!({
+        "id": "resp_1",
+        "status": "completed",
+        "output": [
+            {
+                "type": "mcp_call",
+                "id": "mcp_a",
+                "server_label": "srv-a",
+                "name": "lookup",
+                "arguments": "{\"q\":\"a\"}",
+                "output": "answer-a"
+            },
+            // A regular function call interleaved between the two MCP calls.
+            {
+                "type": "function_call",
+                "id": "fc_item_1",
+                "call_id": "fc_1",
+                "name": "calculator",
+                "arguments": "{\"op\":\"add\"}"
+            },
+            {
+                "type": "mcp_call",
+                "id": "mcp_b",
+                "server_label": "srv-b",
+                "name": "search",
+                "arguments": "{\"q\":\"b\"}",
+                "output": "answer-b"
+            }
+        ]
+    });
+    let parsed = adapter.parse_response(body).unwrap();
+    let rendered = adapter
+        .render_response(&parsed, &sample_prompt(), "resp_1")
+        .unwrap();
+    let output = rendered["output"].as_array().unwrap();
+
+    // Exactly two mcp_call items, each carrying its OWN result — no cross-talk.
+    let mcp_items: Vec<_> = output.iter().filter(|i| i["type"] == "mcp_call").collect();
+    assert_eq!(mcp_items.len(), 2, "two mcp_calls recombine into two items");
+    let item_a = mcp_items
+        .iter()
+        .find(|i| i["id"] == "mcp_a")
+        .expect("the first mcp_call");
+    assert_eq!(item_a["server_label"], "srv-a");
+    assert_eq!(item_a["name"], "lookup");
+    assert_eq!(item_a["arguments"], "{\"q\":\"a\"}");
+    assert_eq!(item_a["output"], "answer-a", "call a keeps its own result");
+    let item_b = mcp_items
+        .iter()
+        .find(|i| i["id"] == "mcp_b")
+        .expect("the second mcp_call");
+    assert_eq!(item_b["server_label"], "srv-b");
+    assert_eq!(item_b["name"], "search");
+    assert_eq!(item_b["arguments"], "{\"q\":\"b\"}");
+    assert_eq!(item_b["output"], "answer-b", "call b keeps its own result");
+
+    // The interleaved regular function call renders independently as its own
+    // `function_call` item (not recombined into, or contaminated by, either MCP
+    // call).
+    let fc = output
+        .iter()
+        .find(|i| i["type"] == "function_call")
+        .expect("the regular function_call");
+    assert_eq!(fc["call_id"], "fc_1");
+    assert_eq!(fc["name"], "calculator");
+
+    // Nothing dropped or duplicated: exactly 2 mcp_call + 1 function_call, and no
+    // dynamic MCP pair leaked as a plain function item.
+    assert_eq!(
+        output.len(),
+        3,
+        "two mcp_calls + one independent function_call, none dropped/duplicated"
+    );
+}
+
+/// On the REQUEST (input) wire, a regular `function_call` + its
+/// `function_call_output` interleaved with a dynamic MCP call/result pair render
+/// independently: the regular pair survives as `function_call` + `function_call_output`,
+/// while the provider-executed MCP pair is dropped (not replayed on the input wire,
+/// matching the AI SDK) — no cross-contamination either way.
+#[test]
+fn responses_request_function_call_pair_independent_of_dynamic_mcp() {
+    let adapter = adapter_for(ApiProtocol::Responses);
+    let prompt = Prompt {
+        model: "test-model".to_string(),
+        system: None,
+        system_provider_metadata: Default::default(),
+        messages: vec![Message {
+            role: Role::Assistant,
+            content: vec![
+                // A regular client function call + its output.
+                Content::ToolCall {
+                    id: "fc_1".to_string(),
+                    name: "calculator".to_string(),
+                    arguments: "{\"op\":\"add\"}".to_string(),
+                    provider_executed: false,
+                    dynamic: false,
+                    provider_metadata: Default::default(),
+                },
+                Content::ToolResult {
+                    call_id: "fc_1".to_string(),
+                    tool_name: Some("calculator".to_string()),
+                    output: ToolResultOutput::Json {
+                        value: serde_json::json!({ "sum": 42 }),
+                    },
+                    dynamic: false,
+                    provider_metadata: Default::default(),
+                },
+                // A dynamic provider-executed MCP call + its inline result,
+                // interleaved. Both must drop on the input wire.
+                Content::ToolCall {
+                    id: "mcp_1".to_string(),
+                    name: "mcp.lookup".to_string(),
+                    arguments: "{\"q\":\"x\"}".to_string(),
+                    provider_executed: true,
+                    dynamic: true,
+                    provider_metadata: Default::default(),
+                },
+                Content::ToolResult {
+                    call_id: "mcp_1".to_string(),
+                    tool_name: Some("mcp.lookup".to_string()),
+                    output: ToolResultOutput::Json {
+                        value: serde_json::json!({
+                            "type": "call", "name": "lookup", "output": "answer"
+                        }),
+                    },
+                    dynamic: true,
+                    provider_metadata: Default::default(),
+                },
+            ],
+        }],
+        tools: vec![],
+        params: GenerationParams::default(),
+        response_format: None,
+        stream: false,
+    };
+    let rendered = adapter.render_request(&prompt).unwrap();
+    let input = rendered["input"].as_array().unwrap();
+
+    // The regular function_call + function_call_output both render, keyed to fc_1.
+    let fc = input
+        .iter()
+        .find(|i| i["type"] == "function_call")
+        .expect("the regular function_call");
+    assert_eq!(fc["call_id"], "fc_1");
+    assert_eq!(fc["name"], "calculator");
+    let fc_out = input
+        .iter()
+        .find(|i| i["type"] == "function_call_output")
+        .expect("the regular function_call_output");
+    assert_eq!(fc_out["call_id"], "fc_1");
+
+    // The dynamic MCP pair is dropped on the input wire (not replayed), and it did
+    // not contaminate the regular pair: exactly one function_call + one
+    // function_call_output, no mcp_call, no second function_call for `mcp_1`.
+    assert!(
+        input.iter().all(|i| i["type"] != "mcp_call"),
+        "a provider-executed MCP call is not replayed as an input item"
+    );
+    assert_eq!(
+        input
+            .iter()
+            .filter(|i| i["type"] == "function_call")
+            .count(),
+        1,
+        "only the regular client call renders; the MCP call does not leak as one"
+    );
+    assert_eq!(
+        input
+            .iter()
+            .filter(|i| i["type"] == "function_call_output")
+            .count(),
+        1,
+        "only the regular client result renders; the MCP result does not leak as one"
+    );
+}
+
 /// A Responses `local_shell_call` parses to a client `ToolCall` named
 /// `local_shell` whose `action` is preserved, and renders back to a
 /// `local_shell_call` item (same-protocol round-trip of the call).

--- a/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
@@ -45,6 +45,7 @@ fn sample_prompt() -> Prompt {
             description: Some("does math".to_string()),
             parameters: serde_json::json!({ "type": "object" }),
             strict: None,
+            provider_metadata: Default::default(),
         }],
         params: GenerationParams {
             temperature: Some(0.5),
@@ -63,15 +64,18 @@ fn sample_result() -> GenerateResult {
         content: vec![
             Content::Reasoning {
                 text: "thinking...".to_string(),
+                provider_metadata: Default::default(),
             },
             Content::Text {
                 text: "the answer is 4".to_string(),
+                provider_metadata: Default::default(),
             },
             Content::ToolCall {
                 id: "call_1".to_string(),
                 name: "calculator".to_string(),
                 arguments: "{\"op\":\"add\"}".to_string(),
                 provider_executed: false,
+                provider_metadata: Default::default(),
             },
         ],
         usage: Some(Usage {
@@ -83,6 +87,7 @@ fn sample_result() -> GenerateResult {
         finish_reason: Some(FinishReason::Stop),
         response_id: None,
         stop_details: None,
+        provider_metadata: Default::default(),
     }
 }
 
@@ -90,7 +95,7 @@ fn text_of(content: &[Content]) -> String {
     content
         .iter()
         .filter_map(|c| match c {
-            Content::Text { text } => Some(text.as_str()),
+            Content::Text { text, .. } => Some(text.as_str()),
             _ => None,
         })
         .collect()
@@ -976,6 +981,7 @@ fn messages_outbound_renders_refusal_stop_details() {
             category: Some("bio".to_string()),
             explanation: None,
         }),
+        provider_metadata: Default::default(),
     };
     let rendered = adapter
         .render_response(&result, &sample_prompt(), "msg_1")
@@ -1494,7 +1500,7 @@ fn chat_completions_parse_captures_refusal_and_reasoning_aliases() {
     let result = adapter.parse_response(body).unwrap();
     assert_eq!(result.finish_reason, Some(FinishReason::ContentFilter));
     assert!(result.content.iter().any(|c| match c {
-        Content::Text { text } => text == "I cannot help.",
+        Content::Text { text, .. } => text == "I cannot help.",
         _ => false,
     }));
 
@@ -1507,7 +1513,7 @@ fn chat_completions_parse_captures_refusal_and_reasoning_aliases() {
     });
     let result = adapter.parse_response(body).unwrap();
     assert!(
-        matches!(result.content.first(), Some(Content::Reasoning { text }) if text == "step by step")
+        matches!(result.content.first(), Some(Content::Reasoning { text, .. }) if text == "step by step")
     );
 
     // `thinking` alias (Aliyun-style)
@@ -1519,7 +1525,7 @@ fn chat_completions_parse_captures_refusal_and_reasoning_aliases() {
     });
     let result = adapter.parse_response(body).unwrap();
     assert!(
-        matches!(result.content.first(), Some(Content::Reasoning { text }) if text == "internal monologue")
+        matches!(result.content.first(), Some(Content::Reasoning { text, .. }) if text == "internal monologue")
     );
 }
 
@@ -1750,11 +1756,13 @@ fn responses_omits_usage_when_none() {
     let result = GenerateResult {
         content: vec![Content::Text {
             text: "ok".to_string(),
+            provider_metadata: Default::default(),
         }],
         usage: None,
         finish_reason: Some(FinishReason::Stop),
         response_id: None,
         stop_details: None,
+        provider_metadata: Default::default(),
     };
     let rendered = adapter
         .render_response(&result, &sample_prompt(), "resp_n")
@@ -2119,11 +2127,13 @@ fn regression_454_5_no_null_on_the_wire() {
     let result = GenerateResult {
         content: vec![Content::Text {
             text: "hi".to_string(),
+            provider_metadata: Default::default(),
         }],
         usage: None,
         finish_reason: None,
         response_id: None,
         stop_details: None,
+        provider_metadata: Default::default(),
     };
     // Chat Completions: `usage` key is absent when there is no usage.
     let chat = adapter_for(ApiProtocol::ChatCompletions)
@@ -2144,6 +2154,7 @@ fn regression_454_5_no_null_on_the_wire() {
         finish_reason: None,
         response_id: None,
         stop_details: None,
+        provider_metadata: Default::default(),
     };
     let chat_empty = adapter_for(ApiProtocol::ChatCompletions)
         .render_response(&empty, &sample_prompt(), "c2")
@@ -2610,6 +2621,7 @@ fn regression_454_5_usage_zero_is_numeric_not_null() {
     let result = GenerateResult {
         content: vec![Content::Text {
             text: "hi".to_string(),
+            provider_metadata: Default::default(),
         }],
         usage: Some(Usage {
             prompt_tokens: 0,
@@ -2620,6 +2632,7 @@ fn regression_454_5_usage_zero_is_numeric_not_null() {
         finish_reason: Some(FinishReason::Stop),
         response_id: None,
         stop_details: None,
+        provider_metadata: Default::default(),
     };
     let chat = adapter_for(ApiProtocol::ChatCompletions)
         .render_response(&result, &sample_prompt(), "c1")
@@ -2755,8 +2768,9 @@ fn image_file_prompt() -> Prompt {
                     data: IMG_B64.to_string(),
                 },
                 filename: None,
-                extra: Default::default(),
+                provider_metadata: Default::default(),
             }],
+            provider_metadata: Default::default(),
         }],
         tools: vec![],
         params: GenerationParams {
@@ -2930,8 +2944,9 @@ fn pdf_file_renders_to_messages_document_block() {
                 data: IMG_B64.to_string(),
             },
             filename: Some("doc.pdf".to_string()),
-            extra: Default::default(),
+            provider_metadata: Default::default(),
         }],
+        provider_metadata: Default::default(),
     }];
     assert!(
         prompt
@@ -3097,12 +3112,13 @@ fn generated_image_renders_into_chat_response_best_effort() {
                 data: IMG_B64.to_string(),
             },
             filename: None,
-            extra: Default::default(),
+            provider_metadata: Default::default(),
         }],
         usage: None,
         finish_reason: Some(FinishReason::Stop),
         response_id: None,
         stop_details: None,
+        provider_metadata: Default::default(),
     };
     let rendered = adapter
         .render_response(&result, &sample_prompt(), "id")
@@ -3163,7 +3179,9 @@ fn tool_result_prompt(call_id: &str, tool_name: Option<&str>, output: ToolResult
                 call_id: call_id.to_string(),
                 tool_name: tool_name.map(str::to_string),
                 output,
+                provider_metadata: Default::default(),
             }],
+            provider_metadata: Default::default(),
         }],
         tools: vec![],
         params: GenerationParams {
@@ -3186,6 +3204,7 @@ fn first_tool_result(prompt: &Prompt) -> (&str, Option<&str>, &ToolResultOutput)
                 call_id,
                 tool_name,
                 output,
+                ..
             } => Some((call_id.as_str(), tool_name.as_deref(), output)),
             _ => None,
         })
@@ -3812,6 +3831,7 @@ fn tool_result_content_serde_round_trips() {
                 },
             ],
         },
+        provider_metadata: Default::default(),
     };
     let value = serde_json::to_value(&original).unwrap();
     assert_eq!(value["type"], "tool_result");
@@ -3830,6 +3850,7 @@ fn tool_result_without_tool_name_omits_the_field() {
         output: ToolResultOutput::Text {
             value: "x".to_string(),
         },
+        provider_metadata: Default::default(),
     })
     .unwrap();
     assert!(
@@ -3885,18 +3906,21 @@ fn messages_renders_provider_executed_as_server_tool_use() {
                 name: "get_weather".to_string(),
                 arguments: "{}".to_string(),
                 provider_executed: false,
+                provider_metadata: Default::default(),
             },
             Content::ToolCall {
                 id: "srvtoolu_1".to_string(),
                 name: "web_search".to_string(),
                 arguments: "{\"query\":\"x\"}".to_string(),
                 provider_executed: true,
+                provider_metadata: Default::default(),
             },
         ],
         usage: None,
         finish_reason: Some(FinishReason::Stop),
         response_id: None,
         stop_details: None,
+        provider_metadata: Default::default(),
     };
     let prompt = sample_prompt();
     let rendered = adapter.render_response(&result, &prompt, "msg_1").unwrap();
@@ -3982,14 +4006,17 @@ fn responses_render_request_drops_provider_executed_calls() {
                     name: "get_weather".to_string(),
                     arguments: "{}".to_string(),
                     provider_executed: false,
+                    provider_metadata: Default::default(),
                 },
                 Content::ToolCall {
                     id: "ws_1".to_string(),
                     name: "web_search".to_string(),
                     arguments: "{}".to_string(),
                     provider_executed: true,
+                    provider_metadata: Default::default(),
                 },
             ],
+            provider_metadata: Default::default(),
         }],
         tools: Vec::new(),
         params: GenerationParams::default(),
@@ -4021,11 +4048,13 @@ fn responses_render_response_reproduces_server_tool_item() {
             name: "web_search".to_string(),
             arguments: "{}".to_string(),
             provider_executed: true,
+            provider_metadata: Default::default(),
         }],
         usage: None,
         finish_reason: Some(FinishReason::Stop),
         response_id: Some("resp_1".to_string()),
         stop_details: None,
+        provider_metadata: Default::default(),
     };
     let rendered = adapter
         .render_response(&result, &sample_prompt(), "resp_1")
@@ -4113,6 +4142,7 @@ fn tool_call_provider_executed_omitted_when_false() {
         name: "t".to_string(),
         arguments: "{}".to_string(),
         provider_executed: false,
+        provider_metadata: Default::default(),
     })
     .unwrap();
     assert!(
@@ -4124,6 +4154,7 @@ fn tool_call_provider_executed_omitted_when_false() {
         name: "t".to_string(),
         arguments: "{}".to_string(),
         provider_executed: true,
+        provider_metadata: Default::default(),
     })
     .unwrap();
     assert_eq!(value_true["provider_executed"], true);
@@ -4153,6 +4184,7 @@ fn prompt_with_tool_choice(choice: ToolChoice) -> Prompt {
             description: None,
             parameters: serde_json::json!({"type": "object"}),
             strict: None,
+            provider_metadata: Default::default(),
         }],
         params: GenerationParams {
             tool_choice: Some(choice),
@@ -4586,6 +4618,7 @@ fn function_tool_strict_round_trips_on_openai_protocols() {
                 description: Some("look up weather".to_string()),
                 parameters: serde_json::json!({ "type": "object" }),
                 strict: Some(true),
+                provider_metadata: Default::default(),
             }],
         );
         assert_eq!(
@@ -4595,6 +4628,7 @@ fn function_tool_strict_round_trips_on_openai_protocols() {
                 description: Some("look up weather".to_string()),
                 parameters: serde_json::json!({ "type": "object" }),
                 strict: Some(true),
+                provider_metadata: Default::default(),
             }],
             "{protocol:?} must preserve function-tool strict"
         );
@@ -4609,6 +4643,7 @@ fn function_tool_strict_renders_in_native_position() {
         description: None,
         parameters: serde_json::json!({ "type": "object" }),
         strict: Some(true),
+        provider_metadata: Default::default(),
     };
     let chat = rendered_tools_json(&ApiProtocol::ChatCompletions, vec![tool.clone()]);
     assert_eq!(chat[0]["type"], "function");
@@ -4627,6 +4662,7 @@ fn function_tool_strict_omitted_when_absent() {
         description: None,
         parameters: serde_json::json!({ "type": "object" }),
         strict: None,
+        provider_metadata: Default::default(),
     };
     let chat = rendered_tools_json(&ApiProtocol::ChatCompletions, vec![tool.clone()]);
     assert!(
@@ -4653,6 +4689,7 @@ fn function_tool_strict_dropped_on_anthropic_and_gemini() {
                 description: Some("desc".to_string()),
                 parameters: serde_json::json!({ "type": "object" }),
                 strict: Some(true),
+                provider_metadata: Default::default(),
             }],
         );
         assert_eq!(
@@ -4662,6 +4699,7 @@ fn function_tool_strict_dropped_on_anthropic_and_gemini() {
                 description: Some("desc".to_string()),
                 parameters: serde_json::json!({ "type": "object" }),
                 strict: None,
+                provider_metadata: Default::default(),
             }],
             "{protocol:?} has no strict slot; it must drop to None but keep the tool"
         );
@@ -4673,6 +4711,7 @@ fn function_tool_strict_dropped_on_anthropic_and_gemini() {
                 description: None,
                 parameters: serde_json::json!({}),
                 strict: Some(true),
+                provider_metadata: Default::default(),
             }],
         );
         assert!(
@@ -4693,26 +4732,31 @@ fn responses_provider_defined_tools_round_trip() {
             id: "openai.web_search_preview".to_string(),
             name: "web_search_preview".to_string(),
             args: serde_json::json!({ "search_context_size": "high" }),
+            provider_metadata: Default::default(),
         },
         Tool::ProviderDefined {
             id: "openai.code_interpreter".to_string(),
             name: "code_interpreter".to_string(),
             args: serde_json::json!({ "container": { "type": "auto" } }),
+            provider_metadata: Default::default(),
         },
         Tool::ProviderDefined {
             id: "openai.file_search".to_string(),
             name: "file_search".to_string(),
             args: serde_json::json!({ "vector_store_ids": ["vs_1"], "max_num_results": 5 }),
+            provider_metadata: Default::default(),
         },
         Tool::ProviderDefined {
             id: "openai.image_generation".to_string(),
             name: "image_generation".to_string(),
             args: serde_json::json!({ "quality": "high" }),
+            provider_metadata: Default::default(),
         },
         Tool::ProviderDefined {
             id: "openai.computer_use_preview".to_string(),
             name: "computer_use_preview".to_string(),
             args: serde_json::json!({ "display_width": 1024, "display_height": 768, "environment": "browser" }),
+            provider_metadata: Default::default(),
         },
     ];
     for tool in cases {
@@ -4730,6 +4774,7 @@ fn responses_provider_defined_renders_flat_native_shape() {
             id: "openai.web_search_preview".to_string(),
             name: "web_search_preview".to_string(),
             args: serde_json::json!({ "search_context_size": "low" }),
+            provider_metadata: Default::default(),
         }],
     );
     assert_eq!(rendered[0]["type"], "web_search_preview");
@@ -4748,16 +4793,19 @@ fn messages_provider_defined_tools_round_trip() {
             id: "anthropic.web_search_20250305".to_string(),
             name: "web_search".to_string(),
             args: serde_json::json!({ "max_uses": 5 }),
+            provider_metadata: Default::default(),
         },
         Tool::ProviderDefined {
             id: "anthropic.code_execution_20250522".to_string(),
             name: "code_execution".to_string(),
             args: serde_json::json!({}),
+            provider_metadata: Default::default(),
         },
         Tool::ProviderDefined {
             id: "anthropic.computer_20250124".to_string(),
             name: "computer".to_string(),
             args: serde_json::json!({ "display_width_px": 1024, "display_height_px": 768 }),
+            provider_metadata: Default::default(),
         },
     ];
     for tool in cases {
@@ -4775,6 +4823,7 @@ fn messages_provider_defined_renders_versioned_native_shape() {
             id: "anthropic.web_search_20250305".to_string(),
             name: "web_search".to_string(),
             args: serde_json::json!({ "max_uses": 3 }),
+            provider_metadata: Default::default(),
         }],
     );
     assert_eq!(rendered[0]["type"], "web_search_20250305");
@@ -4791,21 +4840,25 @@ fn generate_content_provider_defined_tools_round_trip() {
             id: "google.googleSearch".to_string(),
             name: "googleSearch".to_string(),
             args: serde_json::json!({}),
+            provider_metadata: Default::default(),
         },
         Tool::ProviderDefined {
             id: "google.codeExecution".to_string(),
             name: "codeExecution".to_string(),
             args: serde_json::json!({}),
+            provider_metadata: Default::default(),
         },
         Tool::ProviderDefined {
             id: "google.googleSearchRetrieval".to_string(),
             name: "googleSearchRetrieval".to_string(),
             args: serde_json::json!({ "dynamicRetrievalConfig": { "mode": "MODE_DYNAMIC" } }),
+            provider_metadata: Default::default(),
         },
         Tool::ProviderDefined {
             id: "google.urlContext".to_string(),
             name: "urlContext".to_string(),
             args: serde_json::json!({}),
+            provider_metadata: Default::default(),
         },
     ];
     for tool in cases {
@@ -4823,6 +4876,7 @@ fn generate_content_provider_defined_renders_single_key_object() {
             id: "google.googleSearch".to_string(),
             name: "googleSearch".to_string(),
             args: serde_json::json!({}),
+            provider_metadata: Default::default(),
         }],
     );
     // The built-in tool is its own tool-array element with the camelCase key.
@@ -4874,11 +4928,13 @@ fn responses_mixed_function_and_server_tools_round_trip() {
             description: None,
             parameters: serde_json::json!({ "type": "object" }),
             strict: Some(true),
+            provider_metadata: Default::default(),
         },
         Tool::ProviderDefined {
             id: "openai.web_search_preview".to_string(),
             name: "web_search_preview".to_string(),
             args: serde_json::json!({ "search_context_size": "high" }),
+            provider_metadata: Default::default(),
         },
     ];
     let round_tripped = round_trip_tools(&ApiProtocol::Responses, tools.clone());
@@ -4900,6 +4956,7 @@ fn provider_defined_tool_cross_protocol_is_preserved_verbatim() {
         id: "anthropic.web_search_20250305".to_string(),
         name: "web_search".to_string(),
         args: serde_json::json!({ "max_uses": 5 }),
+        provider_metadata: Default::default(),
     };
 
     // Render the Anthropic-native tool onto a Responses (OpenAI) request.
@@ -4924,7 +4981,7 @@ fn provider_defined_tool_cross_protocol_is_preserved_verbatim() {
         .unwrap();
     assert_eq!(reparsed.tools.len(), 1, "tool is forwarded, not dropped");
     match &reparsed.tools[0] {
-        Tool::ProviderDefined { id, name, args } => {
+        Tool::ProviderDefined { id, name, args, .. } => {
             assert_eq!(id, "openai.web_search_20250305");
             assert_eq!(name, "web_search");
             assert_eq!(args["max_uses"], 5);
@@ -4946,6 +5003,7 @@ fn provider_defined_tool_cross_protocol_onto_anthropic_is_preserved() {
         id: "openai.web_search_preview".to_string(),
         name: "web_search_preview".to_string(),
         args: serde_json::json!({ "search_context_size": "high" }),
+        provider_metadata: Default::default(),
     };
     let rendered = rendered_tools_json(&ApiProtocol::Messages, vec![openai_tool]);
     assert_eq!(rendered[0]["type"], "web_search_preview");
@@ -4965,6 +5023,7 @@ fn provider_defined_tool_preserved_into_chat_completions() {
         id: "openai.web_search_preview".to_string(),
         name: "web_search_preview".to_string(),
         args: serde_json::json!({ "search_context_size": "low" }),
+        provider_metadata: Default::default(),
     };
     let rendered = rendered_tools_json(&ApiProtocol::ChatCompletions, vec![tool]);
     assert_eq!(rendered[0]["type"], "web_search_preview");
@@ -4980,6 +5039,7 @@ fn tool_serde_uses_type_tag() {
         description: None,
         parameters: serde_json::json!({}),
         strict: None,
+        provider_metadata: Default::default(),
     })
     .unwrap();
     assert_eq!(function["type"], "function");
@@ -4991,6 +5051,7 @@ fn tool_serde_uses_type_tag() {
         id: "openai.web_search_preview".to_string(),
         name: "web_search_preview".to_string(),
         args: serde_json::json!({}),
+        provider_metadata: Default::default(),
     })
     .unwrap();
     assert_eq!(provider["type"], "provider_defined");
@@ -5004,7 +5065,7 @@ fn sources_of(content: &[Content]) -> Vec<&Source> {
     content
         .iter()
         .filter_map(|c| match c {
-            Content::Source { source } => Some(source),
+            Content::Source { source, .. } => Some(source),
             _ => None,
         })
         .collect()
@@ -5020,6 +5081,7 @@ fn source_serde_round_trips_both_variants() {
             url: "https://example.invalid/a".to_string(),
             title: Some("A".to_string()),
         },
+        provider_metadata: Default::default(),
     };
     let v = serde_json::to_value(&url).unwrap();
     assert_eq!(v["type"], "source");
@@ -5034,6 +5096,7 @@ fn source_serde_round_trips_both_variants() {
             title: "report.pdf".to_string(),
             filename: Some("report.pdf".to_string()),
         },
+        provider_metadata: Default::default(),
     };
     let v = serde_json::to_value(&doc).unwrap();
     assert_eq!(v["source"]["source_type"], "document");
@@ -5047,6 +5110,7 @@ fn source_serde_round_trips_both_variants() {
             url: "https://example.invalid/x".to_string(),
             title: None,
         },
+        provider_metadata: Default::default(),
     })
     .unwrap();
     assert!(no_title["source"].get("title").is_none());
@@ -5811,4 +5875,609 @@ fn responses_streams_and_reencodes_annotation() {
     assert_eq!(ann["type"], "url_citation");
     assert_eq!(ann["url"], "https://example.invalid/s");
     assert_eq!(ann["title"], "S");
+}
+
+// ===== per-part provider_metadata (V3 providerMetadata / providerOptions) =====
+
+/// Read the `anthropic.cacheControl` object out of a part's provider metadata.
+fn anthropic_cache_control(meta: &ProviderMetadata) -> Option<&serde_json::Value> {
+    meta.get("anthropic")?.get("cacheControl")
+}
+
+/// An ephemeral cache-control breakpoint, as Anthropic spells it on the wire.
+fn ephemeral() -> serde_json::Value {
+    serde_json::json!({ "type": "ephemeral" })
+}
+
+/// Anthropic `cache_control` on a request text block survives a full
+/// same-protocol round-trip (parse → render), landing back on the rendered block
+/// as a `cache_control` field. This is prompt caching — the breakpoint must be
+/// reproduced exactly or the cache boundary moves.
+#[test]
+fn messages_cache_control_on_text_block_round_trips() {
+    let adapter = messages::MessagesAdapter;
+    let body = serde_json::json!({
+        "model": "claude-3-5-sonnet",
+        "max_tokens": 64,
+        "messages": [{
+            "role": "user",
+            "content": [{
+                "type": "text",
+                "text": "cache me",
+                "cache_control": { "type": "ephemeral" },
+            }],
+        }],
+    });
+    let prompt = adapter.parse_request(body).unwrap();
+    // It landed in the canonical slot under the anthropic namespace.
+    let user = prompt
+        .messages
+        .iter()
+        .find(|m| m.role == Role::User)
+        .unwrap();
+    match &user.content[0] {
+        Content::Text {
+            provider_metadata, ..
+        } => assert_eq!(
+            anthropic_cache_control(provider_metadata),
+            Some(&ephemeral())
+        ),
+        other => panic!("expected text content, got {other:?}"),
+    }
+    // And it renders back onto the Anthropic text block.
+    let rendered = adapter.render_request(&prompt).unwrap();
+    let block = &rendered["messages"][0]["content"][0];
+    assert_eq!(block["type"], "text");
+    assert_eq!(block["cache_control"], ephemeral());
+}
+
+/// Anthropic tool-level `cache_control` (the "cache the whole tools array"
+/// pattern) round-trips: lifted off the tool on parse, rendered back on the tool.
+#[test]
+fn messages_cache_control_on_tool_round_trips() {
+    let adapter = messages::MessagesAdapter;
+    let body = serde_json::json!({
+        "model": "claude-3-5-sonnet",
+        "max_tokens": 64,
+        "messages": [{ "role": "user", "content": "hi" }],
+        "tools": [{
+            "name": "get_weather",
+            "description": "weather",
+            "input_schema": { "type": "object" },
+            "cache_control": { "type": "ephemeral" },
+        }],
+    });
+    let prompt = adapter.parse_request(body).unwrap();
+    match &prompt.tools[0] {
+        Tool::Function {
+            provider_metadata, ..
+        } => assert_eq!(
+            anthropic_cache_control(provider_metadata),
+            Some(&ephemeral())
+        ),
+        other => panic!("expected function tool, got {other:?}"),
+    }
+    let rendered = adapter.render_request(&prompt).unwrap();
+    assert_eq!(rendered["tools"][0]["cache_control"], ephemeral());
+    // The breakpoint did NOT leak into the tool's `input_schema` / args.
+    assert!(
+        rendered["tools"][0]["input_schema"]
+            .get("cache_control")
+            .is_none()
+    );
+}
+
+/// Anthropic `cache_control` on a `tool_result` block round-trips: a long tool
+/// output can mark a cache boundary, and the breakpoint must survive.
+#[test]
+fn messages_cache_control_on_tool_result_round_trips() {
+    let adapter = messages::MessagesAdapter;
+    let body = serde_json::json!({
+        "model": "claude-3-5-sonnet",
+        "max_tokens": 64,
+        "messages": [{
+            "role": "user",
+            "content": [{
+                "type": "tool_result",
+                "tool_use_id": "toolu_1",
+                "content": "the result",
+                "cache_control": { "type": "ephemeral" },
+            }],
+        }],
+    });
+    let prompt = adapter.parse_request(body).unwrap();
+    let tool_msg = prompt
+        .messages
+        .iter()
+        .find(|m| m.role == Role::Tool)
+        .unwrap();
+    match &tool_msg.content[0] {
+        Content::ToolResult {
+            provider_metadata, ..
+        } => assert_eq!(
+            anthropic_cache_control(provider_metadata),
+            Some(&ephemeral())
+        ),
+        other => panic!("expected tool result, got {other:?}"),
+    }
+    let rendered = adapter.render_request(&prompt).unwrap();
+    // Tool results render inside a user-role message's content blocks.
+    let block = &rendered["messages"][0]["content"][0];
+    assert_eq!(block["type"], "tool_result");
+    assert_eq!(block["cache_control"], ephemeral());
+}
+
+/// Cross-protocol preservation: an Anthropic `cache_control` hint parsed from a
+/// Messages request is preserved (namespaced) when the same canonical prompt is
+/// rendered to a *Chat Completions* upstream. Chat Completions has no
+/// `cache_control` on its wire, so it does not express the hint — but it also
+/// must not lose it: the canonical slot still carries it for any later hop back
+/// to Anthropic, and the OpenAI namespace is untouched.
+#[test]
+fn anthropic_cache_control_preserved_across_protocols() {
+    let inbound = messages::MessagesAdapter;
+    let outbound = chat_completions::ChatCompletionsAdapter;
+    let body = serde_json::json!({
+        "model": "claude-3-5-sonnet",
+        "max_tokens": 64,
+        "messages": [{
+            "role": "user",
+            "content": [{
+                "type": "text",
+                "text": "cache me",
+                "cache_control": { "type": "ephemeral" },
+            }],
+        }],
+    });
+    let prompt = inbound.parse_request(body).unwrap();
+    // The canonical prompt still carries the anthropic-namespaced hint.
+    let user = prompt
+        .messages
+        .iter()
+        .find(|m| m.role == Role::User)
+        .unwrap();
+    match &user.content[0] {
+        Content::Text {
+            provider_metadata, ..
+        } => assert_eq!(
+            anthropic_cache_control(provider_metadata),
+            Some(&ephemeral())
+        ),
+        other => panic!("expected text content, got {other:?}"),
+    }
+    // Rendering to Chat Completions does not surface (or corrupt) the hint: no
+    // `cache_control` appears anywhere in the Chat request body.
+    let rendered = outbound.render_request(&prompt).unwrap();
+    assert!(
+        !rendered.to_string().contains("cache_control"),
+        "Chat Completions must not emit Anthropic cache_control on its wire"
+    );
+    // The canonical IR is unchanged — the hint is still there for a later
+    // Anthropic hop (faithful namespaced preservation).
+    match &prompt
+        .messages
+        .iter()
+        .find(|m| m.role == Role::User)
+        .unwrap()
+        .content[0]
+    {
+        Content::Text {
+            provider_metadata, ..
+        } => assert_eq!(
+            anthropic_cache_control(provider_metadata),
+            Some(&ephemeral())
+        ),
+        other => panic!("expected text content, got {other:?}"),
+    }
+}
+
+/// An Anthropic thinking block's `signature` round-trips through Messages so a
+/// multi-turn thinking conversation can replay the signed reasoning block. The
+/// signature has no canonical field; it rides `provider_metadata["anthropic"]`.
+#[test]
+fn messages_reasoning_signature_round_trips() {
+    let adapter = messages::MessagesAdapter;
+    let response = serde_json::json!({
+        "id": "msg_1",
+        "type": "message",
+        "role": "assistant",
+        "content": [{
+            "type": "thinking",
+            "thinking": "let me think",
+            "signature": "SIG-abc-123",
+        }],
+        "stop_reason": "end_turn",
+        "usage": { "input_tokens": 1, "output_tokens": 1 },
+    });
+    let result = adapter.parse_response(response).unwrap();
+    match &result.content[0] {
+        Content::Reasoning {
+            text,
+            provider_metadata,
+        } => {
+            assert_eq!(text, "let me think");
+            assert_eq!(
+                provider_metadata
+                    .get("anthropic")
+                    .and_then(|a| a.get("signature")),
+                Some(&serde_json::Value::String("SIG-abc-123".into()))
+            );
+        }
+        other => panic!("expected reasoning, got {other:?}"),
+    }
+    // Re-render the reasoning as a request block: the signature reappears.
+    let block = render_content_block_via_request(&adapter, &result.content[0]);
+    assert_eq!(block["type"], "thinking");
+    assert_eq!(block["thinking"], "let me think");
+    assert_eq!(block["signature"], "SIG-abc-123");
+}
+
+/// A `redacted_thinking` block round-trips byte-for-byte: the encrypted `data`
+/// and the `redacted_thinking` block type are both restored on render.
+#[test]
+fn messages_redacted_thinking_round_trips() {
+    let adapter = messages::MessagesAdapter;
+    let response = serde_json::json!({
+        "id": "msg_1",
+        "type": "message",
+        "role": "assistant",
+        "content": [{
+            "type": "redacted_thinking",
+            "data": "ENCRYPTED-PAYLOAD",
+        }],
+        "stop_reason": "end_turn",
+        "usage": { "input_tokens": 1, "output_tokens": 1 },
+    });
+    let result = adapter.parse_response(response).unwrap();
+    let block = render_content_block_via_request(&adapter, &result.content[0]);
+    assert_eq!(block["type"], "redacted_thinking");
+    assert_eq!(block["data"], "ENCRYPTED-PAYLOAD");
+    // It is NOT re-emitted as a plaintext `thinking` block.
+    assert!(block.get("thinking").is_none());
+}
+
+/// Render a single canonical assistant content block through the Messages
+/// request renderer (assistant message) and return the one rendered block.
+fn render_content_block_via_request(
+    adapter: &messages::MessagesAdapter,
+    content: &Content,
+) -> serde_json::Value {
+    let prompt = Prompt {
+        model: "claude-3-5-sonnet".to_string(),
+        system: None,
+        messages: vec![Message {
+            role: Role::Assistant,
+            content: vec![content.clone()],
+            provider_metadata: Default::default(),
+        }],
+        tools: vec![],
+        params: GenerationParams {
+            max_tokens: Some(64),
+            ..Default::default()
+        },
+        response_format: None,
+        stream: false,
+    };
+    let rendered = adapter.render_request(&prompt).unwrap();
+    rendered["messages"][0]["content"][0].clone()
+}
+
+/// OpenAI `system_fingerprint` survives a same-protocol round-trip: it is lifted
+/// from the response into the result's `provider_metadata["openai"]` and
+/// rendered back onto the Chat Completions response object.
+#[test]
+fn chat_system_fingerprint_round_trips_on_result() {
+    let adapter = chat_completions::ChatCompletionsAdapter;
+    let response = serde_json::json!({
+        "id": "chatcmpl-1",
+        "object": "chat.completion",
+        "model": "gpt-4o",
+        "system_fingerprint": "fp_44709d6fcb",
+        "choices": [{
+            "index": 0,
+            "message": { "role": "assistant", "content": "hi" },
+            "finish_reason": "stop",
+        }],
+    });
+    let result = adapter.parse_response(response).unwrap();
+    assert_eq!(
+        result
+            .provider_metadata
+            .get("openai")
+            .and_then(|o| o.get("systemFingerprint")),
+        Some(&serde_json::Value::String("fp_44709d6fcb".into()))
+    );
+    let prompt = Prompt {
+        model: "gpt-4o".to_string(),
+        system: None,
+        messages: vec![],
+        tools: vec![],
+        params: GenerationParams::default(),
+        response_format: None,
+        stream: false,
+    };
+    let rendered = adapter
+        .render_response(&result, &prompt, "chatcmpl-1")
+        .unwrap();
+    assert_eq!(rendered["system_fingerprint"], "fp_44709d6fcb");
+}
+
+/// Gemini `modelVersion` (no canonical field) round-trips through Generate
+/// Content at result level under `provider_metadata["google"]`.
+#[test]
+fn generate_content_model_version_round_trips_on_result() {
+    let adapter = generate_content::GenerateContentAdapter;
+    let response = serde_json::json!({
+        "candidates": [{
+            "content": { "role": "model", "parts": [{ "text": "hi" }] },
+            "finishReason": "STOP",
+            "index": 0,
+        }],
+        "modelVersion": "gemini-2.0-flash-001",
+        "usageMetadata": { "promptTokenCount": 1, "candidatesTokenCount": 1, "totalTokenCount": 2 },
+    });
+    let result = adapter.parse_response(response).unwrap();
+    assert_eq!(
+        result
+            .provider_metadata
+            .get("google")
+            .and_then(|g| g.get("modelVersion")),
+        Some(&serde_json::Value::String("gemini-2.0-flash-001".into()))
+    );
+    let prompt = Prompt {
+        model: "gemini-2.0-flash".to_string(),
+        system: None,
+        messages: vec![],
+        tools: vec![],
+        params: GenerationParams::default(),
+        response_format: None,
+        stream: false,
+    };
+    let rendered = adapter.render_response(&result, &prompt, "resp_1").unwrap();
+    assert_eq!(rendered["modelVersion"], "gemini-2.0-flash-001");
+}
+
+/// Gemini `thoughtSignature` on a thinking part round-trips so a multi-turn
+/// thinking conversation can replay the signed reasoning.
+#[test]
+fn generate_content_thought_signature_round_trips() {
+    let adapter = generate_content::GenerateContentAdapter;
+    let response = serde_json::json!({
+        "candidates": [{
+            "content": { "role": "model", "parts": [
+                { "text": "reasoning", "thought": true, "thoughtSignature": "TS-xyz" },
+            ] },
+            "finishReason": "STOP",
+            "index": 0,
+        }],
+        "usageMetadata": { "promptTokenCount": 1, "candidatesTokenCount": 1, "totalTokenCount": 2 },
+    });
+    let result = adapter.parse_response(response).unwrap();
+    match &result.content[0] {
+        Content::Reasoning {
+            provider_metadata, ..
+        } => assert_eq!(
+            provider_metadata
+                .get("google")
+                .and_then(|g| g.get("thoughtSignature")),
+            Some(&serde_json::Value::String("TS-xyz".into()))
+        ),
+        other => panic!("expected reasoning, got {other:?}"),
+    }
+    // Re-render to a request: the signature reappears on the thought part.
+    let prompt = Prompt {
+        model: "gemini-2.0-flash".to_string(),
+        system: None,
+        messages: vec![Message {
+            role: Role::Assistant,
+            content: vec![result.content[0].clone()],
+            provider_metadata: Default::default(),
+        }],
+        tools: vec![],
+        params: GenerationParams::default(),
+        response_format: None,
+        stream: false,
+    };
+    let rendered = adapter.render_request(&prompt).unwrap();
+    let part = &rendered["contents"][0]["parts"][0];
+    assert_eq!(part["thought"], true);
+    assert_eq!(part["thoughtSignature"], "TS-xyz");
+}
+
+/// The `File.extra` → `provider_metadata` migration is real: an OpenAI image
+/// `detail` hint (the canonical example of the former ad-hoc `extra`) is parsed
+/// under `provider_metadata["openai"]["detail"]` and rendered back onto the
+/// `image_url`. There is no `extra` mechanism anymore — this is the single slot.
+#[test]
+fn chat_image_detail_round_trips_via_provider_metadata() {
+    let adapter = chat_completions::ChatCompletionsAdapter;
+    let body = serde_json::json!({
+        "model": "gpt-4o",
+        "messages": [{
+            "role": "user",
+            "content": [{
+                "type": "image_url",
+                "image_url": { "url": "https://example.invalid/a.png", "detail": "high" },
+            }],
+        }],
+    });
+    let prompt = adapter.parse_request(body).unwrap();
+    match &prompt.messages[0].content[0] {
+        Content::File {
+            provider_metadata, ..
+        } => assert_eq!(
+            provider_metadata
+                .get("openai")
+                .and_then(|o| o.get("detail")),
+            Some(&serde_json::Value::String("high".into()))
+        ),
+        other => panic!("expected file content, got {other:?}"),
+    }
+    let rendered = adapter.render_request(&prompt).unwrap();
+    assert_eq!(
+        rendered["messages"][0]["content"][0]["image_url"]["detail"],
+        "high"
+    );
+}
+
+/// The OpenAI image `detail` hint is preserved (namespaced) across protocols:
+/// routed to an Anthropic upstream, which has no `detail` field, it is not
+/// expressed but also not lost from the canonical IR.
+#[test]
+fn openai_image_detail_preserved_across_protocols() {
+    let inbound = chat_completions::ChatCompletionsAdapter;
+    let outbound = messages::MessagesAdapter;
+    let body = serde_json::json!({
+        "model": "gpt-4o",
+        "messages": [{
+            "role": "user",
+            "content": [{
+                "type": "image_url",
+                "image_url": { "url": "https://example.invalid/a.png", "detail": "low" },
+            }],
+        }],
+    });
+    let prompt = inbound.parse_request(body).unwrap();
+    // Render to Anthropic — the image block carries no `detail`.
+    let rendered = outbound.render_request(&prompt).unwrap();
+    let block = &rendered["messages"][0]["content"][0];
+    assert_eq!(block["type"], "image");
+    assert!(block.get("detail").is_none());
+    // The canonical IR still carries it under the openai namespace.
+    match &prompt.messages[0].content[0] {
+        Content::File {
+            provider_metadata, ..
+        } => assert_eq!(
+            provider_metadata
+                .get("openai")
+                .and_then(|o| o.get("detail")),
+            Some(&serde_json::Value::String("low".into()))
+        ),
+        other => panic!("expected file content, got {other:?}"),
+    }
+}
+
+/// The Anthropic Source ↔ ToolCall correlation is *exact*: the originating
+/// `server_tool_use` id paired with a `web_search_tool_result` block is captured
+/// into the Source's `provider_metadata` on parse, and — when the originating
+/// call did not survive into the rendered content — restored as the synthesized
+/// pair's `tool_use_id`, rather than the by-position placeholder.
+#[test]
+fn messages_source_tool_use_id_correlation_is_exact() {
+    let adapter = messages::MessagesAdapter;
+    let response = serde_json::json!({
+        "id": "msg_1",
+        "type": "message",
+        "role": "assistant",
+        "content": [
+            { "type": "server_tool_use", "id": "srvtoolu_REAL", "name": "web_search", "input": {} },
+            {
+                "type": "web_search_tool_result",
+                "tool_use_id": "srvtoolu_REAL",
+                "content": [{ "type": "web_search_result", "url": "https://example.invalid/x", "title": "X" }],
+            },
+        ],
+        "stop_reason": "end_turn",
+        "usage": { "input_tokens": 1, "output_tokens": 1 },
+    });
+    let result = adapter.parse_response(response).unwrap();
+    // The Source captured the exact originating id.
+    let source = result
+        .content
+        .iter()
+        .find_map(|c| match c {
+            Content::Source {
+                provider_metadata, ..
+            } => Some(provider_metadata.clone()),
+            _ => None,
+        })
+        .expect("a Source was lifted from the web_search_tool_result");
+    assert_eq!(
+        source.get("anthropic").and_then(|a| a.get("toolUseId")),
+        Some(&serde_json::Value::String("srvtoolu_REAL".into()))
+    );
+
+    // Drop the originating call from the content (simulating a hop that did not
+    // round-trip the provider-executed call) and confirm the render falls back
+    // to the EXACT preserved id, not the `srvtoolu_citations` placeholder.
+    let mut result_without_call = result.clone();
+    result_without_call
+        .content
+        .retain(|c| !matches!(c, Content::ToolCall { .. }));
+    let prompt = Prompt {
+        model: "claude-3-5-sonnet".to_string(),
+        system: None,
+        messages: vec![],
+        tools: vec![],
+        params: GenerationParams::default(),
+        response_format: None,
+        stream: false,
+    };
+    let rendered = adapter
+        .render_response(&result_without_call, &prompt, "msg_1")
+        .unwrap();
+    let blocks = rendered["content"].as_array().unwrap();
+    let pair_id = blocks
+        .iter()
+        .find(|b| b["type"] == "web_search_tool_result")
+        .and_then(|b| b["tool_use_id"].as_str())
+        .unwrap();
+    assert_eq!(
+        pair_id, "srvtoolu_REAL",
+        "the synthesized pair must reuse the exact originating tool_use_id"
+    );
+    // The synthesized server_tool_use shares that exact id, so the pair is valid.
+    let call_id = blocks
+        .iter()
+        .find(|b| b["type"] == "server_tool_use")
+        .and_then(|b| b["id"].as_str())
+        .unwrap();
+    assert_eq!(call_id, "srvtoolu_REAL");
+}
+
+/// When the originating provider-executed call *does* survive into the content,
+/// the render reuses its real id and emits no duplicate `server_tool_use` — the
+/// exact-id metadata does not change that established same-protocol behavior.
+#[test]
+fn messages_source_with_surviving_call_reuses_call_id() {
+    let adapter = messages::MessagesAdapter;
+    let response = serde_json::json!({
+        "id": "msg_1",
+        "type": "message",
+        "role": "assistant",
+        "content": [
+            { "type": "server_tool_use", "id": "srvtoolu_REAL", "name": "web_search", "input": {} },
+            {
+                "type": "web_search_tool_result",
+                "tool_use_id": "srvtoolu_REAL",
+                "content": [{ "type": "web_search_result", "url": "https://example.invalid/x", "title": "X" }],
+            },
+        ],
+        "stop_reason": "end_turn",
+        "usage": { "input_tokens": 1, "output_tokens": 1 },
+    });
+    let result = adapter.parse_response(response).unwrap();
+    let prompt = Prompt {
+        model: "claude-3-5-sonnet".to_string(),
+        system: None,
+        messages: vec![],
+        tools: vec![],
+        params: GenerationParams::default(),
+        response_format: None,
+        stream: false,
+    };
+    let rendered = adapter.render_response(&result, &prompt, "msg_1").unwrap();
+    let blocks = rendered["content"].as_array().unwrap();
+    // Exactly one server_tool_use (the originating call), keyed by the real id.
+    let calls: Vec<_> = blocks
+        .iter()
+        .filter(|b| b["type"] == "server_tool_use")
+        .collect();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0]["id"], "srvtoolu_REAL");
+    let result_block = blocks
+        .iter()
+        .find(|b| b["type"] == "web_search_tool_result")
+        .unwrap();
+    assert_eq!(result_block["tool_use_id"], "srvtoolu_REAL");
 }

--- a/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
@@ -2962,3 +2962,49 @@ fn image_url_parses_to_url_data_content() {
         }
     );
 }
+
+#[test]
+fn response_modalities_round_trip_through_chat_completions() {
+    let body = serde_json::json!({
+        "model": "m",
+        "messages": [{ "role": "user", "content": "draw a cat" }],
+        "modalities": ["text", "image"]
+    });
+    let adapter = adapter_for(ApiProtocol::ChatCompletions);
+    let prompt = adapter.parse_request(body).unwrap();
+    assert_eq!(
+        prompt.params.response_modalities,
+        vec![Modality::Text, Modality::Image]
+    );
+    assert!(
+        prompt
+            .required_capabilities()
+            .contains(&Capability::ImageOutput)
+    );
+    let req = adapter.render_request(&prompt).unwrap();
+    assert_eq!(req["modalities"], serde_json::json!(["text", "image"]));
+}
+
+#[test]
+fn response_modalities_round_trip_through_generate_content() {
+    let body = serde_json::json!({
+        "contents": [{ "role": "user", "parts": [{ "text": "draw a cat" }] }],
+        "generationConfig": { "responseModalities": ["TEXT", "IMAGE"] }
+    });
+    let adapter = adapter_for(ApiProtocol::GenerateContent);
+    let prompt = adapter.parse_request(body).unwrap();
+    assert_eq!(
+        prompt.params.response_modalities,
+        vec![Modality::Text, Modality::Image]
+    );
+    assert!(
+        prompt
+            .required_capabilities()
+            .contains(&Capability::ImageOutput)
+    );
+    let req = adapter.render_request(&prompt).unwrap();
+    assert_eq!(
+        req["generationConfig"]["responseModalities"],
+        serde_json::json!(["TEXT", "IMAGE"])
+    );
+}

--- a/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
@@ -4041,6 +4041,68 @@ fn responses_render_response_reproduces_server_tool_item() {
     );
 }
 
+/// `image_generation_call` and `computer_call` output items are parsed as
+/// provider-executed tool calls (no echoed input, matching the AI SDK), and they
+/// round-trip: `render_response` reproduces each as its native `<name>_call`
+/// item keyed by `id`. `local_shell_call` / `mcp_call` are deferred and not
+/// parsed (so they must NOT appear as tool calls), per the documented skip.
+#[test]
+fn responses_parses_and_reproduces_image_and_computer_calls() {
+    let adapter = adapter_for(ApiProtocol::Responses);
+    let body = serde_json::json!({
+        "id": "resp_1",
+        "status": "completed",
+        "output": [
+            { "type": "image_generation_call", "id": "ig_1", "result": "BASE64..." },
+            { "type": "computer_call", "id": "cu_1", "status": "completed" },
+            // deferred — must not surface as tool calls
+            { "type": "local_shell_call", "call_id": "ls_1", "action": {"command": ["ls"]} },
+            { "type": "mcp_call", "id": "mc_1", "name": "fetch", "arguments": "{}" }
+        ]
+    });
+    let result = adapter.parse_response(body).unwrap();
+    let calls: Vec<_> = result
+        .content
+        .iter()
+        .filter_map(|c| match c {
+            Content::ToolCall {
+                name,
+                provider_executed,
+                arguments,
+                ..
+            } => Some((name.as_str(), *provider_executed, arguments.as_str())),
+            _ => None,
+        })
+        .collect();
+    // Only the two (a)-mapped server tools are parsed; the deferred items drop.
+    assert_eq!(
+        calls,
+        vec![("image_generation", true, "{}"), ("computer", true, "{}"),],
+        "image_generation_call/computer_call parse; local_shell_call/mcp_call defer"
+    );
+
+    // Live, not dead: each parsed call is consumed by the reproduction site,
+    // re-emitting its native `<name>_call` output item keyed by `id`.
+    let rendered = adapter
+        .render_response(&result, &sample_prompt(), "resp_1")
+        .unwrap();
+    let output = rendered["output"].as_array().unwrap();
+    let ig = output
+        .iter()
+        .find(|i| i["type"] == "image_generation_call")
+        .expect("image_generation_call reproduced");
+    assert_eq!(ig["id"], "ig_1");
+    let cu = output
+        .iter()
+        .find(|i| i["type"] == "computer_call")
+        .expect("computer_call reproduced");
+    assert_eq!(cu["id"], "cu_1");
+    assert!(
+        output.iter().all(|i| i["type"] != "function_call"),
+        "provider-executed calls must not render as function_call: {rendered}"
+    );
+}
+
 /// `provider_executed` defaults to false and is omitted from the serialized
 /// canonical form when false (no JSON `null`, no `false` noise).
 #[test]
@@ -4354,6 +4416,113 @@ fn exotic_tool_choice_falls_back_to_other_and_round_trips() {
     assert_eq!(
         rendered["toolConfig"], tool_config,
         "Gemini exotic toolConfig must render back verbatim"
+    );
+}
+
+/// Regression: a Gemini `toolConfig` whose `functionCallingConfig` cannot be
+/// reduced to a typed [`ToolChoice`] — because it omits `mode`, or carries an
+/// unmodelled sibling key — must NOT vanish. Before the parser was made
+/// infallible it returned `None` for these shapes while the caller had already
+/// removed `toolConfig` from the top-level extras, so the choice was dropped and
+/// broke even a same-protocol Gemini→Gemini round-trip. It must now degrade to
+/// `ToolChoice::Other` and re-emit verbatim, with no duplicate left in extras.
+#[test]
+fn gemini_unreducible_tool_config_survives_round_trip() {
+    let gemini = adapter_for(ApiProtocol::GenerateContent);
+    // Case 1: `functionCallingConfig` with `allowedFunctionNames` but NO `mode`.
+    // Case 2: a different shape — a `functionCallingConfig` carrying an unknown
+    // sibling key alongside a recognised `mode`.
+    let configs = [
+        serde_json::json!({
+            "functionCallingConfig": {"allowedFunctionNames": ["lookup"]}
+        }),
+        serde_json::json!({
+            "functionCallingConfig": {"mode": "VALIDATED", "responseSchema": {"x": 1}}
+        }),
+    ];
+    for tool_config in configs {
+        let prompt = gemini
+            .parse_request(serde_json::json!({
+                "model": "gemini-2.0-flash",
+                "contents": [{"role": "user", "parts": [{"text": "hi"}]}],
+                "toolConfig": tool_config.clone()
+            }))
+            .unwrap();
+        // The unreducible config is preserved verbatim in the typed slot, not
+        // dropped.
+        assert_eq!(
+            prompt.params.tool_choice,
+            Some(ToolChoice::Other {
+                value: tool_config.clone()
+            }),
+            "unreducible toolConfig must be preserved as Other: {tool_config}"
+        );
+        // It must NOT also linger in the top-level extras sentinel (otherwise it
+        // would be double-written on render).
+        let lingering = prompt
+            .params
+            .extra
+            .get("__google_top_level__")
+            .and_then(|v| v.as_object())
+            .map(|t| t.contains_key("toolConfig"))
+            .unwrap_or(false);
+        assert!(
+            !lingering,
+            "toolConfig must be lifted out of extras, not duplicated: {:?}",
+            prompt.params.extra
+        );
+        // Gemini→Gemini render re-emits the original toolConfig byte-for-byte,
+        // exactly once at the request root.
+        let rendered = gemini.render_request(&prompt).unwrap();
+        assert_eq!(
+            rendered["toolConfig"], tool_config,
+            "unreducible toolConfig must round-trip verbatim"
+        );
+        // And a second render→parse→render hop is still stable (no drift).
+        let reparsed = gemini.parse_request(rendered).unwrap();
+        let rerendered = gemini.render_request(&reparsed).unwrap();
+        assert_eq!(
+            rerendered["toolConfig"], tool_config,
+            "unreducible toolConfig must remain stable across a second hop"
+        );
+    }
+}
+
+/// Cross-protocol translation of `Auto`: authored as a Chat Completions
+/// `"auto"`, it must reach Anthropic as `{type:"auto"}` and Gemini as
+/// `mode:"AUTO"` (and stay `"auto"` on Responses).
+#[test]
+fn tool_choice_auto_translates_across_protocols() {
+    let chat = adapter_for(ApiProtocol::ChatCompletions);
+    let prompt = chat
+        .parse_request(serde_json::json!({
+            "model": "gpt-5",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tool_choice": "auto"
+        }))
+        .unwrap();
+    assert_eq!(prompt.params.tool_choice, Some(ToolChoice::Auto));
+
+    // Anthropic -> {type:"auto"}
+    assert_eq!(
+        adapter_for(ApiProtocol::Messages)
+            .render_request(&prompt)
+            .unwrap()["tool_choice"],
+        serde_json::json!({"type": "auto"})
+    );
+    // Gemini -> toolConfig.functionCallingConfig.mode = AUTO
+    assert_eq!(
+        adapter_for(ApiProtocol::GenerateContent)
+            .render_request(&prompt)
+            .unwrap()["toolConfig"]["functionCallingConfig"]["mode"],
+        "AUTO"
+    );
+    // Responses -> "auto"
+    assert_eq!(
+        adapter_for(ApiProtocol::Responses)
+            .render_request(&prompt)
+            .unwrap()["tool_choice"],
+        "auto"
     );
 }
 

--- a/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
@@ -4921,6 +4921,289 @@ fn parsed_tool_choice_is_not_duplicated_in_extra() {
     );
 }
 
+// ===== typed sampling params (top_k / seed / stop / presence_penalty /
+// frequency_penalty) cross-protocol translation =====
+
+/// Each typed sampling slot the protocol carries survives a render→parse
+/// round-trip on its own wire — the same-protocol fidelity contract. Per the
+/// official wire shapes: Chat Completions carries `seed` / `stop` /
+/// `presence_penalty` / `frequency_penalty` but no top-k; Anthropic carries
+/// `top_k` / `stop_sequences`; Gemini carries all five; Responses carries none.
+#[test]
+fn sampling_params_same_protocol_round_trip() {
+    // Chat Completions: seed, stop, presence_penalty, frequency_penalty.
+    let chat = adapter_for(ApiProtocol::ChatCompletions);
+    let params = chat
+        .parse_request(serde_json::json!({
+            "model": "gpt-5",
+            "messages": [{"role": "user", "content": "hi"}],
+            "seed": 7,
+            "stop": ["END", "STOP"],
+            "presence_penalty": 0.5,
+            "frequency_penalty": -0.25
+        }))
+        .unwrap();
+    let back = chat
+        .parse_request(chat.render_request(&params).unwrap())
+        .unwrap()
+        .params;
+    assert_eq!(back.seed, Some(7));
+    assert_eq!(back.stop, vec!["END".to_string(), "STOP".to_string()]);
+    assert_eq!(back.presence_penalty, Some(0.5));
+    assert_eq!(back.frequency_penalty, Some(-0.25));
+    assert_eq!(back.top_k, None, "Chat Completions has no top-k");
+
+    // A scalar `stop` string normalises to a one-element list.
+    let scalar = chat
+        .parse_request(serde_json::json!({
+            "model": "gpt-5",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stop": "END"
+        }))
+        .unwrap();
+    assert_eq!(scalar.params.stop, vec!["END".to_string()]);
+
+    // Anthropic: top_k, stop_sequences.
+    let anthropic = adapter_for(ApiProtocol::Messages);
+    let back = anthropic
+        .parse_request(
+            anthropic
+                .render_request(
+                    &anthropic
+                        .parse_request(serde_json::json!({
+                            "model": "claude-opus-4-8",
+                            "max_tokens": 16,
+                            "messages": [{"role": "user", "content": "hi"}],
+                            "top_k": 40,
+                            "stop_sequences": ["END"]
+                        }))
+                        .unwrap(),
+                )
+                .unwrap(),
+        )
+        .unwrap()
+        .params;
+    assert_eq!(back.top_k, Some(40));
+    assert_eq!(back.stop, vec!["END".to_string()]);
+
+    // Gemini: all five, nested under generationConfig.
+    let gemini = adapter_for(ApiProtocol::GenerateContent);
+    let back = gemini
+        .parse_request(
+            gemini
+                .render_request(
+                    &gemini
+                        .parse_request(serde_json::json!({
+                            "model": "gemini-2.0-flash",
+                            "contents": [{"role": "user", "parts": [{"text": "hi"}]}],
+                            "generationConfig": {
+                                "topK": 40,
+                                "seed": 7,
+                                "stopSequences": ["END", "STOP"],
+                                "presencePenalty": 0.1,
+                                "frequencyPenalty": -0.1
+                            }
+                        }))
+                        .unwrap(),
+                )
+                .unwrap(),
+        )
+        .unwrap()
+        .params;
+    assert_eq!(back.top_k, Some(40));
+    assert_eq!(back.seed, Some(7));
+    assert_eq!(back.stop, vec!["END".to_string(), "STOP".to_string()]);
+    assert_eq!(back.presence_penalty, Some(0.1));
+    assert_eq!(back.frequency_penalty, Some(-0.1));
+}
+
+/// Cross-protocol translation, Chat → others: `seed` + `stop` +
+/// `presence_penalty` + `frequency_penalty` authored on a Chat Completions body
+/// must reach Gemini as `generationConfig.{seed, stopSequences, presencePenalty,
+/// frequencyPenalty}` (the WHOLE point — these used to no-op as top-level keys
+/// against Gemini's nested-config wire) and `stop` must reach Anthropic as
+/// `stop_sequences`.
+#[test]
+fn sampling_params_translate_chat_to_gemini_and_anthropic() {
+    let chat = adapter_for(ApiProtocol::ChatCompletions);
+    let prompt = chat
+        .parse_request(serde_json::json!({
+            "model": "gpt-5",
+            "messages": [{"role": "user", "content": "hi"}],
+            "seed": 7,
+            "stop": ["END", "STOP"],
+            "presence_penalty": 0.5,
+            "frequency_penalty": -0.25
+        }))
+        .unwrap();
+
+    // Gemini: nested in generationConfig under the Google wire names.
+    let gc = &adapter_for(ApiProtocol::GenerateContent)
+        .render_request(&prompt)
+        .unwrap()["generationConfig"];
+    assert_eq!(gc["seed"], 7);
+    assert_eq!(gc["stopSequences"], serde_json::json!(["END", "STOP"]));
+    assert_eq!(gc["presencePenalty"], 0.5);
+    assert_eq!(gc["frequencyPenalty"], -0.25);
+
+    // Anthropic: `stop` becomes `stop_sequences`; seed / penalties have no
+    // Anthropic wire field and must not appear.
+    let anthropic = adapter_for(ApiProtocol::Messages)
+        .render_request(&prompt)
+        .unwrap();
+    assert_eq!(
+        anthropic["stop_sequences"],
+        serde_json::json!(["END", "STOP"])
+    );
+    assert!(anthropic.get("seed").is_none());
+    assert!(anthropic.get("presence_penalty").is_none());
+    assert!(anthropic.get("frequency_penalty").is_none());
+
+    // Responses carries none of these — they must not leak onto its wire.
+    let responses = adapter_for(ApiProtocol::Responses)
+        .render_request(&prompt)
+        .unwrap();
+    for key in ["seed", "stop", "presence_penalty", "frequency_penalty"] {
+        assert!(
+            responses.get(key).is_none(),
+            "Responses must not render `{key}`"
+        );
+    }
+}
+
+/// Cross-protocol translation, Gemini/Anthropic → others: a Gemini `topK` +
+/// `stopSequences` must reach Anthropic as `top_k` + `stop_sequences` and Chat
+/// Completions as `stop` (Chat has no top-k, so `topK` is dropped there, not
+/// leaked).
+#[test]
+fn sampling_params_translate_gemini_and_anthropic_to_others() {
+    // Author on Gemini, render to Anthropic + Chat.
+    let gemini = adapter_for(ApiProtocol::GenerateContent);
+    let prompt = gemini
+        .parse_request(serde_json::json!({
+            "model": "gemini-2.0-flash",
+            "contents": [{"role": "user", "parts": [{"text": "hi"}]}],
+            "generationConfig": {
+                "topK": 40,
+                "stopSequences": ["END"]
+            }
+        }))
+        .unwrap();
+    assert_eq!(prompt.params.top_k, Some(40));
+
+    // Anthropic: top_k + stop_sequences.
+    let anthropic = adapter_for(ApiProtocol::Messages)
+        .render_request(&prompt)
+        .unwrap();
+    assert_eq!(anthropic["top_k"], 40);
+    assert_eq!(anthropic["stop_sequences"], serde_json::json!(["END"]));
+
+    // Chat Completions: stop survives; top_k is dropped (no wire field), never
+    // splatted verbatim.
+    let chat = adapter_for(ApiProtocol::ChatCompletions)
+        .render_request(&prompt)
+        .unwrap();
+    assert_eq!(chat["stop"], serde_json::json!(["END"]));
+    assert!(
+        chat.get("top_k").is_none() && chat.get("topK").is_none(),
+        "Chat Completions must not carry top-k in any form: {chat}"
+    );
+
+    // Author an Anthropic `top_k` and confirm it reaches Gemini as `topK`.
+    let anthropic_in = adapter_for(ApiProtocol::Messages)
+        .parse_request(serde_json::json!({
+            "model": "claude-opus-4-8",
+            "max_tokens": 16,
+            "messages": [{"role": "user", "content": "hi"}],
+            "top_k": 64
+        }))
+        .unwrap();
+    let gc = &adapter_for(ApiProtocol::GenerateContent)
+        .render_request(&anthropic_in)
+        .unwrap()["generationConfig"];
+    assert_eq!(gc["topK"], 64);
+}
+
+/// A parsed sampling param must NOT also remain in the raw `extra` passthrough —
+/// otherwise it would be double-written (once from the typed slot, once verbatim
+/// from `extra`) and forwarded with its source-wire name into a cross-protocol
+/// target that ignores it.
+#[test]
+fn parsed_sampling_params_are_not_duplicated_in_extra() {
+    // Chat Completions: seed / stop / penalties leave `extra`.
+    let chat = adapter_for(ApiProtocol::ChatCompletions)
+        .parse_request(serde_json::json!({
+            "model": "gpt-5",
+            "messages": [{"role": "user", "content": "hi"}],
+            "seed": 7,
+            "stop": ["END"],
+            "presence_penalty": 0.5,
+            "frequency_penalty": -0.25
+        }))
+        .unwrap();
+    for key in ["seed", "stop", "presence_penalty", "frequency_penalty"] {
+        assert!(
+            !chat.params.extra.contains_key(key),
+            "Chat Completions `{key}` must be promoted out of extra, not duplicated"
+        );
+    }
+
+    // Anthropic: top_k / stop_sequences leave `extra`.
+    let anthropic = adapter_for(ApiProtocol::Messages)
+        .parse_request(serde_json::json!({
+            "model": "claude-opus-4-8",
+            "max_tokens": 16,
+            "messages": [{"role": "user", "content": "hi"}],
+            "top_k": 40,
+            "stop_sequences": ["END"]
+        }))
+        .unwrap();
+    for key in ["top_k", "stop_sequences"] {
+        assert!(
+            !anthropic.params.extra.contains_key(key),
+            "Anthropic `{key}` must be promoted out of extra, not duplicated"
+        );
+    }
+
+    // Gemini: all five leave the generationConfig-level `extra`. (The Gemini
+    // adapter only stashes top-level Google fields under the sentinel key, so
+    // generationConfig knobs that were promoted simply never land in `extra`.)
+    let gemini = adapter_for(ApiProtocol::GenerateContent)
+        .parse_request(serde_json::json!({
+            "model": "gemini-2.0-flash",
+            "contents": [{"role": "user", "parts": [{"text": "hi"}]}],
+            "generationConfig": {
+                "topK": 40,
+                "seed": 7,
+                "stopSequences": ["END"],
+                "presencePenalty": 0.1,
+                "frequencyPenalty": -0.1
+            }
+        }))
+        .unwrap();
+    for key in [
+        "topK",
+        "seed",
+        "stopSequences",
+        "presencePenalty",
+        "frequencyPenalty",
+    ] {
+        assert!(
+            !gemini.params.extra.contains_key(key),
+            "Gemini generationConfig `{key}` must be promoted out of extra"
+        );
+    }
+    // And the render carries each exactly once (no duplicate verbatim splat):
+    // re-rendering and re-parsing recovers the same typed values.
+    let rendered = adapter_for(ApiProtocol::GenerateContent)
+        .render_request(&gemini)
+        .unwrap();
+    let gc = &rendered["generationConfig"];
+    assert_eq!(gc["topK"], 40);
+    assert_eq!(gc["seed"], 7);
+    assert_eq!(gc["stopSequences"], serde_json::json!(["END"]));
+}
+
 /// An exotic `tool_choice` shape that does not map onto any V3 variant is
 /// preserved verbatim via [`ToolChoice::Other`] and round-trips losslessly on
 /// the same protocol.

--- a/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
@@ -2058,19 +2058,21 @@ fn regression_364_tool_result_array_and_thinking() {
             .any(|c| matches!(c, Content::Reasoning { .. })),
         "thinking block preserved as Reasoning"
     );
-    // tool_result with array content is read as text
+    // a text-only tool_result block array collapses to a Text output
     let tr = prompt
         .messages
         .iter()
         .flat_map(|m| &m.content)
         .find_map(|c| match c {
-            Content::ToolResult { content, .. } => Some(content.as_str()),
+            Content::ToolResult { output, .. } => Some(output.clone()),
             _ => None,
         });
     assert_eq!(
         tr,
-        Some("42"),
-        "array tool_result content flattened to text"
+        Some(ToolResultOutput::Text {
+            value: "42".to_string()
+        }),
+        "text-only array tool_result content flattens to a Text output"
     );
 }
 
@@ -3142,5 +3144,435 @@ fn generated_file_url_round_trips_through_generate_content() {
     assert!(
         s.contains("fileData") && s.contains("https://example.invalid/g.png"),
         "rendered response should carry the file URL: {s}"
+    );
+}
+
+// ===== structured tool results (LanguageModelV3 ToolResultOutput parity) =====
+
+/// A canonical prompt whose single Tool-role message carries one tool result
+/// with the given call id, optional tool name, and typed output.
+fn tool_result_prompt(call_id: &str, tool_name: Option<&str>, output: ToolResultOutput) -> Prompt {
+    Prompt {
+        model: "test-model".to_string(),
+        system: None,
+        messages: vec![Message {
+            role: Role::Tool,
+            content: vec![Content::ToolResult {
+                call_id: call_id.to_string(),
+                tool_name: tool_name.map(str::to_string),
+                output,
+            }],
+        }],
+        tools: vec![],
+        params: GenerationParams {
+            max_tokens: Some(256),
+            ..Default::default()
+        },
+        response_format: None,
+        stream: false,
+    }
+}
+
+/// The first tool result `(call_id, tool_name, output)` in a parsed prompt.
+fn first_tool_result(prompt: &Prompt) -> (&str, Option<&str>, &ToolResultOutput) {
+    prompt
+        .messages
+        .iter()
+        .flat_map(|m| &m.content)
+        .find_map(|c| match c {
+            Content::ToolResult {
+                call_id,
+                tool_name,
+                output,
+            } => Some((call_id.as_str(), tool_name.as_deref(), output)),
+            _ => None,
+        })
+        .expect("prompt should carry a tool result")
+}
+
+/// Render `output` through `protocol` as a tool-result request, re-parse it, and
+/// return the canonical output that survived the round trip.
+fn round_trip_tool_output(protocol: ApiProtocol, output: ToolResultOutput) -> ToolResultOutput {
+    let adapter = adapter_for(protocol.clone());
+    let rendered = adapter
+        .render_request(&tool_result_prompt("call_1", None, output))
+        .unwrap_or_else(|e| panic!("{protocol:?} render_request: {e}"));
+    let reparsed = adapter
+        .parse_request(rendered)
+        .unwrap_or_else(|e| panic!("{protocol:?} parse_request: {e}"));
+    first_tool_result(&reparsed).2.clone()
+}
+
+#[test]
+fn tool_result_text_round_trips_through_string_capable_protocols() {
+    // Chat Completions, Messages, and Responses all carry a string tool-result
+    // body, so a Text output survives a round trip unchanged. Generate Content
+    // is excluded: its `functionResponse.response` is always a JSON object, so
+    // Text necessarily degrades there (covered by its own test below).
+    for protocol in [
+        ApiProtocol::ChatCompletions,
+        ApiProtocol::Messages,
+        ApiProtocol::Responses,
+    ] {
+        let output = ToolResultOutput::Text {
+            value: "the result is 42".to_string(),
+        };
+        assert_eq!(
+            round_trip_tool_output(protocol.clone(), output.clone()),
+            output,
+            "{protocol:?} lost a Text tool result"
+        );
+    }
+}
+
+#[test]
+fn tool_result_text_degrades_to_json_result_on_gemini() {
+    // Gemini's `functionResponse.response` must be a JSON object, so a Text
+    // output is rendered losslessly under a `result` key and re-parses as a
+    // Json output carrying that key — a faithful, non-dropping degrade.
+    // <https://ai.google.dev/api/caching#FunctionResponse>
+    let output = ToolResultOutput::Text {
+        value: "the result is 42".to_string(),
+    };
+    let back = round_trip_tool_output(ApiProtocol::GenerateContent, output);
+    assert_eq!(
+        back,
+        ToolResultOutput::Json {
+            value: serde_json::json!({ "result": "the result is 42" }),
+        },
+        "Gemini Text tool result degrades to a Json {{result}} object"
+    );
+}
+
+#[test]
+fn tool_result_json_round_trips_through_structured_protocols() {
+    // Responses (`function_call_output.output`) and Generate Content
+    // (`functionResponse.response`) both carry a structured tool-result body, so
+    // a Json *object* output survives intact.
+    let output = ToolResultOutput::Json {
+        value: serde_json::json!({ "celsius": 21, "unit": "C" }),
+    };
+    for protocol in [ApiProtocol::Responses, ApiProtocol::GenerateContent] {
+        assert_eq!(
+            round_trip_tool_output(protocol.clone(), output.clone()),
+            output,
+            "{protocol:?} lost a Json tool result"
+        );
+    }
+}
+
+#[test]
+fn tool_result_json_degrades_to_text_on_chat_completions() {
+    // OpenAI Chat Completions' `tool` message `content` is a string (or a
+    // text/media part array) — there is no slot for a bare JSON value, so a Json
+    // output is stringified and re-parses as Text (a lossless degrade).
+    // <https://platform.openai.com/docs/api-reference/chat/create#chat-create-messages>
+    let output = ToolResultOutput::Json {
+        value: serde_json::json!({ "celsius": 21, "unit": "C" }),
+    };
+    let back = round_trip_tool_output(ApiProtocol::ChatCompletions, output.clone());
+    assert_eq!(
+        back,
+        ToolResultOutput::Text {
+            value: output.to_provider_string(),
+        },
+        "Chat Completions Json tool result degrades to a stringified Text output"
+    );
+}
+
+#[test]
+fn tool_result_json_degrades_to_text_on_anthropic() {
+    // Anthropic's tool_result body is a string (or block array), with no slot
+    // for a bare JSON value — so a Json output degrades losslessly to its
+    // stringified form rather than being dropped.
+    let output = ToolResultOutput::Json {
+        value: serde_json::json!({ "k": 1 }),
+    };
+    let back = round_trip_tool_output(ApiProtocol::Messages, output.clone());
+    assert_eq!(
+        back,
+        ToolResultOutput::Text {
+            value: output.to_provider_string(),
+        },
+        "Anthropic Json tool result degrades to a stringified Text output"
+    );
+}
+
+#[test]
+fn tool_result_error_text_round_trips_through_anthropic() {
+    // Anthropic is the only request protocol with a native error flag
+    // (`tool_result.is_error`); ErrorText must survive a round trip through it.
+    let output = ToolResultOutput::ErrorText {
+        value: "tool exploded".to_string(),
+    };
+    assert_eq!(
+        round_trip_tool_output(ApiProtocol::Messages, output.clone()),
+        output,
+        "Anthropic lost an ErrorText tool result"
+    );
+}
+
+#[test]
+fn tool_result_error_json_round_trips_through_anthropic() {
+    // Anthropic's error body is a string, so ErrorJson round-trips as ErrorText
+    // (the flag survives, the structure flattens — a lossless degrade).
+    let output = ToolResultOutput::ErrorJson {
+        value: serde_json::json!({ "code": "E_BOOM", "retryable": false }),
+    };
+    let back = round_trip_tool_output(ApiProtocol::Messages, output.clone());
+    assert_eq!(
+        back,
+        ToolResultOutput::ErrorText {
+            value: output.to_provider_string(),
+        },
+        "Anthropic ErrorJson keeps the error flag, flattening to ErrorText"
+    );
+}
+
+#[test]
+fn tool_result_is_error_renders_anthropic_flag() {
+    // The rendered Anthropic wire must carry `is_error: true` for an error
+    // output and omit it otherwise.
+    let err = adapter_for(ApiProtocol::Messages)
+        .render_request(&tool_result_prompt(
+            "t1",
+            None,
+            ToolResultOutput::ErrorText {
+                value: "bad".to_string(),
+            },
+        ))
+        .unwrap();
+    let err_block = &err["messages"][0]["content"][0];
+    assert_eq!(err_block["type"], "tool_result");
+    assert_eq!(err_block["is_error"], serde_json::Value::Bool(true));
+    assert_eq!(err_block["content"], "bad");
+
+    let ok = adapter_for(ApiProtocol::Messages)
+        .render_request(&tool_result_prompt(
+            "t1",
+            None,
+            ToolResultOutput::Text {
+                value: "good".to_string(),
+            },
+        ))
+        .unwrap();
+    assert!(
+        ok["messages"][0]["content"][0].get("is_error").is_none(),
+        "a non-error tool result must omit the is_error flag"
+    );
+}
+
+#[test]
+fn tool_result_content_round_trips_through_anthropic() {
+    // A multimodal (content-variant) tool result: text + an image part survive a
+    // round trip through Anthropic's tool_result block array.
+    let output = ToolResultOutput::Content {
+        value: vec![
+            ToolResultContentPart::Text {
+                text: "see image".to_string(),
+            },
+            ToolResultContentPart::Media {
+                media_type: "image/png".to_string(),
+                data: DataContent::Base64 {
+                    data: IMG_B64.to_string(),
+                },
+            },
+        ],
+    };
+    assert_eq!(
+        round_trip_tool_output(ApiProtocol::Messages, output.clone()),
+        output,
+        "Anthropic lost a multimodal Content tool result"
+    );
+}
+
+#[test]
+fn tool_result_content_renders_anthropic_image_block() {
+    // The rendered Anthropic wire carries the multimodal result as a block
+    // array with a `text` block and an `image` block.
+    let output = ToolResultOutput::Content {
+        value: vec![
+            ToolResultContentPart::Text {
+                text: "look".to_string(),
+            },
+            ToolResultContentPart::Media {
+                media_type: "image/png".to_string(),
+                data: DataContent::Base64 {
+                    data: IMG_B64.to_string(),
+                },
+            },
+        ],
+    };
+    let req = adapter_for(ApiProtocol::Messages)
+        .render_request(&tool_result_prompt("t1", None, output))
+        .unwrap();
+    let blocks = &req["messages"][0]["content"][0]["content"];
+    assert_eq!(blocks[0]["type"], "text");
+    assert_eq!(blocks[0]["text"], "look");
+    assert_eq!(blocks[1]["type"], "image");
+    assert_eq!(blocks[1]["source"]["type"], "base64");
+    assert_eq!(blocks[1]["source"]["media_type"], "image/png");
+    assert_eq!(blocks[1]["source"]["data"], IMG_B64);
+}
+
+#[test]
+fn tool_result_content_round_trips_through_chat_completions() {
+    // OpenAI Chat Completions carries a multimodal tool result as a content-part
+    // array (text + image_url), so a Content output survives there too.
+    let output = ToolResultOutput::Content {
+        value: vec![
+            ToolResultContentPart::Text {
+                text: "pic".to_string(),
+            },
+            ToolResultContentPart::Media {
+                media_type: "image/png".to_string(),
+                data: DataContent::Base64 {
+                    data: IMG_B64.to_string(),
+                },
+            },
+        ],
+    };
+    assert_eq!(
+        round_trip_tool_output(ApiProtocol::ChatCompletions, output.clone()),
+        output,
+        "Chat Completions lost a multimodal Content tool result"
+    );
+}
+
+#[test]
+fn tool_name_survives_gemini_function_response_round_trip() {
+    // Gemini keys tool results by function name; `tool_name` must survive a
+    // render→parse round trip through `functionResponse`.
+    let output = ToolResultOutput::Json {
+        value: serde_json::json!({ "ok": true }),
+    };
+    let adapter = adapter_for(ApiProtocol::GenerateContent);
+    let rendered = adapter
+        .render_request(&tool_result_prompt(
+            "call_1",
+            Some("get_weather"),
+            output.clone(),
+        ))
+        .unwrap();
+    // The rendered wire carries the tool name under `functionResponse.name`.
+    let fr = &rendered["contents"][0]["parts"][0]["functionResponse"];
+    assert_eq!(fr["name"], "get_weather");
+    assert_eq!(fr["response"]["ok"], true);
+
+    let reparsed = adapter.parse_request(rendered).unwrap();
+    let (_, tool_name, parsed_output) = first_tool_result(&reparsed);
+    assert_eq!(
+        tool_name,
+        Some("get_weather"),
+        "Gemini functionResponse must preserve the tool name"
+    );
+    assert_eq!(parsed_output, &output, "Gemini lost the Json tool output");
+}
+
+#[test]
+fn gemini_function_response_carries_call_id_when_distinct() {
+    // When the call id differs from the tool name, the Gemini wire carries it
+    // under `functionResponse.id` and a round trip recovers both.
+    let adapter = adapter_for(ApiProtocol::GenerateContent);
+    let rendered = adapter
+        .render_request(&tool_result_prompt(
+            "call_42",
+            Some("get_weather"),
+            ToolResultOutput::Json {
+                value: serde_json::json!({ "ok": true }),
+            },
+        ))
+        .unwrap();
+    let fr = &rendered["contents"][0]["parts"][0]["functionResponse"];
+    assert_eq!(fr["name"], "get_weather");
+    assert_eq!(fr["id"], "call_42");
+
+    let reparsed = adapter.parse_request(rendered).unwrap();
+    let (call_id, tool_name, _) = first_tool_result(&reparsed);
+    assert_eq!(call_id, "call_42", "Gemini lost the distinct call id");
+    assert_eq!(tool_name, Some("get_weather"));
+}
+
+#[test]
+fn tool_result_output_serde_uses_snake_case_tags() {
+    // The IR serde representation is the cross-protocol contract: snake_case
+    // type tags on both the output union and its content parts.
+    let text = serde_json::to_value(ToolResultOutput::Text {
+        value: "x".to_string(),
+    })
+    .unwrap();
+    assert_eq!(text["type"], "text");
+    assert_eq!(text["value"], "x");
+
+    let err = serde_json::to_value(ToolResultOutput::ErrorText {
+        value: "boom".to_string(),
+    })
+    .unwrap();
+    assert_eq!(err["type"], "error_text");
+
+    let err_json = serde_json::to_value(ToolResultOutput::ErrorJson {
+        value: serde_json::json!({ "a": 1 }),
+    })
+    .unwrap();
+    assert_eq!(err_json["type"], "error_json");
+
+    let content = serde_json::to_value(ToolResultOutput::Content {
+        value: vec![ToolResultContentPart::Media {
+            media_type: "image/png".to_string(),
+            data: DataContent::Url {
+                url: "https://example.invalid/a.png".to_string(),
+            },
+        }],
+    })
+    .unwrap();
+    assert_eq!(content["type"], "content");
+    assert_eq!(content["value"][0]["type"], "media");
+    assert_eq!(content["value"][0]["media_type"], "image/png");
+    assert_eq!(content["value"][0]["data"]["kind"], "url");
+}
+
+#[test]
+fn tool_result_content_serde_round_trips() {
+    // The whole Content block round-trips through serde unchanged, including the
+    // optional tool_name field.
+    let original = Content::ToolResult {
+        call_id: "c1".to_string(),
+        tool_name: Some("calc".to_string()),
+        output: ToolResultOutput::Content {
+            value: vec![
+                ToolResultContentPart::Text {
+                    text: "hi".to_string(),
+                },
+                ToolResultContentPart::Media {
+                    media_type: "image/png".to_string(),
+                    data: DataContent::Base64 {
+                        data: IMG_B64.to_string(),
+                    },
+                },
+            ],
+        },
+    };
+    let value = serde_json::to_value(&original).unwrap();
+    assert_eq!(value["type"], "tool_result");
+    assert_eq!(value["tool_name"], "calc");
+    let back: Content = serde_json::from_value(value).unwrap();
+    assert_eq!(back, original);
+}
+
+#[test]
+fn tool_result_without_tool_name_omits_the_field() {
+    // `tool_name` is `skip_serializing_if = "Option::is_none"`, so a result
+    // without a name must not emit the key.
+    let value = serde_json::to_value(Content::ToolResult {
+        call_id: "c1".to_string(),
+        tool_name: None,
+        output: ToolResultOutput::Text {
+            value: "x".to_string(),
+        },
+    })
+    .unwrap();
+    assert!(
+        value.get("tool_name").is_none(),
+        "absent tool_name must omit the key, not emit null: {value}"
     );
 }

--- a/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
@@ -3110,3 +3110,37 @@ fn generated_image_renders_into_chat_response_best_effort() {
         format!("data:image/png;base64,{IMG_B64}")
     );
 }
+
+#[test]
+fn generated_file_url_round_trips_through_generate_content() {
+    // The URL (`fileData` / `fileUri`) output path mirrors the base64 one.
+    let adapter = adapter_for(ApiProtocol::GenerateContent);
+    let body = serde_json::json!({
+        "candidates": [{
+            "content": { "role": "model", "parts": [
+                { "fileData": { "mimeType": "image/png", "fileUri": "https://example.invalid/g.png" } }
+            ]},
+            "finishReason": "STOP"
+        }]
+    });
+    let result = adapter.parse_response(body).unwrap();
+    let expected = DataContent::Url {
+        url: "https://example.invalid/g.png".to_string(),
+    };
+    let file = result.content.iter().find_map(|c| match c {
+        Content::File {
+            media_type, data, ..
+        } => Some((media_type.as_str(), data)),
+        _ => None,
+    });
+    assert_eq!(file, Some(("image/png", &expected)));
+
+    let rendered = adapter
+        .render_response(&result, &sample_prompt(), "id")
+        .unwrap();
+    let s = serde_json::to_string(&rendered).unwrap();
+    assert!(
+        s.contains("fileData") && s.contains("https://example.invalid/g.png"),
+        "rendered response should carry the file URL: {s}"
+    );
+}

--- a/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
@@ -2733,3 +2733,232 @@ fn extra_passthrough_field_is_not_in_schema() {
         "ResponsesRequest schema must not expose `extra` (pass-through field)",
     );
 }
+
+// ===== multimodal (file) content =====
+
+const IMG_B64: &str = "iVBORw0KGgoAAAANSUhEUg==";
+
+/// A canonical prompt whose single user message is one image file part.
+fn image_file_prompt() -> Prompt {
+    Prompt {
+        model: "test-model".to_string(),
+        system: None,
+        messages: vec![Message {
+            role: Role::User,
+            content: vec![Content::File {
+                media_type: "image/png".to_string(),
+                data: DataContent::Base64 {
+                    data: IMG_B64.to_string(),
+                },
+                filename: None,
+                extra: Default::default(),
+            }],
+        }],
+        tools: vec![],
+        params: GenerationParams {
+            max_tokens: Some(256),
+            ..Default::default()
+        },
+        response_format: None,
+        stream: false,
+    }
+}
+
+/// The first file part `(media_type, data)` in a parsed prompt.
+fn first_file(prompt: &Prompt) -> (&str, &DataContent) {
+    prompt
+        .messages
+        .iter()
+        .flat_map(|m| &m.content)
+        .find_map(|c| match c {
+            Content::File {
+                media_type, data, ..
+            } => Some((media_type.as_str(), data)),
+            _ => None,
+        })
+        .expect("prompt should carry a file part")
+}
+
+#[test]
+fn image_parses_to_file_in_every_protocol() {
+    let base64 = DataContent::Base64 {
+        data: IMG_B64.to_string(),
+    };
+    let cases = [
+        (
+            ApiProtocol::ChatCompletions,
+            serde_json::json!({
+                "model": "m",
+                "messages": [{ "role": "user", "content": [
+                    { "type": "image_url", "image_url": { "url": format!("data:image/png;base64,{IMG_B64}") } }
+                ]}]
+            }),
+        ),
+        (
+            ApiProtocol::Messages,
+            serde_json::json!({
+                "model": "m", "max_tokens": 16,
+                "messages": [{ "role": "user", "content": [
+                    { "type": "image", "source": { "type": "base64", "media_type": "image/png", "data": IMG_B64 } }
+                ]}]
+            }),
+        ),
+        (
+            ApiProtocol::Responses,
+            serde_json::json!({
+                "model": "m",
+                "input": [{ "type": "message", "role": "user", "content": [
+                    { "type": "input_image", "image_url": format!("data:image/png;base64,{IMG_B64}") }
+                ]}]
+            }),
+        ),
+        (
+            ApiProtocol::GenerateContent,
+            serde_json::json!({
+                "contents": [{ "role": "user", "parts": [
+                    { "inlineData": { "mimeType": "image/png", "data": IMG_B64 } }
+                ]}]
+            }),
+        ),
+    ];
+    for (protocol, body) in cases {
+        let prompt = adapter_for(protocol.clone())
+            .parse_request(body)
+            .unwrap_or_else(|e| panic!("{protocol:?} parse failed: {e:?}"));
+        let (media_type, data) = first_file(&prompt);
+        assert_eq!(media_type, "image/png", "{protocol:?} media type");
+        assert_eq!(data, &base64, "{protocol:?} image data");
+        assert!(
+            prompt
+                .required_capabilities()
+                .contains(&Capability::ImageInput),
+            "{protocol:?} must require image_input"
+        );
+    }
+}
+
+#[test]
+fn image_file_survives_cross_protocol_round_trip() {
+    // The 4x4 guarantee: a canonical image renders to each protocol's native
+    // shape and parses back to the same canonical file part.
+    let base64 = DataContent::Base64 {
+        data: IMG_B64.to_string(),
+    };
+    for protocol in all_protocols() {
+        let adapter = adapter_for(protocol.clone());
+        let rendered = adapter.render_request(&image_file_prompt()).unwrap();
+        let reparsed = adapter.parse_request(rendered).unwrap_or_else(|e| {
+            panic!("{protocol:?} could not re-parse its rendered image: {e:?}")
+        });
+        let (media_type, data) = first_file(&reparsed);
+        assert_eq!(media_type, "image/png", "{protocol:?} lost media type");
+        assert_eq!(data, &base64, "{protocol:?} lost image data");
+    }
+}
+
+#[test]
+fn image_file_renders_to_chat_image_url() {
+    let req = adapter_for(ApiProtocol::ChatCompletions)
+        .render_request(&image_file_prompt())
+        .unwrap();
+    let part = &req["messages"][0]["content"][0];
+    assert_eq!(part["type"], "image_url");
+    assert_eq!(
+        part["image_url"]["url"],
+        format!("data:image/png;base64,{IMG_B64}")
+    );
+}
+
+#[test]
+fn image_file_renders_to_messages_image_block() {
+    let req = adapter_for(ApiProtocol::Messages)
+        .render_request(&image_file_prompt())
+        .unwrap();
+    let block = &req["messages"][0]["content"][0];
+    assert_eq!(block["type"], "image");
+    assert_eq!(block["source"]["type"], "base64");
+    assert_eq!(block["source"]["media_type"], "image/png");
+    assert_eq!(block["source"]["data"], IMG_B64);
+}
+
+#[test]
+fn image_file_renders_to_generate_content_inline_data() {
+    let req = adapter_for(ApiProtocol::GenerateContent)
+        .render_request(&image_file_prompt())
+        .unwrap();
+    let part = &req["contents"][0]["parts"][0];
+    assert_eq!(part["inlineData"]["mimeType"], "image/png");
+    assert_eq!(part["inlineData"]["data"], IMG_B64);
+}
+
+#[test]
+fn audio_round_trips_through_chat_completions() {
+    let body = serde_json::json!({
+        "model": "m",
+        "messages": [{ "role": "user", "content": [
+            { "type": "input_audio", "input_audio": { "data": IMG_B64, "format": "mp3" } }
+        ]}]
+    });
+    let adapter = adapter_for(ApiProtocol::ChatCompletions);
+    let prompt = adapter.parse_request(body).unwrap();
+    let (media_type, _) = first_file(&prompt);
+    assert_eq!(media_type, "audio/mp3");
+    assert!(
+        prompt
+            .required_capabilities()
+            .contains(&Capability::AudioInput)
+    );
+    let req = adapter.render_request(&prompt).unwrap();
+    let part = &req["messages"][0]["content"][0];
+    assert_eq!(part["type"], "input_audio");
+    assert_eq!(part["input_audio"]["format"], "mp3");
+    assert_eq!(part["input_audio"]["data"], IMG_B64);
+}
+
+#[test]
+fn pdf_file_renders_to_messages_document_block() {
+    let mut prompt = image_file_prompt();
+    prompt.messages = vec![Message {
+        role: Role::User,
+        content: vec![Content::File {
+            media_type: "application/pdf".to_string(),
+            data: DataContent::Base64 {
+                data: IMG_B64.to_string(),
+            },
+            filename: Some("doc.pdf".to_string()),
+            extra: Default::default(),
+        }],
+    }];
+    assert!(
+        prompt
+            .required_capabilities()
+            .contains(&Capability::FileInput)
+    );
+    let req = adapter_for(ApiProtocol::Messages)
+        .render_request(&prompt)
+        .unwrap();
+    let block = &req["messages"][0]["content"][0];
+    assert_eq!(block["type"], "document");
+    assert_eq!(block["source"]["media_type"], "application/pdf");
+    assert_eq!(block["source"]["data"], IMG_B64);
+}
+
+#[test]
+fn image_url_parses_to_url_data_content() {
+    let body = serde_json::json!({
+        "model": "m",
+        "messages": [{ "role": "user", "content": [
+            { "type": "image_url", "image_url": { "url": "https://example.invalid/a.png" } }
+        ]}]
+    });
+    let prompt = adapter_for(ApiProtocol::ChatCompletions)
+        .parse_request(body)
+        .unwrap();
+    let (_, data) = first_file(&prompt);
+    assert_eq!(
+        data,
+        &DataContent::Url {
+            url: "https://example.invalid/a.png".to_string(),
+        }
+    );
+}

--- a/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
@@ -39,6 +39,7 @@ fn sample_prompt() -> Prompt {
     Prompt {
         model: "test-model".to_string(),
         system: Some("be brief".to_string()),
+        system_provider_metadata: Default::default(),
         messages: vec![Message::text(Role::User, "what is 2+2?")],
         tools: vec![Tool::Function {
             name: "calculator".to_string(),
@@ -726,6 +727,7 @@ fn messages_outbound_renders_output_config_effort() {
     let prompt = Prompt {
         model: "claude-opus-4-8".to_string(),
         system: None,
+        system_provider_metadata: Default::default(),
         messages: vec![Message::text(Role::User, "hi")],
         tools: vec![],
         params: GenerationParams {
@@ -747,6 +749,7 @@ fn messages_outbound_merges_format_and_effort_into_output_config() {
     let prompt = Prompt {
         model: "claude-opus-4-8".to_string(),
         system: None,
+        system_provider_metadata: Default::default(),
         messages: vec![Message::text(Role::User, "hi")],
         tools: vec![],
         params: GenerationParams {
@@ -865,6 +868,7 @@ fn messages_outbound_renders_mid_conversation_system() {
     let prompt = Prompt {
         model: "claude-opus-4-8".to_string(),
         system: Some("top-level system".to_string()),
+        system_provider_metadata: Default::default(),
         messages: vec![
             Message::text(Role::User, "hi"),
             Message::text(Role::System, "switch to terse mode"),
@@ -2760,6 +2764,7 @@ fn image_file_prompt() -> Prompt {
     Prompt {
         model: "test-model".to_string(),
         system: None,
+        system_provider_metadata: Default::default(),
         messages: vec![Message {
             role: Role::User,
             content: vec![Content::File {
@@ -2770,7 +2775,6 @@ fn image_file_prompt() -> Prompt {
                 filename: None,
                 provider_metadata: Default::default(),
             }],
-            provider_metadata: Default::default(),
         }],
         tools: vec![],
         params: GenerationParams {
@@ -2946,7 +2950,6 @@ fn pdf_file_renders_to_messages_document_block() {
             filename: Some("doc.pdf".to_string()),
             provider_metadata: Default::default(),
         }],
-        provider_metadata: Default::default(),
     }];
     assert!(
         prompt
@@ -3173,6 +3176,7 @@ fn tool_result_prompt(call_id: &str, tool_name: Option<&str>, output: ToolResult
     Prompt {
         model: "test-model".to_string(),
         system: None,
+        system_provider_metadata: Default::default(),
         messages: vec![Message {
             role: Role::Tool,
             content: vec![Content::ToolResult {
@@ -3181,7 +3185,6 @@ fn tool_result_prompt(call_id: &str, tool_name: Option<&str>, output: ToolResult
                 output,
                 provider_metadata: Default::default(),
             }],
-            provider_metadata: Default::default(),
         }],
         tools: vec![],
         params: GenerationParams {
@@ -3998,6 +4001,7 @@ fn responses_render_request_drops_provider_executed_calls() {
     let prompt = Prompt {
         model: "gpt-5".to_string(),
         system: None,
+        system_provider_metadata: Default::default(),
         messages: vec![Message {
             role: Role::Assistant,
             content: vec![
@@ -4016,7 +4020,6 @@ fn responses_render_request_drops_provider_executed_calls() {
                     provider_metadata: Default::default(),
                 },
             ],
-            provider_metadata: Default::default(),
         }],
         tools: Vec::new(),
         params: GenerationParams::default(),
@@ -4178,6 +4181,7 @@ fn prompt_with_tool_choice(choice: ToolChoice) -> Prompt {
     Prompt {
         model: "m".to_string(),
         system: None,
+        system_provider_metadata: Default::default(),
         messages: vec![Message::text(Role::User, "hi")],
         tools: vec![Tool::Function {
             name: "search".to_string(),
@@ -4578,6 +4582,7 @@ fn prompt_with_tools(tools: Vec<Tool>) -> Prompt {
     Prompt {
         model: "m".to_string(),
         system: None,
+        system_provider_metadata: Default::default(),
         messages: vec![Message::text(Role::User, "hi")],
         tools,
         params: GenerationParams::default(),
@@ -6145,10 +6150,10 @@ fn render_content_block_via_request(
     let prompt = Prompt {
         model: "claude-3-5-sonnet".to_string(),
         system: None,
+        system_provider_metadata: Default::default(),
         messages: vec![Message {
             role: Role::Assistant,
             content: vec![content.clone()],
-            provider_metadata: Default::default(),
         }],
         tools: vec![],
         params: GenerationParams {
@@ -6190,6 +6195,7 @@ fn chat_system_fingerprint_round_trips_on_result() {
     let prompt = Prompt {
         model: "gpt-4o".to_string(),
         system: None,
+        system_provider_metadata: Default::default(),
         messages: vec![],
         tools: vec![],
         params: GenerationParams::default(),
@@ -6227,6 +6233,7 @@ fn generate_content_model_version_round_trips_on_result() {
     let prompt = Prompt {
         model: "gemini-2.0-flash".to_string(),
         system: None,
+        system_provider_metadata: Default::default(),
         messages: vec![],
         tools: vec![],
         params: GenerationParams::default(),
@@ -6268,10 +6275,10 @@ fn generate_content_thought_signature_round_trips() {
     let prompt = Prompt {
         model: "gemini-2.0-flash".to_string(),
         system: None,
+        system_provider_metadata: Default::default(),
         messages: vec![Message {
             role: Role::Assistant,
             content: vec![result.content[0].clone()],
-            provider_metadata: Default::default(),
         }],
         tools: vec![],
         params: GenerationParams::default(),
@@ -6407,6 +6414,7 @@ fn messages_source_tool_use_id_correlation_is_exact() {
     let prompt = Prompt {
         model: "claude-3-5-sonnet".to_string(),
         system: None,
+        system_provider_metadata: Default::default(),
         messages: vec![],
         tools: vec![],
         params: GenerationParams::default(),
@@ -6460,6 +6468,7 @@ fn messages_source_with_surviving_call_reuses_call_id() {
     let prompt = Prompt {
         model: "claude-3-5-sonnet".to_string(),
         system: None,
+        system_provider_metadata: Default::default(),
         messages: vec![],
         tools: vec![],
         params: GenerationParams::default(),
@@ -6480,4 +6489,332 @@ fn messages_source_with_surviving_call_reuses_call_id() {
         .find(|b| b["type"] == "web_search_tool_result")
         .unwrap();
     assert_eq!(result_block["tool_use_id"], "srvtoolu_REAL");
+}
+
+/// Anthropic `cache_control` on a request **image** block round-trips: lifted
+/// into the canonical slot on parse, rendered back onto the image block. Caching
+/// is not text-only — image/document/tool_use blocks are cacheable too.
+#[test]
+fn messages_cache_control_on_image_block_round_trips() {
+    let adapter = messages::MessagesAdapter;
+    let body = serde_json::json!({
+        "model": "claude-3-5-sonnet",
+        "max_tokens": 64,
+        "messages": [{
+            "role": "user",
+            "content": [{
+                "type": "image",
+                "source": { "type": "base64", "media_type": "image/png", "data": IMG_B64 },
+                "cache_control": { "type": "ephemeral" },
+            }],
+        }],
+    });
+    let prompt = adapter.parse_request(body).unwrap();
+    match &prompt.messages[0].content[0] {
+        Content::File {
+            provider_metadata, ..
+        } => assert_eq!(
+            anthropic_cache_control(provider_metadata),
+            Some(&ephemeral())
+        ),
+        other => panic!("expected file content, got {other:?}"),
+    }
+    let rendered = adapter.render_request(&prompt).unwrap();
+    let block = &rendered["messages"][0]["content"][0];
+    assert_eq!(block["type"], "image");
+    assert_eq!(block["cache_control"], ephemeral());
+}
+
+/// Anthropic `cache_control` on a request **document** block round-trips — a
+/// long PDF prefix is a common cache breakpoint.
+#[test]
+fn messages_cache_control_on_document_block_round_trips() {
+    let adapter = messages::MessagesAdapter;
+    let body = serde_json::json!({
+        "model": "claude-3-5-sonnet",
+        "max_tokens": 64,
+        "messages": [{
+            "role": "user",
+            "content": [{
+                "type": "document",
+                "source": { "type": "base64", "media_type": "application/pdf", "data": IMG_B64 },
+                "cache_control": { "type": "ephemeral" },
+            }],
+        }],
+    });
+    let prompt = adapter.parse_request(body).unwrap();
+    match &prompt.messages[0].content[0] {
+        Content::File {
+            media_type,
+            provider_metadata,
+            ..
+        } => {
+            assert_eq!(media_type, "application/pdf");
+            assert_eq!(
+                anthropic_cache_control(provider_metadata),
+                Some(&ephemeral())
+            );
+        }
+        other => panic!("expected file content, got {other:?}"),
+    }
+    let rendered = adapter.render_request(&prompt).unwrap();
+    let block = &rendered["messages"][0]["content"][0];
+    assert_eq!(block["type"], "document");
+    assert_eq!(block["cache_control"], ephemeral());
+}
+
+/// Anthropic `cache_control` on an assistant **tool_use** block round-trips:
+/// caching applies to `tool_use` blocks just like text/image/document.
+#[test]
+fn messages_cache_control_on_tool_use_block_round_trips() {
+    let adapter = messages::MessagesAdapter;
+    // A tool_use block arrives on an assistant turn; parse it through a request.
+    let body = serde_json::json!({
+        "model": "claude-3-5-sonnet",
+        "max_tokens": 64,
+        "messages": [{
+            "role": "assistant",
+            "content": [{
+                "type": "tool_use",
+                "id": "toolu_1",
+                "name": "get_weather",
+                "input": { "city": "SF" },
+                "cache_control": { "type": "ephemeral" },
+            }],
+        }],
+    });
+    let prompt = adapter.parse_request(body).unwrap();
+    let assistant = prompt
+        .messages
+        .iter()
+        .find(|m| m.role == Role::Assistant)
+        .unwrap();
+    match &assistant.content[0] {
+        Content::ToolCall {
+            provider_metadata, ..
+        } => assert_eq!(
+            anthropic_cache_control(provider_metadata),
+            Some(&ephemeral())
+        ),
+        other => panic!("expected tool call, got {other:?}"),
+    }
+    let rendered = adapter.render_request(&prompt).unwrap();
+    let block = &rendered["messages"][0]["content"][0];
+    assert_eq!(block["type"], "tool_use");
+    assert_eq!(block["cache_control"], ephemeral());
+}
+
+/// `cache_control` is **not** emitted on a `thinking` block: Anthropic rejects
+/// it there (thinking blocks are cached implicitly in a prior assistant turn).
+/// Even when the canonical reasoning part carries an `anthropic.cacheControl`
+/// hint, the render must omit it from the `thinking` block.
+#[test]
+fn messages_cache_control_not_emitted_on_thinking_block() {
+    let adapter = messages::MessagesAdapter;
+    let mut meta = ProviderMetadata::new();
+    set_provider_metadata(&mut meta, "anthropic", "signature", "SIG-1".into());
+    set_provider_metadata(&mut meta, "anthropic", "cacheControl", ephemeral());
+    let reasoning = Content::Reasoning {
+        text: "thinking...".to_string(),
+        provider_metadata: meta,
+    };
+    let block = render_content_block_via_request(&adapter, &reasoning);
+    assert_eq!(block["type"], "thinking");
+    // The signature still rides (continuity), but cache_control must be absent.
+    assert_eq!(block["signature"], "SIG-1");
+    assert!(
+        block.get("cache_control").is_none(),
+        "Anthropic rejects cache_control on a thinking block; it must not be emitted"
+    );
+}
+
+/// System-prompt `cache_control` (the highest-value, most common Anthropic cache
+/// point) round-trips: a `cache_control` on the `system` block array is lifted
+/// into `system_provider_metadata` on parse and re-rendered as a cached
+/// `[{type:"text", text, cache_control}]` system block.
+#[test]
+fn messages_system_cache_control_round_trips() {
+    let adapter = messages::MessagesAdapter;
+    let body = serde_json::json!({
+        "model": "claude-3-5-sonnet",
+        "max_tokens": 64,
+        "system": [{
+            "type": "text",
+            "text": "You are a long, cacheable system prompt.",
+            "cache_control": { "type": "ephemeral" },
+        }],
+        "messages": [{ "role": "user", "content": "hi" }],
+    });
+    let prompt = adapter.parse_request(body).unwrap();
+    // The system text is collapsed, and the cache breakpoint is captured.
+    assert_eq!(
+        prompt.system.as_deref(),
+        Some("You are a long, cacheable system prompt.")
+    );
+    assert_eq!(
+        anthropic_cache_control(&prompt.system_provider_metadata),
+        Some(&ephemeral())
+    );
+    // It re-renders as a cached array-form system block (not a bare string).
+    let rendered = adapter.render_request(&prompt).unwrap();
+    let system = &rendered["system"];
+    assert!(
+        system.is_array(),
+        "system with a cache breakpoint renders as an array"
+    );
+    assert_eq!(system[0]["type"], "text");
+    assert_eq!(
+        system[0]["text"],
+        "You are a long, cacheable system prompt."
+    );
+    assert_eq!(system[0]["cache_control"], ephemeral());
+}
+
+/// A plain-string system prompt (no breakpoint) still renders as a bare string —
+/// the array form is reserved for the cached case.
+#[test]
+fn messages_system_without_cache_control_renders_as_string() {
+    let adapter = messages::MessagesAdapter;
+    let body = serde_json::json!({
+        "model": "claude-3-5-sonnet",
+        "max_tokens": 64,
+        "system": "plain system",
+        "messages": [{ "role": "user", "content": "hi" }],
+    });
+    let prompt = adapter.parse_request(body).unwrap();
+    assert!(prompt.system_provider_metadata.is_empty());
+    let rendered = adapter.render_request(&prompt).unwrap();
+    assert_eq!(rendered["system"], "plain system");
+}
+
+/// The OpenAI image `detail` hint round-trips through **Responses** symmetrically
+/// with Chat Completions: parsed off an `input_image` part under
+/// `provider_metadata["openai"]["detail"]` and rendered back onto `input_image`.
+#[test]
+fn responses_image_detail_round_trips_via_provider_metadata() {
+    let adapter = responses::ResponsesAdapter;
+    let body = serde_json::json!({
+        "model": "gpt-5",
+        "input": [{
+            "type": "message",
+            "role": "user",
+            "content": [{
+                "type": "input_image",
+                "image_url": format!("data:image/png;base64,{IMG_B64}"),
+                "detail": "high",
+            }],
+        }],
+    });
+    let prompt = adapter.parse_request(body).unwrap();
+    match &prompt.messages[0].content[0] {
+        Content::File {
+            provider_metadata, ..
+        } => assert_eq!(
+            provider_metadata
+                .get("openai")
+                .and_then(|o| o.get("detail")),
+            Some(&serde_json::Value::String("high".into()))
+        ),
+        other => panic!("expected file content, got {other:?}"),
+    }
+    let rendered = adapter.render_request(&prompt).unwrap();
+    // The rendered input carries the image part with its `detail` restored.
+    let image = rendered["input"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .flat_map(|item| item["content"].as_array().cloned().unwrap_or_default())
+        .find(|p| p["type"] == "input_image")
+        .expect("an input_image part was rendered");
+    assert_eq!(image["detail"], "high");
+}
+
+/// The OpenAI `detail` hint survives a Chat Completions → Responses hop: both
+/// speak the `openai` namespace, so the hint is expressed natively on the
+/// Responses `input_image` (unlike the cross-provider Anthropic case where it is
+/// preserved-but-not-expressed).
+#[test]
+fn openai_image_detail_crosses_chat_to_responses() {
+    let inbound = chat_completions::ChatCompletionsAdapter;
+    let outbound = responses::ResponsesAdapter;
+    let body = serde_json::json!({
+        "model": "gpt-4o",
+        "messages": [{
+            "role": "user",
+            "content": [{
+                "type": "image_url",
+                "image_url": { "url": "https://example.invalid/a.png", "detail": "low" },
+            }],
+        }],
+    });
+    let prompt = inbound.parse_request(body).unwrap();
+    let rendered = outbound.render_request(&prompt).unwrap();
+    let image = rendered["input"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .flat_map(|item| item["content"].as_array().cloned().unwrap_or_default())
+        .find(|p| p["type"] == "input_image")
+        .expect("an input_image part was rendered");
+    assert_eq!(
+        image["detail"], "low",
+        "the OpenAI detail hint is expressed natively on a same-namespace Responses hop"
+    );
+}
+
+/// Gemini `thoughtSignature` round-trips on a **functionCall** part (not just the
+/// thinking-part path): a tool call that continues a reasoning chain carries the
+/// signature, and it must reappear on the rendered `functionCall` part so a
+/// follow-up turn can replay the chain.
+#[test]
+fn generate_content_thought_signature_round_trips_on_function_call() {
+    let adapter = generate_content::GenerateContentAdapter;
+    let response = serde_json::json!({
+        "candidates": [{
+            "content": { "role": "model", "parts": [
+                {
+                    "functionCall": { "name": "get_weather", "args": { "city": "SF" } },
+                    "thoughtSignature": "TS-fc-1",
+                },
+            ] },
+            "finishReason": "STOP",
+            "index": 0,
+        }],
+        "usageMetadata": { "promptTokenCount": 1, "candidatesTokenCount": 1, "totalTokenCount": 2 },
+    });
+    let result = adapter.parse_response(response).unwrap();
+    match &result.content[0] {
+        Content::ToolCall {
+            name,
+            provider_metadata,
+            ..
+        } => {
+            assert_eq!(name, "get_weather");
+            assert_eq!(
+                provider_metadata
+                    .get("google")
+                    .and_then(|g| g.get("thoughtSignature")),
+                Some(&serde_json::Value::String("TS-fc-1".into()))
+            );
+        }
+        other => panic!("expected tool call, got {other:?}"),
+    }
+    // Re-render to a request: the signature reappears on the functionCall part.
+    let prompt = Prompt {
+        model: "gemini-2.0-flash".to_string(),
+        system: None,
+        system_provider_metadata: Default::default(),
+        messages: vec![Message {
+            role: Role::Assistant,
+            content: vec![result.content[0].clone()],
+        }],
+        tools: vec![],
+        params: GenerationParams::default(),
+        response_format: None,
+        stream: false,
+    };
+    let rendered = adapter.render_request(&prompt).unwrap();
+    let part = &rendered["contents"][0]["parts"][0];
+    assert!(part.get("functionCall").is_some());
+    assert_eq!(part["thoughtSignature"], "TS-fc-1");
 }

--- a/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
@@ -4996,3 +4996,473 @@ fn tool_serde_uses_type_tag() {
     assert_eq!(provider["type"], "provider_defined");
     assert_eq!(provider["id"], "openai.web_search_preview");
 }
+
+// ===== Source (web-search citations) — V3 LanguageModelV3Source parity =====
+
+/// Collect every `Content::Source` from a result's content, in order.
+fn sources_of(content: &[Content]) -> Vec<&Source> {
+    content
+        .iter()
+        .filter_map(|c| match c {
+            Content::Source { source } => Some(source),
+            _ => None,
+        })
+        .collect()
+}
+
+/// The canonical `Source` IR uses an internal `source_type` tag and round-trips
+/// through serde for both the URL and document variants.
+#[test]
+fn source_serde_round_trips_both_variants() {
+    let url = Content::Source {
+        source: Source::Url {
+            id: "https://example.invalid/a#0".to_string(),
+            url: "https://example.invalid/a".to_string(),
+            title: Some("A".to_string()),
+        },
+    };
+    let v = serde_json::to_value(&url).unwrap();
+    assert_eq!(v["type"], "source");
+    assert_eq!(v["source"]["source_type"], "url");
+    assert_eq!(v["source"]["url"], "https://example.invalid/a");
+    assert_eq!(url, serde_json::from_value(v).unwrap());
+
+    let doc = Content::Source {
+        source: Source::Document {
+            id: "report.pdf#0".to_string(),
+            media_type: "application/pdf".to_string(),
+            title: "report.pdf".to_string(),
+            filename: Some("report.pdf".to_string()),
+        },
+    };
+    let v = serde_json::to_value(&doc).unwrap();
+    assert_eq!(v["source"]["source_type"], "document");
+    assert_eq!(v["source"]["media_type"], "application/pdf");
+    assert_eq!(doc, serde_json::from_value(v).unwrap());
+
+    // An absent URL title is omitted entirely (no JSON null) per the IR rule.
+    let no_title = serde_json::to_value(&Content::Source {
+        source: Source::Url {
+            id: "x".to_string(),
+            url: "https://example.invalid/x".to_string(),
+            title: None,
+        },
+    })
+    .unwrap();
+    assert!(no_title["source"].get("title").is_none());
+}
+
+/// Chat Completions: a `message.annotations[]` `url_citation` is lifted into a
+/// `Content::Source` on parse and re-attached at the same location on render —
+/// a same-protocol citation round-trip.
+#[test]
+fn chat_completions_url_citation_round_trip() {
+    let adapter = chat_completions::ChatCompletionsAdapter;
+    let provider_resp = serde_json::json!({
+        "id": "chatcmpl-1",
+        "choices": [{
+            "index": 0,
+            "message": {
+                "role": "assistant",
+                "content": "see source",
+                "annotations": [{
+                    "type": "url_citation",
+                    "url_citation": {
+                        "url": "https://example.invalid/doc",
+                        "title": "Doc",
+                        "start_index": 0,
+                        "end_index": 10
+                    }
+                }]
+            },
+            "finish_reason": "stop"
+        }]
+    });
+    let result = adapter.parse_response(provider_resp).unwrap();
+    let sources = sources_of(&result.content);
+    assert_eq!(sources.len(), 1, "one url citation parsed into a Source");
+    match sources[0] {
+        Source::Url { url, title, id } => {
+            assert_eq!(url, "https://example.invalid/doc");
+            assert_eq!(title.as_deref(), Some("Doc"));
+            // The wire carried no id; one is synthesized from url + index.
+            assert_eq!(id, "https://example.invalid/doc#0");
+        }
+        other => panic!("expected url source, got {other:?}"),
+    }
+
+    // Render back: the citation reappears under `message.annotations[]`.
+    let prompt = sample_prompt();
+    let rendered = adapter
+        .render_response(&result, &prompt, "chatcmpl-1")
+        .unwrap();
+    let ann = &rendered["choices"][0]["message"]["annotations"][0];
+    assert_eq!(ann["type"], "url_citation");
+    assert_eq!(ann["url_citation"]["url"], "https://example.invalid/doc");
+    assert_eq!(ann["url_citation"]["title"], "Doc");
+
+    // And a re-parse of the rendered body recovers the same Source.
+    let reparsed = adapter.parse_response(rendered).unwrap();
+    assert_eq!(sources_of(&reparsed.content), sources_of(&result.content));
+}
+
+/// Gemini: `groundingMetadata.groundingChunks[].web` is lifted into a
+/// `Content::Source` on parse and re-attached on render.
+#[test]
+fn generate_content_grounding_round_trip() {
+    let adapter = generate_content::GenerateContentAdapter;
+    let provider_resp = serde_json::json!({
+        "candidates": [{
+            "content": { "role": "model", "parts": [{ "text": "grounded answer" }] },
+            "groundingMetadata": {
+                "groundingChunks": [
+                    { "web": { "uri": "https://example.invalid/g1", "title": "G1" } },
+                    { "web": { "uri": "https://example.invalid/g2" } }
+                ]
+            },
+            "finishReason": "STOP"
+        }]
+    });
+    let result = adapter.parse_response(provider_resp).unwrap();
+    let sources = sources_of(&result.content);
+    assert_eq!(sources.len(), 2, "two grounding chunks parsed into Sources");
+    match sources[1] {
+        // A chunk without a title yields a titleless Source (no fabricated title).
+        Source::Url { url, title, .. } => {
+            assert_eq!(url, "https://example.invalid/g2");
+            assert!(title.is_none());
+        }
+        other => panic!("expected url source, got {other:?}"),
+    }
+
+    let prompt = sample_prompt();
+    let rendered = adapter.render_response(&result, &prompt, "resp_1").unwrap();
+    let chunks = &rendered["candidates"][0]["groundingMetadata"]["groundingChunks"];
+    assert_eq!(chunks[0]["web"]["uri"], "https://example.invalid/g1");
+    assert_eq!(chunks[0]["web"]["title"], "G1");
+    assert_eq!(chunks[1]["web"]["uri"], "https://example.invalid/g2");
+    // The titleless chunk renders with no `title` key (no null).
+    assert!(chunks[1]["web"].get("title").is_none());
+
+    let reparsed = adapter.parse_response(rendered).unwrap();
+    assert_eq!(sources_of(&reparsed.content), sources_of(&result.content));
+}
+
+/// Anthropic: both citation shapes — a text block's `citations[]`
+/// (`web_search_result_location`) and a `web_search_tool_result` block's
+/// `content[]` (`web_search_result`) — are lifted into `Content::Source` parts,
+/// and render re-attaches them as a `web_search_tool_result` block.
+#[test]
+fn messages_citations_round_trip_both_shapes() {
+    let adapter = messages::MessagesAdapter;
+    let provider_resp = serde_json::json!({
+        "id": "msg_1",
+        "type": "message",
+        "role": "assistant",
+        "content": [
+            {
+                "type": "text",
+                "text": "cited",
+                "citations": [{
+                    "type": "web_search_result_location",
+                    "url": "https://example.invalid/inline",
+                    "title": "Inline",
+                    "cited_text": "snippet",
+                    "encrypted_index": "abc"
+                }]
+            },
+            {
+                "type": "web_search_tool_result",
+                "tool_use_id": "srvtoolu_x",
+                "content": [
+                    { "type": "web_search_result", "url": "https://example.invalid/r1", "title": "R1" },
+                    { "type": "web_search_result", "url": "https://example.invalid/r2", "title": "R2" }
+                ]
+            }
+        ],
+        "stop_reason": "end_turn",
+        "usage": { "input_tokens": 1, "output_tokens": 1 }
+    });
+    let result = adapter.parse_response(provider_resp).unwrap();
+    let sources = sources_of(&result.content);
+    assert_eq!(sources.len(), 3, "inline citation + 2 search results");
+    // Ids are unique across blocks (running index): inline is #0, results #1/#2.
+    let ids: Vec<&str> = sources
+        .iter()
+        .map(|s| match s {
+            Source::Url { id, .. } => id.as_str(),
+            Source::Document { id, .. } => id.as_str(),
+        })
+        .collect();
+    assert_eq!(
+        ids,
+        vec![
+            "https://example.invalid/inline#0",
+            "https://example.invalid/r1#1",
+            "https://example.invalid/r2#2"
+        ]
+    );
+
+    // Render: a single `web_search_tool_result` block carries every URL source.
+    let prompt = sample_prompt();
+    let rendered = adapter.render_response(&result, &prompt, "msg_1").unwrap();
+    let blocks = rendered["content"].as_array().unwrap();
+    let wstr = blocks
+        .iter()
+        .find(|b| b["type"] == "web_search_tool_result")
+        .expect("a web_search_tool_result block was rendered");
+    let entries = wstr["content"].as_array().unwrap();
+    assert_eq!(entries.len(), 3);
+    assert_eq!(entries[0]["type"], "web_search_result");
+    assert_eq!(entries[0]["url"], "https://example.invalid/inline");
+
+    // Re-parse recovers all three sources (now all from the result block).
+    let reparsed = adapter.parse_response(rendered).unwrap();
+    assert_eq!(sources_of(&reparsed.content).len(), 3);
+}
+
+/// Responses: an `output_text` part's `annotations[]` — a `url_citation` and a
+/// `file_citation` — are lifted into `Content::Source` parts (URL + document)
+/// and re-attached on render.
+#[test]
+fn responses_annotations_round_trip_url_and_document() {
+    let adapter = responses::ResponsesAdapter;
+    let provider_resp = serde_json::json!({
+        "id": "resp_1",
+        "object": "response",
+        "status": "completed",
+        "output": [{
+            "type": "message",
+            "role": "assistant",
+            "content": [{
+                "type": "output_text",
+                "text": "answer",
+                "annotations": [
+                    { "type": "url_citation", "url": "https://example.invalid/u", "title": "U" },
+                    { "type": "file_citation", "filename": "report.txt", "file_id": "file_1", "index": 3 }
+                ]
+            }]
+        }]
+    });
+    let result = adapter.parse_response(provider_resp).unwrap();
+    let sources = sources_of(&result.content);
+    assert_eq!(sources.len(), 2);
+    assert!(matches!(sources[0], Source::Url { .. }));
+    match sources[1] {
+        Source::Document {
+            media_type,
+            title,
+            filename,
+            ..
+        } => {
+            assert_eq!(media_type, "text/plain");
+            assert_eq!(title, "report.txt");
+            assert_eq!(filename.as_deref(), Some("report.txt"));
+        }
+        other => panic!("expected document source, got {other:?}"),
+    }
+
+    let prompt = sample_prompt();
+    let rendered = adapter.render_response(&result, &prompt, "resp_1").unwrap();
+    let anns = rendered["output"][0]["content"][0]["annotations"]
+        .as_array()
+        .unwrap();
+    assert_eq!(anns.len(), 2);
+    assert_eq!(anns[0]["type"], "url_citation");
+    assert_eq!(anns[0]["url"], "https://example.invalid/u");
+    assert_eq!(anns[1]["type"], "file_citation");
+    assert_eq!(anns[1]["filename"], "report.txt");
+
+    // The URL source re-parses identically; the document source survives as a
+    // document citation (its provider file_id is a documented drop).
+    let reparsed = adapter.parse_response(rendered).unwrap();
+    assert_eq!(sources_of(&reparsed.content).len(), 2);
+}
+
+/// Cross-protocol: a Gemini grounding response is parsed to canonical Sources,
+/// then rendered onto the Chat Completions wire as `message.annotations[]` —
+/// url + title + a (synthesized) id all cross faithfully.
+#[test]
+fn cross_protocol_gemini_grounding_to_chat_annotations() {
+    let gemini = generate_content::GenerateContentAdapter;
+    let chat = chat_completions::ChatCompletionsAdapter;
+
+    let gemini_resp = serde_json::json!({
+        "candidates": [{
+            "content": { "role": "model", "parts": [{ "text": "x" }] },
+            "groundingMetadata": {
+                "groundingChunks": [
+                    { "web": { "uri": "https://example.invalid/x", "title": "X" } }
+                ]
+            },
+            "finishReason": "STOP"
+        }]
+    });
+    // Gemini upstream -> canonical
+    let canonical = gemini.parse_response(gemini_resp).unwrap();
+    assert_eq!(sources_of(&canonical.content).len(), 1);
+
+    // canonical -> Chat client response: the citation lands on `annotations[]`.
+    let prompt = sample_prompt();
+    let chat_resp = chat
+        .render_response(&canonical, &prompt, "chatcmpl-x")
+        .unwrap();
+    let ann = &chat_resp["choices"][0]["message"]["annotations"][0];
+    assert_eq!(ann["type"], "url_citation");
+    assert_eq!(ann["url_citation"]["url"], "https://example.invalid/x");
+    assert_eq!(ann["url_citation"]["title"], "X");
+
+    // And a Chat client parsing that response recovers the same canonical Source.
+    let back = chat.parse_response(chat_resp).unwrap();
+    assert_eq!(sources_of(&back.content), sources_of(&canonical.content));
+}
+
+/// Streaming, Gemini decode: grounding metadata in a stream chunk surfaces as a
+/// `StreamPart::Source`, deduped across the repeated accumulating chunks.
+#[test]
+fn generate_content_streams_source_deduped() {
+    let adapter = generate_content::GenerateContentAdapter;
+    let mut decoder = adapter.stream_decoder();
+    let chunk = |with_finish: bool| {
+        let mut c = serde_json::json!({
+            "candidates": [{
+                "content": { "role": "model", "parts": [{ "text": "t" }] },
+                "groundingMetadata": {
+                    "groundingChunks": [
+                        { "web": { "uri": "https://example.invalid/s", "title": "S" } }
+                    ]
+                }
+            }]
+        });
+        if with_finish {
+            c["candidates"][0]["finishReason"] = "STOP".into();
+        }
+        SseEvent {
+            event: None,
+            data: c.to_string(),
+        }
+    };
+    let mut parts = decoder.decode(&chunk(false)).unwrap();
+    // The same grounding chunk repeats on the next frame but must not re-emit.
+    parts.extend(decoder.decode(&chunk(true)).unwrap());
+
+    let source_parts: Vec<&Source> = parts
+        .iter()
+        .filter_map(|p| match p {
+            StreamPart::Source { source } => Some(source),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        source_parts.len(),
+        1,
+        "grounding source emitted exactly once"
+    );
+    match source_parts[0] {
+        Source::Url { url, .. } => assert_eq!(url, "https://example.invalid/s"),
+        other => panic!("expected url source, got {other:?}"),
+    }
+}
+
+/// Streaming, Chat decode: `delta.annotations[]` surfaces as a
+/// `StreamPart::Source`, and the Chat encoder re-attaches it on the wire — a
+/// live decode + live re-encode for the same protocol.
+#[test]
+fn chat_completions_streams_and_reencodes_source() {
+    let adapter = chat_completions::ChatCompletionsAdapter;
+    let mut decoder = adapter.stream_decoder();
+    let event = SseEvent {
+        event: None,
+        data: serde_json::json!({
+            "id": "chatcmpl-1",
+            "choices": [{
+                "index": 0,
+                "delta": {
+                    "annotations": [{
+                        "type": "url_citation",
+                        "url_citation": { "url": "https://example.invalid/s", "title": "S" }
+                    }]
+                }
+            }]
+        })
+        .to_string(),
+    };
+    let parts = decoder.decode(&event).unwrap();
+    let src = parts
+        .iter()
+        .find_map(|p| match p {
+            StreamPart::Source { source } => Some(source.clone()),
+            _ => None,
+        })
+        .expect("decoded a StreamPart::Source from delta.annotations");
+
+    // Re-encode the decoded source: it reappears as a `delta.annotations` chunk.
+    let mut encoder = adapter.stream_encoder("chatcmpl-1", "m");
+    let frames = encoder.encode(&StreamPart::Source { source: src }).unwrap();
+    let frame = frames
+        .first()
+        .expect("encoder emitted a frame for the source");
+    let SseFrame::Event { data, .. } = frame else {
+        panic!("expected an SSE event frame");
+    };
+    let chunk: serde_json::Value = serde_json::from_str(data).unwrap();
+    let ann = &chunk["choices"][0]["delta"]["annotations"][0];
+    assert_eq!(ann["type"], "url_citation");
+    assert_eq!(ann["url_citation"]["url"], "https://example.invalid/s");
+}
+
+/// Streaming, Anthropic: a `web_search_tool_result` content block decodes to a
+/// `StreamPart::Source`, which the Messages encoder re-emits as the same block —
+/// a live streamed-citation round-trip on the Anthropic wire.
+#[test]
+fn messages_streams_and_reencodes_source() {
+    let adapter = messages::MessagesAdapter;
+    let mut decoder = adapter.stream_decoder();
+    let event = SseEvent {
+        event: Some("content_block_start".to_string()),
+        data: serde_json::json!({
+            "type": "content_block_start",
+            "index": 2,
+            "content_block": {
+                "type": "web_search_tool_result",
+                "tool_use_id": "srvtoolu_x",
+                "content": [
+                    { "type": "web_search_result", "url": "https://example.invalid/s", "title": "S" }
+                ]
+            }
+        })
+        .to_string(),
+    };
+    let parts = decoder.decode(&event).unwrap();
+    let src = parts
+        .iter()
+        .find_map(|p| match p {
+            StreamPart::Source { source } => Some(source.clone()),
+            _ => None,
+        })
+        .expect("decoded a StreamPart::Source from a streamed web_search_tool_result");
+    match &src {
+        Source::Url { url, title, .. } => {
+            assert_eq!(url, "https://example.invalid/s");
+            assert_eq!(title.as_deref(), Some("S"));
+        }
+        other => panic!("expected url source, got {other:?}"),
+    }
+
+    // Re-encode: the Messages encoder emits a `web_search_tool_result`
+    // content_block_start carrying the same hit.
+    let mut encoder = adapter.stream_encoder("msg_1", "m");
+    let frames = encoder.encode(&StreamPart::Source { source: src }).unwrap();
+    let has_block = frames.iter().any(|f| match f {
+        SseFrame::Event { data, .. } => {
+            let v: serde_json::Value = serde_json::from_str(data).unwrap();
+            v["content_block"]["type"] == "web_search_tool_result"
+                && v["content_block"]["content"][0]["url"] == "https://example.invalid/s"
+        }
+        _ => false,
+    });
+    assert!(
+        has_block,
+        "encoder re-emitted the web_search_tool_result block"
+    );
+}

--- a/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
@@ -40,10 +40,11 @@ fn sample_prompt() -> Prompt {
         model: "test-model".to_string(),
         system: Some("be brief".to_string()),
         messages: vec![Message::text(Role::User, "what is 2+2?")],
-        tools: vec![Tool {
+        tools: vec![Tool::Function {
             name: "calculator".to_string(),
             description: Some("does math".to_string()),
             parameters: serde_json::json!({ "type": "object" }),
+            strict: None,
         }],
         params: GenerationParams {
             temperature: Some(0.5),
@@ -4147,10 +4148,11 @@ fn prompt_with_tool_choice(choice: ToolChoice) -> Prompt {
         model: "m".to_string(),
         system: None,
         messages: vec![Message::text(Role::User, "hi")],
-        tools: vec![Tool {
+        tools: vec![Tool::Function {
             name: "search".to_string(),
             description: None,
             parameters: serde_json::json!({"type": "object"}),
+            strict: None,
         }],
         params: GenerationParams {
             tool_choice: Some(choice),
@@ -4535,4 +4537,462 @@ fn generation_params_omits_absent_tool_choice() {
         value.get("tool_choice").is_none(),
         "absent tool_choice must be omitted: {value}"
     );
+}
+
+// ===== Part C: typed tools (V3 function `strict` + provider-defined tools) =====
+
+/// A prompt carrying exactly the given tool list (and nothing else interesting).
+fn prompt_with_tools(tools: Vec<Tool>) -> Prompt {
+    Prompt {
+        model: "m".to_string(),
+        system: None,
+        messages: vec![Message::text(Role::User, "hi")],
+        tools,
+        params: GenerationParams::default(),
+        response_format: None,
+        stream: false,
+    }
+}
+
+/// Render a tool list through `protocol` and parse it back through the same
+/// protocol — the same-protocol fidelity contract. Returns the recovered tools.
+fn round_trip_tools(protocol: &ApiProtocol, tools: Vec<Tool>) -> Vec<Tool> {
+    let adapter = adapter_for(protocol.clone());
+    let prompt = prompt_with_tools(tools);
+    let rendered = adapter.render_request(&prompt).unwrap();
+    adapter.parse_request(rendered).unwrap().tools
+}
+
+/// The raw `tools` JSON a protocol renders for a tool list (for native-shape
+/// assertions).
+fn rendered_tools_json(protocol: &ApiProtocol, tools: Vec<Tool>) -> serde_json::Value {
+    adapter_for(protocol.clone())
+        .render_request(&prompt_with_tools(tools))
+        .unwrap()["tools"]
+        .clone()
+}
+
+// --- function-tool `strict` ---
+
+/// A function tool's `strict` flag survives a same-protocol round-trip on the
+/// two protocols whose wire has a `strict` slot (Chat Completions, Responses).
+#[test]
+fn function_tool_strict_round_trips_on_openai_protocols() {
+    for protocol in &[ApiProtocol::ChatCompletions, ApiProtocol::Responses] {
+        let tools = round_trip_tools(
+            protocol,
+            vec![Tool::Function {
+                name: "get_weather".to_string(),
+                description: Some("look up weather".to_string()),
+                parameters: serde_json::json!({ "type": "object" }),
+                strict: Some(true),
+            }],
+        );
+        assert_eq!(
+            tools,
+            vec![Tool::Function {
+                name: "get_weather".to_string(),
+                description: Some("look up weather".to_string()),
+                parameters: serde_json::json!({ "type": "object" }),
+                strict: Some(true),
+            }],
+            "{protocol:?} must preserve function-tool strict"
+        );
+    }
+}
+
+/// Chat Completions renders `strict` under `function`; Responses renders it flat.
+#[test]
+fn function_tool_strict_renders_in_native_position() {
+    let tool = Tool::Function {
+        name: "f".to_string(),
+        description: None,
+        parameters: serde_json::json!({ "type": "object" }),
+        strict: Some(true),
+    };
+    let chat = rendered_tools_json(&ApiProtocol::ChatCompletions, vec![tool.clone()]);
+    assert_eq!(chat[0]["type"], "function");
+    assert_eq!(chat[0]["function"]["strict"], true);
+
+    let responses = rendered_tools_json(&ApiProtocol::Responses, vec![tool]);
+    assert_eq!(responses[0]["type"], "function");
+    assert_eq!(responses[0]["strict"], true);
+}
+
+/// `strict` is omitted (not emitted as `false`/`null`) when unset.
+#[test]
+fn function_tool_strict_omitted_when_absent() {
+    let tool = Tool::Function {
+        name: "f".to_string(),
+        description: None,
+        parameters: serde_json::json!({ "type": "object" }),
+        strict: None,
+    };
+    let chat = rendered_tools_json(&ApiProtocol::ChatCompletions, vec![tool.clone()]);
+    assert!(
+        chat[0]["function"].get("strict").is_none(),
+        "absent strict must be omitted: {chat}"
+    );
+    let responses = rendered_tools_json(&ApiProtocol::Responses, vec![tool]);
+    assert!(
+        responses[0].get("strict").is_none(),
+        "absent strict must be omitted: {responses}"
+    );
+}
+
+/// Anthropic and Gemini have no `strict` slot — the flag is documented as
+/// dropped. A function tool still round-trips otherwise; `strict` comes back
+/// `None`.
+#[test]
+fn function_tool_strict_dropped_on_anthropic_and_gemini() {
+    for protocol in &[ApiProtocol::Messages, ApiProtocol::GenerateContent] {
+        let tools = round_trip_tools(
+            protocol,
+            vec![Tool::Function {
+                name: "get_weather".to_string(),
+                description: Some("desc".to_string()),
+                parameters: serde_json::json!({ "type": "object" }),
+                strict: Some(true),
+            }],
+        );
+        assert_eq!(
+            tools,
+            vec![Tool::Function {
+                name: "get_weather".to_string(),
+                description: Some("desc".to_string()),
+                parameters: serde_json::json!({ "type": "object" }),
+                strict: None,
+            }],
+            "{protocol:?} has no strict slot; it must drop to None but keep the tool"
+        );
+        // And it is never emitted on the wire.
+        let rendered = rendered_tools_json(
+            protocol,
+            vec![Tool::Function {
+                name: "f".to_string(),
+                description: None,
+                parameters: serde_json::json!({}),
+                strict: Some(true),
+            }],
+        );
+        assert!(
+            !rendered.to_string().contains("strict"),
+            "{protocol:?} must not emit strict: {rendered}"
+        );
+    }
+}
+
+// --- provider-defined tools: same-protocol round-trips ---
+
+/// Every Responses server tool round-trips losslessly (id `openai.<type>` +
+/// verbatim args), covering the full documented set.
+#[test]
+fn responses_provider_defined_tools_round_trip() {
+    let cases = vec![
+        Tool::ProviderDefined {
+            id: "openai.web_search_preview".to_string(),
+            name: "web_search_preview".to_string(),
+            args: serde_json::json!({ "search_context_size": "high" }),
+        },
+        Tool::ProviderDefined {
+            id: "openai.code_interpreter".to_string(),
+            name: "code_interpreter".to_string(),
+            args: serde_json::json!({ "container": { "type": "auto" } }),
+        },
+        Tool::ProviderDefined {
+            id: "openai.file_search".to_string(),
+            name: "file_search".to_string(),
+            args: serde_json::json!({ "vector_store_ids": ["vs_1"], "max_num_results": 5 }),
+        },
+        Tool::ProviderDefined {
+            id: "openai.image_generation".to_string(),
+            name: "image_generation".to_string(),
+            args: serde_json::json!({ "quality": "high" }),
+        },
+        Tool::ProviderDefined {
+            id: "openai.computer_use_preview".to_string(),
+            name: "computer_use_preview".to_string(),
+            args: serde_json::json!({ "display_width": 1024, "display_height": 768, "environment": "browser" }),
+        },
+    ];
+    for tool in cases {
+        let round_tripped = round_trip_tools(&ApiProtocol::Responses, vec![tool.clone()]);
+        assert_eq!(round_tripped, vec![tool.clone()], "round-trip for {tool:?}");
+    }
+}
+
+/// Responses renders a server tool flat as `{type:<tool>, …args}`.
+#[test]
+fn responses_provider_defined_renders_flat_native_shape() {
+    let rendered = rendered_tools_json(
+        &ApiProtocol::Responses,
+        vec![Tool::ProviderDefined {
+            id: "openai.web_search_preview".to_string(),
+            name: "web_search_preview".to_string(),
+            args: serde_json::json!({ "search_context_size": "low" }),
+        }],
+    );
+    assert_eq!(rendered[0]["type"], "web_search_preview");
+    assert_eq!(rendered[0]["search_context_size"], "low");
+    // No function-only keys leak onto a server tool.
+    assert!(rendered[0].get("parameters").is_none());
+}
+
+/// Every Anthropic server tool round-trips losslessly (an `anthropic.<version>`
+/// id with a stable `name` and verbatim args), covering web search, code
+/// execution, and computer use.
+#[test]
+fn messages_provider_defined_tools_round_trip() {
+    let cases = vec![
+        Tool::ProviderDefined {
+            id: "anthropic.web_search_20250305".to_string(),
+            name: "web_search".to_string(),
+            args: serde_json::json!({ "max_uses": 5 }),
+        },
+        Tool::ProviderDefined {
+            id: "anthropic.code_execution_20250522".to_string(),
+            name: "code_execution".to_string(),
+            args: serde_json::json!({}),
+        },
+        Tool::ProviderDefined {
+            id: "anthropic.computer_20250124".to_string(),
+            name: "computer".to_string(),
+            args: serde_json::json!({ "display_width_px": 1024, "display_height_px": 768 }),
+        },
+    ];
+    for tool in cases {
+        let round_tripped = round_trip_tools(&ApiProtocol::Messages, vec![tool.clone()]);
+        assert_eq!(round_tripped, vec![tool.clone()], "round-trip for {tool:?}");
+    }
+}
+
+/// Anthropic renders a server tool as `{type:<version>, name, …args}`.
+#[test]
+fn messages_provider_defined_renders_versioned_native_shape() {
+    let rendered = rendered_tools_json(
+        &ApiProtocol::Messages,
+        vec![Tool::ProviderDefined {
+            id: "anthropic.web_search_20250305".to_string(),
+            name: "web_search".to_string(),
+            args: serde_json::json!({ "max_uses": 3 }),
+        }],
+    );
+    assert_eq!(rendered[0]["type"], "web_search_20250305");
+    assert_eq!(rendered[0]["name"], "web_search");
+    assert_eq!(rendered[0]["max_uses"], 3);
+}
+
+/// Every Gemini built-in tool round-trips losslessly (id `google.<key>` +
+/// verbatim args), covering search, code execution, and URL context.
+#[test]
+fn generate_content_provider_defined_tools_round_trip() {
+    let cases = vec![
+        Tool::ProviderDefined {
+            id: "google.googleSearch".to_string(),
+            name: "googleSearch".to_string(),
+            args: serde_json::json!({}),
+        },
+        Tool::ProviderDefined {
+            id: "google.codeExecution".to_string(),
+            name: "codeExecution".to_string(),
+            args: serde_json::json!({}),
+        },
+        Tool::ProviderDefined {
+            id: "google.googleSearchRetrieval".to_string(),
+            name: "googleSearchRetrieval".to_string(),
+            args: serde_json::json!({ "dynamicRetrievalConfig": { "mode": "MODE_DYNAMIC" } }),
+        },
+        Tool::ProviderDefined {
+            id: "google.urlContext".to_string(),
+            name: "urlContext".to_string(),
+            args: serde_json::json!({}),
+        },
+    ];
+    for tool in cases {
+        let round_tripped = round_trip_tools(&ApiProtocol::GenerateContent, vec![tool.clone()]);
+        assert_eq!(round_tripped, vec![tool.clone()], "round-trip for {tool:?}");
+    }
+}
+
+/// Gemini renders a built-in tool as a single-key `{<toolKey>: args}` object.
+#[test]
+fn generate_content_provider_defined_renders_single_key_object() {
+    let rendered = rendered_tools_json(
+        &ApiProtocol::GenerateContent,
+        vec![Tool::ProviderDefined {
+            id: "google.googleSearch".to_string(),
+            name: "googleSearch".to_string(),
+            args: serde_json::json!({}),
+        }],
+    );
+    // The built-in tool is its own tool-array element with the camelCase key.
+    let entry = rendered
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|e| e.get("googleSearch").is_some())
+        .expect("googleSearch entry present");
+    assert_eq!(entry["googleSearch"], serde_json::json!({}));
+}
+
+/// A single Gemini tool object carrying both `functionDeclarations` and a
+/// built-in `googleSearch` key expands into both a function tool and a
+/// provider-defined tool, and rebuilds the same wire on render.
+#[test]
+fn generate_content_mixed_function_and_builtin_tools_round_trip() {
+    let adapter = adapter_for(ApiProtocol::GenerateContent);
+    let body = serde_json::json!({
+        "contents": [{ "role": "user", "parts": [{ "text": "hi" }] }],
+        "tools": [{
+            "functionDeclarations": [{
+                "name": "get_weather",
+                "description": "w",
+                "parameters": { "type": "object" }
+            }],
+            "googleSearch": {}
+        }]
+    });
+    let parsed = adapter.parse_request(body).unwrap();
+    assert_eq!(parsed.tools.len(), 2, "one function + one builtin");
+    assert!(matches!(parsed.tools[0], Tool::Function { .. }));
+    assert!(matches!(parsed.tools[1], Tool::ProviderDefined { .. }));
+
+    // Re-render and re-parse: both tools survive (the function-declarations
+    // object plus the googleSearch element).
+    let rendered = adapter.render_request(&parsed).unwrap();
+    let reparsed = adapter.parse_request(rendered).unwrap();
+    assert_eq!(reparsed.tools, parsed.tools);
+}
+
+/// A Responses array mixing a function tool and a server tool keeps both, in
+/// order, with the function/provider split intact.
+#[test]
+fn responses_mixed_function_and_server_tools_round_trip() {
+    let tools = vec![
+        Tool::Function {
+            name: "get_weather".to_string(),
+            description: None,
+            parameters: serde_json::json!({ "type": "object" }),
+            strict: Some(true),
+        },
+        Tool::ProviderDefined {
+            id: "openai.web_search_preview".to_string(),
+            name: "web_search_preview".to_string(),
+            args: serde_json::json!({ "search_context_size": "high" }),
+        },
+    ];
+    let round_tripped = round_trip_tools(&ApiProtocol::Responses, tools.clone());
+    assert_eq!(round_tripped, tools);
+}
+
+// --- provider-defined tools: cross-protocol faithful passthrough ---
+
+/// Documented cross-protocol behavior: a provider-defined tool routed to a
+/// *different* provider's wire is **preserved verbatim** in its source-native
+/// shape (so the upstream decides), never silently dropped and never lossily
+/// "translated". Concretely, an Anthropic `web_search_20250305` rendered onto a
+/// Responses (OpenAI) request still arrives as `{type:"web_search_20250305",
+/// name:"web_search", …}` — and a Responses parser, treating any non-`function`
+/// type as a server tool, recovers it with its original `anthropic.*` id intact.
+#[test]
+fn provider_defined_tool_cross_protocol_is_preserved_verbatim() {
+    let anthropic_tool = Tool::ProviderDefined {
+        id: "anthropic.web_search_20250305".to_string(),
+        name: "web_search".to_string(),
+        args: serde_json::json!({ "max_uses": 5 }),
+    };
+
+    // Render the Anthropic-native tool onto a Responses (OpenAI) request.
+    let rendered = rendered_tools_json(&ApiProtocol::Responses, vec![anthropic_tool.clone()]);
+    // Verbatim source-native shape: the versioned Anthropic `type` + `name` +
+    // args are all present, unchanged — not mapped to `web_search_preview`.
+    assert_eq!(rendered[0]["type"], "web_search_20250305");
+    assert_eq!(rendered[0]["name"], "web_search");
+    assert_eq!(rendered[0]["max_uses"], 5);
+
+    // The Responses inbound parser recovers it as a provider-defined tool. The
+    // `type` it sees is the Anthropic version, namespaced `openai.*` because the
+    // wire it arrived on is OpenAI's — bitrouter cannot know the tool's true
+    // origin from the wire alone, but it is faithfully forwarded, never dropped.
+    let adapter = adapter_for(ApiProtocol::Responses);
+    let reparsed = adapter
+        .parse_request(
+            adapter
+                .render_request(&prompt_with_tools(vec![anthropic_tool]))
+                .unwrap(),
+        )
+        .unwrap();
+    assert_eq!(reparsed.tools.len(), 1, "tool is forwarded, not dropped");
+    match &reparsed.tools[0] {
+        Tool::ProviderDefined { id, name, args } => {
+            assert_eq!(id, "openai.web_search_20250305");
+            assert_eq!(name, "web_search");
+            assert_eq!(args["max_uses"], 5);
+        }
+        other => panic!("expected a provider-defined tool, got {other:?}"),
+    }
+}
+
+/// The same faithful-passthrough holds onto Anthropic's wire: an OpenAI
+/// `web_search_preview` routed to a Messages request is preserved verbatim in
+/// its **source-native (OpenAI)** shape — `{type:"web_search_preview", …args}`,
+/// flat and with no `name` key, exactly as OpenAI serializes it — rather than
+/// being dropped or lossily reshaped into Anthropic's `{type, name, …}` form.
+/// bitrouter never invents a `name` the source did not carry; the upstream
+/// decides what to do with the unfamiliar tool.
+#[test]
+fn provider_defined_tool_cross_protocol_onto_anthropic_is_preserved() {
+    let openai_tool = Tool::ProviderDefined {
+        id: "openai.web_search_preview".to_string(),
+        name: "web_search_preview".to_string(),
+        args: serde_json::json!({ "search_context_size": "high" }),
+    };
+    let rendered = rendered_tools_json(&ApiProtocol::Messages, vec![openai_tool]);
+    assert_eq!(rendered[0]["type"], "web_search_preview");
+    assert_eq!(rendered[0]["search_context_size"], "high");
+    // Source-native (OpenAI) shape is flat: no Anthropic-style `name` is invented.
+    assert!(
+        rendered[0].get("name").is_none(),
+        "must not fabricate an Anthropic `name` key: {rendered}"
+    );
+}
+
+/// And onto Chat Completions (function-only on the wire): a provider-defined
+/// tool is still preserved verbatim into the `tools` array rather than dropped.
+#[test]
+fn provider_defined_tool_preserved_into_chat_completions() {
+    let tool = Tool::ProviderDefined {
+        id: "openai.web_search_preview".to_string(),
+        name: "web_search_preview".to_string(),
+        args: serde_json::json!({ "search_context_size": "low" }),
+    };
+    let rendered = rendered_tools_json(&ApiProtocol::ChatCompletions, vec![tool]);
+    assert_eq!(rendered[0]["type"], "web_search_preview");
+    assert_eq!(rendered[0]["search_context_size"], "low");
+}
+
+/// The canonical `Tool` enum uses an internal `type` tag (`function` /
+/// `provider_defined`) — a compact, self-describing IR serialization.
+#[test]
+fn tool_serde_uses_type_tag() {
+    let function = serde_json::to_value(Tool::Function {
+        name: "f".to_string(),
+        description: None,
+        parameters: serde_json::json!({}),
+        strict: None,
+    })
+    .unwrap();
+    assert_eq!(function["type"], "function");
+    // Absent optionals are omitted (no JSON null).
+    assert!(function.get("description").is_none());
+    assert!(function.get("strict").is_none());
+
+    let provider = serde_json::to_value(Tool::ProviderDefined {
+        id: "openai.web_search_preview".to_string(),
+        name: "web_search_preview".to_string(),
+        args: serde_json::json!({}),
+    })
+    .unwrap();
+    assert_eq!(provider["type"], "provider_defined");
+    assert_eq!(provider["id"], "openai.web_search_preview");
 }

--- a/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
@@ -70,6 +70,7 @@ fn sample_result() -> GenerateResult {
                 id: "call_1".to_string(),
                 name: "calculator".to_string(),
                 arguments: "{\"op\":\"add\"}".to_string(),
+                provider_executed: false,
             },
         ],
         usage: Some(Usage {
@@ -3833,5 +3834,536 @@ fn tool_result_without_tool_name_omits_the_field() {
     assert!(
         value.get("tool_name").is_none(),
         "absent tool_name must omit the key, not emit null: {value}"
+    );
+}
+
+// ===== Part A: provider-executed tool calls (V3 providerExecuted) =====
+
+/// Anthropic `server_tool_use` response blocks parse as provider-executed tool
+/// calls; ordinary `tool_use` blocks do not.
+#[test]
+fn messages_parse_response_marks_server_tool_use_provider_executed() {
+    let adapter = adapter_for(ApiProtocol::Messages);
+    let body = serde_json::json!({
+        "id": "msg_1",
+        "content": [
+            { "type": "tool_use", "id": "toolu_1", "name": "get_weather", "input": {"city": "SF"} },
+            { "type": "server_tool_use", "id": "srvtoolu_1", "name": "web_search", "input": {"query": "claude shannon"} }
+        ],
+        "stop_reason": "end_turn"
+    });
+    let result = adapter.parse_response(body).unwrap();
+    let calls: Vec<_> = result
+        .content
+        .iter()
+        .filter_map(|c| match c {
+            Content::ToolCall {
+                name,
+                provider_executed,
+                ..
+            } => Some((name.as_str(), *provider_executed)),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        calls,
+        vec![("get_weather", false), ("web_search", true)],
+        "client tool_use is not provider-executed; server_tool_use is"
+    );
+}
+
+/// A provider-executed canonical call renders back as an Anthropic
+/// `server_tool_use` block; a client call renders as `tool_use`.
+#[test]
+fn messages_renders_provider_executed_as_server_tool_use() {
+    let adapter = adapter_for(ApiProtocol::Messages);
+    let result = GenerateResult {
+        content: vec![
+            Content::ToolCall {
+                id: "toolu_1".to_string(),
+                name: "get_weather".to_string(),
+                arguments: "{}".to_string(),
+                provider_executed: false,
+            },
+            Content::ToolCall {
+                id: "srvtoolu_1".to_string(),
+                name: "web_search".to_string(),
+                arguments: "{\"query\":\"x\"}".to_string(),
+                provider_executed: true,
+            },
+        ],
+        usage: None,
+        finish_reason: Some(FinishReason::Stop),
+        response_id: None,
+        stop_details: None,
+    };
+    let prompt = sample_prompt();
+    let rendered = adapter.render_response(&result, &prompt, "msg_1").unwrap();
+    let blocks = rendered["content"].as_array().unwrap();
+    assert_eq!(blocks[0]["type"], "tool_use");
+    assert_eq!(blocks[1]["type"], "server_tool_use");
+    assert_eq!(blocks[1]["name"], "web_search");
+}
+
+/// A full Anthropic server-tool round-trip preserves the `server_tool_use`
+/// block type via the `provider_executed` flag.
+#[test]
+fn messages_server_tool_use_round_trips() {
+    let adapter = adapter_for(ApiProtocol::Messages);
+    let body = serde_json::json!({
+        "id": "msg_1",
+        "content": [
+            { "type": "server_tool_use", "id": "srvtoolu_1", "name": "web_search", "input": {"query": "q"} }
+        ],
+        "stop_reason": "end_turn"
+    });
+    let parsed = adapter.parse_response(body).unwrap();
+    let rendered = adapter
+        .render_response(&parsed, &sample_prompt(), "msg_1")
+        .unwrap();
+    assert_eq!(rendered["content"][0]["type"], "server_tool_use");
+    assert_eq!(rendered["content"][0]["id"], "srvtoolu_1");
+}
+
+/// OpenAI Responses built-in tool output items parse as provider-executed tool
+/// calls; a `function_call` item does not.
+#[test]
+fn responses_parse_response_marks_server_tools_provider_executed() {
+    let adapter = adapter_for(ApiProtocol::Responses);
+    let body = serde_json::json!({
+        "id": "resp_1",
+        "status": "completed",
+        "output": [
+            { "type": "function_call", "call_id": "call_1", "name": "get_weather", "arguments": "{}" },
+            { "type": "web_search_call", "id": "ws_1" },
+            { "type": "file_search_call", "id": "fs_1" },
+            { "type": "code_interpreter_call", "id": "ci_1", "code": "print(1)", "container_id": "cntr_1" }
+        ]
+    });
+    let result = adapter.parse_response(body).unwrap();
+    let calls: Vec<_> = result
+        .content
+        .iter()
+        .filter_map(|c| match c {
+            Content::ToolCall {
+                name,
+                provider_executed,
+                arguments,
+                ..
+            } => Some((name.as_str(), *provider_executed, arguments.as_str())),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(calls[0], ("get_weather", false, "{}"));
+    assert_eq!(calls[1], ("web_search", true, "{}"));
+    assert_eq!(calls[2], ("file_search", true, "{}"));
+    assert_eq!(calls[3].0, "code_interpreter");
+    assert!(calls[3].1, "code_interpreter_call is provider-executed");
+    // its code / container survive as the call input
+    let ci_input: serde_json::Value = serde_json::from_str(calls[3].2).unwrap();
+    assert_eq!(ci_input["code"], "print(1)");
+    assert_eq!(ci_input["containerId"], "cntr_1");
+}
+
+/// On the Responses *request* (input) side a provider-executed call is NOT
+/// re-emitted as a client `function_call` item — the provider already ran it.
+#[test]
+fn responses_render_request_drops_provider_executed_calls() {
+    let adapter = adapter_for(ApiProtocol::Responses);
+    let prompt = Prompt {
+        model: "gpt-5".to_string(),
+        system: None,
+        messages: vec![Message {
+            role: Role::Assistant,
+            content: vec![
+                Content::ToolCall {
+                    id: "call_1".to_string(),
+                    name: "get_weather".to_string(),
+                    arguments: "{}".to_string(),
+                    provider_executed: false,
+                },
+                Content::ToolCall {
+                    id: "ws_1".to_string(),
+                    name: "web_search".to_string(),
+                    arguments: "{}".to_string(),
+                    provider_executed: true,
+                },
+            ],
+        }],
+        tools: Vec::new(),
+        params: GenerationParams::default(),
+        response_format: None,
+        stream: false,
+    };
+    let rendered = adapter.render_request(&prompt).unwrap();
+    let input = rendered["input"].as_array().unwrap();
+    let function_calls: Vec<_> = input
+        .iter()
+        .filter(|i| i["type"] == "function_call")
+        .collect();
+    assert_eq!(
+        function_calls.len(),
+        1,
+        "only the client function_call is re-sent as input: {rendered}"
+    );
+    assert_eq!(function_calls[0]["call_id"], "call_1");
+}
+
+/// On the Responses *response* (output) side a provider-executed call is
+/// reproduced as its native server-tool output item, keyed by `id`.
+#[test]
+fn responses_render_response_reproduces_server_tool_item() {
+    let adapter = adapter_for(ApiProtocol::Responses);
+    let result = GenerateResult {
+        content: vec![Content::ToolCall {
+            id: "ws_1".to_string(),
+            name: "web_search".to_string(),
+            arguments: "{}".to_string(),
+            provider_executed: true,
+        }],
+        usage: None,
+        finish_reason: Some(FinishReason::Stop),
+        response_id: Some("resp_1".to_string()),
+        stop_details: None,
+    };
+    let rendered = adapter
+        .render_response(&result, &sample_prompt(), "resp_1")
+        .unwrap();
+    let output = rendered["output"].as_array().unwrap();
+    let item = output
+        .iter()
+        .find(|i| i["type"] == "web_search_call")
+        .expect("server-tool output item reproduced");
+    assert_eq!(item["id"], "ws_1");
+    assert!(
+        output.iter().all(|i| i["type"] != "function_call"),
+        "a provider-executed call must not render as function_call"
+    );
+}
+
+/// `provider_executed` defaults to false and is omitted from the serialized
+/// canonical form when false (no JSON `null`, no `false` noise).
+#[test]
+fn tool_call_provider_executed_omitted_when_false() {
+    let value = serde_json::to_value(Content::ToolCall {
+        id: "c1".to_string(),
+        name: "t".to_string(),
+        arguments: "{}".to_string(),
+        provider_executed: false,
+    })
+    .unwrap();
+    assert!(
+        value.get("provider_executed").is_none(),
+        "false provider_executed must be omitted: {value}"
+    );
+    let value_true = serde_json::to_value(Content::ToolCall {
+        id: "c1".to_string(),
+        name: "t".to_string(),
+        arguments: "{}".to_string(),
+        provider_executed: true,
+    })
+    .unwrap();
+    assert_eq!(value_true["provider_executed"], true);
+}
+
+// ===== Part B: typed tool choice (V3 toolChoice) =====
+
+/// Read whatever a protocol renders for `tool_choice` from an outbound request
+/// body, normalising Gemini's top-level `toolConfig` and the simple-string
+/// forms into a comparable canonical [`ToolChoice`] via the inbound parse path.
+fn rendered_tool_choice(protocol: ApiProtocol, prompt: &Prompt) -> Option<ToolChoice> {
+    let adapter = adapter_for(protocol);
+    let rendered = adapter.render_request(prompt).unwrap();
+    // Round-trip back through the same protocol's parser, which is the public
+    // contract: render then parse must recover the typed choice.
+    adapter.parse_request(rendered).unwrap().params.tool_choice
+}
+
+/// A prompt carrying a specific tool choice.
+fn prompt_with_tool_choice(choice: ToolChoice) -> Prompt {
+    Prompt {
+        model: "m".to_string(),
+        system: None,
+        messages: vec![Message::text(Role::User, "hi")],
+        tools: vec![Tool {
+            name: "search".to_string(),
+            description: None,
+            parameters: serde_json::json!({"type": "object"}),
+        }],
+        params: GenerationParams {
+            tool_choice: Some(choice),
+            ..Default::default()
+        },
+        response_format: None,
+        stream: false,
+    }
+}
+
+/// Each canonical [`ToolChoice`] survives a render→parse round-trip on every
+/// protocol — the same-protocol fidelity contract.
+#[test]
+fn tool_choice_same_protocol_round_trips_on_all_protocols() {
+    let choices = [
+        ToolChoice::Auto,
+        ToolChoice::None,
+        ToolChoice::Required,
+        ToolChoice::Tool {
+            name: "search".to_string(),
+        },
+    ];
+    for choice in choices {
+        for proto in all_protocols() {
+            let prompt = prompt_with_tool_choice(choice.clone());
+            assert_eq!(
+                rendered_tool_choice(proto.clone(), &prompt),
+                Some(choice.clone()),
+                "{proto:?} must round-trip tool_choice {choice:?}"
+            );
+        }
+    }
+}
+
+/// Cross-protocol translation: a `Required` choice authored in one protocol
+/// reaches every other protocol as that protocol's "must call a tool" form
+/// (Chat `required` ↔ Anthropic `any` ↔ Gemini `ANY` ↔ Responses `required`).
+#[test]
+fn tool_choice_required_translates_across_protocols() {
+    // Author it as a raw Chat Completions body, parse to canonical, then render
+    // to every protocol and assert the native shape.
+    let chat = adapter_for(ApiProtocol::ChatCompletions);
+    let body = serde_json::json!({
+        "model": "gpt-5",
+        "messages": [{"role": "user", "content": "hi"}],
+        "tool_choice": "required"
+    });
+    let prompt = chat.parse_request(body).unwrap();
+    assert_eq!(prompt.params.tool_choice, Some(ToolChoice::Required));
+
+    // Anthropic -> {type:"any"}
+    let anthropic = adapter_for(ApiProtocol::Messages)
+        .render_request(&prompt)
+        .unwrap();
+    assert_eq!(anthropic["tool_choice"], serde_json::json!({"type": "any"}));
+    // Responses -> "required"
+    let responses = adapter_for(ApiProtocol::Responses)
+        .render_request(&prompt)
+        .unwrap();
+    assert_eq!(responses["tool_choice"], "required");
+    // Gemini -> toolConfig.functionCallingConfig.mode = ANY
+    let gemini = adapter_for(ApiProtocol::GenerateContent)
+        .render_request(&prompt)
+        .unwrap();
+    assert_eq!(gemini["toolConfig"]["functionCallingConfig"]["mode"], "ANY");
+}
+
+/// Cross-protocol translation of a forced specific tool (V3 `tool`) — by name —
+/// reaches all four protocols in their native shape.
+#[test]
+fn tool_choice_specific_tool_translates_across_protocols() {
+    let prompt = prompt_with_tool_choice(ToolChoice::Tool {
+        name: "search".to_string(),
+    });
+    // Chat Completions: {type:"function", function:{name}}
+    let chat = adapter_for(ApiProtocol::ChatCompletions)
+        .render_request(&prompt)
+        .unwrap();
+    assert_eq!(
+        chat["tool_choice"],
+        serde_json::json!({"type": "function", "function": {"name": "search"}})
+    );
+    // Responses: {type:"function", name} (flat)
+    let responses = adapter_for(ApiProtocol::Responses)
+        .render_request(&prompt)
+        .unwrap();
+    assert_eq!(
+        responses["tool_choice"],
+        serde_json::json!({"type": "function", "name": "search"})
+    );
+    // Anthropic: {type:"tool", name}
+    let anthropic = adapter_for(ApiProtocol::Messages)
+        .render_request(&prompt)
+        .unwrap();
+    assert_eq!(
+        anthropic["tool_choice"],
+        serde_json::json!({"type": "tool", "name": "search"})
+    );
+    // Gemini: mode ANY + allowedFunctionNames:[name]
+    let gemini = adapter_for(ApiProtocol::GenerateContent)
+        .render_request(&prompt)
+        .unwrap();
+    assert_eq!(
+        gemini["toolConfig"]["functionCallingConfig"],
+        serde_json::json!({"mode": "ANY", "allowedFunctionNames": ["search"]})
+    );
+}
+
+/// `None` is faithfully expressed on every protocol (Chat `"none"`, Anthropic
+/// `{type:"none"}` — which Anthropic natively supports — Responses `"none"`,
+/// Gemini `mode:"NONE"`).
+#[test]
+fn tool_choice_none_translates_across_protocols() {
+    let prompt = prompt_with_tool_choice(ToolChoice::None);
+    assert_eq!(
+        adapter_for(ApiProtocol::ChatCompletions)
+            .render_request(&prompt)
+            .unwrap()["tool_choice"],
+        "none"
+    );
+    assert_eq!(
+        adapter_for(ApiProtocol::Messages)
+            .render_request(&prompt)
+            .unwrap()["tool_choice"],
+        serde_json::json!({"type": "none"})
+    );
+    assert_eq!(
+        adapter_for(ApiProtocol::Responses)
+            .render_request(&prompt)
+            .unwrap()["tool_choice"],
+        "none"
+    );
+    assert_eq!(
+        adapter_for(ApiProtocol::GenerateContent)
+            .render_request(&prompt)
+            .unwrap()["toolConfig"]["functionCallingConfig"]["mode"],
+        "NONE"
+    );
+}
+
+/// A parsed `tool_choice` must NOT also remain in the raw `extra` passthrough —
+/// otherwise it would be double-written (and forwarded verbatim cross-protocol).
+#[test]
+fn parsed_tool_choice_is_not_duplicated_in_extra() {
+    // Chat Completions
+    let chat = adapter_for(ApiProtocol::ChatCompletions);
+    let prompt = chat
+        .parse_request(serde_json::json!({
+            "model": "gpt-5",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tool_choice": "required"
+        }))
+        .unwrap();
+    assert!(prompt.params.tool_choice.is_some());
+    assert!(
+        !prompt.params.extra.contains_key("tool_choice"),
+        "Chat Completions tool_choice must be removed from extra"
+    );
+
+    // Anthropic
+    let anthropic = adapter_for(ApiProtocol::Messages);
+    let prompt = anthropic
+        .parse_request(serde_json::json!({
+            "model": "claude-opus-4-8",
+            "max_tokens": 16,
+            "messages": [{"role": "user", "content": "hi"}],
+            "tool_choice": {"type": "any"}
+        }))
+        .unwrap();
+    assert!(prompt.params.tool_choice.is_some());
+    assert!(
+        !prompt.params.extra.contains_key("tool_choice"),
+        "Anthropic tool_choice must be removed from extra"
+    );
+
+    // Responses
+    let responses = adapter_for(ApiProtocol::Responses);
+    let prompt = responses
+        .parse_request(serde_json::json!({
+            "model": "gpt-5",
+            "input": "hi",
+            "tool_choice": "auto"
+        }))
+        .unwrap();
+    assert!(prompt.params.tool_choice.is_some());
+    assert!(
+        !prompt.params.extra.contains_key("tool_choice"),
+        "Responses tool_choice must be removed from extra"
+    );
+
+    // Gemini: toolConfig is lifted out of the top-level sentinel entirely.
+    let gemini = adapter_for(ApiProtocol::GenerateContent);
+    let prompt = gemini
+        .parse_request(serde_json::json!({
+            "model": "gemini-2.0-flash",
+            "contents": [{"role": "user", "parts": [{"text": "hi"}]}],
+            "toolConfig": {"functionCallingConfig": {"mode": "ANY"}}
+        }))
+        .unwrap();
+    assert_eq!(prompt.params.tool_choice, Some(ToolChoice::Required));
+    let top_level = prompt
+        .params
+        .extra
+        .get("__google_top_level__")
+        .and_then(|v| v.as_object());
+    assert!(
+        top_level
+            .map(|t| !t.contains_key("toolConfig"))
+            .unwrap_or(true),
+        "Gemini toolConfig must be lifted out of the top-level extras: {:?}",
+        prompt.params.extra
+    );
+}
+
+/// An exotic `tool_choice` shape that does not map onto any V3 variant is
+/// preserved verbatim via [`ToolChoice::Other`] and round-trips losslessly on
+/// the same protocol.
+#[test]
+fn exotic_tool_choice_falls_back_to_other_and_round_trips() {
+    // Responses `allowed_tools` constraint — no V3 equivalent.
+    let exotic = serde_json::json!({
+        "type": "allowed_tools",
+        "mode": "auto",
+        "tools": [{"type": "function", "name": "search"}]
+    });
+    let responses = adapter_for(ApiProtocol::Responses);
+    let prompt = responses
+        .parse_request(serde_json::json!({
+            "model": "gpt-5",
+            "input": "hi",
+            "tool_choice": exotic.clone()
+        }))
+        .unwrap();
+    assert_eq!(
+        prompt.params.tool_choice,
+        Some(ToolChoice::Other {
+            value: exotic.clone()
+        })
+    );
+    let rendered = responses.render_request(&prompt).unwrap();
+    assert_eq!(
+        rendered["tool_choice"], exotic,
+        "Other tool_choice must render back byte-for-byte"
+    );
+
+    // Gemini `ANY` + multiple allowedFunctionNames — also no V3 equivalent.
+    let gemini = adapter_for(ApiProtocol::GenerateContent);
+    let tool_config = serde_json::json!({
+        "functionCallingConfig": {"mode": "ANY", "allowedFunctionNames": ["a", "b"]}
+    });
+    let prompt = gemini
+        .parse_request(serde_json::json!({
+            "model": "gemini-2.0-flash",
+            "contents": [{"role": "user", "parts": [{"text": "hi"}]}],
+            "toolConfig": tool_config.clone()
+        }))
+        .unwrap();
+    assert!(matches!(
+        prompt.params.tool_choice,
+        Some(ToolChoice::Other { .. })
+    ));
+    let rendered = gemini.render_request(&prompt).unwrap();
+    assert_eq!(
+        rendered["toolConfig"], tool_config,
+        "Gemini exotic toolConfig must render back verbatim"
+    );
+}
+
+/// The canonical `tool_choice` field is omitted from the serialized
+/// `GenerationParams` when absent (no JSON `null`).
+#[test]
+fn generation_params_omits_absent_tool_choice() {
+    let value = serde_json::to_value(GenerationParams::default()).unwrap();
+    assert!(
+        value.get("tool_choice").is_none(),
+        "absent tool_choice must be omitted: {value}"
     );
 }

--- a/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
@@ -3812,6 +3812,13 @@ fn tool_result_output_serde_uses_snake_case_tags() {
     assert_eq!(content["value"][0]["type"], "media");
     assert_eq!(content["value"][0]["media_type"], "image/png");
     assert_eq!(content["value"][0]["data"]["kind"], "url");
+
+    let denied = serde_json::to_value(ToolResultOutput::ExecutionDenied {
+        reason: Some("nope".to_string()),
+    })
+    .unwrap();
+    assert_eq!(denied["type"], "execution_denied");
+    assert_eq!(denied["reason"], "nope");
 }
 
 #[test]
@@ -6817,4 +6824,429 @@ fn generate_content_thought_signature_round_trips_on_function_call() {
     let part = &rendered["contents"][0]["parts"][0];
     assert!(part.get("functionCall").is_some());
     assert_eq!(part["thoughtSignature"], "TS-fc-1");
+}
+
+// ===== tool-approval flow (human-in-the-loop) + execution-denied =====
+//
+// Only OpenAI Responses carries the approval handshake on the wire
+// (`mcp_approval_request` output item / `mcp_approval_response` input item); the
+// other three protocols have no approval item and drop the parts on render. The
+// `execution-denied` tool-result output is the denial leg of that flow.
+
+/// A Responses `mcp_approval_request` output item parses into a
+/// `Content::ToolApprovalRequest` whose `approval_id` is the item id, with the
+/// MCP server identity lifted into `provider_metadata["openai"]`, and renders
+/// back to the identical output item (same-protocol round trip).
+#[test]
+fn responses_mcp_approval_request_round_trips() {
+    let adapter = adapter_for(ApiProtocol::Responses);
+    let body = serde_json::json!({
+        "id": "resp_1",
+        "status": "completed",
+        "output": [
+            {
+                "id": "mcpr_abc",
+                "type": "mcp_approval_request",
+                "server_label": "dmcp",
+                "name": "roll",
+                "arguments": "{\"diceRollExpression\":\"2d4 + 1\"}",
+            }
+        ]
+    });
+    let result = adapter.parse_response(body).unwrap();
+    // Parsed into a ToolApprovalRequest carrying the server identity.
+    let (approval_id, tool_call_id, meta) = result
+        .content
+        .iter()
+        .find_map(|c| match c {
+            Content::ToolApprovalRequest {
+                approval_id,
+                tool_call_id,
+                provider_metadata,
+            } => Some((
+                approval_id.as_str(),
+                tool_call_id.as_str(),
+                provider_metadata,
+            )),
+            _ => None,
+        })
+        .expect("an approval request part");
+    assert_eq!(approval_id, "mcpr_abc");
+    // The wire carries no separate tool-call id; it is synthesized deterministically.
+    assert_eq!(tool_call_id, "approval:mcpr_abc");
+    let openai = meta.get("openai").and_then(|o| o.as_object()).unwrap();
+    assert_eq!(openai["serverLabel"], "dmcp");
+    assert_eq!(openai["name"], "roll");
+    assert_eq!(openai["arguments"], "{\"diceRollExpression\":\"2d4 + 1\"}");
+
+    // Render back: the exact `mcp_approval_request` output item reappears.
+    let rendered = adapter
+        .render_response(&result, &sample_prompt(), "resp_1")
+        .unwrap();
+    let item = rendered["output"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|i| i["type"] == "mcp_approval_request")
+        .expect("mcp_approval_request re-emitted");
+    assert_eq!(item["id"], "mcpr_abc");
+    assert_eq!(item["server_label"], "dmcp");
+    assert_eq!(item["name"], "roll");
+    assert_eq!(item["arguments"], "{\"diceRollExpression\":\"2d4 + 1\"}");
+}
+
+/// A Responses `mcp_approval_request` with no `approval_request_id` falls back to
+/// the item `id` for the approval id (mirroring the AI SDK reference).
+#[test]
+fn responses_mcp_approval_request_prefers_approval_request_id() {
+    let adapter = adapter_for(ApiProtocol::Responses);
+    let body = serde_json::json!({
+        "id": "resp_1",
+        "status": "completed",
+        "output": [
+            {
+                "id": "item_xyz",
+                "approval_request_id": "mcpr_real",
+                "type": "mcp_approval_request",
+                "name": "roll",
+                "server_label": "dmcp",
+            }
+        ]
+    });
+    let result = adapter.parse_response(body).unwrap();
+    let approval_id = result
+        .content
+        .iter()
+        .find_map(|c| match c {
+            Content::ToolApprovalRequest { approval_id, .. } => Some(approval_id.as_str()),
+            _ => None,
+        })
+        .unwrap();
+    // `approval_request_id` wins over the item `id`.
+    assert_eq!(approval_id, "mcpr_real");
+}
+
+/// An approved `mcp_approval_response` input item round-trips through Responses as
+/// a `Content::ToolApprovalResponse` (and emits NO paired execution-denied).
+#[test]
+fn responses_mcp_approval_response_approved_round_trips() {
+    let adapter = adapter_for(ApiProtocol::Responses);
+    let body = serde_json::json!({
+        "model": "gpt-5",
+        "input": [
+            {
+                "type": "mcp_approval_response",
+                "approval_request_id": "mcpr_abc",
+                "approve": true,
+            }
+        ]
+    });
+    let prompt = adapter.parse_request(body).unwrap();
+    let parts: Vec<&Content> = prompt.messages.iter().flat_map(|m| &m.content).collect();
+    // Exactly the approval-response part; no execution-denied result on approval.
+    assert_eq!(
+        parts.len(),
+        1,
+        "approved response yields only the approval part"
+    );
+    match parts[0] {
+        Content::ToolApprovalResponse {
+            approval_id,
+            approved,
+            reason,
+            ..
+        } => {
+            assert_eq!(approval_id, "mcpr_abc");
+            assert!(*approved);
+            assert!(reason.is_none(), "the wire carries no reason");
+        }
+        other => panic!("expected approval response, got {other:?}"),
+    }
+
+    // Render back to the identical input item.
+    let rendered = adapter.render_request(&prompt).unwrap();
+    let item = rendered["input"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|i| i["type"] == "mcp_approval_response")
+        .expect("mcp_approval_response re-emitted");
+    assert_eq!(item["approval_request_id"], "mcpr_abc");
+    assert_eq!(item["approve"], true);
+}
+
+/// A denied `mcp_approval_response` parses into the approval-response part PLUS a
+/// paired `ExecutionDenied` tool result (carrying the approval id), and renders
+/// back to a single `mcp_approval_response` — the denial is NOT duplicated as a
+/// `function_call_output`, matching the AI SDK's execution-denied skip rule.
+#[test]
+fn responses_mcp_approval_response_denied_pairs_execution_denied() {
+    let adapter = adapter_for(ApiProtocol::Responses);
+    let body = serde_json::json!({
+        "model": "gpt-5",
+        "input": [
+            {
+                "type": "mcp_approval_response",
+                "approval_request_id": "mcpr_abc",
+                "approve": false,
+            }
+        ]
+    });
+    let prompt = adapter.parse_request(body).unwrap();
+    let parts: Vec<&Content> = prompt.messages.iter().flat_map(|m| &m.content).collect();
+    assert_eq!(
+        parts.len(),
+        2,
+        "denial yields the approval part + a denied result"
+    );
+    // The approval-response part records the denial.
+    assert!(matches!(
+        parts[0],
+        Content::ToolApprovalResponse {
+            approved: false,
+            ..
+        }
+    ));
+    // The paired tool result is an ExecutionDenied carrying the approval id.
+    match parts[1] {
+        Content::ToolResult {
+            call_id,
+            output,
+            provider_metadata,
+            ..
+        } => {
+            assert_eq!(call_id, "mcpr_abc");
+            assert!(matches!(
+                output,
+                ToolResultOutput::ExecutionDenied { reason: None }
+            ));
+            assert_eq!(
+                provider_metadata["openai"]["approvalId"],
+                serde_json::json!("mcpr_abc"),
+                "the denial carries its approval id so render can skip it",
+            );
+        }
+        other => panic!("expected a tool result, got {other:?}"),
+    }
+
+    // Render: only the `mcp_approval_response` is emitted; the approval-paired
+    // execution-denied is skipped (no duplicate `function_call_output`).
+    let rendered = adapter.render_request(&prompt).unwrap();
+    let input = rendered["input"].as_array().unwrap();
+    let approval_items = input
+        .iter()
+        .filter(|i| i["type"] == "mcp_approval_response")
+        .count();
+    let denial_outputs = input
+        .iter()
+        .filter(|i| i["type"] == "function_call_output")
+        .count();
+    assert_eq!(
+        approval_items, 1,
+        "the denial is conveyed by mcp_approval_response"
+    );
+    assert_eq!(
+        denial_outputs, 0,
+        "an approval-paired execution-denied is not also emitted as a string: {rendered}"
+    );
+}
+
+/// A full approve handshake: the assistant's `mcp_approval_request` is answered
+/// by an approved `mcp_approval_response`, and the tool's actual output rides as
+/// an ordinary `function_call_output`. Both legs survive a same-protocol route.
+#[test]
+fn responses_approval_then_tool_runs_full_handshake() {
+    let adapter = adapter_for(ApiProtocol::Responses);
+    let body = serde_json::json!({
+        "model": "gpt-5",
+        "input": [
+            {
+                "type": "mcp_approval_response",
+                "approval_request_id": "mcpr_abc",
+                "approve": true,
+            },
+            {
+                "type": "function_call_output",
+                "call_id": "mcpr_abc",
+                "output": "4",
+            }
+        ]
+    });
+    let prompt = adapter.parse_request(body).unwrap();
+    let rendered = adapter.render_request(&prompt).unwrap();
+    let input = rendered["input"].as_array().unwrap();
+    // The approval grant is preserved.
+    assert!(input.iter().any(|i| i["type"] == "mcp_approval_response"
+        && i["approve"] == true
+        && i["approval_request_id"] == "mcpr_abc"));
+    // The tool's real result is preserved as a function_call_output.
+    let out = input
+        .iter()
+        .find(|i| i["type"] == "function_call_output")
+        .expect("the approved tool's output survives");
+    assert_eq!(out["call_id"], "mcpr_abc");
+    assert_eq!(out["output"], "4");
+}
+
+/// An *unpaired* `ExecutionDenied` (no approval id in metadata) degrades to a
+/// `function_call_output` whose `output` is the denial string on Responses, and
+/// re-parses as `Text` — exactly as documented (the structured denial has no
+/// distinct tag on the wire without an approval).
+#[test]
+fn responses_unpaired_execution_denied_degrades_to_string() {
+    let adapter = adapter_for(ApiProtocol::Responses);
+    let prompt = tool_result_prompt(
+        "call_1",
+        None,
+        ToolResultOutput::ExecutionDenied {
+            reason: Some("user refused".to_string()),
+        },
+    );
+    let rendered = adapter.render_request(&prompt).unwrap();
+    let out = rendered["input"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|i| i["type"] == "function_call_output")
+        .expect("an unpaired denial renders as function_call_output");
+    assert_eq!(out["output"], "user refused");
+    // Re-parses as Text (the wire has no execution-denied tag without an approval).
+    let back = round_trip_tool_output(
+        ApiProtocol::Responses,
+        ToolResultOutput::ExecutionDenied {
+            reason: Some("user refused".to_string()),
+        },
+    );
+    assert_eq!(
+        back,
+        ToolResultOutput::Text {
+            value: "user refused".to_string()
+        }
+    );
+}
+
+/// An unpaired `ExecutionDenied` with no reason renders the AI SDK's default
+/// denial sentinel.
+#[test]
+fn responses_execution_denied_without_reason_uses_default_sentinel() {
+    let adapter = adapter_for(ApiProtocol::Responses);
+    let prompt = tool_result_prompt(
+        "call_1",
+        None,
+        ToolResultOutput::ExecutionDenied { reason: None },
+    );
+    let rendered = adapter.render_request(&prompt).unwrap();
+    let out = rendered["input"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|i| i["type"] == "function_call_output")
+        .unwrap();
+    assert_eq!(out["output"], "Tool call execution denied.");
+}
+
+/// On the three non-Responses wires there is no approval handshake, so an
+/// `ExecutionDenied` tool result degrades to the denial string (or the default
+/// sentinel) via `to_provider_string`, never silently dropped.
+#[test]
+fn execution_denied_degrades_to_string_on_non_responses_wires() {
+    for protocol in [
+        ApiProtocol::ChatCompletions,
+        ApiProtocol::Messages,
+        ApiProtocol::GenerateContent,
+    ] {
+        let adapter = adapter_for(protocol.clone());
+        let prompt = tool_result_prompt(
+            "call_1",
+            Some("roll"),
+            ToolResultOutput::ExecutionDenied {
+                reason: Some("denied by policy".to_string()),
+            },
+        );
+        let rendered = adapter
+            .render_request(&prompt)
+            .unwrap_or_else(|e| panic!("{protocol:?} render_request: {e}"));
+        // The denial reason text must appear somewhere in the rendered request.
+        let blob = serde_json::to_string(&rendered).unwrap();
+        assert!(
+            blob.contains("denied by policy"),
+            "{protocol:?} dropped the execution-denied reason: {rendered}"
+        );
+    }
+}
+
+/// The three non-Responses adapters drop a `ToolApprovalResponse` request part
+/// (no wire item for it), mirroring the AI SDK converters' `continue`. The
+/// request must still render successfully (no panic, no error).
+#[test]
+fn approval_response_part_is_dropped_on_non_responses_wires() {
+    for protocol in [
+        ApiProtocol::ChatCompletions,
+        ApiProtocol::Messages,
+        ApiProtocol::GenerateContent,
+    ] {
+        let adapter = adapter_for(protocol.clone());
+        let prompt = Prompt {
+            model: "m".to_string(),
+            system: None,
+            system_provider_metadata: Default::default(),
+            messages: vec![Message {
+                role: Role::Tool,
+                content: vec![Content::ToolApprovalResponse {
+                    approval_id: "mcpr_abc".to_string(),
+                    approved: true,
+                    reason: None,
+                    provider_metadata: Default::default(),
+                }],
+            }],
+            tools: vec![],
+            params: GenerationParams::default(),
+            response_format: None,
+            stream: false,
+        };
+        // Renders without error; the approval part has no wire item and is dropped.
+        adapter
+            .render_request(&prompt)
+            .unwrap_or_else(|e| panic!("{protocol:?} render_request: {e}"));
+    }
+}
+
+/// The new content variants and the `ExecutionDenied` output round-trip through
+/// serde unchanged, with the expected tagged-union shapes.
+#[test]
+fn approval_types_serde_round_trip() {
+    // ToolApprovalRequest
+    let req = Content::ToolApprovalRequest {
+        approval_id: "mcpr_abc".to_string(),
+        tool_call_id: "approval:mcpr_abc".to_string(),
+        provider_metadata: Default::default(),
+    };
+    let v = serde_json::to_value(&req).unwrap();
+    assert_eq!(v["type"], "tool_approval_request");
+    assert_eq!(v["approval_id"], "mcpr_abc");
+    assert_eq!(v["tool_call_id"], "approval:mcpr_abc");
+    assert_eq!(serde_json::from_value::<Content>(v).unwrap(), req);
+
+    // ToolApprovalResponse, with an optional reason set.
+    let resp = Content::ToolApprovalResponse {
+        approval_id: "mcpr_abc".to_string(),
+        approved: false,
+        reason: Some("nope".to_string()),
+        provider_metadata: Default::default(),
+    };
+    let v = serde_json::to_value(&resp).unwrap();
+    assert_eq!(v["type"], "tool_approval_response");
+    assert_eq!(v["approved"], false);
+    assert_eq!(v["reason"], "nope");
+    assert_eq!(serde_json::from_value::<Content>(v).unwrap(), resp);
+
+    // ExecutionDenied output, reason omitted when None.
+    let denied = ToolResultOutput::ExecutionDenied { reason: None };
+    let v = serde_json::to_value(&denied).unwrap();
+    assert_eq!(v["type"], "execution_denied");
+    assert!(v.get("reason").is_none(), "None reason omits the key: {v}");
+    assert_eq!(
+        serde_json::from_value::<ToolResultOutput>(v).unwrap(),
+        denied
+    );
 }

--- a/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
@@ -473,6 +473,7 @@ fn sample_prompt_with_schema() -> Prompt {
     Prompt {
         response_format: Some(ResponseFormat::JsonSchema {
             name: Some("weather".to_string()),
+            description: None,
             strict: Some(true),
             schema: serde_json::json!({
                 "type": "object",
@@ -498,6 +499,7 @@ fn chat_completions_inbound_promotes_json_schema_response_format() {
             "type": "json_schema",
             "json_schema": {
                 "name": "weather",
+                "description": "Structured weather report",
                 "strict": true,
                 "schema": {"type": "object", "properties": {"x": {"type": "string"}}}
             }
@@ -507,10 +509,13 @@ fn chat_completions_inbound_promotes_json_schema_response_format() {
     match prompt.response_format {
         Some(ResponseFormat::JsonSchema {
             name,
+            description,
             strict,
             schema,
         }) => {
             assert_eq!(name.as_deref(), Some("weather"));
+            // The OpenAI `json_schema.description` is promoted, not dropped.
+            assert_eq!(description.as_deref(), Some("Structured weather report"));
             assert_eq!(strict, Some(true));
             assert_eq!(schema["properties"]["x"]["type"], "string");
         }
@@ -562,6 +567,7 @@ fn chat_completions_outbound_supplies_default_name() {
     let prompt = Prompt {
         response_format: Some(ResponseFormat::JsonSchema {
             name: None,
+            description: None,
             strict: None,
             schema: serde_json::json!({"type": "object"}),
         }),
@@ -576,6 +582,12 @@ fn chat_completions_outbound_supplies_default_name() {
     assert!(
         rendered["response_format"]["json_schema"]
             .get("strict")
+            .is_none()
+    );
+    // description is likewise omitted, not emitted as null, when unset.
+    assert!(
+        rendered["response_format"]["json_schema"]
+            .get("description")
             .is_none()
     );
 }
@@ -758,6 +770,7 @@ fn messages_outbound_merges_format_and_effort_into_output_config() {
         },
         response_format: Some(ResponseFormat::JsonSchema {
             name: None,
+            description: None,
             strict: None,
             schema: serde_json::json!({"type": "object"}),
         }),
@@ -7249,4 +7262,271 @@ fn approval_types_serde_round_trip() {
         serde_json::from_value::<ToolResultOutput>(v).unwrap(),
         denied
     );
+}
+
+// ===== raw finish-reason preservation (V3 `finishReason.raw`) =====
+//
+// The canonical `FinishReason` enum maps several native reasons onto one
+// variant; for the lossy cases an adapter stashes the raw provider string under
+// `provider_metadata["<provider>"]["rawFinishReason"]` on parse and reads it
+// back on render so a same-protocol round-trip is byte-faithful. These tests
+// pin both halves (parse stashes, render restores) plus the negative case
+// (lossless reasons stash nothing).
+
+/// The `rawFinishReason` value stashed under `provider_id`, if any.
+fn raw_finish(result: &GenerateResult, provider_id: &str) -> Option<String> {
+    result
+        .provider_metadata
+        .get(provider_id)?
+        .as_object()?
+        .get("rawFinishReason")?
+        .as_str()
+        .map(str::to_string)
+}
+
+#[test]
+fn messages_stop_sequence_raw_round_trips() {
+    let adapter = adapter_for(ApiProtocol::Messages);
+    // `stop_sequence` maps to the unified `Stop`, which would otherwise render
+    // back as `end_turn` and lose the distinction.
+    let body = serde_json::json!({
+        "id": "msg_1",
+        "type": "message",
+        "role": "assistant",
+        "model": "claude-opus-4-7",
+        "content": [{"type": "text", "text": "hi"}],
+        "stop_reason": "stop_sequence",
+        "usage": {"input_tokens": 1, "output_tokens": 1},
+    });
+    let result = adapter.parse_response(body).unwrap();
+    assert_eq!(result.finish_reason, Some(FinishReason::Stop));
+    assert_eq!(
+        raw_finish(&result, PROVIDER_ID_ANTHROPIC).as_deref(),
+        Some("stop_sequence"),
+        "lossy stop_reason is stashed for faithful re-render"
+    );
+    // Render restores the exact native value rather than the enum's `end_turn`.
+    let rendered = adapter
+        .render_response(&result, &sample_prompt(), "msg_1")
+        .unwrap();
+    assert_eq!(rendered["stop_reason"], "stop_sequence");
+}
+
+#[test]
+fn messages_end_turn_raw_is_not_stashed() {
+    let adapter = adapter_for(ApiProtocol::Messages);
+    // `end_turn` → `Stop` → renders `end_turn`: lossless, so nothing is stashed.
+    let body = serde_json::json!({
+        "id": "msg_1",
+        "type": "message",
+        "role": "assistant",
+        "model": "claude-opus-4-7",
+        "content": [{"type": "text", "text": "hi"}],
+        "stop_reason": "end_turn",
+        "usage": {"input_tokens": 1, "output_tokens": 1},
+    });
+    let result = adapter.parse_response(body).unwrap();
+    assert_eq!(result.finish_reason, Some(FinishReason::Stop));
+    assert!(
+        raw_finish(&result, PROVIDER_ID_ANTHROPIC).is_none(),
+        "a lossless reason stashes no raw value"
+    );
+    let rendered = adapter
+        .render_response(&result, &sample_prompt(), "msg_1")
+        .unwrap();
+    assert_eq!(rendered["stop_reason"], "end_turn");
+}
+
+#[test]
+fn generate_content_recitation_raw_round_trips() {
+    let adapter = adapter_for(ApiProtocol::GenerateContent);
+    // `RECITATION` collapses to `ContentFilter`, which renders back as `SAFETY`;
+    // the precise sub-reason must survive via the stash.
+    let body = serde_json::json!({
+        "candidates": [{
+            "content": {"role": "model", "parts": [{"text": "hi"}]},
+            "finishReason": "RECITATION",
+            "index": 0,
+        }],
+        "usageMetadata": {"promptTokenCount": 1, "candidatesTokenCount": 1, "totalTokenCount": 2},
+    });
+    let result = adapter.parse_response(body).unwrap();
+    assert_eq!(result.finish_reason, Some(FinishReason::ContentFilter));
+    assert_eq!(
+        raw_finish(&result, PROVIDER_ID_GOOGLE).as_deref(),
+        Some("RECITATION")
+    );
+    let rendered = adapter
+        .render_response(&result, &sample_prompt(), "r1")
+        .unwrap();
+    assert_eq!(rendered["candidates"][0]["finishReason"], "RECITATION");
+}
+
+#[test]
+fn generate_content_stop_raw_is_not_stashed() {
+    let adapter = adapter_for(ApiProtocol::GenerateContent);
+    let body = serde_json::json!({
+        "candidates": [{
+            "content": {"role": "model", "parts": [{"text": "hi"}]},
+            "finishReason": "STOP",
+            "index": 0,
+        }],
+        "usageMetadata": {"promptTokenCount": 1, "candidatesTokenCount": 1, "totalTokenCount": 2},
+    });
+    let result = adapter.parse_response(body).unwrap();
+    assert_eq!(result.finish_reason, Some(FinishReason::Stop));
+    assert!(raw_finish(&result, PROVIDER_ID_GOOGLE).is_none());
+    let rendered = adapter
+        .render_response(&result, &sample_prompt(), "r1")
+        .unwrap();
+    assert_eq!(rendered["candidates"][0]["finishReason"], "STOP");
+}
+
+#[test]
+fn chat_completions_function_call_raw_round_trips() {
+    let adapter = adapter_for(ApiProtocol::ChatCompletions);
+    // The legacy `function_call` reason maps to `ToolCalls`, which renders back
+    // as `tool_calls`; the original string must survive via the stash.
+    let body = serde_json::json!({
+        "id": "chatcmpl-1",
+        "object": "chat.completion",
+        "model": "gpt-4o",
+        "choices": [{
+            "index": 0,
+            "message": {"role": "assistant", "content": "hi"},
+            "finish_reason": "function_call",
+        }],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    });
+    let result = adapter.parse_response(body).unwrap();
+    assert_eq!(result.finish_reason, Some(FinishReason::ToolCalls));
+    assert_eq!(
+        raw_finish(&result, PROVIDER_ID_OPENAI).as_deref(),
+        Some("function_call")
+    );
+    let rendered = adapter
+        .render_response(&result, &sample_prompt(), "chatcmpl-1")
+        .unwrap();
+    assert_eq!(rendered["choices"][0]["finish_reason"], "function_call");
+}
+
+#[test]
+fn chat_completions_stop_raw_is_not_stashed() {
+    let adapter = adapter_for(ApiProtocol::ChatCompletions);
+    let body = serde_json::json!({
+        "id": "chatcmpl-1",
+        "object": "chat.completion",
+        "model": "gpt-4o",
+        "choices": [{
+            "index": 0,
+            "message": {"role": "assistant", "content": "hi"},
+            "finish_reason": "stop",
+        }],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    });
+    let result = adapter.parse_response(body).unwrap();
+    assert_eq!(result.finish_reason, Some(FinishReason::Stop));
+    assert!(raw_finish(&result, PROVIDER_ID_OPENAI).is_none());
+    let rendered = adapter
+        .render_response(&result, &sample_prompt(), "chatcmpl-1")
+        .unwrap();
+    assert_eq!(rendered["choices"][0]["finish_reason"], "stop");
+}
+
+// ===== response_format `description` (V3 `responseFormat.description`) =====
+
+#[test]
+fn responses_inbound_promotes_json_schema_description() {
+    let adapter = adapter_for(ApiProtocol::Responses);
+    let body = serde_json::json!({
+        "model": "gpt-4o",
+        "input": "weather?",
+        "text": {
+            "format": {
+                "type": "json_schema",
+                "name": "weather",
+                "description": "Structured weather report",
+                "schema": {"type": "object"},
+            }
+        }
+    });
+    let prompt = adapter.parse_request(body).unwrap();
+    match prompt.response_format {
+        Some(ResponseFormat::JsonSchema {
+            name, description, ..
+        }) => {
+            assert_eq!(name.as_deref(), Some("weather"));
+            assert_eq!(description.as_deref(), Some("Structured weather report"));
+        }
+        other => panic!("expected JsonSchema, got {other:?}"),
+    }
+}
+
+#[test]
+fn responses_outbound_renders_json_schema_description() {
+    let adapter = adapter_for(ApiProtocol::Responses);
+    let prompt = Prompt {
+        response_format: Some(ResponseFormat::JsonSchema {
+            name: Some("weather".to_string()),
+            description: Some("Structured weather report".to_string()),
+            strict: None,
+            schema: serde_json::json!({"type": "object"}),
+        }),
+        ..sample_prompt()
+    };
+    let rendered = adapter.render_request(&prompt).unwrap();
+    assert_eq!(
+        rendered["text"]["format"]["description"],
+        "Structured weather report"
+    );
+}
+
+#[test]
+fn chat_completions_outbound_renders_json_schema_description() {
+    let adapter = adapter_for(ApiProtocol::ChatCompletions);
+    let prompt = Prompt {
+        response_format: Some(ResponseFormat::JsonSchema {
+            name: Some("weather".to_string()),
+            description: Some("Structured weather report".to_string()),
+            strict: None,
+            schema: serde_json::json!({"type": "object"}),
+        }),
+        ..sample_prompt()
+    };
+    let rendered = adapter.render_request(&prompt).unwrap();
+    assert_eq!(
+        rendered["response_format"]["json_schema"]["description"],
+        "Structured weather report"
+    );
+}
+
+#[test]
+fn json_schema_description_round_trips_openai_family() {
+    // A description survives a same-protocol render→parse hop on both OpenAI
+    // wires (Chat Completions and Responses), and is dropped on the
+    // Anthropic/Google wires that carry no schema description.
+    for proto in [ApiProtocol::ChatCompletions, ApiProtocol::Responses] {
+        let adapter = adapter_for(proto.clone());
+        let prompt = Prompt {
+            response_format: Some(ResponseFormat::JsonSchema {
+                name: Some("weather".to_string()),
+                description: Some("Structured weather report".to_string()),
+                strict: None,
+                schema: serde_json::json!({"type": "object"}),
+            }),
+            ..sample_prompt()
+        };
+        let rendered = adapter.render_request(&prompt).unwrap();
+        let back = adapter.parse_request(rendered).unwrap();
+        match back.response_format {
+            Some(ResponseFormat::JsonSchema { description, .. }) => {
+                assert_eq!(
+                    description.as_deref(),
+                    Some("Structured weather report"),
+                    "{proto:?} should round-trip the description"
+                );
+            }
+            other => panic!("{proto:?}: expected JsonSchema, got {other:?}"),
+        }
+    }
 }

--- a/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
@@ -76,6 +76,7 @@ fn sample_result() -> GenerateResult {
                 name: "calculator".to_string(),
                 arguments: "{\"op\":\"add\"}".to_string(),
                 provider_executed: false,
+                dynamic: false,
                 provider_metadata: Default::default(),
             },
         ],
@@ -3694,6 +3695,7 @@ fn tool_result_prompt(call_id: &str, tool_name: Option<&str>, output: ToolResult
                 call_id: call_id.to_string(),
                 tool_name: tool_name.map(str::to_string),
                 output,
+                dynamic: false,
                 provider_metadata: Default::default(),
             }],
         }],
@@ -4352,6 +4354,7 @@ fn tool_result_content_serde_round_trips() {
                 },
             ],
         },
+        dynamic: false,
         provider_metadata: Default::default(),
     };
     let value = serde_json::to_value(&original).unwrap();
@@ -4371,6 +4374,7 @@ fn tool_result_without_tool_name_omits_the_field() {
         output: ToolResultOutput::Text {
             value: "x".to_string(),
         },
+        dynamic: false,
         provider_metadata: Default::default(),
     })
     .unwrap();
@@ -4427,6 +4431,7 @@ fn messages_renders_provider_executed_as_server_tool_use() {
                 name: "get_weather".to_string(),
                 arguments: "{}".to_string(),
                 provider_executed: false,
+                dynamic: false,
                 provider_metadata: Default::default(),
             },
             Content::ToolCall {
@@ -4434,6 +4439,7 @@ fn messages_renders_provider_executed_as_server_tool_use() {
                 name: "web_search".to_string(),
                 arguments: "{\"query\":\"x\"}".to_string(),
                 provider_executed: true,
+                dynamic: false,
                 provider_metadata: Default::default(),
             },
         ],
@@ -4469,6 +4475,493 @@ fn messages_server_tool_use_round_trips() {
         .unwrap();
     assert_eq!(rendered["content"][0]["type"], "server_tool_use");
     assert_eq!(rendered["content"][0]["id"], "srvtoolu_1");
+}
+
+// ===== A2: Anthropic MCP (`mcp_tool_use` / `mcp_tool_result`) =====
+
+/// An Anthropic `mcp_tool_use` block parses to a `dynamic`, provider-executed
+/// `ToolCall` whose `server_name` is preserved in `provider_metadata`.
+#[test]
+fn messages_parses_mcp_tool_use_as_dynamic_with_server_name() {
+    let adapter = adapter_for(ApiProtocol::Messages);
+    let body = serde_json::json!({
+        "id": "msg_1",
+        "content": [
+            {
+                "type": "mcp_tool_use",
+                "id": "mcptoolu_1",
+                "name": "search_docs",
+                "input": { "query": "q" },
+                "server_name": "docs-server"
+            }
+        ],
+        "stop_reason": "end_turn"
+    });
+    let result = adapter.parse_response(body).unwrap();
+    let call = result
+        .content
+        .iter()
+        .find_map(|c| match c {
+            Content::ToolCall {
+                id,
+                name,
+                dynamic,
+                provider_executed,
+                provider_metadata,
+                ..
+            } => Some((id, name, *dynamic, *provider_executed, provider_metadata)),
+            _ => None,
+        })
+        .expect("an mcp_tool_use call");
+    assert_eq!(call.0, "mcptoolu_1");
+    assert_eq!(call.1, "search_docs");
+    assert!(call.2, "mcp_tool_use is dynamic");
+    assert!(call.3, "mcp_tool_use is provider-executed");
+    // The server identity rides the anthropic namespace.
+    let anthropic = call.4.get("anthropic").and_then(|v| v.as_object()).unwrap();
+    assert_eq!(anthropic["type"], "mcp-tool-use");
+    assert_eq!(anthropic["serverName"], "docs-server");
+}
+
+/// A full Anthropic MCP round-trip: an `mcp_tool_use` call followed by its inline
+/// `mcp_tool_result` parses to a `dynamic` `ToolCall` + `dynamic` `ToolResult`
+/// and renders back to the SAME two blocks, preserving `server_name`, the tool
+/// args, and the inline result content (the A2 fidelity goal).
+#[test]
+fn messages_mcp_tool_use_and_result_round_trip() {
+    let adapter = adapter_for(ApiProtocol::Messages);
+    let body = serde_json::json!({
+        "id": "msg_1",
+        "content": [
+            {
+                "type": "mcp_tool_use",
+                "id": "mcptoolu_1",
+                "name": "search_docs",
+                "input": { "query": "rust" },
+                "server_name": "docs-server"
+            },
+            {
+                "type": "mcp_tool_result",
+                "tool_use_id": "mcptoolu_1",
+                "is_error": false,
+                "content": [ { "type": "text", "text": "found 3 docs" } ]
+            }
+        ],
+        "stop_reason": "end_turn"
+    });
+    let parsed = adapter.parse_response(body).unwrap();
+    // Canonical IR: a dynamic call + a dynamic result.
+    assert!(matches!(
+        parsed.content.first(),
+        Some(Content::ToolCall { dynamic: true, .. })
+    ));
+    assert!(matches!(
+        parsed.content.get(1),
+        Some(Content::ToolResult { dynamic: true, .. })
+    ));
+    let rendered = adapter
+        .render_response(&parsed, &sample_prompt(), "msg_1")
+        .unwrap();
+    let blocks = rendered["content"].as_array().unwrap();
+    // The MCP call block round-trips with its server name and args.
+    assert_eq!(blocks[0]["type"], "mcp_tool_use");
+    assert_eq!(blocks[0]["id"], "mcptoolu_1");
+    assert_eq!(blocks[0]["name"], "search_docs");
+    assert_eq!(blocks[0]["server_name"], "docs-server");
+    assert_eq!(blocks[0]["input"]["query"], "rust");
+    // The inline result block round-trips with its content and pairing id.
+    assert_eq!(blocks[1]["type"], "mcp_tool_result");
+    assert_eq!(blocks[1]["tool_use_id"], "mcptoolu_1");
+    assert_eq!(blocks[1]["is_error"], false);
+    assert_eq!(
+        blocks[1]["content"],
+        serde_json::json!([{ "type": "text", "text": "found 3 docs" }])
+    );
+}
+
+/// An `mcp_tool_result` carrying `is_error: true` round-trips as an error result.
+#[test]
+fn messages_mcp_tool_result_error_round_trips() {
+    let adapter = adapter_for(ApiProtocol::Messages);
+    let body = serde_json::json!({
+        "id": "msg_1",
+        "content": [
+            {
+                "type": "mcp_tool_use",
+                "id": "mcptoolu_1",
+                "name": "do_thing",
+                "input": {},
+                "server_name": "srv"
+            },
+            {
+                "type": "mcp_tool_result",
+                "tool_use_id": "mcptoolu_1",
+                "is_error": true,
+                "content": "boom"
+            }
+        ],
+        "stop_reason": "end_turn"
+    });
+    let parsed = adapter.parse_response(body).unwrap();
+    // The result is an error variant in the canonical IR.
+    let is_error = parsed.content.iter().find_map(|c| match c {
+        Content::ToolResult { output, .. } => Some(output.is_error()),
+        _ => None,
+    });
+    assert_eq!(is_error, Some(true));
+    let rendered = adapter
+        .render_response(&parsed, &sample_prompt(), "msg_1")
+        .unwrap();
+    assert_eq!(rendered["content"][1]["type"], "mcp_tool_result");
+    assert_eq!(rendered["content"][1]["is_error"], true);
+    assert_eq!(rendered["content"][1]["content"], "boom");
+}
+
+/// An Anthropic **request** echoing an assistant turn with `mcp_tool_use` +
+/// `mcp_tool_result` blocks round-trips: the inline MCP result stays in the
+/// assistant turn (it is NOT split into a request-side `tool_result`) and
+/// re-renders as an `mcp_tool_result` block.
+#[test]
+fn messages_request_mcp_blocks_round_trip_in_assistant_turn() {
+    let adapter = adapter_for(ApiProtocol::Messages);
+    let body = serde_json::json!({
+        "model": "claude",
+        "max_tokens": 100,
+        "messages": [
+            { "role": "user", "content": "search the docs" },
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "mcp_tool_use",
+                        "id": "mcptoolu_1",
+                        "name": "search_docs",
+                        "input": { "query": "rust" },
+                        "server_name": "docs-server"
+                    },
+                    {
+                        "type": "mcp_tool_result",
+                        "tool_use_id": "mcptoolu_1",
+                        "is_error": false,
+                        "content": [ { "type": "text", "text": "ok" } ]
+                    }
+                ]
+            }
+        ]
+    });
+    let prompt = adapter.parse_request(body).unwrap();
+    // The MCP result is NOT split into a separate Tool-role message — both blocks
+    // ride the single assistant turn.
+    let assistant = prompt
+        .messages
+        .iter()
+        .find(|m| m.role == Role::Assistant)
+        .expect("an assistant message");
+    assert!(
+        prompt.messages.iter().all(|m| m.role != Role::Tool),
+        "a dynamic MCP result must not become a Tool-role message"
+    );
+    assert!(matches!(
+        assistant.content.first(),
+        Some(Content::ToolCall { dynamic: true, .. })
+    ));
+    assert!(matches!(
+        assistant.content.get(1),
+        Some(Content::ToolResult { dynamic: true, .. })
+    ));
+    // Re-render onto the Anthropic request wire: the assistant content reproduces
+    // both MCP blocks.
+    let rendered = adapter.render_request(&prompt).unwrap();
+    let assistant_msg = rendered["messages"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|m| m["role"] == "assistant")
+        .expect("an assistant request message");
+    let blocks = assistant_msg["content"].as_array().unwrap();
+    assert_eq!(blocks[0]["type"], "mcp_tool_use");
+    assert_eq!(blocks[0]["server_name"], "docs-server");
+    assert_eq!(blocks[1]["type"], "mcp_tool_result");
+    assert_eq!(blocks[1]["tool_use_id"], "mcptoolu_1");
+    assert_eq!(
+        blocks[1]["content"],
+        serde_json::json!([{ "type": "text", "text": "ok" }])
+    );
+}
+
+// ===== A1: Responses MCP (`mcp_call`) + `local_shell_call` =====
+
+/// An OpenAI Responses `mcp_call` (with an inline `output`) parses to a
+/// `dynamic` provider-executed `ToolCall` + a paired `dynamic` `ToolResult`, and
+/// renders back to a SINGLE `mcp_call` item that preserves the inline result —
+/// the A1 fidelity goal (the inline result was previously dropped).
+#[test]
+fn responses_mcp_call_round_trips_with_inline_result() {
+    let adapter = adapter_for(ApiProtocol::Responses);
+    let body = serde_json::json!({
+        "id": "resp_1",
+        "status": "completed",
+        "output": [
+            {
+                "type": "mcp_call",
+                "id": "mcp_1",
+                "server_label": "my-mcp",
+                "name": "lookup",
+                "arguments": "{\"q\":\"x\"}",
+                "output": "the answer"
+            }
+        ]
+    });
+    let parsed = adapter.parse_response(body).unwrap();
+    // Lowered to a dynamic provider-executed call + its dynamic inline result.
+    assert!(matches!(
+        parsed.content.first(),
+        Some(Content::ToolCall {
+            dynamic: true,
+            provider_executed: true,
+            ..
+        })
+    ));
+    assert!(matches!(
+        parsed.content.get(1),
+        Some(Content::ToolResult { dynamic: true, .. })
+    ));
+    let rendered = adapter
+        .render_response(&parsed, &sample_prompt(), "resp_1")
+        .unwrap();
+    // Exactly ONE mcp_call item is re-emitted (the call + result recombined).
+    let mcp_items: Vec<_> = rendered["output"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|i| i["type"] == "mcp_call")
+        .collect();
+    assert_eq!(
+        mcp_items.len(),
+        1,
+        "call + result recombine into one mcp_call"
+    );
+    let item = mcp_items[0];
+    assert_eq!(item["id"], "mcp_1");
+    assert_eq!(item["server_label"], "my-mcp");
+    assert_eq!(item["name"], "lookup");
+    assert_eq!(item["arguments"], "{\"q\":\"x\"}");
+    assert_eq!(item["output"], "the answer", "inline result preserved");
+    // No stray function_call / function_call_output leaked from the split pair.
+    assert!(
+        rendered["output"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|i| i["type"] != "function_call" && i["type"] != "function_call_output"),
+        "the dynamic call/result must not leak as plain function items"
+    );
+}
+
+/// An `mcp_call` carrying an inline `error` (instead of `output`) round-trips the
+/// error faithfully on the single recombined `mcp_call` item.
+#[test]
+fn responses_mcp_call_round_trips_inline_error() {
+    let adapter = adapter_for(ApiProtocol::Responses);
+    let body = serde_json::json!({
+        "id": "resp_1",
+        "status": "completed",
+        "output": [
+            {
+                "type": "mcp_call",
+                "id": "mcp_1",
+                "server_label": "my-mcp",
+                "name": "lookup",
+                "arguments": "{}",
+                "error": "upstream exploded"
+            }
+        ]
+    });
+    let parsed = adapter.parse_response(body).unwrap();
+    let rendered = adapter
+        .render_response(&parsed, &sample_prompt(), "resp_1")
+        .unwrap();
+    let item = rendered["output"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|i| i["type"] == "mcp_call")
+        .unwrap();
+    assert_eq!(item["error"], "upstream exploded");
+    assert!(
+        item.get("output").is_none(),
+        "no output key when only error"
+    );
+}
+
+/// A Responses `local_shell_call` parses to a client `ToolCall` named
+/// `local_shell` whose `action` is preserved, and renders back to a
+/// `local_shell_call` item (same-protocol round-trip of the call).
+#[test]
+fn responses_local_shell_call_round_trips() {
+    let adapter = adapter_for(ApiProtocol::Responses);
+    let body = serde_json::json!({
+        "id": "resp_1",
+        "status": "completed",
+        "output": [
+            {
+                "type": "local_shell_call",
+                "id": "ls_item_1",
+                "call_id": "ls_call_1",
+                "action": {
+                    "type": "exec",
+                    "command": ["echo", "hi"],
+                    "timeout_ms": 1000
+                }
+            }
+        ]
+    });
+    let parsed = adapter.parse_response(body).unwrap();
+    let call = parsed
+        .content
+        .iter()
+        .find_map(|c| match c {
+            Content::ToolCall {
+                id,
+                name,
+                arguments,
+                provider_executed,
+                dynamic,
+                ..
+            } => Some((id, name, arguments, *provider_executed, *dynamic)),
+            _ => None,
+        })
+        .expect("a local_shell call");
+    assert_eq!(call.0, "ls_call_1");
+    assert_eq!(call.1, "local_shell");
+    assert!(
+        !call.3,
+        "local_shell is a client call, not provider-executed"
+    );
+    assert!(!call.4, "local_shell is not a dynamic MCP call");
+    // The action payload survives in the call input.
+    let input: serde_json::Value = serde_json::from_str(call.2).unwrap();
+    assert_eq!(
+        input["action"]["command"],
+        serde_json::json!(["echo", "hi"])
+    );
+    assert_eq!(input["action"]["timeout_ms"], 1000);
+    let rendered = adapter
+        .render_response(&parsed, &sample_prompt(), "resp_1")
+        .unwrap();
+    let item = rendered["output"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|i| i["type"] == "local_shell_call")
+        .expect("a local_shell_call output item");
+    assert_eq!(item["call_id"], "ls_call_1");
+    assert_eq!(
+        item["id"], "ls_item_1",
+        "the item id is restored from metadata"
+    );
+    assert_eq!(item["action"]["command"], serde_json::json!(["echo", "hi"]));
+    assert_eq!(item["action"]["timeout_ms"], 1000);
+}
+
+// ===== cross-protocol degrade =====
+
+/// A `dynamic` MCP `ToolCall` (parsed from an Anthropic `mcp_tool_use`) routed to
+/// a non-MCP wire (Chat Completions) degrades faithfully to a regular tool call:
+/// the call survives with its name + args, but the MCP server identity — which
+/// has no slot on that wire — is dropped.
+#[test]
+fn dynamic_mcp_call_degrades_to_plain_tool_call_cross_protocol() {
+    let messages = adapter_for(ApiProtocol::Messages);
+    let chat = adapter_for(ApiProtocol::ChatCompletions);
+    // Parse an Anthropic MCP call into the canonical IR.
+    let body = serde_json::json!({
+        "id": "msg_1",
+        "content": [
+            {
+                "type": "mcp_tool_use",
+                "id": "mcptoolu_1",
+                "name": "search_docs",
+                "input": { "query": "q" },
+                "server_name": "docs-server"
+            }
+        ],
+        "stop_reason": "end_turn"
+    });
+    let result = messages.parse_response(body).unwrap();
+    // Render that result onto the Chat Completions wire.
+    let rendered = chat
+        .render_response(&result, &sample_prompt(), "chatcmpl_1")
+        .unwrap();
+    let tool_calls = rendered["choices"][0]["message"]["tool_calls"]
+        .as_array()
+        .expect("a plain tool_calls array");
+    assert_eq!(tool_calls.len(), 1);
+    // The call degrades to a regular function tool call: name + args survive…
+    assert_eq!(tool_calls[0]["function"]["name"], "search_docs");
+    assert_eq!(tool_calls[0]["id"], "mcptoolu_1");
+    // …and there is no MCP server identity anywhere on this wire's tool call.
+    let serialized = serde_json::to_string(&tool_calls[0]).unwrap();
+    assert!(
+        !serialized.contains("docs-server") && !serialized.contains("server_name"),
+        "MCP server identity must not leak onto a non-MCP wire: {serialized}"
+    );
+}
+
+/// The new `dynamic` flag is omitted from JSON when false (V3
+/// `skip_serializing_if`) and present when true, on both `ToolCall` and
+/// `ToolResult`.
+#[test]
+fn dynamic_flag_serde_defaults() {
+    // false → omitted on a ToolCall.
+    let call_false = serde_json::to_value(Content::ToolCall {
+        id: "c1".to_string(),
+        name: "t".to_string(),
+        arguments: "{}".to_string(),
+        provider_executed: false,
+        dynamic: false,
+        provider_metadata: Default::default(),
+    })
+    .unwrap();
+    assert!(
+        call_false.get("dynamic").is_none(),
+        "false dynamic must be omitted: {call_false}"
+    );
+    // true → present on a ToolCall.
+    let call_true = serde_json::to_value(Content::ToolCall {
+        id: "c1".to_string(),
+        name: "t".to_string(),
+        arguments: "{}".to_string(),
+        provider_executed: true,
+        dynamic: true,
+        provider_metadata: Default::default(),
+    })
+    .unwrap();
+    assert_eq!(call_true["dynamic"], true);
+    // Defaulting back: a payload without `dynamic` deserializes to false.
+    let back: Content = serde_json::from_value(serde_json::json!({
+        "type": "tool_call",
+        "id": "c1",
+        "name": "t",
+        "arguments": "{}"
+    }))
+    .unwrap();
+    assert!(matches!(back, Content::ToolCall { dynamic: false, .. }));
+    // false → omitted on a ToolResult too.
+    let result_false = serde_json::to_value(Content::ToolResult {
+        call_id: "c1".to_string(),
+        tool_name: None,
+        output: ToolResultOutput::Text {
+            value: "x".to_string(),
+        },
+        dynamic: false,
+        provider_metadata: Default::default(),
+    })
+    .unwrap();
+    assert!(
+        result_false.get("dynamic").is_none(),
+        "false dynamic must be omitted on a result: {result_false}"
+    );
 }
 
 /// OpenAI Responses built-in tool output items parse as provider-executed tool
@@ -4528,6 +5021,7 @@ fn responses_render_request_drops_provider_executed_calls() {
                     name: "get_weather".to_string(),
                     arguments: "{}".to_string(),
                     provider_executed: false,
+                    dynamic: false,
                     provider_metadata: Default::default(),
                 },
                 Content::ToolCall {
@@ -4535,6 +5029,7 @@ fn responses_render_request_drops_provider_executed_calls() {
                     name: "web_search".to_string(),
                     arguments: "{}".to_string(),
                     provider_executed: true,
+                    dynamic: false,
                     provider_metadata: Default::default(),
                 },
             ],
@@ -4569,6 +5064,7 @@ fn responses_render_response_reproduces_server_tool_item() {
             name: "web_search".to_string(),
             arguments: "{}".to_string(),
             provider_executed: true,
+            dynamic: false,
             provider_metadata: Default::default(),
         }],
         usage: None,
@@ -4595,8 +5091,9 @@ fn responses_render_response_reproduces_server_tool_item() {
 /// `image_generation_call` and `computer_call` output items are parsed as
 /// provider-executed tool calls (no echoed input, matching the AI SDK), and they
 /// round-trip: `render_response` reproduces each as its native `<name>_call`
-/// item keyed by `id`. `local_shell_call` / `mcp_call` are deferred and not
-/// parsed (so they must NOT appear as tool calls), per the documented skip.
+/// item keyed by `id`. (`local_shell_call` / `mcp_call` now parse too — exercised
+/// by their dedicated round-trip tests — so this test no longer asserts they are
+/// dropped.)
 #[test]
 fn responses_parses_and_reproduces_image_and_computer_calls() {
     let adapter = adapter_for(ApiProtocol::Responses);
@@ -4605,10 +5102,7 @@ fn responses_parses_and_reproduces_image_and_computer_calls() {
         "status": "completed",
         "output": [
             { "type": "image_generation_call", "id": "ig_1", "result": "BASE64..." },
-            { "type": "computer_call", "id": "cu_1", "status": "completed" },
-            // deferred — must not surface as tool calls
-            { "type": "local_shell_call", "call_id": "ls_1", "action": {"command": ["ls"]} },
-            { "type": "mcp_call", "id": "mc_1", "name": "fetch", "arguments": "{}" }
+            { "type": "computer_call", "id": "cu_1", "status": "completed" }
         ]
     });
     let result = adapter.parse_response(body).unwrap();
@@ -4625,11 +5119,10 @@ fn responses_parses_and_reproduces_image_and_computer_calls() {
             _ => None,
         })
         .collect();
-    // Only the two (a)-mapped server tools are parsed; the deferred items drop.
     assert_eq!(
         calls,
         vec![("image_generation", true, "{}"), ("computer", true, "{}"),],
-        "image_generation_call/computer_call parse; local_shell_call/mcp_call defer"
+        "image_generation_call/computer_call parse as provider-executed server tools"
     );
 
     // Live, not dead: each parsed call is consumed by the reproduction site,
@@ -4663,6 +5156,7 @@ fn tool_call_provider_executed_omitted_when_false() {
         name: "t".to_string(),
         arguments: "{}".to_string(),
         provider_executed: false,
+        dynamic: false,
         provider_metadata: Default::default(),
     })
     .unwrap();
@@ -4675,6 +5169,7 @@ fn tool_call_provider_executed_omitted_when_false() {
         name: "t".to_string(),
         arguments: "{}".to_string(),
         provider_executed: true,
+        dynamic: false,
         provider_metadata: Default::default(),
     })
     .unwrap();

--- a/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
@@ -1592,6 +1592,504 @@ fn messages_stream_encoder_closes_block_on_kind_transition() {
     );
 }
 
+// ===== block-lifecycle markers (StreamPart::TextStart/TextEnd/ReasoningStart/
+// ReasoningEnd): the merged-block fix. =====
+
+/// Encode a canonical part stream through `protocol` and return every emitted
+/// SSE event as `(event_name, data_json)`. Shared by the block-marker tests.
+fn encode_stream_events(
+    protocol: ApiProtocol,
+    parts: &[StreamPart],
+) -> Vec<(String, serde_json::Value)> {
+    let adapter = adapter_for(protocol);
+    let mut encoder = adapter.stream_encoder("resp_m", "test-model");
+    let mut out = Vec::new();
+    for part in parts {
+        for frame in encoder.encode(part).unwrap() {
+            if let SseFrame::Event { event, data } = frame {
+                let json: serde_json::Value = serde_json::from_str(&data).unwrap();
+                out.push((event.unwrap_or_default(), json));
+            }
+        }
+    }
+    for frame in encoder.finish().unwrap() {
+        if let SseFrame::Event { event, data } = frame {
+            let json: serde_json::Value =
+                serde_json::from_str(&data).unwrap_or(serde_json::json!({}));
+            out.push((event.unwrap_or_default(), json));
+        }
+    }
+    out
+}
+
+/// Decode a sequence of SSE `(event_name, data_json)` through `protocol` into
+/// the canonical part stream. Shared by the round-trip tests.
+fn decode_stream(protocol: ApiProtocol, events: &[(&str, serde_json::Value)]) -> Vec<StreamPart> {
+    let adapter = adapter_for(protocol);
+    let mut decoder = adapter.stream_decoder();
+    let mut parts = Vec::new();
+    for (event, data) in events {
+        parts.extend(
+            decoder
+                .decode(&SseEvent {
+                    event: Some((*event).to_string()),
+                    data: data.to_string(),
+                })
+                .unwrap(),
+        );
+    }
+    parts.extend(decoder.finish().unwrap());
+    parts
+}
+
+/// A canonical stream of two *distinct* text blocks, each bracketed by its own
+/// start/end marker (what a block-framed upstream decoder now produces). The
+/// merged-block bug was that, without the markers, this collapsed to a flat
+/// `TextDelta,TextDelta` run that re-encoded into ONE block.
+fn two_text_blocks() -> Vec<StreamPart> {
+    vec![
+        StreamPart::TextStart { id: "0".into() },
+        StreamPart::TextDelta {
+            text: "first".into(),
+        },
+        StreamPart::TextEnd { id: "0".into() },
+        StreamPart::TextStart { id: "1".into() },
+        StreamPart::TextDelta {
+            text: "second".into(),
+        },
+        StreamPart::TextEnd { id: "1".into() },
+        StreamPart::Finish {
+            reason: FinishReason::Stop,
+        },
+    ]
+}
+
+#[test]
+fn anthropic_two_text_blocks_reencode_as_distinct_blocks_not_merged() {
+    // The merged-block fix on the Anthropic wire: two bracketed text blocks must
+    // re-encode as TWO `content_block_start`(type=text) + TWO
+    // `content_block_stop`, never a single merged block. Without the lifecycle
+    // markers both deltas land in one block.
+    let events = encode_stream_events(ApiProtocol::Messages, &two_text_blocks());
+    let text_starts = events
+        .iter()
+        .filter(|(name, data)| {
+            name == "content_block_start"
+                && data.pointer("/content_block/type").and_then(|t| t.as_str()) == Some("text")
+        })
+        .count();
+    let stops = events
+        .iter()
+        .filter(|(name, _)| name == "content_block_stop")
+        .count();
+    assert_eq!(
+        text_starts, 2,
+        "two distinct text blocks must open two text `content_block_start`s, not merge: {events:?}"
+    );
+    assert_eq!(stops, 2, "each opened block must close: {events:?}");
+    // The two blocks must carry distinct indices (not the same index reused).
+    let indices: Vec<u64> = events
+        .iter()
+        .filter(|(name, data)| {
+            name == "content_block_start"
+                && data.pointer("/content_block/type").and_then(|t| t.as_str()) == Some("text")
+        })
+        .filter_map(|(_, data)| data.get("index").and_then(|i| i.as_u64()))
+        .collect();
+    assert_eq!(indices.len(), 2);
+    assert_ne!(indices[0], indices[1], "blocks must use distinct indices");
+}
+
+#[test]
+fn responses_two_text_blocks_reencode_as_distinct_items_not_merged() {
+    // The merged-block fix on the Responses wire: two bracketed text blocks must
+    // re-encode as TWO `output_item.added`(type=message) + TWO
+    // `output_item.done`, each in its own `output_index` — never one merged
+    // message item (which would render the two upstream blocks as one).
+    let events = encode_stream_events(ApiProtocol::Responses, &two_text_blocks());
+    let message_added = events
+        .iter()
+        .filter(|(name, data)| {
+            name == "response.output_item.added"
+                && data.pointer("/item/type").and_then(|t| t.as_str()) == Some("message")
+        })
+        .count();
+    let message_done = events
+        .iter()
+        .filter(|(name, data)| {
+            name == "response.output_item.done"
+                && data.pointer("/item/type").and_then(|t| t.as_str()) == Some("message")
+        })
+        .count();
+    assert_eq!(
+        message_added, 2,
+        "two distinct text blocks must open two message items, not merge: {events:?}"
+    );
+    assert_eq!(message_done, 2, "each message item must close: {events:?}");
+    // Distinct `output_index` per item.
+    let indices: Vec<u64> = events
+        .iter()
+        .filter(|(name, data)| {
+            name == "response.output_item.added"
+                && data.pointer("/item/type").and_then(|t| t.as_str()) == Some("message")
+        })
+        .filter_map(|(_, data)| data.get("output_index").and_then(|i| i.as_u64()))
+        .collect();
+    assert_eq!(indices.len(), 2);
+    assert_ne!(
+        indices[0], indices[1],
+        "message items must use distinct output indices"
+    );
+    // The terminal `response.completed.output` must mirror both items.
+    let completed_output_len = events
+        .iter()
+        .rev()
+        .find(|(name, _)| name == "response.completed")
+        .and_then(|(_, data)| data.pointer("/response/output"))
+        .and_then(|o| o.as_array())
+        .map(|a| a.len())
+        .unwrap_or(0);
+    assert_eq!(
+        completed_output_len, 2,
+        "terminal envelope must replay both message items: {events:?}"
+    );
+}
+
+#[test]
+fn text_reasoning_text_reencodes_with_three_distinct_blocks() {
+    // text → reasoning → text, each bracketed, must re-encode as three distinct
+    // blocks with the right kinds on both block-framed wires — the canonical
+    // ordering (#416/#454-1) plus the merged-block fix together.
+    let parts = vec![
+        StreamPart::TextStart { id: "a".into() },
+        StreamPart::TextDelta {
+            text: "intro".into(),
+        },
+        StreamPart::TextEnd { id: "a".into() },
+        StreamPart::ReasoningStart { id: "b".into() },
+        StreamPart::ReasoningDelta {
+            text: "ponder".into(),
+        },
+        StreamPart::ReasoningEnd { id: "b".into() },
+        StreamPart::TextStart { id: "c".into() },
+        StreamPart::TextDelta {
+            text: "outro".into(),
+        },
+        StreamPart::TextEnd { id: "c".into() },
+        StreamPart::Finish {
+            reason: FinishReason::Stop,
+        },
+    ];
+
+    // Anthropic: 2 text blocks + 1 thinking block, 3 stops.
+    let anthropic = encode_stream_events(ApiProtocol::Messages, &parts);
+    let count_kind = |kind: &str| {
+        anthropic
+            .iter()
+            .filter(|(name, data)| {
+                name == "content_block_start"
+                    && data.pointer("/content_block/type").and_then(|t| t.as_str()) == Some(kind)
+            })
+            .count()
+    };
+    assert_eq!(count_kind("text"), 2, "two text blocks: {anthropic:?}");
+    assert_eq!(
+        count_kind("thinking"),
+        1,
+        "one thinking block: {anthropic:?}"
+    );
+    assert_eq!(
+        anthropic
+            .iter()
+            .filter(|(name, _)| name == "content_block_stop")
+            .count(),
+        3,
+        "three block stops: {anthropic:?}"
+    );
+
+    // Responses: 2 message items + 1 reasoning item.
+    let responses = encode_stream_events(ApiProtocol::Responses, &parts);
+    let count_item = |kind: &str| {
+        responses
+            .iter()
+            .filter(|(name, data)| {
+                name == "response.output_item.added"
+                    && data.pointer("/item/type").and_then(|t| t.as_str()) == Some(kind)
+            })
+            .count()
+    };
+    assert_eq!(count_item("message"), 2, "two message items: {responses:?}");
+    assert_eq!(
+        count_item("reasoning"),
+        1,
+        "one reasoning item: {responses:?}"
+    );
+}
+
+#[test]
+fn coarse_wires_drop_block_markers_and_emit_only_deltas() {
+    // Chat Completions and Generate Content frame no content blocks, so the
+    // block-lifecycle markers re-encode to NOTHING — a bare start/end emits zero
+    // SSE frames — while the text deltas pass through unaffected. This proves the
+    // coarse-vs-framed split: a block-framed upstream re-encoded to a coarse
+    // client simply drops the frames.
+    for protocol in [ApiProtocol::ChatCompletions, ApiProtocol::GenerateContent] {
+        let adapter = adapter_for(protocol.clone());
+        let mut encoder = adapter.stream_encoder("resp_c", "test-model");
+
+        // Each marker alone yields no frames.
+        for marker in [
+            StreamPart::TextStart { id: "0".into() },
+            StreamPart::TextEnd { id: "0".into() },
+            StreamPart::ReasoningStart { id: "1".into() },
+            StreamPart::ReasoningEnd { id: "1".into() },
+        ] {
+            assert!(
+                encoder.encode(&marker).unwrap().is_empty(),
+                "{protocol:?}: marker {marker:?} must emit no frames"
+            );
+        }
+
+        // The full two-block stream decodes back to exactly the two deltas,
+        // concatenated — the markers left no trace.
+        let events = encode_stream_events(protocol.clone(), &two_text_blocks());
+        let mut decoder = adapter.stream_decoder();
+        let mut decoded = Vec::new();
+        for (event, data) in &events {
+            decoded.extend(
+                decoder
+                    .decode(&SseEvent {
+                        event: Some(event.clone()),
+                        data: data.to_string(),
+                    })
+                    .unwrap(),
+            );
+        }
+        decoded.extend(decoder.finish().unwrap());
+        let text: String = decoded
+            .iter()
+            .filter_map(|p| match p {
+                StreamPart::TextDelta { text } => Some(text.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            text, "firstsecond",
+            "{protocol:?}: coarse text deltas survive unaffected"
+        );
+        assert!(
+            !decoded.iter().any(|p| matches!(
+                p,
+                StreamPart::TextStart { .. }
+                    | StreamPart::TextEnd { .. }
+                    | StreamPart::ReasoningStart { .. }
+                    | StreamPart::ReasoningEnd { .. }
+            )),
+            "{protocol:?}: coarse wire must not produce block markers: {decoded:?}"
+        );
+    }
+}
+
+#[test]
+fn block_markers_survive_anthropic_decode_then_reencode_roundtrip() {
+    // Full same-protocol round trip on Anthropic: real two-block upstream SSE
+    // decodes to a marker-bracketed canonical stream, which re-encodes back into
+    // two distinct content blocks. This is the end-to-end merged-block fix.
+    let upstream = [
+        (
+            "message_start",
+            serde_json::json!({ "type": "message_start", "message": { "id": "msg_1", "usage": { "input_tokens": 3 } } }),
+        ),
+        (
+            "content_block_start",
+            serde_json::json!({ "type": "content_block_start", "index": 0, "content_block": { "type": "text", "text": "" } }),
+        ),
+        (
+            "content_block_delta",
+            serde_json::json!({ "type": "content_block_delta", "index": 0, "delta": { "type": "text_delta", "text": "first" } }),
+        ),
+        (
+            "content_block_stop",
+            serde_json::json!({ "type": "content_block_stop", "index": 0 }),
+        ),
+        (
+            "content_block_start",
+            serde_json::json!({ "type": "content_block_start", "index": 1, "content_block": { "type": "text", "text": "" } }),
+        ),
+        (
+            "content_block_delta",
+            serde_json::json!({ "type": "content_block_delta", "index": 1, "delta": { "type": "text_delta", "text": "second" } }),
+        ),
+        (
+            "content_block_stop",
+            serde_json::json!({ "type": "content_block_stop", "index": 1 }),
+        ),
+        (
+            "message_delta",
+            serde_json::json!({ "type": "message_delta", "delta": { "stop_reason": "end_turn" }, "usage": { "output_tokens": 2 } }),
+        ),
+        (
+            "message_stop",
+            serde_json::json!({ "type": "message_stop" }),
+        ),
+    ];
+    let decoded = decode_stream(ApiProtocol::Messages, &upstream);
+    // The decoder must surface the two block boundaries as start/end markers.
+    assert_eq!(
+        decoded
+            .iter()
+            .filter(|p| matches!(p, StreamPart::TextStart { .. }))
+            .count(),
+        2,
+        "decode must emit two TextStart markers: {decoded:?}"
+    );
+    assert_eq!(
+        decoded
+            .iter()
+            .filter(|p| matches!(p, StreamPart::TextEnd { .. }))
+            .count(),
+        2,
+        "decode must emit two TextEnd markers: {decoded:?}"
+    );
+
+    // Re-encode and assert the two distinct blocks survive.
+    let reencoded = encode_stream_events(ApiProtocol::Messages, &decoded);
+    let text_starts = reencoded
+        .iter()
+        .filter(|(name, data)| {
+            name == "content_block_start"
+                && data.pointer("/content_block/type").and_then(|t| t.as_str()) == Some("text")
+        })
+        .count();
+    assert_eq!(
+        text_starts, 2,
+        "round trip must preserve two distinct text blocks: {reencoded:?}"
+    );
+}
+
+#[test]
+fn block_markers_survive_responses_decode_then_reencode_roundtrip() {
+    // Full same-protocol round trip on Responses: two real `message` items
+    // decode to marker-bracketed canonical parts and re-encode into two distinct
+    // message items.
+    let upstream = [
+        (
+            "response.created",
+            serde_json::json!({ "type": "response.created", "response": { "id": "resp_1" } }),
+        ),
+        (
+            "response.output_item.added",
+            serde_json::json!({ "type": "response.output_item.added", "output_index": 0, "item": { "type": "message", "id": "msg_a", "role": "assistant" } }),
+        ),
+        (
+            "response.output_text.delta",
+            serde_json::json!({ "type": "response.output_text.delta", "item_id": "msg_a", "output_index": 0, "delta": "first" }),
+        ),
+        (
+            "response.output_item.done",
+            serde_json::json!({ "type": "response.output_item.done", "output_index": 0, "item": { "type": "message", "id": "msg_a", "role": "assistant" } }),
+        ),
+        (
+            "response.output_item.added",
+            serde_json::json!({ "type": "response.output_item.added", "output_index": 1, "item": { "type": "message", "id": "msg_b", "role": "assistant" } }),
+        ),
+        (
+            "response.output_text.delta",
+            serde_json::json!({ "type": "response.output_text.delta", "item_id": "msg_b", "output_index": 1, "delta": "second" }),
+        ),
+        (
+            "response.output_item.done",
+            serde_json::json!({ "type": "response.output_item.done", "output_index": 1, "item": { "type": "message", "id": "msg_b", "role": "assistant" } }),
+        ),
+        (
+            "response.completed",
+            serde_json::json!({ "type": "response.completed", "response": { "id": "resp_1", "status": "completed" } }),
+        ),
+    ];
+    let decoded = decode_stream(ApiProtocol::Responses, &upstream);
+    assert_eq!(
+        decoded
+            .iter()
+            .filter(|p| matches!(p, StreamPart::TextStart { .. }))
+            .count(),
+        2,
+        "decode must emit two TextStart markers: {decoded:?}"
+    );
+    assert_eq!(
+        decoded
+            .iter()
+            .filter(|p| matches!(p, StreamPart::TextEnd { .. }))
+            .count(),
+        2,
+        "decode must emit two TextEnd markers: {decoded:?}"
+    );
+
+    let reencoded = encode_stream_events(ApiProtocol::Responses, &decoded);
+    let message_added = reencoded
+        .iter()
+        .filter(|(name, data)| {
+            name == "response.output_item.added"
+                && data.pointer("/item/type").and_then(|t| t.as_str()) == Some("message")
+        })
+        .count();
+    assert_eq!(
+        message_added, 2,
+        "round trip must preserve two distinct message items: {reencoded:?}"
+    );
+}
+
+#[test]
+fn tool_call_streaming_still_frames_distinctly_with_markers_present() {
+    // Regression guard: the markers must not disturb tool-call framing. A text
+    // block followed by two tool calls must still produce, on Responses, one
+    // message item + two distinct `function_call` items (each tool call in its
+    // own output slot) — tool blocks carry no start/end marker by design.
+    let parts = vec![
+        StreamPart::TextStart { id: "0".into() },
+        StreamPart::TextDelta {
+            text: "calling".into(),
+        },
+        StreamPart::TextEnd { id: "0".into() },
+        StreamPart::ToolCallDelta {
+            id: "call_a".into(),
+            name: Some("first".into()),
+            arguments: "{}".into(),
+        },
+        StreamPart::ToolCallDelta {
+            id: "call_b".into(),
+            name: Some("second".into()),
+            arguments: "{}".into(),
+        },
+        StreamPart::Finish {
+            reason: FinishReason::Stop,
+        },
+    ];
+    let events = encode_stream_events(ApiProtocol::Responses, &parts);
+    let function_added = events
+        .iter()
+        .filter(|(name, data)| {
+            name == "response.output_item.added"
+                && data.pointer("/item/type").and_then(|t| t.as_str()) == Some("function_call")
+        })
+        .count();
+    assert_eq!(
+        function_added, 2,
+        "two tool calls must open two function_call items: {events:?}"
+    );
+    // And exactly one message item from the single text block.
+    let message_added = events
+        .iter()
+        .filter(|(name, data)| {
+            name == "response.output_item.added"
+                && data.pointer("/item/type").and_then(|t| t.as_str()) == Some("message")
+        })
+        .count();
+    assert_eq!(
+        message_added, 1,
+        "one text block → one message item: {events:?}"
+    );
+}
+
 #[test]
 fn messages_stream_error_maps_to_proper_http_status() {
     // Messages mid-stream `error` events carry `error.type` — a 4xx must

--- a/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
@@ -5148,6 +5148,66 @@ fn generate_content_grounding_round_trip() {
     assert_eq!(sources_of(&reparsed.content), sources_of(&result.content));
 }
 
+/// Gemini SHOULD-FIX: grounding chunk kinds beyond `web` are mapped, not
+/// silently dropped. A `retrievedContext` chunk with an http(s) uri becomes a
+/// [`Source::Url`]; an `image` chunk maps via its `sourceUri`; a `maps` chunk
+/// with a `uri` becomes a URL; and a `gs://` `retrievedContext` becomes a
+/// [`Source::Document`] with the media type inferred from the path.
+#[test]
+fn generate_content_grounding_maps_all_chunk_kinds() {
+    let adapter = generate_content::GenerateContentAdapter;
+    let provider_resp = serde_json::json!({
+        "candidates": [{
+            "content": { "role": "model", "parts": [{ "text": "grounded" }] },
+            "groundingMetadata": {
+                "groundingChunks": [
+                    { "retrievedContext": { "uri": "https://example.invalid/rag", "title": "RAG" } },
+                    { "image": { "sourceUri": "https://example.invalid/page", "imageUri": "https://example.invalid/i.png", "title": "Img" } },
+                    { "maps": { "uri": "https://maps.example.invalid/p", "title": "Place" } },
+                    { "retrievedContext": { "uri": "gs://bucket/report.pdf", "title": "Report" } }
+                ]
+            },
+            "finishReason": "STOP"
+        }]
+    });
+    let result = adapter.parse_response(provider_resp).unwrap();
+    let sources = sources_of(&result.content);
+    assert_eq!(sources.len(), 4, "every grounding chunk kind is mapped");
+
+    // retrievedContext (http) -> Url
+    match sources[0] {
+        Source::Url { url, title, .. } => {
+            assert_eq!(url, "https://example.invalid/rag");
+            assert_eq!(title.as_deref(), Some("RAG"));
+        }
+        other => panic!("expected url source for retrievedContext(http), got {other:?}"),
+    }
+    // image -> Url keyed by sourceUri (not imageUri)
+    match sources[1] {
+        Source::Url { url, .. } => assert_eq!(url, "https://example.invalid/page"),
+        other => panic!("expected url source for image chunk, got {other:?}"),
+    }
+    // maps -> Url
+    match sources[2] {
+        Source::Url { url, .. } => assert_eq!(url, "https://maps.example.invalid/p"),
+        other => panic!("expected url source for maps chunk, got {other:?}"),
+    }
+    // retrievedContext (gs://) -> Document with inferred media type + filename
+    match sources[3] {
+        Source::Document {
+            media_type,
+            title,
+            filename,
+            ..
+        } => {
+            assert_eq!(media_type, "application/pdf");
+            assert_eq!(title, "Report");
+            assert_eq!(filename.as_deref(), Some("report.pdf"));
+        }
+        other => panic!("expected document source for retrievedContext(gs://), got {other:?}"),
+    }
+}
+
 /// Anthropic: both citation shapes — a text block's `citations[]`
 /// (`web_search_result_location`) and a `web_search_tool_result` block's
 /// `content[]` (`web_search_result`) — are lifted into `Content::Source` parts,
@@ -5219,6 +5279,193 @@ fn messages_citations_round_trip_both_shapes() {
     // Re-parse recovers all three sources (now all from the result block).
     let reparsed = adapter.parse_response(rendered).unwrap();
     assert_eq!(sources_of(&reparsed.content).len(), 3);
+}
+
+/// Anthropic MUST-FIX: a response carrying BOTH a `server_tool_use` and its
+/// `web_search_tool_result` renders a VALID paired wire — the originating call's
+/// real id is reused as the result block's `tool_use_id` (same-protocol reuse,
+/// no second `server_tool_use` is synthesized). A client echoing this assistant
+/// turn into a follow-up must not see an orphan call/result.
+#[test]
+fn messages_web_search_pair_reuses_real_id() {
+    let adapter = messages::MessagesAdapter;
+    // Upstream: a `server_tool_use` call followed by its result block.
+    let provider_resp = serde_json::json!({
+        "id": "msg_1",
+        "type": "message",
+        "role": "assistant",
+        "content": [
+            { "type": "server_tool_use", "id": "srvtoolu_real", "name": "web_search", "input": { "query": "q" } },
+            {
+                "type": "web_search_tool_result",
+                "tool_use_id": "srvtoolu_real",
+                "content": [
+                    { "type": "web_search_result", "url": "https://example.invalid/r1", "title": "R1" }
+                ]
+            }
+        ],
+        "stop_reason": "end_turn",
+        "usage": { "input_tokens": 1, "output_tokens": 1 }
+    });
+    let parsed = adapter.parse_response(provider_resp).unwrap();
+    let rendered = adapter
+        .render_response(&parsed, &sample_prompt(), "msg_1")
+        .unwrap();
+    let blocks = rendered["content"].as_array().unwrap();
+    // Exactly one `server_tool_use` (the real one) — no synthesized duplicate.
+    let server_calls: Vec<&serde_json::Value> = blocks
+        .iter()
+        .filter(|b| b["type"] == "server_tool_use")
+        .collect();
+    assert_eq!(
+        server_calls.len(),
+        1,
+        "no duplicate server_tool_use synthesized"
+    );
+    let call_id = server_calls[0]["id"].as_str().unwrap();
+    let result = blocks
+        .iter()
+        .find(|b| b["type"] == "web_search_tool_result")
+        .expect("a web_search_tool_result block was rendered");
+    // The pair correlates: the result's tool_use_id == the call's real id.
+    assert_eq!(call_id, "srvtoolu_real");
+    assert_eq!(
+        result["tool_use_id"].as_str().unwrap(),
+        call_id,
+        "result block reuses the originating server_tool_use id"
+    );
+}
+
+/// Anthropic MUST-FIX (mixed wire): when an inline-cited text block's `Source`
+/// precedes the `server_tool_use` in canonical order, the render must still
+/// reuse the REAL call id (not synthesize a second pair that would orphan the
+/// real `server_tool_use`). Exactly one `server_tool_use` is emitted and its id
+/// equals the single result block's `tool_use_id`.
+#[test]
+fn messages_web_search_pair_no_orphan_with_inline_citation() {
+    let adapter = messages::MessagesAdapter;
+    let provider_resp = serde_json::json!({
+        "id": "msg_1",
+        "type": "message",
+        "role": "assistant",
+        "content": [
+            {
+                "type": "text",
+                "text": "cited",
+                "citations": [{
+                    "type": "web_search_result_location",
+                    "url": "https://example.invalid/inline",
+                    "title": "Inline",
+                    "cited_text": "snippet",
+                    "encrypted_index": "abc"
+                }]
+            },
+            { "type": "server_tool_use", "id": "srvtoolu_real", "name": "web_search", "input": { "query": "q" } },
+            {
+                "type": "web_search_tool_result",
+                "tool_use_id": "srvtoolu_real",
+                "content": [
+                    { "type": "web_search_result", "url": "https://example.invalid/r1", "title": "R1" }
+                ]
+            }
+        ],
+        "stop_reason": "end_turn",
+        "usage": { "input_tokens": 1, "output_tokens": 1 }
+    });
+    let parsed = adapter.parse_response(provider_resp).unwrap();
+    let rendered = adapter
+        .render_response(&parsed, &sample_prompt(), "msg_1")
+        .unwrap();
+    let blocks = rendered["content"].as_array().unwrap();
+    // Exactly one server_tool_use (the real one): no synthesized duplicate, so
+    // no orphan call.
+    let server_calls: Vec<&serde_json::Value> = blocks
+        .iter()
+        .filter(|b| b["type"] == "server_tool_use")
+        .collect();
+    assert_eq!(
+        server_calls.len(),
+        1,
+        "no orphaned/duplicate server_tool_use"
+    );
+    assert_eq!(server_calls[0]["id"], "srvtoolu_real");
+    // Exactly one result block, pairing with the real call id; it carries every
+    // URL source (the inline one + the result hit).
+    let results: Vec<&serde_json::Value> = blocks
+        .iter()
+        .filter(|b| b["type"] == "web_search_tool_result")
+        .collect();
+    assert_eq!(
+        results.len(),
+        1,
+        "all sources collapse into one result block"
+    );
+    assert_eq!(results[0]["tool_use_id"], "srvtoolu_real");
+    assert_eq!(results[0]["content"].as_array().unwrap().len(), 2);
+}
+
+/// Anthropic MUST-FIX (cross-protocol): a Gemini grounding response rendered to
+/// an Anthropic client has no originating `server_tool_use`, so the render
+/// SYNTHESIZES a matching call block immediately before the
+/// `web_search_tool_result`. Both blocks must be present and share one id, so
+/// the emitted wire is a valid pair.
+#[test]
+fn messages_web_search_pair_synthesized_cross_protocol() {
+    let gemini = generate_content::GenerateContentAdapter;
+    let messages = messages::MessagesAdapter;
+    let gemini_resp = serde_json::json!({
+        "candidates": [{
+            "content": { "role": "model", "parts": [{ "text": "grounded" }] },
+            "groundingMetadata": {
+                "groundingChunks": [
+                    { "web": { "uri": "https://example.invalid/g", "title": "G" } }
+                ]
+            },
+            "finishReason": "STOP"
+        }]
+    });
+    // Gemini upstream -> canonical (a bare `Source`, no provider-executed call).
+    let canonical = gemini.parse_response(gemini_resp).unwrap();
+    assert_eq!(sources_of(&canonical.content).len(), 1);
+    assert!(
+        !canonical
+            .content
+            .iter()
+            .any(|c| matches!(c, Content::ToolCall { .. })),
+        "Gemini grounding carries no tool call"
+    );
+
+    // canonical -> Anthropic client response.
+    let rendered = messages
+        .render_response(&canonical, &sample_prompt(), "msg_1")
+        .unwrap();
+    let blocks = rendered["content"].as_array().unwrap();
+    let server_call = blocks
+        .iter()
+        .find(|b| b["type"] == "server_tool_use")
+        .expect("a server_tool_use block was synthesized");
+    let result = blocks
+        .iter()
+        .find(|b| b["type"] == "web_search_tool_result")
+        .expect("a web_search_tool_result block was rendered");
+    assert_eq!(server_call["name"], "web_search");
+    // The synthesized pair shares one id -> valid wire.
+    assert_eq!(
+        server_call["id"].as_str().unwrap(),
+        result["tool_use_id"].as_str().unwrap(),
+        "synthesized pair shares one tool_use_id"
+    );
+    // The synthesized call precedes its result block on the wire.
+    let call_pos = blocks.iter().position(|b| b["type"] == "server_tool_use");
+    let result_pos = blocks
+        .iter()
+        .position(|b| b["type"] == "web_search_tool_result");
+    assert!(call_pos < result_pos, "the call precedes its result block");
+
+    // The rendered wire re-parses cleanly: the synthesized call becomes a
+    // provider-executed tool call, the result block its source.
+    let reparsed = messages.parse_response(rendered).unwrap();
+    assert_eq!(sources_of(&reparsed.content).len(), 1);
 }
 
 /// Responses: an `output_text` part's `annotations[]` — a `url_citation` and a
@@ -5449,20 +5696,119 @@ fn messages_streams_and_reencodes_source() {
         other => panic!("expected url source, got {other:?}"),
     }
 
-    // Re-encode: the Messages encoder emits a `web_search_tool_result`
-    // content_block_start carrying the same hit.
+    // Re-encode: the Messages encoder buffers streamed citations and flushes
+    // them as one collapsed `server_tool_use` ↔ `web_search_tool_result` pair at
+    // terminal. The `Source` part alone emits no result block (it is buffered);
+    // the terminal `Finish` triggers the flush.
     let mut encoder = adapter.stream_encoder("msg_1", "m");
-    let frames = encoder.encode(&StreamPart::Source { source: src }).unwrap();
-    let has_block = frames.iter().any(|f| match f {
+    let buffered = encoder.encode(&StreamPart::Source { source: src }).unwrap();
+    assert!(
+        !buffered.iter().any(|f| match f {
+            SseFrame::Event { data, .. } => {
+                let v: serde_json::Value = serde_json::from_str(data).unwrap();
+                v["content_block"]["type"] == "web_search_tool_result"
+            }
+            _ => false,
+        }),
+        "the source is buffered, not emitted as its own block yet"
+    );
+    let frames = encoder
+        .encode(&StreamPart::Finish {
+            reason: FinishReason::Stop,
+        })
+        .unwrap();
+    // Collect the synthesized pair's blocks and assert the wire is a VALID pair:
+    // a `server_tool_use` and a `web_search_tool_result` sharing one id.
+    let server_tool_id = frames.iter().find_map(|f| match f {
         SseFrame::Event { data, .. } => {
             let v: serde_json::Value = serde_json::from_str(data).unwrap();
-            v["content_block"]["type"] == "web_search_tool_result"
-                && v["content_block"]["content"][0]["url"] == "https://example.invalid/s"
+            (v["content_block"]["type"] == "server_tool_use")
+                .then(|| v["content_block"]["id"].as_str().unwrap().to_string())
         }
-        _ => false,
+        _ => None,
     });
-    assert!(
-        has_block,
-        "encoder re-emitted the web_search_tool_result block"
+    let result_tool_use_id = frames.iter().find_map(|f| match f {
+        SseFrame::Event { data, .. } => {
+            let v: serde_json::Value = serde_json::from_str(data).unwrap();
+            (v["content_block"]["type"] == "web_search_tool_result"
+                && v["content_block"]["content"][0]["url"] == "https://example.invalid/s")
+                .then(|| {
+                    v["content_block"]["tool_use_id"]
+                        .as_str()
+                        .unwrap()
+                        .to_string()
+                })
+        }
+        _ => None,
+    });
+    let server_tool_id =
+        server_tool_id.expect("encoder emitted a synthesized server_tool_use block");
+    let result_tool_use_id =
+        result_tool_use_id.expect("encoder emitted the paired web_search_tool_result block");
+    assert_eq!(
+        server_tool_id, result_tool_use_id,
+        "the streamed pair shares one tool_use_id (valid wire)"
     );
+}
+
+/// Streaming, Responses SHOULD-FIX: a `response.output_text.annotation.added`
+/// event decodes to a `StreamPart::Source` (no longer dropped by the catch-all),
+/// and the Responses encoder re-emits it as the same annotation event — a live
+/// streamed-citation round-trip on the Responses wire.
+#[test]
+fn responses_streams_and_reencodes_annotation() {
+    let adapter = responses::ResponsesAdapter;
+    let mut decoder = adapter.stream_decoder();
+    let event = SseEvent {
+        event: Some("response.output_text.annotation.added".to_string()),
+        data: serde_json::json!({
+            "type": "response.output_text.annotation.added",
+            "item_id": "msg_1",
+            "output_index": 0,
+            "content_index": 0,
+            "annotation_index": 0,
+            "annotation": {
+                "type": "url_citation",
+                "url": "https://example.invalid/s",
+                "title": "S",
+                "start_index": 0,
+                "end_index": 5
+            }
+        })
+        .to_string(),
+    };
+    let parts = decoder.decode(&event).unwrap();
+    let src = parts
+        .iter()
+        .find_map(|p| match p {
+            StreamPart::Source { source } => Some(source.clone()),
+            _ => None,
+        })
+        .expect("decoded a StreamPart::Source from response.output_text.annotation.added");
+    match &src {
+        Source::Url { url, title, .. } => {
+            assert_eq!(url, "https://example.invalid/s");
+            assert_eq!(title.as_deref(), Some("S"));
+        }
+        other => panic!("expected url source, got {other:?}"),
+    }
+
+    // Re-encode the decoded source: it reappears as a
+    // `response.output_text.annotation.added` event with the same citation.
+    let mut encoder = adapter.stream_encoder("resp_1", "m");
+    let frames = encoder.encode(&StreamPart::Source { source: src }).unwrap();
+    let ann = frames
+        .iter()
+        .find_map(|f| match f {
+            SseFrame::Event { data, .. } => {
+                let v: serde_json::Value = serde_json::from_str(data).unwrap();
+                (v["type"] == "response.output_text.annotation.added")
+                    .then_some(v["annotation"].clone())
+            }
+            _ => None,
+        })
+        .expect("encoder re-emitted a response.output_text.annotation.added event");
+    assert_eq!(ann["type"], "url_citation");
+    assert_eq!(ann["url"], "https://example.invalid/s");
+    assert_eq!(ann["title"], "S");
 }

--- a/crates/bitrouter-sdk/src/language_model/stream.rs
+++ b/crates/bitrouter-sdk/src/language_model/stream.rs
@@ -86,6 +86,9 @@ impl StreamInterest {
             StreamPart::Usage { .. } => Self::USAGE,
             // No hook subscribes to file parts yet; they pass through unfiltered.
             StreamPart::File { .. } => 0,
+            // No hook subscribes to source (citation) parts; they pass through
+            // unfiltered, exactly like file parts.
+            StreamPart::Source { .. } => 0,
             StreamPart::ResponseStarted { .. } => Self::RESPONSE_STARTED,
             // `ResponseCompleted` is a terminal part — a hook interested in
             // `Finish` is, by construction, also interested in it.

--- a/crates/bitrouter-sdk/src/language_model/stream.rs
+++ b/crates/bitrouter-sdk/src/language_model/stream.rs
@@ -84,6 +84,8 @@ impl StreamInterest {
             StreamPart::ReasoningDelta { .. } => Self::REASONING_DELTA,
             StreamPart::ToolCallDelta { .. } => Self::TOOL_CALL_DELTA,
             StreamPart::Usage { .. } => Self::USAGE,
+            // No hook subscribes to file parts yet; they pass through unfiltered.
+            StreamPart::File { .. } => 0,
             StreamPart::ResponseStarted { .. } => Self::RESPONSE_STARTED,
             // `ResponseCompleted` is a terminal part — a hook interested in
             // `Finish` is, by construction, also interested in it.

--- a/crates/bitrouter-sdk/src/language_model/stream.rs
+++ b/crates/bitrouter-sdk/src/language_model/stream.rs
@@ -84,6 +84,14 @@ impl StreamInterest {
             StreamPart::ReasoningDelta { .. } => Self::REASONING_DELTA,
             StreamPart::ToolCallDelta { .. } => Self::TOOL_CALL_DELTA,
             StreamPart::Usage { .. } => Self::USAGE,
+            // Block-lifecycle markers carry no text and gate no hook — a hook
+            // interested in `TextDelta` / `ReasoningDelta` (e.g. the guardrail
+            // matcher) acts on the deltas themselves; the start/end frames pass
+            // through unfiltered so the framing is never disturbed.
+            StreamPart::TextStart { .. }
+            | StreamPart::TextEnd { .. }
+            | StreamPart::ReasoningStart { .. }
+            | StreamPart::ReasoningEnd { .. } => 0,
             // No hook subscribes to file parts yet; they pass through unfiltered.
             StreamPart::File { .. } => 0,
             // No hook subscribes to source (citation) parts; they pass through
@@ -436,6 +444,56 @@ mod tests {
         assert!(!StreamInterest::none().matches(&StreamPart::TextDelta {
             text: "x".to_string()
         }));
+        // Block-lifecycle markers gate no hook: never matched even by `all()`,
+        // so they pass through the hook chain unfiltered (the `=> 0` arm).
+        for marker in [
+            StreamPart::TextStart { id: "0".into() },
+            StreamPart::TextEnd { id: "0".into() },
+            StreamPart::ReasoningStart { id: "1".into() },
+            StreamPart::ReasoningEnd { id: "1".into() },
+        ] {
+            assert!(
+                !StreamInterest::all().matches(&marker),
+                "block markers are passthrough: {marker:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn block_markers_do_not_affect_disconnect_billing_estimate() {
+        // Disconnect-billing estimates output tokens from observed `TextDelta` /
+        // `ReasoningDelta` chars. The new block-lifecycle markers carry no text,
+        // so they must contribute zero — billing is unaffected by the boundary
+        // frames a block-framed stream now emits.
+        let mut acc = UsageAccumulator::default();
+        for marker in [
+            StreamPart::TextStart { id: "0".into() },
+            StreamPart::TextEnd { id: "0".into() },
+            StreamPart::ReasoningStart { id: "1".into() },
+            StreamPart::ReasoningEnd { id: "1".into() },
+        ] {
+            acc.observe(&marker);
+        }
+        assert_eq!(
+            acc.estimated_output_tokens(),
+            0,
+            "markers alone estimate zero output tokens"
+        );
+
+        // With real deltas interleaved, only the delta chars count toward the
+        // estimate — the markers add nothing on top.
+        let mut acc = UsageAccumulator::default();
+        for part in [
+            StreamPart::TextStart { id: "0".into() },
+            StreamPart::TextDelta {
+                text: "12345678".into(), // 8 chars
+            },
+            StreamPart::TextEnd { id: "0".into() },
+        ] {
+            acc.observe(&part);
+        }
+        // 8 chars / 4 chars-per-token = 2 tokens, same as if the markers were absent.
+        assert_eq!(acc.estimated_output_tokens(), 2);
     }
 
     #[test]

--- a/crates/bitrouter-sdk/src/language_model/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/tests.rs
@@ -329,11 +329,13 @@ async fn fallback_tries_next_on_5xx_then_succeeds() {
             MockResponse::Generate(GenerateResult {
                 content: vec![Content::Text {
                     text: "from b".into(),
+                    provider_metadata: Default::default(),
                 }],
                 usage: None,
                 finish_reason: Some(FinishReason::Stop),
                 response_id: None,
                 stop_details: None,
+                provider_metadata: Default::default(),
             }),
         ])),
         |_b| {},
@@ -343,7 +345,8 @@ async fn fallback_tries_next_on_5xx_then_succeeds() {
     assert_eq!(
         resp.result.content,
         vec![Content::Text {
-            text: "from b".into()
+            text: "from b".into(),
+            provider_metadata: Default::default(),
         }]
     );
 }
@@ -364,11 +367,13 @@ async fn fallback_tries_next_on_payment_required_then_succeeds() {
             MockResponse::Generate(GenerateResult {
                 content: vec![Content::Text {
                     text: "from account b".into(),
+                    provider_metadata: Default::default(),
                 }],
                 usage: None,
                 finish_reason: Some(FinishReason::Stop),
                 response_id: None,
                 stop_details: None,
+                provider_metadata: Default::default(),
             }),
         ])),
         |_b| {},
@@ -381,7 +386,8 @@ async fn fallback_tries_next_on_payment_required_then_succeeds() {
     assert_eq!(
         resp.result.content,
         vec![Content::Text {
-            text: "from account b".into()
+            text: "from account b".into(),
+            provider_metadata: Default::default(),
         }]
     );
 }
@@ -397,11 +403,15 @@ async fn fallback_does_not_retry_on_4xx() {
             }),
             // b would succeed, but a 400 must not fall through to it.
             MockResponse::Generate(GenerateResult {
-                content: vec![Content::Text { text: "b".into() }],
+                content: vec![Content::Text {
+                    text: "b".into(),
+                    provider_metadata: Default::default(),
+                }],
                 usage: None,
                 finish_reason: None,
                 response_id: None,
                 stop_details: None,
+                provider_metadata: Default::default(),
             }),
         ])),
         |_b| {},
@@ -451,11 +461,15 @@ async fn fallback_does_not_retry_on_4xx_even_with_observe_only_execution_hook() 
                 message: "bad".into(),
             }),
             MockResponse::Generate(GenerateResult {
-                content: vec![Content::Text { text: "b".into() }],
+                content: vec![Content::Text {
+                    text: "b".into(),
+                    provider_metadata: Default::default(),
+                }],
                 usage: None,
                 finish_reason: None,
                 response_id: None,
                 stop_details: None,
+                provider_metadata: Default::default(),
             }),
         ])),
         |b| {

--- a/crates/bitrouter-sdk/src/language_model/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/tests.rs
@@ -39,6 +39,7 @@ fn request() -> PipelineRequest {
     let prompt = Prompt {
         model: "test-model".to_string(),
         system: None,
+        system_provider_metadata: Default::default(),
         messages: vec![Message::text(Role::User, "hi")],
         tools: Vec::new(),
         params: GenerationParams::default(),
@@ -925,6 +926,7 @@ async fn executor_rejects_response_format_on_unsupported_outbound() {
     let prompt = Prompt {
         model: "m".into(),
         system: None,
+        system_provider_metadata: Default::default(),
         messages: vec![Message::text(Role::User, "hi")],
         tools: vec![],
         params: GenerationParams::default(),

--- a/crates/bitrouter-sdk/src/language_model/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/tests.rs
@@ -932,6 +932,7 @@ async fn executor_rejects_response_format_on_unsupported_outbound() {
         params: GenerationParams::default(),
         response_format: Some(ResponseFormat::JsonSchema {
             name: None,
+            description: None,
             strict: None,
             schema: serde_json::json!({"type": "object"}),
         }),

--- a/crates/bitrouter-sdk/src/language_model/types.rs
+++ b/crates/bitrouter-sdk/src/language_model/types.rs
@@ -19,7 +19,7 @@ use crate::caller::CallerContext;
 /// `providerOptions` and the output form is `providerMetadata`; both share this
 /// one wire shape, so the canonical IR carries a single `provider_metadata` slot
 /// in both directions.
-/// <https://github.com/vercel/ai/blob/main/packages/provider/src/shared/v3/shared-v3-provider-metadata.ts>
+/// <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/provider/src/shared/v3/shared-v3-provider-metadata.ts>
 ///
 /// A [`BTreeMap`] (not a `HashMap`) so serialization is deterministic — the same
 /// metadata always renders in the same key order, which keeps round-trip tests
@@ -201,7 +201,7 @@ pub enum Content {
     /// A media / file part — image, audio, video, or document. Modelled à la the
     /// Vercel AI SDK `LanguageModelV3File`: a single media-typed part rather than
     /// a per-modality variant, identified by its IANA `media_type`.
-    /// <https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v3/language-model-v3-file.ts>
+    /// <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/provider/src/language-model/v3/language-model-v3-file.ts>
     File {
         /// IANA media type, e.g. `image/png`, `audio/mpeg`, `application/pdf`.
         media_type: String,
@@ -222,7 +222,7 @@ pub enum Content {
     },
     /// A tool/function call requested by the model. Models the Vercel AI SDK
     /// `LanguageModelV3ToolCall` content part.
-    /// <https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v3/language-model-v3-tool-call.ts>
+    /// <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/provider/src/language-model/v3/language-model-v3-tool-call.ts>
     ToolCall {
         /// Provider-assigned call id.
         id: String,
@@ -240,7 +240,7 @@ pub enum Content {
         /// load-bearing: a provider-executed call must **not** be re-sent to the
         /// upstream as a client `function_call` on a follow-up turn (the
         /// provider already ran it), so render paths branch on this flag.
-        /// <https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v3/language-model-v3-tool-call.ts>
+        /// <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/provider/src/language-model/v3/language-model-v3-tool-call.ts>
         ///
         /// The sibling V3 `dynamic` flag (provider-executed MCP tools defined at
         /// runtime) is intentionally **not** modeled. It arises only from
@@ -269,7 +269,7 @@ pub enum Content {
     /// [`ToolResultOutput`] union (text / JSON / error / multimodal content)
     /// rather than a flat opaque string, so structure, the error flag, and
     /// multimodal results survive cross-protocol routing.
-    /// <https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v3/language-model-v3-prompt.ts>
+    /// <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/provider/src/language-model/v3/language-model-v3-prompt.ts>
     ToolResult {
         /// The call id this result answers.
         call_id: String,
@@ -303,7 +303,7 @@ pub enum Content {
     /// entries into these parts, and `render_response` re-attaches them to the
     /// provider's citation location. Sources never appear in a request, so
     /// request-side render paths skip this variant (documented at each site).
-    /// <https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v3/language-model-v3-source.ts>
+    /// <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/provider/src/language-model/v3/language-model-v3-source.ts>
     Source {
         /// The citation source (URL or document).
         source: Source,
@@ -322,16 +322,20 @@ pub enum Content {
     /// user approval before it runs; the matching [`Self::ToolApprovalResponse`]
     /// (keyed by [`approval_id`](Self::ToolApprovalRequest::approval_id)) carries
     /// the grant or denial back on the next turn.
-    /// <https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v3/language-model-v3-tool-approval-request.ts>
+    /// <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/provider/src/language-model/v3/language-model-v3-tool-approval-request.ts>
     ///
     /// The only wire that carries this handshake is OpenAI Responses, where it is
     /// the `mcp_approval_request` output item (`{id, type, server_label, name,
-    /// arguments}`). On parse, `approval_id` is the item's `approval_request_id`
-    /// (falling back to its `id`), and the MCP `server_label` / `name` /
-    /// `arguments` ride in `provider_metadata["openai"]` so the render reproduces
-    /// the exact `mcp_approval_request` item byte-for-byte. The other three wires
-    /// (Anthropic / Generate Content / Chat Completions) have no approval-request
-    /// item and skip this variant on render (documented at each site).
+    /// arguments, approval_request_id?}`). On parse, `approval_id` is the item's
+    /// `approval_request_id` (the correlation key, falling back to its `id`), and
+    /// the MCP `server_label` / `name` / `arguments` ride in
+    /// `provider_metadata["openai"]` so the render reproduces the exact
+    /// `mcp_approval_request` item byte-for-byte. When the item carried a raw `id`
+    /// *distinct* from that correlation key, the `id` is also preserved under
+    /// `provider_metadata["openai"]["itemId"]` and restored on render, so the
+    /// two-id form round-trips losslessly. The other three wires (Anthropic /
+    /// Generate Content / Chat Completions) have no approval-request item and skip
+    /// this variant on render (documented at each site).
     /// <https://platform.openai.com/docs/api-reference/responses/object>
     ToolApprovalRequest {
         /// Approval id, referenced by the subsequent
@@ -346,9 +350,10 @@ pub enum Content {
         tool_call_id: String,
         /// Per-part namespaced provider metadata. On a Responses
         /// `mcp_approval_request` this carries the MCP server identity under
-        /// `provider_metadata["openai"]` (`serverLabel` / `name` / `arguments`) so
-        /// the render restores the exact item; the canonical flat shape itself has
-        /// no MCP-server slot.
+        /// `provider_metadata["openai"]` (`serverLabel` / `name` / `arguments`),
+        /// plus the raw item `id` as `itemId` when it differed from `approval_id`,
+        /// so the render restores the exact item; the canonical flat shape itself
+        /// has no MCP-server slot.
         #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
         provider_metadata: ProviderMetadata,
     },
@@ -357,7 +362,7 @@ pub enum Content {
     /// client/tool layer (a `tool`-role input part) to grant or deny a
     /// provider-executed tool call that emitted a [`Self::ToolApprovalRequest`],
     /// keyed by the shared [`approval_id`](Self::ToolApprovalResponse::approval_id).
-    /// <https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v3/language-model-v3-prompt.ts>
+    /// <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/provider/src/language-model/v3/language-model-v3-prompt.ts>
     ///
     /// The only wire that carries it is OpenAI Responses, as the
     /// `mcp_approval_response` input item (`{type, approval_request_id,
@@ -396,7 +401,7 @@ pub enum Content {
 /// plain text, a JSON value, an error (text or JSON), or a multimodal content
 /// array. Adapters translate each variant to/from the upstream's native wire
 /// shape and degrade losslessly when a provider can't express a variant.
-/// <https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v3/language-model-v3-prompt.ts>
+/// <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/provider/src/language-model/v3/language-model-v3-prompt.ts>
 ///
 /// The V3 union's sixth member, `execution-denied`
 /// (`{ type: 'execution-denied', reason? }`), is modeled by
@@ -412,7 +417,7 @@ pub enum Content {
 /// (`reason ?? 'Tool call execution denied.'`) that re-parses as a [`Self::Text`].
 /// On the other three wires it likewise degrades to that string via
 /// [`Self::to_provider_string`].
-/// <https://github.com/vercel/ai/blob/main/packages/openai/src/responses/convert-to-openai-responses-input.ts>
+/// <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/openai/src/responses/convert-to-openai-responses-input.ts>
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ToolResultOutput {
@@ -449,7 +454,7 @@ pub enum ToolResultOutput {
     /// a denial paired with its approval is skipped on render (the
     /// `mcp_approval_response` conveys it); elsewhere it degrades to the reason
     /// string via [`Self::to_provider_string`].
-    /// <https://github.com/vercel/ai/blob/main/packages/openai/src/responses/convert-to-openai-responses-input.ts>
+    /// <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/openai/src/responses/convert-to-openai-responses-input.ts>
     ExecutionDenied {
         /// Optional human-readable denial reason. `None` falls back to the
         /// default denial string on render.
@@ -502,7 +507,7 @@ impl ToolResultOutput {
                 .collect(),
             // A denied execution collapses to its reason, or the AI SDK's default
             // denial sentinel when none was given.
-            // <https://github.com/vercel/ai/blob/main/packages/openai/src/responses/convert-to-openai-responses-input.ts>
+            // <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/openai/src/responses/convert-to-openai-responses-input.ts>
             Self::ExecutionDenied { reason } => reason
                 .clone()
                 .unwrap_or_else(|| "Tool call execution denied.".to_string()),
@@ -528,7 +533,7 @@ impl ToolResultOutput {
 ///   conversions likewise drop any unrecognised content part, so omitting it is
 ///   lossless for a faithful-passthrough router.
 ///
-/// <https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v3/language-model-v3-prompt.ts>
+/// <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/provider/src/language-model/v3/language-model-v3-prompt.ts>
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ToolResultContentPart {
@@ -629,7 +634,7 @@ impl DataContent {
 /// `groundingChunks`); an adapter's `parse_response` lifts those out into
 /// [`Content::Source`] parts, and `render_response` re-attaches them at the
 /// provider's native citation location (never per-part on a request).
-/// <https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v3/language-model-v3-source.ts>
+/// <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/provider/src/language-model/v3/language-model-v3-source.ts>
 ///
 /// V3 requires `id` on both variants, but providers rarely transmit a citation
 /// id (OpenAI / Gemini / Anthropic web-search results carry none). Adapters
@@ -703,7 +708,7 @@ impl Source {
 /// a sibling of `role`/`content` (which the Anthropic API rejects). Block-level
 /// [`Content`] metadata therefore covers every caching breakpoint, so a
 /// per-message slot would be unconstructed dead weight.
-/// <https://github.com/vercel/ai/blob/main/packages/anthropic/src/convert-to-anthropic-prompt.ts>
+/// <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts>
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Message {
     /// The speaker role.
@@ -727,8 +732,8 @@ impl Message {
 
 /// A tool the model may call — a faithful port of the Vercel AI SDK
 /// `LanguageModelV3FunctionTool | LanguageModelV3ProviderTool` union.
-/// <https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v3/language-model-v3-function-tool.ts>
-/// <https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v3/language-model-v3-provider-tool.ts>
+/// <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/provider/src/language-model/v3/language-model-v3-function-tool.ts>
+/// <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/provider/src/language-model/v3/language-model-v3-provider-tool.ts>
 ///
 /// Like [`ToolChoice`] and [`ResponseFormat`], each inbound adapter promotes a
 /// provider-native tool entry into this typed slot at parse time, and each
@@ -759,6 +764,15 @@ pub enum Tool {
     /// `parameters` is V3's `inputSchema` (a JSON Schema). `strict` is V3's
     /// top-level strict-mode flag — captured from the wire where present so it
     /// is not lost across the canonical boundary.
+    ///
+    /// The V3 `LanguageModelV3FunctionTool.inputExamples`
+    /// (`Array<{ input: JSONObject }>`) field has **no slot here, by design.**
+    /// None of the four provider *request* wires (Chat Completions / Messages /
+    /// Responses / Generate Content) carries per-tool input examples in its tool
+    /// definition, so no `parse_request` could construct it and no
+    /// `render_request` could emit it — an `input_examples` field would be both
+    /// unconstructed and unconsumed dead code. (Same documented-N/A reasoning as
+    /// the [`Content::ToolCall`] `dynamic` flag.)
     Function {
         /// Tool name. Unique within the request.
         name: String,
@@ -815,7 +829,7 @@ impl Tool {
 
 /// How the model must treat the available [`Tool`]s on this request — a faithful
 /// port of the Vercel AI SDK `LanguageModelV3ToolChoice` tagged union.
-/// <https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v3/language-model-v3-tool-choice.ts>
+/// <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/provider/src/language-model/v3/language-model-v3-tool-choice.ts>
 ///
 /// Each protocol expresses tool choice with a different wire shape (Chat
 /// Completions `"auto"|"none"|"required"` or `{type:"function",…}`; Anthropic
@@ -857,8 +871,15 @@ pub enum ToolChoice {
 
 /// Constraint on the shape of the model's response.
 ///
-/// Today the only variant is [`Self::JsonSchema`]; future variants (`json_object`,
-/// `text`, `regex`) can be added without breaking existing call sites.
+/// Mirrors the Vercel AI SDK V3 `responseFormat` call option. V3 has **no**
+/// standalone response-format type file — the shape is inlined on
+/// `LanguageModelV3CallOptions` as
+/// `responseFormat?: { type: 'text' } | { type: 'json', schema?, name?, description? }`.
+/// [`Self::JsonSchema`] is the `{ type: 'json' }` arm (carrying the optional
+/// `schema` / `name` / `description`); the `{ type: 'text' }` arm is the absence
+/// of a constraint here (a `None` [`Prompt::response_format`]), so it needs no
+/// variant. Future variants (`json_object`, `regex`) can be added without
+/// breaking existing call sites.
 ///
 /// Each inbound adapter promotes the provider-native field into this typed
 /// slot at `parse_request` time (e.g. Chat Completions' `response_format`,
@@ -867,6 +888,7 @@ pub enum ToolChoice {
 /// `render_request`. Cross-protocol routing therefore works automatically:
 /// a Chat Completions client asking for `json_schema` against a Messages upstream
 /// emits `output_config.format`.
+/// <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/provider/src/language-model/v3/language-model-v3-call-options.ts>
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ResponseFormat {
@@ -1140,22 +1162,42 @@ impl Prompt {
 /// Token usage counts. Counts use `0` (not `null`) for "known to be zero";
 /// missing usage is represented by `Option<Usage>` being `None` upstream.
 ///
-/// Field-level parity with the Vercel AI SDK V3 `LanguageModelV3Usage`
-/// (`inputTokens` / `outputTokens` / `totalTokens` / `reasoningTokens` /
-/// `cachedInputTokens`): [`prompt_tokens`](Self::prompt_tokens) is V3
-/// `inputTokens`, [`completion_tokens`](Self::completion_tokens) is
-/// `outputTokens`, [`reasoning_tokens`](Self::reasoning_tokens) is
-/// `reasoningTokens`, and [`cache_read_tokens`](Self::cache_read_tokens) is
-/// `cachedInputTokens`. V3's `totalTokens` is **not** a stored field here: it is
-/// purely `prompt_tokens + completion_tokens` ([`total`](Self::total)) in this
-/// model — the cache buckets are folded into `prompt_tokens` at parse time (see
-/// the Messages `parse_usage`), so the derived total already equals every
-/// provider's reported total. Storing a separate `total_tokens` would be a
-/// redundant field that could disagree with its own components, so it is
-/// intentionally omitted. [`cache_write_tokens`](Self::cache_write_tokens) has
-/// no V3 counterpart (V3 folds cache-write into `inputTokens`); bitrouter keeps
-/// it distinct so a billing layer can meter cache creation separately.
-/// <https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v3/language-model-v3-usage.ts>
+/// Token usage, carrying the same information as the Vercel AI SDK V3
+/// `LanguageModelV3Usage` in a **flat** shape suited to a router.
+///
+/// V3 itself models usage as a **nested** record —
+/// `inputTokens: { total, noCache, cacheRead, cacheWrite }`,
+/// `outputTokens: { total, text, reasoning }`, plus an optional `raw` blob.
+/// bitrouter is a faithful-passthrough router: it carries the upstream's wire
+/// counts and never has to hand a client back a `LanguageModelV3Usage` *object*,
+/// so a flat field set is the more convenient internal form. Every V3 number is
+/// either stored directly or derivable from the flat fields:
+///
+/// - V3 `inputTokens.total` → [`prompt_tokens`](Self::prompt_tokens). The cache
+///   buckets are *included* in this total (folded in at parse time — see the
+///   Messages `parse_usage`), matching V3's "total input" semantics.
+/// - V3 `inputTokens.cacheRead` → [`cache_read_tokens`](Self::cache_read_tokens),
+///   a subset of `prompt_tokens`.
+/// - V3 `inputTokens.cacheWrite` → [`cache_write_tokens`](Self::cache_write_tokens),
+///   a subset of `prompt_tokens`. (The earlier flat `Usage` had no cache-write
+///   slot; this field restores the V3 `cacheWrite` bucket so a billing layer can
+///   meter cache creation distinctly from cache reads.)
+/// - V3 `inputTokens.noCache` is **derivable**, not stored:
+///   `prompt_tokens - cache_read_tokens - cache_write_tokens`. Storing it too
+///   would be a redundant field that could disagree with its own components.
+/// - V3 `outputTokens.total` → [`completion_tokens`](Self::completion_tokens).
+/// - V3 `outputTokens.reasoning` → [`reasoning_tokens`](Self::reasoning_tokens),
+///   a subset of `completion_tokens`.
+/// - V3 `outputTokens.text` is **derivable**, not stored:
+///   `completion_tokens - reasoning_tokens`.
+///
+/// V3 carries no top-level `totalTokens`; the grand total is purely
+/// `prompt_tokens + completion_tokens` ([`total`](Self::total)) here, computed on
+/// demand rather than stored so it can never drift from its components. The V3
+/// `raw` provider blob is not retained on this struct — a raw provider field that
+/// lacks a canonical slot rides instead in
+/// [`GenerateResult::provider_metadata`](crate::language_model::GenerateResult).
+/// <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/provider/src/language-model/v3/language-model-v3-usage.ts>
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Usage {
     /// Prompt / input tokens.
@@ -1192,10 +1234,26 @@ impl Usage {
 
 /// Why generation stopped.
 ///
+/// The Vercel AI SDK V3 `LanguageModelV3FinishReason` is a record carrying
+/// **both** a `unified` enum (`stop` / `length` / `content-filter` /
+/// `tool-calls` / `error` / `other`) and the provider's `raw` finish-reason
+/// string. bitrouter splits the two: this enum *is* the V3 `unified` reason, and
+/// the `raw` string rides **out-of-band** in
+/// [`GenerateResult::provider_metadata`](GenerateResult)`["<provider>"]["rawFinishReason"]`.
+/// Carrying `raw` separately — and only when the unified mapping is lossy (when
+/// several native reasons collapse onto one variant, e.g. Anthropic
+/// `stop_sequence` and `end_turn` both → [`Self::Stop`]) — lets a same-protocol
+/// round-trip reproduce the exact native string while a cross-protocol route
+/// still has a portable unified reason; reasons that already map losslessly
+/// (e.g. Gemini `STOP`) store nothing. See
+/// [`GenerateResult::provider_metadata`](GenerateResult) for the full
+/// stash/restore contract.
+///
 /// `Other` and `Error` are escape valves: a finish reason the canonical set
-/// doesn't model (kept verbatim for observability), or a mid-stream upstream
-/// failure surfaced through the canonical IR rather than abruptly aborting
-/// the stream.
+/// doesn't model (kept verbatim for observability — the V3 `other` case), or a
+/// mid-stream upstream failure surfaced through the canonical IR rather than
+/// abruptly aborting the stream (the V3 `error` case).
+/// <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/provider/src/language-model/v3/language-model-v3-finish-reason.ts>
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum FinishReason {
@@ -1372,7 +1430,7 @@ pub enum StreamPart {
     /// boundaries survive a same-protocol round trip. The two coarse wires
     /// (Chat Completions / Generate Content) carry no block frame, so their
     /// decoders never emit it and their encoders treat it as a no-op.
-    /// <https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v3/language-model-v3-stream-part.ts>
+    /// <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/provider/src/language-model/v3/language-model-v3-stream-part.ts>
     TextStart {
         /// Upstream block id (Anthropic block index rendered as a string, or a
         /// Responses item id). Stable within one stream; used by a framing
@@ -1425,7 +1483,7 @@ pub enum StreamPart {
     /// A complete generated file (e.g. an image), emitted whole — matching the
     /// Vercel AI SDK `LanguageModelV3` stream `file` part, where files arrive as
     /// one part rather than chunked deltas.
-    /// <https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v3/language-model-v3-file.ts>
+    /// <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/provider/src/language-model/v3/language-model-v3-file.ts>
     File {
         /// IANA media type, e.g. `image/png`.
         media_type: String,
@@ -1437,7 +1495,7 @@ pub enum StreamPart {
     /// Gemini emits the candidate's `groundingChunks` per chunk and OpenAI Chat
     /// streams `delta.annotations`, both decoded here; the client-side encoders
     /// re-attach it to the protocol's native citation location.
-    /// <https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v3/language-model-v3-source.ts>
+    /// <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/provider/src/language-model/v3/language-model-v3-source.ts>
     Source {
         /// The citation source (URL or document).
         source: Source,

--- a/crates/bitrouter-sdk/src/language_model/types.rs
+++ b/crates/bitrouter-sdk/src/language_model/types.rs
@@ -642,13 +642,14 @@ impl DataContent {
 /// the response (see `synthesize_source_id` in each adapter) so the required
 /// field is always populated without inventing identity the wire never carried.
 ///
-/// The V3 per-source `providerMetadata` (e.g. Anthropic `cited_text` /
-/// `encrypted_index`, a document citation's page/char ranges) is intentionally
-/// **not** modeled here yet — it is deferred to the separate provider-metadata
-/// task that adds a metadata slot uniformly across the content parts. Its
-/// absence is why the text-to-source linkage (`cited_text` and char/page
-/// offsets) cannot cross faithfully today; that loss is inherent to the current
-/// parity target, not to any one adapter.
+/// The enclosing [`Content::Source`] part carries the uniform
+/// `provider_metadata` slot (the V3 `providerMetadata` mechanism), but the
+/// specific Anthropic citation sub-fields — `cited_text` / `encrypted_index`
+/// and a document citation's page/char ranges — are **not** lifted into it:
+/// they are never parsed or rendered. That is why the text-to-source linkage
+/// (`cited_text` and char/page offsets) cannot cross faithfully today; the loss
+/// is inherent to the current parity target (V3 `Source` carries only
+/// id/url/title/mediaType/filename), not to any one adapter.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "source_type", rename_all = "snake_case")]
 pub enum Source {

--- a/crates/bitrouter-sdk/src/language_model/types.rs
+++ b/crates/bitrouter-sdk/src/language_model/types.rs
@@ -6,9 +6,73 @@
 //! protocol-conversion surface (tool calls, reasoning variants, content blocks).
 
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use crate::caller::CallerContext;
+
+/// A uniform, namespaced metadata slot carried on every content part, message,
+/// tool, and result — a faithful port of the Vercel AI SDK V3
+/// `SharedV3ProviderMetadata` / `SharedV3ProviderOptions`
+/// (`Record<string, Record<string, JSONValue>>`): the outer map is keyed by a
+/// provider id (`"anthropic"`, `"openai"`, `"google"`, …) and the inner object
+/// holds that provider's metadata for the part. On the AI SDK the input form is
+/// `providerOptions` and the output form is `providerMetadata`; both share this
+/// one wire shape, so the canonical IR carries a single `provider_metadata` slot
+/// in both directions.
+/// <https://github.com/vercel/ai/blob/main/packages/provider/src/shared/v3/shared-v3-provider-metadata.ts>
+///
+/// A [`BTreeMap`] (not a `HashMap`) so serialization is deterministic — the same
+/// metadata always renders in the same key order, which keeps round-trip tests
+/// and request hashing stable.
+///
+/// **Namespacing is load-bearing for cross-protocol routing.** Each adapter
+/// reads and writes **only its own** provider id's entry (see
+/// [`PROVIDER_ID_ANTHROPIC`](crate::language_model::protocol) etc.) and leaves
+/// every other namespace untouched, so e.g. an Anthropic `cacheControl` hint
+/// survives verbatim under `provider_metadata["anthropic"]` even when the part
+/// is routed to an OpenAI upstream (which simply ignores a foreign namespace).
+pub type ProviderMetadata = BTreeMap<String, serde_json::Value>;
+
+/// Read a single provider namespace's metadata object out of a
+/// [`ProviderMetadata`] map — the `{key: JSONValue}` inner record an adapter
+/// owns. Returns `None` when the provider has no entry, so a render path can
+/// cheaply skip parts that carry nothing for it.
+pub(crate) fn provider_namespace<'a>(
+    meta: &'a ProviderMetadata,
+    provider_id: &str,
+) -> Option<&'a serde_json::Map<String, serde_json::Value>> {
+    meta.get(provider_id).and_then(|v| v.as_object())
+}
+
+/// Insert `value` under `key` within `provider_id`'s namespace in a
+/// [`ProviderMetadata`] map, creating the namespace object on first write. The
+/// single mutation primitive every adapter uses to lift a provider-native hint
+/// (Anthropic `cacheControl`, a reasoning `signature`, an OpenAI image `detail`,
+/// …) into the canonical slot without disturbing other providers' namespaces.
+pub(crate) fn set_provider_metadata(
+    meta: &mut ProviderMetadata,
+    provider_id: &str,
+    key: &str,
+    value: serde_json::Value,
+) {
+    match meta
+        .entry(provider_id.to_string())
+        .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()))
+        .as_object_mut()
+    {
+        Some(obj) => {
+            obj.insert(key.to_string(), value);
+        }
+        // The entry existed but was not a JSON object (only reachable from a
+        // hand-built canonical value); replace it with a fresh single-key
+        // object so the write is never silently lost.
+        None => {
+            let mut obj = serde_json::Map::new();
+            obj.insert(key.to_string(), value);
+            meta.insert(provider_id.to_string(), serde_json::Value::Object(obj));
+        }
+    }
+}
 
 /// The wire protocol an upstream provider speaks.
 ///
@@ -106,12 +170,29 @@ pub enum Content {
     Text {
         /// The text body.
         text: String,
+        /// Per-part namespaced provider metadata (V3 `providerMetadata` /
+        /// `providerOptions`). On a text block this carries e.g. Anthropic
+        /// `provider_metadata["anthropic"]["cacheControl"]` — the prompt-caching
+        /// `{"type":"ephemeral"}` breakpoint that marks where the prompt cache
+        /// boundary sits.
+        /// <https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching>
+        #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+        provider_metadata: ProviderMetadata,
     },
     /// Model reasoning / thinking content (kept distinct so it is never
     /// silently dropped — v0 #454-1 regression).
     Reasoning {
         /// The reasoning text.
         text: String,
+        /// Per-part namespaced provider metadata. Carries the reasoning trace's
+        /// cryptographic continuity tokens so multi-turn thinking round-trips:
+        /// Anthropic's thinking-block `signature` and the `redacted_thinking`
+        /// marker under `provider_metadata["anthropic"]`, and OpenAI/Gemini
+        /// reasoning continuity (`thoughtSignature` / encrypted reasoning) under
+        /// their own namespaces.
+        /// <https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking>
+        #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+        provider_metadata: ProviderMetadata,
     },
     /// A media / file part — image, audio, video, or document. Modelled à la the
     /// Vercel AI SDK `LanguageModelV3File`: a single media-typed part rather than
@@ -125,10 +206,15 @@ pub enum Content {
         /// Original filename, when the provider supplies or requires it.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         filename: Option<String>,
-        /// Provider-specific per-part fields preserved verbatim (e.g. an image
-        /// `detail` hint). Mirrors the AI SDK's per-part `providerMetadata`.
-        #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-        extra: HashMap<String, serde_json::Value>,
+        /// Per-part namespaced provider metadata (V3 `providerMetadata` /
+        /// `providerOptions`). Replaces the former ad-hoc `extra` map so there is
+        /// one metadata mechanism across every part: an OpenAI image `detail`
+        /// hint now rides at `provider_metadata["openai"]["detail"]`, and
+        /// Anthropic block-level `cacheControl` at
+        /// `provider_metadata["anthropic"]["cacheControl"]`.
+        /// <https://platform.openai.com/docs/guides/vision>
+        #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+        provider_metadata: ProviderMetadata,
     },
     /// A tool/function call requested by the model. Models the Vercel AI SDK
     /// `LanguageModelV3ToolCall` content part.
@@ -166,6 +252,13 @@ pub enum Content {
         /// <https://platform.claude.com/docs/en/agents-and-tools/mcp-connector>
         #[serde(default, skip_serializing_if = "std::ops::Not::not")]
         provider_executed: bool,
+        /// Per-part namespaced provider metadata. On a `tool_use` block this
+        /// carries the Anthropic block-level `cacheControl` breakpoint
+        /// (`provider_metadata["anthropic"]["cacheControl"]`) — prompt caching
+        /// applies to `tool_use` blocks just like text/image/document blocks.
+        /// <https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching>
+        #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+        provider_metadata: ProviderMetadata,
     },
     /// A tool/function result supplied back to the model. Models the Vercel AI
     /// SDK `LanguageModelV3ToolResultPart`: the result is a typed
@@ -191,6 +284,14 @@ pub enum Content {
         tool_name: Option<String>,
         /// The typed result body.
         output: ToolResultOutput,
+        /// Per-part namespaced provider metadata. On a `tool_result` block this
+        /// carries the Anthropic block-level `cacheControl` breakpoint
+        /// (`provider_metadata["anthropic"]["cacheControl"]`) — prompt caching
+        /// applies to `tool_result` blocks too, so a long tool output can mark a
+        /// cache boundary.
+        /// <https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching>
+        #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+        provider_metadata: ProviderMetadata,
     },
     /// A citation / grounding source attached to the model's reply — the V3
     /// `LanguageModelV3Source` content part. Response-side only: an adapter's
@@ -202,6 +303,14 @@ pub enum Content {
     Source {
         /// The citation source (URL or document).
         source: Source,
+        /// Per-part namespaced provider metadata. Carries the Anthropic
+        /// originating `tool_use_id` — the `server_tool_use` id that pairs with
+        /// the `web_search_tool_result` block this source came from — under
+        /// `provider_metadata["anthropic"]["toolUseId"]`, so the Anthropic render
+        /// restores the *exact* pairing id rather than reusing one by position.
+        /// <https://platform.claude.com/docs/en/agents-and-tools/tool-use/web-search-tool>
+        #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+        provider_metadata: ProviderMetadata,
     },
 }
 
@@ -489,6 +598,14 @@ pub struct Message {
     pub role: Role,
     /// Ordered content blocks.
     pub content: Vec<Content>,
+    /// Message-level namespaced provider metadata (V3 `providerMetadata` /
+    /// `providerOptions` on a prompt message). Anthropic also accepts
+    /// `cache_control` at the message level (not only per content block), so a
+    /// whole turn can mark a prompt-cache breakpoint; it rides here under
+    /// `provider_metadata["anthropic"]["cacheControl"]`.
+    /// <https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching>
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub provider_metadata: ProviderMetadata,
 }
 
 impl Message {
@@ -496,7 +613,11 @@ impl Message {
     pub fn text(role: Role, text: impl Into<String>) -> Self {
         Self {
             role,
-            content: vec![Content::Text { text: text.into() }],
+            content: vec![Content::Text {
+                text: text.into(),
+                provider_metadata: ProviderMetadata::new(),
+            }],
+            provider_metadata: ProviderMetadata::new(),
         }
     }
 }
@@ -547,6 +668,14 @@ pub enum Tool {
         /// and Gemini have no equivalent and drop it.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         strict: Option<bool>,
+        /// Per-part namespaced provider metadata. On a tool this carries the
+        /// Anthropic tool-level `cacheControl` breakpoint
+        /// (`provider_metadata["anthropic"]["cacheControl"]`) — placing
+        /// `cache_control` on the last tool definition caches the whole tools
+        /// array, a common prompt-caching pattern for large tool catalogs.
+        /// <https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching>
+        #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+        provider_metadata: ProviderMetadata,
     },
     /// A provider-defined (server-side) tool: `{id, name, args}`, mirroring V3's
     /// `LanguageModelV3ProviderTool`. `id` is provider-namespaced as
@@ -560,6 +689,13 @@ pub enum Tool {
         name: String,
         /// Provider-specific configuration arguments, preserved verbatim.
         args: serde_json::Value,
+        /// Per-part namespaced provider metadata. Carries the Anthropic
+        /// tool-level `cacheControl` breakpoint
+        /// (`provider_metadata["anthropic"]["cacheControl"]`) for a server tool,
+        /// mirroring [`Self::Function`].
+        /// <https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching>
+        #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+        provider_metadata: ProviderMetadata,
     },
 }
 
@@ -950,6 +1086,14 @@ pub struct GenerateResult {
     /// or responses that carry no detail.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stop_details: Option<StopDetails>,
+    /// Result-level namespaced provider metadata (V3 `providerMetadata` on the
+    /// generation result). Carries response-level provider nuances that have no
+    /// dedicated canonical field: OpenAI `system_fingerprint`
+    /// (`provider_metadata["openai"]["systemFingerprint"]`) and Gemini
+    /// `modelVersion` (`provider_metadata["google"]["modelVersion"]`).
+    /// <https://platform.openai.com/docs/api-reference/chat/object>
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub provider_metadata: ProviderMetadata,
 }
 
 /// One part of a streaming response, in canonical internal form. `StreamHook`
@@ -1246,6 +1390,7 @@ mod tests {
             description: None,
             parameters: serde_json::json!({ "type": "object" }),
             strict: None,
+            provider_metadata: Default::default(),
         }];
         assert_eq!(p.required_capabilities(), vec![Capability::Tools]);
     }
@@ -1270,6 +1415,7 @@ mod tests {
             description: None,
             parameters: serde_json::json!({}),
             strict: None,
+            provider_metadata: Default::default(),
         }];
         p.params.reasoning_effort = Some("low".to_string());
         let caps = p.required_capabilities();
@@ -1289,8 +1435,9 @@ mod tests {
                     data: "AAAA".to_string(),
                 },
                 filename: None,
-                extra: Default::default(),
+                provider_metadata: Default::default(),
             }],
+            provider_metadata: Default::default(),
         }];
         p
     }
@@ -1335,12 +1482,13 @@ mod tests {
                 url: "https://example.invalid/a.png".to_string(),
             },
             filename: None,
-            extra: Default::default(),
+            provider_metadata: Default::default(),
         };
         let mut p = bare_prompt();
         p.messages = vec![Message {
             role: Role::User,
             content: vec![img(), img()],
+            provider_metadata: Default::default(),
         }];
         assert_eq!(p.required_capabilities(), vec![Capability::ImageInput]);
     }
@@ -1364,7 +1512,7 @@ mod tests {
                 url: "https://example.invalid/y.png".to_string(),
             },
             filename: Some("y.png".to_string()),
-            extra: Default::default(),
+            provider_metadata: Default::default(),
         };
         let value = serde_json::to_value(&original).unwrap();
         assert_eq!(value["type"], "file");

--- a/crates/bitrouter-sdk/src/language_model/types.rs
+++ b/crates/bitrouter-sdk/src/language_model/types.rs
@@ -139,12 +139,122 @@ pub enum Content {
         /// JSON-encoded arguments.
         arguments: String,
     },
-    /// A tool/function result supplied back to the model.
+    /// A tool/function result supplied back to the model. Models the Vercel AI
+    /// SDK `LanguageModelV3ToolResultPart`: the result is a typed
+    /// [`ToolResultOutput`] union (text / JSON / error / multimodal content)
+    /// rather than a flat opaque string, so structure, the error flag, and
+    /// multimodal results survive cross-protocol routing.
+    /// <https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v3/language-model-v3-prompt.ts>
     ToolResult {
         /// The call id this result answers.
         call_id: String,
-        /// Result body. May itself be structured (v0 #364).
-        content: String,
+        /// The tool's name, when the wire carries it. Anthropic / OpenAI tool
+        /// results key only by call id and leave this `None`; Gemini's
+        /// `functionResponse` keys by name and populates it.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        tool_name: Option<String>,
+        /// The typed result body.
+        output: ToolResultOutput,
+    },
+}
+
+/// The result body of a [`Content::ToolResult`]. A faithful port of the Vercel
+/// AI SDK `LanguageModelV3ToolResultOutput` tagged union: a tool result can be
+/// plain text, a JSON value, an error (text or JSON), or a multimodal content
+/// array. Adapters translate each variant to/from the upstream's native wire
+/// shape and degrade losslessly when a provider can't express a variant.
+/// <https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v3/language-model-v3-prompt.ts>
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ToolResultOutput {
+    /// Plain-text output sent directly to the model.
+    Text {
+        /// The text body.
+        value: String,
+    },
+    /// A structured JSON result.
+    Json {
+        /// The JSON value.
+        value: serde_json::Value,
+    },
+    /// A textual error message (the V3 `error-text` output).
+    ErrorText {
+        /// The error text.
+        value: String,
+    },
+    /// A structured JSON error (the V3 `error-json` output).
+    ErrorJson {
+        /// The error value.
+        value: serde_json::Value,
+    },
+    /// A multimodal result: an ordered array of text / media parts.
+    Content {
+        /// The ordered content parts.
+        value: Vec<ToolResultContentPart>,
+    },
+}
+
+impl ToolResultOutput {
+    /// Parse a provider tool-result body that carries no error flag and no
+    /// typed shape (OpenAI Chat Completions `tool` content / Responses
+    /// `function_call_output.output`). A JSON string maps to [`Self::Text`];
+    /// any other JSON value (object, array, number, …) maps to [`Self::Json`],
+    /// preserving structure the flat-string IR used to lose.
+    pub fn from_untyped_value(value: &serde_json::Value) -> Self {
+        match value {
+            serde_json::Value::String(s) => Self::Text { value: s.clone() },
+            other => Self::Json {
+                value: other.clone(),
+            },
+        }
+    }
+
+    /// Whether this output represents an error (the V3 `error-text` /
+    /// `error-json` outputs). Lets an adapter set a provider's native error flag
+    /// (e.g. Anthropic's `tool_result.is_error`).
+    pub fn is_error(&self) -> bool {
+        matches!(self, Self::ErrorText { .. } | Self::ErrorJson { .. })
+    }
+
+    /// Collapse this output to a single string for providers whose tool-result
+    /// field is string-only (OpenAI Chat Completions / Responses). `Text` /
+    /// `ErrorText` pass through verbatim; `Json` / `ErrorJson` stringify their
+    /// value; `Content` concatenates its text parts (media parts have no string
+    /// form on these wires and are dropped).
+    pub fn to_provider_string(&self) -> String {
+        match self {
+            Self::Text { value } | Self::ErrorText { value } => value.clone(),
+            Self::Json { value } | Self::ErrorJson { value } => value.to_string(),
+            Self::Content { value } => value
+                .iter()
+                .filter_map(|p| match p {
+                    ToolResultContentPart::Text { text } => Some(text.as_str()),
+                    ToolResultContentPart::Media { .. } => None,
+                })
+                .collect(),
+        }
+    }
+}
+
+/// One part of a [`ToolResultOutput::Content`] multimodal tool result. Mirrors
+/// the V3 `content` output's element union, reduced to the two payload forms a
+/// faithful-passthrough router carries: inline/URL media (via the shared
+/// [`DataContent`]) and text.
+/// <https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v3/language-model-v3-prompt.ts>
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ToolResultContentPart {
+    /// A text fragment.
+    Text {
+        /// The text body.
+        text: String,
+    },
+    /// A media fragment — image, audio, etc., keyed by IANA media type.
+    Media {
+        /// IANA media type, e.g. `image/png`.
+        media_type: String,
+        /// The payload — inline base64 bytes or a URL.
+        data: DataContent,
     },
 }
 

--- a/crates/bitrouter-sdk/src/language_model/types.rs
+++ b/crates/bitrouter-sdk/src/language_model/types.rs
@@ -1016,6 +1016,34 @@ pub struct GenerationParams {
     /// protocols instead of leaking a raw provider-shaped value through `extra`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tool_choice: Option<ToolChoice>,
+    /// Top-k sampling cutoff. Carried by Anthropic (`top_k`) and Gemini
+    /// (`generationConfig.topK`); Chat Completions and Responses have no such
+    /// wire field and never render it. Like every typed sampling slot below,
+    /// each inbound adapter promotes its native field here and removes it from
+    /// `extra`; each outbound adapter renders it into the target's native shape,
+    /// so it translates across protocols instead of no-op'ing through `extra`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub top_k: Option<u32>,
+    /// Deterministic-sampling seed. Carried by Chat Completions (`seed`) and
+    /// Gemini (`generationConfig.seed`); Anthropic and Responses have no wire
+    /// field for it. `i64` matches the JSON integer range these wires accept.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub seed: Option<i64>,
+    /// Stop sequences — generation halts when any is produced. Empty means none.
+    /// Renders as Chat Completions `stop`, Anthropic `stop_sequences`, and Gemini
+    /// `generationConfig.stopSequences`; Responses has no wire field for it.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub stop: Vec<String>,
+    /// Presence penalty. Carried by Chat Completions (`presence_penalty`) and
+    /// Gemini (`generationConfig.presencePenalty`); Anthropic and Responses have
+    /// no wire field for it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub presence_penalty: Option<f64>,
+    /// Frequency penalty. Carried by Chat Completions (`frequency_penalty`) and
+    /// Gemini (`generationConfig.frequencyPenalty`); Anthropic and Responses have
+    /// no wire field for it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub frequency_penalty: Option<f64>,
     /// Any provider-specific extras passed through untouched.
     #[serde(skip_serializing_if = "HashMap::is_empty", default)]
     pub extra: HashMap<String, serde_json::Value>,

--- a/crates/bitrouter-sdk/src/language_model/types.rs
+++ b/crates/bitrouter-sdk/src/language_model/types.rs
@@ -148,9 +148,17 @@ pub enum Content {
     ToolResult {
         /// The call id this result answers.
         call_id: String,
-        /// The tool's name, when the wire carries it. Anthropic / OpenAI tool
-        /// results key only by call id and leave this `None`; Gemini's
-        /// `functionResponse` keys by name and populates it.
+        /// The tool's name, when the wire carries it. The V3 type makes this a
+        /// required `string`, but that is faithful only to Gemini, whose
+        /// `functionResponse` keys results by name. The OpenAI (Chat Completions
+        /// and Responses) and Anthropic tool-result wires key purely by call id
+        /// and never transmit the name, so it is genuinely absent there —
+        /// modeling it as `Option` records that absence honestly. Fabricating a
+        /// placeholder name to satisfy a required field would be worse: it would
+        /// invent data the wire never carried and could collide with a real tool
+        /// name on a downstream re-render. `None` is the correct value when the
+        /// provider omits it; the field round-trips only where the wire supplies
+        /// it (Gemini).
         #[serde(default, skip_serializing_if = "Option::is_none")]
         tool_name: Option<String>,
         /// The typed result body.
@@ -164,6 +172,19 @@ pub enum Content {
 /// array. Adapters translate each variant to/from the upstream's native wire
 /// shape and degrade losslessly when a provider can't express a variant.
 /// <https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v3/language-model-v3-prompt.ts>
+///
+/// The V3 union has a sixth member, `execution-denied`
+/// (`{ type: 'execution-denied', reason? }`), that is intentionally **not**
+/// modeled here. It carries no distinct tag on any of the four request wires:
+/// the OpenAI Responses input conversion renders it as a plain
+/// `function_call_output.output` string (`reason ?? 'Tool call execution
+/// denied.'`) that re-parses indistinguishably from a [`Self::Text`], and its
+/// structured form arises only from the human-in-the-loop tool-approval flow
+/// (`tool-approval-request` / `tool-approval-response`), which this SDK does not
+/// yet implement. When that flow lands it will reintroduce the denial as part of
+/// the approval types rather than as a free-standing tool-result variant, so
+/// adding it now would be unconstructed dead code.
+/// <https://github.com/vercel/ai/blob/main/packages/openai/src/responses/convert-to-openai-responses-input.ts>
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ToolResultOutput {
@@ -229,7 +250,11 @@ impl ToolResultOutput {
                 .iter()
                 .filter_map(|p| match p {
                     ToolResultContentPart::Text { text } => Some(text.as_str()),
-                    ToolResultContentPart::Media { .. } => None,
+                    // Media bytes and provider file references have no string form
+                    // on a string-only tool wire; both drop out of the collapse.
+                    ToolResultContentPart::Media { .. } | ToolResultContentPart::FileId { .. } => {
+                        None
+                    }
                 })
                 .collect(),
         }
@@ -237,9 +262,23 @@ impl ToolResultOutput {
 }
 
 /// One part of a [`ToolResultOutput::Content`] multimodal tool result. Mirrors
-/// the V3 `content` output's element union, reduced to the two payload forms a
-/// faithful-passthrough router carries: inline/URL media (via the shared
-/// [`DataContent`]) and text.
+/// the V3 `content` output's element union. That union names eight element kinds
+/// (`text`, `file-data`, `file-url`, `file-id`, `image-data`, `image-url`,
+/// `image-file-id`, `custom`); they collapse onto the payload forms a
+/// faithful-passthrough router actually carries:
+/// - `text` → [`Self::Text`].
+/// - `file-data` / `file-url` / `image-data` / `image-url` → [`Self::Media`],
+///   whose [`DataContent`] holds inline base64 bytes or a URL (the data/URL split
+///   absorbs the `*-data` vs `*-url` distinction; the IANA `media_type` absorbs
+///   the file-vs-image distinction).
+/// - `file-id` / `image-file-id` → [`Self::FileId`], a provider-side uploaded-file
+///   reference (e.g. an OpenAI `file_id`) carried instead of inline bytes/URL.
+/// - `custom` (`{ type: 'custom', providerOptions? }`) is dropped: it has no
+///   transportable payload of its own — only opaque, provider-scoped
+///   `providerOptions` with no cross-provider meaning — and the reference
+///   conversions likewise drop any unrecognised content part, so omitting it is
+///   lossless for a faithful-passthrough router.
+///
 /// <https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v3/language-model-v3-prompt.ts>
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -255,6 +294,21 @@ pub enum ToolResultContentPart {
         media_type: String,
         /// The payload — inline base64 bytes or a URL.
         data: DataContent,
+    },
+    /// A provider-side uploaded-file reference (the V3 `file-id` /
+    /// `image-file-id` content kinds): the bytes live with the provider and the
+    /// tool result carries only the opaque id. On the OpenAI Responses wire this
+    /// is an `input_image` / `input_file` part whose payload is `file_id` rather
+    /// than `image_url` / `file_data`.
+    /// <https://platform.openai.com/docs/api-reference/responses/input-item-list>
+    FileId {
+        /// IANA media type when known. Selects the image-vs-file rendering
+        /// (`image/*` → `input_image`, otherwise `input_file`); `None` when the
+        /// wire part gives no type hint.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        media_type: Option<String>,
+        /// The provider's file identifier.
+        id: String,
     },
 }
 

--- a/crates/bitrouter-sdk/src/language_model/types.rs
+++ b/crates/bitrouter-sdk/src/language_model/types.rs
@@ -185,11 +185,15 @@ pub enum Content {
         /// The reasoning text.
         text: String,
         /// Per-part namespaced provider metadata. Carries the reasoning trace's
-        /// cryptographic continuity tokens so multi-turn thinking round-trips:
-        /// Anthropic's thinking-block `signature` and the `redacted_thinking`
-        /// marker under `provider_metadata["anthropic"]`, and OpenAI/Gemini
-        /// reasoning continuity (`thoughtSignature` / encrypted reasoning) under
-        /// their own namespaces.
+        /// cryptographic continuity tokens so a multi-turn thinking conversation
+        /// round-trips: Anthropic's thinking-block `signature` and the
+        /// `redacted_thinking` marker under `provider_metadata["anthropic"]`, and
+        /// Gemini's `thoughtSignature` under `provider_metadata["google"]`.
+        ///
+        /// The OpenAI Responses reasoning parse does **not** populate this slot:
+        /// it lifts only the visible summary text and writes empty metadata, so
+        /// OpenAI's `encrypted_content` reasoning continuity is not yet captured
+        /// here (capturing it is future work, not an implied guarantee).
         /// <https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking>
         #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
         provider_metadata: ProviderMetadata,
@@ -592,20 +596,23 @@ impl Source {
 }
 
 /// A single message in the conversation.
+///
+/// There is intentionally **no** message-level `provider_metadata` slot: no
+/// request wire carries metadata on a message *separate from its content
+/// blocks*. Anthropic prompt caching is expressed per content block (text /
+/// image / document / `tool_use` / `tool_result`), and message-level
+/// `cache_control` is not a distinct wire field — the Vercel AI SDK folds a
+/// message's `cacheControl` onto its **last** content block rather than emitting
+/// a sibling of `role`/`content` (which the Anthropic API rejects). Block-level
+/// [`Content`] metadata therefore covers every caching breakpoint, so a
+/// per-message slot would be unconstructed dead weight.
+/// <https://github.com/vercel/ai/blob/main/packages/anthropic/src/convert-to-anthropic-prompt.ts>
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Message {
     /// The speaker role.
     pub role: Role,
     /// Ordered content blocks.
     pub content: Vec<Content>,
-    /// Message-level namespaced provider metadata (V3 `providerMetadata` /
-    /// `providerOptions` on a prompt message). Anthropic also accepts
-    /// `cache_control` at the message level (not only per content block), so a
-    /// whole turn can mark a prompt-cache breakpoint; it rides here under
-    /// `provider_metadata["anthropic"]["cacheControl"]`.
-    /// <https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching>
-    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub provider_metadata: ProviderMetadata,
 }
 
 impl Message {
@@ -617,7 +624,6 @@ impl Message {
                 text: text.into(),
                 provider_metadata: ProviderMetadata::new(),
             }],
-            provider_metadata: ProviderMetadata::new(),
         }
     }
 }
@@ -917,6 +923,21 @@ pub struct Prompt {
     /// providers (Anthropic) carry it out-of-band.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub system: Option<String>,
+    /// Namespaced provider metadata for the system instruction (V3
+    /// `providerOptions` on the system message). Kept parallel to [`Self::system`]
+    /// — rather than folded into a `SystemPrompt` shape — so the common
+    /// `system: Option<String>` reads stay untouched across every adapter.
+    ///
+    /// Its load-bearing use is Anthropic system-prompt **prompt caching**: a
+    /// system block may carry `cache_control` (`{"type":"ephemeral"}`), and the
+    /// system prefix is the highest-value, most common cache breakpoint. It rides
+    /// here under `system_provider_metadata["anthropic"]["cacheControl"]` so the
+    /// Messages adapter can re-render the system as a cached
+    /// `[{type:"text", text, cache_control}]` block instead of a bare string,
+    /// which a plain `Option<String>` would otherwise flatten away.
+    /// <https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching>
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub system_provider_metadata: ProviderMetadata,
     /// Conversation messages, in order.
     pub messages: Vec<Message>,
     /// Tools available to the model.
@@ -1355,6 +1376,7 @@ mod tests {
         Prompt {
             model: "m".into(),
             system: None,
+            system_provider_metadata: Default::default(),
             messages: vec![],
             tools: vec![],
             params: GenerationParams::default(),
@@ -1437,7 +1459,6 @@ mod tests {
                 filename: None,
                 provider_metadata: Default::default(),
             }],
-            provider_metadata: Default::default(),
         }];
         p
     }
@@ -1488,7 +1509,6 @@ mod tests {
         p.messages = vec![Message {
             role: Role::User,
             content: vec![img(), img()],
-            provider_metadata: Default::default(),
         }];
         assert_eq!(p.required_capabilities(), vec![Capability::ImageInput]);
     }

--- a/crates/bitrouter-sdk/src/language_model/types.rs
+++ b/crates/bitrouter-sdk/src/language_model/types.rs
@@ -592,6 +592,16 @@ pub enum StreamPart {
         /// Arguments fragment.
         arguments: String,
     },
+    /// A complete generated file (e.g. an image), emitted whole — matching the
+    /// Vercel AI SDK `LanguageModelV3` stream `file` part, where files arrive as
+    /// one part rather than chunked deltas.
+    /// <https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v3/language-model-v3-file.ts>
+    File {
+        /// IANA media type, e.g. `image/png`.
+        media_type: String,
+        /// The file payload — inline base64 bytes or a URL.
+        data: DataContent,
+    },
     /// A usage report. May arrive mid-stream (per-checkpoint) or only at the end.
     Usage {
         /// The usage counts.

--- a/crates/bitrouter-sdk/src/language_model/types.rs
+++ b/crates/bitrouter-sdk/src/language_model/types.rs
@@ -192,6 +192,17 @@ pub enum Content {
         /// The typed result body.
         output: ToolResultOutput,
     },
+    /// A citation / grounding source attached to the model's reply — the V3
+    /// `LanguageModelV3Source` content part. Response-side only: an adapter's
+    /// `parse_response` lifts a provider's native citation/annotation/grounding
+    /// entries into these parts, and `render_response` re-attaches them to the
+    /// provider's citation location. Sources never appear in a request, so
+    /// request-side render paths skip this variant (documented at each site).
+    /// <https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v3/language-model-v3-source.ts>
+    Source {
+        /// The citation source (URL or document).
+        source: Source,
+    },
 }
 
 /// The result body of a [`Content::ToolResult`]. A faithful port of the Vercel
@@ -396,6 +407,78 @@ impl DataContent {
                 url: value.to_string(),
             },
         )
+    }
+}
+
+/// A citation / grounding source attached to the model's reply — a faithful
+/// port of the Vercel AI SDK `LanguageModelV3Source` tagged union. A source is
+/// **response-side metadata**: unlike text or media it is never a free-standing
+/// part on any request wire. Providers carry it as message/response
+/// *annotations* (OpenAI `url_citation`), text-block *citations* / a
+/// `web_search_tool_result` block (Anthropic), or *grounding* metadata (Gemini
+/// `groundingChunks`); an adapter's `parse_response` lifts those out into
+/// [`Content::Source`] parts, and `render_response` re-attaches them at the
+/// provider's native citation location (never per-part on a request).
+/// <https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v3/language-model-v3-source.ts>
+///
+/// V3 requires `id` on both variants, but providers rarely transmit a citation
+/// id (OpenAI / Gemini / Anthropic web-search results carry none). Adapters
+/// therefore **synthesize** a stable id from the source's URL and its index in
+/// the response (see `synthesize_source_id` in each adapter) so the required
+/// field is always populated without inventing identity the wire never carried.
+///
+/// The V3 per-source `providerMetadata` (e.g. Anthropic `cited_text` /
+/// `encrypted_index`, a document citation's page/char ranges) is intentionally
+/// **not** modeled here yet — it is deferred to the separate provider-metadata
+/// task that adds a metadata slot uniformly across the content parts. Its
+/// absence is why the text-to-source linkage (`cited_text` and char/page
+/// offsets) cannot cross faithfully today; that loss is inherent to the current
+/// parity target, not to any one adapter.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "source_type", rename_all = "snake_case")]
+pub enum Source {
+    /// A URL citation — the V3 `sourceType: 'url'` source. Maps to OpenAI
+    /// `url_citation` annotations, Anthropic `web_search_result` /
+    /// `web_search_result_location` citations, and Gemini web `groundingChunks`.
+    Url {
+        /// Stable source id. Synthesized from `url` + response index where the
+        /// provider transmits none.
+        id: String,
+        /// The cited web address.
+        url: String,
+        /// Human-readable title of the cited page, when the provider supplies
+        /// one.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        title: Option<String>,
+    },
+    /// A document citation — the V3 `sourceType: 'document'` source. Maps to
+    /// OpenAI Responses `file_citation` / `container_file_citation` /
+    /// `file_path` annotations and Anthropic `page_location` / `char_location`
+    /// document citations. `title` is required by V3; `media_type` identifies
+    /// the cited document's IANA type.
+    Document {
+        /// Stable source id. Synthesized where the provider transmits none.
+        id: String,
+        /// IANA media type of the cited document, e.g. `text/plain` or
+        /// `application/pdf`.
+        media_type: String,
+        /// Document title (required by V3). Adapters fall back to the filename
+        /// or file id when the provider gives no separate title.
+        title: String,
+        /// Original filename, when the provider supplies one.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        filename: Option<String>,
+    },
+}
+
+impl Source {
+    /// Synthesize a stable [`Source`] id from a citation's URL and its index in
+    /// the response. V3 requires an `id`, but the OpenAI / Anthropic web-search
+    /// / Gemini grounding wires rarely carry one; this derives a deterministic,
+    /// collision-resistant id (`url#<index>`) so a same-protocol round-trip
+    /// reproduces a stable identity without fabricating provider-side identity.
+    pub fn synthesize_id(url: &str, index: usize) -> String {
+        format!("{url}#{index}")
     }
 }
 
@@ -904,6 +987,16 @@ pub enum StreamPart {
         media_type: String,
         /// The file payload — inline base64 bytes or a URL.
         data: DataContent,
+    },
+    /// A citation / grounding source, emitted whole — the V3 stream `source`
+    /// part. Citations stream as one complete part (never chunked deltas):
+    /// Gemini emits the candidate's `groundingChunks` per chunk and OpenAI Chat
+    /// streams `delta.annotations`, both decoded here; the client-side encoders
+    /// re-attach it to the protocol's native citation location.
+    /// <https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v3/language-model-v3-source.ts>
+    Source {
+        /// The citation source (URL or document).
+        source: Source,
     },
     /// A usage report. May arrive mid-stream (per-checkpoint) or only at the end.
     Usage {

--- a/crates/bitrouter-sdk/src/language_model/types.rs
+++ b/crates/bitrouter-sdk/src/language_model/types.rs
@@ -418,15 +418,77 @@ impl Message {
     }
 }
 
-/// A tool/function the model may call.
+/// A tool the model may call — a faithful port of the Vercel AI SDK
+/// `LanguageModelV3FunctionTool | LanguageModelV3ProviderTool` union.
+/// <https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v3/language-model-v3-function-tool.ts>
+/// <https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v3/language-model-v3-provider-tool.ts>
+///
+/// Like [`ToolChoice`] and [`ResponseFormat`], each inbound adapter promotes a
+/// provider-native tool entry into this typed slot at parse time, and each
+/// outbound adapter renders it back into the upstream's native shape. The two
+/// variants behave very differently across protocols:
+///
+/// - [`Self::Function`] is portable: every protocol has a function/tool slot,
+///   so a function tool round-trips across all four wires. Only the optional
+///   `strict` flag is protocol-specific (Chat Completions / Responses honor it;
+///   Anthropic and Gemini have no equivalent and drop it — documented at those
+///   render sites).
+/// - [`Self::ProviderDefined`] is **not** portable. V3 namespaces these tools by
+///   provider precisely because their `args` schema is provider-specific and has
+///   no cross-provider equivalent (an OpenAI `web_search_preview` is not an
+///   Anthropic `web_search_20250305`). On a **same-protocol** round-trip the
+///   native shape is reproduced exactly (`id` + `args` preserved). On a
+///   **cross-protocol** route the tool is preserved **verbatim** in its source
+///   provider's native shape and splatted into the target request so the
+///   upstream — not bitrouter — decides what to do with it; bitrouter never
+///   silently drops it and never invents a lossy "equivalent" (the same
+///   faithful-passthrough rule as [`ToolChoice::Other`]). See
+///   [`provider_defined_native`](crate::language_model::protocol) for the shared
+///   reconstruction.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct Tool {
-    /// Tool name.
-    pub name: String,
-    /// Human description.
-    pub description: Option<String>,
-    /// JSON Schema for the tool's parameters.
-    pub parameters: serde_json::Value,
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Tool {
+    /// A client-side function tool: `{name, description?, parameters, strict?}`.
+    /// `parameters` is V3's `inputSchema` (a JSON Schema). `strict` is V3's
+    /// top-level strict-mode flag — captured from the wire where present so it
+    /// is not lost across the canonical boundary.
+    Function {
+        /// Tool name. Unique within the request.
+        name: String,
+        /// Human description.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        description: Option<String>,
+        /// JSON Schema for the tool's parameters (V3 `inputSchema`).
+        parameters: serde_json::Value,
+        /// V3 strict-mode flag. Chat Completions / Responses honor it; Anthropic
+        /// and Gemini have no equivalent and drop it.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        strict: Option<bool>,
+    },
+    /// A provider-defined (server-side) tool: `{id, name, args}`, mirroring V3's
+    /// `LanguageModelV3ProviderTool`. `id` is provider-namespaced as
+    /// `<provider-id>.<tool-name>` (e.g. `openai.web_search_preview`,
+    /// `anthropic.web_search_20250305`, `google.google_search`). `args` is the
+    /// provider-specific configuration object for the tool, preserved verbatim.
+    ProviderDefined {
+        /// Provider-namespaced id, `<provider-id>.<tool-name>`.
+        id: String,
+        /// Tool name. Unique within the request.
+        name: String,
+        /// Provider-specific configuration arguments, preserved verbatim.
+        args: serde_json::Value,
+    },
+}
+
+impl Tool {
+    /// The tool's name — present on both variants. Used where a feature needs to
+    /// reference a tool by name without caring whether it is a client function
+    /// tool or a provider-defined one (e.g. policy tool-access checks).
+    pub fn name(&self) -> &str {
+        match self {
+            Self::Function { name, .. } | Self::ProviderDefined { name, .. } => name,
+        }
+    }
 }
 
 /// How the model must treat the available [`Tool`]s on this request — a faithful
@@ -1086,10 +1148,11 @@ mod tests {
     #[test]
     fn tools_require_tools_capability() {
         let mut p = bare_prompt();
-        p.tools = vec![Tool {
+        p.tools = vec![Tool::Function {
             name: "get_weather".into(),
             description: None,
             parameters: serde_json::json!({ "type": "object" }),
+            strict: None,
         }];
         assert_eq!(p.required_capabilities(), vec![Capability::Tools]);
     }
@@ -1109,10 +1172,11 @@ mod tests {
             strict: None,
             schema: serde_json::json!({ "type": "object" }),
         });
-        p.tools = vec![Tool {
+        p.tools = vec![Tool::Function {
             name: "t".into(),
             description: None,
             parameters: serde_json::json!({}),
+            strict: None,
         }];
         p.params.reasoning_effort = Some("low".to_string());
         let caps = p.required_capabilities();

--- a/crates/bitrouter-sdk/src/language_model/types.rs
+++ b/crates/bitrouter-sdk/src/language_model/types.rs
@@ -316,6 +316,79 @@ pub enum Content {
         #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
         provider_metadata: ProviderMetadata,
     },
+    /// A human-in-the-loop **tool-approval request** — the V3
+    /// `LanguageModelV3ToolApprovalRequest` content part. Emitted by a provider
+    /// (assistant output) for a provider-executed tool call that needs explicit
+    /// user approval before it runs; the matching [`Self::ToolApprovalResponse`]
+    /// (keyed by [`approval_id`](Self::ToolApprovalRequest::approval_id)) carries
+    /// the grant or denial back on the next turn.
+    /// <https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v3/language-model-v3-tool-approval-request.ts>
+    ///
+    /// The only wire that carries this handshake is OpenAI Responses, where it is
+    /// the `mcp_approval_request` output item (`{id, type, server_label, name,
+    /// arguments}`). On parse, `approval_id` is the item's `approval_request_id`
+    /// (falling back to its `id`), and the MCP `server_label` / `name` /
+    /// `arguments` ride in `provider_metadata["openai"]` so the render reproduces
+    /// the exact `mcp_approval_request` item byte-for-byte. The other three wires
+    /// (Anthropic / Generate Content / Chat Completions) have no approval-request
+    /// item and skip this variant on render (documented at each site).
+    /// <https://platform.openai.com/docs/api-reference/responses/object>
+    ToolApprovalRequest {
+        /// Approval id, referenced by the subsequent
+        /// [`Self::ToolApprovalResponse`]. On Responses this is the
+        /// `mcp_approval_request.approval_request_id` (falling back to its `id`).
+        approval_id: String,
+        /// The tool call this approval is for (V3 `toolCallId`). The Responses
+        /// `mcp_approval_request` item does not transmit a separate tool-call id,
+        /// so it is synthesized from `approval_id` (`approval:<approval_id>`) — a
+        /// deterministic value, mirroring how the AI SDK generates one — and round
+        /// trips stably on a same-protocol hop.
+        tool_call_id: String,
+        /// Per-part namespaced provider metadata. On a Responses
+        /// `mcp_approval_request` this carries the MCP server identity under
+        /// `provider_metadata["openai"]` (`serverLabel` / `name` / `arguments`) so
+        /// the render restores the exact item; the canonical flat shape itself has
+        /// no MCP-server slot.
+        #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+        provider_metadata: ProviderMetadata,
+    },
+    /// A human-in-the-loop **tool-approval response** — the V3
+    /// `LanguageModelV3ToolApprovalResponsePart`. Supplied back by the
+    /// client/tool layer (a `tool`-role input part) to grant or deny a
+    /// provider-executed tool call that emitted a [`Self::ToolApprovalRequest`],
+    /// keyed by the shared [`approval_id`](Self::ToolApprovalResponse::approval_id).
+    /// <https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v3/language-model-v3-prompt.ts>
+    ///
+    /// The only wire that carries it is OpenAI Responses, as the
+    /// `mcp_approval_response` input item (`{type, approval_request_id,
+    /// approve}`). On parse, `approval_id` is `approval_request_id` and `approved`
+    /// is `approve`; on render this variant re-emits exactly that item. A denial
+    /// (`approved == false`) additionally yields a paired
+    /// [`ToolResultOutput::ExecutionDenied`] result carrying the approval id, so
+    /// the structured denial survives in the canonical IR (see `parse_input` in
+    /// the Responses adapter). The other three wires drop this part on render —
+    /// the AI SDK's converters do the same (`continue`) — because they have no
+    /// approval-response item (documented at each site).
+    /// <https://platform.openai.com/docs/api-reference/responses/object>
+    ToolApprovalResponse {
+        /// The approval id this response answers — the
+        /// [`Self::ToolApprovalRequest::approval_id`] it grants or denies. On
+        /// Responses this is the `mcp_approval_response.approval_request_id`.
+        approval_id: String,
+        /// Whether the tool call is approved (`mcp_approval_response.approve`).
+        approved: bool,
+        /// Optional human-readable reason (V3 `reason`). No built-in wire carries
+        /// it on the approval item — the Responses `mcp_approval_response` has no
+        /// `reason` field — so it is `None` after any wire round-trip and rides
+        /// only when a caller sets it on the canonical value.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        reason: Option<String>,
+        /// Per-part namespaced provider metadata (V3 `providerOptions`). Carries
+        /// no Responses-native field today; present for parity with the other
+        /// content parts and so a foreign provider's namespace survives a route.
+        #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+        provider_metadata: ProviderMetadata,
+    },
 }
 
 /// The result body of a [`Content::ToolResult`]. A faithful port of the Vercel
@@ -325,17 +398,20 @@ pub enum Content {
 /// shape and degrade losslessly when a provider can't express a variant.
 /// <https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v3/language-model-v3-prompt.ts>
 ///
-/// The V3 union has a sixth member, `execution-denied`
-/// (`{ type: 'execution-denied', reason? }`), that is intentionally **not**
-/// modeled here. It carries no distinct tag on any of the four request wires:
-/// the OpenAI Responses input conversion renders it as a plain
-/// `function_call_output.output` string (`reason ?? 'Tool call execution
-/// denied.'`) that re-parses indistinguishably from a [`Self::Text`], and its
-/// structured form arises only from the human-in-the-loop tool-approval flow
-/// (`tool-approval-request` / `tool-approval-response`), which this SDK does not
-/// yet implement. When that flow lands it will reintroduce the denial as part of
-/// the approval types rather than as a free-standing tool-result variant, so
-/// adding it now would be unconstructed dead code.
+/// The V3 union's sixth member, `execution-denied`
+/// (`{ type: 'execution-denied', reason? }`), is modeled by
+/// [`Self::ExecutionDenied`]. It arises from the human-in-the-loop tool-approval
+/// flow ([`Content::ToolApprovalRequest`] / [`Content::ToolApprovalResponse`]):
+/// when a user denies a provider-executed tool call, its result is a denial
+/// rather than an ordinary output. Only OpenAI Responses carries the flow on the
+/// wire; there the denial has two faithful renderings, both reproduced here
+/// (`render_responses_tool_output`): a denial paired with its approval (the
+/// approval id rides in `provider_metadata["openai"]["approvalId"]`) is **skipped**
+/// on render — the `mcp_approval_response` already conveyed it — and an unpaired
+/// denial degrades to a `function_call_output.output` string
+/// (`reason ?? 'Tool call execution denied.'`) that re-parses as a [`Self::Text`].
+/// On the other three wires it likewise degrades to that string via
+/// [`Self::to_provider_string`].
 /// <https://github.com/vercel/ai/blob/main/packages/openai/src/responses/convert-to-openai-responses-input.ts>
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -364,6 +440,21 @@ pub enum ToolResultOutput {
     Content {
         /// The ordered content parts.
         value: Vec<ToolResultContentPart>,
+    },
+    /// A denied tool execution — the V3 `execution-denied` output. The result of
+    /// a provider-executed tool call the user refused via the tool-approval flow
+    /// ([`Content::ToolApprovalResponse`] with `approved == false`). `reason` is
+    /// the optional human-readable explanation; when absent, renders fall back to
+    /// `"Tool call execution denied."` (matching the AI SDK). On OpenAI Responses
+    /// a denial paired with its approval is skipped on render (the
+    /// `mcp_approval_response` conveys it); elsewhere it degrades to the reason
+    /// string via [`Self::to_provider_string`].
+    /// <https://github.com/vercel/ai/blob/main/packages/openai/src/responses/convert-to-openai-responses-input.ts>
+    ExecutionDenied {
+        /// Optional human-readable denial reason. `None` falls back to the
+        /// default denial string on render.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        reason: Option<String>,
     },
 }
 
@@ -409,6 +500,12 @@ impl ToolResultOutput {
                     }
                 })
                 .collect(),
+            // A denied execution collapses to its reason, or the AI SDK's default
+            // denial sentinel when none was given.
+            // <https://github.com/vercel/ai/blob/main/packages/openai/src/responses/convert-to-openai-responses-input.ts>
+            Self::ExecutionDenied { reason } => reason
+                .clone()
+                .unwrap_or_else(|| "Tool call execution denied.".to_string()),
         }
     }
 }

--- a/crates/bitrouter-sdk/src/language_model/types.rs
+++ b/crates/bitrouter-sdk/src/language_model/types.rs
@@ -727,4 +727,18 @@ mod tests {
         assert_eq!(Capability::WebSearch.as_str(), "web_search");
         assert_eq!(Capability::Logprobs.as_str(), "logprobs");
     }
+
+    #[test]
+    fn extra_only_features_are_not_auto_detected() {
+        // web_search / logprobs ride `params.extra` and are advertise-only (not
+        // gated) — a request carrying them must still require no capabilities.
+        let mut p = bare_prompt();
+        p.params
+            .extra
+            .insert("logprobs".into(), serde_json::json!(true));
+        p.params
+            .extra
+            .insert("web_search_options".into(), serde_json::json!({}));
+        assert!(p.required_capabilities().is_empty());
+    }
 }

--- a/crates/bitrouter-sdk/src/language_model/types.rs
+++ b/crates/bitrouter-sdk/src/language_model/types.rs
@@ -241,25 +241,34 @@ pub enum Content {
         /// upstream as a client `function_call` on a follow-up turn (the
         /// provider already ran it), so render paths branch on this flag.
         /// <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/provider/src/language-model/v3/language-model-v3-tool-call.ts>
-        ///
-        /// The sibling V3 `dynamic` flag (provider-executed MCP tools defined at
-        /// runtime) is intentionally **not** modeled. It arises only from
-        /// Anthropic `mcp_tool_use` and OpenAI Responses `mcp_call`, both of
-        /// which carry a load-bearing server identifier (`server_name` /
-        /// `server_label`) that this flat `ToolCall` has no slot for. Setting
-        /// `dynamic` without also preserving that identifier would re-render an
-        /// MCP block missing its server — worse than omitting it — and the
-        /// Anthropic MCP connector is still beta-gated, not GA. So a faithful
-        /// `dynamic` round-trip is deferred until the `ToolCall` shape grows a
-        /// server-identifier slot, mirroring how the `execution-denied`
-        /// tool-result variant is deferred above.
-        /// <https://platform.claude.com/docs/en/agents-and-tools/mcp-connector>
         #[serde(default, skip_serializing_if = "std::ops::Not::not")]
         provider_executed: bool,
+        /// The sibling V3 `dynamic` flag — a provider-executed tool defined at
+        /// **runtime**, i.e. an MCP (Model Context Protocol) tool the provider
+        /// runs on a remote server. `false` (the default) is an ordinary,
+        /// statically-declared tool. `true` marks a call that arrived as an
+        /// Anthropic `mcp_tool_use` block or an OpenAI Responses `mcp_call` item;
+        /// such a call carries a load-bearing **server identifier** — Anthropic's
+        /// `server_name` or OpenAI's `server_label` — which this flat shape has no
+        /// core field for, so it rides in
+        /// [`provider_metadata`](Self::ToolCall::provider_metadata) under the
+        /// originating provider's namespace (`provider_metadata["anthropic"]`'s
+        /// `serverName` / `type: "mcp-tool-use"`, or
+        /// `provider_metadata["openai"]`). The render paths branch on this flag to
+        /// re-emit the MCP-native block on the **same** wire (`mcp_tool_use` /
+        /// `mcp_call`) and degrade it to a plain tool call on every other wire,
+        /// where the server identity is provider-specific and is dropped.
+        /// <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/provider/src/language-model/v3/language-model-v3-tool-call.ts>
+        /// <https://platform.claude.com/docs/en/agents-and-tools/mcp-connector>
+        #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+        dynamic: bool,
         /// Per-part namespaced provider metadata. On a `tool_use` block this
         /// carries the Anthropic block-level `cacheControl` breakpoint
         /// (`provider_metadata["anthropic"]["cacheControl"]`) — prompt caching
-        /// applies to `tool_use` blocks just like text/image/document blocks.
+        /// applies to `tool_use` blocks just like text/image/document blocks. For
+        /// a [`dynamic`](Self::ToolCall::dynamic) MCP call it ALSO carries the MCP
+        /// server identity (Anthropic `serverName` + `type: "mcp-tool-use"`, or
+        /// OpenAI `serverLabel`).
         /// <https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching>
         #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
         provider_metadata: ProviderMetadata,
@@ -288,11 +297,28 @@ pub enum Content {
         tool_name: Option<String>,
         /// The typed result body.
         output: ToolResultOutput,
+        /// The V3 `LanguageModelV3ToolResult` `dynamic` flag — set when this
+        /// result answers a [`dynamic`](Self::ToolCall::dynamic) provider-executed
+        /// MCP tool call, i.e. it arrived **inline** with its call as an Anthropic
+        /// `mcp_tool_result` block or as the `output`/`error` carried on an OpenAI
+        /// Responses `mcp_call` item. `false` (the default) is an ordinary tool
+        /// result. The render paths use it to pair the result back with its MCP
+        /// call: Anthropic re-emits an `mcp_tool_result` block (rather than a plain
+        /// `tool_result`), and OpenAI recombines this result with its same-id
+        /// dynamic [`ToolCall`](Self::ToolCall) into a single `mcp_call` output
+        /// item. On any non-MCP wire the flag is simply dropped and the result
+        /// degrades to that provider's ordinary tool-result shape.
+        /// <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/provider/src/language-model/v3/language-model-v3-tool-result.ts>
+        #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+        dynamic: bool,
         /// Per-part namespaced provider metadata. On a `tool_result` block this
         /// carries the Anthropic block-level `cacheControl` breakpoint
         /// (`provider_metadata["anthropic"]["cacheControl"]`) — prompt caching
         /// applies to `tool_result` blocks too, so a long tool output can mark a
-        /// cache boundary.
+        /// cache boundary. For an OpenAI Responses `mcp_call` result it also
+        /// carries the originating item id under
+        /// `provider_metadata["openai"]["itemId"]`, restored when recombining the
+        /// inline `mcp_call`.
         /// <https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching>
         #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
         provider_metadata: ProviderMetadata,

--- a/crates/bitrouter-sdk/src/language_model/types.rs
+++ b/crates/bitrouter-sdk/src/language_model/types.rs
@@ -113,6 +113,23 @@ pub enum Content {
         /// The reasoning text.
         text: String,
     },
+    /// A media / file part — image, audio, video, or document. Modelled à la the
+    /// Vercel AI SDK `LanguageModelV3File`: a single media-typed part rather than
+    /// a per-modality variant, identified by its IANA `media_type`.
+    /// <https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v3/language-model-v3-file.ts>
+    File {
+        /// IANA media type, e.g. `image/png`, `audio/mpeg`, `application/pdf`.
+        media_type: String,
+        /// The payload — inline base64 bytes or a URL the upstream fetches.
+        data: DataContent,
+        /// Original filename, when the provider supplies or requires it.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        filename: Option<String>,
+        /// Provider-specific per-part fields preserved verbatim (e.g. an image
+        /// `detail` hint). Mirrors the AI SDK's per-part `providerMetadata`.
+        #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+        extra: HashMap<String, serde_json::Value>,
+    },
     /// A tool/function call requested by the model.
     ToolCall {
         /// Provider-assigned call id.
@@ -129,6 +146,65 @@ pub enum Content {
         /// Result body. May itself be structured (v0 #364).
         content: String,
     },
+}
+
+/// The payload of a [`Content::File`] part. The Vercel AI SDK models this as
+/// `Uint8Array | string | URL`; a faithful-passthrough router never decodes the
+/// bytes, so we keep only the two wire forms every provider accepts: an inline
+/// base64 blob or a URL.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum DataContent {
+    /// Base64-encoded inline bytes (no `data:` URI prefix).
+    Base64 {
+        /// The base64 payload.
+        data: String,
+    },
+    /// A URL the upstream fetches directly.
+    Url {
+        /// The resource URL.
+        url: String,
+    },
+}
+
+impl DataContent {
+    /// Render as a single URL string: inline base64 bytes become a `data:` URI;
+    /// a URL passes through unchanged. For wire forms that carry media in one
+    /// URL field (e.g. OpenAI `image_url.url`).
+    pub fn to_url(&self, media_type: &str) -> String {
+        match self {
+            DataContent::Base64 { data } => format!("data:{media_type};base64,{data}"),
+            DataContent::Url { url } => url.clone(),
+        }
+    }
+
+    /// Parse a URL-or-`data:`-URI into an optional embedded media type and the
+    /// payload. `data:<mt>;base64,<payload>` yields `(Some(mt), Base64)`; any
+    /// other string becomes `(None, Url)`.
+    pub fn from_url(value: &str) -> (Option<String>, DataContent) {
+        if let Some(rest) = value.strip_prefix("data:")
+            && let Some((meta, payload)) = rest.split_once(',')
+            && meta.contains(";base64")
+        {
+            let media_type = meta
+                .split(';')
+                .next()
+                .filter(|m| !m.is_empty())
+                .map(str::to_string);
+            return (
+                media_type,
+                DataContent::Base64 {
+                    data: payload.to_string(),
+                },
+            );
+        }
+        (
+            None,
+            DataContent::Url {
+                url: value.to_string(),
+            },
+        )
+    }
 }
 
 /// A single message in the conversation.
@@ -214,6 +290,20 @@ pub enum Capability {
     WebSearch,
     /// Token log-probabilities in the response.
     Logprobs,
+    /// Image input (vision) — a message carries an `image/*` file part.
+    ImageInput,
+    /// Audio input — a message carries an `audio/*` file part.
+    AudioInput,
+    /// Video input — a message carries a `video/*` file part.
+    VideoInput,
+    /// Document / file input — a message carries a non-image/audio/video file
+    /// part (e.g. `application/pdf`).
+    FileInput,
+    /// Image output (generation) — the request asks for an `image` output
+    /// modality.
+    ImageOutput,
+    /// Audio output (speech) — the request asks for an `audio` output modality.
+    AudioOutput,
 }
 
 impl Capability {
@@ -226,8 +316,48 @@ impl Capability {
             Self::Reasoning => "reasoning",
             Self::WebSearch => "web_search",
             Self::Logprobs => "logprobs",
+            Self::ImageInput => "image_input",
+            Self::AudioInput => "audio_input",
+            Self::VideoInput => "video_input",
+            Self::FileInput => "file_input",
+            Self::ImageOutput => "image_output",
+            Self::AudioOutput => "audio_output",
         }
     }
+
+    /// The input-modality capability implied by a file part's IANA media type;
+    /// everything that is not image/audio/video is treated as a document.
+    fn from_input_media_type(media_type: &str) -> Capability {
+        match media_type.split('/').next() {
+            Some("image") => Capability::ImageInput,
+            Some("audio") => Capability::AudioInput,
+            Some("video") => Capability::VideoInput,
+            _ => Capability::FileInput,
+        }
+    }
+
+    /// The output-modality capability implied by a requested response modality;
+    /// `Text` implies no extra capability.
+    fn from_output_modality(modality: Modality) -> Option<Capability> {
+        match modality {
+            Modality::Image => Some(Capability::ImageOutput),
+            Modality::Audio => Some(Capability::AudioOutput),
+            Modality::Text => None,
+        }
+    }
+}
+
+/// A content modality. Used for the requested output modalities
+/// ([`GenerationParams::response_modalities`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Modality {
+    /// Text.
+    Text,
+    /// Image.
+    Image,
+    /// Audio.
+    Audio,
 }
 
 /// Sampling / generation parameters, carried verbatim where possible.
@@ -245,6 +375,11 @@ pub struct GenerationParams {
     /// Reasoning effort hint (`low` / `medium` / `high`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning_effort: Option<String>,
+    /// Requested output modalities (OpenAI `modalities` / Gemini
+    /// `responseModalities`). Empty means text-only (the default). Drives
+    /// `image_output` / `audio_output` capability detection.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub response_modalities: Vec<Modality>,
     /// Any provider-specific extras passed through untouched.
     #[serde(skip_serializing_if = "HashMap::is_empty", default)]
     pub extra: HashMap<String, serde_json::Value>,
@@ -283,12 +418,13 @@ impl Prompt {
     /// to restrict the fallback chain to providers that advertise all of these,
     /// instead of silently degrading the request.
     ///
-    /// Only capabilities detectable from the canonical [`Prompt`] are returned:
-    /// `structured_outputs` (a `response_format`), `tools` (a non-empty tool
-    /// list), and `reasoning` (a reasoning-effort hint). Other capabilities a
-    /// provider may advertise — `web_search`, `logprobs`, and input/output
-    /// modalities — are not yet expressible in the canonical request, so they
-    /// are surfaced in the catalog but never gate routing here.
+    /// Detected from the canonical [`Prompt`]: `structured_outputs` (a
+    /// `response_format`), `tools` (a non-empty tool list), `reasoning` (a
+    /// reasoning-effort hint), the input modalities of any [`Content::File`]
+    /// parts (`image_input` / `audio_input` / `video_input` / `file_input`), and
+    /// the requested output modalities (`image_output` / `audio_output`).
+    /// `web_search` and `logprobs` ride [`GenerationParams::extra`] and are not
+    /// expressible here, so they stay catalog-only and never gate routing.
     pub fn required_capabilities(&self) -> Vec<Capability> {
         let mut caps = Vec::new();
         if self.response_format.is_some() {
@@ -299,6 +435,24 @@ impl Prompt {
         }
         if self.params.reasoning_effort.is_some() {
             caps.push(Capability::Reasoning);
+        }
+        // Input modalities: each file part contributes the capability implied by
+        // its media type, deduplicated (one `image_input` for several images).
+        for content in self.messages.iter().flat_map(|m| &m.content) {
+            if let Content::File { media_type, .. } = content {
+                let cap = Capability::from_input_media_type(media_type);
+                if !caps.contains(&cap) {
+                    caps.push(cap);
+                }
+            }
+        }
+        // Output modalities: from the requested response modalities.
+        for modality in &self.params.response_modalities {
+            if let Some(cap) = Capability::from_output_modality(*modality)
+                && !caps.contains(&cap)
+            {
+                caps.push(cap);
+            }
         }
         caps
     }
@@ -717,6 +871,102 @@ mod tests {
         assert_eq!(caps.len(), 3);
     }
 
+    fn user_file_prompt(media_type: &str) -> Prompt {
+        let mut p = bare_prompt();
+        p.messages = vec![Message {
+            role: Role::User,
+            content: vec![Content::File {
+                media_type: media_type.to_string(),
+                data: DataContent::Base64 {
+                    data: "AAAA".to_string(),
+                },
+                filename: None,
+                extra: Default::default(),
+            }],
+        }];
+        p
+    }
+
+    #[test]
+    fn image_file_requires_image_input() {
+        assert_eq!(
+            user_file_prompt("image/png").required_capabilities(),
+            vec![Capability::ImageInput]
+        );
+    }
+
+    #[test]
+    fn audio_file_requires_audio_input() {
+        assert_eq!(
+            user_file_prompt("audio/mpeg").required_capabilities(),
+            vec![Capability::AudioInput]
+        );
+    }
+
+    #[test]
+    fn video_file_requires_video_input() {
+        assert_eq!(
+            user_file_prompt("video/mp4").required_capabilities(),
+            vec![Capability::VideoInput]
+        );
+    }
+
+    #[test]
+    fn document_file_requires_file_input() {
+        assert_eq!(
+            user_file_prompt("application/pdf").required_capabilities(),
+            vec![Capability::FileInput]
+        );
+    }
+
+    #[test]
+    fn repeated_image_parts_dedupe_to_one_image_input() {
+        let img = || Content::File {
+            media_type: "image/png".to_string(),
+            data: DataContent::Url {
+                url: "https://example.invalid/a.png".to_string(),
+            },
+            filename: None,
+            extra: Default::default(),
+        };
+        let mut p = bare_prompt();
+        p.messages = vec![Message {
+            role: Role::User,
+            content: vec![img(), img()],
+        }];
+        assert_eq!(p.required_capabilities(), vec![Capability::ImageInput]);
+    }
+
+    #[test]
+    fn response_modalities_require_output_capabilities() {
+        let mut p = bare_prompt();
+        p.params.response_modalities = vec![Modality::Text, Modality::Image, Modality::Audio];
+        // Text implies no capability; image / audio each map to an output cap.
+        assert_eq!(
+            p.required_capabilities(),
+            vec![Capability::ImageOutput, Capability::AudioOutput]
+        );
+    }
+
+    #[test]
+    fn file_content_serde_round_trips() {
+        let original = Content::File {
+            media_type: "image/png".to_string(),
+            data: DataContent::Url {
+                url: "https://example.invalid/y.png".to_string(),
+            },
+            filename: Some("y.png".to_string()),
+            extra: Default::default(),
+        };
+        let value = serde_json::to_value(&original).unwrap();
+        assert_eq!(value["type"], "file");
+        assert_eq!(value["media_type"], "image/png");
+        assert_eq!(value["data"]["kind"], "url");
+        assert_eq!(value["data"]["url"], "https://example.invalid/y.png");
+        let back: Content = serde_json::from_value(value).unwrap();
+        assert_eq!(back, original);
+    }
+
     #[test]
     fn capability_token_matches_registry_vocabulary() {
         // These tokens must stay byte-identical to the registry Zod enum and
@@ -726,6 +976,12 @@ mod tests {
         assert_eq!(Capability::Reasoning.as_str(), "reasoning");
         assert_eq!(Capability::WebSearch.as_str(), "web_search");
         assert_eq!(Capability::Logprobs.as_str(), "logprobs");
+        assert_eq!(Capability::ImageInput.as_str(), "image_input");
+        assert_eq!(Capability::AudioInput.as_str(), "audio_input");
+        assert_eq!(Capability::VideoInput.as_str(), "video_input");
+        assert_eq!(Capability::FileInput.as_str(), "file_input");
+        assert_eq!(Capability::ImageOutput.as_str(), "image_output");
+        assert_eq!(Capability::AudioOutput.as_str(), "audio_output");
     }
 
     #[test]

--- a/crates/bitrouter-sdk/src/language_model/types.rs
+++ b/crates/bitrouter-sdk/src/language_model/types.rs
@@ -130,7 +130,9 @@ pub enum Content {
         #[serde(default, skip_serializing_if = "HashMap::is_empty")]
         extra: HashMap<String, serde_json::Value>,
     },
-    /// A tool/function call requested by the model.
+    /// A tool/function call requested by the model. Models the Vercel AI SDK
+    /// `LanguageModelV3ToolCall` content part.
+    /// <https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v3/language-model-v3-tool-call.ts>
     ToolCall {
         /// Provider-assigned call id.
         id: String,
@@ -138,6 +140,32 @@ pub enum Content {
         name: String,
         /// JSON-encoded arguments.
         arguments: String,
+        /// Whether the tool ran **server-side at the provider** rather than
+        /// being handed back to the client to execute — the V3
+        /// `providerExecuted` flag. `false` (the default) is an ordinary client
+        /// tool call (Chat Completions `tool_calls`, Anthropic `tool_use`,
+        /// Gemini `functionCall`); `true` marks a provider-executed server tool
+        /// (OpenAI Responses `web_search_call` / `code_interpreter_call` /
+        /// `file_search_call`, Anthropic `server_tool_use`). The distinction is
+        /// load-bearing: a provider-executed call must **not** be re-sent to the
+        /// upstream as a client `function_call` on a follow-up turn (the
+        /// provider already ran it), so render paths branch on this flag.
+        /// <https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v3/language-model-v3-tool-call.ts>
+        ///
+        /// The sibling V3 `dynamic` flag (provider-executed MCP tools defined at
+        /// runtime) is intentionally **not** modeled. It arises only from
+        /// Anthropic `mcp_tool_use` and OpenAI Responses `mcp_call`, both of
+        /// which carry a load-bearing server identifier (`server_name` /
+        /// `server_label`) that this flat `ToolCall` has no slot for. Setting
+        /// `dynamic` without also preserving that identifier would re-render an
+        /// MCP block missing its server — worse than omitting it — and the
+        /// Anthropic MCP connector is still beta-gated, not GA. So a faithful
+        /// `dynamic` round-trip is deferred until the `ToolCall` shape grows a
+        /// server-identifier slot, mirroring how the `execution-denied`
+        /// tool-result variant is deferred above.
+        /// <https://platform.claude.com/docs/en/agents-and-tools/mcp-connector>
+        #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+        provider_executed: bool,
     },
     /// A tool/function result supplied back to the model. Models the Vercel AI
     /// SDK `LanguageModelV3ToolResultPart`: the result is a typed
@@ -401,6 +429,48 @@ pub struct Tool {
     pub parameters: serde_json::Value,
 }
 
+/// How the model must treat the available [`Tool`]s on this request — a faithful
+/// port of the Vercel AI SDK `LanguageModelV3ToolChoice` tagged union.
+/// <https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v3/language-model-v3-tool-choice.ts>
+///
+/// Each protocol expresses tool choice with a different wire shape (Chat
+/// Completions `"auto"|"none"|"required"` or `{type:"function",…}`; Anthropic
+/// `{type:"auto"|"any"|"tool"|"none"}`; Responses `"auto"|"none"|"required"` or
+/// `{type:"function",name}`; Gemini `functionCallingConfig.mode`). Each inbound
+/// adapter promotes its native field into this typed slot at parse time and
+/// **removes it from the raw `extra`** so it is not double-written; each outbound
+/// adapter renders it back into the upstream's native shape. Promoting it makes
+/// cross-protocol routing correct: without it a raw provider-shaped `tool_choice`
+/// (e.g. an OpenAI `{type:"function",…}`) would be splatted verbatim into a
+/// different provider's request and be silently ignored or rejected.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ToolChoice {
+    /// The model decides whether to call a tool (V3 `auto`). The default when
+    /// tools are present.
+    Auto,
+    /// The model must not call any tool (V3 `none`).
+    None,
+    /// The model must call one of the available tools, but which one is its
+    /// choice (V3 `required`).
+    Required,
+    /// The model must call this specific tool by name (V3 `tool`).
+    Tool {
+        /// The tool name the model is forced to call.
+        name: String,
+    },
+    /// A provider-specific tool-choice shape that does not map onto any of the
+    /// four V3 variants (e.g. Gemini's `mode: "ANY"` paired with
+    /// `allowedFunctionNames`, or an OpenAI `allowed_tools` constraint),
+    /// preserved verbatim so an exotic choice is never lost on a same-protocol
+    /// round-trip. Carries the raw provider-native JSON; an adapter that cannot
+    /// express it on its own wire degrades it (documented at each render site).
+    Other {
+        /// The provider-native `tool_choice` value, untouched.
+        value: serde_json::Value,
+    },
+}
+
 /// Constraint on the shape of the model's response.
 ///
 /// Today the only variant is [`Self::JsonSchema`]; future variants (`json_object`,
@@ -544,6 +614,13 @@ pub struct GenerationParams {
     /// `image_output` / `audio_output` capability detection.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub response_modalities: Vec<Modality>,
+    /// How the model must treat the available tools (V3 `toolChoice`). Each
+    /// inbound adapter promotes its native `tool_choice` field into this typed
+    /// slot and removes it from `extra`; each outbound adapter renders it back
+    /// into the upstream's native shape, so it routes correctly across
+    /// protocols instead of leaking a raw provider-shaped value through `extra`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_choice: Option<ToolChoice>,
     /// Any provider-specific extras passed through untouched.
     #[serde(skip_serializing_if = "HashMap::is_empty", default)]
     pub extra: HashMap<String, serde_json::Value>,

--- a/crates/bitrouter-sdk/src/language_model/types.rs
+++ b/crates/bitrouter-sdk/src/language_model/types.rs
@@ -1287,18 +1287,102 @@ pub struct GenerateResult {
 /// One part of a streaming response, in canonical internal form. `StreamHook`
 /// operates on a `Stream<Item = StreamPart>` before outbound protocol
 /// conversion.
+///
+/// **Relationship to the Vercel AI SDK V3 `LanguageModelV3StreamPart`.**
+/// bitrouter is a re-encoder: it decodes an upstream's SSE into these canonical
+/// parts and re-encodes them into the client's own SSE lifecycle, so a variant
+/// is modeled only when it changes the *re-encoded* bytes. The block-lifecycle
+/// members are carried because two of the client wires frame content into
+/// explicit blocks: text-start/end ([`Self::TextStart`] / [`Self::TextEnd`]) and
+/// reasoning-start/end ([`Self::ReasoningStart`] / [`Self::ReasoningEnd`]) fix a
+/// concrete merged-block bug on the Anthropic Messages and OpenAI Responses
+/// encoders (see [`Self::TextStart`]). The following V3 members are
+/// deliberately **not** modeled, each for a no-dead-code reason:
+///
+/// - **`tool-input-start` / `tool-input-end`.** Tool-argument streaming is
+///   already framed losslessly without dedicated markers: a
+///   [`Self::ToolCallDelta`] whose `name` is `Some` *is* the start signal — both
+///   block-framed encoders force-close the open block and open a new tool block
+///   on it, so consecutive tool calls land in distinct blocks (Anthropic
+///   `tool_use`, Responses `function_call`), and the block closes on the next
+///   block/terminal. A separate `tool-input-end` would change no re-encoded
+///   byte, so it would be unconstructed-or-unconsumed churn.
+/// - **`stream-start { warnings }`.** Warnings describe settings a provider
+///   could not honor; bitrouter forwards requests faithfully and never gates a
+///   setting, and no client *response* wire has a streaming `warnings` slot, so
+///   such a part could be neither meaningfully produced nor emitted — the same
+///   reasoning that omits `warnings` from [`GenerateResult`].
+/// - **`raw` (`includeRawChunks`).** bitrouter re-encodes canonical parts into
+///   the client's wire; it never tunnels an upstream's raw chunk through, so a
+///   `raw` part would have no encoder that could emit it.
+/// - **`response-metadata` (mid-stream id/timestamp/modelId).** The response id
+///   is already surfaced once as [`Self::ResponseStarted`] (and on
+///   [`Self::ResponseCompleted`] for Responses); no client encoder consumes a
+///   mid-stream model-id/timestamp refresh, so a dedicated part would be dead.
+/// - **`error`.** A terminal upstream error is modeled as
+///   [`FinishReason::Error`] and surfaced through each encoder's
+///   `encode_error` (protocol-shaped terminal frame: Anthropic `error`, Chat
+///   error chunk, Responses `response.failed`). A separate `error` `StreamPart`
+///   would duplicate that path with no extra fidelity.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum StreamPart {
+    /// Opens a text block — the V3 `text-start` part. Carries the upstream
+    /// block id so a client encoder that frames text into explicit blocks
+    /// (Anthropic `content_block_start`, Responses `output_item.added` +
+    /// `content_part.added`) opens a *fresh* block here rather than inferring
+    /// the boundary from delta transitions.
+    ///
+    /// **Why this exists (the merged-block fix).** Without an explicit start/end
+    /// pair the canonical stream is a flat run of [`Self::TextDelta`]s, so two
+    /// *distinct* upstream text blocks (e.g. Anthropic `content_block` index 0
+    /// then index 2, or two Responses `message` items) decode to
+    /// `TextDelta`,`TextDelta` with no separator and re-encode into a **single**
+    /// merged block — a real fidelity loss on the two block-framed wires.
+    /// The decoder now emits this marker on each `content_block_start` (text) /
+    /// message-item open, and the encoder closes-then-reopens on it, so block
+    /// boundaries survive a same-protocol round trip. The two coarse wires
+    /// (Chat Completions / Generate Content) carry no block frame, so their
+    /// decoders never emit it and their encoders treat it as a no-op.
+    /// <https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v3/language-model-v3-stream-part.ts>
+    TextStart {
+        /// Upstream block id (Anthropic block index rendered as a string, or a
+        /// Responses item id). Stable within one stream; used by a framing
+        /// encoder to correlate the matching [`Self::TextEnd`].
+        id: String,
+    },
     /// An incremental chunk of assistant text.
     TextDelta {
         /// The text fragment.
         text: String,
     },
+    /// Closes the text block opened by the matching [`Self::TextStart`] — the V3
+    /// `text-end` part. A framing encoder emits its block-close frame here
+    /// (Anthropic `content_block_stop`, Responses `output_text.done` +
+    /// `content_part.done` + `output_item.done`); the coarse wires no-op it.
+    TextEnd {
+        /// Block id, matching the opening [`Self::TextStart`].
+        id: String,
+    },
+    /// Opens a reasoning / thinking block — the V3 `reasoning-start` part. The
+    /// reasoning counterpart of [`Self::TextStart`]; see its docs for the
+    /// merged-block rationale. Decoded from Anthropic `thinking` /
+    /// `redacted_thinking` `content_block_start` and Responses `reasoning`
+    /// item opens.
+    ReasoningStart {
+        /// Upstream reasoning-block id.
+        id: String,
+    },
     /// An incremental chunk of reasoning / thinking text.
     ReasoningDelta {
         /// The reasoning fragment.
         text: String,
+    },
+    /// Closes the reasoning block opened by the matching [`Self::ReasoningStart`]
+    /// — the V3 `reasoning-end` part.
+    ReasoningEnd {
+        /// Reasoning-block id, matching the opening [`Self::ReasoningStart`].
+        id: String,
     },
     /// An incremental chunk of a tool call's arguments.
     ToolCallDelta {

--- a/crates/bitrouter-sdk/src/language_model/types.rs
+++ b/crates/bitrouter-sdk/src/language_model/types.rs
@@ -876,6 +876,17 @@ pub enum ResponseFormat {
         /// Messages and Generate Content.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         name: Option<String>,
+        /// Optional schema description — the V3 `responseFormat.description`.
+        /// Used by some providers as extra LLM guidance for the structured
+        /// output. Carried by the OpenAI family only: Chat Completions'
+        /// `response_format.json_schema.description` and Responses'
+        /// `text.format.description`. Anthropic `output_config.format` and
+        /// Gemini `responseSchema` carry no schema-level description, so it is
+        /// `None` after a round-trip through those wires (the same
+        /// OpenAI-family-only treatment as [`name`](Self::JsonSchema::name)).
+        /// <https://platform.openai.com/docs/guides/structured-outputs>
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        description: Option<String>,
         /// Strict-mode flag. Chat Completions / Responses only; Messages and Generate Content are always strict.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         strict: Option<bool>,
@@ -1100,6 +1111,23 @@ impl Prompt {
 
 /// Token usage counts. Counts use `0` (not `null`) for "known to be zero";
 /// missing usage is represented by `Option<Usage>` being `None` upstream.
+///
+/// Field-level parity with the Vercel AI SDK V3 `LanguageModelV3Usage`
+/// (`inputTokens` / `outputTokens` / `totalTokens` / `reasoningTokens` /
+/// `cachedInputTokens`): [`prompt_tokens`](Self::prompt_tokens) is V3
+/// `inputTokens`, [`completion_tokens`](Self::completion_tokens) is
+/// `outputTokens`, [`reasoning_tokens`](Self::reasoning_tokens) is
+/// `reasoningTokens`, and [`cache_read_tokens`](Self::cache_read_tokens) is
+/// `cachedInputTokens`. V3's `totalTokens` is **not** a stored field here: it is
+/// purely `prompt_tokens + completion_tokens` ([`total`](Self::total)) in this
+/// model — the cache buckets are folded into `prompt_tokens` at parse time (see
+/// the Messages `parse_usage`), so the derived total already equals every
+/// provider's reported total. Storing a separate `total_tokens` would be a
+/// redundant field that could disagree with its own components, so it is
+/// intentionally omitted. [`cache_write_tokens`](Self::cache_write_tokens) has
+/// no V3 counterpart (V3 folds cache-write into `inputTokens`); bitrouter keeps
+/// it distinct so a billing layer can meter cache creation separately.
+/// <https://github.com/vercel/ai/blob/main/packages/provider/src/language-model/v3/language-model-v3-usage.ts>
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Usage {
     /// Prompt / input tokens.
@@ -1181,6 +1209,34 @@ pub struct StopDetails {
 }
 
 /// A complete non-streaming generation result.
+///
+/// **Relationship to the Vercel AI SDK V3 `LanguageModelV3GenerateResult`.** This
+/// type carries `content`, `usage`, `finishReason`, `providerMetadata`, and the
+/// `response.id` (as [`response_id`](Self::response_id)). Three V3 result members
+/// are intentionally **not** modeled as fields here, each for a concrete
+/// no-dead-code reason:
+///
+/// - **`warnings`** (V3 `Array<SharedV3Warning>` — settings a provider could not
+///   honor). bitrouter forwards provider requests **faithfully** and never gates
+///   or silently substitutes a setting, so the "unsupported setting" class barely
+///   arises; the residual cross-protocol degrades (e.g. a function `strict` flag
+///   dropped when routing to Anthropic/Gemini) happen inside
+///   [`render_request`](crate::language_model::protocol::OutboundAdapter::render_request),
+///   which returns only a request body and has **no channel** to the separate
+///   [`parse_response`](crate::language_model::protocol::OutboundAdapter::parse_response)
+///   that builds this result. Moreover none of the four client-facing response
+///   wires (Chat Completions / Messages / Responses / Generate Content) has a
+///   `warnings` slot in its **response** body, so a warning could never be
+///   emitted back to a client either. A `warnings` field would therefore be both
+///   unconstructed and unconsumed — pure dead weight — so it is omitted rather
+///   than added empty.
+/// - **`response.modelId`** and **`response.timestamp`**. The model id is already
+///   surfaced from the routed [`ExecutionResult::model_id`] (which observability
+///   stamps onto `gen_ai.response.model`), and Gemini's wire `modelVersion` rides
+///   [`Self::provider_metadata`]`["google"]`; no consumer needs the raw echoed
+///   `model`/`created` of the response body, so storing them here would be a dead
+///   field. Raw `response.headers` and `request.body` are out of scope (telemetry
+///   passthrough, not part of the canonical result).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct GenerateResult {
     /// Ordered content blocks of the model's reply.
@@ -1207,8 +1263,22 @@ pub struct GenerateResult {
     /// Result-level namespaced provider metadata (V3 `providerMetadata` on the
     /// generation result). Carries response-level provider nuances that have no
     /// dedicated canonical field: OpenAI `system_fingerprint`
-    /// (`provider_metadata["openai"]["systemFingerprint"]`) and Gemini
-    /// `modelVersion` (`provider_metadata["google"]["modelVersion"]`).
+    /// (`provider_metadata["openai"]["systemFingerprint"]`), Gemini
+    /// `modelVersion` (`provider_metadata["google"]["modelVersion"]`), and the
+    /// **raw provider finish reason** under
+    /// `provider_metadata["<provider>"]["rawFinishReason"]` for finish reasons
+    /// that the unified [`FinishReason`] enum cannot reproduce on its own. The
+    /// canonical enum maps several native reasons onto one variant (Anthropic
+    /// `stop_sequence` and `end_turn` both → [`FinishReason::Stop`]; Gemini
+    /// `RECITATION` / `BLOCKLIST` / `PROHIBITED_CONTENT` and `SAFETY` all →
+    /// [`FinishReason::ContentFilter`]; Chat Completions `function_call` →
+    /// [`FinishReason::ToolCalls`]), so rendering from the enum alone would lose
+    /// the exact native string on a same-protocol round-trip. The lossy
+    /// mappings stash the raw string here at parse time, and each adapter's
+    /// `render_response` reads it back (preferring it over the enum mapping) so
+    /// the native finish reason survives byte-for-byte — and so observability
+    /// can surface the precise upstream reason. Reasons that already map
+    /// losslessly (e.g. `STOP`, `MAX_TOKENS`) store nothing.
     /// <https://platform.openai.com/docs/api-reference/chat/object>
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub provider_metadata: ProviderMetadata,
@@ -1492,6 +1562,7 @@ mod tests {
         let mut p = bare_prompt();
         p.response_format = Some(ResponseFormat::JsonSchema {
             name: None,
+            description: None,
             strict: None,
             schema: serde_json::json!({ "type": "object" }),
         });
@@ -1526,6 +1597,7 @@ mod tests {
         let mut p = bare_prompt();
         p.response_format = Some(ResponseFormat::JsonSchema {
             name: None,
+            description: None,
             strict: None,
             schema: serde_json::json!({ "type": "object" }),
         });

--- a/crates/bitrouter-sdk/src/language_model/types.rs
+++ b/crates/bitrouter-sdk/src/language_model/types.rs
@@ -206,6 +206,14 @@ pub enum ResponseFormat {
 pub enum Capability {
     /// JSON-Schema-constrained output — [`ResponseFormat::JsonSchema`].
     StructuredOutputs,
+    /// Tool / function calling — the request supplies a non-empty tool list.
+    Tools,
+    /// Extended reasoning / thinking — the request sets a reasoning-effort hint.
+    Reasoning,
+    /// Provider-side web search / browsing.
+    WebSearch,
+    /// Token log-probabilities in the response.
+    Logprobs,
 }
 
 impl Capability {
@@ -214,6 +222,10 @@ impl Capability {
     pub fn as_str(&self) -> &'static str {
         match self {
             Self::StructuredOutputs => "structured_outputs",
+            Self::Tools => "tools",
+            Self::Reasoning => "reasoning",
+            Self::WebSearch => "web_search",
+            Self::Logprobs => "logprobs",
         }
     }
 }
@@ -270,10 +282,23 @@ impl Prompt {
     /// features it actually uses. A capability-aware routing table can use this
     /// to restrict the fallback chain to providers that advertise all of these,
     /// instead of silently degrading the request.
+    ///
+    /// Only capabilities detectable from the canonical [`Prompt`] are returned:
+    /// `structured_outputs` (a `response_format`), `tools` (a non-empty tool
+    /// list), and `reasoning` (a reasoning-effort hint). Other capabilities a
+    /// provider may advertise — `web_search`, `logprobs`, and input/output
+    /// modalities — are not yet expressible in the canonical request, so they
+    /// are surfaced in the catalog but never gate routing here.
     pub fn required_capabilities(&self) -> Vec<Capability> {
         let mut caps = Vec::new();
         if self.response_format.is_some() {
             caps.push(Capability::StructuredOutputs);
+        }
+        if !self.tools.is_empty() {
+            caps.push(Capability::Tools);
+        }
+        if self.params.reasoning_effort.is_some() {
+            caps.push(Capability::Reasoning);
         }
         caps
     }
@@ -654,7 +679,52 @@ mod tests {
     }
 
     #[test]
+    fn tools_require_tools_capability() {
+        let mut p = bare_prompt();
+        p.tools = vec![Tool {
+            name: "get_weather".into(),
+            description: None,
+            parameters: serde_json::json!({ "type": "object" }),
+        }];
+        assert_eq!(p.required_capabilities(), vec![Capability::Tools]);
+    }
+
+    #[test]
+    fn reasoning_effort_requires_reasoning_capability() {
+        let mut p = bare_prompt();
+        p.params.reasoning_effort = Some("high".to_string());
+        assert_eq!(p.required_capabilities(), vec![Capability::Reasoning]);
+    }
+
+    #[test]
+    fn multiple_features_require_all_their_capabilities() {
+        let mut p = bare_prompt();
+        p.response_format = Some(ResponseFormat::JsonSchema {
+            name: None,
+            strict: None,
+            schema: serde_json::json!({ "type": "object" }),
+        });
+        p.tools = vec![Tool {
+            name: "t".into(),
+            description: None,
+            parameters: serde_json::json!({}),
+        }];
+        p.params.reasoning_effort = Some("low".to_string());
+        let caps = p.required_capabilities();
+        assert!(caps.contains(&Capability::StructuredOutputs));
+        assert!(caps.contains(&Capability::Tools));
+        assert!(caps.contains(&Capability::Reasoning));
+        assert_eq!(caps.len(), 3);
+    }
+
+    #[test]
     fn capability_token_matches_registry_vocabulary() {
+        // These tokens must stay byte-identical to the registry Zod enum and
+        // the cloud's imported `Capability` — they are the cross-repo contract.
         assert_eq!(Capability::StructuredOutputs.as_str(), "structured_outputs");
+        assert_eq!(Capability::Tools.as_str(), "tools");
+        assert_eq!(Capability::Reasoning.as_str(), "reasoning");
+        assert_eq!(Capability::WebSearch.as_str(), "web_search");
+        assert_eq!(Capability::Logprobs.as_str(), "logprobs");
     }
 }

--- a/plugins/bitrouter-guardrails/src/hooks.rs
+++ b/plugins/bitrouter-guardrails/src/hooks.rs
@@ -45,7 +45,7 @@ fn request_text(ctx: &PipelineContext) -> String {
     for message in &prompt.messages {
         for content in &message.content {
             match content {
-                Content::Text { text } | Content::Reasoning { text } => {
+                Content::Text { text, .. } | Content::Reasoning { text, .. } => {
                     buf.push_str(text);
                     buf.push('\n');
                 }

--- a/plugins/bitrouter-guardrails/src/hooks.rs
+++ b/plugins/bitrouter-guardrails/src/hooks.rs
@@ -63,6 +63,11 @@ fn request_text(ctx: &PipelineContext) -> String {
                     // File parts (image / audio / document) carry no scannable
                     // text, so they contribute nothing to the guardrail buffer.
                 }
+                Content::Source { .. } => {
+                    // Citation sources are response-side metadata (a url/title),
+                    // not user-authored prompt text, so they are not scanned by
+                    // the request-side guardrail.
+                }
             }
         }
     }

--- a/plugins/bitrouter-guardrails/src/hooks.rs
+++ b/plugins/bitrouter-guardrails/src/hooks.rs
@@ -49,13 +49,19 @@ fn request_text(ctx: &PipelineContext) -> String {
                     buf.push_str(text);
                     buf.push('\n');
                 }
-                Content::ToolResult { content, .. } => {
-                    buf.push_str(content);
+                Content::ToolResult { output, .. } => {
+                    // Scan the flattened text of the tool result (text parts and
+                    // stringified JSON) so guardrail rules still see tool output.
+                    buf.push_str(&output.to_provider_string());
                     buf.push('\n');
                 }
                 Content::ToolCall { arguments, .. } => {
                     buf.push_str(arguments);
                     buf.push('\n');
+                }
+                Content::File { .. } => {
+                    // File parts (image / audio / document) carry no scannable
+                    // text, so they contribute nothing to the guardrail buffer.
                 }
             }
         }

--- a/plugins/bitrouter-guardrails/src/hooks.rs
+++ b/plugins/bitrouter-guardrails/src/hooks.rs
@@ -68,6 +68,20 @@ fn request_text(ctx: &PipelineContext) -> String {
                     // not user-authored prompt text, so they are not scanned by
                     // the request-side guardrail.
                 }
+                Content::ToolApprovalResponse { reason, .. } => {
+                    // A tool-approval response carries no model/user content other
+                    // than an optional human-authored denial reason; scan that
+                    // when present so guardrail rules still see it.
+                    if let Some(reason) = reason {
+                        buf.push_str(reason);
+                        buf.push('\n');
+                    }
+                }
+                Content::ToolApprovalRequest { .. } => {
+                    // A tool-approval request is a provider-emitted handshake
+                    // marker (approval/tool-call ids); it carries no user-authored
+                    // prompt text to scan.
+                }
             }
         }
     }

--- a/plugins/bitrouter-guardrails/src/tests.rs
+++ b/plugins/bitrouter-guardrails/src/tests.rs
@@ -24,6 +24,7 @@ fn prompt(text: &str, stream: bool) -> Prompt {
     Prompt {
         model: "m".to_string(),
         system: None,
+        system_provider_metadata: Default::default(),
         messages: vec![Message::text(Role::User, text)],
         tools: Vec::new(),
         params: GenerationParams::default(),

--- a/plugins/bitrouter-observe/src/otel/exporter.rs
+++ b/plugins/bitrouter-observe/src/otel/exporter.rs
@@ -1132,7 +1132,10 @@ mod hop_tests {
             model_id: target.service_id.clone(),
             account_label: target.account_label.clone(),
             result: GenerateResult {
-                content: vec![Content::Text { text: "ok".into() }],
+                content: vec![Content::Text {
+                    text: "ok".into(),
+                    provider_metadata: Default::default(),
+                }],
                 usage: Some(Usage {
                     prompt_tokens: 11,
                     completion_tokens: 7,
@@ -1141,6 +1144,7 @@ mod hop_tests {
                 finish_reason: Some(FinishReason::Stop),
                 response_id: Some("chatcmpl-test123".into()),
                 stop_details: None,
+                provider_metadata: Default::default(),
             },
             latency_ms: 42,
             generation_time_ms: 40,

--- a/plugins/bitrouter-observe/src/otel/exporter.rs
+++ b/plugins/bitrouter-observe/src/otel/exporter.rs
@@ -1117,6 +1117,7 @@ mod hop_tests {
         let prompt = Prompt {
             model: "test-model".to_string(),
             system: None,
+            system_provider_metadata: Default::default(),
             messages: vec![Message::text(Role::User, "hi")],
             tools: Vec::new(),
             params,

--- a/plugins/bitrouter-observe/src/otel/metrics.rs
+++ b/plugins/bitrouter-observe/src/otel/metrics.rs
@@ -181,6 +181,7 @@ fn stream_part_type(part: &StreamPart) -> &'static str {
         StreamPart::TextDelta { .. } => "text_delta",
         StreamPart::ReasoningDelta { .. } => "reasoning_delta",
         StreamPart::ToolCallDelta { .. } => "tool_call_delta",
+        StreamPart::File { .. } => "file",
         StreamPart::Usage { .. } => "usage",
         StreamPart::ResponseStarted { .. } => "response_started",
         StreamPart::Finish { .. } => "finish",

--- a/plugins/bitrouter-observe/src/otel/metrics.rs
+++ b/plugins/bitrouter-observe/src/otel/metrics.rs
@@ -182,6 +182,7 @@ fn stream_part_type(part: &StreamPart) -> &'static str {
         StreamPart::ReasoningDelta { .. } => "reasoning_delta",
         StreamPart::ToolCallDelta { .. } => "tool_call_delta",
         StreamPart::File { .. } => "file",
+        StreamPart::Source { .. } => "source",
         StreamPart::Usage { .. } => "usage",
         StreamPart::ResponseStarted { .. } => "response_started",
         StreamPart::Finish { .. } => "finish",

--- a/plugins/bitrouter-observe/src/otel/metrics.rs
+++ b/plugins/bitrouter-observe/src/otel/metrics.rs
@@ -178,8 +178,12 @@ impl OtelMetrics {
 
 fn stream_part_type(part: &StreamPart) -> &'static str {
     match part {
+        StreamPart::TextStart { .. } => "text_start",
         StreamPart::TextDelta { .. } => "text_delta",
+        StreamPart::TextEnd { .. } => "text_end",
+        StreamPart::ReasoningStart { .. } => "reasoning_start",
         StreamPart::ReasoningDelta { .. } => "reasoning_delta",
+        StreamPart::ReasoningEnd { .. } => "reasoning_end",
         StreamPart::ToolCallDelta { .. } => "tool_call_delta",
         StreamPart::File { .. } => "file",
         StreamPart::Source { .. } => "source",


### PR DESCRIPTION
## Summary

Brings the SDK's canonical `language_model` IR (`Content` / `StreamPart` / `Tool` / `GenerationParams` / `GenerateResult`) to **full functional parity with the Vercel AI SDK `LanguageModelV3`** across all four protocols — Chat Completions, Messages (Anthropic), Responses (OpenAI), Generate Content (Gemini) — so requests and responses round-trip faithfully on each wire and degrade cleanly cross-protocol.

## What's included

- **Multimodal** — file content IR (image / audio / video / document), capability detection, 4×4 cross-protocol conversion matrix.
- **Tools** — structured tool results (6-member V3 output union incl. `execution-denied`); provider-executed calls; typed `ToolChoice` (cross-protocol translated); function `strict` + provider-defined tools; **dynamic MCP tool calls** (Anthropic `mcp_tool_use`/`mcp_tool_result`, Responses `mcp_call` recombined with its inline result, `local_shell_call`).
- **Source** — web-search citations across protocols (OpenAI annotations ↔ Anthropic block citations ↔ Gemini grounding).
- **Metadata** — uniform per-part `provider_metadata` + Anthropic `cache_control` (incl. system-prompt caching).
- **Approval** — tool-approval flow + `execution-denied`.
- **Result / stream** — finish-reason raw preservation + `responseFormat.description`; stream **block-boundary lifecycle markers** (fixes a real merged-block bug on the framed wires); typed sampling params (`top_k`/`seed`/`stop`/`presence_penalty`/`frequency_penalty`) translated cross-protocol.
- **Fidelity** — all V3 doc-citations pinned to `@ai-sdk/provider@3.0.10`.

## Verification

- **870 tests pass** (`cargo nextest run --workspace --all-features`); `cargo clippy --workspace --all-features --all-targets` clean; `cargo fmt --all -- --check` clean; `cargo doc -D warnings` clean.
- Each area was independently audited and the parity independently verified end-to-end.
- Synced onto current `main` (alpha.11; #536 capability vocab, #537 disconnect billing, #538 run-to-completion, #526 MCP server, #546 cost-routed skill) — merge `5efd552`.

## Design notes

- bitrouter is a faithful-passthrough **router**: it carries wire information and never returns a V3 object, so `Usage` / `FinishReason` are deliberately kept **flat** (information-preserving — the raw finish reason rides `provider_metadata`) rather than adopting V3's nested shapes. Cross-protocol degradation is faithful and documented at each site; nothing is silently dropped.

## Honest deferrals (documented in-code, planned as follow-up PRs)

- **A3** — Source `cited_text` / char-page offsets (text-to-source linkage); the `provider_metadata` slot exists, just lift them in.
- **A4** — OpenAI Responses reasoning `encrypted_content` continuity.
- Streamed `mcp_call` / `mcp_tool_use` (needs `StreamPart` plumbing); Responses `local_shell_call_output` request-side degrade.
- Genuine N/A for a router: `inputExamples`, `warnings`, `abortSignal` / `headers` / `raw` / `response-metadata`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
