### PR TITLE
feat: protocol-native routing

### DIFF
--- a/crates/bitrouter-providers/providers/openai.toml
+++ b/crates/bitrouter-providers/providers/openai.toml
@@ -7,14 +7,17 @@
 # - https://platform.openai.com/docs/api-reference/introduction
 #   (base URL `https://api.openai.com/v1`)
 #
-# Default wire protocol: Chat Completions. The Responses API is also live and
-# accepts the same Bearer credential — operators select it per-request via
-# routing config (it shares this provider's auth and `api_base`).
+# Wire protocols: Chat Completions (the preferred default head) and Responses.
+# Both are live at this base URL and share the same Bearer credential, so the
+# provider advertises the ordered set. Protocol-native routing then serves an
+# inbound Responses request over Responses and an inbound Chat Completions
+# request over Chat — a faithful same-protocol round-trip — while the head stays
+# the default for any other inbound protocol.
 
 id = "openai"
 display_name = "OpenAI"
 api_base = "https://api.openai.com/v1"
-api_protocol = "chat_completions"
+api_protocol = ["chat_completions", "responses"]
 doc_url = "https://platform.openai.com/docs/api-reference"
 
 [auth]

--- a/crates/bitrouter-providers/src/apply.rs
+++ b/crates/bitrouter-providers/src/apply.rs
@@ -232,7 +232,10 @@ mod tests {
         assert_eq!(p.api_base, "https://api.openai.com/v1");
         assert_eq!(
             p.api_protocol.resolve("gpt-4o"),
-            Some(&ProtocolList(vec![ApiProtocol::ChatCompletions]))
+            Some(&ProtocolList(vec![
+                ApiProtocol::ChatCompletions,
+                ApiProtocol::Responses
+            ]))
         );
     }
 
@@ -246,7 +249,10 @@ mod tests {
         assert_eq!(p.api_base, "https://gateway.internal.example/v1");
         assert_eq!(
             p.api_protocol.resolve("gpt-4o"),
-            Some(&ProtocolList(vec![ApiProtocol::ChatCompletions]))
+            Some(&ProtocolList(vec![
+                ApiProtocol::ChatCompletions,
+                ApiProtocol::Responses
+            ]))
         );
     }
 

--- a/crates/bitrouter-providers/src/apply.rs
+++ b/crates/bitrouter-providers/src/apply.rs
@@ -8,7 +8,7 @@
 //! Opt-out: set `inherit_defaults: false` at the top level of the config.
 
 use bitrouter_sdk::config::{Config, Pattern, PatternMap, ProviderConfig};
-use bitrouter_sdk::language_model::types::ApiProtocol;
+use bitrouter_sdk::language_model::types::{ApiProtocol, ProtocolList};
 
 use crate::builtin;
 use crate::entry::ProtocolMapping;
@@ -103,6 +103,13 @@ pub fn apply_builtin_defaults(config: &mut Config) {
         if provider.api_protocol.is_empty() {
             provider.api_protocol = protocol_mapping_to_pattern_map(&builtin.api_protocol);
         }
+        if provider.protocol_endpoints.is_empty() && !builtin.protocol_endpoints.is_empty() {
+            provider.protocol_endpoints = builtin
+                .protocol_endpoints
+                .iter()
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect();
+        }
         // A multi-account provider carries its credentials in `accounts`,
         // not the top-level `api_key`. Skip both the env-var fill and the
         // inactive guard for it — it is explicitly account-managed and
@@ -131,14 +138,14 @@ pub fn apply_builtin_defaults(config: &mut Config) {
     }
 }
 
-/// Translate a built-in's [`ProtocolMapping`] into the existing
-/// `PatternMap<ApiProtocol>` used by [`bitrouter_sdk::config::ProviderConfig`].
-/// `Single(p)` becomes a single `*` → p entry; `PerModel` keys parse via
+/// Translate a built-in's [`ProtocolMapping`] into the
+/// `PatternMap<ProtocolList>` used by [`bitrouter_sdk::config::ProviderConfig`].
+/// `Single(list)` becomes a single `*` → list entry; `PerModel` keys parse via
 /// [`Pattern::parse`] (same wildcard rules used by user-written configs).
-fn protocol_mapping_to_pattern_map(m: &ProtocolMapping) -> PatternMap<ApiProtocol> {
+fn protocol_mapping_to_pattern_map(m: &ProtocolMapping) -> PatternMap<ProtocolList> {
     let mut map = PatternMap::new();
     match m {
-        ProtocolMapping::Single(p) => map.push(Pattern::Wildcard, p.clone()),
+        ProtocolMapping::Single(list) => map.push(Pattern::Wildcard, list.clone()),
         ProtocolMapping::PerModel(items) => {
             for (k, v) in items {
                 map.push(Pattern::parse(k), v.clone());
@@ -225,7 +232,7 @@ mod tests {
         assert_eq!(p.api_base, "https://api.openai.com/v1");
         assert_eq!(
             p.api_protocol.resolve("gpt-4o"),
-            Some(&ApiProtocol::ChatCompletions)
+            Some(&ProtocolList(vec![ApiProtocol::ChatCompletions]))
         );
     }
 
@@ -239,7 +246,7 @@ mod tests {
         assert_eq!(p.api_base, "https://gateway.internal.example/v1");
         assert_eq!(
             p.api_protocol.resolve("gpt-4o"),
-            Some(&ApiProtocol::ChatCompletions)
+            Some(&ProtocolList(vec![ApiProtocol::ChatCompletions]))
         );
     }
 
@@ -290,7 +297,7 @@ mod tests {
             assert_eq!(p.api_key, "sk-ant-test");
             assert_eq!(
                 p.api_protocol.resolve("claude-opus-4-1"),
-                Some(&ApiProtocol::Messages)
+                Some(&ProtocolList(vec![ApiProtocol::Messages]))
             );
         });
     }

--- a/crates/bitrouter-providers/src/apply.rs
+++ b/crates/bitrouter-providers/src/apply.rs
@@ -8,7 +8,7 @@
 //! Opt-out: set `inherit_defaults: false` at the top level of the config.
 
 use bitrouter_sdk::config::{Config, Pattern, PatternMap, ProviderConfig};
-use bitrouter_sdk::language_model::types::{ApiProtocol, ProtocolList};
+use bitrouter_sdk::language_model::types::ProtocolList;
 
 use crate::builtin;
 use crate::entry::ProtocolMapping;
@@ -161,6 +161,7 @@ mod tests {
     use std::env;
 
     use bitrouter_sdk::config::{Config, ProviderConfig};
+    use bitrouter_sdk::language_model::types::ApiProtocol;
 
     /// Mutating `std::env` in tests is sketchy (it's process-global), so we
     /// run env-var cases serially under a `Mutex` and always set/unset in a

--- a/crates/bitrouter-providers/src/builtin.rs
+++ b/crates/bitrouter-providers/src/builtin.rs
@@ -115,6 +115,21 @@ mod tests {
     }
 
     #[test]
+    fn openai_advertises_chat_and_responses() {
+        use bitrouter_sdk::language_model::types::ApiProtocol;
+        // OpenAI serves the same models over both Chat Completions and the
+        // Responses API at one base URL. Advertising the ordered set lets
+        // protocol-native routing honour an inbound Responses request without
+        // per-request config, while Chat Completions stays the preferred head
+        // (the default for any other inbound protocol).
+        let openai = find("openai").unwrap();
+        assert_eq!(
+            openai.api_protocol.resolve("gpt-5.5"),
+            Some(vec![ApiProtocol::ChatCompletions, ApiProtocol::Responses])
+        );
+    }
+
+    #[test]
     fn looks_up_by_id() {
         assert!(find("bitrouter").is_some());
         assert!(find("openai").is_some());

--- a/crates/bitrouter-providers/src/builtin.rs
+++ b/crates/bitrouter-providers/src/builtin.rs
@@ -110,7 +110,7 @@ mod tests {
         use bitrouter_sdk::language_model::types::ApiProtocol;
         assert_eq!(
             entry.api_protocol.resolve("gpt-4o"),
-            Some(ApiProtocol::ChatCompletions)
+            Some(vec![ApiProtocol::ChatCompletions])
         );
     }
 
@@ -135,30 +135,30 @@ mod tests {
         // GPT family → Responses (zen serves them via /responses).
         assert_eq!(
             zen.api_protocol.resolve("opencode/gpt-5.5"),
-            Some(ApiProtocol::Responses)
+            Some(vec![ApiProtocol::Responses])
         );
         assert_eq!(
             zen.api_protocol.resolve("opencode/gpt-5.3-codex"),
-            Some(ApiProtocol::Responses)
+            Some(vec![ApiProtocol::Responses])
         );
         // Claude family → Messages.
         assert_eq!(
             zen.api_protocol.resolve("opencode/claude-opus-4.7"),
-            Some(ApiProtocol::Messages)
+            Some(vec![ApiProtocol::Messages])
         );
         // Gemini family → Google.
         assert_eq!(
             zen.api_protocol.resolve("opencode/gemini-3.1-pro"),
-            Some(ApiProtocol::GenerateContent)
+            Some(vec![ApiProtocol::GenerateContent])
         );
         // Everything else (qwen, glm, kimi, minimax, …) → Chat Completions.
         assert_eq!(
             zen.api_protocol.resolve("opencode/qwen3.6-plus"),
-            Some(ApiProtocol::ChatCompletions)
+            Some(vec![ApiProtocol::ChatCompletions])
         );
         assert_eq!(
             zen.api_protocol.resolve("opencode/minimax-m2.7"),
-            Some(ApiProtocol::ChatCompletions)
+            Some(vec![ApiProtocol::ChatCompletions])
         );
     }
 
@@ -169,20 +169,20 @@ mod tests {
         // MiniMax → Messages (go serves MiniMax via /messages).
         assert_eq!(
             go.api_protocol.resolve("opencode-go/minimax-m2.7"),
-            Some(ApiProtocol::Messages)
+            Some(vec![ApiProtocol::Messages])
         );
         // Everyone else (glm, kimi, deepseek, mimo, qwen) → Chat Completions.
         assert_eq!(
             go.api_protocol.resolve("opencode-go/glm-5.1"),
-            Some(ApiProtocol::ChatCompletions)
+            Some(vec![ApiProtocol::ChatCompletions])
         );
         assert_eq!(
             go.api_protocol.resolve("opencode-go/kimi-k2.6"),
-            Some(ApiProtocol::ChatCompletions)
+            Some(vec![ApiProtocol::ChatCompletions])
         );
         assert_eq!(
             go.api_protocol.resolve("opencode-go/deepseek-v4-pro"),
-            Some(ApiProtocol::ChatCompletions)
+            Some(vec![ApiProtocol::ChatCompletions])
         );
     }
 
@@ -209,22 +209,22 @@ mod tests {
         // Claude family → Messages.
         assert_eq!(
             copilot.api_protocol.resolve("claude-sonnet-4.6"),
-            Some(ApiProtocol::Messages)
+            Some(vec![ApiProtocol::Messages])
         );
         // GPT-5-codex → Responses (chat-completions returns 404 in
         // Copilot for these models).
         assert_eq!(
             copilot.api_protocol.resolve("gpt-5.3-codex"),
-            Some(ApiProtocol::Responses)
+            Some(vec![ApiProtocol::Responses])
         );
         // Default → Chat Completions.
         assert_eq!(
             copilot.api_protocol.resolve("gpt-4o"),
-            Some(ApiProtocol::ChatCompletions)
+            Some(vec![ApiProtocol::ChatCompletions])
         );
         assert_eq!(
             copilot.api_protocol.resolve("gemini-2.5-pro"),
-            Some(ApiProtocol::ChatCompletions)
+            Some(vec![ApiProtocol::ChatCompletions])
         );
     }
 

--- a/crates/bitrouter-providers/src/entry.rs
+++ b/crates/bitrouter-providers/src/entry.rs
@@ -19,7 +19,7 @@ use std::collections::BTreeMap;
 
 use serde::Deserialize;
 
-use bitrouter_sdk::language_model::types::ApiProtocol;
+use bitrouter_sdk::language_model::types::{ApiProtocol, ProtocolList};
 
 /// One built-in provider entry.
 #[derive(Debug, Clone, Deserialize)]
@@ -32,10 +32,16 @@ pub struct ProviderEntry {
     /// Default upstream `api_base`. May be overridden by a user-written
     /// provider config.
     pub api_base: String,
-    /// The wire protocol the provider serves. Either a single protocol (most
-    /// providers) or a glob → protocol map (opencode-zen-shape: same provider,
-    /// different protocols per model id).
+    /// The wire protocol(s) the provider serves. Either one protocol set for
+    /// every model (most providers), or a glob → protocol-set map
+    /// (opencode-zen-shape: same provider, different protocols per model id).
     pub api_protocol: ProtocolMapping,
+    /// Optional per-protocol base-URL override (protocol name → base URL), for
+    /// a provider that serves different protocols at different paths under one
+    /// host — e.g. OpenAI-style under `BASE/v1` and Anthropic Messages under
+    /// `BASE/anthropic`. Empty for the common single-endpoint provider.
+    #[serde(default)]
+    pub protocol_endpoints: BTreeMap<String, String>,
     /// Authentication scheme (how the credential is placed on each request).
     pub auth: AuthScheme,
     /// Link to the provider's official API documentation. Required so future
@@ -43,44 +49,47 @@ pub struct ProviderEntry {
     pub doc_url: String,
 }
 
-/// Either a single protocol, or a glob → protocol map for providers that
-/// serve different protocols on different model ids (e.g. opencode-zen).
+/// Either one protocol set for every model, or a glob → protocol-set map for
+/// providers that serve different protocols on different model ids (e.g.
+/// opencode-zen). Each value is a [`ProtocolList`] — a bare string or an
+/// ordered sequence — so single- and multi-protocol upstreams share one schema.
 ///
-/// `#[serde(untagged)]` so the TOML can write either:
+/// `#[serde(untagged)]` so the TOML can write any of:
 /// ```toml
-/// api_protocol = "chat_completions"
+/// api_protocol = "chat_completions"                  # one protocol
+/// api_protocol = ["chat_completions", "responses"]   # an ordered set
 /// ```
-/// or
+/// or per model id:
 /// ```toml
 /// [api_protocol]
 /// "claude-*" = "messages"
-/// "*" = "chat_completions"
+/// "*" = ["chat_completions", "responses"]
 /// ```
 #[derive(Debug, Clone, Deserialize)]
 #[serde(untagged)]
 pub enum ProtocolMapping {
-    /// Same protocol for every model.
-    Single(ApiProtocol),
-    /// Glob-prefix matched protocol per model id. Longest match wins.
-    PerModel(BTreeMap<String, ApiProtocol>),
+    /// Same protocol set for every model.
+    Single(ProtocolList),
+    /// Glob-prefix matched protocol set per model id. Longest match wins.
+    PerModel(BTreeMap<String, ProtocolList>),
 }
 
 impl ProtocolMapping {
-    /// Resolve the protocol for one model id. Returns `None` if no pattern
-    /// matches (callers fall back to a sensible default).
-    pub fn resolve(&self, model_id: &str) -> Option<ApiProtocol> {
+    /// Resolve the ordered protocol set for one model id, most preferred first.
+    /// Returns `None` if no pattern matches (callers fall back to a default).
+    pub fn resolve(&self, model_id: &str) -> Option<Vec<ApiProtocol>> {
         match self {
-            ProtocolMapping::Single(api_protocol) => Some(api_protocol.clone()),
-            ProtocolMapping::PerModel(api_protocol) => {
-                let mut best: Option<(&str, &ApiProtocol)> = None;
-                for (pat, proto) in api_protocol {
+            ProtocolMapping::Single(list) => Some(list.as_slice().to_vec()),
+            ProtocolMapping::PerModel(map) => {
+                let mut best: Option<(&str, &ProtocolList)> = None;
+                for (pat, list) in map {
                     if pattern_matches(pat, model_id)
                         && best.as_ref().is_none_or(|(b, _)| pat.len() > b.len())
                     {
-                        best = Some((pat.as_str(), proto));
+                        best = Some((pat.as_str(), list));
                     }
                 }
-                best.map(|(_, p)| p.clone())
+                best.map(|(_, l)| l.as_slice().to_vec())
             }
         }
     }
@@ -180,7 +189,7 @@ mod tests {
         assert_eq!(entry.auth.env_var(), Some("OPENAI_API_KEY"));
         assert_eq!(
             entry.api_protocol.resolve("gpt-4o"),
-            Some(ApiProtocol::ChatCompletions)
+            Some(vec![ApiProtocol::ChatCompletions])
         );
     }
 
@@ -238,11 +247,46 @@ mod tests {
         let entry: ProviderEntry = toml::from_str(src).unwrap();
         assert_eq!(
             entry.api_protocol.resolve("claude-opus-4-1"),
-            Some(ApiProtocol::Messages)
+            Some(vec![ApiProtocol::Messages])
         );
         assert_eq!(
             entry.api_protocol.resolve("gpt-5-mini"),
-            Some(ApiProtocol::ChatCompletions)
+            Some(vec![ApiProtocol::ChatCompletions])
+        );
+    }
+
+    #[test]
+    fn parses_multi_protocol_set_with_endpoints() {
+        // Case 1: one vendor serving its models over several protocols —
+        // OpenAI-style under /v1 and Anthropic Messages under /anthropic.
+        let src = r#"
+            id = "minimax"
+            display_name = "MiniMax"
+            api_base = "https://api.minimax.io"
+            doc_url = "https://www.minimax.io/platform/document"
+
+            [api_protocol]
+            "*" = ["chat_completions", "responses", "messages"]
+
+            [protocol_endpoints]
+            messages = "https://api.minimax.io/anthropic/v1"
+
+            [auth]
+            kind = "bearer"
+            env = "MINIMAX_API_KEY"
+        "#;
+        let entry: ProviderEntry = toml::from_str(src).unwrap();
+        assert_eq!(
+            entry.api_protocol.resolve("MiniMax-M2"),
+            Some(vec![
+                ApiProtocol::ChatCompletions,
+                ApiProtocol::Responses,
+                ApiProtocol::Messages,
+            ])
+        );
+        assert_eq!(
+            entry.protocol_endpoints.get("messages").map(String::as_str),
+            Some("https://api.minimax.io/anthropic/v1")
         );
     }
 

--- a/crates/bitrouter-sdk/src/config/mod.rs
+++ b/crates/bitrouter-sdk/src/config/mod.rs
@@ -24,7 +24,7 @@ use serde::Deserialize;
 
 use crate::error::{BitrouterError, Result};
 use crate::language_model::routing::SortOrder;
-use crate::language_model::types::ApiProtocol;
+use crate::language_model::types::{ApiProtocol, ProtocolList};
 
 pub mod pattern;
 pub mod presets;
@@ -259,9 +259,20 @@ pub struct ProviderConfig {
     pub api_base: String,
     /// Upstream API key (often a `${VAR}` reference).
     pub api_key: String,
-    /// Glob-prefix `api_protocol` pattern list. Precedence: per-model override
-    /// > longest matching pattern > provider default (`openai`).
-    pub api_protocol: PatternMap<ApiProtocol>,
+    /// Glob-prefix `api_protocol` pattern list — each pattern maps to an
+    /// ordered set of supported wire protocols (the head is the preferred
+    /// default). Precedence: per-model override > longest matching pattern >
+    /// host-inferred default. A bare protocol string still parses to a
+    /// one-element set, so single-protocol providers are unchanged.
+    pub api_protocol: PatternMap<ProtocolList>,
+    /// Optional per-protocol base-URL override, keyed by protocol name
+    /// ([`ApiProtocol::as_str`]). When one provider serves different protocols
+    /// at different paths under a single host — e.g. OpenAI-style under
+    /// `BASE/v1` and Anthropic Messages under `BASE/anthropic` — give each
+    /// protocol's base here; protocol-native routing copies the chosen
+    /// protocol's base onto the routing target. Protocols absent here use
+    /// [`api_base`](Self::api_base).
+    pub protocol_endpoints: HashMap<String, String>,
     /// Glob-prefix `rate_limits` pattern list, keyed per matched pattern.
     pub rate_limits: PatternMap<RateLimit>,
     /// Declared model entries. Empty + `auto_discover` triggers discovery.
@@ -355,6 +366,7 @@ impl std::fmt::Debug for ProviderConfig {
                 },
             )
             .field("api_protocol", &self.api_protocol)
+            .field("protocol_endpoints", &self.protocol_endpoints)
             .field("rate_limits", &self.rate_limits)
             .field("models", &self.models)
             .field("auto_discover", &self.auto_discover)
@@ -373,6 +385,7 @@ impl Default for ProviderConfig {
             api_base: String::new(),
             api_key: String::new(),
             api_protocol: PatternMap::new(),
+            protocol_endpoints: HashMap::new(),
             rate_limits: PatternMap::new(),
             models: Vec::new(),
             auto_discover: false,
@@ -404,20 +417,44 @@ impl ProviderConfig {
 }
 
 impl ProviderConfig {
-    /// Resolve the effective `ApiProtocol` for `model_id`: per-model override
-    /// wins, then the longest matching `api_protocol` pattern, then the
-    /// provider default (`openai`). Includes the `auto_discover` protocol
-    /// inference from the api-base host.
-    pub fn protocol_for(&self, model_id: &str) -> ApiProtocol {
+    /// The ordered set of wire protocols `model_id` can be served under, most
+    /// preferred first: a per-model override wins, else the longest matching
+    /// `api_protocol` pattern, else the single host-inferred default. The
+    /// router prefers whichever member matches the inbound request (native
+    /// routing) and otherwise falls back to the head.
+    pub fn protocols_for(&self, model_id: &str) -> Vec<ApiProtocol> {
         if let Some(m) = self.models.iter().find(|m| m.id == model_id)
-            && let Some(p) = &m.api_protocol
+            && let Some(list) = &m.api_protocol
+            && !list.is_empty()
         {
-            return p.clone();
+            return list.as_slice().to_vec();
         }
-        if let Some(p) = self.api_protocol.resolve(model_id) {
-            return p.clone();
+        if let Some(list) = self.api_protocol.resolve(model_id)
+            && !list.is_empty()
+        {
+            return list.as_slice().to_vec();
         }
-        infer_protocol(&self.api_base)
+        vec![infer_protocol(&self.api_base)]
+    }
+
+    /// The preferred (default) wire protocol for `model_id` — the head of
+    /// [`protocols_for`](Self::protocols_for). Used when the inbound protocol
+    /// is not one the upstream supports. Falls back to the host-inferred
+    /// protocol for a model with an (unusual) empty protocol set.
+    pub fn protocol_for(&self, model_id: &str) -> ApiProtocol {
+        self.protocols_for(model_id)
+            .into_iter()
+            .next()
+            .unwrap_or_else(|| infer_protocol(&self.api_base))
+    }
+
+    /// The base-URL override for `protocol`, if this provider serves that
+    /// protocol at a non-default path — see
+    /// [`protocol_endpoints`](Self::protocol_endpoints).
+    pub fn endpoint_for(&self, protocol: &ApiProtocol) -> Option<&str> {
+        self.protocol_endpoints
+            .get(protocol.as_str())
+            .map(String::as_str)
     }
 }
 
@@ -438,9 +475,10 @@ pub fn infer_protocol(api_base: &str) -> ApiProtocol {
 pub struct ProviderModel {
     /// Model id at the provider.
     pub id: String,
-    /// Per-model protocol override (highest precedence).
+    /// Per-model protocol override (highest precedence) — an ordered set of
+    /// supported protocols, or a bare string for a single one.
     #[serde(default)]
-    pub api_protocol: Option<ApiProtocol>,
+    pub api_protocol: Option<ProtocolList>,
     /// Per-model rate-limit override.
     #[serde(default)]
     pub rate_limits: Option<RateLimit>,
@@ -715,6 +753,9 @@ fn resolve_one_derivation(
     // intrinsic to the child (you almost always want different endpoints).
     if child.api_protocol.is_empty() {
         child.api_protocol = parent.api_protocol.clone();
+    }
+    if child.protocol_endpoints.is_empty() {
+        child.protocol_endpoints = parent.protocol_endpoints.clone();
     }
     if child.rate_limits.is_empty() {
         child.rate_limits = parent.rate_limits.clone();

--- a/crates/bitrouter-sdk/src/config/routing_table.rs
+++ b/crates/bitrouter-sdk/src/config/routing_table.rs
@@ -1166,4 +1166,113 @@ providers:
         assert_eq!(chain[0].api_protocol, ApiProtocol::Messages);
         assert_eq!(chain[1].api_protocol, ApiProtocol::ChatCompletions);
     }
+
+    #[tokio::test]
+    async fn native_routing_applies_through_a_virtual_model() {
+        // Strategy 2: a `models:` virtual model whose endpoint is a
+        // multi-protocol provider still routes each target natively.
+        let yaml = r#"
+providers:
+  minimax:
+    api_base: https://api.minimax.io/v1
+    api_key: k-mm
+    api_protocol:
+      - "*": [chat_completions, messages]
+    models: [{ id: MiniMax-M2 }]
+models:
+  combo:
+    endpoints:
+      - { provider: minimax, service_id: MiniMax-M2 }
+"#;
+        let t = table(yaml);
+        let chain = t
+            .route_chain(
+                "combo",
+                &prefs_inbound(ApiProtocol::Messages),
+                &CallerContext::local(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(chain.len(), 1);
+        assert_eq!(chain[0].provider_name, "minimax");
+        assert_eq!(chain[0].api_protocol, ApiProtocol::Messages);
+    }
+
+    #[tokio::test]
+    async fn inbound_protocol_survives_preset_resolution() {
+        // The inbound protocol (a caller pref) must survive the merge over the
+        // preset-derived prefs base, so native routing still applies when a
+        // request goes through an `@preset`.
+        let yaml = r#"
+providers:
+  minimax:
+    api_base: https://api.minimax.io/v1
+    api_key: k-mm
+    api_protocol:
+      - "*": [chat_completions, messages]
+    models: [{ id: MiniMax-M2 }]
+presets:
+  pick:
+    model: MiniMax-M2
+"#;
+        let t = table(yaml);
+        let chain = t
+            .route_chain(
+                "@pick",
+                &prefs_inbound(ApiProtocol::Messages),
+                &CallerContext::local(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(chain[0].provider_name, "minimax");
+        assert_eq!(chain[0].api_protocol, ApiProtocol::Messages);
+    }
+
+    #[tokio::test]
+    async fn account_base_wins_over_per_protocol_endpoint() {
+        // Per-target precedence in the multi-account branch: an account that
+        // pins its own base keeps it (multi-region); an account without one
+        // gets the per-protocol endpoint for the natively-selected protocol.
+        let yaml = r#"
+providers:
+  mm:
+    api_base: https://api.minimax.io/v1
+    api_protocol:
+      - "*": [chat_completions, messages]
+    protocol_endpoints:
+      messages: https://api.minimax.io/anthropic/v1
+    models: [{ id: m }]
+    accounts:
+      - { api_key: k-pinned, label: pinned, api_base: "https://eu.minimax.io/v1" }
+      - { api_key: k-default, label: default }
+"#;
+        let t = table(yaml);
+        let chain = t
+            .route_chain(
+                "mm:m",
+                &prefs_inbound(ApiProtocol::Messages),
+                &CallerContext::local(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(chain.len(), 2);
+        // Both serve the inbound protocol natively.
+        assert!(
+            chain
+                .iter()
+                .all(|h| h.api_protocol == ApiProtocol::Messages)
+        );
+        let pinned = chain
+            .iter()
+            .find(|h| h.account_label.as_deref() == Some("pinned"))
+            .unwrap();
+        let default = chain
+            .iter()
+            .find(|h| h.account_label.as_deref() == Some("default"))
+            .unwrap();
+        // Pinned account keeps its own base, ignoring the per-protocol endpoint.
+        assert_eq!(pinned.api_base, "https://eu.minimax.io/v1");
+        // Account without a base gets the per-protocol /anthropic endpoint.
+        assert_eq!(default.api_base, "https://api.minimax.io/anthropic/v1");
+    }
 }

--- a/crates/bitrouter-sdk/src/config/routing_table.rs
+++ b/crates/bitrouter-sdk/src/config/routing_table.rs
@@ -18,7 +18,7 @@ use crate::caller::CallerContext;
 use crate::config::{Config, presets::resolve_presets};
 use crate::error::{BitrouterError, Result};
 use crate::language_model::routing::{ModelInfo, RoutingPrefs, RoutingTable, SortOrder};
-use crate::language_model::types::RoutingTarget;
+use crate::language_model::types::{ApiProtocol, RoutingTarget};
 
 /// A `RoutingTable` over an in-memory `bitrouter.yaml` config. Reloadable.
 pub struct ConfigRoutingTable {
@@ -100,13 +100,26 @@ fn build_targets(
     provider_id: &str,
     provider: &crate::config::ProviderConfig,
     model_id: &str,
+    inbound: Option<&ApiProtocol>,
 ) -> Vec<RoutingTarget> {
-    let protocol = provider.protocol_for(model_id);
+    // Protocol-native routing: prefer the inbound protocol when this upstream
+    // supports it (a faithful same-protocol round-trip), else the provider's
+    // configured default head.
+    let protocol = select_protocol(&provider.protocols_for(model_id), inbound);
+    // A per-protocol endpoint override lets one provider serve different
+    // protocols at different paths (e.g. OpenAI under `/v1`, Anthropic Messages
+    // under `/anthropic`). It applies to the provider base, not to an account
+    // that pins its own host.
+    let protocol_base = provider.endpoint_for(&protocol);
+
     if provider.accounts.is_empty() {
+        let api_base = protocol_base
+            .map(str::to_string)
+            .unwrap_or_else(|| provider.api_base.clone());
         return vec![RoutingTarget {
             provider_name: provider_id.to_string(),
             service_id: model_id.to_string(),
-            api_base: provider.api_base.clone(),
+            api_base,
             api_key: provider.api_key.clone(),
             api_protocol: protocol,
             account_label: None,
@@ -130,10 +143,15 @@ fn build_targets(
             } else {
                 account.label.clone()
             };
-            let api_base = if account.api_base.is_empty() {
-                provider.api_base.clone()
-            } else {
+            // An account that pins its own base keeps it (multi-region /
+            // multi-org); otherwise the per-protocol endpoint, else the
+            // provider base.
+            let api_base = if !account.api_base.is_empty() {
                 account.api_base.clone()
+            } else {
+                protocol_base
+                    .map(str::to_string)
+                    .unwrap_or_else(|| provider.api_base.clone())
             };
             RoutingTarget {
                 provider_name: provider_id.to_string(),
@@ -148,6 +166,23 @@ fn build_targets(
             }
         })
         .collect()
+}
+
+/// Pick the wire protocol for a target: the inbound protocol when the upstream
+/// supports it (native — a faithful same-protocol round-trip), else the
+/// provider's preferred head. `protocols` is non-empty —
+/// [`ProviderConfig::protocols_for`](crate::config::ProviderConfig::protocols_for)
+/// always yields at least one.
+fn select_protocol(protocols: &[ApiProtocol], inbound: Option<&ApiProtocol>) -> ApiProtocol {
+    if let Some(p) = inbound
+        && protocols.contains(p)
+    {
+        return p.clone();
+    }
+    protocols
+        .first()
+        .cloned()
+        .unwrap_or(ApiProtocol::ChatCompletions)
 }
 
 /// The rotation offset in `0..n` for a `balance` provider's next
@@ -233,7 +268,12 @@ fn resolve_virtual_model(
         }
         endpoints.push((
             endpoint.provider.clone(),
-            build_targets(&endpoint.provider, provider, &endpoint.service_id),
+            build_targets(
+                &endpoint.provider,
+                provider,
+                &endpoint.service_id,
+                prefs.inbound_protocol.as_ref(),
+            ),
         ));
     }
 
@@ -278,7 +318,12 @@ pub fn resolve_route_chain(
         && let Some(provider) = config.providers.get(provider_id)
         && provider.active
     {
-        return Ok(build_targets(provider_id, provider, model_id));
+        return Ok(build_targets(
+            provider_id,
+            provider,
+            model_id,
+            prefs.inbound_protocol.as_ref(),
+        ));
     }
 
     // ---- Strategy 2: explicit virtual model ----
@@ -306,7 +351,12 @@ pub fn resolve_route_chain(
         if provider.models.iter().any(|m| m.id == clean) {
             chain.push((
                 provider_id.clone(),
-                build_targets(provider_id, provider, &clean),
+                build_targets(
+                    provider_id,
+                    provider,
+                    &clean,
+                    prefs.inbound_protocol.as_ref(),
+                ),
             ));
         }
     }
@@ -321,9 +371,25 @@ pub fn resolve_route_chain(
     // Order the cascade. `Latency` / `Cost` have no metrics source yet, so
     // they fall back to the alphabetical initial sort. Account-expanded
     // targets within one provider keep their build order.
+    //
+    // Native-protocol preference is a *tie-break only*: a stable secondary key
+    // ranking providers that already serve the inbound protocol natively ahead
+    // of those that would translate — but only among candidates the primary
+    // order ranks equal. Today the primary key (provider id) is total, so this
+    // never reorders; it becomes load-bearing once cost/latency scoring (which
+    // can tie) replaces the alphabetical fallback. It never overrides the
+    // primary order, so cost/latency stays authoritative.
+    let inbound = prefs.inbound_protocol.as_ref();
+    let serves_inbound_natively = |targets: &[RoutingTarget]| -> bool {
+        matches!(inbound, Some(p) if targets.first().is_some_and(|t| &t.api_protocol == p))
+    };
     match prefs.sort {
         SortOrder::Alphabetical | SortOrder::Latency | SortOrder::Cost => {
-            chain.sort_by(|a, b| a.0.cmp(&b.0));
+            chain.sort_by(|a, b| {
+                // native-capable (true) sorts first → compare b against a.
+                a.0.cmp(&b.0)
+                    .then_with(|| serves_inbound_natively(&b.1).cmp(&serves_inbound_natively(&a.1)))
+            });
         }
     }
     Ok(chain.into_iter().flat_map(|(_, t)| t).collect())
@@ -435,6 +501,11 @@ fn merge_prefs(base: &mut RoutingPrefs, extra: &RoutingPrefs) {
         if !base.ignore.contains(p) {
             base.ignore.push(p.clone());
         }
+    }
+    // The inbound protocol is a per-request fact set by the pipeline (not a
+    // preset knob); carry it so target construction can route natively.
+    if extra.inbound_protocol.is_some() {
+        base.inbound_protocol = extra.inbound_protocol.clone();
     }
 }
 
@@ -976,5 +1047,123 @@ providers:
         assert_eq!(chain[2].provider_name, "zeta");
         assert_eq!(chain[1].api_key, "z1");
         assert_eq!(chain[2].api_key, "z2");
+    }
+
+    // ===== protocol-native routing =====
+
+    // Case 1: one provider serving its model over several protocols, with a
+    // per-protocol endpoint for the Anthropic Messages path.
+    const MULTI_PROTOCOL: &str = r#"
+providers:
+  minimax:
+    api_base: https://api.minimax.io/v1
+    api_key: k-mm
+    api_protocol:
+      - "*": [chat_completions, responses, messages]
+    protocol_endpoints:
+      messages: https://api.minimax.io/anthropic/v1
+    models: [{ id: MiniMax-M2 }]
+"#;
+
+    /// Routing prefs carrying an inbound protocol, the rest default.
+    fn prefs_inbound(p: ApiProtocol) -> RoutingPrefs {
+        RoutingPrefs {
+            inbound_protocol: Some(p),
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn native_routing_picks_inbound_protocol_over_per_protocol_endpoint() {
+        // Inbound Messages → the upstream supports it → route Messages
+        // natively, over the per-protocol /anthropic endpoint.
+        let t = table(MULTI_PROTOCOL);
+        let chain = t
+            .route_chain(
+                "minimax:MiniMax-M2",
+                &prefs_inbound(ApiProtocol::Messages),
+                &CallerContext::local(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(chain.len(), 1);
+        assert_eq!(chain[0].api_protocol, ApiProtocol::Messages);
+        assert_eq!(chain[0].api_base, "https://api.minimax.io/anthropic/v1");
+    }
+
+    #[tokio::test]
+    async fn native_routing_picks_supported_non_head_protocol() {
+        // Inbound Responses is supported but not the head; native preference
+        // still selects it, at the provider's default base (no endpoint set).
+        let t = table(MULTI_PROTOCOL);
+        let chain = t
+            .route_chain(
+                "minimax:MiniMax-M2",
+                &prefs_inbound(ApiProtocol::Responses),
+                &CallerContext::local(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(chain[0].api_protocol, ApiProtocol::Responses);
+        assert_eq!(chain[0].api_base, "https://api.minimax.io/v1");
+    }
+
+    #[tokio::test]
+    async fn falls_back_to_default_head_when_inbound_unsupported() {
+        // GenerateContent isn't in the set → fall back to the preferred head
+        // (chat_completions), at the default base.
+        let t = table(MULTI_PROTOCOL);
+        let chain = t
+            .route_chain(
+                "minimax:MiniMax-M2",
+                &prefs_inbound(ApiProtocol::GenerateContent),
+                &CallerContext::local(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(chain[0].api_protocol, ApiProtocol::ChatCompletions);
+        assert_eq!(chain[0].api_base, "https://api.minimax.io/v1");
+    }
+
+    #[tokio::test]
+    async fn no_inbound_protocol_uses_default_head() {
+        // Today's default path: no inbound protocol → the preferred head at the
+        // provider base. Guards the backward-compatible behaviour.
+        let t = table(MULTI_PROTOCOL);
+        let chain = t
+            .route_chain(
+                "minimax:MiniMax-M2",
+                &RoutingPrefs::default(),
+                &CallerContext::local(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(chain[0].api_protocol, ApiProtocol::ChatCompletions);
+        assert_eq!(chain[0].api_base, "https://api.minimax.io/v1");
+    }
+
+    #[tokio::test]
+    async fn native_preference_does_not_reorder_the_cascade() {
+        // `shared-model` is served by anthropic (messages-native, by host
+        // inference) and openai (chat). Even with inbound Messages, the primary
+        // alphabetical order is authoritative — anthropic, then openai — proving
+        // native preference is a tie-break that never changes which upstream is
+        // chosen. Each target still gets its own per-target protocol.
+        let t = table(PROVIDERS);
+        let chain = t
+            .route_chain(
+                "shared-model",
+                &prefs_inbound(ApiProtocol::Messages),
+                &CallerContext::local(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(chain.len(), 2);
+        assert_eq!(chain[0].provider_name, "anthropic");
+        assert_eq!(chain[1].provider_name, "openai");
+        // anthropic serves Messages natively; openai (host-inferred chat) does
+        // not support Messages → its configured head.
+        assert_eq!(chain[0].api_protocol, ApiProtocol::Messages);
+        assert_eq!(chain[1].api_protocol, ApiProtocol::ChatCompletions);
     }
 }

--- a/crates/bitrouter-sdk/src/config/tests.rs
+++ b/crates/bitrouter-sdk/src/config/tests.rs
@@ -74,6 +74,69 @@ providers:
 }
 
 #[test]
+fn multi_protocol_provider_resolves_set_and_endpoints() {
+    // Case 1: one provider advertising several protocols for its models, with a
+    // per-protocol endpoint override for the Anthropic Messages path.
+    let yaml = r#"
+providers:
+  minimax:
+    api_base: https://api.minimax.io
+    api_key: k
+    api_protocol:
+      - "*": [chat_completions, responses, messages]
+    protocol_endpoints:
+      messages: https://api.minimax.io/anthropic/v1
+    models:
+      - id: MiniMax-M2
+      - id: special
+        api_protocol: responses
+"#;
+    let cfg = parse_with(yaml, |_| None).unwrap();
+    let p = cfg.providers.get("minimax").unwrap();
+    // The full ordered protocol set for a pattern-matched model.
+    assert_eq!(
+        p.protocols_for("MiniMax-M2"),
+        vec![
+            ApiProtocol::ChatCompletions,
+            ApiProtocol::Responses,
+            ApiProtocol::Messages
+        ]
+    );
+    // `protocol_for` is the head (preferred default).
+    assert_eq!(p.protocol_for("MiniMax-M2"), ApiProtocol::ChatCompletions);
+    // A per-model override wins and is a one-element set.
+    assert_eq!(p.protocols_for("special"), vec![ApiProtocol::Responses]);
+    // Per-protocol endpoint override is keyed by protocol name.
+    assert_eq!(
+        p.endpoint_for(&ApiProtocol::Messages),
+        Some("https://api.minimax.io/anthropic/v1")
+    );
+    assert_eq!(p.endpoint_for(&ApiProtocol::ChatCompletions), None);
+}
+
+#[test]
+fn single_protocol_string_still_parses_as_one_element_set() {
+    // Backward-compat: a bare protocol string is a one-element set, and
+    // `protocol_for` behaves exactly as before.
+    let yaml = r#"
+providers:
+  openai:
+    api_base: https://api.openai.com/v1
+    api_key: k
+    api_protocol:
+      - "*": chat_completions
+    models: [{ id: gpt-4o }]
+"#;
+    let cfg = parse_with(yaml, |_| None).unwrap();
+    let p = cfg.providers.get("openai").unwrap();
+    assert_eq!(
+        p.protocols_for("gpt-4o"),
+        vec![ApiProtocol::ChatCompletions]
+    );
+    assert_eq!(p.protocol_for("gpt-4o"), ApiProtocol::ChatCompletions);
+}
+
+#[test]
 fn parses_context_tier_pricing() {
     let yaml = r#"
 providers:

--- a/crates/bitrouter-sdk/src/language_model/context.rs
+++ b/crates/bitrouter-sdk/src/language_model/context.rs
@@ -500,6 +500,19 @@ mod tests {
         assert!(ctx.prompt().params.extra.is_empty());
     }
 
+    #[test]
+    fn inbound_protocol_threads_from_request_to_context() {
+        // The HTTP server stamps the inbound protocol on the request; the
+        // context exposes it to route resolution. `None` when unset.
+        let mut req = PipelineRequest::new("m", CallerContext::local(), empty_prompt());
+        assert_eq!(PipelineContext::new(req.clone()).inbound_protocol(), None);
+        req.inbound_protocol = Some(ApiProtocol::Messages);
+        assert_eq!(
+            PipelineContext::new(req).inbound_protocol(),
+            Some(ApiProtocol::Messages)
+        );
+    }
+
     fn prompt_with_text(system: Option<&str>, user_text: &str) -> Prompt {
         Prompt {
             model: "gpt-5".into(),

--- a/crates/bitrouter-sdk/src/language_model/context.rs
+++ b/crates/bitrouter-sdk/src/language_model/context.rs
@@ -12,7 +12,8 @@ use crate::event::{EventBus, PipelineEvent};
 use crate::language_model::settlement::SettlementContext;
 use crate::language_model::stream::UsageAccumulator;
 use crate::language_model::types::{
-    Content, ExecutionResult, PipelineRequest, PipelineResponse, Prompt, RoutingTarget, Usage,
+    ApiProtocol, Content, ExecutionResult, PipelineRequest, PipelineResponse, Prompt,
+    RoutingTarget, Usage,
 };
 use crate::plugin::PluginId;
 
@@ -52,6 +53,10 @@ pub struct PipelineContext {
     caller: CallerContext,
     headers: http::HeaderMap,
     prompt: Prompt,
+    /// The inbound wire protocol (Stage 0). Route resolution uses it to prefer
+    /// a native, same-protocol upstream. `None` when the request was built
+    /// without a known inbound protocol.
+    inbound_protocol: Option<ApiProtocol>,
 
     // ===== accumulated: written per stage, readable downstream =====
     /// The resolved fallback chain (Stage 2).
@@ -92,6 +97,7 @@ impl PipelineContext {
             caller: req.caller,
             headers: req.headers,
             prompt: req.prompt,
+            inbound_protocol: req.inbound_protocol,
             route_chain: None,
             execution_result: None,
             metadata: HashMap::new(),
@@ -156,6 +162,12 @@ impl PipelineContext {
     /// The canonical request body.
     pub fn prompt(&self) -> &Prompt {
         &self.prompt
+    }
+
+    /// The inbound wire protocol the request arrived on, if known. Route
+    /// resolution uses it to prefer a native (same-protocol) upstream.
+    pub fn inbound_protocol(&self) -> Option<ApiProtocol> {
+        self.inbound_protocol.clone()
     }
 
     /// Replace the canonical model name (used after preset/variant stripping).
@@ -412,6 +424,7 @@ mod tests {
             caller: CallerContext::local(),
             headers: http::HeaderMap::new(),
             prompt,
+            inbound_protocol: None,
         };
         PipelineContext::new(req)
     }

--- a/crates/bitrouter-sdk/src/language_model/pipeline.rs
+++ b/crates/bitrouter-sdk/src/language_model/pipeline.rs
@@ -334,6 +334,9 @@ impl Pipeline {
         // requests, so those route unchanged.
         let prefs = RoutingPrefs {
             require_capabilities: ctx.prompt().required_capabilities(),
+            // Carry the inbound protocol so the table can prefer a native,
+            // same-protocol upstream for each chosen target.
+            inbound_protocol: ctx.inbound_protocol(),
             ..RoutingPrefs::default()
         };
         let mut chain = self

--- a/crates/bitrouter-sdk/src/language_model/routing.rs
+++ b/crates/bitrouter-sdk/src/language_model/routing.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use crate::caller::CallerContext;
 use crate::error::{BitrouterError, Result};
 use crate::language_model::hooks::FallbackDecision;
-use crate::language_model::types::{Capability, RoutingTarget};
+use crate::language_model::types::{ApiProtocol, Capability, RoutingTarget};
 
 /// How a cascade chain should be ordered.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
@@ -48,6 +48,13 @@ pub struct RoutingPrefs {
     /// [`Prompt::required_capabilities`](crate::language_model::Prompt::required_capabilities).
     /// Empty (the default) imposes no capability constraint.
     pub require_capabilities: Vec<Capability>,
+    /// The inbound wire protocol the request arrived on, if known. A
+    /// protocol-native [`RoutingTable`] prefers, for each chosen target, the
+    /// protocol matching this when the upstream supports it (a faithful
+    /// same-protocol round-trip), otherwise the provider's configured default.
+    /// `None` imposes no native preference. Set by the pipeline from
+    /// [`PipelineContext::inbound_protocol`](crate::language_model::PipelineContext::inbound_protocol).
+    pub inbound_protocol: Option<ApiProtocol>,
 }
 
 /// Summary of a routable model, for `GET /v1/models`.

--- a/crates/bitrouter-sdk/src/language_model/types.rs
+++ b/crates/bitrouter-sdk/src/language_model/types.rs
@@ -1773,6 +1773,12 @@ pub struct PipelineRequest {
     pub headers: http::HeaderMap,
     /// The canonical request body.
     pub prompt: Prompt,
+    /// The wire protocol the request arrived on, when known — set by the HTTP
+    /// server from the endpoint that was hit. Lets the router prefer a
+    /// same-protocol (native) upstream so a faithful round-trip replaces a
+    /// lossy cross-protocol translation. `None` for callers that build a
+    /// request directly (no native preference is then applied).
+    pub inbound_protocol: Option<ApiProtocol>,
 }
 
 impl PipelineRequest {
@@ -1785,6 +1791,7 @@ impl PipelineRequest {
             caller,
             headers: http::HeaderMap::new(),
             prompt,
+            inbound_protocol: None,
         }
     }
 }

--- a/crates/bitrouter-sdk/src/language_model/types.rs
+++ b/crates/bitrouter-sdk/src/language_model/types.rs
@@ -147,6 +147,76 @@ impl<'de> Deserialize<'de> for ApiProtocol {
     }
 }
 
+/// One or more wire protocols a `(provider, model)` can be served under, in
+/// preference order. The list head is the *preferred* (default) outbound
+/// protocol; protocol-native routing may instead pick whichever member matches
+/// the inbound request's protocol, turning a lossy cross-protocol translation
+/// into a faithful same-protocol round-trip.
+///
+/// Deserializes from **either** a bare protocol string or a sequence, so a
+/// single-protocol provider and a multi-protocol one share one schema:
+///
+/// ```yaml
+/// api_protocol:
+///   - "*": ["chat_completions", "responses", "messages"]   # an ordered set
+///   - "claude-*": messages                                  # still a bare string
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ProtocolList(pub Vec<ApiProtocol>);
+
+impl ProtocolList {
+    /// The preferred (default) protocol — the list head.
+    pub fn preferred(&self) -> Option<&ApiProtocol> {
+        self.0.first()
+    }
+
+    /// Whether `protocol` is one of the supported protocols.
+    pub fn contains(&self, protocol: &ApiProtocol) -> bool {
+        self.0.contains(protocol)
+    }
+
+    /// The supported protocols as a slice, in preference order.
+    pub fn as_slice(&self) -> &[ApiProtocol] {
+        &self.0
+    }
+
+    /// Whether no protocol is listed.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl From<ApiProtocol> for ProtocolList {
+    fn from(p: ApiProtocol) -> Self {
+        ProtocolList(vec![p])
+    }
+}
+
+impl Serialize for ProtocolList {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        self.0.serialize(s)
+    }
+}
+
+impl<'de> Deserialize<'de> for ProtocolList {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        // Accept a bare protocol string (`"messages"`) or a sequence
+        // (`["messages", "chat_completions"]`). Both formats we parse from
+        // (YAML, TOML) are self-describing, so the untagged dispatch is
+        // unambiguous: a string deserializes `One`, a sequence `Many`.
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum OneOrMany {
+            One(ApiProtocol),
+            Many(Vec<ApiProtocol>),
+        }
+        Ok(match OneOrMany::deserialize(d)? {
+            OneOrMany::One(p) => ProtocolList(vec![p]),
+            OneOrMany::Many(v) => ProtocolList(v),
+        })
+    }
+}
+
 /// A conversation role.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]

--- a/crates/bitrouter-sdk/src/server.rs
+++ b/crates/bitrouter-sdk/src/server.rs
@@ -602,6 +602,10 @@ async fn handle(
     };
     let mut req = PipelineRequest::new(prompt.model.clone(), caller, prompt.clone());
     req.headers = headers;
+    // Carry the inbound wire protocol so route resolution can prefer a native,
+    // same-protocol upstream — a faithful round-trip instead of a lossy
+    // cross-protocol translation.
+    req.inbound_protocol = Some(inbound.clone());
 
     if prompt.stream {
         stream_response(


### PR DESCRIPTION
## Protocol-native routing

When a request arrives in protocol *P* (Anthropic Messages / OpenAI Chat Completions / OpenAI Responses / Google GenerateContent) and the chosen upstream natively speaks *P*, route same-protocol — `messages → messages`, `responses → responses` — instead of translating through a different wire format. A same-protocol round-trip is byte-faithful; a cross-protocol one silently drops protocol-native metadata (reasoning signatures, `cache_control`, `thoughtSignature`, …) and can break upstreams outright (e.g. Gemini 3 rejects a tool turn missing `thought_signature`; OpenAI Responses reasoning continuity is Responses-only).

Two structural facts blocked this before, and this PR fixes both:
1. The inbound protocol was discarded right after decode, so the router never saw it.
2. Each `(provider, model)` resolved to exactly one outgoing protocol, so an upstream speaking several protocols could only be reached through one.

### What changed

**1. A protocol *set* per (provider, model).**
- New `ProtocolList` (`language_model/types.rs`) deserializes from **either** a bare protocol string or a sequence, so single- and multi-protocol providers share one schema. `ProviderConfig.api_protocol` → `PatternMap<ProtocolList>`; `ProviderModel.api_protocol` → `Option<ProtocolList>`.
- `protocols_for(model)` returns the ordered set (preferred first); `protocol_for(model)` still returns the preferred head — **unchanged for every existing single-protocol config**.
- New optional `protocol_endpoints` map (protocol name → base URL) for a provider that serves different protocols at different paths under one host — e.g. OpenAI-style under `/v1` and Anthropic Messages under `/anthropic`.
- The builtin catalog carries sets + endpoints; `openai.toml` now advertises `[chat_completions, responses]` (both live at the same base), so an inbound Responses request is served natively without per-request config — Chat Completions stays the default head.

**2. The router prefers the inbound protocol, per target.**
- The inbound protocol is threaded from the HTTP server through `PipelineRequest` → `PipelineContext` → `RoutingPrefs` to route resolution.
- For each chosen target, `build_targets` selects the inbound protocol when the upstream supports it (native), else the configured head; a per-protocol endpoint is applied to the target base.
- **Candidate ordering is untouched.** Native preference is a per-target protocol choice plus a stable secondary tie-break that is a strict no-op while the primary (alphabetical) order is total — so cost/latency stays authoritative and the feature never changes *which* upstream is chosen. No cost regression by construction.

### Compatibility
Single-protocol config is byte-identical in behavior; `protocol_for` is unchanged; existing cascade ordering is unchanged. A bare protocol string still parses to a one-element set.

### Tests
451 tests pass with `config_file`+`server` features; clippy clean; full workspace green. Coverage: multi-protocol parse (string and sequence forms), `protocols_for`/`endpoint_for`, native selection / head fallback / per-protocol endpoint, the "native never reorders the cascade" guarantee, virtual-model and `@preset` paths, account-base vs per-protocol-endpoint precedence, and request→context threading.

### Deliberately deferred (fast-follow)
- **IR-fidelity captures** — OpenAI Responses `reasoning.encrypted_content` and Anthropic citation offsets. These are knowingly-deferred parity items (the IR currently drops reasoning on the request side); capturing them for fully-faithful same-protocol round-trips warrants its own PR. Native routing already preserves every metadata field the IR captures today.
- **Registry protocol vocabulary** — expressing the protocol set in the provider registry (it can't yet distinguish Responses from Chat Completions) ships under the usual consumer-first lock-step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
