### PR TITLE
feat(server-tools): pass ToolContext to RouterToolset

### DIFF
--- a/crates/bitrouter-sdk/src/language_model/context.rs
+++ b/crates/bitrouter-sdk/src/language_model/context.rs
@@ -214,6 +214,15 @@ impl PipelineContext {
         self.metadata.get(plugin_id)
     }
 
+    /// The full per-request metadata map. Used to snapshot a request's
+    /// plugin-scoped state into an owned
+    /// [`ToolContext`](crate::language_model::server_tools::toolset::ToolContext)
+    /// for a server-tool execution, which may outlive this borrow (e.g. on the
+    /// streaming path).
+    pub fn metadata(&self) -> &HashMap<PluginId, serde_json::Value> {
+        &self.metadata
+    }
+
     /// Insert a typed, request-scoped extension, replacing any existing value
     /// of the same type. The value is shared (`Arc`) and copied into the
     /// per-stream [`StreamContext`], so a Stage-1 hook can deposit a value that

--- a/crates/bitrouter-sdk/src/language_model/pipeline.rs
+++ b/crates/bitrouter-sdk/src/language_model/pipeline.rs
@@ -21,6 +21,7 @@ use crate::language_model::hooks::{
 use crate::language_model::routing::{FallbackPolicy, RoutingPrefs, RoutingTable};
 use crate::language_model::server_tools::loop_controller::{ServerToolLoop, UpstreamTurn};
 use crate::language_model::server_tools::stream::UpstreamStream;
+use crate::language_model::server_tools::toolset::ToolContext;
 use crate::language_model::settlement::{SettlementContext, SettlementRecorder};
 use crate::language_model::stream::{StreamOutcome, StreamProcessor};
 use crate::language_model::types::{
@@ -227,12 +228,13 @@ impl Pipeline {
         // ---- Stage 3: execution (with the server-side tool loop when configured) ----
         let exec_outcome = match &self.server_tool_loop {
             Some(server_loop) => {
+                let tool_ctx = ToolContext::from_pipeline(&ctx);
                 let upstream = PipelineUpstream {
                     pipeline: self,
                     chain: &chain,
                     ctx: &ctx,
                 };
-                server_loop.run(ctx.prompt(), ctx.caller(), &upstream).await
+                server_loop.run(ctx.prompt(), &tool_ctx, &upstream).await
             }
             None => self.execute_with_fallback(&chain, ctx.prompt(), &ctx).await,
         };
@@ -289,6 +291,7 @@ impl Pipeline {
         // settlement is unchanged. Otherwise the pipeline stays single-shot.
         let upstream = match &self.server_tool_loop {
             Some(server_loop) => {
+                let tool_ctx = ToolContext::from_pipeline(&ctx);
                 let upstream_impl: Arc<dyn UpstreamStream> = Arc::new(PipelineStreamUpstream {
                     executor: self.executor.clone(),
                     chain: chain.clone(),
@@ -296,7 +299,7 @@ impl Pipeline {
                 });
                 server_loop
                     .clone()
-                    .run_stream(ctx.prompt(), ctx.caller(), upstream_impl)
+                    .run_stream(ctx.prompt(), &tool_ctx, upstream_impl)
                     .await?
             }
             None => self.execute_stream_with_fallback(&chain, &ctx).await?,

--- a/crates/bitrouter-sdk/src/language_model/server_tools/loop_controller.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/loop_controller.rs
@@ -11,8 +11,7 @@ use async_trait::async_trait;
 use super::approval::ApprovalPolicy;
 use super::classify::{RouterCall, TurnDisposition, classify_turn};
 use super::config::ServerToolLoopConfig;
-use super::toolset::ToolsetRegistry;
-use crate::caller::CallerContext;
+use super::toolset::{ToolContext, ToolsetRegistry};
 use crate::error::{BitrouterError, Result};
 use crate::language_model::types::{
     Content, ExecutionResult, FinishReason, Message, Prompt, ProviderMetadata, Role,
@@ -70,9 +69,9 @@ impl ServerToolLoop {
     pub(crate) async fn inject(
         &self,
         base: &Prompt,
-        caller: &CallerContext,
+        ctx: &ToolContext,
     ) -> Result<(Prompt, std::collections::BTreeSet<String>)> {
-        let (injected, owned) = self.registry.list_all(caller).await?;
+        let (injected, owned) = self.registry.list_all(ctx).await?;
         let mut working = base.clone();
         for tool in &injected {
             if working.tools.iter().any(|t| t.name() == tool.name()) {
@@ -97,10 +96,10 @@ impl ServerToolLoop {
     pub async fn run(
         &self,
         base: &Prompt,
-        caller: &CallerContext,
+        ctx: &ToolContext,
         upstream: &dyn UpstreamTurn,
     ) -> Result<ExecutionResult> {
-        let (mut working, owned) = self.inject(base, caller).await?;
+        let (mut working, owned) = self.inject(base, ctx).await?;
 
         let mut total = Usage::default();
         let mut had_usage = false;
@@ -128,7 +127,7 @@ impl ServerToolLoop {
                     {
                         return Ok(truncate(result, total, had_usage, "max_tool_iterations"));
                     }
-                    let (tool_results, had_error) = self.execute_calls(&calls, caller).await;
+                    let (tool_results, had_error) = self.execute_calls(&calls, ctx).await;
                     consecutive_errors = if had_error { consecutive_errors + 1 } else { 0 };
                     append_turn(&mut working, result.result.content.clone(), tool_results);
                     rounds += 1;
@@ -146,9 +145,9 @@ impl ServerToolLoop {
     pub(crate) async fn call_one(
         &self,
         call: &RouterCall,
-        caller: &CallerContext,
+        ctx: &ToolContext,
     ) -> (ToolResultOutput, bool) {
-        if !self.approval.allow(call, caller).await {
+        if !self.approval.allow(call, ctx.caller()).await {
             return (
                 ToolResultOutput::ExecutionDenied {
                     reason: Some("denied by approval policy".to_string()),
@@ -166,7 +165,7 @@ impl ServerToolLoop {
         };
         match tokio::time::timeout(
             self.config.tool_timeout,
-            set.call_tool(&call.name, &call.arguments, caller),
+            set.call_tool(&call.name, &call.arguments, ctx),
         )
         .await
         {
@@ -188,15 +187,11 @@ impl ServerToolLoop {
 
     /// Execute each router-owned call, returning the tool-result content blocks
     /// and whether any call produced an error.
-    async fn execute_calls(
-        &self,
-        calls: &[RouterCall],
-        caller: &CallerContext,
-    ) -> (Vec<Content>, bool) {
+    async fn execute_calls(&self, calls: &[RouterCall], ctx: &ToolContext) -> (Vec<Content>, bool) {
         let mut results = Vec::with_capacity(calls.len());
         let mut had_error = false;
         for call in calls {
-            let (output, err) = self.call_one(call, caller).await;
+            let (output, err) = self.call_one(call, ctx).await;
             had_error |= err;
             results.push(Content::ToolResult {
                 call_id: call.id.clone(),
@@ -250,6 +245,7 @@ fn truncate(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::caller::CallerContext;
     use crate::language_model::server_tools::approval::AllowAll;
     use crate::language_model::server_tools::toolset::RouterToolset;
     use crate::language_model::types::{GenerateResult, Tool};
@@ -263,7 +259,7 @@ mod tests {
 
     #[async_trait]
     impl RouterToolset for MockToolset {
-        async fn list_tools(&self, _caller: &CallerContext) -> Result<Vec<Tool>> {
+        async fn list_tools(&self, _ctx: &ToolContext) -> Result<Vec<Tool>> {
             Ok(self
                 .names
                 .iter()
@@ -280,7 +276,7 @@ mod tests {
             &self,
             name: &str,
             _arguments: &str,
-            _caller: &CallerContext,
+            _ctx: &ToolContext,
         ) -> Result<ToolResultOutput> {
             if self.fail {
                 Err(BitrouterError::Internal(format!("{name} boom")))
@@ -331,6 +327,10 @@ mod tests {
             config,
             Arc::new(AllowAll),
         )
+    }
+
+    fn tool_ctx() -> ToolContext {
+        ToolContext::new(CallerContext::local(), Default::default())
     }
 
     fn base_prompt() -> Prompt {
@@ -397,7 +397,7 @@ mod tests {
             exec(vec![text("the answer")]),
         ]);
         let result = loop_
-            .run(&base_prompt(), &CallerContext::local(), &upstream)
+            .run(&base_prompt(), &tool_ctx(), &upstream)
             .await
             .unwrap();
         let seen = upstream.seen();
@@ -426,7 +426,7 @@ mod tests {
             tool_call("client_fn"),
         ])]);
         let result = loop_
-            .run(&base_prompt(), &CallerContext::local(), &upstream)
+            .run(&base_prompt(), &tool_ctx(), &upstream)
             .await
             .unwrap();
         assert_eq!(upstream.seen().len(), 1);
@@ -444,7 +444,7 @@ mod tests {
             exec(vec![text("recovered")]),
         ]);
         let result = loop_
-            .run(&base_prompt(), &CallerContext::local(), &upstream)
+            .run(&base_prompt(), &tool_ctx(), &upstream)
             .await
             .unwrap();
         let seen = upstream.seen();
@@ -478,7 +478,7 @@ mod tests {
             exec(vec![tool_call("search")]),
         ]);
         let result = loop_
-            .run(&base_prompt(), &CallerContext::local(), &upstream)
+            .run(&base_prompt(), &tool_ctx(), &upstream)
             .await
             .unwrap();
         // round 0 executes (rounds 0 < 1), round 1 hits the cap.

--- a/crates/bitrouter-sdk/src/language_model/server_tools/mcp_toolset.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/mcp_toolset.rs
@@ -13,8 +13,7 @@ use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 
-use super::toolset::RouterToolset;
-use crate::caller::CallerContext;
+use super::toolset::{RouterToolset, ToolContext};
 use crate::error::Result;
 use crate::language_model::types::{
     ProviderMetadata, Tool, ToolResultContentPart, ToolResultOutput,
@@ -147,14 +146,17 @@ impl McpRouterToolset {
 
 #[async_trait]
 impl RouterToolset for McpRouterToolset {
-    async fn list_tools(&self, caller: &CallerContext) -> Result<Vec<Tool>> {
+    async fn list_tools(&self, ctx: &ToolContext) -> Result<Vec<Tool>> {
         let request = McpRequest::direct(
             self.server_name.clone(),
             "tools/list",
             serde_json::json!({}),
-            caller.clone(),
+            ctx.caller().clone(),
         );
-        let target = self.routing.resolve(&request.selector, caller).await?;
+        let target = self
+            .routing
+            .resolve(&request.selector, ctx.caller())
+            .await?;
         let response = self.executor.execute(&target, &request).await?;
         let tools = tools_from_list(&response.result, self.prefix.as_deref());
         if let Ok(mut advertised) = self.advertised.lock() {
@@ -170,7 +172,7 @@ impl RouterToolset for McpRouterToolset {
         &self,
         name: &str,
         arguments: &str,
-        caller: &CallerContext,
+        ctx: &ToolContext,
     ) -> Result<ToolResultOutput> {
         let parsed: serde_json::Value =
             serde_json::from_str(arguments).unwrap_or_else(|_| serde_json::json!({}));
@@ -182,9 +184,12 @@ impl RouterToolset for McpRouterToolset {
             self.server_name.clone(),
             "tools/call",
             params,
-            caller.clone(),
+            ctx.caller().clone(),
         );
-        let target = self.routing.resolve(&request.selector, caller).await?;
+        let target = self
+            .routing
+            .resolve(&request.selector, ctx.caller())
+            .await?;
         let response = self.executor.execute(&target, &request).await?;
         Ok(output_from_call(&response.result))
     }
@@ -210,6 +215,7 @@ impl RouterToolset for McpRouterToolset {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::caller::CallerContext;
     use crate::mcp::transport::McpTransport;
     use crate::mcp::{McpResponse, McpStreamPart, McpTarget, ServerSelector};
     use futures::stream::BoxStream;
@@ -332,15 +338,15 @@ mod tests {
             "demo",
             Some("mcp__demo__".to_string()),
         );
-        let caller = CallerContext::local();
+        let ctx = ToolContext::new(CallerContext::local(), Default::default());
 
-        let tools = toolset.list_tools(&caller).await.unwrap();
+        let tools = toolset.list_tools(&ctx).await.unwrap();
         assert_eq!(tools.len(), 2);
         assert!(toolset.owns("mcp__demo__search"));
         assert!(!toolset.owns("some_client_tool"));
 
         let out = toolset
-            .call_tool("mcp__demo__search", "{\"q\":\"rust\"}", &caller)
+            .call_tool("mcp__demo__search", "{\"q\":\"rust\"}", &ctx)
             .await
             .unwrap();
         assert_eq!(

--- a/crates/bitrouter-sdk/src/language_model/server_tools/stream.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/stream.rs
@@ -14,7 +14,7 @@ use futures::StreamExt;
 
 use super::classify::RouterCall;
 use super::loop_controller::{ServerToolLoop, add_usage};
-use crate::caller::CallerContext;
+use super::toolset::ToolContext;
 use crate::error::Result;
 use crate::language_model::executor::StreamPartStream;
 use crate::language_model::types::{
@@ -43,11 +43,11 @@ impl ServerToolLoop {
     pub async fn run_stream(
         self: Arc<Self>,
         base: &Prompt,
-        caller: &CallerContext,
+        ctx: &ToolContext,
         upstream: Arc<dyn UpstreamStream>,
     ) -> Result<StreamPartStream> {
-        let (working, owned) = self.inject(base, caller).await?;
-        let caller = caller.clone();
+        let (working, owned) = self.inject(base, ctx).await?;
+        let ctx = ctx.clone();
         let loop_ = self;
 
         let stream = async_stream::stream! {
@@ -186,7 +186,7 @@ impl ServerToolLoop {
                         server_name,
                         dynamic: true,
                     });
-                    let (output, err) = loop_.call_one(call, &caller).await;
+                    let (output, err) = loop_.call_one(call, &ctx).await;
                     round_error |= err;
                     yield Ok(StreamPart::ServerToolResult {
                         call_id: call.id.clone(),
@@ -252,6 +252,7 @@ impl ServerToolLoop {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::caller::CallerContext;
     use crate::language_model::server_tools::approval::AllowAll;
     use crate::language_model::server_tools::config::ServerToolLoopConfig;
     use crate::language_model::server_tools::toolset::{RouterToolset, ToolsetRegistry};
@@ -263,7 +264,7 @@ mod tests {
 
     #[async_trait]
     impl RouterToolset for OneTool {
-        async fn list_tools(&self, _caller: &CallerContext) -> Result<Vec<Tool>> {
+        async fn list_tools(&self, _ctx: &ToolContext) -> Result<Vec<Tool>> {
             Ok(vec![Tool::Function {
                 name: "search".to_string(),
                 description: None,
@@ -276,7 +277,7 @@ mod tests {
             &self,
             _name: &str,
             _arguments: &str,
-            _caller: &CallerContext,
+            _ctx: &ToolContext,
         ) -> Result<ToolResultOutput> {
             Ok(ToolResultOutput::Text {
                 value: "ran".to_string(),
@@ -308,6 +309,10 @@ mod tests {
             ServerToolLoopConfig::default(),
             Arc::new(AllowAll),
         ))
+    }
+
+    fn tool_ctx() -> ToolContext {
+        ToolContext::new(CallerContext::local(), Default::default())
     }
 
     fn base_prompt() -> Prompt {
@@ -363,7 +368,7 @@ mod tests {
         });
         let parts = collect(
             loop_()
-                .run_stream(&base_prompt(), &CallerContext::local(), upstream)
+                .run_stream(&base_prompt(), &tool_ctx(), upstream)
                 .await
                 .unwrap(),
         )
@@ -422,7 +427,7 @@ mod tests {
         });
         let parts = collect(
             loop_()
-                .run_stream(&base_prompt(), &CallerContext::local(), upstream)
+                .run_stream(&base_prompt(), &tool_ctx(), upstream)
                 .await
                 .unwrap(),
         )
@@ -471,7 +476,7 @@ mod tests {
         });
         let parts = collect(
             loop_()
-                .run_stream(&base_prompt(), &CallerContext::local(), upstream)
+                .run_stream(&base_prompt(), &tool_ctx(), upstream)
                 .await
                 .unwrap(),
         )

--- a/crates/bitrouter-sdk/src/language_model/server_tools/toolset.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/toolset.rs
@@ -1,14 +1,55 @@
 //! The [`RouterToolset`] executor seam and a [`ToolsetRegistry`] that composes
 //! several toolsets and resolves an intercepted tool call to its owner.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
 
 use async_trait::async_trait;
 
 use crate::caller::CallerContext;
 use crate::error::Result;
+use crate::language_model::context::PipelineContext;
 use crate::language_model::types::{Tool, ToolResultOutput};
+use crate::plugin::PluginId;
+
+/// An owned, cheap-to-clone snapshot of the per-request context handed to a
+/// [`RouterToolset`]. Carries the [`CallerContext`] and the request's
+/// plugin-scoped metadata map — where a consumer stashes request-scoped state
+/// such as the resolved principal or a per-request tool declaration.
+///
+/// Owned rather than a `&PipelineContext` because a server-tool execution can
+/// outlive the borrow: the streaming stitcher moves it into a `'static` stream.
+#[derive(Debug, Clone)]
+pub struct ToolContext {
+    caller: CallerContext,
+    metadata: HashMap<PluginId, serde_json::Value>,
+}
+
+impl ToolContext {
+    /// Build a context from explicit parts (consumers, tests).
+    pub fn new(caller: CallerContext, metadata: HashMap<PluginId, serde_json::Value>) -> Self {
+        Self { caller, metadata }
+    }
+
+    /// Snapshot the live pipeline context for a server-tool execution.
+    pub fn from_pipeline(ctx: &PipelineContext) -> Self {
+        Self {
+            caller: ctx.caller().clone(),
+            metadata: ctx.metadata().clone(),
+        }
+    }
+
+    /// The authenticated caller.
+    pub fn caller(&self) -> &CallerContext {
+        &self.caller
+    }
+
+    /// Read a plugin's request-scoped metadata blob (e.g. a resolved principal,
+    /// or a per-request tool declaration stashed by a pre-request hook).
+    pub fn get_metadata(&self, plugin_id: &PluginId) -> Option<&serde_json::Value> {
+        self.metadata.get(plugin_id)
+    }
+}
 
 /// A set of tools that BitRouter advertises to the model and executes itself.
 ///
@@ -18,16 +59,19 @@ use crate::language_model::types::{Tool, ToolResultOutput};
 /// own tools.
 #[async_trait]
 pub trait RouterToolset: Send + Sync {
-    /// Tools to advertise on this request, as canonical IR function tools.
-    async fn list_tools(&self, caller: &CallerContext) -> Result<Vec<Tool>>;
+    /// Tools to advertise on this request, as canonical IR function tools. `ctx`
+    /// exposes the caller and the request's metadata, so an implementation may
+    /// advertise tools conditionally on the request.
+    async fn list_tools(&self, ctx: &ToolContext) -> Result<Vec<Tool>>;
 
     /// Execute one model-issued call this set owns. `arguments` is the raw
-    /// JSON string carried on the model's `Content::ToolCall`.
+    /// JSON string carried on the model's `Content::ToolCall`; `ctx` carries the
+    /// caller and request metadata.
     async fn call_tool(
         &self,
         name: &str,
         arguments: &str,
-        caller: &CallerContext,
+        ctx: &ToolContext,
     ) -> Result<ToolResultOutput>;
 
     /// Whether this set owns `name`.
@@ -55,11 +99,11 @@ impl ToolsetRegistry {
 
     /// Every set's advertised tools, paired with the set of router-owned tool
     /// names (used by the loop to classify which calls it must execute).
-    pub async fn list_all(&self, caller: &CallerContext) -> Result<(Vec<Tool>, BTreeSet<String>)> {
+    pub async fn list_all(&self, ctx: &ToolContext) -> Result<(Vec<Tool>, BTreeSet<String>)> {
         let mut tools = Vec::new();
         let mut owned = BTreeSet::new();
         for set in &self.sets {
-            for tool in set.list_tools(caller).await? {
+            for tool in set.list_tools(ctx).await? {
                 owned.insert(tool.name().to_string());
                 tools.push(tool);
             }
@@ -84,14 +128,14 @@ mod tests {
 
     #[async_trait]
     impl RouterToolset for MockToolset {
-        async fn list_tools(&self, _caller: &CallerContext) -> Result<Vec<Tool>> {
+        async fn list_tools(&self, _ctx: &ToolContext) -> Result<Vec<Tool>> {
             Ok(self.tools.clone())
         }
         async fn call_tool(
             &self,
             name: &str,
             _arguments: &str,
-            _caller: &CallerContext,
+            _ctx: &ToolContext,
         ) -> Result<ToolResultOutput> {
             Ok(ToolResultOutput::Text {
                 value: format!("ran {name}"),
@@ -118,7 +162,8 @@ mod tests {
             tools: vec![func("search"), func("fetch")],
         });
         let reg = ToolsetRegistry::new(vec![mock]);
-        let (tools, owned) = reg.list_all(&CallerContext::local()).await.unwrap();
+        let ctx = ToolContext::new(CallerContext::local(), Default::default());
+        let (tools, owned) = reg.list_all(&ctx).await.unwrap();
         assert_eq!(tools.len(), 2);
         assert!(owned.contains("search"));
         assert!(owned.contains("fetch"));

--- a/crates/bitrouter-sdk/src/language_model/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/tests.rs
@@ -1102,12 +1102,14 @@ async fn server_tool_loop_resolves_a_router_tool_call() {
     use crate::language_model::server_tools::approval::AllowAll;
     use crate::language_model::server_tools::config::ServerToolLoopConfig;
     use crate::language_model::server_tools::loop_controller::ServerToolLoop;
-    use crate::language_model::server_tools::toolset::{RouterToolset, ToolsetRegistry};
+    use crate::language_model::server_tools::toolset::{
+        RouterToolset, ToolContext, ToolsetRegistry,
+    };
 
     struct OneTool;
     #[async_trait]
     impl RouterToolset for OneTool {
-        async fn list_tools(&self, _c: &CallerContext) -> Result<Vec<Tool>> {
+        async fn list_tools(&self, _c: &ToolContext) -> Result<Vec<Tool>> {
             Ok(vec![Tool::Function {
                 name: "search".to_string(),
                 description: None,
@@ -1120,7 +1122,7 @@ async fn server_tool_loop_resolves_a_router_tool_call() {
             &self,
             _name: &str,
             _arguments: &str,
-            _c: &CallerContext,
+            _c: &ToolContext,
         ) -> Result<ToolResultOutput> {
             Ok(ToolResultOutput::Text {
                 value: "tool ran".to_string(),
@@ -1179,12 +1181,14 @@ async fn server_tool_loop_streams_router_tool_activity() {
     use crate::language_model::server_tools::approval::AllowAll;
     use crate::language_model::server_tools::config::ServerToolLoopConfig;
     use crate::language_model::server_tools::loop_controller::ServerToolLoop;
-    use crate::language_model::server_tools::toolset::{RouterToolset, ToolsetRegistry};
+    use crate::language_model::server_tools::toolset::{
+        RouterToolset, ToolContext, ToolsetRegistry,
+    };
 
     struct OneTool;
     #[async_trait]
     impl RouterToolset for OneTool {
-        async fn list_tools(&self, _c: &CallerContext) -> Result<Vec<Tool>> {
+        async fn list_tools(&self, _c: &ToolContext) -> Result<Vec<Tool>> {
             Ok(vec![Tool::Function {
                 name: "search".to_string(),
                 description: None,
@@ -1197,7 +1201,7 @@ async fn server_tool_loop_streams_router_tool_activity() {
             &self,
             _n: &str,
             _a: &str,
-            _c: &CallerContext,
+            _c: &ToolContext,
         ) -> Result<ToolResultOutput> {
             Ok(ToolResultOutput::Text {
                 value: "ran".to_string(),


### PR DESCRIPTION
## Summary

Widens the `RouterToolset` seam (shipped in #555) so a toolset receives a per-request **`ToolContext`** instead of only a `&CallerContext`. This is the small, generic enabler for request-aware server tools — a set can advertise/configure itself from the request, and a consumer can read request-scoped state (e.g. a resolved principal) to attribute a nested call.

## What changed

- New `ToolContext { caller, metadata }` (in `server_tools::toolset`): an owned, `Clone` snapshot carrying the `CallerContext` and the request's plugin-scoped metadata map. Built via `ToolContext::from_pipeline(&PipelineContext)`.
- `RouterToolset::list_tools` / `call_tool` now take `&ToolContext` (threaded through `ToolsetRegistry`, `ServerToolLoop`, and the stream stitcher).
- `PipelineContext::metadata()` accessor added so the snapshot can copy the per-request metadata map.

## Why owned, not `&PipelineContext`

A server-tool execution can outlive the borrow: the streaming stitcher moves the context into a `'static` boxed stream. An owned, cheap-to-clone snapshot satisfies that lifetime where a borrow can't.

## Notes

- `McpRouterToolset` only needs `ctx.caller()` — behaviour unchanged.
- No new IR; near-mechanical change.

## Testing

- `cargo nextest run --all-features` — 921/921 pass.
- `cargo clippy --all-features`, `cargo fmt --check`, and the `doc` job (`cargo doc --workspace --all-features --no-deps`, `-D warnings`) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)