### PR TITLE
fix(protocol): don't fragment streamed tool calls

### DIFF
--- a/crates/bitrouter-sdk/src/language_model/protocol/chat_completions.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/chat_completions.rs
@@ -1410,9 +1410,10 @@ fn render_usage(usage: &Usage) -> serde_json::Value {
 /// state machine — unknown chunk shapes are ignored, never panicked on.
 #[derive(Default)]
 struct ChatStreamDecoder {
-    /// Accumulates tool-call name per index so the canonical
-    /// `ToolCallDelta.id` is stable across chunks.
-    tool_ids: Vec<(String, String)>,
+    /// Remembers the tool-call id per `index` (only the first chunk of a call
+    /// carries `id`) so the canonical `ToolCallDelta.id` is stable across the
+    /// continuation chunks.
+    tool_ids: Vec<String>,
     done: bool,
     /// Whether the one-shot [`StreamPart::ResponseStarted`] has been emitted.
     /// Every chunk repeats the top-level `id`; we surface it only once.
@@ -1477,23 +1478,27 @@ impl StreamDecoder for ChatStreamDecoder {
                         let name = tc
                             .get("function")
                             .and_then(|f| f.get("name"))
-                            .and_then(|n| n.as_str());
+                            .and_then(|n| n.as_str())
+                            // Some OpenAI-compatible upstreams (e.g. Kimi / DeepSeek
+                            // serving stacks that emit `functions.<name>:<idx>` tool
+                            // ids) re-send `"name":""` on every argument-continuation
+                            // chunk. An empty string is not a name announcement, so
+                            // normalize it to `None` — otherwise a downstream encoder
+                            // reads it as the start of a *new* tool call.
+                            .filter(|n| !n.is_empty());
                         let args = tc
                             .get("function")
                             .and_then(|f| f.get("arguments"))
                             .and_then(|a| a.as_str())
                             .unwrap_or("");
                         while self.tool_ids.len() <= idx {
-                            self.tool_ids.push((String::new(), String::new()));
+                            self.tool_ids.push(String::new());
                         }
                         if let Some(id) = id {
-                            self.tool_ids[idx].0 = id.to_string();
-                        }
-                        if let Some(name) = name {
-                            self.tool_ids[idx].1 = name.to_string();
+                            self.tool_ids[idx] = id.to_string();
                         }
                         parts.push(StreamPart::ToolCallDelta {
-                            id: self.tool_ids[idx].0.clone(),
+                            id: self.tool_ids[idx].clone(),
                             name: name.map(|n| n.to_string()),
                             arguments: args.to_string(),
                         });

--- a/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
@@ -921,7 +921,7 @@ impl InboundAdapter for GenerateContentAdapter {
     }
 
     fn stream_encoder(&self, _request_id: &str, _model: &str) -> Box<dyn StreamEncoder> {
-        Box::new(GenerateContentStreamEncoder)
+        Box::new(GenerateContentStreamEncoder::default())
     }
 }
 
@@ -1386,11 +1386,44 @@ impl StreamDecoder for GenerateContentStreamDecoder {
 
 /// Generate Content `streamGenerateContent` SSE encoder — each canonical part becomes one
 /// `GenerateContentResponse` chunk.
-struct GenerateContentStreamEncoder;
+/// Generate Content has no incremental tool-argument frame — a `functionCall`
+/// part carries the whole `{name, args}` at once. So unlike Chat Completions /
+/// Responses (which stream argument deltas), this encoder must BUFFER a tool
+/// call and emit it as one chunk once complete. Accumulating also makes it
+/// robust to upstreams that re-send `name:""` on every continuation chunk
+/// (which would otherwise emit one broken `functionCall` per fragment).
+#[derive(Default)]
+struct GenerateContentStreamEncoder {
+    /// `(name, accumulated raw-JSON arguments)` of the tool call awaiting emission.
+    pending_tool: Option<(String, String)>,
+}
+
+impl GenerateContentStreamEncoder {
+    /// Emit the buffered tool call, if any, as one `functionCall` chunk.
+    fn flush_pending_tool(&mut self) -> Option<serde_json::Value> {
+        let (name, args) = self.pending_tool.take()?;
+        let args: serde_json::Value =
+            serde_json::from_str(if args.is_empty() { "{}" } else { &args })
+                .unwrap_or_else(|_| serde_json::json!({}));
+        Some(serde_json::json!({
+            "candidates": [{ "content": { "role": "model", "parts": [{
+                "functionCall": { "name": name, "args": args }
+            }] } }]
+        }))
+    }
+
+    fn to_frame(chunk: serde_json::Value) -> SseFrame {
+        SseFrame::Event {
+            event: None,
+            data: chunk.to_string(),
+        }
+    }
+}
 
 impl StreamEncoder for GenerateContentStreamEncoder {
     fn encode(&mut self, part: &StreamPart) -> Result<Vec<SseFrame>> {
-        let chunk = match part {
+        let mut chunks: Vec<serde_json::Value> = Vec::new();
+        match part {
             // Observability-only metadata (upstream response id) — never
             // forwarded to the Google-protocol client.
             StreamPart::ResponseStarted { .. } => return Ok(Vec::new()),
@@ -1401,9 +1434,33 @@ impl StreamEncoder for GenerateContentStreamEncoder {
             | StreamPart::TextEnd { .. }
             | StreamPart::ReasoningStart { .. }
             | StreamPart::ReasoningEnd { .. } => return Ok(Vec::new()),
+            // A tool call buffers until complete (see struct docs). A delta with
+            // a *non-empty* name starts a new call (flush the previous one); an
+            // empty/absent name is an argument continuation of the open call —
+            // some upstreams re-send `name:""` on every chunk, which must NOT be
+            // read as a new call.
+            StreamPart::ToolCallDelta {
+                name, arguments, ..
+            } => match name.as_deref().filter(|n| !n.is_empty()) {
+                Some(name) => {
+                    if let Some(c) = self.flush_pending_tool() {
+                        chunks.push(c);
+                    }
+                    self.pending_tool = Some((name.to_string(), arguments.clone()));
+                }
+                None => match self.pending_tool.as_mut() {
+                    Some((_, acc)) => acc.push_str(arguments),
+                    None => self.pending_tool = Some((String::new(), arguments.clone())),
+                },
+            },
+            // Every other emitting part flushes the buffered tool call first, so
+            // a completed `functionCall` is never stranded behind later content.
             // A generated file -> an `inlineData` / `fileData` part in one chunk.
             // <https://ai.google.dev/gemini-api/docs/image-generation>
             StreamPart::File { media_type, data } => {
+                if let Some(c) = self.flush_pending_tool() {
+                    chunks.push(c);
+                }
                 let file_part = match data {
                     DataContent::Base64 { data } => serde_json::json!({
                         "inlineData": { "mimeType": media_type, "data": data }
@@ -1412,31 +1469,26 @@ impl StreamEncoder for GenerateContentStreamEncoder {
                         "fileData": { "mimeType": media_type, "fileUri": url }
                     }),
                 };
-                serde_json::json!({
+                chunks.push(serde_json::json!({
                     "candidates": [{ "content": { "role": "model", "parts": [file_part] } }]
-                })
+                }));
             }
-            StreamPart::TextDelta { text } => serde_json::json!({
-                "candidates": [{ "content": { "role": "model", "parts": [{ "text": text }] } }]
-            }),
-            StreamPart::ReasoningDelta { text } => serde_json::json!({
-                "candidates": [{ "content": { "role": "model",
-                    "parts": [{ "text": text, "thought": true }] } }]
-            }),
-            StreamPart::ToolCallDelta {
-                name, arguments, ..
-            } => {
-                let args: serde_json::Value = serde_json::from_str(if arguments.is_empty() {
-                    "{}"
-                } else {
-                    arguments
-                })
-                .unwrap_or(serde_json::json!({}));
-                serde_json::json!({
-                    "candidates": [{ "content": { "role": "model", "parts": [{
-                        "functionCall": { "name": name.clone().unwrap_or_default(), "args": args }
-                    }] } }]
-                })
+            StreamPart::TextDelta { text } => {
+                if let Some(c) = self.flush_pending_tool() {
+                    chunks.push(c);
+                }
+                chunks.push(serde_json::json!({
+                    "candidates": [{ "content": { "role": "model", "parts": [{ "text": text }] } }]
+                }));
+            }
+            StreamPart::ReasoningDelta { text } => {
+                if let Some(c) = self.flush_pending_tool() {
+                    chunks.push(c);
+                }
+                chunks.push(serde_json::json!({
+                    "candidates": [{ "content": { "role": "model",
+                        "parts": [{ "text": text, "thought": true }] } }]
+                }));
             }
             // Re-attach a streamed citation as a one-chunk
             // `candidate.groundingMetadata.groundingChunks` web entry — the
@@ -1445,38 +1497,54 @@ impl StreamEncoder for GenerateContentStreamEncoder {
             // <https://ai.google.dev/api/generate-content#GroundingChunk>
             StreamPart::Source { source } => match source {
                 Source::Url { url, title, .. } => {
+                    if let Some(c) = self.flush_pending_tool() {
+                        chunks.push(c);
+                    }
                     let mut web = serde_json::Map::new();
                     web.insert("uri".into(), url.clone().into());
                     if let Some(title) = title {
                         web.insert("title".into(), title.clone().into());
                     }
-                    serde_json::json!({
+                    chunks.push(serde_json::json!({
                         "candidates": [{
                             "content": { "role": "model", "parts": [] },
                             "groundingMetadata": {
                                 "groundingChunks": [{ "web": serde_json::Value::Object(web) }]
                             },
                         }]
-                    })
+                    }));
                 }
                 // No `groundingChunks.web` form for a document citation.
                 Source::Document { .. } => return Ok(Vec::new()),
             },
-            StreamPart::Usage { usage } => serde_json::json!({
-                "usageMetadata": {
-                    "promptTokenCount": usage.prompt_tokens,
-                    "candidatesTokenCount": usage.completion_tokens,
-                    "totalTokenCount": usage.total(),
-                    "thoughtsTokenCount": usage.reasoning_tokens,
+            StreamPart::Usage { usage } => {
+                if let Some(c) = self.flush_pending_tool() {
+                    chunks.push(c);
                 }
-            }),
-            StreamPart::Finish { reason } => serde_json::json!({
-                "candidates": [{
-                    "content": { "role": "model", "parts": [] },
-                    "finishReason": finish_reason_str(reason),
-                }]
-            }),
+                chunks.push(serde_json::json!({
+                    "usageMetadata": {
+                        "promptTokenCount": usage.prompt_tokens,
+                        "candidatesTokenCount": usage.completion_tokens,
+                        "totalTokenCount": usage.total(),
+                        "thoughtsTokenCount": usage.reasoning_tokens,
+                    }
+                }));
+            }
+            StreamPart::Finish { reason } => {
+                if let Some(c) = self.flush_pending_tool() {
+                    chunks.push(c);
+                }
+                chunks.push(serde_json::json!({
+                    "candidates": [{
+                        "content": { "role": "model", "parts": [] },
+                        "finishReason": finish_reason_str(reason),
+                    }]
+                }));
+            }
             StreamPart::ResponseCompleted { status, usage, .. } => {
+                if let Some(c) = self.flush_pending_tool() {
+                    chunks.push(c);
+                }
                 // Inbound was Responses; Generate Content has no response-completed
                 // concept — emit a terminal candidate with a mapped
                 // `finishReason`, plus `usageMetadata` if usage was carried.
@@ -1499,13 +1567,20 @@ impl StreamEncoder for GenerateContentStreamEncoder {
                         "thoughtsTokenCount": u.reasoning_tokens,
                     });
                 }
-                chunk
+                chunks.push(chunk);
             }
         };
-        Ok(vec![SseFrame::Event {
-            event: None,
-            data: chunk.to_string(),
-        }])
+        Ok(chunks.into_iter().map(Self::to_frame).collect())
+    }
+
+    /// Flush any tool call still buffered when the stream ends without a
+    /// trailing `Finish` / `ResponseCompleted` part.
+    fn finish(&mut self) -> Result<Vec<SseFrame>> {
+        Ok(self
+            .flush_pending_tool()
+            .map(Self::to_frame)
+            .into_iter()
+            .collect())
     }
 
     fn encode_error(&mut self, message: &str) -> Vec<SseFrame> {

--- a/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
@@ -1384,14 +1384,16 @@ impl StreamDecoder for GenerateContentStreamDecoder {
     }
 }
 
-/// Generate Content `streamGenerateContent` SSE encoder — each canonical part becomes one
-/// `GenerateContentResponse` chunk.
-/// Generate Content has no incremental tool-argument frame — a `functionCall`
-/// part carries the whole `{name, args}` at once. So unlike Chat Completions /
-/// Responses (which stream argument deltas), this encoder must BUFFER a tool
-/// call and emit it as one chunk once complete. Accumulating also makes it
-/// robust to upstreams that re-send `name:""` on every continuation chunk
-/// (which would otherwise emit one broken `functionCall` per fragment).
+/// Generate Content `streamGenerateContent` SSE encoder — most canonical parts
+/// become one `GenerateContentResponse` chunk each.
+///
+/// Tool calls are the exception: Generate Content has no incremental
+/// tool-argument frame — a `functionCall` part carries the whole `{name, args}`
+/// at once. So unlike Chat Completions / Responses (which stream argument
+/// deltas), this encoder must BUFFER a tool call and emit it as one chunk once
+/// complete. Accumulating also makes it robust to upstreams that re-send
+/// `name:""` on every continuation chunk (which would otherwise emit one broken
+/// `functionCall` per fragment).
 #[derive(Default)]
 struct GenerateContentStreamEncoder {
     /// `(name, accumulated raw-JSON arguments)` of the tool call awaiting emission.
@@ -1585,7 +1587,9 @@ impl StreamEncoder for GenerateContentStreamEncoder {
 
     fn encode_error(&mut self, message: &str) -> Vec<SseFrame> {
         // Generate Content surfaces a mid-stream error as a chunk carrying an `error`
-        // object (mirrors the non-streaming error envelope).
+        // object (mirrors the non-streaming error envelope). Any buffered tool call
+        // is intentionally dropped — a partial `functionCall` must not be emitted
+        // alongside an error.
         vec![SseFrame::Event {
             event: None,
             data: serde_json::json!({

--- a/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
@@ -2613,10 +2613,14 @@ impl StreamEncoder for MessagesStreamEncoder {
                 name,
                 arguments,
             } => {
-                if let Some(name) = name {
+                if let Some(name) = name.as_deref().filter(|n| !n.is_empty()) {
                     // A new tool call always opens its own block, even if a
                     // tool_use block was already open (consecutive tool calls
-                    // are distinct blocks). Force-close, then open.
+                    // are distinct blocks). Force-close, then open. Only a
+                    // *non-empty* name opens a block: some upstreams re-send
+                    // `name:""` on every argument-continuation delta, and
+                    // treating `Some("")` as a new call would fragment one tool
+                    // call into one empty-named `tool_use` block per delta.
                     self.close_block(&mut frames);
                     self.ensure_block_open(&mut frames, EncoderBlockKind::ToolUse);
                     frames.push(Self::ev(

--- a/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
@@ -2795,11 +2795,16 @@ impl StreamEncoder for ResponsesStreamEncoder {
                 name,
                 arguments,
             } => {
-                // A delta carrying a `name` starts a new function-call
-                // item. `open_tool_item` closes any previously-open item
-                // (reasoning / message / prior tool) first, so each tool
-                // call lands in its own output slot.
-                if let Some(name) = name {
+                // A delta carrying a *non-empty* `name` starts a new
+                // function-call item. `open_tool_item` closes any previously-open
+                // item (reasoning / message / prior tool) first, so each tool
+                // call lands in its own output slot. An empty name is NOT a new
+                // call: some upstreams re-send `name:""` on every
+                // argument-continuation delta, and treating `Some("")` as a new
+                // call fragments one tool call into one broken item per delta
+                // (empty name + partial args) — which Codex rejects as
+                // "unsupported call" / unparsable arguments.
+                if let Some(name) = name.as_deref().filter(|n| !n.is_empty()) {
                     self.open_tool_item(&mut frames, id, name);
                 }
                 if !arguments.is_empty() {

--- a/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
@@ -9013,3 +9013,392 @@ fn json_schema_description_round_trips_openai_family() {
         }
     }
 }
+
+// ===== regression: empty-string continuation tool-name fragments tool calls =====
+//
+// Some OpenAI-compatible upstreams (e.g. Kimi / DeepSeek serving stacks that
+// emit `functions.<name>:<idx>` tool ids) re-send `"function":{"name":""}` on
+// every argument-continuation chunk. Treating that empty name as a *new* tool
+// call fragmented one call into one broken `function_call` item per delta
+// (item 0: real name + empty args; the rest: empty name + a partial-args
+// fragment), so a Responses-API client rejected every item ("unsupported call"
+// / "EOF while parsing function arguments") and looped forever.
+
+/// Encode a canonical stream into Responses SSE and return the `function_call`
+/// items present in the terminal `response.completed.output` array.
+fn responses_encode_tool_items(parts: &[StreamPart]) -> Vec<serde_json::Value> {
+    let adapter = adapter_for(ApiProtocol::Responses);
+    let mut encoder = adapter.stream_encoder("resp_repro", "kimi");
+    let mut frames = Vec::new();
+    for p in parts {
+        frames.extend(encoder.encode(p).unwrap());
+    }
+    let completed = frames
+        .iter()
+        .find_map(|f| match f {
+            SseFrame::Event { event, data } if event.as_deref() == Some("response.completed") => {
+                Some(serde_json::from_str::<serde_json::Value>(data).unwrap())
+            }
+            _ => None,
+        })
+        .expect("response.completed present");
+    completed["response"]["output"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|i| i["type"] == "function_call")
+        .cloned()
+        .collect()
+}
+
+/// Decoder normalizes an empty continuation `name` to `None` so the canonical
+/// IR never carries `Some("")` as a (non-)name announcement.
+#[test]
+fn chat_decode_empty_continuation_name_normalized_to_none() {
+    let parts = decode_stream(
+        ApiProtocol::ChatCompletions,
+        &[
+            (
+                "",
+                serde_json::json!({"choices":[{"delta":{"tool_calls":[
+                    {"index":0,"id":"functions.exec_command:0","type":"function",
+                     "function":{"name":"exec_command","arguments":""}}]}}]}),
+            ),
+            (
+                "",
+                serde_json::json!({"choices":[{"delta":{"tool_calls":[
+                    {"index":0,"id":"functions.exec_command:0","type":"function",
+                     "function":{"name":"","arguments":"{\"cmd\":\""}}]}}]}),
+            ),
+            (
+                "",
+                serde_json::json!({"choices":[{"delta":{"tool_calls":[
+                    {"index":0,"id":"functions.exec_command:0","type":"function",
+                     "function":{"name":"","arguments":"ls\"}"}}]}}]}),
+            ),
+            (
+                "",
+                serde_json::json!({"choices":[{"delta":{},"finish_reason":"tool_calls"}]}),
+            ),
+        ],
+    );
+    let names: Vec<Option<String>> = parts
+        .iter()
+        .filter_map(|p| match p {
+            StreamPart::ToolCallDelta { name, .. } => Some(name.clone()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(names[0].as_deref(), Some("exec_command"));
+    assert_eq!(names[1], None, "empty continuation name normalized to None");
+    assert_eq!(names[2], None, "empty continuation name normalized to None");
+}
+
+/// End-to-end (chat upstream → Responses client): an empty-name continuation
+/// stream re-encodes to exactly ONE function_call item with the full arguments.
+#[test]
+fn responses_encode_empty_continuation_name_single_tool_call() {
+    let parts = decode_stream(
+        ApiProtocol::ChatCompletions,
+        &[
+            (
+                "",
+                serde_json::json!({"choices":[{"delta":{"tool_calls":[
+                    {"index":0,"id":"functions.exec_command:0","type":"function",
+                     "function":{"name":"exec_command","arguments":""}}]}}]}),
+            ),
+            (
+                "",
+                serde_json::json!({"choices":[{"delta":{"tool_calls":[
+                    {"index":0,"id":"functions.exec_command:0","type":"function",
+                     "function":{"name":"","arguments":"{\"cmd\":\""}}]}}]}),
+            ),
+            (
+                "",
+                serde_json::json!({"choices":[{"delta":{"tool_calls":[
+                    {"index":0,"id":"functions.exec_command:0","type":"function",
+                     "function":{"name":"","arguments":"ls\"}"}}]}}]}),
+            ),
+            (
+                "",
+                serde_json::json!({"choices":[{"delta":{},"finish_reason":"tool_calls"}]}),
+            ),
+        ],
+    );
+    let items = responses_encode_tool_items(&parts);
+    assert_eq!(
+        items.len(),
+        1,
+        "one tool call, not one item per delta: {items:?}"
+    );
+    assert_eq!(items[0]["name"], "exec_command");
+    assert_eq!(items[0]["call_id"], "functions.exec_command:0");
+    assert_eq!(items[0]["arguments"], "{\"cmd\":\"ls\"}");
+}
+
+/// Encoder defense-in-depth: even if a `Some("")` continuation name reaches the
+/// Responses encoder directly (any protocol decoder / future upstream), it is
+/// treated as a continuation, not a new call.
+#[test]
+fn responses_encoder_treats_empty_name_delta_as_continuation() {
+    let id = "functions.exec_command:0".to_string();
+    let parts = vec![
+        StreamPart::ToolCallDelta {
+            id: id.clone(),
+            name: Some("exec_command".into()),
+            arguments: "".into(),
+        },
+        StreamPart::ToolCallDelta {
+            id: id.clone(),
+            name: Some("".into()),
+            arguments: "{\"cmd\":\"".into(),
+        },
+        StreamPart::ToolCallDelta {
+            id: id.clone(),
+            name: Some("".into()),
+            arguments: "ls\"}".into(),
+        },
+        StreamPart::Finish {
+            reason: FinishReason::ToolCalls,
+        },
+    ];
+    let items = responses_encode_tool_items(&parts);
+    assert_eq!(
+        items.len(),
+        1,
+        "empty-name deltas must not open new items: {items:?}"
+    );
+    assert_eq!(items[0]["name"], "exec_command");
+    assert_eq!(items[0]["arguments"], "{\"cmd\":\"ls\"}");
+}
+
+/// The empty-name continuation chunks used by the Codex repro, reused to prove
+/// the Anthropic (Messages) and Gemini encoder paths behave the same way.
+fn empty_continuation_name_chat_events() -> Vec<(&'static str, serde_json::Value)> {
+    vec![
+        (
+            "",
+            serde_json::json!({"choices":[{"delta":{"tool_calls":[
+                {"index":0,"id":"functions.exec_command:0","type":"function",
+                 "function":{"name":"exec_command","arguments":""}}]}}]}),
+        ),
+        (
+            "",
+            serde_json::json!({"choices":[{"delta":{"tool_calls":[
+                {"index":0,"id":"functions.exec_command:0","type":"function",
+                 "function":{"name":"","arguments":"{\"cmd\":\""}}]}}]}),
+        ),
+        (
+            "",
+            serde_json::json!({"choices":[{"delta":{"tool_calls":[
+                {"index":0,"id":"functions.exec_command:0","type":"function",
+                 "function":{"name":"","arguments":"ls\"}"}}]}}]}),
+        ),
+        (
+            "",
+            serde_json::json!({"choices":[{"delta":{},"finish_reason":"tool_calls"}]}),
+        ),
+    ]
+}
+
+/// Encode a canonical stream as Anthropic Messages SSE and return one
+/// `(name, accumulated_input_json)` per `tool_use` block (keyed by block index).
+fn messages_encode_tool_blocks(parts: &[StreamPart]) -> Vec<(String, String)> {
+    let adapter = adapter_for(ApiProtocol::Messages);
+    let mut encoder = adapter.stream_encoder("msg_repro", "claude");
+    let mut frames = Vec::new();
+    for p in parts {
+        frames.extend(encoder.encode(p).unwrap());
+    }
+    use std::collections::BTreeMap;
+    let mut blocks: BTreeMap<i64, (String, String)> = BTreeMap::new();
+    for f in &frames {
+        if let SseFrame::Event { event, data } = f {
+            let v: serde_json::Value = serde_json::from_str(data).unwrap();
+            match event.as_deref() {
+                Some("content_block_start") if v["content_block"]["type"] == "tool_use" => {
+                    let idx = v["index"].as_i64().unwrap_or(-1);
+                    let name = v["content_block"]["name"]
+                        .as_str()
+                        .unwrap_or("")
+                        .to_string();
+                    blocks.entry(idx).or_insert((name, String::new()));
+                }
+                Some("content_block_delta") if v["delta"]["type"] == "input_json_delta" => {
+                    let idx = v["index"].as_i64().unwrap_or(-1);
+                    if let Some(b) = blocks.get_mut(&idx) {
+                        b.1.push_str(v["delta"]["partial_json"].as_str().unwrap_or(""));
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    blocks.into_values().collect()
+}
+
+/// Anthropic path (e.g. headless Claude Code): an empty-name continuation
+/// stream re-encodes to exactly ONE `tool_use` block with the full input,
+/// rather than one empty-named block per delta.
+#[test]
+fn messages_encode_empty_continuation_name_single_tool_use() {
+    let parts = decode_stream(
+        ApiProtocol::ChatCompletions,
+        &empty_continuation_name_chat_events(),
+    );
+    let blocks = messages_encode_tool_blocks(&parts);
+    assert_eq!(
+        blocks.len(),
+        1,
+        "one tool_use block, not one per delta: {blocks:?}"
+    );
+    assert_eq!(blocks[0].0, "exec_command");
+    assert_eq!(blocks[0].1, "{\"cmd\":\"ls\"}");
+}
+
+/// Messages encoder defense-in-depth: a `Some("")` continuation reaching the
+/// encoder directly is a continuation, not a new tool_use block.
+#[test]
+fn messages_encoder_treats_empty_name_delta_as_continuation() {
+    let id = "functions.exec_command:0".to_string();
+    let parts = vec![
+        StreamPart::ToolCallDelta {
+            id: id.clone(),
+            name: Some("exec_command".into()),
+            arguments: "".into(),
+        },
+        StreamPart::ToolCallDelta {
+            id: id.clone(),
+            name: Some("".into()),
+            arguments: "{\"cmd\":\"".into(),
+        },
+        StreamPart::ToolCallDelta {
+            id: id.clone(),
+            name: Some("".into()),
+            arguments: "ls\"}".into(),
+        },
+        StreamPart::Finish {
+            reason: FinishReason::ToolCalls,
+        },
+    ];
+    let blocks = messages_encode_tool_blocks(&parts);
+    assert_eq!(
+        blocks.len(),
+        1,
+        "empty-name deltas must not open new blocks: {blocks:?}"
+    );
+    assert_eq!(blocks[0].0, "exec_command");
+    assert_eq!(blocks[0].1, "{\"cmd\":\"ls\"}");
+}
+
+/// Encode a canonical stream as Generate Content SSE (including the terminal
+/// `finish()` flush) and return one `(name, args_json_string)` per emitted
+/// `functionCall` part.
+fn gemini_encode_function_calls(parts: &[StreamPart]) -> Vec<(String, String)> {
+    let adapter = adapter_for(ApiProtocol::GenerateContent);
+    let mut encoder = adapter.stream_encoder("g_repro", "gemini");
+    let mut frames = Vec::new();
+    for p in parts {
+        frames.extend(encoder.encode(p).unwrap());
+    }
+    frames.extend(encoder.finish().unwrap());
+    let mut calls = Vec::new();
+    for f in &frames {
+        if let SseFrame::Event { data, .. } = f {
+            let v: serde_json::Value = serde_json::from_str(data).unwrap();
+            if let Some(arr) = v["candidates"][0]["content"]["parts"].as_array() {
+                for part in arr {
+                    if let Some(fc) = part.get("functionCall") {
+                        calls.push((
+                            fc["name"].as_str().unwrap_or("").to_string(),
+                            fc["args"].to_string(),
+                        ));
+                    }
+                }
+            }
+        }
+    }
+    calls
+}
+
+/// Gemini path: a fragmented tool call (name on first chunk, args streamed
+/// across deltas) re-encodes to ONE `functionCall` with the FULL args — the
+/// encoder accumulates instead of emitting one `functionCall{args:{}}` per
+/// delta.
+#[test]
+fn gemini_encode_fragmented_args_single_function_call() {
+    let id = "call_1".to_string();
+    let parts = vec![
+        StreamPart::ToolCallDelta {
+            id: id.clone(),
+            name: Some("exec_command".into()),
+            arguments: "".into(),
+        },
+        StreamPart::ToolCallDelta {
+            id: id.clone(),
+            name: None,
+            arguments: "{\"cmd\":".into(),
+        },
+        StreamPart::ToolCallDelta {
+            id: id.clone(),
+            name: None,
+            arguments: "\"ls\"}".into(),
+        },
+        StreamPart::Finish {
+            reason: FinishReason::ToolCalls,
+        },
+    ];
+    let calls = gemini_encode_function_calls(&parts);
+    assert_eq!(
+        calls.len(),
+        1,
+        "one functionCall, not one per delta: {calls:?}"
+    );
+    assert_eq!(calls[0].0, "exec_command");
+    assert_eq!(calls[0].1, "{\"cmd\":\"ls\"}");
+}
+
+/// Gemini path: empty-name continuation chunks (upstreams that re-send
+/// `name:""` every chunk) also collapse to ONE complete `functionCall`.
+#[test]
+fn gemini_encode_empty_continuation_name_single_function_call() {
+    let parts = decode_stream(
+        ApiProtocol::ChatCompletions,
+        &empty_continuation_name_chat_events(),
+    );
+    let calls = gemini_encode_function_calls(&parts);
+    assert_eq!(
+        calls.len(),
+        1,
+        "one functionCall, not fragmented: {calls:?}"
+    );
+    assert_eq!(calls[0].0, "exec_command");
+    assert_eq!(calls[0].1, "{\"cmd\":\"ls\"}");
+}
+
+/// Gemini path: two distinct (parallel) tool calls still emit two complete
+/// `functionCall` parts — accumulation must not merge separate calls.
+#[test]
+fn gemini_encode_two_tool_calls_emit_two_function_calls() {
+    let parts = vec![
+        StreamPart::ToolCallDelta {
+            id: "a".into(),
+            name: Some("first".into()),
+            arguments: "{\"x\":1}".into(),
+        },
+        StreamPart::ToolCallDelta {
+            id: "b".into(),
+            name: Some("second".into()),
+            arguments: "{\"y\":2}".into(),
+        },
+        StreamPart::Finish {
+            reason: FinishReason::ToolCalls,
+        },
+    ];
+    let calls = gemini_encode_function_calls(&parts);
+    assert_eq!(calls.len(), 2, "two distinct calls: {calls:?}");
+    assert_eq!(calls[0].0, "first");
+    assert_eq!(calls[0].1, "{\"x\":1}");
+    assert_eq!(calls[1].0, "second");
+    assert_eq!(calls[1].1, "{\"y\":2}");
+}


### PR DESCRIPTION
## Problem

Tool calls break for some models when streamed to a tool-using client (e.g. Codex on the Responses API, Claude Code on the Anthropic Messages API): the agent never runs the tool and loops/hangs.

Two distinct defects, both about assembling a **streamed** tool call:

### 1. Empty-name continuation chunks fragment a tool call (Responses + Messages)
Some OpenAI-compatible upstreams re-send `"function":{"name":""}` — an empty-string name that is *present*, not omitted — on **every** argument-continuation chunk. The Chat Completions stream decoder passed that through as `Some("")`, and both the Responses and Anthropic Messages encoders treated any `Some(name)` as the start of a **new** tool call. One tool call therefore fragmented into many broken items:

- item 0: real name, **empty arguments**
- items 1..N: **empty name**, one argument fragment each

A Responses client (Codex) rejects these as `unsupported call:` / `failed to parse function arguments: EOF`; an Anthropic client (Claude Code) rejects them as `No such tool available:`. Either way the tool never runs and the loop spins. The trigger is intermittent (depends on upstream serialization), which matches the "sometimes hangs / partially works" reports.

### 2. Gemini encoder never accumulated streamed tool args
The Generate Content stream encoder emitted one `functionCall` per `ToolCallDelta`, parsing *that fragment* as standalone JSON — so any upstream that streams arguments in fragments produced multiple `functionCall` parts each with `args:{}` (arguments lost entirely), independent of the empty-name issue.

## Fix

- **chat_completions decoder** — normalize an empty tool name to `None` (root fix; keeps the canonical IR clean for every downstream encoder).
- **responses / messages encoders** — only a *non-empty* name opens a new tool call; an empty name is an argument continuation of the open call (defense-in-depth).
- **generate_content encoder** — buffer the pending tool call `(name, accumulated args)` and flush one complete `functionCall` when the next named call starts, any other content part arrives, on finish, or at stream end.
- drop the write-only stored-name half of the decoder's tool-id map (dead code).

## Tests

Regression tests across all three encoder paths (empty-name continuation collapses to one item/block/`functionCall`; fragmented args accumulate; parallel calls stay distinct; decoder normalizes empty→`None`).

Full workspace suite **874 passed**, `cargo clippy --all-features` clean, `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)