### PR TITLE
fix(chat): drop provider-defined tools (no chat wire form)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-alpha.14](https://github.com/bitrouter/bitrouter/compare/v1.0.0-alpha.13...v1.0.0-alpha.14)
+
+
+### 🐛 Bug Fixes
+
+- *(chat)* Drop provider-defined tools (no chat wire form) ([#553](https://github.com/bitrouter/bitrouter/pull/553)) - ([b0b4ef3](https://github.com/bitrouter/bitrouter/commit/b0b4ef365d83d9a5f2ee380067320ff5303d9f2c))
+
+
 ## [1.0.0-alpha.13](https://github.com/bitrouter/bitrouter/compare/v1.0.0-alpha.12...v1.0.0-alpha.13)
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "bitrouter"
-version = "1.0.0-alpha.13"
+version = "1.0.0-alpha.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "bitrouter-bedrock"
-version = "1.0.0-alpha.13"
+version = "1.0.0-alpha.14"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -772,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "bitrouter-cloud-sdk"
-version = "1.0.0-alpha.13"
+version = "1.0.0-alpha.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "bitrouter-guardrails"
-version = "1.0.0-alpha.13"
+version = "1.0.0-alpha.14"
 dependencies = [
  "async-trait",
  "bitrouter-sdk",
@@ -807,7 +807,7 @@ dependencies = [
 
 [[package]]
 name = "bitrouter-mcp"
-version = "1.0.0-alpha.13"
+version = "1.0.0-alpha.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -828,7 +828,7 @@ dependencies = [
 
 [[package]]
 name = "bitrouter-observe"
-version = "1.0.0-alpha.13"
+version = "1.0.0-alpha.14"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -852,7 +852,7 @@ dependencies = [
 
 [[package]]
 name = "bitrouter-providers"
-version = "1.0.0-alpha.13"
+version = "1.0.0-alpha.14"
 dependencies = [
  "async-trait",
  "base64",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "bitrouter-sdk"
-version = "1.0.0-alpha.13"
+version = "1.0.0-alpha.14"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "bitrouter-skills"
-version = "1.0.0-alpha.13"
+version = "1.0.0-alpha.14"
 dependencies = [
  "reqwest 0.12.28",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*", "plugins/*", "apps/*", "mcp"]
 
 [workspace.package]
-version = "1.0.0-alpha.13"
+version = "1.0.0-alpha.14"
 edition = "2024"
 license = "Apache-2.0"
 authors = ["Archer <archer@bitrouter.ai>"]
@@ -15,13 +15,13 @@ rust-version = "1.88"
 
 [workspace.dependencies]
 # internal crates
-bitrouter-sdk = { path = "crates/bitrouter-sdk", version = "1.0.0-alpha.13", default-features = false }
-bitrouter-bedrock = { path = "crates/bitrouter-bedrock", version = "1.0.0-alpha.13" }
-bitrouter-cloud-sdk = { path = "crates/bitrouter-cloud-sdk", version = "1.0.0-alpha.13" }
-bitrouter-providers = { path = "crates/bitrouter-providers", version = "1.0.0-alpha.13" }
-bitrouter-skills = { path = "crates/bitrouter-skills", version = "1.0.0-alpha.13" }
-bitrouter-guardrails = { path = "plugins/bitrouter-guardrails", version = "1.0.0-alpha.13" }
-bitrouter-observe = { path = "plugins/bitrouter-observe", version = "1.0.0-alpha.13", default-features = false }
+bitrouter-sdk = { path = "crates/bitrouter-sdk", version = "1.0.0-alpha.14", default-features = false }
+bitrouter-bedrock = { path = "crates/bitrouter-bedrock", version = "1.0.0-alpha.14" }
+bitrouter-cloud-sdk = { path = "crates/bitrouter-cloud-sdk", version = "1.0.0-alpha.14" }
+bitrouter-providers = { path = "crates/bitrouter-providers", version = "1.0.0-alpha.14" }
+bitrouter-skills = { path = "crates/bitrouter-skills", version = "1.0.0-alpha.14" }
+bitrouter-guardrails = { path = "plugins/bitrouter-guardrails", version = "1.0.0-alpha.14" }
+bitrouter-observe = { path = "plugins/bitrouter-observe", version = "1.0.0-alpha.14", default-features = false }
 
 # shared third-party
 anyhow = "1"

--- a/apps/bitrouter/Cargo.toml
+++ b/apps/bitrouter/Cargo.toml
@@ -23,7 +23,7 @@ bitrouter-providers = { workspace = true, features = ["pkce"] }
 bitrouter-skills.workspace = true
 bitrouter-guardrails.workspace = true
 bitrouter-observe = { workspace = true, features = ["otel-http"] }
-bitrouter-mcp = { path = "../../mcp", version = "1.0.0-alpha.13" }
+bitrouter-mcp = { path = "../../mcp", version = "1.0.0-alpha.14" }
 chrono.workspace = true
 sha2.workspace = true
 base64.workspace = true

--- a/crates/bitrouter-sdk/src/language_model/protocol/chat_completions.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/chat_completions.rs
@@ -746,16 +746,12 @@ impl OutboundAdapter for ChatCompletionsAdapter {
         let mut req = serde_json::Map::new();
         req.insert("model".into(), prompt.model.clone().into());
         req.insert("messages".into(), messages.into());
-        if !prompt.tools.is_empty() {
-            req.insert(
-                "tools".into(),
-                prompt
-                    .tools
-                    .iter()
-                    .map(render_chat_tool)
-                    .collect::<Vec<_>>()
-                    .into(),
-            );
+        // Drop tools with no Chat Completions wire form (provider-defined /
+        // server tools); only emit `tools` if at least one function tool remains,
+        // so a request that carried only server tools doesn't send `tools: []`.
+        let tools: Vec<_> = prompt.tools.iter().filter_map(render_chat_tool).collect();
+        if !tools.is_empty() {
+            req.insert("tools".into(), tools.into());
         }
         // Absent params are omitted entirely, never serialised as null (#454-5).
         if let Some(t) = prompt.params.temperature {
@@ -1001,17 +997,22 @@ impl OutboundAdapter for ChatCompletionsAdapter {
 ///
 /// A [`Tool::Function`] becomes `{type:"function", function:{name, description,
 /// parameters, strict?}}`; the `strict` flag is emitted when set (previously it
-/// was always dropped).
+/// was always dropped). Returns `Some(_)`.
 /// <https://platform.openai.com/docs/api-reference/chat/create#chat-create-tools>
 ///
 /// Chat Completions has **no** provider-defined ("server") tool envelope on the
-/// wire, so a [`Tool::ProviderDefined`] only reaches here on a cross-protocol
-/// route (a client targeting another provider's server tool, routed to an
-/// OpenAI-compatible upstream). Per the faithful-passthrough rule it is
-/// preserved verbatim in its source-native shape so the upstream decides; the
-/// object is splatted directly into the `tools` array rather than dropped or
-/// lossily mapped.
-fn render_chat_tool(tool: &Tool) -> serde_json::Value {
+/// wire — its `tools` array accepts only `{type:"function", …}`. A
+/// [`Tool::ProviderDefined`] therefore has no valid Chat Completions
+/// representation: emitting its source-native shape (e.g. `{type:"web_search"}`,
+/// or a Codex `{type:"namespace"}` group) is a structurally-invalid `tools`
+/// entry that a strict upstream (DeepSeek, Kimi, OpenAI itself) rejects — which
+/// fails the **entire request** with an opaque error rather than ignoring one
+/// tool. Such a server tool could not be executed on a Chat Completions upstream
+/// anyway, so it is dropped (returns `None`), keeping the request — and its
+/// function tools — valid. This is wire-structural, not capability gating: a
+/// tool the target wire cannot express is omitted, never a function tool the
+/// model might support.
+fn render_chat_tool(tool: &Tool) -> Option<serde_json::Value> {
     match tool {
         Tool::Function {
             name,
@@ -1034,11 +1035,9 @@ fn render_chat_tool(tool: &Tool) -> serde_json::Value {
             if let Some(strict) = strict {
                 function.insert("strict".into(), (*strict).into());
             }
-            serde_json::json!({ "type": "function", "function": function })
+            Some(serde_json::json!({ "type": "function", "function": function }))
         }
-        Tool::ProviderDefined { id, name, args, .. } => {
-            super::provider_defined_native(id, name, args)
-        }
+        Tool::ProviderDefined { .. } => None,
     }
 }
 

--- a/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
@@ -6479,18 +6479,104 @@ fn provider_defined_tool_cross_protocol_onto_anthropic_is_preserved() {
 }
 
 /// And onto Chat Completions (function-only on the wire): a provider-defined
-/// tool is still preserved verbatim into the `tools` array rather than dropped.
+/// tool has no valid representation, so it is DROPPED rather than splatted as a
+/// `{type:<tool>}` entry — which a strict upstream rejects, failing the whole
+/// request. A function tool alongside it still renders.
 #[test]
-fn provider_defined_tool_preserved_into_chat_completions() {
-    let tool = Tool::ProviderDefined {
+fn provider_defined_tool_dropped_from_chat_completions() {
+    let server = Tool::ProviderDefined {
         id: "openai.web_search_preview".to_string(),
         name: "web_search_preview".to_string(),
         args: serde_json::json!({ "search_context_size": "low" }),
         provider_metadata: Default::default(),
     };
-    let rendered = rendered_tools_json(&ApiProtocol::ChatCompletions, vec![tool]);
-    assert_eq!(rendered[0]["type"], "web_search_preview");
-    assert_eq!(rendered[0]["search_context_size"], "low");
+    let func = Tool::Function {
+        name: "get_weather".to_string(),
+        description: None,
+        parameters: serde_json::json!({ "type": "object" }),
+        strict: None,
+        provider_metadata: Default::default(),
+    };
+    let adapter = adapter_for(ApiProtocol::ChatCompletions);
+
+    // A server tool alone leaves no tools at all — omit the key, never `tools: []`.
+    let only_server = adapter
+        .render_request(&prompt_with_tools(vec![server.clone()]))
+        .unwrap();
+    assert!(
+        only_server.get("tools").is_none(),
+        "server-only tools must be omitted, not sent as an invalid entry: {only_server}"
+    );
+
+    // Mixed with a function tool: only the function tool survives.
+    let mixed = adapter
+        .render_request(&prompt_with_tools(vec![server, func]))
+        .unwrap();
+    let tools = mixed["tools"].as_array().expect("function tool present");
+    assert_eq!(tools.len(), 1, "only the function tool survives: {tools:?}");
+    assert_eq!(tools[0]["type"], "function");
+    assert_eq!(tools[0]["function"]["name"], "get_weather");
+}
+
+/// Cross-protocol regression (Codex): a Responses request carrying OpenAI
+/// server tools (`web_search`) and a Codex `namespace` group alongside real
+/// function tools, routed to a Chat Completions upstream, renders ONLY the
+/// function tools — every entry is `{type:"function"}`. Pre-fix the server /
+/// namespace tools were splatted verbatim and DeepSeek rejected the whole
+/// request (`upstream_error`), which Codex surfaced as a stream disconnect.
+#[test]
+fn responses_server_tools_dropped_when_routed_to_chat_completions() {
+    let responses_req = serde_json::json!({
+        "model": "m",
+        "input": [{ "role": "user", "content": "hi" }],
+        "tools": [
+            { "type": "function", "name": "exec_command", "parameters": { "type": "object" } },
+            { "type": "web_search", "external_web_access": true },
+            { "type": "namespace", "name": "multi_agent_v1", "tools": [], "description": "x" }
+        ]
+    });
+    let prompt = adapter_for(ApiProtocol::Responses)
+        .parse_request(responses_req)
+        .unwrap();
+    let chat = adapter_for(ApiProtocol::ChatCompletions)
+        .render_request(&prompt)
+        .unwrap();
+    let tools = chat["tools"].as_array().expect("function tool present");
+    assert_eq!(tools.len(), 1, "only the function tool survives: {tools:?}");
+    assert!(
+        tools.iter().all(|t| t["type"] == "function"),
+        "every Chat Completions tool must be a function: {tools:?}"
+    );
+    assert_eq!(tools[0]["function"]["name"], "exec_command");
+}
+
+/// Cross-protocol regression (Claude Code): a Messages request carrying an
+/// Anthropic server tool (`web_search_20250305`) alongside a custom function
+/// tool, routed to a Chat Completions upstream, renders only the function tool.
+#[test]
+fn messages_server_tools_dropped_when_routed_to_chat_completions() {
+    let messages_req = serde_json::json!({
+        "model": "m",
+        "max_tokens": 100,
+        "messages": [{ "role": "user", "content": "hi" }],
+        "tools": [
+            { "name": "get_weather", "input_schema": { "type": "object" } },
+            { "type": "web_search_20250305", "name": "web_search", "max_uses": 3 }
+        ]
+    });
+    let prompt = adapter_for(ApiProtocol::Messages)
+        .parse_request(messages_req)
+        .unwrap();
+    let chat = adapter_for(ApiProtocol::ChatCompletions)
+        .render_request(&prompt)
+        .unwrap();
+    let tools = chat["tools"].as_array().expect("function tool present");
+    assert_eq!(tools.len(), 1, "only the function tool survives: {tools:?}");
+    assert!(
+        tools.iter().all(|t| t["type"] == "function"),
+        "every Chat Completions tool must be a function: {tools:?}"
+    );
+    assert_eq!(tools[0]["function"]["name"], "get_weather");
 }
 
 /// The canonical `Tool` enum uses an internal `type` tag (`function` /


### PR DESCRIPTION
## Problem (found while verifying alpha.13 on staging)

Codex against any non-OpenAI model returned **`stream disconnected before completion: request failed; please retry`** (Codex retries 5× then gives up); Claude Code returned `api_error`. Raw streaming worked fine — so it looked transient, but it's **deterministic and request-shaped**.

Instrumenting the boundary (logging proxy between Codex and staging) showed staging returns HTTP 200 with a tiny **291-byte** SSE body: `event: response.failed … {"error":{"code":"upstream_error","message":"request failed; please retry"}}`. The upstream provider rejected the request. Bisecting a real **53 KB** Codex request isolated the cause to **two tools**: `{type:"web_search"}` and `{type:"namespace", name:"multi_agent_v1", …}`. With the 8 plain function tools only, the identical request succeeds.

### Root cause

Chat Completions' `tools` array accepts **only** `{type:"function", …}` — it has no provider-defined ("server") tool envelope. But `render_chat_tool` splatted a `Tool::ProviderDefined` verbatim in its source-native shape (`{type:"web_search"}`, the Codex `{type:"namespace"}` group, Anthropic `{type:"web_search_20250305"}`, …). A strict upstream (DeepSeek, Kimi, OpenAI's own `/chat/completions`) rejects that structurally-invalid entry and fails the **entire request** with an opaque error.

Real-world blast radius: Codex *always* sends `web_search` + `namespace`; Claude Code sends `web_search_20250305`. So every such request routed to a non-OpenAI Chat Completions upstream died on turn one. Confirmed live on staging for **both** the Responses (Codex) and Messages (Claude Code) paths.

## Fix

A `Tool::ProviderDefined` has **no valid Chat Completions representation**, so drop it when rendering to that wire (keeping the request and its function tools valid) instead of emitting an entry no Chat Completions endpoint accepts. `render_chat_tool` now returns `Option`; `render_request` `filter_map`s and omits the `tools` key entirely if nothing remains (never `tools: []`).

This is **wire-structural, not capability gating** — only a tool the target wire *cannot express* is omitted, never a function tool the model might support. The server tool could not execute on a Chat Completions upstream anyway. Same-protocol server-tool round-trips (Responses→Responses, Messages→Messages) and Gemini rendering are untouched; verbatim passthrough is preserved exactly where the target wire can carry it.

> Note: this changes a previously deliberate, documented choice (the old `provider_defined_tool_preserved_into_chat_completions` test asserted verbatim splat). That choice was actively harmful here — passthrough lost *all* tools and the whole turn, strictly worse than dropping one untranslatable tool.

## Tests

- Flipped the prior splat test → `provider_defined_tool_dropped_from_chat_completions` (incl. the `tools`-omitted-when-empty case).
- Added cross-protocol regressions mirroring the real flows: Responses (web_search + namespace + function) → chat, and Messages (web_search_20250305 + function) → chat — both render only the function tool.

`cargo test -p bitrouter-sdk --all-features` 430+5, clippy clean, fmt clean. Independently reviewed (APPROVE-with-nits).

## Follow-ups (out of scope, not blocking)

1. **Expand a Codex `namespace` group into its constituent function sub-tools** when routing to Chat Completions, rather than dropping it — its sub-tools (`close_agent`, `send_input`, …) *do* have valid `{type:"function"}` forms, so expanding preserves Codex multi-agent capability. Needs response-side tool-call routing for the flattened names.
2. (Pre-existing) A `tool_choice` that names a now-dropped server tool could leave a dangling reference; consider normalizing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)