### PR TITLE
feat(mcp): answer the MCP initialize/ping handshake at the gateway

### DIFF
--- a/apps/bitrouter/tests/e2e.rs
+++ b/apps/bitrouter/tests/e2e.rs
@@ -529,6 +529,82 @@ async fn e2e_mcp_route_invokes_the_pure_routing_pipeline() {
     let response = router.clone().oneshot(request).await.unwrap();
     assert_eq!(response.status(), 403);
 
+    // MCP lifecycle: `initialize` is answered by the gateway itself (not proxied
+    // to the executor, which only knows tools/resources/prompts), so compliant
+    // clients can complete the handshake. A supported requested protocolVersion
+    // is echoed; serverInfo identifies the gateway.
+    let init = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": { "protocolVersion": "2025-06-18", "capabilities": {} }
+    });
+    let request = Request::builder()
+        .method("POST")
+        .uri("/mcp/known")
+        .header("content-type", "application/json")
+        .body(axum::body::Body::from(init.to_string()))
+        .unwrap();
+    let response = router.clone().oneshot(request).await.unwrap();
+    assert_eq!(response.status(), 200);
+    let bytes = axum::body::to_bytes(response.into_body(), 1 << 16)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(json["id"], 1);
+    assert_eq!(json["result"]["protocolVersion"], "2025-06-18");
+    assert!(json["result"]["capabilities"]["tools"].is_object());
+    assert_eq!(
+        json["result"]["serverInfo"]["name"],
+        "bitrouter-mcp-gateway"
+    );
+
+    // An unsupported requested version falls back to the gateway's latest.
+    let init_old = serde_json::json!({
+        "jsonrpc": "2.0", "id": 2, "method": "initialize",
+        "params": { "protocolVersion": "1999-01-01" }
+    });
+    let request = Request::builder()
+        .method("POST")
+        .uri("/mcp/known")
+        .header("content-type", "application/json")
+        .body(axum::body::Body::from(init_old.to_string()))
+        .unwrap();
+    let response = router.clone().oneshot(request).await.unwrap();
+    let bytes = axum::body::to_bytes(response.into_body(), 1 << 16)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(json["result"]["protocolVersion"], "2025-11-25");
+
+    // `notifications/initialized` is a notification — acked with 202, no body.
+    let note = serde_json::json!({ "jsonrpc": "2.0", "method": "notifications/initialized" });
+    let request = Request::builder()
+        .method("POST")
+        .uri("/mcp/known")
+        .header("content-type", "application/json")
+        .body(axum::body::Body::from(note.to_string()))
+        .unwrap();
+    let response = router.clone().oneshot(request).await.unwrap();
+    assert_eq!(response.status(), 202);
+
+    // `ping` → empty result, never proxied to the executor.
+    let ping = serde_json::json!({ "jsonrpc": "2.0", "id": 9, "method": "ping" });
+    let request = Request::builder()
+        .method("POST")
+        .uri("/mcp/known")
+        .header("content-type", "application/json")
+        .body(axum::body::Body::from(ping.to_string()))
+        .unwrap();
+    let response = router.clone().oneshot(request).await.unwrap();
+    assert_eq!(response.status(), 200);
+    let bytes = axum::body::to_bytes(response.into_body(), 1 << 16)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(json["id"], 9);
+    assert!(json["result"].as_object().unwrap().is_empty());
+
     // Unknown MCP server → JSON-RPC "Method not found" wrapped in HTTP 404.
     let bad = Request::builder()
         .method("POST")

--- a/crates/bitrouter-sdk/src/server.rs
+++ b/crates/bitrouter-sdk/src/server.rs
@@ -298,6 +298,57 @@ async fn mcp_invoke_inner(
         .cloned()
         .unwrap_or(serde_json::Value::Null);
 
+    // MCP lifecycle methods are answered by the gateway itself — they negotiate
+    // the client<->gateway session and MUST NOT be proxied to an upstream
+    // executor (which dispatches only `tools/*`, `resources/*`, `prompts/*` and
+    // rejects everything else as "method not found"). Without this, every
+    // spec-compliant client (Claude clients, opencode, the MCP SDK) fails its
+    // opening `initialize` over Streamable HTTP and never reaches a tool call;
+    // only handshake-skipping callers (curl, `bitrouter tools`) worked before.
+    // See <https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle>.
+    match method.as_str() {
+        "initialize" => {
+            // Spec: echo the client's protocol version when we support it,
+            // otherwise answer with our latest. `params.protocolVersion` is the
+            // client's requested version.
+            let protocol_version = params
+                .get("protocolVersion")
+                .and_then(|v| v.as_str())
+                .filter(|v| MCP_SUPPORTED_PROTOCOL_VERSIONS.contains(v))
+                .unwrap_or(MCP_SUPPORTED_PROTOCOL_VERSIONS[0]);
+            return Json(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": inbound_id,
+                "result": {
+                    "protocolVersion": protocol_version,
+                    // The gateway proxies tool calls; resources/prompts are not
+                    // advertised so clients don't probe upstreams that may not
+                    // implement them.
+                    "capabilities": { "tools": {} },
+                    "serverInfo": {
+                        "name": "bitrouter-mcp-gateway",
+                        "version": env!("CARGO_PKG_VERSION"),
+                    },
+                },
+            }))
+            .into_response();
+        }
+        // JSON-RPC notifications carry no `id` and expect no result body — ack
+        // with 202 Accepted per the Streamable HTTP transport.
+        "notifications/initialized" | "notifications/cancelled" => {
+            return axum::http::StatusCode::ACCEPTED.into_response();
+        }
+        "ping" => {
+            return Json(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": inbound_id,
+                "result": {},
+            }))
+            .into_response();
+        }
+        _ => {}
+    }
+
     // Default caller: `local` when auth is disabled, otherwise an `anonymous`
     // placeholder that a downstream `mcp::PreRequestHook` may upgrade to the
     // real identity by reading `ctx.headers()` and calling `ctx.set_caller()`.


### PR DESCRIPTION
## Problem

BitRouter's MCP gateway proxied **every** inbound JSON-RPC method to the per-upstream `RmcpExecutor`, whose dispatch only knows `tools/*`, `resources/*`, `prompts/*` and rejects anything else as `-32601 "method not found"`. But every spec-compliant MCP client opens a connection with the lifecycle handshake — `POST initialize`, then `notifications/initialized`.

Result: over Streamable HTTP a client's opening `initialize` got `-32601`; the client then fell back to the legacy SSE transport (`GET /mcp/{server}` → `405`, since only `POST` is mounted) and gave up. Only handshake-skipping callers (curl, `bitrouter tools`) ever worked.

Confirmed with **opencode 1.3.0** — its debug log shows StreamableHTTP failing on `initialize`, then SSE failing on the 405:

```
transport=StreamableHTTP url=.../mcp/memory
  error=Error POSTing to endpoint: {"code":-32601,"message":"... method 'initialize' not supported by v1.0 RmcpExecutor"}
transport=SSE url=.../mcp/memory  error=Non-200 status code (405)
```

## Fix

Answer the MCP lifecycle methods at the gateway itself (it *is* the MCP server from the client's perspective) instead of proxying them to an upstream executor:

- `initialize` → negotiate the protocol version (echo the client's requested version when supported, else the gateway's latest from `MCP_SUPPORTED_PROTOCOL_VERSIONS`), advertise `serverInfo` + `tools` capability.
- `notifications/initialized` / `notifications/cancelled` → `202 Accepted`, no body.
- `ping` → empty result.

Handled in `mcp_invoke_inner` before the request reaches the pipeline/executor, so it covers both `POST /mcp/{server}` and the aggregate `POST /mcp`.

## Verification

- New e2e assertions (`apps/bitrouter/tests/e2e.rs`): `initialize` → 200 with the echoed/clamped protocol version and `serverInfo.name`; an unsupported requested version falls back to the gateway's latest; `notifications/initialized` → 202; `ping` → empty result.
- Live: opencode now reports `✓ memory connected` to the gateway over Streamable HTTP and can drive tool calls through it.

## Scope

This unblocks **any** compliant MCP client on the gateway and is independent of the Walrus-memory namespace-scoping work (touches only `crates/bitrouter-sdk/src/server.rs` and `apps/bitrouter/tests/e2e.rs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
