### PR TITLE
chore(release): bump workspace to v1.0.0-alpha.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "bitrouter"
-version = "1.0.0-alpha.15"
+version = "1.0.0-alpha.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -783,7 +783,7 @@ dependencies = [
 
 [[package]]
 name = "bitrouter-attestation"
-version = "1.0.0-alpha.15"
+version = "1.0.0-alpha.16"
 dependencies = [
  "async-trait",
  "dcap-qvl",
@@ -802,7 +802,7 @@ dependencies = [
 
 [[package]]
 name = "bitrouter-attestation-plugin"
-version = "1.0.0-alpha.15"
+version = "1.0.0-alpha.16"
 dependencies = [
  "async-trait",
  "bitrouter-attestation",
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "bitrouter-bedrock"
-version = "1.0.0-alpha.15"
+version = "1.0.0-alpha.16"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -828,7 +828,7 @@ dependencies = [
 
 [[package]]
 name = "bitrouter-cloud-sdk"
-version = "1.0.0-alpha.15"
+version = "1.0.0-alpha.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "bitrouter-guardrails"
-version = "1.0.0-alpha.15"
+version = "1.0.0-alpha.16"
 dependencies = [
  "async-trait",
  "bitrouter-sdk",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "bitrouter-mcp"
-version = "1.0.0-alpha.15"
+version = "1.0.0-alpha.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -884,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "bitrouter-observe"
-version = "1.0.0-alpha.15"
+version = "1.0.0-alpha.16"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -908,7 +908,7 @@ dependencies = [
 
 [[package]]
 name = "bitrouter-providers"
-version = "1.0.0-alpha.15"
+version = "1.0.0-alpha.16"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "bitrouter-sdk"
-version = "1.0.0-alpha.15"
+version = "1.0.0-alpha.16"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "bitrouter-skills"
-version = "1.0.0-alpha.15"
+version = "1.0.0-alpha.16"
 dependencies = [
  "reqwest 0.12.28",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*", "plugins/*", "apps/*", "mcp"]
 
 [workspace.package]
-version = "1.0.0-alpha.15"
+version = "1.0.0-alpha.16"
 edition = "2024"
 license = "Apache-2.0"
 authors = ["Archer <archer@bitrouter.ai>"]
@@ -15,15 +15,15 @@ rust-version = "1.88"
 
 [workspace.dependencies]
 # internal crates
-bitrouter-sdk = { path = "crates/bitrouter-sdk", version = "1.0.0-alpha.15", default-features = false }
-bitrouter-attestation = { path = "crates/bitrouter-attestation", version = "1.0.0-alpha.15" }
-bitrouter-bedrock = { path = "crates/bitrouter-bedrock", version = "1.0.0-alpha.15" }
-bitrouter-cloud-sdk = { path = "crates/bitrouter-cloud-sdk", version = "1.0.0-alpha.15" }
-bitrouter-providers = { path = "crates/bitrouter-providers", version = "1.0.0-alpha.15" }
-bitrouter-skills = { path = "crates/bitrouter-skills", version = "1.0.0-alpha.15" }
-bitrouter-guardrails = { path = "plugins/bitrouter-guardrails", version = "1.0.0-alpha.15" }
-bitrouter-attestation-plugin = { path = "plugins/bitrouter-attestation", version = "1.0.0-alpha.15" }
-bitrouter-observe = { path = "plugins/bitrouter-observe", version = "1.0.0-alpha.15", default-features = false }
+bitrouter-sdk = { path = "crates/bitrouter-sdk", version = "1.0.0-alpha.16", default-features = false }
+bitrouter-attestation = { path = "crates/bitrouter-attestation", version = "1.0.0-alpha.16" }
+bitrouter-bedrock = { path = "crates/bitrouter-bedrock", version = "1.0.0-alpha.16" }
+bitrouter-cloud-sdk = { path = "crates/bitrouter-cloud-sdk", version = "1.0.0-alpha.16" }
+bitrouter-providers = { path = "crates/bitrouter-providers", version = "1.0.0-alpha.16" }
+bitrouter-skills = { path = "crates/bitrouter-skills", version = "1.0.0-alpha.16" }
+bitrouter-guardrails = { path = "plugins/bitrouter-guardrails", version = "1.0.0-alpha.16" }
+bitrouter-attestation-plugin = { path = "plugins/bitrouter-attestation", version = "1.0.0-alpha.16" }
+bitrouter-observe = { path = "plugins/bitrouter-observe", version = "1.0.0-alpha.16", default-features = false }
 
 # shared third-party
 anyhow = "1"

--- a/apps/bitrouter/Cargo.toml
+++ b/apps/bitrouter/Cargo.toml
@@ -24,7 +24,7 @@ bitrouter-providers = { workspace = true, features = ["pkce"] }
 bitrouter-skills.workspace = true
 bitrouter-guardrails.workspace = true
 bitrouter-observe = { workspace = true, features = ["otel-http"] }
-bitrouter-mcp = { path = "../../mcp", version = "1.0.0-alpha.15" }
+bitrouter-mcp = { path = "../../mcp", version = "1.0.0-alpha.16" }
 chrono.workspace = true
 sha2.workspace = true
 base64.workspace = true


### PR DESCRIPTION
Bumps the workspace version `1.0.0-alpha.15` → `1.0.0-alpha.16` (all crates inherit via `version.workspace`, plus internal dependency pins in the root `Cargo.toml`, the `bitrouter-mcp` pin in `apps/bitrouter/Cargo.toml`, and `Cargo.lock`).

This accompanies the alpha.16 release. The new leaf crate `bitrouter-attestation` was published to crates.io manually at `v1.0.0-alpha.16` to claim the name (the automated release token cannot publish brand-new crates); subsequent versions can go through trusted publishing.

Note: `bitrouter-attestation-plugin` is also a new, never-published crate and will need the same treatment (it can only be published after `bitrouter-sdk v1.0.0-alpha.16` is on crates.io, since it depends on it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)