### PR TITLE
feat(server-tools): router-executed server-side tool loop

### DIFF
--- a/apps/bitrouter/src/assemble.rs
+++ b/apps/bitrouter/src/assemble.rs
@@ -13,6 +13,11 @@ use bitrouter_sdk::App;
 use bitrouter_sdk::acp::{AcpStdioExecutor, ConfigAcpRoutingTable};
 use bitrouter_sdk::config::{Config, ConfigRoutingTable};
 use bitrouter_sdk::language_model::protocol::OutboundDispatch;
+use bitrouter_sdk::language_model::server_tools::approval::AllowAll;
+use bitrouter_sdk::language_model::server_tools::config::ServerToolLoopConfig;
+use bitrouter_sdk::language_model::server_tools::loop_controller::ServerToolLoop;
+use bitrouter_sdk::language_model::server_tools::mcp_toolset::McpRouterToolset;
+use bitrouter_sdk::language_model::server_tools::toolset::{RouterToolset, ToolsetRegistry};
 use bitrouter_sdk::language_model::{AuthAppliers, HttpExecutor, HttpTimeouts};
 use bitrouter_sdk::mcp::aggregating_executor::AggregatingExecutor;
 use bitrouter_sdk::mcp::caching_executor::{CacheTtls, CachingExecutor};
@@ -303,6 +308,12 @@ pub async fn build_app_with_path(
         }
     });
 
+    // Server-side tool loop — wired only when `server_tools.mcp_servers` names
+    // at least one configured MCP server. Reuses the MCP executor/routing built
+    // above; here BitRouter is an MCP *client* that executes the model's tool
+    // calls inside the LLM loop (distinct from the `/mcp` gateway above).
+    let server_tool_loop = build_server_tool_loop(config, &mcp_routing, &mcp_executor);
+
     // Optional ACP pure-routing pipeline — wired only when the config
     // declares at least one upstream agent. Mirrors the MCP wiring above;
     // the `bitrouter agent-proxy <id>` CLI dispatches against this pipeline.
@@ -348,6 +359,10 @@ pub async fn build_app_with_path(
                 metering_store_for_recorder,
                 pricing_for_recorder,
             ));
+            // Server-side tool loop (router-executed MCP tools), when configured.
+            if let Some(server_loop) = server_tool_loop {
+                lm.server_tool_loop(server_loop);
+            }
         });
     // Stage-1 guardrail plugin, appended after the closure so its hooks land
     // after auth + policy in registration order. Skipped when no rules are
@@ -392,6 +407,61 @@ pub async fn build_app_with_path(
         otel_exporter: otel_for_assembled,
         otel_init_error,
     })
+}
+
+/// Build the server-side tool loop from `config.server_tools` over the MCP
+/// executor/routing already assembled for the `/mcp` gateway. Returns `None`
+/// when no `server_tools.mcp_servers` are configured (or the MCP stack is
+/// absent). Each named server is attached as an [`McpRouterToolset`] using a
+/// `Direct` selector and the server's `tool_prefix` (default `"{name}__"`), so
+/// router tool names cannot collide with the caller's own tools.
+fn build_server_tool_loop(
+    config: &Config,
+    mcp_routing: &Option<Arc<ConfigMcpRoutingTable>>,
+    mcp_executor: &Option<Arc<dyn bitrouter_sdk::mcp::Executor>>,
+) -> Option<Arc<ServerToolLoop>> {
+    let settings = &config.server_tools;
+    if settings.mcp_servers.is_empty() {
+        return None;
+    }
+    let (Some(routing), Some(executor)) = (mcp_routing, mcp_executor) else {
+        tracing::warn!(
+            "server_tools.mcp_servers is set but no mcp_servers are configured; \
+             the server-side tool loop is disabled"
+        );
+        return None;
+    };
+    let routing: Arc<dyn bitrouter_sdk::mcp::RoutingTable> = routing.clone();
+    let mut sets: Vec<Arc<dyn RouterToolset>> = Vec::with_capacity(settings.mcp_servers.len());
+    for name in &settings.mcp_servers {
+        let Some(server) = config.mcp_servers.get(name) else {
+            tracing::warn!(server = %name,
+                "server_tools.mcp_servers names an MCP server absent from mcp_servers; skipping");
+            continue;
+        };
+        let prefix = server
+            .tool_prefix
+            .clone()
+            .unwrap_or_else(|| format!("{name}__"));
+        sets.push(Arc::new(McpRouterToolset::new(
+            executor.clone(),
+            routing.clone(),
+            name.clone(),
+            Some(prefix),
+        )));
+    }
+    if sets.is_empty() {
+        return None;
+    }
+    let mut loop_config = ServerToolLoopConfig::default();
+    if let Some(max) = settings.max_iterations {
+        loop_config.max_iterations = max;
+    }
+    Some(Arc::new(ServerToolLoop::new(
+        ToolsetRegistry::new(sets),
+        loop_config,
+        Arc::new(AllowAll),
+    )))
 }
 
 /// Build the per-provider `AuthAppliers` registry. Each entry covers a
@@ -638,5 +708,24 @@ mod otel_config_tests {
             .expect("legacy shim is Ok")
             .expect("legacy shim yields Some");
         assert_eq!(cfg.endpoint, "http://legacy:4318");
+    }
+}
+
+#[cfg(test)]
+mod server_tools_tests {
+    use super::{Config, build_server_tool_loop};
+
+    #[test]
+    fn no_loop_when_server_tools_unset() {
+        let config = Config::default();
+        assert!(build_server_tool_loop(&config, &None, &None).is_none());
+    }
+
+    #[test]
+    fn no_loop_when_named_but_mcp_stack_absent() {
+        let mut config = Config::default();
+        config.server_tools.mcp_servers = vec!["docs".to_string()];
+        // server_tools names a server but no MCP executor/routing was built.
+        assert!(build_server_tool_loop(&config, &None, &None).is_none());
     }
 }

--- a/crates/bitrouter-sdk/src/config/mod.rs
+++ b/crates/bitrouter-sdk/src/config/mod.rs
@@ -63,6 +63,10 @@ pub struct Config {
     /// `POST /mcp/{id}` and what the `mcp` pipeline's routing table looks up.
     /// Empty by default — when empty, the binary does not mount the MCP route.
     pub mcp_servers: HashMap<String, crate::mcp::transport::McpServerConfig>,
+    /// Server-side tool loop: MCP server ids whose tools BitRouter injects into
+    /// LLM requests and executes itself. Empty by default — the pipeline stays
+    /// single-shot.
+    pub server_tools: crate::language_model::server_tools::config::ServerToolsConfig,
     /// Upstream ACP agents, keyed by agent id. Looked up by the `acp`
     /// pipeline's routing table; the `bitrouter agent-proxy <id>` CLI
     /// dispatches against this. Empty by default.
@@ -83,6 +87,7 @@ impl Default for Config {
             plugins: HashMap::new(),
             mcp: McpConfig::default(),
             mcp_servers: HashMap::new(),
+            server_tools: Default::default(),
             agents: HashMap::new(),
             inherit_defaults: true,
         }

--- a/crates/bitrouter-sdk/src/language_model/builder.rs
+++ b/crates/bitrouter-sdk/src/language_model/builder.rs
@@ -12,6 +12,7 @@ use crate::language_model::hooks::{
 };
 use crate::language_model::pipeline::{DEFAULT_KEEPALIVE, Pipeline};
 use crate::language_model::routing::{DefaultFallbackPolicy, FallbackPolicy, RoutingTable};
+use crate::language_model::server_tools::loop_controller::ServerToolLoop;
 use crate::language_model::settlement::SettlementRecorder;
 
 /// Builds a [`Pipeline`] for the `language_model` protocol. Every method takes
@@ -27,6 +28,7 @@ pub struct PipelineBuilder {
     routing_table: Option<Arc<dyn RoutingTable>>,
     fallback_policy: Option<Arc<dyn FallbackPolicy>>,
     executor: Option<Arc<dyn Executor>>,
+    server_tool_loop: Option<Arc<ServerToolLoop>>,
     keepalive_interval: Duration,
 }
 
@@ -43,6 +45,7 @@ impl PipelineBuilder {
             routing_table: None,
             fallback_policy: None,
             executor: None,
+            server_tool_loop: None,
             keepalive_interval: DEFAULT_KEEPALIVE,
         }
     }
@@ -56,6 +59,14 @@ impl PipelineBuilder {
     /// Set the executor that performs upstream calls (required).
     pub fn executor(&mut self, executor: Arc<dyn Executor>) -> &mut Self {
         self.executor = Some(executor);
+        self
+    }
+
+    /// Attach a server-side tool loop (`server_tools`). When set, non-streaming
+    /// execution injects the loop's router tools, executes the model's calls to
+    /// them, and re-calls the upstream until the model stops calling them.
+    pub fn server_tool_loop(&mut self, server_loop: Arc<ServerToolLoop>) -> &mut Self {
+        self.server_tool_loop = Some(server_loop);
         self
     }
 
@@ -140,6 +151,7 @@ impl PipelineBuilder {
             routing_table,
             fallback_policy,
             executor,
+            server_tool_loop: self.server_tool_loop,
             keepalive_interval: self.keepalive_interval,
             pending_settlements: Arc::new(std::sync::Mutex::new(tokio::task::JoinSet::new())),
             detached_executions: tokio_util::task::TaskTracker::new(),

--- a/crates/bitrouter-sdk/src/language_model/mod.rs
+++ b/crates/bitrouter-sdk/src/language_model/mod.rs
@@ -64,6 +64,7 @@ pub mod hooks;
 pub mod pipeline;
 pub mod protocol;
 pub mod routing;
+pub mod server_tools;
 pub mod settlement;
 pub mod stream;
 pub mod types;

--- a/crates/bitrouter-sdk/src/language_model/pipeline.rs
+++ b/crates/bitrouter-sdk/src/language_model/pipeline.rs
@@ -10,6 +10,7 @@ use futures::{FutureExt, StreamExt};
 use futures_core::Stream;
 use tracing::Instrument;
 
+use crate::caller::CallerContext;
 use crate::error::{BitrouterError, Result};
 use crate::language_model::context::PipelineContext;
 use crate::language_model::executor::{Executor, StreamPartStream};
@@ -19,6 +20,7 @@ use crate::language_model::hooks::{
 };
 use crate::language_model::routing::{FallbackPolicy, RoutingPrefs, RoutingTable};
 use crate::language_model::server_tools::loop_controller::{ServerToolLoop, UpstreamTurn};
+use crate::language_model::server_tools::stream::UpstreamStream;
 use crate::language_model::settlement::{SettlementContext, SettlementRecorder};
 use crate::language_model::stream::{StreamOutcome, StreamProcessor};
 use crate::language_model::types::{
@@ -75,6 +77,27 @@ impl UpstreamTurn for PipelineUpstream<'_> {
     async fn run(&self, prompt: &Prompt) -> Result<ExecutionResult> {
         self.pipeline
             .execute_with_fallback(self.chain, prompt, self.ctx)
+            .await
+    }
+}
+
+/// Drives one upstream **streaming** turn for the server-side tool loop. The
+/// loop pins to the turn's resolved `target`, and each iteration uses a fresh
+/// throwaway [`PipelineContext`] (the executor reads it only for outbound trace
+/// headers), so the real request context stays owned by the settlement guard.
+struct PipelineStreamUpstream {
+    executor: Arc<dyn Executor>,
+    target: RoutingTarget,
+    caller: CallerContext,
+}
+
+#[async_trait]
+impl UpstreamStream for PipelineStreamUpstream {
+    async fn run(&self, prompt: &Prompt) -> Result<StreamPartStream> {
+        let req = PipelineRequest::new(prompt.model.clone(), self.caller.clone(), prompt.clone());
+        let ctx = PipelineContext::new(req);
+        self.executor
+            .execute_stream(&self.target, prompt, &ctx)
             .await
     }
 }
@@ -254,7 +277,27 @@ impl Pipeline {
         self.observe_after(Phase::Route, &ctx).await;
         log_request_received(&ctx, chain.first(), true);
 
-        let upstream = self.execute_stream_with_fallback(&chain, &ctx).await?;
+        // Route Stage 3 through the server-side tool loop when configured: the
+        // merged stream becomes the "upstream" the settlement guard drains, so
+        // settlement is unchanged. Otherwise the pipeline stays single-shot.
+        let upstream = match &self.server_tool_loop {
+            Some(server_loop) => {
+                let target = chain
+                    .first()
+                    .cloned()
+                    .ok_or_else(|| BitrouterError::NotFound("empty routing chain".to_string()))?;
+                let upstream_impl: Arc<dyn UpstreamStream> = Arc::new(PipelineStreamUpstream {
+                    executor: self.executor.clone(),
+                    target,
+                    caller: ctx.caller().clone(),
+                });
+                server_loop
+                    .clone()
+                    .run_stream(ctx.prompt(), ctx.caller(), upstream_impl)
+                    .await?
+            }
+            None => self.execute_stream_with_fallback(&chain, &ctx).await?,
+        };
         // A placeholder execution result so Settlement has provider/model ids;
         // usage is folded in from the StreamContext at stream end.
         let head = chain.first().cloned();

--- a/crates/bitrouter-sdk/src/language_model/pipeline.rs
+++ b/crates/bitrouter-sdk/src/language_model/pipeline.rs
@@ -5,6 +5,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
 
+use async_trait::async_trait;
 use futures::{FutureExt, StreamExt};
 use futures_core::Stream;
 use tracing::Instrument;
@@ -17,10 +18,11 @@ use crate::language_model::hooks::{
     RequestOutcome, RouteHook, StreamHook,
 };
 use crate::language_model::routing::{FallbackPolicy, RoutingPrefs, RoutingTable};
+use crate::language_model::server_tools::loop_controller::{ServerToolLoop, UpstreamTurn};
 use crate::language_model::settlement::{SettlementContext, SettlementRecorder};
 use crate::language_model::stream::{StreamOutcome, StreamProcessor};
 use crate::language_model::types::{
-    ExecutionResult, PipelineRequest, PipelineResponse, RoutingTarget, StreamPart,
+    ExecutionResult, PipelineRequest, PipelineResponse, Prompt, RoutingTarget, StreamPart,
 };
 
 /// The default SSE keepalive interval.
@@ -39,6 +41,12 @@ pub struct Pipeline {
     pub(crate) routing_table: Arc<dyn RoutingTable>,
     pub(crate) fallback_policy: Arc<dyn FallbackPolicy>,
     pub(crate) executor: Arc<dyn Executor>,
+    /// When set, non-streaming execution runs through the server-side tool loop
+    /// (`server_tools`): router tools are injected, the model's calls to them
+    /// are executed by BitRouter, and the upstream is re-called until the model
+    /// stops calling them — all behind one caller response. `None` keeps the
+    /// pipeline strictly single-shot.
+    pub(crate) server_tool_loop: Option<Arc<ServerToolLoop>>,
     pub(crate) keepalive_interval: Duration,
     /// Detached settlement tasks spawned when a streaming client disconnects
     /// (`StreamSettlementGuard::drop` —.5: no lost streaming
@@ -52,6 +60,23 @@ pub struct Pipeline {
     /// and awaits it on graceful shutdown so a SIGTERM can't cut a request that
     /// the upstream is still billing us for.
     pub(crate) detached_executions: tokio_util::task::TaskTracker,
+}
+
+/// Adapts the pipeline's fallback execution into an [`UpstreamTurn`] so the
+/// server-side tool loop can re-call the upstream for each iteration.
+struct PipelineUpstream<'a> {
+    pipeline: &'a Pipeline,
+    chain: &'a [RoutingTarget],
+    ctx: &'a PipelineContext,
+}
+
+#[async_trait]
+impl UpstreamTurn for PipelineUpstream<'_> {
+    async fn run(&self, prompt: &Prompt) -> Result<ExecutionResult> {
+        self.pipeline
+            .execute_with_fallback(self.chain, prompt, self.ctx)
+            .await
+    }
 }
 
 impl Pipeline {
@@ -169,8 +194,19 @@ impl Pipeline {
         self.observe_after(Phase::Route, &ctx).await;
         log_request_received(&ctx, chain.first(), false);
 
-        // ---- Stage 3: execution with fallback ----
-        match self.execute_with_fallback(&chain, &ctx).await {
+        // ---- Stage 3: execution (with the server-side tool loop when configured) ----
+        let exec_outcome = match &self.server_tool_loop {
+            Some(server_loop) => {
+                let upstream = PipelineUpstream {
+                    pipeline: self,
+                    chain: &chain,
+                    ctx: &ctx,
+                };
+                server_loop.run(ctx.prompt(), ctx.caller(), &upstream).await
+            }
+            None => self.execute_with_fallback(&chain, ctx.prompt(), &ctx).await,
+        };
+        match exec_outcome {
             Ok(result) => {
                 ctx.execution_result = Some(result);
                 self.observe_after(Phase::Execution, &ctx).await;
@@ -356,12 +392,13 @@ impl Pipeline {
     async fn execute_with_fallback(
         &self,
         chain: &[RoutingTarget],
+        prompt: &Prompt,
         ctx: &PipelineContext,
     ) -> Result<ExecutionResult> {
         let mut last_error: Option<BitrouterError> = None;
         for target in chain {
             self.observe_hop_start(ctx, target).await;
-            let outcome = self.executor.execute(target, ctx.prompt(), ctx).await;
+            let outcome = self.executor.execute(target, prompt, ctx).await;
             match &outcome {
                 Ok(result) => {
                     self.observe_hop_end(ctx, target, HopOutcome::Generated(result))

--- a/crates/bitrouter-sdk/src/language_model/pipeline.rs
+++ b/crates/bitrouter-sdk/src/language_model/pipeline.rs
@@ -81,13 +81,14 @@ impl UpstreamTurn for PipelineUpstream<'_> {
     }
 }
 
-/// Drives one upstream **streaming** turn for the server-side tool loop. The
-/// loop pins to the turn's resolved `target`, and each iteration uses a fresh
+/// Drives one upstream **streaming** turn for the server-side tool loop. Each
+/// iteration tries the routing `chain` in order until one stream starts
+/// (commit-on-start failover, mirroring the single-shot path), and uses a fresh
 /// throwaway [`PipelineContext`] (the executor reads it only for outbound trace
 /// headers), so the real request context stays owned by the settlement guard.
 struct PipelineStreamUpstream {
     executor: Arc<dyn Executor>,
-    target: RoutingTarget,
+    chain: Vec<RoutingTarget>,
     caller: CallerContext,
 }
 
@@ -96,9 +97,15 @@ impl UpstreamStream for PipelineStreamUpstream {
     async fn run(&self, prompt: &Prompt) -> Result<StreamPartStream> {
         let req = PipelineRequest::new(prompt.model.clone(), self.caller.clone(), prompt.clone());
         let ctx = PipelineContext::new(req);
-        self.executor
-            .execute_stream(&self.target, prompt, &ctx)
-            .await
+        let mut last_error: Option<BitrouterError> = None;
+        for target in &self.chain {
+            match self.executor.execute_stream(target, prompt, &ctx).await {
+                Ok(stream) => return Ok(stream),
+                Err(e) => last_error = Some(e),
+            }
+        }
+        Err(last_error
+            .unwrap_or_else(|| BitrouterError::NotFound("empty routing chain".to_string())))
     }
 }
 
@@ -282,13 +289,9 @@ impl Pipeline {
         // settlement is unchanged. Otherwise the pipeline stays single-shot.
         let upstream = match &self.server_tool_loop {
             Some(server_loop) => {
-                let target = chain
-                    .first()
-                    .cloned()
-                    .ok_or_else(|| BitrouterError::NotFound("empty routing chain".to_string()))?;
                 let upstream_impl: Arc<dyn UpstreamStream> = Arc::new(PipelineStreamUpstream {
                     executor: self.executor.clone(),
-                    target,
+                    chain: chain.clone(),
                     caller: ctx.caller().clone(),
                 });
                 server_loop

--- a/crates/bitrouter-sdk/src/language_model/protocol/chat_completions.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/chat_completions.rs
@@ -1633,6 +1633,14 @@ impl StreamEncoder for ChatStreamEncoder {
                 // (image generation is a separate API), so a generated file is
                 // surfaced only on the non-streaming path. Documented limitation.
             }
+            StreamPart::ServerToolCall { .. } | StreamPart::ServerToolResult { .. } => {
+                // Chat Completions has no server-tool / MCP wire form (cf. the
+                // provider-defined-tool drop on this wire), and emitting a
+                // `tool_calls` delta would make the client try to execute a tool
+                // BitRouter already ran. Router-executed tool activity is
+                // therefore dropped here; the model's narration and final answer
+                // still stream. Documented limitation.
+            }
             StreamPart::TextStart { .. }
             | StreamPart::TextEnd { .. }
             | StreamPart::ReasoningStart { .. }

--- a/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
@@ -1475,6 +1475,17 @@ impl StreamEncoder for GenerateContentStreamEncoder {
                     "candidates": [{ "content": { "role": "model", "parts": [file_part] } }]
                 }));
             }
+            // Generate Content has no server-tool / MCP stream form; emitting a
+            // functionCall/functionResponse here would look to the client like a
+            // pending call it must answer. Router-executed tool activity is
+            // dropped on this wire (the model's narration + final answer still
+            // stream); flush any buffered ordinary tool call first. Documented
+            // limitation.
+            StreamPart::ServerToolCall { .. } | StreamPart::ServerToolResult { .. } => {
+                if let Some(c) = self.flush_pending_tool() {
+                    chunks.push(c);
+                }
+            }
             StreamPart::TextDelta { text } => {
                 if let Some(c) = self.flush_pending_tool() {
                     chunks.push(c);

--- a/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
@@ -2330,8 +2330,17 @@ fn server_tool_result_content(output: &ToolResultOutput) -> (serde_json::Value, 
         ToolResultOutput::ErrorText { value } => {
             (serde_json::json!([{ "type": "text", "text": value }]), true)
         }
-        ToolResultOutput::Json { value } => (value.clone(), false),
-        ToolResultOutput::ErrorJson { value } => (value.clone(), true),
+        // `mcp_tool_result.content` must be a string or an array of content
+        // blocks — a non-text MCP result (a raw JSON body) is wrapped in a text
+        // block rather than passed through as a bare object.
+        ToolResultOutput::Json { value } => (
+            serde_json::json!([{ "type": "text", "text": value.to_string() }]),
+            false,
+        ),
+        ToolResultOutput::ErrorJson { value } => (
+            serde_json::json!([{ "type": "text", "text": value.to_string() }]),
+            true,
+        ),
         ToolResultOutput::Content { value } => {
             let parts: Vec<serde_json::Value> = value
                 .iter()

--- a/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
@@ -2318,6 +2318,42 @@ enum EncoderBlockKind {
     ToolUse,
 }
 
+/// Map a router tool-result output to an Anthropic `mcp_tool_result`
+/// `content` value (an array of content blocks, or a raw JSON body) plus the
+/// `is_error` flag. Mirrors the non-streaming `mcp_tool_result` render.
+fn server_tool_result_content(output: &ToolResultOutput) -> (serde_json::Value, bool) {
+    match output {
+        ToolResultOutput::Text { value } => (
+            serde_json::json!([{ "type": "text", "text": value }]),
+            false,
+        ),
+        ToolResultOutput::ErrorText { value } => {
+            (serde_json::json!([{ "type": "text", "text": value }]), true)
+        }
+        ToolResultOutput::Json { value } => (value.clone(), false),
+        ToolResultOutput::ErrorJson { value } => (value.clone(), true),
+        ToolResultOutput::Content { value } => {
+            let parts: Vec<serde_json::Value> = value
+                .iter()
+                .filter_map(|p| match p {
+                    ToolResultContentPart::Text { text } => {
+                        Some(serde_json::json!({ "type": "text", "text": text }))
+                    }
+                    _ => None,
+                })
+                .collect();
+            (serde_json::Value::Array(parts), false)
+        }
+        ToolResultOutput::ExecutionDenied { reason } => (
+            serde_json::json!([{
+                "type": "text",
+                "text": format!("execution denied: {}", reason.as_deref().unwrap_or("")),
+            }]),
+            true,
+        ),
+    }
+}
+
 struct MessagesStreamEncoder {
     request_id: String,
     model: String,
@@ -2642,6 +2678,80 @@ impl StreamEncoder for MessagesStreamEncoder {
                         }),
                     ));
                 }
+            }
+            // A router-executed tool call rendered as a whole server-tool block:
+            // a named MCP server -> `mcp_tool_use` (carrying `server_name`), else
+            // the generic `server_tool_use`. Either marks the call
+            // provider-executed, so the client never re-runs it. Opened and
+            // closed as one block, mirroring `flush_pending_sources`.
+            StreamPart::ServerToolCall {
+                id,
+                name,
+                arguments,
+                server_name,
+                dynamic,
+            } => {
+                self.close_block(&mut frames);
+                // Open with an empty input; the arguments stream as an
+                // `input_json_delta`, matching how Anthropic frames a tool_use
+                // block (the client builds `input` from the deltas).
+                let content_block = match server_name {
+                    Some(server) if *dynamic => serde_json::json!({
+                        "type": "mcp_tool_use",
+                        "id": id, "name": name, "server_name": server, "input": {},
+                    }),
+                    _ => serde_json::json!({
+                        "type": "server_tool_use", "id": id, "name": name, "input": {},
+                    }),
+                };
+                frames.push(Self::ev(
+                    "content_block_start",
+                    serde_json::json!({
+                        "type": "content_block_start",
+                        "index": self.block_index,
+                        "content_block": content_block,
+                    }),
+                ));
+                if !arguments.is_empty() {
+                    frames.push(Self::ev(
+                        "content_block_delta",
+                        serde_json::json!({
+                            "type": "content_block_delta",
+                            "index": self.block_index,
+                            "delta": { "type": "input_json_delta", "partial_json": arguments },
+                        }),
+                    ));
+                }
+                frames.push(Self::ev(
+                    "content_block_stop",
+                    serde_json::json!({ "type": "content_block_stop", "index": self.block_index }),
+                ));
+                self.block_index += 1;
+            }
+            // The matching result, rendered as a whole `mcp_tool_result` block.
+            StreamPart::ServerToolResult {
+                call_id, output, ..
+            } => {
+                self.close_block(&mut frames);
+                let (content, is_error) = server_tool_result_content(output);
+                frames.push(Self::ev(
+                    "content_block_start",
+                    serde_json::json!({
+                        "type": "content_block_start",
+                        "index": self.block_index,
+                        "content_block": {
+                            "type": "mcp_tool_result",
+                            "tool_use_id": call_id,
+                            "is_error": is_error,
+                            "content": content,
+                        },
+                    }),
+                ));
+                frames.push(Self::ev(
+                    "content_block_stop",
+                    serde_json::json!({ "type": "content_block_stop", "index": self.block_index }),
+                ));
+                self.block_index += 1;
             }
             StreamPart::Source { source } => {
                 // Buffer a streamed citation as a `web_search_result` entry; all

--- a/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
@@ -966,6 +966,7 @@ impl InboundAdapter for ResponsesAdapter {
             tool_item: None,
             completed_items: Vec::new(),
             annotation_index: 0,
+            pending_mcp_call: None,
         })
     }
 }
@@ -2360,6 +2361,47 @@ struct ResponsesStreamEncoder {
     /// supplying the monotonically increasing `annotation_index` each event
     /// carries.
     annotation_index: u64,
+    /// A buffered [`StreamPart::ServerToolCall`] awaiting its result, so the
+    /// pair emits as one `mcp_call` output item (OpenAI carries arguments +
+    /// output on a single item).
+    pending_mcp_call: Option<PendingMcpCall>,
+}
+
+/// A buffered router tool call awaiting its [`StreamPart::ServerToolResult`].
+struct PendingMcpCall {
+    id: String,
+    name: String,
+    arguments: String,
+    server_name: Option<String>,
+}
+
+/// Map a router tool-result output to an OpenAI `mcp_call` `output` string and
+/// optional `error` string.
+fn mcp_call_output(output: &ToolResultOutput) -> (String, Option<String>) {
+    match output {
+        ToolResultOutput::Text { value } => (value.clone(), None),
+        ToolResultOutput::ErrorText { value } => (String::new(), Some(value.clone())),
+        ToolResultOutput::Json { value } => (value.to_string(), None),
+        ToolResultOutput::ErrorJson { value } => (String::new(), Some(value.to_string())),
+        ToolResultOutput::Content { value } => {
+            let text = value
+                .iter()
+                .filter_map(|p| match p {
+                    ToolResultContentPart::Text { text } => Some(text.as_str()),
+                    _ => None,
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+            (text, None)
+        }
+        ToolResultOutput::ExecutionDenied { reason } => (
+            String::new(),
+            Some(format!(
+                "execution denied: {}",
+                reason.as_deref().unwrap_or("")
+            )),
+        ),
+    }
 }
 
 /// Tracking state for one open message / reasoning item.
@@ -2827,6 +2869,65 @@ impl StreamEncoder for ResponsesStreamEncoder {
                         }),
                     ));
                 }
+            }
+            // Buffer a router-executed call; the matching result completes it
+            // into one `mcp_call` output item.
+            StreamPart::ServerToolCall {
+                id,
+                name,
+                arguments,
+                server_name,
+                ..
+            } => {
+                self.pending_mcp_call = Some(PendingMcpCall {
+                    id: id.clone(),
+                    name: name.clone(),
+                    arguments: arguments.clone(),
+                    server_name: server_name.clone(),
+                });
+            }
+            // Emit the complete `mcp_call` output item (arguments + output on one
+            // item), pairing it with the buffered call.
+            StreamPart::ServerToolResult {
+                call_id, output, ..
+            } => {
+                self.close_reasoning_item(&mut frames);
+                self.close_text_item(&mut frames);
+                self.close_tool_item(&mut frames);
+                let pending = self.pending_mcp_call.take();
+                let pending = pending.filter(|p| &p.id == call_id);
+                let name = pending.as_ref().map(|p| p.name.clone()).unwrap_or_default();
+                let arguments = pending
+                    .as_ref()
+                    .map(|p| p.arguments.clone())
+                    .unwrap_or_default();
+                let server_label = pending.as_ref().and_then(|p| p.server_name.clone());
+                let (out_str, err) = mcp_call_output(output);
+                let output_index = self.allocate_output_index();
+                let item_id = format!("mcp_{}", uuid::Uuid::new_v4());
+                let mut item = serde_json::json!({
+                    "type": "mcp_call",
+                    "id": item_id,
+                    "name": name,
+                    "arguments": arguments,
+                    "output": out_str,
+                    "status": "completed",
+                });
+                if let Some(server) = &server_label {
+                    item["server_label"] = serde_json::Value::String(server.clone());
+                }
+                if let Some(e) = &err {
+                    item["error"] = serde_json::Value::String(e.clone());
+                }
+                frames.push(self.ev(
+                    "response.output_item.added",
+                    serde_json::json!({ "output_index": output_index, "item": item.clone() }),
+                ));
+                frames.push(self.ev(
+                    "response.output_item.done",
+                    serde_json::json!({ "output_index": output_index, "item": item.clone() }),
+                ));
+                self.completed_items.push(item);
             }
             StreamPart::Source { source } => {
                 // A citation is a `response.output_text.annotation.added` event

--- a/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
@@ -9488,3 +9488,98 @@ fn gemini_encode_two_tool_calls_emit_two_function_calls() {
     assert_eq!(calls[1].0, "second");
     assert_eq!(calls[1].1, "{\"y\":2}");
 }
+
+// ===== server-side tool loop: ServerToolCall / ServerToolResult rendering =====
+
+fn server_tool_call_parts() -> [StreamPart; 2] {
+    [
+        StreamPart::ServerToolCall {
+            id: "c1".into(),
+            name: "mcp__docs__search".into(),
+            arguments: "{\"q\":\"rust\"}".into(),
+            server_name: Some("docs".into()),
+            dynamic: true,
+        },
+        StreamPart::ServerToolResult {
+            call_id: "c1".into(),
+            tool_name: Some("mcp__docs__search".into()),
+            output: ToolResultOutput::Text {
+                value: "found it".into(),
+            },
+            dynamic: true,
+        },
+    ]
+}
+
+#[test]
+fn messages_encodes_server_tool_call_and_result_blocks() {
+    let events = encode_stream_events(ApiProtocol::Messages, &server_tool_call_parts());
+    // An `mcp_tool_use` content block carrying the server_name.
+    assert!(
+        events.iter().any(|(ev, d)| ev == "content_block_start"
+            && d.pointer("/content_block/type").and_then(|v| v.as_str()) == Some("mcp_tool_use")
+            && d.pointer("/content_block/server_name")
+                .and_then(|v| v.as_str())
+                == Some("docs")),
+        "expected an mcp_tool_use block with server_name: {events:?}"
+    );
+    // The arguments stream as an input_json_delta.
+    assert!(
+        events.iter().any(|(ev, d)| ev == "content_block_delta"
+            && d.pointer("/delta/type").and_then(|v| v.as_str()) == Some("input_json_delta")),
+        "expected an input_json_delta: {events:?}"
+    );
+    // An `mcp_tool_result` block referencing the call, carrying the output.
+    assert!(
+        events.iter().any(|(ev, d)| ev == "content_block_start"
+            && d.pointer("/content_block/type").and_then(|v| v.as_str())
+                == Some("mcp_tool_result")
+            && d.pointer("/content_block/tool_use_id")
+                .and_then(|v| v.as_str())
+                == Some("c1")),
+        "expected an mcp_tool_result block: {events:?}"
+    );
+}
+
+#[test]
+fn responses_encodes_mcp_call_output_item() {
+    let events = encode_stream_events(ApiProtocol::Responses, &server_tool_call_parts());
+    let item = events
+        .iter()
+        .find(|(ev, d)| {
+            ev == "response.output_item.done"
+                && d.pointer("/item/type").and_then(|v| v.as_str()) == Some("mcp_call")
+        })
+        .map(|(_, d)| d)
+        .expect("expected an mcp_call output item");
+    assert_eq!(
+        item.pointer("/item/name").and_then(|v| v.as_str()),
+        Some("mcp__docs__search")
+    );
+    assert_eq!(
+        item.pointer("/item/output").and_then(|v| v.as_str()),
+        Some("found it")
+    );
+    assert_eq!(
+        item.pointer("/item/server_label").and_then(|v| v.as_str()),
+        Some("docs")
+    );
+}
+
+#[test]
+fn coarse_wires_drop_server_tool_activity() {
+    // Chat Completions and Generate Content have no server-tool / MCP stream
+    // form; the activity is dropped (the final answer still streams).
+    for proto in [ApiProtocol::ChatCompletions, ApiProtocol::GenerateContent] {
+        let events = encode_stream_events(proto.clone(), &server_tool_call_parts());
+        assert!(
+            !events.iter().any(|(_, d)| {
+                let s = d.to_string();
+                s.contains("mcp_tool_use")
+                    || s.contains("mcp_call")
+                    || s.contains("server_tool_use")
+            }),
+            "coarse wire {proto:?} must drop server-tool activity: {events:?}"
+        );
+    }
+}

--- a/crates/bitrouter-sdk/src/language_model/server_tools/approval.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/approval.rs
@@ -1,0 +1,25 @@
+//! The approval seam: a policy point evaluated before each router tool call.
+//! v1 ships [`AllowAll`]; a deployment can supply a policy that gates by tool,
+//! caller, or arguments without touching the loop core.
+
+use async_trait::async_trait;
+
+use super::classify::RouterCall;
+use crate::caller::CallerContext;
+
+/// Decides whether a router tool call may execute.
+#[async_trait]
+pub trait ApprovalPolicy: Send + Sync {
+    /// Whether `call` (issued for `caller`) may be executed.
+    async fn allow(&self, call: &RouterCall, caller: &CallerContext) -> bool;
+}
+
+/// Approves every router tool call — the v1 default.
+pub struct AllowAll;
+
+#[async_trait]
+impl ApprovalPolicy for AllowAll {
+    async fn allow(&self, _call: &RouterCall, _caller: &CallerContext) -> bool {
+        true
+    }
+}

--- a/crates/bitrouter-sdk/src/language_model/server_tools/classify.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/classify.rs
@@ -1,0 +1,138 @@
+//! Pure classification of a model turn: decide whether the loop must execute
+//! router-owned tool calls, hand the turn back to the caller, or stop.
+
+use std::collections::BTreeSet;
+
+use crate::language_model::types::Content;
+
+/// One router-owned tool call extracted from a model turn.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RouterCall {
+    /// Provider-assigned call id.
+    pub id: String,
+    /// Tool name.
+    pub name: String,
+    /// Raw JSON-encoded arguments.
+    pub arguments: String,
+}
+
+/// What the loop should do after one upstream turn.
+#[derive(Debug, PartialEq, Eq)]
+pub enum TurnDisposition {
+    /// No router-owned calls — the turn is the final answer.
+    Done,
+    /// A client-owned tool call is present (mixed or pure-client): the whole
+    /// turn returns to the caller, which executes its own tools. v1 does not
+    /// partially execute a mixed turn.
+    HandBack,
+    /// Every tool call is router-owned — execute them and loop.
+    Execute(Vec<RouterCall>),
+}
+
+/// Classify `content` against the set of router-owned tool names.
+///
+/// Provider-executed calls (`provider_executed: true`) were already run by the
+/// upstream and are ignored. If any client-owned call is present the turn is
+/// handed back; otherwise the router-owned calls (if any) are executed.
+pub fn classify_turn(content: &[Content], owned: &BTreeSet<String>) -> TurnDisposition {
+    let mut router_calls = Vec::new();
+    let mut has_client_call = false;
+    for block in content {
+        if let Content::ToolCall {
+            id,
+            name,
+            arguments,
+            provider_executed,
+            ..
+        } = block
+        {
+            if *provider_executed {
+                continue;
+            }
+            if owned.contains(name) {
+                router_calls.push(RouterCall {
+                    id: id.clone(),
+                    name: name.clone(),
+                    arguments: arguments.clone(),
+                });
+            } else {
+                has_client_call = true;
+            }
+        }
+    }
+    if has_client_call {
+        TurnDisposition::HandBack
+    } else if router_calls.is_empty() {
+        TurnDisposition::Done
+    } else {
+        TurnDisposition::Execute(router_calls)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::language_model::types::ProviderMetadata;
+
+    fn call(name: &str, provider_executed: bool) -> Content {
+        Content::ToolCall {
+            id: format!("{name}-id"),
+            name: name.to_string(),
+            arguments: "{}".to_string(),
+            provider_executed,
+            dynamic: false,
+            provider_metadata: ProviderMetadata::new(),
+        }
+    }
+
+    fn text() -> Content {
+        Content::Text {
+            text: "answer".to_string(),
+            provider_metadata: ProviderMetadata::new(),
+        }
+    }
+
+    fn owned(names: &[&str]) -> BTreeSet<String> {
+        names.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn execute_when_all_calls_router_owned() {
+        let d = classify_turn(&[call("search", false)], &owned(&["search"]));
+        assert_eq!(
+            d,
+            TurnDisposition::Execute(vec![RouterCall {
+                id: "search-id".to_string(),
+                name: "search".to_string(),
+                arguments: "{}".to_string(),
+            }])
+        );
+    }
+
+    #[test]
+    fn handback_when_mixed_router_and_client() {
+        let d = classify_turn(
+            &[call("search", false), call("client_fn", false)],
+            &owned(&["search"]),
+        );
+        assert_eq!(d, TurnDisposition::HandBack);
+    }
+
+    #[test]
+    fn handback_when_only_client_call() {
+        let d = classify_turn(&[call("client_fn", false)], &owned(&["search"]));
+        assert_eq!(d, TurnDisposition::HandBack);
+    }
+
+    #[test]
+    fn done_when_no_tool_calls() {
+        let d = classify_turn(&[text()], &owned(&["search"]));
+        assert_eq!(d, TurnDisposition::Done);
+    }
+
+    #[test]
+    fn done_when_owned_but_provider_executed() {
+        let d = classify_turn(&[call("search", true)], &owned(&["search"]));
+        assert_eq!(d, TurnDisposition::Done);
+    }
+}

--- a/crates/bitrouter-sdk/src/language_model/server_tools/config.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/config.rs
@@ -1,6 +1,10 @@
-//! Bounds for the server-side tool loop.
+//! Configuration for the server-side tool loop: the runtime
+//! [`ServerToolLoopConfig`] bounds and the deserialised [`ServerToolsConfig`]
+//! YAML section.
 
 use std::time::Duration;
+
+use serde::Deserialize;
 
 /// Bounds the [`ServerToolLoop`](super::loop_controller::ServerToolLoop): how
 /// many tool rounds it runs, how long each tool may take, the total wall-clock
@@ -28,4 +32,18 @@ impl Default for ServerToolLoopConfig {
             max_consecutive_errors: 3,
         }
     }
+}
+
+/// The OSS `server_tools` config section. Names the MCP servers whose tools
+/// BitRouter attaches to LLM requests and executes inside the loop, with an
+/// optional override of the loop's iteration cap. An empty `mcp_servers`
+/// leaves the pipeline strictly single-shot.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct ServerToolsConfig {
+    /// MCP server names (keys of `mcp_servers`) whose tools are injected into
+    /// LLM requests and executed by the loop.
+    pub mcp_servers: Vec<String>,
+    /// Optional override of the loop's maximum tool-execution rounds.
+    pub max_iterations: Option<u32>,
 }

--- a/crates/bitrouter-sdk/src/language_model/server_tools/config.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/config.rs
@@ -1,0 +1,31 @@
+//! Bounds for the server-side tool loop.
+
+use std::time::Duration;
+
+/// Bounds the [`ServerToolLoop`](super::loop_controller::ServerToolLoop): how
+/// many tool rounds it runs, how long each tool may take, the total wall-clock
+/// budget for the turn, and how many consecutive tool-error rounds it tolerates
+/// before giving up.
+#[derive(Debug, Clone)]
+pub struct ServerToolLoopConfig {
+    /// Maximum number of tool-execution rounds. Reaching it terminates the
+    /// loop with a truncation finish reason. Default 10.
+    pub max_iterations: u32,
+    /// Per-tool execution timeout. Default 30s.
+    pub tool_timeout: Duration,
+    /// Total wall-clock budget for the whole turn. Default 120s.
+    pub total_budget: Duration,
+    /// Consecutive tool-error rounds tolerated before giving up. Default 3.
+    pub max_consecutive_errors: u32,
+}
+
+impl Default for ServerToolLoopConfig {
+    fn default() -> Self {
+        Self {
+            max_iterations: 10,
+            tool_timeout: Duration::from_secs(30),
+            total_budget: Duration::from_secs(120),
+            max_consecutive_errors: 3,
+        }
+    }
+}

--- a/crates/bitrouter-sdk/src/language_model/server_tools/loop_controller.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/loop_controller.rs
@@ -50,6 +50,42 @@ impl ServerToolLoop {
         }
     }
 
+    /// The loop's bounds.
+    pub fn config(&self) -> &ServerToolLoopConfig {
+        &self.config
+    }
+
+    /// The MCP server backing the toolset that owns `name`, if any — used to
+    /// label a streamed router tool call for `mcp_tool_use` rendering.
+    pub(crate) fn server_name_for(&self, name: &str) -> Option<String> {
+        self.registry
+            .resolve(name)
+            .and_then(|set| set.server_name())
+            .map(str::to_string)
+    }
+
+    /// Clone `base`, advertise the registry's router tools on it (failing on a
+    /// name collision with a caller tool), and return the working prompt plus
+    /// the set of router-owned tool names.
+    pub(crate) async fn inject(
+        &self,
+        base: &Prompt,
+        caller: &CallerContext,
+    ) -> Result<(Prompt, std::collections::BTreeSet<String>)> {
+        let (injected, owned) = self.registry.list_all(caller).await?;
+        let mut working = base.clone();
+        for tool in &injected {
+            if working.tools.iter().any(|t| t.name() == tool.name()) {
+                return Err(BitrouterError::Internal(format!(
+                    "router tool name collides with a caller tool: {}",
+                    tool.name()
+                )));
+            }
+        }
+        working.tools.extend(injected);
+        Ok((working, owned))
+    }
+
     /// Run the loop. `upstream` performs one upstream turn (with fallback) for a
     /// working prompt; the loop owns the working prompt, injects router tools
     /// into it, appends assistant + tool-result turns between iterations, and
@@ -64,17 +100,7 @@ impl ServerToolLoop {
         caller: &CallerContext,
         upstream: &dyn UpstreamTurn,
     ) -> Result<ExecutionResult> {
-        let (injected, owned) = self.registry.list_all(caller).await?;
-        let mut working = base.clone();
-        for tool in &injected {
-            if working.tools.iter().any(|t| t.name() == tool.name()) {
-                return Err(BitrouterError::Internal(format!(
-                    "router tool name collides with a caller tool: {}",
-                    tool.name()
-                )));
-            }
-        }
-        working.tools.extend(injected);
+        let (mut working, owned) = self.inject(base, caller).await?;
 
         let mut total = Usage::default();
         let mut had_usage = false;
@@ -114,6 +140,52 @@ impl ServerToolLoop {
         }
     }
 
+    /// Execute one router-owned call: approval gate, then the owning toolset
+    /// under the per-tool timeout. Returns the result output and whether it
+    /// errored. Shared by the non-streaming loop and the stream stitcher.
+    pub(crate) async fn call_one(
+        &self,
+        call: &RouterCall,
+        caller: &CallerContext,
+    ) -> (ToolResultOutput, bool) {
+        if !self.approval.allow(call, caller).await {
+            return (
+                ToolResultOutput::ExecutionDenied {
+                    reason: Some("denied by approval policy".to_string()),
+                },
+                false,
+            );
+        }
+        let Some(set) = self.registry.resolve(&call.name) else {
+            return (
+                ToolResultOutput::ErrorText {
+                    value: format!("no toolset owns '{}'", call.name),
+                },
+                true,
+            );
+        };
+        match tokio::time::timeout(
+            self.config.tool_timeout,
+            set.call_tool(&call.name, &call.arguments, caller),
+        )
+        .await
+        {
+            Ok(Ok(out)) => (out, false),
+            Ok(Err(err)) => (
+                ToolResultOutput::ErrorText {
+                    value: err.to_string(),
+                },
+                true,
+            ),
+            Err(_) => (
+                ToolResultOutput::ErrorText {
+                    value: format!("tool '{}' timed out", call.name),
+                },
+                true,
+            ),
+        }
+    }
+
     /// Execute each router-owned call, returning the tool-result content blocks
     /// and whether any call produced an error.
     async fn execute_calls(
@@ -124,37 +196,8 @@ impl ServerToolLoop {
         let mut results = Vec::with_capacity(calls.len());
         let mut had_error = false;
         for call in calls {
-            let output = if !self.approval.allow(call, caller).await {
-                ToolResultOutput::ExecutionDenied {
-                    reason: Some("denied by approval policy".to_string()),
-                }
-            } else if let Some(set) = self.registry.resolve(&call.name) {
-                match tokio::time::timeout(
-                    self.config.tool_timeout,
-                    set.call_tool(&call.name, &call.arguments, caller),
-                )
-                .await
-                {
-                    Ok(Ok(out)) => out,
-                    Ok(Err(err)) => {
-                        had_error = true;
-                        ToolResultOutput::ErrorText {
-                            value: err.to_string(),
-                        }
-                    }
-                    Err(_) => {
-                        had_error = true;
-                        ToolResultOutput::ErrorText {
-                            value: format!("tool '{}' timed out", call.name),
-                        }
-                    }
-                }
-            } else {
-                had_error = true;
-                ToolResultOutput::ErrorText {
-                    value: format!("no toolset owns '{}'", call.name),
-                }
-            };
+            let (output, err) = self.call_one(call, caller).await;
+            had_error |= err;
             results.push(Content::ToolResult {
                 call_id: call.id.clone(),
                 tool_name: Some(call.name.clone()),
@@ -181,7 +224,7 @@ fn append_turn(working: &mut Prompt, assistant_content: Vec<Content>, tool_resul
 }
 
 /// Sum the per-iteration usage into the running total.
-fn add_usage(total: &mut Usage, add: &Usage) {
+pub(crate) fn add_usage(total: &mut Usage, add: &Usage) {
     total.prompt_tokens += add.prompt_tokens;
     total.completion_tokens += add.completion_tokens;
     total.reasoning_tokens += add.reasoning_tokens;

--- a/crates/bitrouter-sdk/src/language_model/server_tools/loop_controller.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/loop_controller.rs
@@ -1,10 +1,12 @@
 //! [`ServerToolLoop`] — the non-streaming controller. It injects router tools
 //! into a working prompt, then drives upstream turns through a caller-supplied
-//! closure, executing router-owned tool calls and looping until the model
-//! stops calling them or a bound is hit.
+//! [`UpstreamTurn`], executing router-owned tool calls and looping until the
+//! model stops calling them or a bound is hit.
 
 use std::sync::Arc;
 use std::time::Instant;
+
+use async_trait::async_trait;
 
 use super::approval::ApprovalPolicy;
 use super::classify::{RouterCall, TurnDisposition, classify_turn};
@@ -16,6 +18,16 @@ use crate::language_model::types::{
     Content, ExecutionResult, FinishReason, Message, Prompt, ProviderMetadata, Role,
     ToolResultOutput, Usage,
 };
+
+/// One upstream turn for a working prompt — the loop's callback into the
+/// pipeline's `execute_with_fallback`. A trait (rather than a closure) so the
+/// resulting future has a concrete, `Send` type when the pipeline spawns the
+/// request.
+#[async_trait]
+pub trait UpstreamTurn: Send + Sync {
+    /// Run one upstream turn for `prompt`.
+    async fn run(&self, prompt: &Prompt) -> Result<ExecutionResult>;
+}
 
 /// Drives the server-side tool loop over a [`ToolsetRegistry`].
 pub struct ServerToolLoop {
@@ -38,23 +50,20 @@ impl ServerToolLoop {
         }
     }
 
-    /// Run the loop. `run_upstream` performs one upstream turn (with fallback)
-    /// for a working prompt; the loop owns the working prompt, injects router
-    /// tools into it, appends assistant + tool-result turns between iterations,
-    /// and accumulates usage across iterations.
+    /// Run the loop. `upstream` performs one upstream turn (with fallback) for a
+    /// working prompt; the loop owns the working prompt, injects router tools
+    /// into it, appends assistant + tool-result turns between iterations, and
+    /// accumulates usage across iterations.
     ///
     /// Returns the final upstream [`ExecutionResult`] (its `usage` replaced by
     /// the accumulated total). On reaching a bound, the result carries a
     /// truncation finish reason.
-    pub async fn run<F>(
+    pub async fn run(
         &self,
         base: &Prompt,
         caller: &CallerContext,
-        mut run_upstream: F,
-    ) -> Result<ExecutionResult>
-    where
-        F: AsyncFnMut(&Prompt) -> Result<ExecutionResult>,
-    {
+        upstream: &dyn UpstreamTurn,
+    ) -> Result<ExecutionResult> {
         let (injected, owned) = self.registry.list_all(caller).await?;
         let mut working = base.clone();
         for tool in &injected {
@@ -74,7 +83,7 @@ impl ServerToolLoop {
         let mut rounds = 0u32;
 
         loop {
-            let mut result = run_upstream(&working).await?;
+            let mut result = upstream.run(&working).await?;
             if let Some(usage) = &result.result.usage {
                 add_usage(&mut total, usage);
                 had_usage = true;
@@ -201,8 +210,8 @@ mod tests {
     use crate::language_model::server_tools::approval::AllowAll;
     use crate::language_model::server_tools::toolset::RouterToolset;
     use crate::language_model::types::{GenerateResult, Tool};
-    use async_trait::async_trait;
-    use std::sync::atomic::{AtomicU32, Ordering::SeqCst};
+    use std::collections::VecDeque;
+    use std::sync::Mutex;
 
     struct MockToolset {
         names: Vec<String>,
@@ -240,6 +249,32 @@ mod tests {
         }
         fn owns(&self, name: &str) -> bool {
             self.names.iter().any(|n| n == name)
+        }
+    }
+
+    /// Replays canned upstream results, recording each working prompt it saw.
+    struct ScriptedUpstream {
+        responses: Mutex<VecDeque<ExecutionResult>>,
+        seen: Mutex<Vec<Prompt>>,
+    }
+
+    impl ScriptedUpstream {
+        fn new(responses: Vec<ExecutionResult>) -> Self {
+            Self {
+                responses: Mutex::new(responses.into()),
+                seen: Mutex::new(Vec::new()),
+            }
+        }
+        fn seen(&self) -> Vec<Prompt> {
+            self.seen.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait]
+    impl UpstreamTurn for ScriptedUpstream {
+        async fn run(&self, prompt: &Prompt) -> Result<ExecutionResult> {
+            self.seen.lock().unwrap().push(prompt.clone());
+            Ok(self.responses.lock().unwrap().pop_front().unwrap())
         }
     }
 
@@ -314,26 +349,25 @@ mod tests {
     #[tokio::test]
     async fn executes_router_call_then_returns_text() {
         let loop_ = loop_with(&["search"], false, ServerToolLoopConfig::default());
-        let calls = AtomicU32::new(0);
+        let upstream = ScriptedUpstream::new(vec![
+            exec(vec![tool_call("search")]),
+            exec(vec![text("the answer")]),
+        ]);
         let result = loop_
-            .run(
-                &base_prompt(),
-                &CallerContext::local(),
-                async |p: &Prompt| {
-                    let n = calls.fetch_add(1, SeqCst);
-                    assert!(p.tools.iter().any(|t| t.name() == "search"));
-                    Ok(if n == 0 {
-                        exec(vec![tool_call("search")])
-                    } else {
-                        // The tool result turn must be present on the second call.
-                        assert!(p.messages.iter().any(|m| matches!(m.role, Role::Tool)));
-                        exec(vec![text("the answer")])
-                    })
-                },
-            )
+            .run(&base_prompt(), &CallerContext::local(), &upstream)
             .await
             .unwrap();
-        assert_eq!(calls.load(SeqCst), 2);
+        let seen = upstream.seen();
+        assert_eq!(seen.len(), 2);
+        // The injected router tool is on the outbound prompt...
+        assert!(seen[0].tools.iter().any(|t| t.name() == "search"));
+        // ...and the tool-result turn is present on the second call.
+        assert!(
+            seen[1]
+                .messages
+                .iter()
+                .any(|m| matches!(m.role, Role::Tool))
+        );
         assert!(
             matches!(&result.result.content[0], Content::Text { text, .. } if text == "the answer")
         );
@@ -344,19 +378,15 @@ mod tests {
     #[tokio::test]
     async fn hands_back_a_mixed_turn_without_executing() {
         let loop_ = loop_with(&["search"], false, ServerToolLoopConfig::default());
-        let calls = AtomicU32::new(0);
+        let upstream = ScriptedUpstream::new(vec![exec(vec![
+            tool_call("search"),
+            tool_call("client_fn"),
+        ])]);
         let result = loop_
-            .run(
-                &base_prompt(),
-                &CallerContext::local(),
-                async |_p: &Prompt| {
-                    calls.fetch_add(1, SeqCst);
-                    Ok(exec(vec![tool_call("search"), tool_call("client_fn")]))
-                },
-            )
+            .run(&base_prompt(), &CallerContext::local(), &upstream)
             .await
             .unwrap();
-        assert_eq!(calls.load(SeqCst), 1);
+        assert_eq!(upstream.seen().len(), 1);
         assert!(matches!(
             &result.result.content[0],
             Content::ToolCall { .. }
@@ -366,32 +396,28 @@ mod tests {
     #[tokio::test]
     async fn tool_error_is_fed_back_and_loop_continues() {
         let loop_ = loop_with(&["search"], true, ServerToolLoopConfig::default());
-        let calls = AtomicU32::new(0);
+        let upstream = ScriptedUpstream::new(vec![
+            exec(vec![tool_call("search")]),
+            exec(vec![text("recovered")]),
+        ]);
         let result = loop_
-            .run(
-                &base_prompt(),
-                &CallerContext::local(),
-                async |p: &Prompt| {
-                    let n = calls.fetch_add(1, SeqCst);
-                    Ok(if n == 0 {
-                        exec(vec![tool_call("search")])
-                    } else {
-                        // The fed-back tool result must be an error.
-                        let tool_msg = p.messages.iter().find(|m| matches!(m.role, Role::Tool));
-                        assert!(matches!(
-                            tool_msg.and_then(|m| m.content.first()),
-                            Some(Content::ToolResult {
-                                output: ToolResultOutput::ErrorText { .. },
-                                ..
-                            })
-                        ));
-                        exec(vec![text("recovered")])
-                    })
-                },
-            )
+            .run(&base_prompt(), &CallerContext::local(), &upstream)
             .await
             .unwrap();
-        assert_eq!(calls.load(SeqCst), 2);
+        let seen = upstream.seen();
+        assert_eq!(seen.len(), 2);
+        // The fed-back tool result is an error block.
+        let tool_msg = seen[1]
+            .messages
+            .iter()
+            .find(|m| matches!(m.role, Role::Tool));
+        assert!(matches!(
+            tool_msg.and_then(|m| m.content.first()),
+            Some(Content::ToolResult {
+                output: ToolResultOutput::ErrorText { .. },
+                ..
+            })
+        ));
         assert!(
             matches!(&result.result.content[0], Content::Text { text, .. } if text == "recovered")
         );
@@ -404,20 +430,16 @@ mod tests {
             ..Default::default()
         };
         let loop_ = loop_with(&["search"], false, config);
-        let calls = AtomicU32::new(0);
+        let upstream = ScriptedUpstream::new(vec![
+            exec(vec![tool_call("search")]),
+            exec(vec![tool_call("search")]),
+        ]);
         let result = loop_
-            .run(
-                &base_prompt(),
-                &CallerContext::local(),
-                async |_p: &Prompt| {
-                    calls.fetch_add(1, SeqCst);
-                    Ok(exec(vec![tool_call("search")]))
-                },
-            )
+            .run(&base_prompt(), &CallerContext::local(), &upstream)
             .await
             .unwrap();
         // round 0 executes (rounds 0 < 1), round 1 hits the cap.
-        assert_eq!(calls.load(SeqCst), 2);
+        assert_eq!(upstream.seen().len(), 2);
         assert_eq!(
             result.result.finish_reason,
             Some(FinishReason::Other("max_tool_iterations".to_string()))

--- a/crates/bitrouter-sdk/src/language_model/server_tools/loop_controller.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/loop_controller.rs
@@ -1,0 +1,426 @@
+//! [`ServerToolLoop`] — the non-streaming controller. It injects router tools
+//! into a working prompt, then drives upstream turns through a caller-supplied
+//! closure, executing router-owned tool calls and looping until the model
+//! stops calling them or a bound is hit.
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use super::approval::ApprovalPolicy;
+use super::classify::{RouterCall, TurnDisposition, classify_turn};
+use super::config::ServerToolLoopConfig;
+use super::toolset::ToolsetRegistry;
+use crate::caller::CallerContext;
+use crate::error::{BitrouterError, Result};
+use crate::language_model::types::{
+    Content, ExecutionResult, FinishReason, Message, Prompt, ProviderMetadata, Role,
+    ToolResultOutput, Usage,
+};
+
+/// Drives the server-side tool loop over a [`ToolsetRegistry`].
+pub struct ServerToolLoop {
+    registry: ToolsetRegistry,
+    config: ServerToolLoopConfig,
+    approval: Arc<dyn ApprovalPolicy>,
+}
+
+impl ServerToolLoop {
+    /// Build a loop over `registry`, bounded by `config`, gated by `approval`.
+    pub fn new(
+        registry: ToolsetRegistry,
+        config: ServerToolLoopConfig,
+        approval: Arc<dyn ApprovalPolicy>,
+    ) -> Self {
+        Self {
+            registry,
+            config,
+            approval,
+        }
+    }
+
+    /// Run the loop. `run_upstream` performs one upstream turn (with fallback)
+    /// for a working prompt; the loop owns the working prompt, injects router
+    /// tools into it, appends assistant + tool-result turns between iterations,
+    /// and accumulates usage across iterations.
+    ///
+    /// Returns the final upstream [`ExecutionResult`] (its `usage` replaced by
+    /// the accumulated total). On reaching a bound, the result carries a
+    /// truncation finish reason.
+    pub async fn run<F>(
+        &self,
+        base: &Prompt,
+        caller: &CallerContext,
+        mut run_upstream: F,
+    ) -> Result<ExecutionResult>
+    where
+        F: AsyncFnMut(&Prompt) -> Result<ExecutionResult>,
+    {
+        let (injected, owned) = self.registry.list_all(caller).await?;
+        let mut working = base.clone();
+        for tool in &injected {
+            if working.tools.iter().any(|t| t.name() == tool.name()) {
+                return Err(BitrouterError::Internal(format!(
+                    "router tool name collides with a caller tool: {}",
+                    tool.name()
+                )));
+            }
+        }
+        working.tools.extend(injected);
+
+        let mut total = Usage::default();
+        let mut had_usage = false;
+        let start = Instant::now();
+        let mut consecutive_errors = 0u32;
+        let mut rounds = 0u32;
+
+        loop {
+            let mut result = run_upstream(&working).await?;
+            if let Some(usage) = &result.result.usage {
+                add_usage(&mut total, usage);
+                had_usage = true;
+            }
+
+            match classify_turn(&result.result.content, &owned) {
+                TurnDisposition::Done | TurnDisposition::HandBack => {
+                    if had_usage {
+                        result.result.usage = Some(total);
+                    }
+                    return Ok(result);
+                }
+                TurnDisposition::Execute(calls) => {
+                    if rounds >= self.config.max_iterations
+                        || start.elapsed() >= self.config.total_budget
+                    {
+                        return Ok(truncate(result, total, had_usage, "max_tool_iterations"));
+                    }
+                    let (tool_results, had_error) = self.execute_calls(&calls, caller).await;
+                    consecutive_errors = if had_error { consecutive_errors + 1 } else { 0 };
+                    append_turn(&mut working, result.result.content.clone(), tool_results);
+                    rounds += 1;
+                    if consecutive_errors >= self.config.max_consecutive_errors {
+                        return Ok(truncate(result, total, had_usage, "tool_errors"));
+                    }
+                }
+            }
+        }
+    }
+
+    /// Execute each router-owned call, returning the tool-result content blocks
+    /// and whether any call produced an error.
+    async fn execute_calls(
+        &self,
+        calls: &[RouterCall],
+        caller: &CallerContext,
+    ) -> (Vec<Content>, bool) {
+        let mut results = Vec::with_capacity(calls.len());
+        let mut had_error = false;
+        for call in calls {
+            let output = if !self.approval.allow(call, caller).await {
+                ToolResultOutput::ExecutionDenied {
+                    reason: Some("denied by approval policy".to_string()),
+                }
+            } else if let Some(set) = self.registry.resolve(&call.name) {
+                match tokio::time::timeout(
+                    self.config.tool_timeout,
+                    set.call_tool(&call.name, &call.arguments, caller),
+                )
+                .await
+                {
+                    Ok(Ok(out)) => out,
+                    Ok(Err(err)) => {
+                        had_error = true;
+                        ToolResultOutput::ErrorText {
+                            value: err.to_string(),
+                        }
+                    }
+                    Err(_) => {
+                        had_error = true;
+                        ToolResultOutput::ErrorText {
+                            value: format!("tool '{}' timed out", call.name),
+                        }
+                    }
+                }
+            } else {
+                had_error = true;
+                ToolResultOutput::ErrorText {
+                    value: format!("no toolset owns '{}'", call.name),
+                }
+            };
+            results.push(Content::ToolResult {
+                call_id: call.id.clone(),
+                tool_name: Some(call.name.clone()),
+                output,
+                dynamic: false,
+                provider_metadata: ProviderMetadata::new(),
+            });
+        }
+        (results, had_error)
+    }
+}
+
+/// Append the model's tool-call turn and the tool-result turn to the working
+/// prompt so the next upstream call sees the results.
+fn append_turn(working: &mut Prompt, assistant_content: Vec<Content>, tool_results: Vec<Content>) {
+    working.messages.push(Message {
+        role: Role::Assistant,
+        content: assistant_content,
+    });
+    working.messages.push(Message {
+        role: Role::Tool,
+        content: tool_results,
+    });
+}
+
+/// Sum the per-iteration usage into the running total.
+fn add_usage(total: &mut Usage, add: &Usage) {
+    total.prompt_tokens += add.prompt_tokens;
+    total.completion_tokens += add.completion_tokens;
+    total.reasoning_tokens += add.reasoning_tokens;
+    total.cache_read_tokens += add.cache_read_tokens;
+    total.cache_write_tokens += add.cache_write_tokens;
+}
+
+/// Finish a bounded loop: replace usage with the accumulated total and set a
+/// truncation finish reason.
+fn truncate(
+    mut result: ExecutionResult,
+    total: Usage,
+    had_usage: bool,
+    reason: &str,
+) -> ExecutionResult {
+    if had_usage {
+        result.result.usage = Some(total);
+    }
+    result.result.finish_reason = Some(FinishReason::Other(reason.to_string()));
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::language_model::server_tools::approval::AllowAll;
+    use crate::language_model::server_tools::toolset::RouterToolset;
+    use crate::language_model::types::{GenerateResult, Tool};
+    use async_trait::async_trait;
+    use std::sync::atomic::{AtomicU32, Ordering::SeqCst};
+
+    struct MockToolset {
+        names: Vec<String>,
+        fail: bool,
+    }
+
+    #[async_trait]
+    impl RouterToolset for MockToolset {
+        async fn list_tools(&self, _caller: &CallerContext) -> Result<Vec<Tool>> {
+            Ok(self
+                .names
+                .iter()
+                .map(|n| Tool::Function {
+                    name: n.clone(),
+                    description: None,
+                    parameters: serde_json::json!({ "type": "object" }),
+                    strict: None,
+                    provider_metadata: ProviderMetadata::new(),
+                })
+                .collect())
+        }
+        async fn call_tool(
+            &self,
+            name: &str,
+            _arguments: &str,
+            _caller: &CallerContext,
+        ) -> Result<ToolResultOutput> {
+            if self.fail {
+                Err(BitrouterError::Internal(format!("{name} boom")))
+            } else {
+                Ok(ToolResultOutput::Text {
+                    value: format!("ran {name}"),
+                })
+            }
+        }
+        fn owns(&self, name: &str) -> bool {
+            self.names.iter().any(|n| n == name)
+        }
+    }
+
+    fn loop_with(names: &[&str], fail: bool, config: ServerToolLoopConfig) -> ServerToolLoop {
+        let toolset = Arc::new(MockToolset {
+            names: names.iter().map(|s| s.to_string()).collect(),
+            fail,
+        });
+        ServerToolLoop::new(
+            ToolsetRegistry::new(vec![toolset]),
+            config,
+            Arc::new(AllowAll),
+        )
+    }
+
+    fn base_prompt() -> Prompt {
+        Prompt {
+            model: "m".to_string(),
+            system: None,
+            system_provider_metadata: ProviderMetadata::new(),
+            messages: vec![Message::text(Role::User, "hi")],
+            tools: Vec::new(),
+            params: Default::default(),
+            response_format: None,
+            tool_choice: None,
+            stream: false,
+        }
+    }
+
+    fn exec(content: Vec<Content>) -> ExecutionResult {
+        ExecutionResult {
+            provider_id: "p".to_string(),
+            model_id: "m".to_string(),
+            account_label: None,
+            result: GenerateResult {
+                content,
+                usage: Some(Usage {
+                    prompt_tokens: 1,
+                    completion_tokens: 1,
+                    reasoning_tokens: 0,
+                    cache_read_tokens: 0,
+                    cache_write_tokens: 0,
+                }),
+                finish_reason: Some(FinishReason::Stop),
+                response_id: None,
+                stop_details: None,
+                provider_metadata: ProviderMetadata::new(),
+            },
+            latency_ms: 0,
+            generation_time_ms: 0,
+        }
+    }
+
+    fn tool_call(name: &str) -> Content {
+        Content::ToolCall {
+            id: format!("{name}-1"),
+            name: name.to_string(),
+            arguments: "{}".to_string(),
+            provider_executed: false,
+            dynamic: false,
+            provider_metadata: ProviderMetadata::new(),
+        }
+    }
+
+    fn text(s: &str) -> Content {
+        Content::Text {
+            text: s.to_string(),
+            provider_metadata: ProviderMetadata::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn executes_router_call_then_returns_text() {
+        let loop_ = loop_with(&["search"], false, ServerToolLoopConfig::default());
+        let calls = AtomicU32::new(0);
+        let result = loop_
+            .run(
+                &base_prompt(),
+                &CallerContext::local(),
+                async |p: &Prompt| {
+                    let n = calls.fetch_add(1, SeqCst);
+                    assert!(p.tools.iter().any(|t| t.name() == "search"));
+                    Ok(if n == 0 {
+                        exec(vec![tool_call("search")])
+                    } else {
+                        // The tool result turn must be present on the second call.
+                        assert!(p.messages.iter().any(|m| matches!(m.role, Role::Tool)));
+                        exec(vec![text("the answer")])
+                    })
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(calls.load(SeqCst), 2);
+        assert!(
+            matches!(&result.result.content[0], Content::Text { text, .. } if text == "the answer")
+        );
+        // usage summed across the two iterations.
+        assert_eq!(result.result.usage.unwrap().prompt_tokens, 2);
+    }
+
+    #[tokio::test]
+    async fn hands_back_a_mixed_turn_without_executing() {
+        let loop_ = loop_with(&["search"], false, ServerToolLoopConfig::default());
+        let calls = AtomicU32::new(0);
+        let result = loop_
+            .run(
+                &base_prompt(),
+                &CallerContext::local(),
+                async |_p: &Prompt| {
+                    calls.fetch_add(1, SeqCst);
+                    Ok(exec(vec![tool_call("search"), tool_call("client_fn")]))
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(calls.load(SeqCst), 1);
+        assert!(matches!(
+            &result.result.content[0],
+            Content::ToolCall { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn tool_error_is_fed_back_and_loop_continues() {
+        let loop_ = loop_with(&["search"], true, ServerToolLoopConfig::default());
+        let calls = AtomicU32::new(0);
+        let result = loop_
+            .run(
+                &base_prompt(),
+                &CallerContext::local(),
+                async |p: &Prompt| {
+                    let n = calls.fetch_add(1, SeqCst);
+                    Ok(if n == 0 {
+                        exec(vec![tool_call("search")])
+                    } else {
+                        // The fed-back tool result must be an error.
+                        let tool_msg = p.messages.iter().find(|m| matches!(m.role, Role::Tool));
+                        assert!(matches!(
+                            tool_msg.and_then(|m| m.content.first()),
+                            Some(Content::ToolResult {
+                                output: ToolResultOutput::ErrorText { .. },
+                                ..
+                            })
+                        ));
+                        exec(vec![text("recovered")])
+                    })
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(calls.load(SeqCst), 2);
+        assert!(
+            matches!(&result.result.content[0], Content::Text { text, .. } if text == "recovered")
+        );
+    }
+
+    #[tokio::test]
+    async fn terminates_at_max_iterations() {
+        let config = ServerToolLoopConfig {
+            max_iterations: 1,
+            ..Default::default()
+        };
+        let loop_ = loop_with(&["search"], false, config);
+        let calls = AtomicU32::new(0);
+        let result = loop_
+            .run(
+                &base_prompt(),
+                &CallerContext::local(),
+                async |_p: &Prompt| {
+                    calls.fetch_add(1, SeqCst);
+                    Ok(exec(vec![tool_call("search")]))
+                },
+            )
+            .await
+            .unwrap();
+        // round 0 executes (rounds 0 < 1), round 1 hits the cap.
+        assert_eq!(calls.load(SeqCst), 2);
+        assert_eq!(
+            result.result.finish_reason,
+            Some(FinishReason::Other("max_tool_iterations".to_string()))
+        );
+    }
+}

--- a/crates/bitrouter-sdk/src/language_model/server_tools/mcp_toolset.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/mcp_toolset.rs
@@ -1,5 +1,5 @@
-//! [`McpRouterToolset`] — a [`RouterToolset`](super::toolset::RouterToolset)
-//! backed by the [`crate::mcp`] routing module. BitRouter acts as an MCP
+//! [`McpRouterToolset`] — a [`RouterToolset`] backed by the [`crate::mcp`]
+//! routing module. BitRouter acts as an MCP
 //! *client*: it discovers an upstream MCP server's tools (`tools/list`),
 //! advertises them to the model, and executes the model's calls (`tools/call`)
 //! inside the LLM loop.

--- a/crates/bitrouter-sdk/src/language_model/server_tools/mcp_toolset.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/mcp_toolset.rs
@@ -1,0 +1,349 @@
+//! [`McpRouterToolset`] — a [`RouterToolset`](super::toolset::RouterToolset)
+//! backed by the [`crate::mcp`] routing module. BitRouter acts as an MCP
+//! *client*: it discovers an upstream MCP server's tools (`tools/list`),
+//! advertises them to the model, and executes the model's calls (`tools/call`)
+//! inside the LLM loop.
+//!
+//! Generic over `Arc<dyn crate::mcp::Executor>`, so it works with the bundled
+//! `RmcpExecutor` (behind the `mcp` feature) or any custom executor — it needs
+//! no feature gate of its own.
+
+use std::collections::BTreeSet;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+
+use super::toolset::RouterToolset;
+use crate::caller::CallerContext;
+use crate::error::Result;
+use crate::language_model::types::{
+    ProviderMetadata, Tool, ToolResultContentPart, ToolResultOutput,
+};
+use crate::mcp::{Executor as McpExecutor, McpRequest, RoutingTable as McpRoutingTable};
+
+/// Convert an MCP `tools/list` result into canonical IR function tools. Each
+/// MCP tool `{name, description?, inputSchema}` becomes a [`Tool::Function`];
+/// `prefix` (if set) is prepended to the name so router tool names cannot
+/// collide with the caller's own.
+fn tools_from_list(value: &serde_json::Value, prefix: Option<&str>) -> Vec<Tool> {
+    let Some(entries) = value.get("tools").and_then(|t| t.as_array()) else {
+        return Vec::new();
+    };
+    let mut tools = Vec::with_capacity(entries.len());
+    for entry in entries {
+        let Some(name) = entry.get("name").and_then(|n| n.as_str()) else {
+            continue;
+        };
+        let full_name = match prefix {
+            Some(p) => format!("{p}{name}"),
+            None => name.to_string(),
+        };
+        let description = entry
+            .get("description")
+            .and_then(|d| d.as_str())
+            .map(str::to_string);
+        let parameters = entry
+            .get("inputSchema")
+            .cloned()
+            .unwrap_or_else(|| serde_json::json!({ "type": "object" }));
+        tools.push(Tool::Function {
+            name: full_name,
+            description,
+            parameters,
+            strict: None,
+            provider_metadata: ProviderMetadata::new(),
+        });
+    }
+    tools
+}
+
+/// Convert an MCP `tools/call` result into a canonical IR tool-result output.
+/// All-text content maps to [`ToolResultOutput::Text`] (single) or
+/// [`ToolResultOutput::Content`] (multiple); `isError` maps to the error
+/// variants. Non-text or unrecognised shapes are preserved verbatim as
+/// [`ToolResultOutput::Json`] (lossless).
+fn output_from_call(value: &serde_json::Value) -> ToolResultOutput {
+    let is_error = value
+        .get("isError")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+    if let Some(content) = value.get("content").and_then(|c| c.as_array()) {
+        let all_text = content
+            .iter()
+            .all(|i| i.get("type").and_then(|t| t.as_str()) == Some("text"));
+        if all_text {
+            let parts: Vec<ToolResultContentPart> = content
+                .iter()
+                .filter_map(|i| i.get("text").and_then(|t| t.as_str()))
+                .map(|s| ToolResultContentPart::Text {
+                    text: s.to_string(),
+                })
+                .collect();
+            let joined = parts
+                .iter()
+                .filter_map(|p| match p {
+                    ToolResultContentPart::Text { text } => Some(text.as_str()),
+                    _ => None,
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+            return if is_error {
+                ToolResultOutput::ErrorText { value: joined }
+            } else if parts.len() <= 1 {
+                ToolResultOutput::Text { value: joined }
+            } else {
+                ToolResultOutput::Content { value: parts }
+            };
+        }
+    }
+    if is_error {
+        ToolResultOutput::ErrorJson {
+            value: value.clone(),
+        }
+    } else {
+        ToolResultOutput::Json {
+            value: value.clone(),
+        }
+    }
+}
+
+/// A [`RouterToolset`] over one upstream MCP server.
+pub struct McpRouterToolset {
+    executor: Arc<dyn McpExecutor>,
+    routing: Arc<dyn McpRoutingTable>,
+    server_name: String,
+    prefix: Option<String>,
+    /// Advertised (prefixed) tool names, cached on `list_tools` so `owns` can
+    /// route an intercepted call back to this set.
+    advertised: Mutex<BTreeSet<String>>,
+}
+
+impl McpRouterToolset {
+    /// Build a toolset for the named MCP server.
+    pub fn new(
+        executor: Arc<dyn McpExecutor>,
+        routing: Arc<dyn McpRoutingTable>,
+        server_name: impl Into<String>,
+        prefix: Option<String>,
+    ) -> Self {
+        Self {
+            executor,
+            routing,
+            server_name: server_name.into(),
+            prefix,
+            advertised: Mutex::new(BTreeSet::new()),
+        }
+    }
+
+    /// Strip the configured prefix off a router-facing tool name to recover the
+    /// MCP server's own name.
+    fn unprefixed<'a>(&self, name: &'a str) -> &'a str {
+        match &self.prefix {
+            Some(p) => name.strip_prefix(p.as_str()).unwrap_or(name),
+            None => name,
+        }
+    }
+}
+
+#[async_trait]
+impl RouterToolset for McpRouterToolset {
+    async fn list_tools(&self, caller: &CallerContext) -> Result<Vec<Tool>> {
+        let request = McpRequest::direct(
+            self.server_name.clone(),
+            "tools/list",
+            serde_json::json!({}),
+            caller.clone(),
+        );
+        let target = self.routing.resolve(&request.selector, caller).await?;
+        let response = self.executor.execute(&target, &request).await?;
+        let tools = tools_from_list(&response.result, self.prefix.as_deref());
+        if let Ok(mut advertised) = self.advertised.lock() {
+            advertised.clear();
+            for tool in &tools {
+                advertised.insert(tool.name().to_string());
+            }
+        }
+        Ok(tools)
+    }
+
+    async fn call_tool(
+        &self,
+        name: &str,
+        arguments: &str,
+        caller: &CallerContext,
+    ) -> Result<ToolResultOutput> {
+        let parsed: serde_json::Value =
+            serde_json::from_str(arguments).unwrap_or_else(|_| serde_json::json!({}));
+        let params = serde_json::json!({
+            "name": self.unprefixed(name),
+            "arguments": parsed,
+        });
+        let request = McpRequest::direct(
+            self.server_name.clone(),
+            "tools/call",
+            params,
+            caller.clone(),
+        );
+        let target = self.routing.resolve(&request.selector, caller).await?;
+        let response = self.executor.execute(&target, &request).await?;
+        Ok(output_from_call(&response.result))
+    }
+
+    fn owns(&self, name: &str) -> bool {
+        if self
+            .prefix
+            .as_ref()
+            .is_some_and(|p| name.starts_with(p.as_str()))
+        {
+            return true;
+        }
+        self.advertised
+            .lock()
+            .is_ok_and(|advertised| advertised.contains(name))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mcp::transport::McpTransport;
+    use crate::mcp::{McpResponse, McpStreamPart, McpTarget, ServerSelector};
+    use futures::stream::BoxStream;
+
+    fn list_json() -> serde_json::Value {
+        serde_json::json!({
+            "tools": [
+                { "name": "search", "description": "web search",
+                  "inputSchema": { "type": "object", "properties": { "q": { "type": "string" } } } },
+                { "name": "echo" }
+            ]
+        })
+    }
+
+    #[test]
+    fn tools_from_list_applies_prefix_and_defaults() {
+        let tools = tools_from_list(&list_json(), Some("mcp__demo__"));
+        assert_eq!(tools.len(), 2);
+        let Tool::Function {
+            name,
+            description,
+            parameters,
+            ..
+        } = &tools[0]
+        else {
+            panic!("expected function tool");
+        };
+        assert_eq!(name, "mcp__demo__search");
+        assert_eq!(description.as_deref(), Some("web search"));
+        assert_eq!(parameters["type"], "object");
+        // Second tool had no description / inputSchema → defaults.
+        let Tool::Function {
+            name, description, ..
+        } = &tools[1]
+        else {
+            panic!("expected function tool");
+        };
+        assert_eq!(name, "mcp__demo__echo");
+        assert!(description.is_none());
+    }
+
+    #[test]
+    fn output_from_call_maps_text_and_errors() {
+        let ok = serde_json::json!({ "content": [ { "type": "text", "text": "42" } ] });
+        assert_eq!(
+            output_from_call(&ok),
+            ToolResultOutput::Text {
+                value: "42".to_string()
+            }
+        );
+        let err = serde_json::json!({ "isError": true, "content": [ { "type": "text", "text": "boom" } ] });
+        assert_eq!(
+            output_from_call(&err),
+            ToolResultOutput::ErrorText {
+                value: "boom".to_string()
+            }
+        );
+        let img = serde_json::json!({ "content": [ { "type": "image", "data": "..." } ] });
+        assert!(matches!(
+            output_from_call(&img),
+            ToolResultOutput::Json { .. }
+        ));
+    }
+
+    struct MockMcp {
+        list: serde_json::Value,
+        call: serde_json::Value,
+    }
+
+    #[async_trait]
+    impl McpExecutor for MockMcp {
+        async fn execute(&self, _target: &McpTarget, request: &McpRequest) -> Result<McpResponse> {
+            let result = if request.method == "tools/list" {
+                self.list.clone()
+            } else {
+                self.call.clone()
+            };
+            Ok(McpResponse {
+                request_id: request.request_id.clone(),
+                result,
+            })
+        }
+        async fn execute_streaming(
+            &self,
+            _target: &McpTarget,
+            _request: &McpRequest,
+        ) -> Result<BoxStream<'static, Result<McpStreamPart>>> {
+            Err(crate::error::BitrouterError::internal("not used in tests"))
+        }
+    }
+
+    struct MockRouting;
+
+    #[async_trait]
+    impl McpRoutingTable for MockRouting {
+        async fn resolve(
+            &self,
+            _selector: &ServerSelector,
+            _caller: &CallerContext,
+        ) -> Result<McpTarget> {
+            Ok(McpTarget::Direct {
+                server_name: "demo".to_string(),
+                transport: McpTransport::Http {
+                    url: "http://localhost".to_string(),
+                    headers: Default::default(),
+                },
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn mcp_toolset_lists_executes_and_owns() {
+        let mock = Arc::new(MockMcp {
+            list: list_json(),
+            call: serde_json::json!({ "content": [ { "type": "text", "text": "done" } ] }),
+        });
+        let toolset = McpRouterToolset::new(
+            mock,
+            Arc::new(MockRouting),
+            "demo",
+            Some("mcp__demo__".to_string()),
+        );
+        let caller = CallerContext::local();
+
+        let tools = toolset.list_tools(&caller).await.unwrap();
+        assert_eq!(tools.len(), 2);
+        assert!(toolset.owns("mcp__demo__search"));
+        assert!(!toolset.owns("some_client_tool"));
+
+        let out = toolset
+            .call_tool("mcp__demo__search", "{\"q\":\"rust\"}", &caller)
+            .await
+            .unwrap();
+        assert_eq!(
+            out,
+            ToolResultOutput::Text {
+                value: "done".to_string()
+            }
+        );
+    }
+}

--- a/crates/bitrouter-sdk/src/language_model/server_tools/mcp_toolset.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/mcp_toolset.rs
@@ -201,6 +201,10 @@ impl RouterToolset for McpRouterToolset {
             .lock()
             .is_ok_and(|advertised| advertised.contains(name))
     }
+
+    fn server_name(&self) -> Option<&str> {
+        Some(&self.server_name)
+    }
 }
 
 #[cfg(test)]

--- a/crates/bitrouter-sdk/src/language_model/server_tools/mod.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/mod.rs
@@ -15,4 +15,5 @@
 //! Per crate guideline 2, this module does not `pub use` from its submodules;
 //! downstream reaches types directly (e.g. `server_tools::toolset::RouterToolset`).
 
+pub mod classify;
 pub mod toolset;

--- a/crates/bitrouter-sdk/src/language_model/server_tools/mod.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/mod.rs
@@ -1,0 +1,18 @@
+//! Server-side tool loop — BitRouter as the tool executor.
+//!
+//! BitRouter injects tools into an outbound `Prompt`, intercepts the model's
+//! calls to them, executes them itself, feeds the results back, and re-calls
+//! the upstream — looping until the model stops calling router-owned tools,
+//! all behind a single caller-visible response. A router tool looks like an
+//! ordinary function tool to the upstream provider and like a server-resolved
+//! tool to the caller.
+//!
+//! [`toolset::RouterToolset`] is the provider-agnostic executor seam; the MCP
+//! implementation bridges the [`crate::mcp`] routing module (an MCP *client*
+//! consuming upstream MCP servers) into the LLM request loop — the inverse of
+//! the standalone `bitrouter-mcp` server crate.
+//!
+//! Per crate guideline 2, this module does not `pub use` from its submodules;
+//! downstream reaches types directly (e.g. `server_tools::toolset::RouterToolset`).
+
+pub mod toolset;

--- a/crates/bitrouter-sdk/src/language_model/server_tools/mod.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/mod.rs
@@ -15,6 +15,9 @@
 //! Per crate guideline 2, this module does not `pub use` from its submodules;
 //! downstream reaches types directly (e.g. `server_tools::toolset::RouterToolset`).
 
+pub mod approval;
 pub mod classify;
+pub mod config;
+pub mod loop_controller;
 pub mod mcp_toolset;
 pub mod toolset;

--- a/crates/bitrouter-sdk/src/language_model/server_tools/mod.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/mod.rs
@@ -16,4 +16,5 @@
 //! downstream reaches types directly (e.g. `server_tools::toolset::RouterToolset`).
 
 pub mod classify;
+pub mod mcp_toolset;
 pub mod toolset;

--- a/crates/bitrouter-sdk/src/language_model/server_tools/mod.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/mod.rs
@@ -20,4 +20,5 @@ pub mod classify;
 pub mod config;
 pub mod loop_controller;
 pub mod mcp_toolset;
+pub mod stream;
 pub mod toolset;

--- a/crates/bitrouter-sdk/src/language_model/server_tools/stream.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/stream.rs
@@ -1,0 +1,439 @@
+//! The streaming stitcher: merge the N upstream streams of a tool loop into one
+//! caller-visible [`StreamPart`] stream. Router tool calls are intercepted
+//! (their raw `ToolCallDelta`s suppressed), executed, and re-emitted as
+//! `ServerToolCall` + `ServerToolResult` parts; intermediate terminals are
+//! suppressed; usage is accumulated into one final part; and a single terminal
+//! `Finish` closes the merged stream. Keep-alive during tool execution is the
+//! SSE layer's job (a gap in this part stream), not a `StreamPart`.
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use async_trait::async_trait;
+use futures::StreamExt;
+
+use super::classify::RouterCall;
+use super::loop_controller::{ServerToolLoop, add_usage};
+use crate::caller::CallerContext;
+use crate::error::Result;
+use crate::language_model::executor::StreamPartStream;
+use crate::language_model::types::{
+    Content, FinishReason, Message, Prompt, ProviderMetadata, Role, StreamPart, Usage,
+};
+
+/// One upstream streaming turn for a working prompt — the loop's callback into
+/// the pipeline's streaming execution. A trait (not a closure) so the merged
+/// stream has a concrete, `Send`, `'static` type.
+#[async_trait]
+pub trait UpstreamStream: Send + Sync {
+    /// Open one upstream stream for `prompt`.
+    async fn run(&self, prompt: &Prompt) -> Result<StreamPartStream>;
+}
+
+/// A tool call reconstructed from streamed `ToolCallDelta` fragments.
+struct BufferedCall {
+    id: String,
+    name: String,
+    args: String,
+}
+
+impl ServerToolLoop {
+    /// Run the loop over streaming upstream turns, returning one merged stream.
+    /// Mirrors [`ServerToolLoop::run`] but for the streaming path.
+    pub async fn run_stream(
+        self: Arc<Self>,
+        base: &Prompt,
+        caller: &CallerContext,
+        upstream: Arc<dyn UpstreamStream>,
+    ) -> Result<StreamPartStream> {
+        let (working, owned) = self.inject(base, caller).await?;
+        let caller = caller.clone();
+        let loop_ = self;
+
+        let stream = async_stream::stream! {
+            let mut working = working;
+            let mut total = Usage::default();
+            let mut had_usage = false;
+            let start = Instant::now();
+            let mut rounds = 0u32;
+            let mut consecutive_errors = 0u32;
+
+            loop {
+                let mut upstream_stream = match upstream.run(&working).await {
+                    Ok(s) => s,
+                    Err(e) => {
+                        yield Err(e);
+                        return;
+                    }
+                };
+
+                let mut buffered: Vec<BufferedCall> = Vec::new();
+                let mut assistant_text = String::new();
+                let mut finish: Option<FinishReason> = None;
+
+                // Forward narration in real time; buffer tool-call deltas;
+                // accumulate usage; capture (but suppress) the terminal.
+                while let Some(item) = upstream_stream.next().await {
+                    let part = match item {
+                        Ok(p) => p,
+                        Err(e) => {
+                            yield Err(e);
+                            return;
+                        }
+                    };
+                    match part {
+                        StreamPart::Usage { usage } => {
+                            add_usage(&mut total, &usage);
+                            had_usage = true;
+                        }
+                        StreamPart::Finish { reason } => finish = Some(reason),
+                        StreamPart::ResponseCompleted { .. } => {
+                            if finish.is_none() {
+                                finish = Some(FinishReason::Stop);
+                            }
+                        }
+                        StreamPart::ToolCallDelta {
+                            id,
+                            name,
+                            arguments,
+                        } => match buffered.iter_mut().find(|b| b.id == id) {
+                            Some(b) => {
+                                if let Some(n) = name.as_deref().filter(|n| !n.is_empty()) {
+                                    b.name = n.to_string();
+                                }
+                                b.args.push_str(&arguments);
+                            }
+                            None => buffered.push(BufferedCall {
+                                id,
+                                name: name.unwrap_or_default(),
+                                args: arguments,
+                            }),
+                        },
+                        StreamPart::TextDelta { text } => {
+                            assistant_text.push_str(&text);
+                            yield Ok(StreamPart::TextDelta { text });
+                        }
+                        other => yield Ok(other),
+                    }
+                }
+
+                let has_client = buffered.iter().any(|b| !owned.contains(&b.name));
+                let router: Vec<RouterCall> = buffered
+                    .iter()
+                    .filter(|b| owned.contains(&b.name))
+                    .map(|b| RouterCall {
+                        id: b.id.clone(),
+                        name: b.name.clone(),
+                        arguments: b.args.clone(),
+                    })
+                    .collect();
+
+                // Terminal turns: a client-owned call present (hand the whole
+                // turn back), or no router calls at all (final answer).
+                if has_client || router.is_empty() {
+                    if has_client {
+                        for b in &buffered {
+                            yield Ok(StreamPart::ToolCallDelta {
+                                id: b.id.clone(),
+                                name: Some(b.name.clone()),
+                                arguments: b.args.clone(),
+                            });
+                        }
+                    }
+                    if had_usage {
+                        yield Ok(StreamPart::Usage { usage: total });
+                    }
+                    yield Ok(StreamPart::Finish {
+                        reason: finish.unwrap_or(FinishReason::Stop),
+                    });
+                    return;
+                }
+
+                // Bound the loop.
+                if rounds >= loop_.config().max_iterations
+                    || start.elapsed() >= loop_.config().total_budget
+                {
+                    if had_usage {
+                        yield Ok(StreamPart::Usage { usage: total });
+                    }
+                    yield Ok(StreamPart::Finish {
+                        reason: FinishReason::Other("max_tool_iterations".to_string()),
+                    });
+                    return;
+                }
+
+                // Execute each router call, surfacing the activity.
+                let mut tool_results = Vec::with_capacity(router.len());
+                let mut round_error = false;
+                for call in &router {
+                    let server_name = loop_.server_name_for(&call.name);
+                    yield Ok(StreamPart::ServerToolCall {
+                        id: call.id.clone(),
+                        name: call.name.clone(),
+                        arguments: call.arguments.clone(),
+                        server_name,
+                        dynamic: true,
+                    });
+                    let (output, err) = loop_.call_one(call, &caller).await;
+                    round_error |= err;
+                    yield Ok(StreamPart::ServerToolResult {
+                        call_id: call.id.clone(),
+                        tool_name: Some(call.name.clone()),
+                        output: output.clone(),
+                        dynamic: true,
+                    });
+                    tool_results.push(Content::ToolResult {
+                        call_id: call.id.clone(),
+                        tool_name: Some(call.name.clone()),
+                        output,
+                        dynamic: false,
+                        provider_metadata: ProviderMetadata::new(),
+                    });
+                }
+
+                // Append the assistant tool-call turn + tool results so the next
+                // upstream turn sees them.
+                let mut assistant_content = Vec::new();
+                if !assistant_text.is_empty() {
+                    assistant_content.push(Content::Text {
+                        text: std::mem::take(&mut assistant_text),
+                        provider_metadata: ProviderMetadata::new(),
+                    });
+                }
+                for call in &router {
+                    assistant_content.push(Content::ToolCall {
+                        id: call.id.clone(),
+                        name: call.name.clone(),
+                        arguments: call.arguments.clone(),
+                        provider_executed: false,
+                        dynamic: false,
+                        provider_metadata: ProviderMetadata::new(),
+                    });
+                }
+                working.messages.push(Message {
+                    role: Role::Assistant,
+                    content: assistant_content,
+                });
+                working.messages.push(Message {
+                    role: Role::Tool,
+                    content: tool_results,
+                });
+
+                rounds += 1;
+                consecutive_errors = if round_error { consecutive_errors + 1 } else { 0 };
+                if consecutive_errors >= loop_.config().max_consecutive_errors {
+                    if had_usage {
+                        yield Ok(StreamPart::Usage { usage: total });
+                    }
+                    yield Ok(StreamPart::Finish {
+                        reason: FinishReason::Other("tool_errors".to_string()),
+                    });
+                    return;
+                }
+            }
+        };
+
+        Ok(Box::pin(stream))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::language_model::server_tools::approval::AllowAll;
+    use crate::language_model::server_tools::config::ServerToolLoopConfig;
+    use crate::language_model::server_tools::toolset::{RouterToolset, ToolsetRegistry};
+    use crate::language_model::types::{Tool, ToolResultOutput};
+    use std::collections::VecDeque;
+    use std::sync::Mutex;
+
+    struct OneTool;
+
+    #[async_trait]
+    impl RouterToolset for OneTool {
+        async fn list_tools(&self, _caller: &CallerContext) -> Result<Vec<Tool>> {
+            Ok(vec![Tool::Function {
+                name: "search".to_string(),
+                description: None,
+                parameters: serde_json::json!({ "type": "object" }),
+                strict: None,
+                provider_metadata: ProviderMetadata::new(),
+            }])
+        }
+        async fn call_tool(
+            &self,
+            _name: &str,
+            _arguments: &str,
+            _caller: &CallerContext,
+        ) -> Result<ToolResultOutput> {
+            Ok(ToolResultOutput::Text {
+                value: "ran".to_string(),
+            })
+        }
+        fn owns(&self, name: &str) -> bool {
+            name == "search"
+        }
+        fn server_name(&self) -> Option<&str> {
+            Some("docs")
+        }
+    }
+
+    struct ScriptedStream {
+        scripts: Mutex<VecDeque<Vec<StreamPart>>>,
+    }
+
+    #[async_trait]
+    impl UpstreamStream for ScriptedStream {
+        async fn run(&self, _prompt: &Prompt) -> Result<StreamPartStream> {
+            let parts = self.scripts.lock().unwrap().pop_front().unwrap();
+            Ok(Box::pin(futures::stream::iter(parts.into_iter().map(Ok))))
+        }
+    }
+
+    fn loop_() -> Arc<ServerToolLoop> {
+        Arc::new(ServerToolLoop::new(
+            ToolsetRegistry::new(vec![Arc::new(OneTool)]),
+            ServerToolLoopConfig::default(),
+            Arc::new(AllowAll),
+        ))
+    }
+
+    fn base_prompt() -> Prompt {
+        Prompt {
+            model: "m".to_string(),
+            system: None,
+            system_provider_metadata: ProviderMetadata::new(),
+            messages: vec![Message::text(Role::User, "hi")],
+            tools: Vec::new(),
+            params: Default::default(),
+            response_format: None,
+            tool_choice: None,
+            stream: true,
+        }
+    }
+
+    async fn collect(stream: StreamPartStream) -> Vec<StreamPart> {
+        let mut stream = stream;
+        let mut out = Vec::new();
+        while let Some(item) = stream.next().await {
+            out.push(item.unwrap());
+        }
+        out
+    }
+
+    #[tokio::test]
+    async fn stitches_router_tool_call_into_one_continuous_stream() {
+        let scripts = vec![
+            vec![
+                StreamPart::TextDelta {
+                    text: "searching ".into(),
+                },
+                StreamPart::ToolCallDelta {
+                    id: "c1".into(),
+                    name: Some("search".into()),
+                    arguments: "{}".into(),
+                },
+                StreamPart::Finish {
+                    reason: FinishReason::ToolCalls,
+                },
+            ],
+            vec![
+                StreamPart::TextDelta {
+                    text: "answer".into(),
+                },
+                StreamPart::Finish {
+                    reason: FinishReason::Stop,
+                },
+            ],
+        ];
+        let upstream = Arc::new(ScriptedStream {
+            scripts: Mutex::new(scripts.into()),
+        });
+        let parts = collect(
+            loop_()
+                .run_stream(&base_prompt(), &CallerContext::local(), upstream)
+                .await
+                .unwrap(),
+        )
+        .await;
+
+        // Exactly one terminal Finish.
+        assert_eq!(
+            parts
+                .iter()
+                .filter(|p| matches!(p, StreamPart::Finish { .. }))
+                .count(),
+            1
+        );
+        // The router call is surfaced as ServerToolCall + ServerToolResult...
+        assert!(
+            parts
+                .iter()
+                .any(|p| matches!(p, StreamPart::ServerToolCall { name, server_name, .. } if name == "search" && server_name.as_deref() == Some("docs")))
+        );
+        assert!(
+            parts
+                .iter()
+                .any(|p| matches!(p, StreamPart::ServerToolResult { .. }))
+        );
+        // ...and the raw router ToolCallDelta is NOT forwarded.
+        assert!(
+            !parts
+                .iter()
+                .any(|p| matches!(p, StreamPart::ToolCallDelta { .. }))
+        );
+        // Both turns' text streamed through, in order.
+        let text: String = parts
+            .iter()
+            .filter_map(|p| match p {
+                StreamPart::TextDelta { text } => Some(text.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(text, "searching answer");
+    }
+
+    #[tokio::test]
+    async fn hands_back_a_client_tool_call() {
+        let scripts = vec![vec![
+            StreamPart::ToolCallDelta {
+                id: "x".into(),
+                name: Some("client_fn".into()),
+                arguments: "{}".into(),
+            },
+            StreamPart::Finish {
+                reason: FinishReason::ToolCalls,
+            },
+        ]];
+        let upstream = Arc::new(ScriptedStream {
+            scripts: Mutex::new(scripts.into()),
+        });
+        let parts = collect(
+            loop_()
+                .run_stream(&base_prompt(), &CallerContext::local(), upstream)
+                .await
+                .unwrap(),
+        )
+        .await;
+
+        // The client tool call is forwarded for the caller to execute...
+        assert!(
+            parts
+                .iter()
+                .any(|p| matches!(p, StreamPart::ToolCallDelta { name, .. } if name.as_deref() == Some("client_fn")))
+        );
+        // ...nothing was executed server-side.
+        assert!(
+            !parts
+                .iter()
+                .any(|p| matches!(p, StreamPart::ServerToolCall { .. }))
+        );
+        assert_eq!(
+            parts
+                .iter()
+                .filter(|p| matches!(p, StreamPart::Finish { .. }))
+                .count(),
+            1
+        );
+    }
+}

--- a/crates/bitrouter-sdk/src/language_model/server_tools/stream.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/stream.rs
@@ -87,7 +87,14 @@ impl ServerToolLoop {
                             had_usage = true;
                         }
                         StreamPart::Finish { reason } => finish = Some(reason),
-                        StreamPart::ResponseCompleted { .. } => {
+                        StreamPart::ResponseCompleted { usage, .. } => {
+                            // The Responses decoder carries usage only here (never
+                            // a standalone `Usage` part), so it must be folded in
+                            // or the loop under-bills a Responses upstream.
+                            if let Some(u) = usage {
+                                add_usage(&mut total, &u);
+                                had_usage = true;
+                            }
                             if finish.is_none() {
                                 finish = Some(FinishReason::Stop);
                             }
@@ -116,6 +123,11 @@ impl ServerToolLoop {
                         other => yield Ok(other),
                     }
                 }
+
+                // Drop malformed calls whose name never arrived — they are
+                // neither router- nor client-executable, and would otherwise
+                // force a spurious hand-back of an empty-named tool call.
+                buffered.retain(|b| !b.name.is_empty());
 
                 let has_client = buffered.iter().any(|b| !owned.contains(&b.name));
                 let router: Vec<RouterCall> = buffered
@@ -435,5 +447,44 @@ mod tests {
                 .count(),
             1
         );
+    }
+
+    #[tokio::test]
+    async fn accumulates_usage_from_response_completed() {
+        // A Responses-style upstream carries usage only on ResponseCompleted
+        // (never a standalone Usage part); the stitcher must still emit a
+        // consolidated Usage so settlement bills the authoritative count.
+        let scripts = vec![vec![
+            StreamPart::TextDelta { text: "hi".into() },
+            StreamPart::ResponseCompleted {
+                id: "r1".into(),
+                status: "completed".into(),
+                usage: Some(Usage {
+                    prompt_tokens: 7,
+                    completion_tokens: 3,
+                    ..Default::default()
+                }),
+            },
+        ]];
+        let upstream = Arc::new(ScriptedStream {
+            scripts: Mutex::new(scripts.into()),
+        });
+        let parts = collect(
+            loop_()
+                .run_stream(&base_prompt(), &CallerContext::local(), upstream)
+                .await
+                .unwrap(),
+        )
+        .await;
+
+        let usage = parts
+            .iter()
+            .find_map(|p| match p {
+                StreamPart::Usage { usage } => Some(usage),
+                _ => None,
+            })
+            .expect("a consolidated Usage part is emitted");
+        assert_eq!(usage.prompt_tokens, 7);
+        assert_eq!(usage.completion_tokens, 3);
     }
 }

--- a/crates/bitrouter-sdk/src/language_model/server_tools/toolset.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/toolset.rs
@@ -32,6 +32,13 @@ pub trait RouterToolset: Send + Sync {
 
     /// Whether this set owns `name`.
     fn owns(&self, name: &str) -> bool;
+
+    /// The MCP server backing this set, when applicable. Lets the loop label a
+    /// router tool call with its server so a framing encoder can reproduce the
+    /// native `mcp_tool_use` block. Default `None` (e.g. an in-process set).
+    fn server_name(&self) -> Option<&str> {
+        None
+    }
 }
 
 /// Composes several [`RouterToolset`]s: aggregates their advertised tools and

--- a/crates/bitrouter-sdk/src/language_model/server_tools/toolset.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/toolset.rs
@@ -1,0 +1,121 @@
+//! The [`RouterToolset`] executor seam and a [`ToolsetRegistry`] that composes
+//! several toolsets and resolves an intercepted tool call to its owner.
+
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::caller::CallerContext;
+use crate::error::Result;
+use crate::language_model::types::{Tool, ToolResultOutput};
+
+/// A set of tools that BitRouter advertises to the model and executes itself.
+///
+/// Provider/transport-agnostic: an implementation may be backed by MCP, an
+/// in-process registry, or anything else. Tool names are provider-namespaced
+/// (prefixed) by the implementation so they cannot collide with the caller's
+/// own tools.
+#[async_trait]
+pub trait RouterToolset: Send + Sync {
+    /// Tools to advertise on this request, as canonical IR function tools.
+    async fn list_tools(&self, caller: &CallerContext) -> Result<Vec<Tool>>;
+
+    /// Execute one model-issued call this set owns. `arguments` is the raw
+    /// JSON string carried on the model's `Content::ToolCall`.
+    async fn call_tool(
+        &self,
+        name: &str,
+        arguments: &str,
+        caller: &CallerContext,
+    ) -> Result<ToolResultOutput>;
+
+    /// Whether this set owns `name`.
+    fn owns(&self, name: &str) -> bool;
+}
+
+/// Composes several [`RouterToolset`]s: aggregates their advertised tools and
+/// routes an intercepted call to the owning set.
+pub struct ToolsetRegistry {
+    sets: Vec<Arc<dyn RouterToolset>>,
+}
+
+impl ToolsetRegistry {
+    /// Build a registry over `sets`.
+    pub fn new(sets: Vec<Arc<dyn RouterToolset>>) -> Self {
+        Self { sets }
+    }
+
+    /// Every set's advertised tools, paired with the set of router-owned tool
+    /// names (used by the loop to classify which calls it must execute).
+    pub async fn list_all(&self, caller: &CallerContext) -> Result<(Vec<Tool>, BTreeSet<String>)> {
+        let mut tools = Vec::new();
+        let mut owned = BTreeSet::new();
+        for set in &self.sets {
+            for tool in set.list_tools(caller).await? {
+                owned.insert(tool.name().to_string());
+                tools.push(tool);
+            }
+        }
+        Ok((tools, owned))
+    }
+
+    /// The set that owns `name`, if any.
+    pub fn resolve(&self, name: &str) -> Option<&Arc<dyn RouterToolset>> {
+        self.sets.iter().find(|set| set.owns(name))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::language_model::types::ProviderMetadata;
+
+    struct MockToolset {
+        tools: Vec<Tool>,
+    }
+
+    #[async_trait]
+    impl RouterToolset for MockToolset {
+        async fn list_tools(&self, _caller: &CallerContext) -> Result<Vec<Tool>> {
+            Ok(self.tools.clone())
+        }
+        async fn call_tool(
+            &self,
+            name: &str,
+            _arguments: &str,
+            _caller: &CallerContext,
+        ) -> Result<ToolResultOutput> {
+            Ok(ToolResultOutput::Text {
+                value: format!("ran {name}"),
+            })
+        }
+        fn owns(&self, name: &str) -> bool {
+            self.tools.iter().any(|t| t.name() == name)
+        }
+    }
+
+    fn func(name: &str) -> Tool {
+        Tool::Function {
+            name: name.to_string(),
+            description: None,
+            parameters: serde_json::json!({}),
+            strict: None,
+            provider_metadata: ProviderMetadata::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn registry_lists_tools_and_resolves_owner() {
+        let mock = Arc::new(MockToolset {
+            tools: vec![func("search"), func("fetch")],
+        });
+        let reg = ToolsetRegistry::new(vec![mock]);
+        let (tools, owned) = reg.list_all(&CallerContext::local()).await.unwrap();
+        assert_eq!(tools.len(), 2);
+        assert!(owned.contains("search"));
+        assert!(owned.contains("fetch"));
+        assert!(reg.resolve("search").is_some());
+        assert!(reg.resolve("missing").is_none());
+    }
+}

--- a/crates/bitrouter-sdk/src/language_model/stream.rs
+++ b/crates/bitrouter-sdk/src/language_model/stream.rs
@@ -97,6 +97,9 @@ impl StreamInterest {
             // No hook subscribes to source (citation) parts; they pass through
             // unfiltered, exactly like file parts.
             StreamPart::Source { .. } => 0,
+            // Server-tool activity (router-executed calls + results) carries no
+            // assistant text and gates no hook; passes through unfiltered.
+            StreamPart::ServerToolCall { .. } | StreamPart::ServerToolResult { .. } => 0,
             StreamPart::ResponseStarted { .. } => Self::RESPONSE_STARTED,
             // `ResponseCompleted` is a terminal part — a hook interested in
             // `Finish` is, by construction, also interested in it.

--- a/crates/bitrouter-sdk/src/language_model/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/tests.rs
@@ -1173,3 +1173,110 @@ async fn without_loop_a_tool_call_turn_is_returned_unchanged() {
     let resp = pipeline.execute(request()).await.expect("request succeeds");
     assert!(matches!(&resp.result.content[0], Content::ToolCall { .. }));
 }
+
+#[tokio::test]
+async fn server_tool_loop_streams_router_tool_activity() {
+    use crate::language_model::server_tools::approval::AllowAll;
+    use crate::language_model::server_tools::config::ServerToolLoopConfig;
+    use crate::language_model::server_tools::loop_controller::ServerToolLoop;
+    use crate::language_model::server_tools::toolset::{RouterToolset, ToolsetRegistry};
+
+    struct OneTool;
+    #[async_trait]
+    impl RouterToolset for OneTool {
+        async fn list_tools(&self, _c: &CallerContext) -> Result<Vec<Tool>> {
+            Ok(vec![Tool::Function {
+                name: "search".to_string(),
+                description: None,
+                parameters: serde_json::json!({ "type": "object" }),
+                strict: None,
+                provider_metadata: Default::default(),
+            }])
+        }
+        async fn call_tool(
+            &self,
+            _n: &str,
+            _a: &str,
+            _c: &CallerContext,
+        ) -> Result<ToolResultOutput> {
+            Ok(ToolResultOutput::Text {
+                value: "ran".to_string(),
+            })
+        }
+        fn owns(&self, name: &str) -> bool {
+            name == "search"
+        }
+        fn server_name(&self) -> Option<&str> {
+            Some("docs")
+        }
+    }
+
+    // Iteration 1 streams a router tool call; iteration 2 streams the answer.
+    let executor = Arc::new(MockExecutor::new(vec![
+        MockResponse::Stream(vec![
+            StreamPart::TextDelta {
+                text: "searching ".to_string(),
+            },
+            StreamPart::ToolCallDelta {
+                id: "c1".to_string(),
+                name: Some("search".to_string()),
+                arguments: "{}".to_string(),
+            },
+            StreamPart::Finish {
+                reason: FinishReason::ToolCalls,
+            },
+        ]),
+        MockResponse::Stream(vec![
+            StreamPart::TextDelta {
+                text: "answer".to_string(),
+            },
+            StreamPart::Finish {
+                reason: FinishReason::Stop,
+            },
+        ]),
+    ]));
+    let server_loop = Arc::new(ServerToolLoop::new(
+        ToolsetRegistry::new(vec![Arc::new(OneTool)]),
+        ServerToolLoopConfig::default(),
+        Arc::new(AllowAll),
+    ));
+    let pipeline = pipeline_with(routing_table(&["openai"]), executor, |b| {
+        b.server_tool_loop(server_loop);
+    });
+
+    let mut stream = pipeline
+        .execute_stream(stream_request())
+        .await
+        .expect("stream starts");
+    let mut parts = Vec::new();
+    while let Some(item) = stream.next().await {
+        parts.push(item.expect("stream part ok"));
+    }
+
+    // The router tool ran server-side, surfaced as ServerToolCall + Result...
+    assert!(
+        parts
+            .iter()
+            .any(|p| matches!(p, StreamPart::ServerToolCall { name, .. } if name == "search"))
+    );
+    assert!(
+        parts
+            .iter()
+            .any(|p| matches!(p, StreamPart::ServerToolResult { .. }))
+    );
+    // ...the raw router ToolCallDelta was suppressed...
+    assert!(
+        !parts
+            .iter()
+            .any(|p| matches!(p, StreamPart::ToolCallDelta { .. }))
+    );
+    // ...and both turns' text streamed through to one continuous answer.
+    let text: String = parts
+        .iter()
+        .filter_map(|p| match p {
+            StreamPart::TextDelta { text } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(text, "searching answer");
+}

--- a/crates/bitrouter-sdk/src/language_model/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/tests.rs
@@ -1068,3 +1068,108 @@ async fn nonstream_disconnect_still_runs_to_completion_and_bills_full() {
         "non-stream disconnect bills the full upstream usage, not zero"
     );
 }
+
+// ===== server-side tool loop wiring =====
+
+fn router_tool_call() -> Content {
+    Content::ToolCall {
+        id: "c1".to_string(),
+        name: "search".to_string(),
+        arguments: "{}".to_string(),
+        provider_executed: false,
+        dynamic: false,
+        provider_metadata: Default::default(),
+    }
+}
+
+fn gen_result(content: Vec<Content>) -> GenerateResult {
+    GenerateResult {
+        content,
+        usage: Some(Usage {
+            prompt_tokens: 3,
+            completion_tokens: 2,
+            ..Default::default()
+        }),
+        finish_reason: Some(FinishReason::ToolCalls),
+        response_id: None,
+        stop_details: None,
+        provider_metadata: Default::default(),
+    }
+}
+
+#[tokio::test]
+async fn server_tool_loop_resolves_a_router_tool_call() {
+    use crate::language_model::server_tools::approval::AllowAll;
+    use crate::language_model::server_tools::config::ServerToolLoopConfig;
+    use crate::language_model::server_tools::loop_controller::ServerToolLoop;
+    use crate::language_model::server_tools::toolset::{RouterToolset, ToolsetRegistry};
+
+    struct OneTool;
+    #[async_trait]
+    impl RouterToolset for OneTool {
+        async fn list_tools(&self, _c: &CallerContext) -> Result<Vec<Tool>> {
+            Ok(vec![Tool::Function {
+                name: "search".to_string(),
+                description: None,
+                parameters: serde_json::json!({ "type": "object" }),
+                strict: None,
+                provider_metadata: Default::default(),
+            }])
+        }
+        async fn call_tool(
+            &self,
+            _name: &str,
+            _arguments: &str,
+            _c: &CallerContext,
+        ) -> Result<ToolResultOutput> {
+            Ok(ToolResultOutput::Text {
+                value: "tool ran".to_string(),
+            })
+        }
+        fn owns(&self, name: &str) -> bool {
+            name == "search"
+        }
+    }
+
+    let executor = Arc::new(MockExecutor::new(vec![
+        MockResponse::Generate(gen_result(vec![router_tool_call()])),
+        MockResponse::Generate(gen_result(vec![Content::Text {
+            text: "final answer".to_string(),
+            provider_metadata: Default::default(),
+        }])),
+    ]));
+    let server_loop = Arc::new(ServerToolLoop::new(
+        ToolsetRegistry::new(vec![Arc::new(OneTool)]),
+        ServerToolLoopConfig::default(),
+        Arc::new(AllowAll),
+    ));
+    let pipeline = pipeline_with(routing_table(&["openai"]), executor, |b| {
+        b.server_tool_loop(server_loop);
+    });
+
+    let resp = pipeline.execute(request()).await.expect("request succeeds");
+    // The router tool call was executed by the loop; the caller sees the final
+    // text after two upstream calls, with usage summed across both.
+    assert!(
+        matches!(&resp.result.content[0], Content::Text { text, .. } if text == "final answer")
+    );
+    assert_eq!(resp.result.usage.unwrap().prompt_tokens, 6);
+}
+
+#[tokio::test]
+async fn without_loop_a_tool_call_turn_is_returned_unchanged() {
+    // No server_tool_loop configured: the pipeline stays single-shot and hands
+    // the model's tool-call turn straight back to the caller (only one upstream
+    // call is consumed).
+    let executor = Arc::new(MockExecutor::new(vec![
+        MockResponse::Generate(gen_result(vec![router_tool_call()])),
+        MockResponse::Generate(gen_result(vec![Content::Text {
+            text: "unused".to_string(),
+            provider_metadata: Default::default(),
+        }])),
+    ]));
+    let pipeline = pipeline_with(routing_table(&["openai"]), executor, |_b| {});
+
+    let resp = pipeline.execute(request()).await.expect("request succeeds");
+    assert!(matches!(&resp.result.content[0], Content::ToolCall { .. }));
+}

--- a/crates/bitrouter-sdk/src/language_model/types.rs
+++ b/crates/bitrouter-sdk/src/language_model/types.rs
@@ -1503,6 +1503,46 @@ pub enum StreamPart {
         /// Arguments fragment.
         arguments: String,
     },
+    /// A complete **provider/router-executed** tool call, emitted whole (not as
+    /// [`Self::ToolCallDelta`] fragments). The server-side tool loop emits this
+    /// for a tool BitRouter executed itself; a framing encoder renders it as the
+    /// protocol's native server-tool / MCP call block (Anthropic
+    /// `server_tool_use` / `mcp_tool_use`, Responses `mcp_call`). The coarse
+    /// wires (Chat Completions / Generate Content) degrade it — see each
+    /// encoder. `dynamic` marks an MCP (Model Context Protocol) tool, mirroring
+    /// [`Content::ToolCall::dynamic`].
+    ServerToolCall {
+        /// Provider-assigned call id, paired with the matching
+        /// [`Self::ServerToolResult`].
+        id: String,
+        /// Tool name.
+        name: String,
+        /// JSON-encoded arguments, whole.
+        arguments: String,
+        /// The MCP server that owns the tool, when known. Lets a framing
+        /// encoder reproduce the Anthropic `mcp_tool_use` block's `server_name`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        server_name: Option<String>,
+        /// Whether this is a dynamic (MCP) tool call.
+        #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+        dynamic: bool,
+    },
+    /// The result of a [`Self::ServerToolCall`], emitted whole. Rendered as the
+    /// protocol's native server-tool / MCP result block (Anthropic
+    /// `mcp_tool_result` / `web_search_tool_result`, Responses `mcp_call`
+    /// output); degraded on the coarse wires. Mirrors [`Content::ToolResult`].
+    ServerToolResult {
+        /// The [`Self::ServerToolCall`] id this result answers.
+        call_id: String,
+        /// The tool's name, when known.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        tool_name: Option<String>,
+        /// The typed result body.
+        output: ToolResultOutput,
+        /// Whether this answers a dynamic (MCP) tool call.
+        #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+        dynamic: bool,
+    },
     /// A complete generated file (e.g. an image), emitted whole — matching the
     /// Vercel AI SDK `LanguageModelV3` stream `file` part, where files arrive as
     /// one part rather than chunked deltas.

--- a/plugins/bitrouter-observe/src/otel/metrics.rs
+++ b/plugins/bitrouter-observe/src/otel/metrics.rs
@@ -185,6 +185,8 @@ fn stream_part_type(part: &StreamPart) -> &'static str {
         StreamPart::ReasoningDelta { .. } => "reasoning_delta",
         StreamPart::ReasoningEnd { .. } => "reasoning_end",
         StreamPart::ToolCallDelta { .. } => "tool_call_delta",
+        StreamPart::ServerToolCall { .. } => "server_tool_call",
+        StreamPart::ServerToolResult { .. } => "server_tool_result",
         StreamPart::File { .. } => "file",
         StreamPart::Source { .. } => "source",
         StreamPart::Usage { .. } => "usage",

--- a/skills/bitrouter/references/providers.md
+++ b/skills/bitrouter/references/providers.md
@@ -156,6 +156,18 @@ mcp_servers:
 
 Once configured, `POST /mcp/<name>` proxies JSON-RPC through. Inspect with `bitrouter tools list` / `bitrouter tools status` / `bitrouter tools discover <name>`.
 
+## Server tools (router-executed)
+
+Attach an MCP server's tools to LLM requests: BitRouter advertises them to the model, executes the model's calls to them itself, and loops until the model stops calling them — all inside one client response. The named servers must also be declared under `mcp_servers:` above.
+
+```yaml
+server_tools:
+  mcp_servers: [ctx7, git]   # ids from mcp_servers: above
+  max_iterations: 10         # optional; max tool rounds per request (default 10)
+```
+
+Tool names are prefixed (`<name>__<tool>`, or the server's `tool_prefix`) so they can't collide with the caller's own tools. Empty/unset leaves the pipeline single-shot. This is the inverse of `bitrouter mcp serve` (which makes BitRouter an MCP *server*): here BitRouter is an MCP *client* consuming those tools inside the request loop.
+
 ## ACP agents
 
 ```yaml


### PR DESCRIPTION
## Summary

Adds a **server-side tool loop**: BitRouter advertises tools (MCP-backed) to the model, executes the model's calls to them itself, feeds the results back, and re-calls the upstream until the model stops calling them — presenting one response (non-streaming) or one continuous stream (streaming) to the caller. To the upstream a router tool looks like an ordinary function tool; to the caller it looks like a server-executed tool. Opt-in: empty config keeps the pipeline strictly single-shot.

## What's included

**Engine (`language_model/server_tools/`)**
- `RouterToolset` executor seam + `ToolsetRegistry` (provider/transport-agnostic).
- `McpRouterToolset` over the existing `crate::mcp::Executor` (`tools/list` → `Tool::Function` with a server prefix; `tools/call` → `ToolResultOutput`). No new feature gate — works with any `mcp::Executor`.
- `ServerToolLoop`: inject router tools (failing on a name collision with a caller tool), classify each turn, execute router-owned calls (approval-gated, per-tool timeout), feed results back, loop — bounded by max tool-rounds / wall-clock budget / consecutive-error cap, accumulating usage.
- Approval seam with an `AllowAll` default.

**Streaming**
- New `StreamPart::ServerToolCall` / `ServerToolResult` (whole parts mirroring the non-streaming `Content` blocks).
- Native rendering on the wires with a server-tool/MCP form: Messages → `mcp_tool_use` (+ `input_json_delta`) + `mcp_tool_result`; Responses → one `mcp_call` output item. Chat Completions and Generate Content have no server-tool stream form and drop the activity (the final answer still streams).
- A stitcher merges the loop's N upstream streams into one: forwards narration live, suppresses the raw router tool-call deltas, executes each call (re-emitting it as the activity parts), appends the tool turn to the working prompt, accumulates usage into one final part, and emits a single terminal.

**Config + wiring**
- `[server_tools]` config (MCP server ids to attach + optional `max_iterations`).
- Wired into the pipeline (non-streaming and streaming) and the binary assembly; documented in the `bitrouter` skill.

## Notable design points
- The streaming path uses a throwaway `PipelineContext` per loop iteration (the executor reads the context only for outbound trace headers), so the streaming settlement guard / disconnect-billing path is structurally untouched — the merged stream is simply the "upstream" the guard drains.
- `UpstreamTurn` / `UpstreamStream` traits (rather than async closures) keep the spawned, `'static` futures `Send`.

## v1 limitations (documented)
- A turn mixing router and client tool calls is handed back to the caller unchanged (no partial server-side execution).
- Reaching the iteration cap terminates with a truncation finish reason (non-resumable).
- Per-iteration tool activity is dropped on the coarse wires (Chat Completions / Generate Content).
- Custom/in-process tools are not implemented; the `RouterToolset` seam is the extension point.

## Testing
- 908 workspace tests pass (`cargo nextest run --all-features`); `cargo clippy --all-features` and `cargo fmt --check` clean.
- Unit tests for the seam/registry, turn classification, MCP conversions, the non-streaming loop, and the stitcher; per-protocol encoder golden tests; end-to-end pipeline tests for both non-streaming and streaming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)