### PR TITLE
fix(protocol): translate tool_choice across protocols

### DIFF
--- a/apps/bitrouter/src/auth/tests.rs
+++ b/apps/bitrouter/src/auth/tests.rs
@@ -30,6 +30,7 @@ fn prompt() -> Prompt {
         tools: Vec::new(),
         params: GenerationParams::default(),
         response_format: None,
+        tool_choice: None,
         stream: false,
     }
 }

--- a/apps/bitrouter/src/policy/tests.rs
+++ b/apps/bitrouter/src/policy/tests.rs
@@ -21,6 +21,7 @@ fn ctx(model: &str, policy_id: Option<&str>) -> PipelineContext {
         tools: Vec::new(),
         params: GenerationParams::default(),
         response_format: None,
+        tool_choice: None,
         stream: false,
     };
     let req = PipelineRequest::new(model, CallerContext::new("k1", "u1"), prompt);
@@ -51,6 +52,7 @@ fn ctx_with_tools(tools: &[&str], policy_id: Option<&str>) -> PipelineContext {
             .collect(),
         params: GenerationParams::default(),
         response_format: None,
+        tool_choice: None,
         stream: false,
     };
     let req = PipelineRequest::new("m", CallerContext::new("k1", "u1"), prompt);

--- a/apps/bitrouter/tests/e2e.rs
+++ b/apps/bitrouter/tests/e2e.rs
@@ -79,6 +79,7 @@ fn chat_prompt() -> Prompt {
         tools: Vec::new(),
         params: GenerationParams::default(),
         response_format: None,
+        tool_choice: None,
         stream: false,
     }
 }

--- a/crates/bitrouter-sdk/src/language_model/context.rs
+++ b/crates/bitrouter-sdk/src/language_model/context.rs
@@ -426,6 +426,7 @@ mod tests {
             tools: vec![],
             params: Default::default(),
             response_format: None,
+            tool_choice: None,
             stream: false,
         }
     }
@@ -497,6 +498,7 @@ mod tests {
             tools: vec![],
             params: Default::default(),
             response_format: None,
+            tool_choice: None,
             stream: true,
         }
     }
@@ -539,6 +541,7 @@ mod tests {
             tools: vec![],
             params: Default::default(),
             response_format: None,
+            tool_choice: None,
             stream: true,
         };
         let ctx = ctx_from_prompt(prompt);

--- a/crates/bitrouter-sdk/src/language_model/protocol/chat_completions.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/chat_completions.rs
@@ -20,7 +20,7 @@ use crate::language_model::protocol::{
 use crate::language_model::stream::SseFrame;
 use crate::language_model::types::{
     ApiProtocol, Content, FinishReason, GenerateResult, GenerationParams, Message, Prompt,
-    ResponseFormat, Role, RoutingTarget, StreamPart, Usage,
+    ResponseFormat, Role, RoutingTarget, StreamPart, ToolChoice, Usage,
 };
 
 /// The Chat Completions inbound + outbound protocol adapter.
@@ -295,6 +295,11 @@ impl InboundAdapter for ChatCompletionsAdapter {
             None => None,
         };
 
+        // Promote a known-shape `tool_choice` into the canonical slot so it can
+        // translate across protocols (the v0 #547 bug: Anthropic's object form
+        // reaching an OpenAI upstream). Unmapped shapes stay in `extra`.
+        let tool_choice = parse_chat_tool_choice(&mut extra);
+
         Ok(Prompt {
             model: req.model,
             system,
@@ -305,12 +310,13 @@ impl InboundAdapter for ChatCompletionsAdapter {
                 top_p: req.top_p,
                 max_tokens: req.max_tokens.or(req.max_completion_tokens),
                 reasoning_effort: req.reasoning_effort,
-                // Every Chat Completions field without a typed slot — tool_choice,
-                // stop / stop_sequences, seed, n, presence/frequency_penalty,
+                // Every Chat Completions field without a typed slot — stop /
+                // stop_sequences, seed, n, presence/frequency_penalty,
                 // logit_bias, … — rides in `extra` and is splatted back on render.
                 extra,
             },
             response_format,
+            tool_choice,
             stream: req.stream,
         })
     }
@@ -452,9 +458,15 @@ impl OutboundAdapter for ChatCompletionsAdapter {
         if let Some(rf) = &prompt.response_format {
             req.insert("response_format".into(), render_chat_response_format(rf));
         }
+        // Render the canonical tool_choice into Chat Completions' native shape.
+        // Inserted before the extras splat so it wins over any leftover
+        // `tool_choice` (matching how response_format is handled).
+        if let Some(tc) = &prompt.tool_choice {
+            req.insert("tool_choice".into(), render_chat_tool_choice(tc));
+        }
         // Splat the extras back into the outbound request — this is how
-        // `tool_choice`, `stop`, `seed`, etc. survive the round trip. Typed
-        // fields above win over any same-named extra.
+        // `stop`, `seed`, `parallel_tool_calls`, etc. survive the round trip.
+        // Typed fields above win over any same-named extra.
         for (k, v) in &prompt.params.extra {
             req.entry(k.clone()).or_insert_with(|| v.clone());
         }
@@ -614,6 +626,52 @@ fn render_chat_response_format(rf: &ResponseFormat) -> serde_json::Value {
     }
     js.insert("schema".into(), schema.clone());
     serde_json::json!({ "type": "json_schema", "json_schema": serde_json::Value::Object(js) })
+}
+
+/// Promote a Chat Completions `tool_choice` into the canonical [`ToolChoice`],
+/// removing it from `extra` when it maps to a known shape. Unmapped shapes
+/// (e.g. `{ "type": "allowed_tools", … }`) are left untouched so they pass
+/// through opaquely.
+/// <https://platform.openai.com/docs/api-reference/chat/create#chat-create-tool_choice>
+fn parse_chat_tool_choice(extra: &mut HashMap<String, serde_json::Value>) -> Option<ToolChoice> {
+    let parsed = match extra.get("tool_choice")? {
+        serde_json::Value::String(s) => match s.as_str() {
+            "auto" => Some(ToolChoice::Auto),
+            "required" => Some(ToolChoice::Required),
+            "none" => Some(ToolChoice::None),
+            _ => None,
+        },
+        serde_json::Value::Object(o)
+            if o.get("type").and_then(|t| t.as_str()) == Some("function") =>
+        {
+            o.get("function")
+                .and_then(|f| f.get("name"))
+                .and_then(|n| n.as_str())
+                .map(|name| ToolChoice::Tool {
+                    name: name.to_string(),
+                })
+        }
+        _ => None,
+    };
+    if parsed.is_some() {
+        extra.remove("tool_choice");
+    }
+    parsed
+}
+
+/// Render the canonical [`ToolChoice`] into Chat Completions' native shape: the
+/// bare strings `auto` / `required` / `none`, or a `{ type: "function",
+/// function: { name } }` object to force one tool.
+fn render_chat_tool_choice(tc: &ToolChoice) -> serde_json::Value {
+    match tc {
+        ToolChoice::Auto => serde_json::json!("auto"),
+        ToolChoice::Required => serde_json::json!("required"),
+        ToolChoice::None => serde_json::json!("none"),
+        ToolChoice::Tool { name } => serde_json::json!({
+            "type": "function",
+            "function": { "name": name },
+        }),
+    }
 }
 
 #[async_trait]

--- a/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
@@ -20,7 +20,7 @@ use crate::language_model::protocol::{
 use crate::language_model::stream::SseFrame;
 use crate::language_model::types::{
     ApiProtocol, Content, FinishReason, GenerateResult, GenerationParams, Message, Prompt,
-    ResponseFormat, Role, RoutingTarget, StreamPart, Usage,
+    ResponseFormat, Role, RoutingTarget, StreamPart, ToolChoice, Usage,
 };
 
 /// The Generate Content protocol adapter.
@@ -230,13 +230,72 @@ fn finish_reason_str(r: &FinishReason) -> String {
     }
 }
 
+/// Promote Google's `toolConfig.functionCallingConfig` into the canonical
+/// [`ToolChoice`], removing the function-calling config (and `toolConfig` itself
+/// when it becomes empty) from the top-level `extra` map. `ANY` with exactly one
+/// `allowedFunctionNames` maps to a forced single tool; `ANY` otherwise to
+/// `Required`. Unmapped modes are left untouched.
+/// <https://ai.google.dev/api/caching#FunctionCallingConfig>
+fn parse_gc_tool_choice(
+    extra: &mut std::collections::HashMap<String, serde_json::Value>,
+) -> Option<ToolChoice> {
+    let tool_config = extra.get_mut("toolConfig")?.as_object_mut()?;
+    let fcc = tool_config.get("functionCallingConfig")?.as_object()?;
+    let mode = fcc
+        .get("mode")
+        .and_then(|m| m.as_str())
+        .map(|s| s.to_ascii_uppercase());
+    let names: Vec<String> = fcc
+        .get("allowedFunctionNames")
+        .and_then(|n| n.as_array())
+        .map(|a| {
+            a.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+    let parsed = match mode.as_deref() {
+        Some("AUTO") => Some(ToolChoice::Auto),
+        Some("NONE") => Some(ToolChoice::None),
+        Some("ANY") if names.len() == 1 => Some(ToolChoice::Tool {
+            name: names[0].clone(),
+        }),
+        Some("ANY") => Some(ToolChoice::Required),
+        _ => None,
+    };
+    let drop_tool_config = if parsed.is_some() {
+        tool_config.remove("functionCallingConfig");
+        tool_config.is_empty()
+    } else {
+        false
+    };
+    if drop_tool_config {
+        extra.remove("toolConfig");
+    }
+    parsed
+}
+
+/// Render the canonical [`ToolChoice`] into Google's `functionCallingConfig`
+/// body (`{ mode, allowedFunctionNames? }`).
+fn render_gc_function_calling_config(tc: &ToolChoice) -> serde_json::Value {
+    match tc {
+        ToolChoice::Auto => serde_json::json!({ "mode": "AUTO" }),
+        ToolChoice::Required => serde_json::json!({ "mode": "ANY" }),
+        ToolChoice::None => serde_json::json!({ "mode": "NONE" }),
+        ToolChoice::Tool { name } => serde_json::json!({
+            "mode": "ANY",
+            "allowedFunctionNames": [name],
+        }),
+    }
+}
+
 impl InboundAdapter for GenerateContentAdapter {
     fn protocol(&self) -> ApiProtocol {
         ApiProtocol::GenerateContent
     }
 
     fn parse_request(&self, body: serde_json::Value) -> Result<Prompt> {
-        let req: GenerateContentRequest = serde_json::from_value(body.clone())
+        let mut req: GenerateContentRequest = serde_json::from_value(body.clone())
             .map_err(|e| describe_deser_error("GenerateContentRequest", &e, &body))?;
 
         let system = req.system_instruction.as_ref().map(|si| {
@@ -327,6 +386,10 @@ impl InboundAdapter for GenerateContentAdapter {
             }
             None => (GenerationParams::default(), None),
         };
+        // Promote `toolConfig.functionCallingConfig` into the canonical
+        // tool_choice slot so it translates across protocols; the rest of
+        // `toolConfig` (and other top-level extras) still ride through.
+        let tool_choice = parse_gc_tool_choice(&mut req.extra);
         // Preserve top-level Google fields (`toolConfig`, `safetySettings`,
         // `cachedContent`, …) across the round-trip. They're namespaced so they
         // don't collide with `generationConfig`-level extras above and only the
@@ -345,6 +408,7 @@ impl InboundAdapter for GenerateContentAdapter {
             tools,
             params,
             response_format,
+            tool_choice,
             stream: req.stream,
         })
     }
@@ -445,6 +509,21 @@ impl OutboundAdapter for GenerateContentAdapter {
         {
             for (k, v) in top {
                 req.entry(k.clone()).or_insert_with(|| v.clone());
+            }
+        }
+        // Render the canonical tool_choice into Google's
+        // `toolConfig.functionCallingConfig`, merging into any lifted `toolConfig`
+        // (e.g. a passed-through `retrievalConfig`) and overriding its
+        // function-calling config so the canonical slot wins.
+        if let Some(tc) = &prompt.tool_choice {
+            let tool_config = req
+                .entry("toolConfig".to_string())
+                .or_insert_with(|| serde_json::json!({}));
+            if let Some(obj) = tool_config.as_object_mut() {
+                obj.insert(
+                    "functionCallingConfig".into(),
+                    render_gc_function_calling_config(tc),
+                );
             }
         }
         Ok(serde_json::Value::Object(req))

--- a/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
@@ -233,8 +233,12 @@ fn finish_reason_str(r: &FinishReason) -> String {
 /// Promote Google's `toolConfig.functionCallingConfig` into the canonical
 /// [`ToolChoice`], removing the function-calling config (and `toolConfig` itself
 /// when it becomes empty) from the top-level `extra` map. `ANY` with exactly one
-/// `allowedFunctionNames` maps to a forced single tool; `ANY` otherwise to
-/// `Required`. Unmapped modes are left untouched.
+/// `allowedFunctionNames` maps to a forced single tool; `ANY` with none maps to
+/// `Required`. `allowedFunctionNames` is a restricting set with no canonical
+/// equivalent beyond that single-tool case, so shapes that would lose it — `ANY`
+/// with two or more names, or `AUTO`/`NONE` carrying names — are left untouched
+/// to pass through verbatim rather than silently widened. Unmapped modes are
+/// likewise left untouched.
 /// <https://ai.google.dev/api/caching#FunctionCallingConfig>
 fn parse_gc_tool_choice(
     extra: &mut std::collections::HashMap<String, serde_json::Value>,
@@ -255,12 +259,12 @@ fn parse_gc_tool_choice(
         })
         .unwrap_or_default();
     let parsed = match mode.as_deref() {
-        Some("AUTO") => Some(ToolChoice::Auto),
-        Some("NONE") => Some(ToolChoice::None),
+        Some("AUTO") if names.is_empty() => Some(ToolChoice::Auto),
+        Some("NONE") if names.is_empty() => Some(ToolChoice::None),
+        Some("ANY") if names.is_empty() => Some(ToolChoice::Required),
         Some("ANY") if names.len() == 1 => Some(ToolChoice::Tool {
             name: names[0].clone(),
         }),
-        Some("ANY") => Some(ToolChoice::Required),
         _ => None,
     };
     let drop_tool_config = if parsed.is_some() {

--- a/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
@@ -23,7 +23,7 @@ use crate::language_model::protocol::{
 use crate::language_model::stream::SseFrame;
 use crate::language_model::types::{
     ApiProtocol, AuthScheme, Content, FinishReason, GenerateResult, GenerationParams, Message,
-    Prompt, ResponseFormat, Role, RoutingTarget, StopDetails, StreamPart, Usage,
+    Prompt, ResponseFormat, Role, RoutingTarget, StopDetails, StreamPart, ToolChoice, Usage,
 };
 
 /// The Messages inbound + outbound protocol adapter.
@@ -402,6 +402,11 @@ impl InboundAdapter for MessagesAdapter {
             response_format = Some(rf);
         }
 
+        // Promote a known-shape `tool_choice` into the canonical slot so it
+        // translates across protocols (the v0 #547 bug: Anthropic's object form
+        // reaching an OpenAI upstream verbatim). Unmapped shapes stay in `extra`.
+        let tool_choice = parse_messages_tool_choice(&mut extra);
+
         Ok(Prompt {
             model: req.model,
             system,
@@ -415,6 +420,7 @@ impl InboundAdapter for MessagesAdapter {
                 extra,
             },
             response_format,
+            tool_choice,
             stream: req.stream,
         })
     }
@@ -539,9 +545,37 @@ impl OutboundAdapter for MessagesAdapter {
                 serde_json::Value::Object(output_config),
             );
         }
-        // Splat anthropic-specific extras (tool_choice, stop_sequences, …) back
-        // into the outbound request. Typed fields win over same-named extras.
+        // Render the canonical tool_choice into Anthropic's native shape, before
+        // the extras splat so it wins over any leftover `tool_choice`. Anthropic
+        // nests parallel-tool control inside the object, so fold the
+        // protocol-neutral top-level `parallel_tool_calls` (the shape every other
+        // protocol uses) back into `disable_parallel_tool_use` here.
+        let parallel_tool_calls = prompt
+            .params
+            .extra
+            .get("parallel_tool_calls")
+            .and_then(|v| v.as_bool());
+        if prompt.tool_choice.is_some() || parallel_tool_calls.is_some() {
+            let mut tc = match &prompt.tool_choice {
+                Some(tc) => render_messages_tool_choice(tc),
+                // `disable_parallel_tool_use` only exists on a tool_choice object;
+                // default to `auto` (Anthropic's own default) to carry it.
+                None => serde_json::json!({ "type": "auto" }),
+            };
+            if let Some(parallel) = parallel_tool_calls
+                && let Some(obj) = tc.as_object_mut()
+            {
+                obj.insert("disable_parallel_tool_use".into(), (!parallel).into());
+            }
+            req.insert("tool_choice".into(), tc);
+        }
+        // Splat anthropic-specific extras (stop_sequences, top_k, …) back into
+        // the outbound request. `parallel_tool_calls` is skipped — it was folded
+        // into `tool_choice` above, and Anthropic has no top-level field for it.
         for (k, v) in &prompt.params.extra {
+            if k == "parallel_tool_calls" {
+                continue;
+            }
             req.entry(k.clone()).or_insert_with(|| v.clone());
         }
         req.insert("stream".into(), prompt.stream.into());
@@ -650,6 +684,56 @@ fn json_schema_from(format: &serde_json::Value) -> Option<ResponseFormat> {
 fn render_messages_response_format(rf: &ResponseFormat) -> serde_json::Value {
     let ResponseFormat::JsonSchema { schema, .. } = rf;
     serde_json::json!({ "type": "json_schema", "schema": schema })
+}
+
+/// Promote an Anthropic `tool_choice` into the canonical [`ToolChoice`], removing
+/// it from `extra` when it maps to a known shape. Unmapped shapes are left
+/// untouched so they pass through opaquely. Anthropic nests parallel-tool control
+/// inside the object as `disable_parallel_tool_use`; lift it to the
+/// protocol-neutral top-level `parallel_tool_calls` (the shape every other
+/// protocol uses) so it survives translation rather than being dropped with the
+/// consumed object.
+/// <https://docs.anthropic.com/en/api/messages> → `tool_choice`.
+fn parse_messages_tool_choice(
+    extra: &mut std::collections::HashMap<String, serde_json::Value>,
+) -> Option<ToolChoice> {
+    let (parsed, disable_parallel) = {
+        let obj = extra.get("tool_choice").and_then(|v| v.as_object())?;
+        let parsed = match obj.get("type").and_then(|t| t.as_str()) {
+            Some("auto") => Some(ToolChoice::Auto),
+            Some("any") => Some(ToolChoice::Required),
+            Some("none") => Some(ToolChoice::None),
+            Some("tool") => obj
+                .get("name")
+                .and_then(|n| n.as_str())
+                .map(|name| ToolChoice::Tool {
+                    name: name.to_string(),
+                }),
+            _ => None,
+        };
+        let disable_parallel = obj
+            .get("disable_parallel_tool_use")
+            .and_then(|v| v.as_bool());
+        (parsed, disable_parallel)
+    };
+    if parsed.is_some() {
+        if let Some(disable) = disable_parallel {
+            extra.insert("parallel_tool_calls".to_string(), (!disable).into());
+        }
+        extra.remove("tool_choice");
+    }
+    parsed
+}
+
+/// Render the canonical [`ToolChoice`] into Anthropic's native `tool_choice`
+/// object: `{type:"auto"|"any"|"none"}` or `{type:"tool", name}`.
+fn render_messages_tool_choice(tc: &ToolChoice) -> serde_json::Value {
+    match tc {
+        ToolChoice::Auto => serde_json::json!({ "type": "auto" }),
+        ToolChoice::Required => serde_json::json!({ "type": "any" }),
+        ToolChoice::None => serde_json::json!({ "type": "none" }),
+        ToolChoice::Tool { name } => serde_json::json!({ "type": "tool", "name": name }),
+    }
 }
 
 #[async_trait]

--- a/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
@@ -29,7 +29,7 @@ use crate::language_model::protocol::{
 use crate::language_model::stream::SseFrame;
 use crate::language_model::types::{
     ApiProtocol, Content, FinishReason, GenerateResult, GenerationParams, Message, Prompt,
-    ResponseFormat, Role, RoutingTarget, StreamPart, Usage,
+    ResponseFormat, Role, RoutingTarget, StreamPart, ToolChoice, Usage,
 };
 
 /// The Responses protocol adapter.
@@ -365,6 +365,11 @@ impl InboundAdapter for ResponsesAdapter {
             None => None,
         };
 
+        // Promote a known-shape `tool_choice` into the canonical slot so it can
+        // translate across protocols; unmapped shapes (hosted-tool selectors,
+        // `allowed_tools`, …) stay in `extra` and pass through.
+        let tool_choice = parse_responses_tool_choice(&mut extra);
+
         Ok(Prompt {
             model: req.model,
             system,
@@ -376,12 +381,13 @@ impl InboundAdapter for ResponsesAdapter {
                 max_tokens: req.max_output_tokens,
                 reasoning_effort: req.reasoning.and_then(|r| r.effort),
                 // Splat every Responses-API field without a typed slot —
-                // tool_choice, parallel_tool_calls, max_tool_calls, metadata,
-                // include[], previous_response_id, store, stream_options, … —
-                // into `extra` so render_request can put them back.
+                // parallel_tool_calls, max_tool_calls, metadata, include[],
+                // previous_response_id, store, stream_options, … — into `extra`
+                // so render_request can put them back.
                 extra,
             },
             response_format,
+            tool_choice,
             stream: req.stream,
         })
     }
@@ -488,9 +494,13 @@ impl OutboundAdapter for ResponsesAdapter {
             text.insert("format".into(), render_responses_response_format(rf));
             req.insert("text".into(), serde_json::Value::Object(text));
         }
-        // Splat Responses-API extras (tool_choice, parallel_tool_calls,
-        // metadata, include, …) back onto the outbound request. Typed fields
-        // win.
+        // Render the canonical tool_choice into Responses' native shape, before
+        // the extras splat so it wins over any leftover `tool_choice`.
+        if let Some(tc) = &prompt.tool_choice {
+            req.insert("tool_choice".into(), render_responses_tool_choice(tc));
+        }
+        // Splat Responses-API extras (parallel_tool_calls, metadata, include, …)
+        // back onto the outbound request. Typed fields win.
         for (k, v) in &prompt.params.extra {
             req.entry(k.clone()).or_insert_with(|| v.clone());
         }
@@ -605,6 +615,51 @@ fn render_responses_response_format(rf: &ResponseFormat) -> serde_json::Value {
     }
     obj.insert("schema".into(), schema.clone());
     serde_json::Value::Object(obj)
+}
+
+/// Promote a Responses `tool_choice` into the canonical [`ToolChoice`], removing
+/// it from `extra` when it maps to a known shape. Hosted-tool / `allowed_tools`
+/// selectors are left untouched so they pass through opaquely.
+/// <https://platform.openai.com/docs/api-reference/responses/create#responses-create-tool_choice>
+fn parse_responses_tool_choice(
+    extra: &mut std::collections::HashMap<String, serde_json::Value>,
+) -> Option<ToolChoice> {
+    let parsed = match extra.get("tool_choice")? {
+        serde_json::Value::String(s) => match s.as_str() {
+            "auto" => Some(ToolChoice::Auto),
+            "required" => Some(ToolChoice::Required),
+            "none" => Some(ToolChoice::None),
+            _ => None,
+        },
+        serde_json::Value::Object(o)
+            if o.get("type").and_then(|t| t.as_str()) == Some("function") =>
+        {
+            // Responses carries the forced function name flat on the object,
+            // not nested under `function` as Chat Completions does.
+            o.get("name")
+                .and_then(|n| n.as_str())
+                .map(|name| ToolChoice::Tool {
+                    name: name.to_string(),
+                })
+        }
+        _ => None,
+    };
+    if parsed.is_some() {
+        extra.remove("tool_choice");
+    }
+    parsed
+}
+
+/// Render the canonical [`ToolChoice`] into Responses' native shape: the bare
+/// strings `auto` / `required` / `none`, or `{ type: "function", name }` to
+/// force one tool (flat `name`, unlike Chat Completions' nested form).
+fn render_responses_tool_choice(tc: &ToolChoice) -> serde_json::Value {
+    match tc {
+        ToolChoice::Auto => serde_json::json!("auto"),
+        ToolChoice::Required => serde_json::json!("required"),
+        ToolChoice::None => serde_json::json!("none"),
+        ToolChoice::Tool { name } => serde_json::json!({ "type": "function", "name": name }),
+    }
 }
 
 #[async_trait]

--- a/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
@@ -34,6 +34,25 @@ fn all_protocols() -> [ApiProtocol; 4] {
     ]
 }
 
+/// A minimal valid request body for `protocol`, carrying a single user turn —
+/// enough for `parse_request` to succeed so a test can layer one extra field on.
+fn minimal_request(protocol: ApiProtocol) -> serde_json::Value {
+    match protocol {
+        ApiProtocol::Messages => serde_json::json!({
+            "model": "m", "max_tokens": 1024,
+            "messages": [{ "role": "user", "content": "hi" }],
+        }),
+        ApiProtocol::ChatCompletions => serde_json::json!({
+            "model": "m", "messages": [{ "role": "user", "content": "hi" }],
+        }),
+        ApiProtocol::Responses => serde_json::json!({ "model": "m", "input": "hi" }),
+        ApiProtocol::GenerateContent => serde_json::json!({
+            "model": "m", "contents": [{ "role": "user", "parts": [{ "text": "hi" }] }],
+        }),
+        ApiProtocol::Custom(_) => unreachable!("test helper only handles built-in protocols"),
+    }
+}
+
 /// A canonical prompt exercising system + a user message + a tool definition.
 fn sample_prompt() -> Prompt {
     Prompt {
@@ -51,6 +70,7 @@ fn sample_prompt() -> Prompt {
             ..Default::default()
         },
         response_format: None,
+        tool_choice: None,
         stream: false,
     }
 }
@@ -726,6 +746,7 @@ fn messages_outbound_renders_output_config_effort() {
             ..Default::default()
         },
         response_format: None,
+        tool_choice: None,
         stream: false,
     };
     let rendered = adapter.render_request(&prompt).unwrap();
@@ -751,6 +772,7 @@ fn messages_outbound_merges_format_and_effort_into_output_config() {
             strict: None,
             schema: serde_json::json!({"type": "object"}),
         }),
+        tool_choice: None,
         stream: false,
     };
     let rendered = adapter.render_request(&prompt).unwrap();
@@ -865,6 +887,7 @@ fn messages_outbound_renders_mid_conversation_system() {
         tools: vec![],
         params: GenerationParams::default(),
         response_format: None,
+        tool_choice: None,
         stream: false,
     };
     let rendered = adapter.render_request(&prompt).unwrap();
@@ -2731,5 +2754,216 @@ fn extra_passthrough_field_is_not_in_schema() {
     assert!(
         s.get("properties").and_then(|p| p.get("extra")).is_none(),
         "ResponsesRequest schema must not expose `extra` (pass-through field)",
+    );
+}
+
+/// #547 — an Anthropic Messages client (Claude Code) sends `tool_choice` in
+/// Anthropic's object shape. Routed to an OpenAI Chat Completions upstream it
+/// MUST become OpenAI's native shape (the bare string `"auto"`, not the object
+/// `{"type":"auto"}`, which OpenAI rejects), not pass through verbatim. Before
+/// the fix `tool_choice` rode `extra` opaquely and broke tool use on
+/// non-Anthropic models while plain-text generation still worked.
+#[test]
+fn regression_547_messages_tool_choice_translates_to_chat() {
+    let inbound = adapter_for(ApiProtocol::Messages);
+    let outbound = adapter_for(ApiProtocol::ChatCompletions);
+
+    // auto / any / none map to the bare strings; a forced tool maps to the
+    // nested `{type:function, function:{name}}` object.
+    let cases = [
+        (
+            serde_json::json!({ "type": "auto" }),
+            serde_json::json!("auto"),
+        ),
+        (
+            serde_json::json!({ "type": "any" }),
+            serde_json::json!("required"),
+        ),
+        (
+            serde_json::json!({ "type": "none" }),
+            serde_json::json!("none"),
+        ),
+        (
+            serde_json::json!({ "type": "tool", "name": "Edit" }),
+            serde_json::json!({ "type": "function", "function": { "name": "Edit" } }),
+        ),
+    ];
+
+    for (anthropic, expected_openai) in cases {
+        let request = serde_json::json!({
+            "model": "deepseek/deepseek-v4-pro",
+            "max_tokens": 1024,
+            "messages": [{ "role": "user", "content": "edit the file" }],
+            "tools": [{ "name": "Edit", "input_schema": { "type": "object" } }],
+            "tool_choice": anthropic,
+        });
+        let prompt = inbound
+            .parse_request(request)
+            .expect("parse messages request");
+        let rendered = outbound
+            .render_request(&prompt)
+            .expect("render chat request");
+        assert_eq!(
+            rendered["tool_choice"], expected_openai,
+            "Anthropic {anthropic} must render as OpenAI {expected_openai}"
+        );
+        // The translated value must not leak the inbound object shape.
+        assert_ne!(rendered["tool_choice"], anthropic);
+    }
+}
+
+/// `tool_choice` is canonical, so it round-trips across every inbound→outbound
+/// pair in the 4×4 matrix. Drives each native shape and asserts the canonical
+/// promotion + re-rendering for a forced-tool choice (the variant that differs
+/// most between protocols).
+#[test]
+fn tool_choice_round_trips_across_protocol_matrix() {
+    // Native `tool_choice` (or, for Google, `toolConfig`) that forces tool "X".
+    fn force_tool_field(p: ApiProtocol) -> (&'static str, serde_json::Value) {
+        match p {
+            ApiProtocol::Messages => (
+                "tool_choice",
+                serde_json::json!({ "type": "tool", "name": "X" }),
+            ),
+            ApiProtocol::ChatCompletions => (
+                "tool_choice",
+                serde_json::json!({ "type": "function", "function": { "name": "X" } }),
+            ),
+            ApiProtocol::Responses => (
+                "tool_choice",
+                serde_json::json!({ "type": "function", "name": "X" }),
+            ),
+            ApiProtocol::GenerateContent => (
+                "toolConfig",
+                serde_json::json!({
+                    "functionCallingConfig": { "mode": "ANY", "allowedFunctionNames": ["X"] }
+                }),
+            ),
+            ApiProtocol::Custom(_) => unreachable!(),
+        }
+    }
+
+    // Did the outbound request force exactly tool "X"?
+    fn forces_tool_x(p: ApiProtocol, req: &serde_json::Value) -> bool {
+        match p {
+            ApiProtocol::Messages => {
+                req["tool_choice"] == serde_json::json!({ "type": "tool", "name": "X" })
+            }
+            ApiProtocol::ChatCompletions => {
+                req["tool_choice"]["type"] == "function"
+                    && req["tool_choice"]["function"]["name"] == "X"
+            }
+            ApiProtocol::Responses => {
+                req["tool_choice"]["type"] == "function" && req["tool_choice"]["name"] == "X"
+            }
+            ApiProtocol::GenerateContent => {
+                let fcc = &req["toolConfig"]["functionCallingConfig"];
+                fcc["mode"] == "ANY" && fcc["allowedFunctionNames"][0] == "X"
+            }
+            ApiProtocol::Custom(_) => unreachable!(),
+        }
+    }
+
+    for from in all_protocols() {
+        for to in all_protocols() {
+            let inbound = adapter_for(from.clone());
+            let outbound = adapter_for(to.clone());
+
+            let mut body = minimal_request(from.clone());
+            let (field, value) = force_tool_field(from.clone());
+            body[field] = value;
+
+            let prompt = inbound
+                .parse_request(body)
+                .unwrap_or_else(|e| panic!("{from:?} parse_request: {e}"));
+            assert_eq!(
+                prompt.tool_choice,
+                Some(ToolChoice::Tool { name: "X".into() }),
+                "{from:?} must promote a forced-tool choice into the canonical slot"
+            );
+
+            let rendered = outbound
+                .render_request(&prompt)
+                .unwrap_or_else(|e| panic!("{to:?} render_request: {e}"));
+            assert!(
+                forces_tool_x(to.clone(), &rendered),
+                "{from:?} → {to:?} must force tool X; got {rendered}"
+            );
+        }
+    }
+}
+
+/// Anthropic nests `disable_parallel_tool_use` inside `tool_choice`; every other
+/// protocol carries it as a top-level `parallel_tool_calls`. Canonicalizing
+/// `tool_choice` must not drop it — it translates both ways and survives an
+/// Anthropic round-trip.
+#[test]
+fn tool_choice_preserves_parallel_tool_use_control() {
+    let messages = adapter_for(ApiProtocol::Messages);
+    let chat = adapter_for(ApiProtocol::ChatCompletions);
+
+    // Anthropic → OpenAI: nested flag becomes the top-level boolean.
+    let anthropic_req = serde_json::json!({
+        "model": "m",
+        "max_tokens": 1024,
+        "messages": [{ "role": "user", "content": "hi" }],
+        "tool_choice": { "type": "auto", "disable_parallel_tool_use": true },
+    });
+    let prompt = messages.parse_request(anthropic_req).unwrap();
+    let chat_out = chat.render_request(&prompt).unwrap();
+    assert_eq!(chat_out["tool_choice"], "auto");
+    assert_eq!(
+        chat_out["parallel_tool_calls"], false,
+        "disable_parallel_tool_use must survive as parallel_tool_calls"
+    );
+
+    // OpenAI → Anthropic: top-level boolean becomes the nested flag.
+    let chat_req = serde_json::json!({
+        "model": "m",
+        "messages": [{ "role": "user", "content": "hi" }],
+        "parallel_tool_calls": false,
+    });
+    let prompt = chat.parse_request(chat_req).unwrap();
+    let anthropic_out = messages.render_request(&prompt).unwrap();
+    assert_eq!(
+        anthropic_out["tool_choice"],
+        serde_json::json!({ "type": "auto", "disable_parallel_tool_use": true }),
+        "parallel_tool_calls must reach Anthropic nested under tool_choice"
+    );
+    // ...and not leak as a top-level field Anthropic doesn't define.
+    assert!(anthropic_out.get("parallel_tool_calls").is_none());
+
+    // Anthropic → Anthropic round-trip keeps the nested flag intact.
+    let round_trip = messages
+        .render_request(&messages.parse_request(anthropic_out).unwrap())
+        .unwrap();
+    assert_eq!(
+        round_trip["tool_choice"]["disable_parallel_tool_use"], true,
+        "Anthropic round-trip must not drop disable_parallel_tool_use"
+    );
+}
+
+/// A `tool_choice` shape an adapter can't map to the canonical slot (e.g. a
+/// Responses hosted-tool / `allowed_tools` selector) is left in `extra` and
+/// passes through verbatim on a same-protocol round-trip — never silently
+/// dropped or mangled.
+#[test]
+fn unmapped_tool_choice_passes_through_unchanged() {
+    let responses = adapter_for(ApiProtocol::Responses);
+    let exotic = serde_json::json!({ "type": "allowed_tools", "mode": "auto", "tools": [] });
+    let req = serde_json::json!({
+        "model": "m",
+        "input": "hi",
+        "tool_choice": exotic,
+    });
+    let prompt = responses.parse_request(req).unwrap();
+    assert_eq!(
+        prompt.tool_choice, None,
+        "an unmapped shape must not be force-fit into the canonical slot"
+    );
+    let rendered = responses.render_request(&prompt).unwrap();
+    assert_eq!(
+        rendered["tool_choice"], exotic,
+        "an unmapped tool_choice must pass through verbatim"
     );
 }

--- a/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
@@ -2967,3 +2967,31 @@ fn unmapped_tool_choice_passes_through_unchanged() {
         "an unmapped tool_choice must pass through verbatim"
     );
 }
+
+/// Generate Content's `allowedFunctionNames` is a restricting *set*; the
+/// canonical slot only models the single-tool case. A multi-name `ANY` (or an
+/// `AUTO`/`NONE` carrying names) must therefore be left in `extra` and pass
+/// through verbatim — never narrowed to a bare `Required`/`Auto` that would
+/// silently widen the constraint.
+#[test]
+fn gc_tool_choice_with_restricting_set_passes_through() {
+    let gc = adapter_for(ApiProtocol::GenerateContent);
+    let cases = [
+        serde_json::json!({ "mode": "ANY", "allowedFunctionNames": ["A", "B"] }),
+        serde_json::json!({ "mode": "AUTO", "allowedFunctionNames": ["A"] }),
+    ];
+    for fcc in cases {
+        let mut body = minimal_request(ApiProtocol::GenerateContent);
+        body["toolConfig"] = serde_json::json!({ "functionCallingConfig": fcc });
+        let prompt = gc.parse_request(body.clone()).unwrap();
+        assert_eq!(
+            prompt.tool_choice, None,
+            "a restricting-set config must not be force-fit into the canonical slot: {fcc}"
+        );
+        let rendered = gc.render_request(&prompt).unwrap();
+        assert_eq!(
+            rendered["toolConfig"], body["toolConfig"],
+            "a restricting-set toolConfig must pass through verbatim: {fcc}"
+        );
+    }
+}

--- a/crates/bitrouter-sdk/src/language_model/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/tests.rs
@@ -43,6 +43,7 @@ fn request() -> PipelineRequest {
         tools: Vec::new(),
         params: GenerationParams::default(),
         response_format: None,
+        tool_choice: None,
         stream: false,
     };
     PipelineRequest::new("test-model", CallerContext::new("k1", "u1"), prompt)
@@ -921,6 +922,7 @@ async fn executor_rejects_response_format_on_unsupported_outbound() {
             strict: None,
             schema: serde_json::json!({"type": "object"}),
         }),
+        tool_choice: None,
         stream: false,
     };
     let req = PipelineRequest::new("m", CallerContext::new("k", "u"), prompt.clone());

--- a/crates/bitrouter-sdk/src/language_model/types.rs
+++ b/crates/bitrouter-sdk/src/language_model/types.rs
@@ -190,6 +190,45 @@ pub enum ResponseFormat {
     },
 }
 
+/// Constraint on whether — and which — tool the model may call.
+///
+/// Like [`ResponseFormat`], each inbound adapter promotes the provider-native
+/// `tool_choice` (Generate Content: `tool_config.function_calling_config`) into
+/// this typed slot at `parse_request` time, and each outbound adapter renders it
+/// back into the upstream's native shape on `render_request`. Cross-protocol
+/// routing therefore translates automatically: an Anthropic Messages client
+/// sending `tool_choice: {"type":"auto"}` against an OpenAI Chat Completions
+/// upstream emits the bare string `"auto"` — not the object form, which OpenAI
+/// rejects (the v0 #547 bug). Provider-specific shapes a given adapter can't map
+/// (e.g. Responses hosted-tool selectors) are left in `extra` and pass through
+/// opaquely, exactly as before.
+///
+/// Parallel-tool-use control is a distinct concern, not part of this slot. The
+/// Messages adapter translates Anthropic's nested `disable_parallel_tool_use`
+/// to/from the protocol-neutral top-level `parallel_tool_calls` (the shape Chat
+/// Completions / Responses use), which rides `extra`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ToolChoice {
+    /// The model decides freely whether to call a tool. Chat Completions /
+    /// Responses `"auto"`, Messages `{"type":"auto"}`, Generate Content `AUTO`.
+    Auto,
+    /// The model must call at least one tool. Chat Completions / Responses
+    /// `"required"`, Messages `{"type":"any"}`, Generate Content `ANY`.
+    Required,
+    /// The model must not call any tool. Chat Completions / Responses `"none"`,
+    /// Messages `{"type":"none"}`, Generate Content `NONE`.
+    None,
+    /// The model must call exactly this tool. Chat Completions
+    /// `{"type":"function","function":{"name":…}}`, Responses
+    /// `{"type":"function","name":…}`, Messages `{"type":"tool","name":…}`,
+    /// Generate Content `ANY` + `allowedFunctionNames`.
+    Tool {
+        /// The tool the model is forced to call.
+        name: String,
+    },
+}
+
 /// An optional inference feature a request may require and a provider may
 /// advertise. Capabilities are API-agnostic: the same capability maps to a
 /// different wire parameter in each protocol (structured outputs is Chat
@@ -273,6 +312,11 @@ pub struct Prompt {
     /// adapters render it back natively.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub response_format: Option<ResponseFormat>,
+    /// Constraint on whether / which tool the model may call. Inbound adapters
+    /// promote the provider-native `tool_choice` into this slot; outbound
+    /// adapters render it back natively, so it translates across protocols.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_choice: Option<ToolChoice>,
     /// Whether the caller requested a streaming response.
     pub stream: bool,
 }
@@ -655,6 +699,7 @@ mod tests {
             tools: vec![],
             params: GenerationParams::default(),
             response_format: None,
+            tool_choice: None,
             stream: false,
         }
     }

--- a/plugins/bitrouter-guardrails/src/tests.rs
+++ b/plugins/bitrouter-guardrails/src/tests.rs
@@ -28,6 +28,7 @@ fn prompt(text: &str, stream: bool) -> Prompt {
         tools: Vec::new(),
         params: GenerationParams::default(),
         response_format: None,
+        tool_choice: None,
         stream,
     }
 }

--- a/plugins/bitrouter-observe/src/otel/exporter.rs
+++ b/plugins/bitrouter-observe/src/otel/exporter.rs
@@ -1121,6 +1121,7 @@ mod hop_tests {
             tools: Vec::new(),
             params,
             response_format: None,
+            tool_choice: None,
             stream: false,
         };
         PipelineRequest::new("test-model", CallerContext::new("k1", "u1"), prompt)


### PR DESCRIPTION
## Summary

Fixes #547 — tool calls failing (`No such tool available`) for non-Anthropic models reached via the Anthropic `/v1/messages` API.

`tool_choice` was the only tool-control field never promoted to a canonical slot. Unlike `tools`, `response_format`, and reasoning effort, it rode through `GenerationParams::extra` opaquely and was forwarded to the upstream verbatim in whatever shape the inbound client sent.

For an Anthropic Messages client (e.g. Claude Code) routed to an OpenAI-protocol model (`deepseek/deepseek-v4-pro`, qwen, …), the Anthropic object form `{"type":"auto"}` reached the OpenAI Chat Completions upstream **unchanged** — an invalid value there (OpenAI expects the bare string `"auto"`). Tool use broke for non-Anthropic models while plain-text generation (which carries no `tool_choice`) kept working.

## Root cause

`tool_choice` translation across the 4×4 inbound/outbound protocol matrix was simply missing. `response_format` already solved the same class of problem by being a canonical typed slot that each adapter promotes/renders — `tool_choice` was never given the same treatment.

## Fix

Promote `tool_choice` to a canonical `ToolChoice` (`Auto` / `Required` / `None` / `Tool{name}`) on `Prompt`, mirroring `ResponseFormat`. Each inbound adapter maps its native shape into the slot; each outbound adapter renders it back natively:

| Protocol | auto / required / none | force one tool |
|---|---|---|
| Messages | `{type:auto\|any\|none}` | `{type:tool,name}` |
| Chat Completions | `"auto"` / `"required"` / `"none"` | `{type:function,function:{name}}` |
| Responses | `"auto"` / `"required"` / `"none"` | `{type:function,name}` |
| Generate Content | `functionCallingConfig.mode` AUTO/ANY/NONE | ANY + `allowedFunctionNames` |

- Shapes an adapter can't map (e.g. a Responses hosted-tool / `allowed_tools` selector) stay in `extra` and pass through verbatim — never force-fit or dropped.
- Anthropic nests parallel-tool control inside `tool_choice`; the `disable_parallel_tool_use` flag is folded to/from the protocol-neutral top-level `parallel_tool_calls` so it survives translation rather than being silently dropped.

## Tests

- `regression_547_messages_tool_choice_translates_to_chat` — the exact reported path (Anthropic → OpenAI shapes).
- `tool_choice_round_trips_across_protocol_matrix` — all 16 inbound→outbound pairs force the right tool.
- `tool_choice_preserves_parallel_tool_use_control` — `disable_parallel_tool_use` ↔ `parallel_tool_calls`, both directions + Anthropic round-trip.
- `unmapped_tool_choice_passes_through_unchanged` — exotic shapes pass through.

`cargo nextest run --all-features` (712 passed), `cargo clippy --all-features`, and `cargo fmt -- --check` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)