### PR TITLE
feat(fusion): multi-model deliberation server tool + alias

### DIFF
--- a/apps/bitrouter/src/assemble.rs
+++ b/apps/bitrouter/src/assemble.rs
@@ -317,11 +317,18 @@ pub async fn build_app_with_path(
     // is configured. The panel/judge run on a dedicated, loop-less
     // sub-completion pipeline (so a panel member cannot recursively invoke
     // Fusion), reusing the same routing table and upstream executor as the main
-    // pipeline.
+    // pipeline. The metering recorder is attached so each nested panel/judge
+    // completion is billed to the same caller as the parent request (no auth or
+    // policy hooks — a nested call is a sub-operation of an already-authorised
+    // request, and the parent principal is carried on the caller context).
     let fusion_runner: Option<Arc<dyn NestedRunner>> = if config.server_tools.fusion.is_some() {
         let mut sub = PipelineBuilder::new();
         sub.routing_table(routing_table.clone())
-            .executor(executor.clone());
+            .executor(executor.clone())
+            .settlement_recorder(MeteringRecorder::new(
+                metering_store.clone(),
+                pricing.clone(),
+            ));
         let sub_pipeline = Arc::new(
             sub.build()
                 .context("building the fusion sub-completion pipeline")?,

--- a/apps/bitrouter/src/assemble.rs
+++ b/apps/bitrouter/src/assemble.rs
@@ -10,15 +10,20 @@ use anyhow::{Context, Result};
 use sea_orm::DatabaseConnection;
 
 use bitrouter_sdk::App;
+use bitrouter_sdk::PromptTransform;
 use bitrouter_sdk::acp::{AcpStdioExecutor, ConfigAcpRoutingTable};
 use bitrouter_sdk::config::{Config, ConfigRoutingTable};
 use bitrouter_sdk::language_model::protocol::OutboundDispatch;
 use bitrouter_sdk::language_model::server_tools::approval::AllowAll;
 use bitrouter_sdk::language_model::server_tools::config::ServerToolLoopConfig;
+use bitrouter_sdk::language_model::server_tools::fusion::FusionToolset;
+use bitrouter_sdk::language_model::server_tools::fusion::alias::FusionAliasConfig;
+use bitrouter_sdk::language_model::server_tools::fusion::declarations::FusionDeclarationsHook;
 use bitrouter_sdk::language_model::server_tools::loop_controller::ServerToolLoop;
 use bitrouter_sdk::language_model::server_tools::mcp_toolset::McpRouterToolset;
+use bitrouter_sdk::language_model::server_tools::nested::{NestedRunner, PipelineNestedRunner};
 use bitrouter_sdk::language_model::server_tools::toolset::{RouterToolset, ToolsetRegistry};
-use bitrouter_sdk::language_model::{AuthAppliers, HttpExecutor, HttpTimeouts};
+use bitrouter_sdk::language_model::{AuthAppliers, HttpExecutor, HttpTimeouts, PipelineBuilder};
 use bitrouter_sdk::mcp::aggregating_executor::AggregatingExecutor;
 use bitrouter_sdk::mcp::caching_executor::{CacheTtls, CachingExecutor};
 use bitrouter_sdk::mcp::config_routing::{ConfigMcpRoutingTable, McpServerAggregateConfig};
@@ -308,11 +313,41 @@ pub async fn build_app_with_path(
         }
     });
 
-    // Server-side tool loop — wired only when `server_tools.mcp_servers` names
-    // at least one configured MCP server. Reuses the MCP executor/routing built
-    // above; here BitRouter is an MCP *client* that executes the model's tool
-    // calls inside the LLM loop (distinct from the `/mcp` gateway above).
-    let server_tool_loop = build_server_tool_loop(config, &mcp_routing, &mcp_executor);
+    // Fusion (multi-model deliberation) — built only when `server_tools.fusion`
+    // is configured. The panel/judge run on a dedicated, loop-less
+    // sub-completion pipeline (so a panel member cannot recursively invoke
+    // Fusion), reusing the same routing table and upstream executor as the main
+    // pipeline.
+    let fusion_runner: Option<Arc<dyn NestedRunner>> = if config.server_tools.fusion.is_some() {
+        let mut sub = PipelineBuilder::new();
+        sub.routing_table(routing_table.clone())
+            .executor(executor.clone());
+        let sub_pipeline = Arc::new(
+            sub.build()
+                .context("building the fusion sub-completion pipeline")?,
+        );
+        Some(Arc::new(PipelineNestedRunner::new(sub_pipeline)))
+    } else {
+        None
+    };
+
+    // Server-side tool loop — wired when `server_tools.mcp_servers` names a
+    // configured MCP server and/or Fusion is enabled. Reuses the MCP
+    // executor/routing built above; here BitRouter is an MCP *client* that
+    // executes the model's tool calls inside the LLM loop (distinct from the
+    // `/mcp` gateway above).
+    let server_tool_loop =
+        build_server_tool_loop(config, &mcp_routing, &mcp_executor, fusion_runner);
+
+    // The bitrouter/fusion model alias (an ingress prompt transform) and the
+    // Fusion declaration-parsing hook are wired below when Fusion is enabled.
+    let fusion_enabled = config.server_tools.fusion.is_some();
+    let fusion_alias: Option<Arc<dyn PromptTransform>> = config
+        .server_tools
+        .fusion
+        .as_ref()
+        .and_then(FusionAliasConfig::from_settings)
+        .map(|c| Arc::new(c) as Arc<dyn PromptTransform>);
 
     // Optional ACP pure-routing pipeline — wired only when the config
     // declares at least one upstream agent. Mirrors the MCP wiring above;
@@ -337,6 +372,13 @@ pub async fn build_app_with_path(
         .metrics_renderer(metrics_renderer)
         .language_model(move |lm| {
             lm.routing_table(routing_table).executor(executor);
+            // Fusion declaration capture runs first and is pure observation: it
+            // parses any bitrouter:fusion declaration (or the one the alias
+            // injected) off the prompt and stashes the resolved config, before
+            // auth, so the toolset can read it regardless of credential state.
+            if fusion_enabled {
+                lm.pre_request_hook(FusionDeclarationsHook);
+            }
             // Stage 1, in order: auth → policy. The guardrail plugin appends its
             // hooks after this closure (see `.plugin(...)` below), preserving the
             // auth → policy → guardrail order.
@@ -371,6 +413,13 @@ pub async fn build_app_with_path(
         app
     } else {
         app.plugin(GuardrailsPlugin::with_static(guardrail_rules))
+    };
+    // The bitrouter/fusion model alias: an ingress prompt transform that
+    // rewrites the alias onto a real outer model and attaches the Fusion
+    // declaration. Wired only when `server_tools.fusion` resolves an alias.
+    let app = match fusion_alias {
+        Some(transform) => app.prompt_transform(transform),
+        None => app,
     };
     // Apply the optional MCP pipeline configuration in a second builder step
     // so the language_model configuration above stays the same shape it has
@@ -409,47 +458,56 @@ pub async fn build_app_with_path(
     })
 }
 
-/// Build the server-side tool loop from `config.server_tools` over the MCP
-/// executor/routing already assembled for the `/mcp` gateway. Returns `None`
-/// when no `server_tools.mcp_servers` are configured (or the MCP stack is
-/// absent). Each named server is attached as an [`McpRouterToolset`] using a
-/// `Direct` selector and the server's `tool_prefix` (default `"{name}__"`), so
-/// router tool names cannot collide with the caller's own tools.
+/// Build the server-side tool loop from `config.server_tools`. Returns `None`
+/// when neither MCP server tools nor Fusion are configured.
+///
+/// Each named MCP server is attached as an [`McpRouterToolset`] using a `Direct`
+/// selector and the server's `tool_prefix` (default `"{name}__"`), so router
+/// tool names cannot collide with the caller's own tools. When `fusion_runner`
+/// is provided, the `bitrouter:fusion` [`FusionToolset`] is added over it.
 fn build_server_tool_loop(
     config: &Config,
     mcp_routing: &Option<Arc<ConfigMcpRoutingTable>>,
     mcp_executor: &Option<Arc<dyn bitrouter_sdk::mcp::Executor>>,
+    fusion_runner: Option<Arc<dyn NestedRunner>>,
 ) -> Option<Arc<ServerToolLoop>> {
     let settings = &config.server_tools;
-    if settings.mcp_servers.is_empty() {
-        return None;
+    let mut sets: Vec<Arc<dyn RouterToolset>> = Vec::new();
+
+    // MCP-backed server tools.
+    if !settings.mcp_servers.is_empty() {
+        if let (Some(routing), Some(executor)) = (mcp_routing, mcp_executor) {
+            let routing: Arc<dyn bitrouter_sdk::mcp::RoutingTable> = routing.clone();
+            for name in &settings.mcp_servers {
+                let Some(server) = config.mcp_servers.get(name) else {
+                    tracing::warn!(server = %name,
+                        "server_tools.mcp_servers names an MCP server absent from mcp_servers; skipping");
+                    continue;
+                };
+                let prefix = server
+                    .tool_prefix
+                    .clone()
+                    .unwrap_or_else(|| format!("{name}__"));
+                sets.push(Arc::new(McpRouterToolset::new(
+                    executor.clone(),
+                    routing.clone(),
+                    name.clone(),
+                    Some(prefix),
+                )));
+            }
+        } else {
+            tracing::warn!(
+                "server_tools.mcp_servers is set but no mcp_servers are configured; \
+                 MCP server tools are disabled"
+            );
+        }
     }
-    let (Some(routing), Some(executor)) = (mcp_routing, mcp_executor) else {
-        tracing::warn!(
-            "server_tools.mcp_servers is set but no mcp_servers are configured; \
-             the server-side tool loop is disabled"
-        );
-        return None;
-    };
-    let routing: Arc<dyn bitrouter_sdk::mcp::RoutingTable> = routing.clone();
-    let mut sets: Vec<Arc<dyn RouterToolset>> = Vec::with_capacity(settings.mcp_servers.len());
-    for name in &settings.mcp_servers {
-        let Some(server) = config.mcp_servers.get(name) else {
-            tracing::warn!(server = %name,
-                "server_tools.mcp_servers names an MCP server absent from mcp_servers; skipping");
-            continue;
-        };
-        let prefix = server
-            .tool_prefix
-            .clone()
-            .unwrap_or_else(|| format!("{name}__"));
-        sets.push(Arc::new(McpRouterToolset::new(
-            executor.clone(),
-            routing.clone(),
-            name.clone(),
-            Some(prefix),
-        )));
+
+    // Fusion multi-model deliberation tool.
+    if let Some(runner) = fusion_runner {
+        sets.push(Arc::new(FusionToolset::new(runner)));
     }
+
     if sets.is_empty() {
         return None;
     }
@@ -713,19 +771,51 @@ mod otel_config_tests {
 
 #[cfg(test)]
 mod server_tools_tests {
+    use std::sync::Arc;
+
+    use bitrouter_sdk::language_model::server_tools::nested::{
+        NestedOutcome, NestedRequest, NestedRunner,
+    };
+    use bitrouter_sdk::language_model::server_tools::toolset::ToolContext;
+
     use super::{Config, build_server_tool_loop};
+
+    struct NoopRunner;
+    #[async_trait::async_trait]
+    impl NestedRunner for NoopRunner {
+        async fn run(
+            &self,
+            req: NestedRequest,
+            _ctx: &ToolContext,
+        ) -> std::result::Result<NestedOutcome, String> {
+            Ok(NestedOutcome {
+                model: req.model,
+                text: String::new(),
+                usage: Default::default(),
+            })
+        }
+    }
 
     #[test]
     fn no_loop_when_server_tools_unset() {
         let config = Config::default();
-        assert!(build_server_tool_loop(&config, &None, &None).is_none());
+        assert!(build_server_tool_loop(&config, &None, &None, None).is_none());
     }
 
     #[test]
     fn no_loop_when_named_but_mcp_stack_absent() {
         let mut config = Config::default();
         config.server_tools.mcp_servers = vec!["docs".to_string()];
-        // server_tools names a server but no MCP executor/routing was built.
-        assert!(build_server_tool_loop(&config, &None, &None).is_none());
+        // server_tools names a server but no MCP executor/routing was built,
+        // and Fusion is not enabled.
+        assert!(build_server_tool_loop(&config, &None, &None, None).is_none());
+    }
+
+    #[test]
+    fn loop_built_for_fusion_even_without_mcp() {
+        let config = Config::default();
+        let runner: Arc<dyn NestedRunner> = Arc::new(NoopRunner);
+        // A Fusion runner alone is enough to build the loop.
+        assert!(build_server_tool_loop(&config, &None, &None, Some(runner)).is_some());
     }
 }

--- a/apps/bitrouter/tests/e2e.rs
+++ b/apps/bitrouter/tests/e2e.rs
@@ -145,6 +145,7 @@ async fn e2e_http_server_chat_completions_end_to_end() {
         mcp: assembled.app.mcp().cloned(),
         skip_auth: assembled.app.skip_auth(),
         metrics_renderer: assembled.app.metrics_renderer().cloned(),
+        prompt_transforms: assembled.app.prompt_transforms().to_vec(),
     };
     let server = TestServer::new(build_router(state));
 
@@ -440,6 +441,7 @@ async fn e2e_mcp_route_invokes_the_pure_routing_pipeline() {
         mcp: app.mcp().cloned(),
         skip_auth: true,
         metrics_renderer: None,
+        prompt_transforms: Vec::new(),
     };
     let router = build_router(state);
 
@@ -743,6 +745,7 @@ async fn e2e_mcp_aggregate_and_sse_endpoints() {
         mcp: app.mcp().cloned(),
         skip_auth: true,
         metrics_renderer: None,
+        prompt_transforms: Vec::new(),
     };
     let options = RouterOptions {
         omit_v1_models: false,
@@ -1006,6 +1009,7 @@ async fn matrix_server() -> (TestServer, MockServer) {
         mcp: assembled.app.mcp().cloned(),
         skip_auth: assembled.app.skip_auth(),
         metrics_renderer: assembled.app.metrics_renderer().cloned(),
+        prompt_transforms: assembled.app.prompt_transforms().to_vec(),
     };
     (TestServer::new(build_router(state)), upstream)
 }

--- a/apps/bitrouter/tests/full_stack.rs
+++ b/apps/bitrouter/tests/full_stack.rs
@@ -215,6 +215,7 @@ plugins:
         mcp: assembled.app.mcp().cloned(),
         skip_auth: assembled.app.skip_auth(),
         metrics_renderer: assembled.app.metrics_renderer().cloned(),
+        prompt_transforms: assembled.app.prompt_transforms().to_vec(),
     };
     let router = build_router(state);
     let server = TestServer::new(router);

--- a/apps/bitrouter/tests/observe_hierarchy.rs
+++ b/apps/bitrouter/tests/observe_hierarchy.rs
@@ -180,6 +180,7 @@ plugins:
         mcp: assembled.app.mcp().cloned(),
         skip_auth: assembled.app.skip_auth(),
         metrics_renderer: assembled.app.metrics_renderer().cloned(),
+        prompt_transforms: assembled.app.prompt_transforms().to_vec(),
     };
     let options = RouterOptions::default()
         .with_router_wrapper(bitrouter_observe::otel::http_layer::router_wrapper());

--- a/crates/bitrouter-sdk/src/app.rs
+++ b/crates/bitrouter-sdk/src/app.rs
@@ -58,6 +58,20 @@ pub trait Plugin {
     fn install(&self, app: &mut AppBuilder);
 }
 
+/// An ingress-time rewrite of a parsed request [`Prompt`], applied by the HTTP
+/// server after protocol parsing and before the request enters the pipeline.
+///
+/// This is the seam for transforms that must touch the prompt body — its
+/// `tools`, `tool_choice`, or `system` — which the pipeline context exposes
+/// read-only downstream. The `bitrouter/fusion` model alias is the first
+/// consumer: it rewrites the alias model to a real one and attaches the Fusion
+/// declaration. Transforms run in registration order.
+pub trait PromptTransform: Send + Sync {
+    /// Rewrite the prompt in place. A transform that does not apply to this
+    /// request leaves it untouched.
+    fn apply(&self, prompt: &mut language_model::types::Prompt);
+}
+
 /// A fully assembled application: one pipeline per enabled protocol, plus the
 /// injected infrastructure and the collected migration set.
 pub struct App {
@@ -70,6 +84,8 @@ pub struct App {
     migrations: Vec<MigrationItem>,
     skip_auth: bool,
     mcp_aggregate_route: Option<String>,
+    /// Ingress-time prompt transforms, applied by the HTTP server in order.
+    prompt_transforms: Vec<Arc<dyn PromptTransform>>,
 }
 
 impl App {
@@ -113,6 +129,12 @@ impl App {
         self.metrics_renderer.as_ref()
     }
 
+    /// The ingress-time prompt transforms wired into the app, applied by the
+    /// HTTP server in registration order before a request enters the pipeline.
+    pub fn prompt_transforms(&self) -> &[Arc<dyn PromptTransform>] {
+        &self.prompt_transforms
+    }
+
     /// HTTP path for the MCP aggregate route, when configured (`POST <path>`
     /// fans out across every `aggregate: true` MCP server). `None` means
     /// only per-server routes (`POST /mcp/{server}`) are mounted.
@@ -132,6 +154,7 @@ pub struct AppBuilder {
     migrations: Vec<MigrationItem>,
     skip_auth: bool,
     mcp_aggregate_route: Option<String>,
+    prompt_transforms: Vec<Arc<dyn PromptTransform>>,
 }
 
 impl AppBuilder {
@@ -145,6 +168,7 @@ impl AppBuilder {
             migrations: Vec::new(),
             skip_auth: false,
             mcp_aggregate_route: None,
+            prompt_transforms: Vec::new(),
         }
     }
 
@@ -201,6 +225,15 @@ impl AppBuilder {
     /// `Arc<PrometheusHook>` you registered as an `ObserveHook`.
     pub fn metrics_renderer(mut self, renderer: Arc<dyn MetricsRenderer>) -> Self {
         self.metrics_renderer = Some(renderer);
+        self
+    }
+
+    /// Register an ingress-time [`PromptTransform`]. The HTTP server applies it
+    /// (and any others, in registration order) after protocol parsing, before
+    /// the request enters the pipeline. Used to wire model aliases such as
+    /// `bitrouter/fusion`.
+    pub fn prompt_transform(mut self, transform: Arc<dyn PromptTransform>) -> Self {
+        self.prompt_transforms.push(transform);
         self
     }
 
@@ -264,6 +297,7 @@ impl AppBuilder {
             migrations: self.migrations,
             skip_auth: self.skip_auth,
             mcp_aggregate_route,
+            prompt_transforms: self.prompt_transforms,
         })
     }
 }
@@ -271,5 +305,44 @@ impl AppBuilder {
 impl Default for AppBuilder {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::language_model::types::{GenerationParams, Prompt, ProviderMetadata};
+
+    struct SetModel(&'static str);
+    impl PromptTransform for SetModel {
+        fn apply(&self, prompt: &mut Prompt) {
+            prompt.model = self.0.to_string();
+        }
+    }
+
+    fn bare_prompt() -> Prompt {
+        Prompt {
+            model: "orig".to_string(),
+            system: None,
+            system_provider_metadata: ProviderMetadata::new(),
+            messages: Vec::new(),
+            tools: Vec::new(),
+            params: GenerationParams::default(),
+            response_format: None,
+            tool_choice: None,
+            stream: false,
+        }
+    }
+
+    #[test]
+    fn registers_and_applies_prompt_transforms() {
+        let app = AppBuilder::new()
+            .prompt_transform(Arc::new(SetModel("x/y")))
+            .build()
+            .unwrap();
+        assert_eq!(app.prompt_transforms().len(), 1);
+        let mut prompt = bare_prompt();
+        app.prompt_transforms()[0].apply(&mut prompt);
+        assert_eq!(prompt.model, "x/y");
     }
 }

--- a/crates/bitrouter-sdk/src/app.rs
+++ b/crates/bitrouter-sdk/src/app.rs
@@ -58,8 +58,9 @@ pub trait Plugin {
     fn install(&self, app: &mut AppBuilder);
 }
 
-/// An ingress-time rewrite of a parsed request [`Prompt`], applied by the HTTP
-/// server after protocol parsing and before the request enters the pipeline.
+/// An ingress-time rewrite of a parsed request [`Prompt`](language_model::types::Prompt),
+/// applied by the HTTP server after protocol parsing and before the request
+/// enters the pipeline.
 ///
 /// This is the seam for transforms that must touch the prompt body — its
 /// `tools`, `tool_choice`, or `system` — which the pipeline context exposes

--- a/crates/bitrouter-sdk/src/language_model/server_tools/config.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/config.rs
@@ -46,4 +46,7 @@ pub struct ServerToolsConfig {
     pub mcp_servers: Vec<String>,
     /// Optional override of the loop's maximum tool-execution rounds.
     pub max_iterations: Option<u32>,
+    /// Multi-model deliberation (Fusion). When set, the `bitrouter:fusion`
+    /// server tool and the `bitrouter/fusion` model alias are enabled.
+    pub fusion: Option<super::fusion::config::FusionSettings>,
 }

--- a/crates/bitrouter-sdk/src/language_model/server_tools/fusion/alias.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/fusion/alias.rs
@@ -124,8 +124,8 @@ impl crate::app::PromptTransform for FusionAliasConfig {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use super::super::config::{FusionConfig, FusionSettings};
+    use super::*;
     use crate::language_model::types::{GenerationParams, ProviderMetadata};
 
     fn prompt_with_model(model: &str) -> Prompt {
@@ -240,7 +240,12 @@ mod tests {
         cfg.synthesizer = Some("openai/gpt-latest".to_string());
         let mut prompt = prompt_with_model("bitrouter/fusion");
         cfg.apply(&mut prompt);
-        let decl = prompt.tools.iter().find(|t| t.name() == "fusion").unwrap().clone();
+        let decl = prompt
+            .tools
+            .iter()
+            .find(|t| t.name() == "fusion")
+            .unwrap()
+            .clone();
         let parsed = FusionConfig::from_tool(&decl, "x").unwrap();
         assert_eq!(parsed.synthesizer.as_deref(), Some("openai/gpt-latest"));
     }

--- a/crates/bitrouter-sdk/src/language_model/server_tools/fusion/alias.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/fusion/alias.rs
@@ -1,0 +1,182 @@
+//! The `bitrouter/fusion` model alias — the bitrouter analog of OpenRouter's
+//! Fusion Router.
+//!
+//! A request addressed to the alias is rewritten, before the pipeline sees it,
+//! into a normal request on a default outer model carrying a `bitrouter:fusion`
+//! declaration. The declaration then flows through the ordinary
+//! declaration → hook → toolset path. This is an ingress transform (the
+//! pipeline context exposes the prompt read-only), so a consumer calls
+//! [`FusionAliasConfig::apply`] while building the request.
+//!
+//! The model is *nudged* toward the tool via the system prompt rather than
+//! forced via `tool_choice`: the server-tool loop reuses `tool_choice` across
+//! turns, so forcing it would re-trigger the deliberation every iteration.
+//!
+//! Reference: <https://openrouter.ai/docs/guides/features/server-tools/fusion>
+
+use super::config::{DEFAULT_MAX_STEPS, FUSION_TOOL};
+use crate::language_model::types::{Prompt, ProviderMetadata, Tool};
+
+/// The defaults the alias expands to (the "Quality" preset by default).
+#[derive(Clone, Debug)]
+pub struct FusionAliasConfig {
+    /// The model slug that triggers the alias (e.g. `bitrouter/fusion`).
+    pub alias: String,
+    /// The model the alias resolves the request to.
+    pub outer_model: String,
+    /// Default panel models.
+    pub panel: Vec<String>,
+    /// Default judge model.
+    pub judge: String,
+    /// Optional dedicated synthesizer model.
+    pub synthesizer: Option<String>,
+    /// Provider web tools forwarded to every panel member (web_search/fetch),
+    /// in provider-namespaced declaration form.
+    pub web_tools: Vec<serde_json::Value>,
+}
+
+impl FusionAliasConfig {
+    /// Rewrite a prompt addressed to the alias: swap in the outer model, inject
+    /// the `bitrouter:fusion` declaration, and nudge the model toward it. Returns
+    /// `true` when the alias matched and the prompt was rewritten.
+    pub fn apply(&self, prompt: &mut Prompt) -> bool {
+        if prompt.model != self.alias {
+            return false;
+        }
+        prompt.model = self.outer_model.clone();
+        prompt.tools.push(self.declaration());
+        let nudge = "This request uses multi-model deliberation. Call the `fusion` \
+                     tool once with the user's question as `prompt`, then write your \
+                     final answer grounded in the returned analysis.";
+        prompt.system = Some(match prompt.system.take() {
+            Some(existing) => format!("{existing}\n\n{nudge}"),
+            None => nudge.to_string(),
+        });
+        true
+    }
+
+    fn declaration(&self) -> Tool {
+        let panel: Vec<serde_json::Value> = self
+            .panel
+            .iter()
+            .map(|m| serde_json::json!({ "model": m, "tools": self.web_tools }))
+            .collect();
+        let mut args = serde_json::json!({
+            "panel": panel,
+            "judge": { "model": self.judge },
+            "max_steps": DEFAULT_MAX_STEPS,
+        });
+        if let Some(synth) = &self.synthesizer {
+            args["synthesizer"] = serde_json::json!(synth);
+        }
+        Tool::ProviderDefined {
+            // Named `fusion` (not the namespaced form) so the loop's inject step
+            // strips this declaration before the upstream call.
+            id: "bitrouter.fusion".to_string(),
+            name: FUSION_TOOL.to_string(),
+            args,
+            provider_metadata: ProviderMetadata::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use super::super::config::FusionConfig;
+    use crate::language_model::types::{GenerationParams, ProviderMetadata};
+
+    fn prompt_with_model(model: &str) -> Prompt {
+        Prompt {
+            model: model.to_string(),
+            system: None,
+            system_provider_metadata: ProviderMetadata::new(),
+            messages: Vec::new(),
+            tools: Vec::new(),
+            params: GenerationParams::default(),
+            response_format: None,
+            tool_choice: None,
+            stream: false,
+        }
+    }
+
+    fn sample_cfg() -> FusionAliasConfig {
+        FusionAliasConfig {
+            alias: "bitrouter/fusion".to_string(),
+            outer_model: "anthropic/claude-opus-4.8".to_string(),
+            panel: vec![
+                "anthropic/claude-opus-4.8".to_string(),
+                "openai/gpt-latest".to_string(),
+            ],
+            judge: "anthropic/claude-opus-4.8".to_string(),
+            synthesizer: None,
+            web_tools: vec![serde_json::json!({
+                "type": "anthropic:web_search_20250305", "name": "web_search"
+            })],
+        }
+    }
+
+    #[test]
+    fn rewrites_alias_and_injects_a_parseable_declaration() {
+        let cfg = sample_cfg();
+        let mut prompt = prompt_with_model("bitrouter/fusion");
+        assert!(cfg.apply(&mut prompt));
+        assert_eq!(prompt.model, "anthropic/claude-opus-4.8");
+
+        // The injected declaration is named `fusion` so the loop strips it
+        // before the upstream call, and it parses back into a FusionConfig.
+        let decl = prompt
+            .tools
+            .iter()
+            .find(|t| t.name() == "fusion")
+            .expect("fusion declaration injected")
+            .clone();
+        let parsed = FusionConfig::from_tool(&decl, "anthropic/claude-opus-4.8").unwrap();
+        assert_eq!(parsed.panel.len(), 2);
+        assert_eq!(parsed.judge.model, "anthropic/claude-opus-4.8");
+        // The per-member web tool rides along.
+        assert_eq!(parsed.panel[0].tools.len(), 1);
+
+        // System nudges the model toward the fusion tool.
+        assert!(
+            prompt
+                .system
+                .as_deref()
+                .unwrap_or("")
+                .to_lowercase()
+                .contains("fusion")
+        );
+    }
+
+    #[test]
+    fn preserves_an_existing_system_prompt() {
+        let cfg = sample_cfg();
+        let mut prompt = prompt_with_model("bitrouter/fusion");
+        prompt.system = Some("Be terse.".to_string());
+        cfg.apply(&mut prompt);
+        let system = prompt.system.unwrap();
+        assert!(system.starts_with("Be terse."));
+        assert!(system.to_lowercase().contains("fusion"));
+    }
+
+    #[test]
+    fn leaves_non_alias_requests_untouched() {
+        let cfg = sample_cfg();
+        let mut prompt = prompt_with_model("anthropic/claude-opus-4.8");
+        assert!(!cfg.apply(&mut prompt));
+        assert!(prompt.tools.is_empty());
+        assert!(prompt.system.is_none());
+        assert_eq!(prompt.model, "anthropic/claude-opus-4.8");
+    }
+
+    #[test]
+    fn forwards_synthesizer_when_configured() {
+        let mut cfg = sample_cfg();
+        cfg.synthesizer = Some("openai/gpt-latest".to_string());
+        let mut prompt = prompt_with_model("bitrouter/fusion");
+        cfg.apply(&mut prompt);
+        let decl = prompt.tools.iter().find(|t| t.name() == "fusion").unwrap().clone();
+        let parsed = FusionConfig::from_tool(&decl, "x").unwrap();
+        assert_eq!(parsed.synthesizer.as_deref(), Some("openai/gpt-latest"));
+    }
+}

--- a/crates/bitrouter-sdk/src/language_model/server_tools/fusion/alias.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/fusion/alias.rs
@@ -14,7 +14,7 @@
 //!
 //! Reference: <https://openrouter.ai/docs/guides/features/server-tools/fusion>
 
-use super::config::{DEFAULT_MAX_STEPS, FUSION_TOOL};
+use super::config::{DEFAULT_MAX_STEPS, FUSION_TOOL, FusionSettings};
 use crate::language_model::types::{Prompt, ProviderMetadata, Tool};
 
 /// The defaults the alias expands to (the "Quality" preset by default).
@@ -36,6 +36,41 @@ pub struct FusionAliasConfig {
 }
 
 impl FusionAliasConfig {
+    /// Build an alias config from the `server_tools.fusion` settings, applying
+    /// defaults: alias = `bitrouter/fusion`; outer model = configured, else the
+    /// judge, else the first panel model; judge = configured, else the first
+    /// panel model, else the outer model; panel = configured, else the outer
+    /// model alone. Returns `None` when nothing identifies an outer model (no
+    /// outer_model, judge, or panel) — i.e. Fusion is effectively unconfigured.
+    pub fn from_settings(settings: &FusionSettings) -> Option<Self> {
+        let outer_model = settings
+            .outer_model
+            .clone()
+            .or_else(|| settings.judge.clone())
+            .or_else(|| settings.panel.first().cloned())?;
+        let judge = settings
+            .judge
+            .clone()
+            .or_else(|| settings.panel.first().cloned())
+            .unwrap_or_else(|| outer_model.clone());
+        let panel = if settings.panel.is_empty() {
+            vec![outer_model.clone()]
+        } else {
+            settings.panel.clone()
+        };
+        Some(FusionAliasConfig {
+            alias: settings
+                .alias
+                .clone()
+                .unwrap_or_else(|| "bitrouter/fusion".to_string()),
+            outer_model,
+            panel,
+            judge,
+            synthesizer: settings.synthesizer.clone(),
+            web_tools: settings.web_tools.clone(),
+        })
+    }
+
     /// Rewrite a prompt addressed to the alias: swap in the outer model, inject
     /// the `bitrouter:fusion` declaration, and nudge the model toward it. Returns
     /// `true` when the alias matched and the prompt was rewritten.
@@ -80,10 +115,18 @@ impl FusionAliasConfig {
     }
 }
 
+impl crate::app::PromptTransform for FusionAliasConfig {
+    fn apply(&self, prompt: &mut Prompt) {
+        // Discard the matched flag; the server applies every transform and a
+        // non-matching one is a no-op.
+        FusionAliasConfig::apply(self, prompt);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use super::super::config::FusionConfig;
+    use super::super::config::{FusionConfig, FusionSettings};
     use crate::language_model::types::{GenerationParams, ProviderMetadata};
 
     fn prompt_with_model(model: &str) -> Prompt {
@@ -167,6 +210,29 @@ mod tests {
         assert!(prompt.tools.is_empty());
         assert!(prompt.system.is_none());
         assert_eq!(prompt.model, "anthropic/claude-opus-4.8");
+    }
+
+    #[test]
+    fn built_from_settings_with_defaults() {
+        // Only a panel is set; outer model and judge default sensibly.
+        let settings = FusionSettings {
+            panel: vec!["a/1".to_string(), "b/2".to_string()],
+            judge: None,
+            synthesizer: None,
+            alias: None,
+            outer_model: None,
+            web_tools: Vec::new(),
+        };
+        let cfg = FusionAliasConfig::from_settings(&settings).expect("enabled");
+        assert_eq!(cfg.alias, "bitrouter/fusion");
+        assert_eq!(cfg.outer_model, "a/1");
+        assert_eq!(cfg.judge, "a/1");
+        assert_eq!(cfg.panel, vec!["a/1".to_string(), "b/2".to_string()]);
+    }
+
+    #[test]
+    fn from_settings_is_none_when_nothing_configured() {
+        assert!(FusionAliasConfig::from_settings(&FusionSettings::default()).is_none());
     }
 
     #[test]

--- a/crates/bitrouter-sdk/src/language_model/server_tools/fusion/alias.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/fusion/alias.rs
@@ -14,7 +14,7 @@
 //!
 //! Reference: <https://openrouter.ai/docs/guides/features/server-tools/fusion>
 
-use super::config::{DEFAULT_MAX_STEPS, FUSION_TOOL, FusionSettings};
+use super::config::{FUSION_TOOL, FusionSettings};
 use crate::language_model::types::{Prompt, ProviderMetadata, Tool};
 
 /// The defaults the alias expands to (the "Quality" preset by default).
@@ -99,7 +99,6 @@ impl FusionAliasConfig {
         let mut args = serde_json::json!({
             "panel": panel,
             "judge": { "model": self.judge },
-            "max_steps": DEFAULT_MAX_STEPS,
         });
         if let Some(synth) = &self.synthesizer {
             args["synthesizer"] = serde_json::json!(synth);

--- a/crates/bitrouter-sdk/src/language_model/server_tools/fusion/config.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/fusion/config.rs
@@ -24,8 +24,6 @@ use crate::plugin::PluginId;
 pub const FUSION_TOOL: &str = "fusion";
 /// Maximum panel size — matches the documented Fusion bound.
 pub const MAX_PANEL: usize = 8;
-/// Default per-panel-member tool-calling steps.
-pub const DEFAULT_MAX_STEPS: u32 = 8;
 
 /// Plugin id under which the resolved [`FusionConfig`] is stashed on the request
 /// context by the pre-request hook, for the toolset to read back.
@@ -65,8 +63,6 @@ pub struct FusionConfig {
     /// final answer from the returned analysis.
     #[serde(default)]
     pub synthesizer: Option<String>,
-    /// Per-panel-member tool-calling step budget.
-    pub max_steps: u32,
 }
 
 impl FusionConfig {
@@ -81,7 +77,6 @@ impl FusionConfig {
                 model: model.to_string(),
             },
             synthesizer: None,
-            max_steps: DEFAULT_MAX_STEPS,
         }
     }
 
@@ -121,17 +116,11 @@ impl FusionConfig {
             .get("synthesizer")
             .and_then(|v| v.as_str())
             .map(str::to_string);
-        let max_steps = args
-            .get("max_steps")
-            .and_then(|v| v.as_u64())
-            .map(|v| v as u32)
-            .unwrap_or(DEFAULT_MAX_STEPS);
 
         Some(FusionConfig {
             panel,
             judge: JudgeSpec { model: judge_model },
             synthesizer,
-            max_steps,
         })
     }
 
@@ -150,7 +139,11 @@ pub fn is_fusion_name(name: &str) -> bool {
 }
 
 fn parse_member(v: &serde_json::Value) -> Option<PanelMemberSpec> {
-    let model = v.get("model").and_then(|m| m.as_str())?.to_string();
+    let model = v
+        .get("model")
+        .and_then(|m| m.as_str())
+        .filter(|s| !s.is_empty())?
+        .to_string();
     let tools = v
         .get("tools")
         .and_then(|t| t.as_array())
@@ -243,8 +236,7 @@ mod tests {
                 "panel": [{"model": "anthropic/claude-opus-4.8"},
                           {"model": "openai/gpt-latest"},
                           {"model": "google/gemini-pro"}],
-                "judge": {"model": "anthropic/claude-opus-4.8"},
-                "max_steps": 6
+                "judge": {"model": "anthropic/claude-opus-4.8"}
             }),
         );
         let cfg = FusionConfig::from_tool(&tool, "anthropic/claude-opus-4.8").unwrap();
@@ -253,7 +245,6 @@ mod tests {
             vec!["anthropic/claude-opus-4.8", "openai/gpt-latest", "google/gemini-pro"]
         );
         assert_eq!(cfg.judge.model, "anthropic/claude-opus-4.8");
-        assert_eq!(cfg.max_steps, 6);
     }
 
     #[test]
@@ -264,7 +255,6 @@ mod tests {
         assert_eq!(cfg.panel.len(), 1);
         assert_eq!(cfg.panel[0].model, "parent/model");
         assert_eq!(cfg.judge.model, "parent/model");
-        assert_eq!(cfg.max_steps, DEFAULT_MAX_STEPS);
     }
 
     #[test]

--- a/crates/bitrouter-sdk/src/language_model/server_tools/fusion/config.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/fusion/config.rs
@@ -241,17 +241,26 @@ mod tests {
         );
         let cfg = FusionConfig::from_tool(&tool, "anthropic/claude-opus-4.8").unwrap();
         assert_eq!(
-            cfg.panel.iter().map(|m| m.model.as_str()).collect::<Vec<_>>(),
-            vec!["anthropic/claude-opus-4.8", "openai/gpt-latest", "google/gemini-pro"]
+            cfg.panel
+                .iter()
+                .map(|m| m.model.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "anthropic/claude-opus-4.8",
+                "openai/gpt-latest",
+                "google/gemini-pro"
+            ]
         );
         assert_eq!(cfg.judge.model, "anthropic/claude-opus-4.8");
     }
 
     #[test]
     fn empty_panel_falls_back_to_parent() {
-        let cfg =
-            FusionConfig::from_tool(&fusion_tool("fusion", serde_json::json!({})), "parent/model")
-                .unwrap();
+        let cfg = FusionConfig::from_tool(
+            &fusion_tool("fusion", serde_json::json!({})),
+            "parent/model",
+        )
+        .unwrap();
         assert_eq!(cfg.panel.len(), 1);
         assert_eq!(cfg.panel[0].model, "parent/model");
         assert_eq!(cfg.judge.model, "parent/model");
@@ -285,7 +294,9 @@ mod tests {
 
     #[test]
     fn ignores_non_fusion_tools() {
-        assert!(FusionConfig::from_tool(&fusion_tool("advisor", serde_json::json!({})), "p").is_none());
+        assert!(
+            FusionConfig::from_tool(&fusion_tool("advisor", serde_json::json!({})), "p").is_none()
+        );
         let func = Tool::Function {
             name: "fusion".into(),
             description: None,
@@ -300,7 +311,10 @@ mod tests {
     fn round_trips_through_context_metadata() {
         let cfg = FusionConfig::single("m/1");
         let mut meta: HashMap<_, _> = HashMap::new();
-        meta.insert(fusion_plugin_id().clone(), serde_json::to_value(&cfg).unwrap());
+        meta.insert(
+            fusion_plugin_id().clone(),
+            serde_json::to_value(&cfg).unwrap(),
+        );
         let ctx = ToolContext::new(CallerContext::local(), meta);
         assert_eq!(FusionConfig::from_context(&ctx), Some(cfg));
 

--- a/crates/bitrouter-sdk/src/language_model/server_tools/fusion/config.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/fusion/config.rs
@@ -192,6 +192,29 @@ fn spec_to_tool(spec: &serde_json::Value) -> Option<Tool> {
     })
 }
 
+/// The `server_tools.fusion` config section. Its presence enables the Fusion
+/// server tool and the `bitrouter/fusion` model alias; its fields supply the
+/// alias defaults (the panel/judge a bare `bitrouter/fusion` request expands
+/// to). An explicit `bitrouter:fusion` declaration on a request overrides these.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct FusionSettings {
+    /// Default panel models the alias expands to.
+    pub panel: Vec<String>,
+    /// Default judge model (defaults to the first panel model).
+    pub judge: Option<String>,
+    /// Optional dedicated synthesizer model.
+    pub synthesizer: Option<String>,
+    /// Alias slug (defaults to `bitrouter/fusion`).
+    pub alias: Option<String>,
+    /// The model the alias resolves to (defaults to the judge, then the first
+    /// panel model).
+    pub outer_model: Option<String>,
+    /// Provider web tools forwarded to every panel member, in
+    /// provider-namespaced declaration form (e.g. `{type: "<provider>:<tool>"}`).
+    pub web_tools: Vec<serde_json::Value>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/bitrouter-sdk/src/language_model/server_tools/fusion/config.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/fusion/config.rs
@@ -1,0 +1,312 @@
+//! Parsing of the `bitrouter:fusion` server-tool declaration into a config, and
+//! the per-request plumbing the toolset reads it back from.
+//!
+//! A caller declares Fusion by putting a provider-defined tool in the request
+//! `tools` array whose name resolves to `fusion` (bare, or namespaced:
+//! `bitrouter:fusion`, `bitrouter.fusion`). Its config rides the tool's `args`
+//! (tolerating OpenRouter's `parameters` wrapper). A pre-request hook parses it
+//! once, resolves panel/judge models against the outer request model, and
+//! stashes the result on the request context under [`fusion_plugin_id`]; the
+//! toolset reads it back from the [`ToolContext`].
+//!
+//! Reference design (behavior modeled after OpenRouter Fusion):
+//! <https://openrouter.ai/docs/guides/features/server-tools/fusion>
+
+use std::sync::OnceLock;
+
+use serde::{Deserialize, Serialize};
+
+use crate::language_model::server_tools::toolset::ToolContext;
+use crate::language_model::types::{ProviderMetadata, Tool};
+use crate::plugin::PluginId;
+
+/// Router-tool name the model calls to run a deliberation.
+pub const FUSION_TOOL: &str = "fusion";
+/// Maximum panel size — matches the documented Fusion bound.
+pub const MAX_PANEL: usize = 8;
+/// Default per-panel-member tool-calling steps.
+pub const DEFAULT_MAX_STEPS: u32 = 8;
+
+/// Plugin id under which the resolved [`FusionConfig`] is stashed on the request
+/// context by the pre-request hook, for the toolset to read back.
+pub fn fusion_plugin_id() -> &'static PluginId {
+    static ID: OnceLock<PluginId> = OnceLock::new();
+    ID.get_or_init(|| PluginId::new("bitrouter:fusion-declaration"))
+}
+
+/// One panel member: a model that answers the prompt in parallel with the rest.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct PanelMemberSpec {
+    /// The member's model.
+    pub model: String,
+    /// Provider-native server tools forwarded to this member (e.g. web_search),
+    /// in provider-namespaced declaration form; see [`forwarded_tools`].
+    #[serde(default)]
+    pub tools: Vec<serde_json::Value>,
+}
+
+/// The judge: compares (does not merge) the panel answers into structured
+/// analysis.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct JudgeSpec {
+    /// The judge model.
+    pub model: String,
+}
+
+/// A fully resolved Fusion invocation (panel/judge models already defaulted to
+/// the outer request model where the declaration omitted them).
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct FusionConfig {
+    /// The panel — one entry per model answering in parallel (1..=[`MAX_PANEL`]).
+    pub panel: Vec<PanelMemberSpec>,
+    /// The judge.
+    pub judge: JudgeSpec,
+    /// Optional dedicated synthesizer; when `None`, the calling model writes the
+    /// final answer from the returned analysis.
+    #[serde(default)]
+    pub synthesizer: Option<String>,
+    /// Per-panel-member tool-calling step budget.
+    pub max_steps: u32,
+}
+
+impl FusionConfig {
+    /// A degenerate one-member panel judged by the same model.
+    pub fn single(model: &str) -> Self {
+        FusionConfig {
+            panel: vec![PanelMemberSpec {
+                model: model.to_string(),
+                tools: Vec::new(),
+            }],
+            judge: JudgeSpec {
+                model: model.to_string(),
+            },
+            synthesizer: None,
+            max_steps: DEFAULT_MAX_STEPS,
+        }
+    }
+
+    /// Parse a `bitrouter:fusion` declaration. Unspecified panel/judge models
+    /// fall back to `parent_model`; the panel is clamped to [`MAX_PANEL`].
+    /// Tolerates an OpenRouter-style `parameters` wrapper around the args.
+    /// Returns `None` for any tool that is not a Fusion declaration.
+    pub fn from_tool(tool: &Tool, parent_model: &str) -> Option<Self> {
+        let Tool::ProviderDefined { name, args, .. } = tool else {
+            return None;
+        };
+        if !is_fusion_name(name) {
+            return None;
+        }
+        let args = args.get("parameters").unwrap_or(args);
+
+        let mut panel: Vec<PanelMemberSpec> = args
+            .get("panel")
+            .and_then(|v| v.as_array())
+            .map(|arr| arr.iter().filter_map(parse_member).collect())
+            .unwrap_or_default();
+        if panel.is_empty() {
+            panel.push(PanelMemberSpec {
+                model: parent_model.to_string(),
+                tools: Vec::new(),
+            });
+        }
+        panel.truncate(MAX_PANEL);
+
+        let judge_model = args
+            .get("judge")
+            .and_then(|j| j.get("model"))
+            .and_then(|v| v.as_str())
+            .unwrap_or(parent_model)
+            .to_string();
+        let synthesizer = args
+            .get("synthesizer")
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+        let max_steps = args
+            .get("max_steps")
+            .and_then(|v| v.as_u64())
+            .map(|v| v as u32)
+            .unwrap_or(DEFAULT_MAX_STEPS);
+
+        Some(FusionConfig {
+            panel,
+            judge: JudgeSpec { model: judge_model },
+            synthesizer,
+            max_steps,
+        })
+    }
+
+    /// Read the resolved config off a request context (the pre-request hook
+    /// stashed it under [`fusion_plugin_id`]).
+    pub fn from_context(ctx: &ToolContext) -> Option<Self> {
+        ctx.get_metadata(fusion_plugin_id())
+            .and_then(|v| serde_json::from_value(v.clone()).ok())
+    }
+}
+
+/// Recognise a Fusion declaration by tool name: the bare name, or a namespaced
+/// form whose final `:`/`.` segment is the name.
+pub fn is_fusion_name(name: &str) -> bool {
+    name.rsplit([':', '.']).next().unwrap_or(name) == FUSION_TOOL
+}
+
+fn parse_member(v: &serde_json::Value) -> Option<PanelMemberSpec> {
+    let model = v.get("model").and_then(|m| m.as_str())?.to_string();
+    let tools = v
+        .get("tools")
+        .and_then(|t| t.as_array())
+        .cloned()
+        .unwrap_or_default();
+    Some(PanelMemberSpec { model, tools })
+}
+
+/// Convert a panel member's declared server-tool specs into canonical IR tools
+/// to forward into its nested completion. Each spec `{type, name?, …config}` is
+/// a provider-defined (server) tool whose `type` is provider-namespaced
+/// (`<provider>:<tool>` or `<provider>.<tool>`); it renders back to the nested
+/// upstream's native shape via the SDK's `provider_defined_native`. Specs
+/// without a string `type` are skipped.
+pub fn forwarded_tools(specs: &[serde_json::Value]) -> Vec<Tool> {
+    specs.iter().filter_map(spec_to_tool).collect()
+}
+
+fn spec_to_tool(spec: &serde_json::Value) -> Option<Tool> {
+    let obj = spec.as_object()?;
+    let ty = obj.get("type").and_then(|v| v.as_str())?;
+    // Canonical provider-defined id is `<provider>.<tool>`; accept the `:`
+    // namespacing the declarations use and normalise the first separator.
+    let id = ty.replacen(':', ".", 1);
+    let tail = id.rsplit('.').next().unwrap_or(&id);
+    let name = obj
+        .get("name")
+        .and_then(|v| v.as_str())
+        .unwrap_or(tail)
+        .to_string();
+    let mut args = obj.clone();
+    args.remove("type");
+    args.remove("name");
+    Some(Tool::ProviderDefined {
+        id,
+        name,
+        args: serde_json::Value::Object(args),
+        provider_metadata: ProviderMetadata::new(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::caller::CallerContext;
+    use crate::language_model::server_tools::toolset::ToolContext;
+    use crate::language_model::types::{ProviderMetadata, Tool};
+    use std::collections::HashMap;
+
+    fn fusion_tool(name: &str, args: serde_json::Value) -> Tool {
+        Tool::ProviderDefined {
+            id: format!(
+                "bitrouter.{}",
+                name.rsplit([':', '.']).next().unwrap_or(name)
+            ),
+            name: name.to_string(),
+            args,
+            provider_metadata: ProviderMetadata::new(),
+        }
+    }
+
+    #[test]
+    fn parses_panel_judge_and_keeps_order() {
+        let tool = fusion_tool(
+            "fusion",
+            serde_json::json!({
+                "panel": [{"model": "anthropic/claude-opus-4.8"},
+                          {"model": "openai/gpt-latest"},
+                          {"model": "google/gemini-pro"}],
+                "judge": {"model": "anthropic/claude-opus-4.8"},
+                "max_steps": 6
+            }),
+        );
+        let cfg = FusionConfig::from_tool(&tool, "anthropic/claude-opus-4.8").unwrap();
+        assert_eq!(
+            cfg.panel.iter().map(|m| m.model.as_str()).collect::<Vec<_>>(),
+            vec!["anthropic/claude-opus-4.8", "openai/gpt-latest", "google/gemini-pro"]
+        );
+        assert_eq!(cfg.judge.model, "anthropic/claude-opus-4.8");
+        assert_eq!(cfg.max_steps, 6);
+    }
+
+    #[test]
+    fn empty_panel_falls_back_to_parent() {
+        let cfg =
+            FusionConfig::from_tool(&fusion_tool("fusion", serde_json::json!({})), "parent/model")
+                .unwrap();
+        assert_eq!(cfg.panel.len(), 1);
+        assert_eq!(cfg.panel[0].model, "parent/model");
+        assert_eq!(cfg.judge.model, "parent/model");
+        assert_eq!(cfg.max_steps, DEFAULT_MAX_STEPS);
+    }
+
+    #[test]
+    fn clamps_panel_over_eight() {
+        let members: Vec<_> = (0..12)
+            .map(|i| serde_json::json!({ "model": format!("m/{i}") }))
+            .collect();
+        let cfg = FusionConfig::from_tool(
+            &fusion_tool("fusion", serde_json::json!({ "panel": members })),
+            "p/m",
+        )
+        .unwrap();
+        assert_eq!(cfg.panel.len(), MAX_PANEL);
+    }
+
+    #[test]
+    fn recognises_namespaced_name_and_parameters_wrapper() {
+        let tool = fusion_tool(
+            "bitrouter:fusion",
+            serde_json::json!({
+                "parameters": { "judge": {"model": "j/x"}, "synthesizer": "s/y" }
+            }),
+        );
+        let cfg = FusionConfig::from_tool(&tool, "parent/model").unwrap();
+        assert_eq!(cfg.judge.model, "j/x");
+        assert_eq!(cfg.synthesizer.as_deref(), Some("s/y"));
+    }
+
+    #[test]
+    fn ignores_non_fusion_tools() {
+        assert!(FusionConfig::from_tool(&fusion_tool("advisor", serde_json::json!({})), "p").is_none());
+        let func = Tool::Function {
+            name: "fusion".into(),
+            description: None,
+            parameters: serde_json::json!({}),
+            strict: None,
+            provider_metadata: ProviderMetadata::new(),
+        };
+        assert!(FusionConfig::from_tool(&func, "p").is_none());
+    }
+
+    #[test]
+    fn round_trips_through_context_metadata() {
+        let cfg = FusionConfig::single("m/1");
+        let mut meta: HashMap<_, _> = HashMap::new();
+        meta.insert(fusion_plugin_id().clone(), serde_json::to_value(&cfg).unwrap());
+        let ctx = ToolContext::new(CallerContext::local(), meta);
+        assert_eq!(FusionConfig::from_context(&ctx), Some(cfg));
+
+        let empty = ToolContext::new(CallerContext::local(), HashMap::new());
+        assert!(FusionConfig::from_context(&empty).is_none());
+    }
+
+    #[test]
+    fn forwards_panel_member_web_tools() {
+        let forwarded = forwarded_tools(&[serde_json::json!({
+            "type": "anthropic:web_search_20250305", "name": "web_search", "max_uses": 3
+        })]);
+        assert_eq!(forwarded.len(), 1);
+        let Tool::ProviderDefined { id, name, args, .. } = &forwarded[0] else {
+            panic!("expected a provider-defined tool");
+        };
+        assert_eq!(id, "anthropic.web_search_20250305");
+        assert_eq!(name, "web_search");
+        assert_eq!(args["max_uses"], 3);
+        assert!(args.get("type").is_none() && args.get("name").is_none());
+    }
+}

--- a/crates/bitrouter-sdk/src/language_model/server_tools/fusion/declarations.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/fusion/declarations.rs
@@ -1,0 +1,87 @@
+//! Stage-0 capture of the request's Fusion declaration.
+//!
+//! The toolset receives only a [`ToolContext`](super::super::toolset::ToolContext)
+//! (caller + metadata), not the prompt. This always-run pre-request hook parses
+//! the `bitrouter:fusion` declaration off the prompt once, resolves its panel /
+//! judge models against the outer request model, and stashes the result on the
+//! request context under [`fusion_plugin_id`] for the toolset to read back. Pure
+//! observation — it never denies.
+
+use async_trait::async_trait;
+
+use super::config::{FusionConfig, fusion_plugin_id};
+use crate::error::Result;
+use crate::language_model::context::PipelineContext;
+use crate::language_model::hooks::{HookDecision, PreRequestHook};
+
+/// Pre-request hook that stashes the parsed Fusion declaration on the context.
+pub struct FusionDeclarationsHook;
+
+#[async_trait]
+impl PreRequestHook for FusionDeclarationsHook {
+    async fn check(&self, ctx: &mut PipelineContext) -> Result<HookDecision> {
+        let parent_model = ctx.prompt().model.clone();
+        let config = ctx
+            .prompt()
+            .tools
+            .iter()
+            .find_map(|t| FusionConfig::from_tool(t, &parent_model));
+        if let Some(config) = config
+            && let Ok(value) = serde_json::to_value(&config)
+        {
+            ctx.set_metadata(fusion_plugin_id(), value);
+        }
+        Ok(HookDecision::Allow)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::caller::CallerContext;
+    use crate::language_model::types::{
+        GenerationParams, PipelineRequest, Prompt, ProviderMetadata, Tool,
+    };
+
+    fn ctx_with(tools: Vec<Tool>, model: &str) -> PipelineContext {
+        let prompt = Prompt {
+            model: model.to_string(),
+            system: None,
+            system_provider_metadata: ProviderMetadata::new(),
+            messages: Vec::new(),
+            tools,
+            params: GenerationParams::default(),
+            response_format: None,
+            tool_choice: None,
+            stream: false,
+        };
+        PipelineContext::new(PipelineRequest::new(model, CallerContext::local(), prompt))
+    }
+
+    fn fusion_decl(args: serde_json::Value) -> Tool {
+        Tool::ProviderDefined {
+            id: "bitrouter.fusion".to_string(),
+            name: "fusion".to_string(),
+            args,
+            provider_metadata: ProviderMetadata::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn stashes_resolved_config_with_parent_fallback() {
+        let mut ctx = ctx_with(vec![fusion_decl(serde_json::json!({}))], "parent/m");
+        let decision = FusionDeclarationsHook.check(&mut ctx).await.unwrap();
+        assert!(matches!(decision, HookDecision::Allow));
+        let stashed: FusionConfig =
+            serde_json::from_value(ctx.get_metadata(fusion_plugin_id()).unwrap().clone()).unwrap();
+        assert_eq!(stashed.panel[0].model, "parent/m");
+        assert_eq!(stashed.judge.model, "parent/m");
+    }
+
+    #[tokio::test]
+    async fn no_stash_without_a_declaration() {
+        let mut ctx = ctx_with(Vec::new(), "parent/m");
+        FusionDeclarationsHook.check(&mut ctx).await.unwrap();
+        assert!(ctx.get_metadata(fusion_plugin_id()).is_none());
+    }
+}

--- a/crates/bitrouter-sdk/src/language_model/server_tools/fusion/engine.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/fusion/engine.rs
@@ -67,6 +67,10 @@ pub async fn run_fusion(
     }
 
     // 2) Judge — compare (not merge) the answers into structured analysis.
+    // The judge requests structured output; pick a judge model that advertises
+    // it, since a provider that rejects `response_format` fails the call before
+    // the lenient parser (which only salvages JSON-in-text from models that
+    // accept the request) can run.
     let judge_req = NestedRequest {
         model: config.judge.model.clone(),
         system: Some(judge_system_prompt().to_string()),
@@ -107,11 +111,24 @@ pub async fn run_fusion(
                 tools: Vec::new(),
                 response_format: None,
             };
-            let synth = async { runner.run(synth_req, ctx).await }
+            match async { runner.run(synth_req, ctx).await }
                 .instrument(tracing::info_span!("fusion.synthesizer", model = %synth_model))
-                .await?;
-            accumulate(&mut usage, &synth.usage);
-            ToolResultOutput::Text { value: synth.text }
+                .await
+            {
+                Ok(synth) => {
+                    accumulate(&mut usage, &synth.usage);
+                    ToolResultOutput::Text { value: synth.text }
+                }
+                // Degrade gracefully: the panel + judge work is already done, so
+                // hand the calling model the analysis to write the answer from
+                // rather than discarding everything on a synthesizer failure.
+                Err(e) => {
+                    tracing::warn!(error = %e, "fusion synthesizer failed; returning analysis");
+                    ToolResultOutput::Json {
+                        value: json!({ "panel_models": panel_models, "analysis": analysis_json }),
+                    }
+                }
+            }
         }
     };
     Ok(FusionOutcome { output, usage })
@@ -203,7 +220,6 @@ mod tests {
                 model: judge.to_string(),
             },
             synthesizer: synth.map(str::to_string),
-            max_steps: 8,
         }
     }
 
@@ -258,6 +274,50 @@ mod tests {
             "1 panel + 1 judge + 1 synthesizer"
         );
         assert!(matches!(out.output, ToolResultOutput::Text { .. }));
+    }
+
+    #[tokio::test]
+    async fn synthesizer_failure_falls_back_to_analysis() {
+        // Panel + judge succeed; the synthesizer fails → the engine returns the
+        // analysis JSON instead of erroring out.
+        struct SynthFails;
+        #[async_trait]
+        impl NestedRunner for SynthFails {
+            async fn run(
+                &self,
+                req: NestedRequest,
+                _ctx: &ToolContext,
+            ) -> Result<NestedOutcome, String> {
+                if req.response_format.is_some() {
+                    return Ok(NestedOutcome {
+                        model: req.model,
+                        text: "{\"consensus\":[\"ok\"]}".to_string(),
+                        usage: Usage::default(),
+                    });
+                }
+                if req.model == "synth/z" {
+                    return Err("synth down".to_string());
+                }
+                Ok(NestedOutcome {
+                    model: req.model,
+                    text: "answer".to_string(),
+                    usage: Usage::default(),
+                })
+            }
+        }
+        let out = run_fusion(
+            &cfg(&["a/1"], "j", Some("synth/z")),
+            Arc::new(SynthFails),
+            "q",
+            &ctx(),
+        )
+        .await
+        .unwrap();
+        let value = match out.output {
+            ToolResultOutput::Json { value } => value,
+            _ => panic!("expected analysis fallback"),
+        };
+        assert_eq!(value["analysis"]["consensus"][0], "ok");
     }
 
     #[tokio::test]

--- a/crates/bitrouter-sdk/src/language_model/server_tools/fusion/engine.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/fusion/engine.rs
@@ -1,0 +1,323 @@
+//! The Fusion engine: fan the prompt out to the panel in parallel, judge the
+//! answers, and return structured analysis plus the aggregated token usage. The
+//! calling model writes the final answer from the analysis (or an optional
+//! synthesizer model does).
+//!
+//! Reference design: <https://openrouter.ai/docs/guides/features/server-tools/fusion>
+
+use std::sync::Arc;
+
+use futures::future::join_all;
+use serde_json::json;
+use tracing::Instrument;
+
+use super::config::{FusionConfig, forwarded_tools};
+use super::judge::{JudgeAnalysis, analysis_schema, judge_system_prompt};
+use crate::language_model::server_tools::nested::{NestedRequest, NestedRunner};
+use crate::language_model::server_tools::toolset::ToolContext;
+use crate::language_model::types::{ResponseFormat, ToolResultOutput, Usage};
+
+/// The engine's result: the tool output (the analysis JSON, or synthesized
+/// prose) plus the usage summed across panel + judge (+ synthesizer), so the
+/// caller can surface it as server-tool usage.
+pub struct FusionOutcome {
+    /// What the calling model receives as the tool result.
+    pub output: ToolResultOutput,
+    /// Token usage aggregated across every nested completion.
+    pub usage: Usage,
+}
+
+/// Run one Fusion deliberation.
+#[tracing::instrument(
+    skip_all,
+    fields(panel_size = config.panel.len(), judge_model = %config.judge.model)
+)]
+pub async fn run_fusion(
+    config: &FusionConfig,
+    runner: Arc<dyn NestedRunner>,
+    prompt: &str,
+    ctx: &ToolContext,
+) -> Result<FusionOutcome, String> {
+    let mut usage = Usage::default();
+
+    // 1) Panel — every member answers the same prompt in parallel.
+    let panel_futs = config.panel.iter().map(|member| {
+        let runner = runner.clone();
+        let req = NestedRequest {
+            model: member.model.clone(),
+            system: None,
+            user: prompt.to_string(),
+            tools: forwarded_tools(&member.tools),
+            response_format: None,
+        };
+        let span = tracing::info_span!("fusion.panel", model = %member.model);
+        async move { runner.run(req, ctx).await }.instrument(span)
+    });
+    let answers: Vec<(String, String)> = join_all(panel_futs)
+        .await
+        .into_iter()
+        .filter_map(Result::ok)
+        .map(|o| {
+            accumulate(&mut usage, &o.usage);
+            (o.model, o.text)
+        })
+        .collect();
+    if answers.is_empty() {
+        return Err("every panel member failed".to_string());
+    }
+
+    // 2) Judge — compare (not merge) the answers into structured analysis.
+    let judge_req = NestedRequest {
+        model: config.judge.model.clone(),
+        system: Some(judge_system_prompt().to_string()),
+        user: render_judge_input(prompt, &answers),
+        tools: Vec::new(),
+        response_format: Some(ResponseFormat::JsonSchema {
+            name: Some("fusion_analysis".to_string()),
+            description: Some("Comparison of the panel answers.".to_string()),
+            strict: Some(true),
+            schema: analysis_schema(),
+        }),
+    };
+    let judge_out = async { runner.run(judge_req, ctx).await }
+        .instrument(tracing::info_span!("fusion.judge", model = %config.judge.model))
+        .await?;
+    accumulate(&mut usage, &judge_out.usage);
+    let analysis = JudgeAnalysis::parse_lenient(&judge_out.text)?;
+    let analysis_json = serde_json::to_value(&analysis).map_err(|e| e.to_string())?;
+
+    // 3) Result — hand the analysis to the calling model, or synthesize prose.
+    let panel_models: Vec<String> = answers.iter().map(|(m, _)| m.clone()).collect();
+    let output = match &config.synthesizer {
+        None => ToolResultOutput::Json {
+            value: json!({ "panel_models": panel_models, "analysis": analysis_json }),
+        },
+        Some(synth_model) => {
+            let synth_req = NestedRequest {
+                model: synth_model.clone(),
+                system: Some(
+                    "Write the best possible final answer to the user's prompt, \
+                     grounded in the provided comparison of expert answers."
+                        .to_string(),
+                ),
+                user: format!(
+                    "Prompt:\n{prompt}\n\nComparison (JSON):\n{}",
+                    serde_json::to_string_pretty(&analysis_json).unwrap_or_default()
+                ),
+                tools: Vec::new(),
+                response_format: None,
+            };
+            let synth = async { runner.run(synth_req, ctx).await }
+                .instrument(tracing::info_span!("fusion.synthesizer", model = %synth_model))
+                .await?;
+            accumulate(&mut usage, &synth.usage);
+            ToolResultOutput::Text { value: synth.text }
+        }
+    };
+    Ok(FusionOutcome { output, usage })
+}
+
+fn render_judge_input(prompt: &str, answers: &[(String, String)]) -> String {
+    let mut s = format!("Original prompt:\n{prompt}\n\nAnswers to compare:\n");
+    for (i, (model, text)) in answers.iter().enumerate() {
+        s.push_str(&format!(
+            "\n--- Answer {} (model: {}) ---\n{}\n",
+            i + 1,
+            model,
+            text
+        ));
+    }
+    s
+}
+
+/// Sum one nested call's usage into the running total.
+fn accumulate(total: &mut Usage, add: &Usage) {
+    total.prompt_tokens += add.prompt_tokens;
+    total.completion_tokens += add.completion_tokens;
+    total.reasoning_tokens += add.reasoning_tokens;
+    total.cache_read_tokens += add.cache_read_tokens;
+    total.cache_write_tokens += add.cache_write_tokens;
+    total.web_search_count += add.web_search_count;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use super::super::config::{FusionConfig, JudgeSpec, PanelMemberSpec};
+    use crate::caller::CallerContext;
+    use crate::language_model::server_tools::nested::{NestedOutcome, NestedRequest, NestedRunner};
+    use crate::language_model::server_tools::toolset::ToolContext;
+    use crate::language_model::types::{ToolResultOutput, Usage};
+    use async_trait::async_trait;
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+
+    /// Records every nested request; replays a fixed analysis for the judge call
+    /// (the one carrying a response_format) and a per-model answer otherwise.
+    struct MockRunner {
+        seen: Mutex<Vec<NestedRequest>>,
+    }
+    #[async_trait]
+    impl NestedRunner for MockRunner {
+        async fn run(
+            &self,
+            req: NestedRequest,
+            _ctx: &ToolContext,
+        ) -> Result<NestedOutcome, String> {
+            let is_judge = req.response_format.is_some();
+            let model = req.model.clone();
+            self.seen.lock().unwrap().push(req);
+            let text = if is_judge {
+                "{\"consensus\":[\"sky is blue\"],\"contradictions\":[],\"partial_coverage\":[],\
+                 \"unique_insights\":[],\"blind_spots\":[]}"
+                    .to_string()
+            } else {
+                format!("answer from {model}")
+            };
+            Ok(NestedOutcome {
+                model,
+                text,
+                usage: Usage {
+                    prompt_tokens: 1,
+                    completion_tokens: 2,
+                    ..Default::default()
+                },
+            })
+        }
+    }
+
+    fn ctx() -> ToolContext {
+        ToolContext::new(CallerContext::local(), HashMap::new())
+    }
+
+    fn cfg(panel: &[&str], judge: &str, synth: Option<&str>) -> FusionConfig {
+        FusionConfig {
+            panel: panel
+                .iter()
+                .map(|m| PanelMemberSpec {
+                    model: m.to_string(),
+                    tools: Vec::new(),
+                })
+                .collect(),
+            judge: JudgeSpec {
+                model: judge.to_string(),
+            },
+            synthesizer: synth.map(str::to_string),
+            max_steps: 8,
+        }
+    }
+
+    #[tokio::test]
+    async fn fans_out_panel_then_judges_and_returns_analysis() {
+        let runner = Arc::new(MockRunner {
+            seen: Mutex::new(Vec::new()),
+        });
+        let out = run_fusion(
+            &cfg(&["a/1", "b/2"], "judge/x", None),
+            runner.clone(),
+            "what color is the sky?",
+            &ctx(),
+        )
+        .await
+        .unwrap();
+
+        let seen = runner.seen.lock().unwrap();
+        assert_eq!(seen.len(), 3, "2 panel + 1 judge");
+        assert_eq!(
+            seen.iter().filter(|r| r.response_format.is_some()).count(),
+            1,
+            "only the judge carries a response_format"
+        );
+        let value = match out.output {
+            ToolResultOutput::Json { value } => value,
+            _ => panic!("expected a JSON analysis output"),
+        };
+        assert_eq!(value["analysis"]["consensus"][0], "sky is blue");
+        assert_eq!(value["panel_models"].as_array().unwrap().len(), 2);
+        // usage summed across 3 calls (each 1 prompt + 2 completion).
+        assert_eq!(out.usage.prompt_tokens, 3);
+        assert_eq!(out.usage.completion_tokens, 6);
+    }
+
+    #[tokio::test]
+    async fn synthesizer_produces_text_and_adds_a_call() {
+        let runner = Arc::new(MockRunner {
+            seen: Mutex::new(Vec::new()),
+        });
+        let out = run_fusion(
+            &cfg(&["a/1"], "judge/x", Some("synth/z")),
+            runner.clone(),
+            "q",
+            &ctx(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            runner.seen.lock().unwrap().len(),
+            3,
+            "1 panel + 1 judge + 1 synthesizer"
+        );
+        assert!(matches!(out.output, ToolResultOutput::Text { .. }));
+    }
+
+    #[tokio::test]
+    async fn all_panel_failures_is_an_error() {
+        struct FailRunner;
+        #[async_trait]
+        impl NestedRunner for FailRunner {
+            async fn run(
+                &self,
+                _req: NestedRequest,
+                _ctx: &ToolContext,
+            ) -> Result<NestedOutcome, String> {
+                Err("boom".to_string())
+            }
+        }
+        let res = run_fusion(&cfg(&["a/1"], "j", None), Arc::new(FailRunner), "q", &ctx()).await;
+        assert!(res.is_err());
+    }
+
+    #[tokio::test]
+    async fn surviving_panel_members_still_judge() {
+        // One member fails, one succeeds → judge still runs over the survivor.
+        struct PartialRunner;
+        #[async_trait]
+        impl NestedRunner for PartialRunner {
+            async fn run(
+                &self,
+                req: NestedRequest,
+                _ctx: &ToolContext,
+            ) -> Result<NestedOutcome, String> {
+                if req.response_format.is_some() {
+                    return Ok(NestedOutcome {
+                        model: req.model,
+                        text: "{\"consensus\":[\"ok\"]}".to_string(),
+                        usage: Usage::default(),
+                    });
+                }
+                if req.model == "bad/1" {
+                    return Err("down".to_string());
+                }
+                Ok(NestedOutcome {
+                    model: req.model,
+                    text: "good answer".to_string(),
+                    usage: Usage::default(),
+                })
+            }
+        }
+        let out = run_fusion(
+            &cfg(&["bad/1", "good/2"], "j", None),
+            Arc::new(PartialRunner),
+            "q",
+            &ctx(),
+        )
+        .await
+        .unwrap();
+        let value = match out.output {
+            ToolResultOutput::Json { value } => value,
+            _ => panic!("expected json"),
+        };
+        // Only the surviving member is listed.
+        assert_eq!(value["panel_models"], serde_json::json!(["good/2"]));
+    }
+}

--- a/crates/bitrouter-sdk/src/language_model/server_tools/fusion/engine.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/fusion/engine.rs
@@ -159,8 +159,8 @@ fn accumulate(total: &mut Usage, add: &Usage) {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use super::super::config::{FusionConfig, JudgeSpec, PanelMemberSpec};
+    use super::*;
     use crate::caller::CallerContext;
     use crate::language_model::server_tools::nested::{NestedOutcome, NestedRequest, NestedRunner};
     use crate::language_model::server_tools::toolset::ToolContext;

--- a/crates/bitrouter-sdk/src/language_model/server_tools/fusion/judge.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/fusion/judge.rs
@@ -1,0 +1,129 @@
+//! The Fusion judge: its output schema, system prompt, and a tolerant parser.
+//!
+//! The judge *compares* the panel answers — it does not merge them or
+//! majority-vote. Its lift comes from reasoning about disagreement.
+//!
+//! Reference: <https://openrouter.ai/docs/guides/features/server-tools/fusion>
+
+use serde::{Deserialize, Serialize};
+
+/// The five-field structured analysis the judge emits.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct JudgeAnalysis {
+    /// Points all or most models agree on (treated as higher-confidence).
+    #[serde(default)]
+    pub consensus: Vec<String>,
+    /// Direct disagreements between panel answers.
+    #[serde(default)]
+    pub contradictions: Vec<String>,
+    /// Claims only some models covered.
+    #[serde(default)]
+    pub partial_coverage: Vec<String>,
+    /// Valuable insights from a single model.
+    #[serde(default)]
+    pub unique_insights: Vec<String>,
+    /// Gaps no model addressed.
+    #[serde(default)]
+    pub blind_spots: Vec<String>,
+}
+
+impl JudgeAnalysis {
+    /// Parse the judge's text, tolerating ```json fences and surrounding prose
+    /// by extracting the outermost `{ … }` object.
+    pub fn parse_lenient(text: &str) -> Result<Self, String> {
+        let trimmed = strip_fence(text);
+        let start = trimmed.find('{').ok_or("judge produced no JSON object")?;
+        let end = trimmed.rfind('}').ok_or("judge produced no JSON object")?;
+        if end < start {
+            return Err("judge produced no JSON object".to_string());
+        }
+        serde_json::from_str(&trimmed[start..=end])
+            .map_err(|e| format!("judge JSON parse failed: {e}"))
+    }
+}
+
+fn strip_fence(text: &str) -> &str {
+    let t = text.trim();
+    let t = t
+        .strip_prefix("```json")
+        .or_else(|| t.strip_prefix("```"))
+        .unwrap_or(t);
+    t.strip_suffix("```").unwrap_or(t).trim()
+}
+
+/// The JSON-schema contract handed to the judge as `response_format`.
+pub fn analysis_schema() -> serde_json::Value {
+    let arr = serde_json::json!({ "type": "array", "items": { "type": "string" } });
+    serde_json::json!({
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["consensus", "contradictions", "partial_coverage", "unique_insights", "blind_spots"],
+        "properties": {
+            "consensus": arr,
+            "contradictions": arr,
+            "partial_coverage": arr,
+            "unique_insights": arr,
+            "blind_spots": arr,
+        }
+    })
+}
+
+/// The judge system prompt. Emphasizes comparison over merging.
+pub fn judge_system_prompt() -> &'static str {
+    "You are an impartial judge comparing several independent answers to the same \
+     prompt. Do NOT merge them and do NOT majority-vote. Identify, as JSON: \
+     consensus (points all or most answers agree on — higher confidence), \
+     contradictions (direct disagreements), partial_coverage (claims only some \
+     answers make), unique_insights (valuable points from a single answer), and \
+     blind_spots (gaps none addressed). Return only the JSON object."
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn schema_has_the_five_analysis_fields() {
+        let schema = analysis_schema();
+        let props = schema["properties"].as_object().unwrap();
+        for k in [
+            "consensus",
+            "contradictions",
+            "partial_coverage",
+            "unique_insights",
+            "blind_spots",
+        ] {
+            assert!(props.contains_key(k), "schema missing {k}");
+        }
+    }
+
+    #[test]
+    fn parses_judge_json_even_when_fenced() {
+        let raw = "```json\n{\"consensus\":[\"a\"],\"contradictions\":[],\
+                   \"partial_coverage\":[],\"unique_insights\":[],\"blind_spots\":[]}\n```";
+        assert_eq!(
+            JudgeAnalysis::parse_lenient(raw).unwrap().consensus,
+            vec!["a".to_string()]
+        );
+    }
+
+    #[test]
+    fn parses_with_surrounding_prose() {
+        let raw = "Here is my analysis:\n{\"consensus\":[],\"contradictions\":[\"x vs y\"],\
+                   \"partial_coverage\":[],\"unique_insights\":[],\"blind_spots\":[]}\nDone.";
+        let a = JudgeAnalysis::parse_lenient(raw).unwrap();
+        assert_eq!(a.contradictions, vec!["x vs y".to_string()]);
+    }
+
+    #[test]
+    fn missing_fields_default_to_empty() {
+        let a = JudgeAnalysis::parse_lenient("{\"consensus\":[\"only this\"]}").unwrap();
+        assert_eq!(a.consensus, vec!["only this".to_string()]);
+        assert!(a.blind_spots.is_empty());
+    }
+
+    #[test]
+    fn no_json_object_is_an_error() {
+        assert!(JudgeAnalysis::parse_lenient("no json here").is_err());
+    }
+}

--- a/crates/bitrouter-sdk/src/language_model/server_tools/fusion/mod.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/fusion/mod.rs
@@ -6,5 +6,195 @@
 //! <https://openrouter.ai/docs/guides/features/server-tools/fusion>
 
 pub mod config;
+pub mod declarations;
 pub mod engine;
 pub mod judge;
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use self::config::{FUSION_TOOL, FusionConfig, is_fusion_name};
+use self::engine::run_fusion;
+use crate::error::Result;
+use crate::language_model::server_tools::nested::NestedRunner;
+use crate::language_model::server_tools::toolset::{RouterToolset, ToolContext};
+use crate::language_model::types::{ProviderMetadata, Tool, ToolResultOutput};
+
+/// The `bitrouter:fusion` server tool, generic over a [`NestedRunner`] so the
+/// OSS daemon and a hosted deployment can each supply their own (the latter
+/// adds identity + billing).
+///
+/// Advertise it only at the outermost loop: the engine runs nested completions,
+/// and a deployment must ensure panel members cannot recursively invoke Fusion
+/// (the reference wiring runs them on a loop-less sub-pipeline).
+pub struct FusionToolset {
+    runner: Arc<dyn NestedRunner>,
+}
+
+impl FusionToolset {
+    /// Build the toolset over a nested-completion runner.
+    pub fn new(runner: Arc<dyn NestedRunner>) -> Self {
+        Self { runner }
+    }
+}
+
+fn error_output(message: impl Into<String>) -> ToolResultOutput {
+    ToolResultOutput::Json {
+        value: serde_json::json!({ "status": "error", "error": message.into() }),
+    }
+}
+
+#[async_trait]
+impl RouterToolset for FusionToolset {
+    async fn list_tools(&self, ctx: &ToolContext) -> Result<Vec<Tool>> {
+        // Advertised only when the request declared Fusion (directly or via the
+        // model alias). The declaration hook stashes the resolved config.
+        if FusionConfig::from_context(ctx).is_none() {
+            return Ok(Vec::new());
+        }
+        Ok(vec![Tool::Function {
+            name: FUSION_TOOL.to_string(),
+            description: Some(
+                "Deliberate on a prompt with a multi-model panel and a judge. A \
+                 panel of models answers in parallel, a judge compares (not \
+                 merges) their answers, and you receive structured analysis \
+                 (consensus, contradictions, partial_coverage, unique_insights, \
+                 blind_spots) to write the final answer from."
+                    .to_string(),
+            ),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "prompt": { "type": "string", "description": "The question to deliberate on." }
+                },
+                "required": ["prompt"],
+                "additionalProperties": false
+            }),
+            strict: None,
+            provider_metadata: ProviderMetadata::new(),
+        }])
+    }
+
+    async fn call_tool(
+        &self,
+        _name: &str,
+        arguments: &str,
+        ctx: &ToolContext,
+    ) -> Result<ToolResultOutput> {
+        let Some(config) = FusionConfig::from_context(ctx) else {
+            return Ok(error_output("fusion was not declared on this request"));
+        };
+        let args: serde_json::Value =
+            serde_json::from_str(arguments).unwrap_or_else(|_| serde_json::json!({}));
+        let Some(prompt) = args.get("prompt").and_then(|v| v.as_str()) else {
+            return Ok(error_output("fusion call is missing required `prompt`"));
+        };
+        match run_fusion(&config, self.runner.clone(), prompt, ctx).await {
+            Ok(outcome) => {
+                // Surface the aggregated nested usage for observability; each
+                // nested completion is also metered by its own sub-pipeline.
+                tracing::info!(
+                    target: "bitrouter::fusion",
+                    panel = config.panel.len(),
+                    prompt_tokens = outcome.usage.prompt_tokens,
+                    completion_tokens = outcome.usage.completion_tokens,
+                    "fusion deliberation complete"
+                );
+                Ok(outcome.output)
+            }
+            Err(e) => Ok(error_output(format!("fusion: {e}"))),
+        }
+    }
+
+    fn owns(&self, name: &str) -> bool {
+        is_fusion_name(name)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use super::config::{FusionConfig, fusion_plugin_id};
+    use crate::caller::CallerContext;
+    use crate::language_model::server_tools::nested::{NestedOutcome, NestedRequest, NestedRunner};
+    use crate::language_model::server_tools::toolset::{RouterToolset, ToolContext};
+    use crate::language_model::types::ToolResultOutput;
+    use async_trait::async_trait;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    struct StubRunner;
+    #[async_trait]
+    impl NestedRunner for StubRunner {
+        async fn run(
+            &self,
+            req: NestedRequest,
+            _ctx: &ToolContext,
+        ) -> std::result::Result<NestedOutcome, String> {
+            let text = if req.response_format.is_some() {
+                "{\"consensus\":[\"agreed\"]}".to_string()
+            } else {
+                "an answer".to_string()
+            };
+            Ok(NestedOutcome {
+                model: req.model,
+                text,
+                usage: Default::default(),
+            })
+        }
+    }
+
+    fn ctx_declared() -> ToolContext {
+        let mut meta = HashMap::new();
+        meta.insert(
+            fusion_plugin_id().clone(),
+            serde_json::to_value(FusionConfig::single("m/1")).unwrap(),
+        );
+        ToolContext::new(CallerContext::local(), meta)
+    }
+    fn ctx_undeclared() -> ToolContext {
+        ToolContext::new(CallerContext::local(), HashMap::new())
+    }
+
+    #[tokio::test]
+    async fn advertises_fusion_only_when_declared() {
+        let ts = FusionToolset::new(Arc::new(StubRunner));
+        assert!(ts.list_tools(&ctx_undeclared()).await.unwrap().is_empty());
+        let tools = ts.list_tools(&ctx_declared()).await.unwrap();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].name(), "fusion");
+        assert!(ts.owns("fusion"));
+        assert!(ts.owns("bitrouter:fusion"));
+        assert!(!ts.owns("advisor"));
+    }
+
+    #[tokio::test]
+    async fn executes_fusion_and_returns_analysis() {
+        let ts = FusionToolset::new(Arc::new(StubRunner));
+        let out = ts
+            .call_tool("fusion", r#"{"prompt":"hi"}"#, &ctx_declared())
+            .await
+            .unwrap();
+        assert!(
+            matches!(&out, ToolResultOutput::Json { value } if value["analysis"]["consensus"][0] == "agreed")
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_prompt_is_an_error_result() {
+        let ts = FusionToolset::new(Arc::new(StubRunner));
+        let out = ts.call_tool("fusion", "{}", &ctx_declared()).await.unwrap();
+        assert!(matches!(&out, ToolResultOutput::Json { value } if value["status"] == "error"));
+    }
+
+    #[tokio::test]
+    async fn undeclared_call_is_an_error_result() {
+        let ts = FusionToolset::new(Arc::new(StubRunner));
+        let out = ts
+            .call_tool("fusion", r#"{"prompt":"hi"}"#, &ctx_undeclared())
+            .await
+            .unwrap();
+        assert!(matches!(&out, ToolResultOutput::Json { value } if value["status"] == "error"));
+    }
+}

--- a/crates/bitrouter-sdk/src/language_model/server_tools/fusion/mod.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/fusion/mod.rs
@@ -22,9 +22,8 @@ use crate::language_model::server_tools::nested::NestedRunner;
 use crate::language_model::server_tools::toolset::{RouterToolset, ToolContext};
 use crate::language_model::types::{ProviderMetadata, Tool, ToolResultOutput};
 
-/// The `bitrouter:fusion` server tool, generic over a [`NestedRunner`] so the
-/// OSS daemon and a hosted deployment can each supply their own (the latter
-/// adds identity + billing).
+/// The `bitrouter:fusion` server tool, generic over a [`NestedRunner`] so each
+/// deployment supplies its own (a custom runner can add identity + metering).
 ///
 /// Advertise it only at the outermost loop: the engine runs nested completions,
 /// and a deployment must ensure panel members cannot recursively invoke Fusion
@@ -93,8 +92,9 @@ impl RouterToolset for FusionToolset {
         };
         match run_fusion(&config, self.runner.clone(), prompt, ctx).await {
             Ok(outcome) => {
-                // Surface the aggregated nested usage for observability; each
-                // nested completion is also metered by its own sub-pipeline.
+                // Surface the aggregated nested usage for observability. Each
+                // nested completion is also metered individually by whatever
+                // settlement recorders the runner's sub-pipeline carries.
                 tracing::info!(
                     target: "bitrouter::fusion",
                     panel = config.panel.len(),

--- a/crates/bitrouter-sdk/src/language_model/server_tools/fusion/mod.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/fusion/mod.rs
@@ -6,3 +6,4 @@
 //! <https://openrouter.ai/docs/guides/features/server-tools/fusion>
 
 pub mod config;
+pub mod judge;

--- a/crates/bitrouter-sdk/src/language_model/server_tools/fusion/mod.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/fusion/mod.rs
@@ -1,0 +1,8 @@
+//! Fusion: a multi-model deliberation server tool. A panel of models answers a
+//! prompt in parallel, a judge compares (not merges) their answers into
+//! structured analysis, and the calling model writes the final answer from it.
+//!
+//! Reference design (behavior modeled after OpenRouter Fusion):
+//! <https://openrouter.ai/docs/guides/features/server-tools/fusion>
+
+pub mod config;

--- a/crates/bitrouter-sdk/src/language_model/server_tools/fusion/mod.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/fusion/mod.rs
@@ -115,8 +115,8 @@ impl RouterToolset for FusionToolset {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use super::config::{FusionConfig, fusion_plugin_id};
+    use super::*;
     use crate::caller::CallerContext;
     use crate::language_model::server_tools::nested::{NestedOutcome, NestedRequest, NestedRunner};
     use crate::language_model::server_tools::toolset::{RouterToolset, ToolContext};

--- a/crates/bitrouter-sdk/src/language_model/server_tools/fusion/mod.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/fusion/mod.rs
@@ -5,6 +5,7 @@
 //! Reference design (behavior modeled after OpenRouter Fusion):
 //! <https://openrouter.ai/docs/guides/features/server-tools/fusion>
 
+pub mod alias;
 pub mod config;
 pub mod declarations;
 pub mod engine;

--- a/crates/bitrouter-sdk/src/language_model/server_tools/fusion/mod.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/fusion/mod.rs
@@ -6,4 +6,5 @@
 //! <https://openrouter.ai/docs/guides/features/server-tools/fusion>
 
 pub mod config;
+pub mod engine;
 pub mod judge;

--- a/crates/bitrouter-sdk/src/language_model/server_tools/loop_controller.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/loop_controller.rs
@@ -87,7 +87,8 @@ impl ServerToolLoop {
         let (injected, owned) = self.registry.list_all(ctx).await?;
         let mut working = base.clone();
         working.tools.retain(|t| {
-            !(matches!(t, Tool::ProviderDefined { .. }) && self.registry.resolve(t.name()).is_some())
+            !(matches!(t, Tool::ProviderDefined { .. })
+                && self.registry.resolve(t.name()).is_some())
         });
         for tool in &injected {
             if working.tools.iter().any(|t| t.name() == tool.name()) {

--- a/crates/bitrouter-sdk/src/language_model/server_tools/loop_controller.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/loop_controller.rs
@@ -69,11 +69,16 @@ impl ServerToolLoop {
     ///
     /// A caller may *declare* a router tool as a provider-defined tool (e.g. an
     /// `{type: "<provider>:<tool>"}` server-tool entry). Such declarations are
-    /// dropped from the working prompt for any name the registry owns: the
+    /// dropped from the working prompt for any name the registry *owns*: the
     /// toolset re-advertises that tool as an executable function tool, and the
     /// raw provider-defined form must not reach the upstream — it has no
     /// portable wire form and a same-protocol upstream would reject an unknown
     /// server tool. Dropping them also avoids a spurious self-collision below.
+    ///
+    /// Ownership (`registry.resolve`), not the set of advertised names, is the
+    /// strip predicate: a toolset may own a declaration under a namespaced name
+    /// (e.g. `bitrouter:fusion`) while advertising the bare executable name
+    /// (`fusion`), and the namespaced declaration must still be stripped.
     pub(crate) async fn inject(
         &self,
         base: &Prompt,
@@ -81,9 +86,9 @@ impl ServerToolLoop {
     ) -> Result<(Prompt, std::collections::BTreeSet<String>)> {
         let (injected, owned) = self.registry.list_all(ctx).await?;
         let mut working = base.clone();
-        working
-            .tools
-            .retain(|t| !(matches!(t, Tool::ProviderDefined { .. }) && owned.contains(t.name())));
+        working.tools.retain(|t| {
+            !(matches!(t, Tool::ProviderDefined { .. }) && self.registry.resolve(t.name()).is_some())
+        });
         for tool in &injected {
             if working.tools.iter().any(|t| t.name() == tool.name()) {
                 return Err(BitrouterError::Internal(format!(
@@ -472,6 +477,60 @@ mod tests {
         assert!(
             matches!(search[0], Tool::Function { .. }),
             "the remaining `search` is the executable function form"
+        );
+    }
+
+    #[tokio::test]
+    async fn inject_strips_namespaced_declaration_owned_under_a_bare_name() {
+        // A toolset that owns by tail-match (like the Fusion toolset) advertises
+        // the bare `fusion` but also owns the namespaced `bitrouter:fusion`. The
+        // namespaced provider-defined declaration must be stripped so it never
+        // reaches the upstream as an unknown server tool.
+        struct TailToolset;
+        #[async_trait]
+        impl RouterToolset for TailToolset {
+            async fn list_tools(&self, _c: &ToolContext) -> Result<Vec<Tool>> {
+                Ok(vec![Tool::Function {
+                    name: "fusion".to_string(),
+                    description: None,
+                    parameters: serde_json::json!({ "type": "object" }),
+                    strict: None,
+                    provider_metadata: ProviderMetadata::new(),
+                }])
+            }
+            async fn call_tool(
+                &self,
+                _n: &str,
+                _a: &str,
+                _c: &ToolContext,
+            ) -> Result<ToolResultOutput> {
+                Ok(ToolResultOutput::Text {
+                    value: "x".to_string(),
+                })
+            }
+            fn owns(&self, name: &str) -> bool {
+                name.rsplit([':', '.']).next().unwrap_or(name) == "fusion"
+            }
+        }
+
+        let loop_ = ServerToolLoop::new(
+            ToolsetRegistry::new(vec![Arc::new(TailToolset)]),
+            ServerToolLoopConfig::default(),
+            Arc::new(AllowAll),
+        );
+        let mut base = base_prompt();
+        base.tools.push(Tool::ProviderDefined {
+            id: "bitrouter.fusion".to_string(),
+            name: "bitrouter:fusion".to_string(),
+            args: serde_json::json!({}),
+            provider_metadata: ProviderMetadata::new(),
+        });
+        let (working, _owned) = loop_.inject(&base, &tool_ctx()).await.unwrap();
+        // Only the advertised bare `fusion` function remains.
+        assert_eq!(working.tools.len(), 1);
+        assert!(
+            matches!(&working.tools[0], Tool::Function { name, .. } if name == "fusion"),
+            "namespaced declaration stripped; executable function advertised"
         );
     }
 

--- a/crates/bitrouter-sdk/src/language_model/server_tools/mod.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/mod.rs
@@ -20,5 +20,6 @@ pub mod classify;
 pub mod config;
 pub mod loop_controller;
 pub mod mcp_toolset;
+pub mod nested;
 pub mod stream;
 pub mod toolset;

--- a/crates/bitrouter-sdk/src/language_model/server_tools/mod.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/mod.rs
@@ -18,6 +18,7 @@
 pub mod approval;
 pub mod classify;
 pub mod config;
+pub mod fusion;
 pub mod loop_controller;
 pub mod mcp_toolset;
 pub mod nested;

--- a/crates/bitrouter-sdk/src/language_model/server_tools/nested.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/nested.rs
@@ -1,0 +1,141 @@
+//! The nested-completion interface: a billing-agnostic way for a server tool to
+//! run one model completion through a pipeline and read its text + usage back.
+//!
+//! `run` receives the per-request [`ToolContext`] so a deployment that needs
+//! identity or billing can read it off the context — this crate never models
+//! either. The plain [`PipelineNestedRunner`] below uses only the caller carried
+//! on the context; a hosted deployment supplies its own [`NestedRunner`] that
+//! layers on metering.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::language_model::Pipeline;
+use crate::language_model::server_tools::toolset::ToolContext;
+use crate::language_model::types::{
+    Content, GenerationParams, Message, PipelineRequest, Prompt, ProviderMetadata, ResponseFormat,
+    Role, Tool, Usage,
+};
+
+/// One nested completion.
+#[derive(Clone, Debug)]
+pub struct NestedRequest {
+    /// Model that serves the nested call.
+    pub model: String,
+    /// System instructions for the nested model, if any.
+    pub system: Option<String>,
+    /// The user turn.
+    pub user: String,
+    /// Server tools the nested model may use (e.g. forwarded web_search).
+    pub tools: Vec<Tool>,
+    /// Optional structured-output contract (used by the Fusion judge).
+    pub response_format: Option<ResponseFormat>,
+}
+
+/// A nested completion's final text, the serving model, and its usage.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct NestedOutcome {
+    /// The model that served the call.
+    pub model: String,
+    /// The concatenated text content of the response.
+    pub text: String,
+    /// Token usage reported by the nested completion.
+    pub usage: Usage,
+}
+
+/// Runs a nested completion, returning its outcome or a human-readable error
+/// (surfaced to the calling model as a tool result with `status: "error"`).
+#[async_trait]
+pub trait NestedRunner: Send + Sync {
+    /// Run one nested completion. `ctx` is the per-request context of the
+    /// server-tool call that triggered this nested run.
+    async fn run(
+        &self,
+        request: NestedRequest,
+        ctx: &ToolContext,
+    ) -> std::result::Result<NestedOutcome, String>;
+}
+
+/// The plain runner: runs the nested completion through a sub-pipeline, using
+/// the caller carried on the [`ToolContext`]. It carries no identity or billing
+/// — those are layered by a custom [`NestedRunner`] in a hosted deployment.
+pub struct PipelineNestedRunner {
+    sub_pipeline: Arc<Pipeline>,
+}
+
+impl PipelineNestedRunner {
+    /// Build a runner over a sub-completion pipeline.
+    pub fn new(sub_pipeline: Arc<Pipeline>) -> Self {
+        Self { sub_pipeline }
+    }
+}
+
+#[async_trait]
+impl NestedRunner for PipelineNestedRunner {
+    async fn run(
+        &self,
+        request: NestedRequest,
+        ctx: &ToolContext,
+    ) -> std::result::Result<NestedOutcome, String> {
+        let prompt = Prompt {
+            model: request.model.clone(),
+            system: request.system,
+            system_provider_metadata: ProviderMetadata::new(),
+            messages: vec![Message::text(Role::User, request.user)],
+            tools: request.tools,
+            params: GenerationParams::default(),
+            response_format: request.response_format,
+            tool_choice: None,
+            stream: false,
+        };
+        let req = PipelineRequest::new(request.model.clone(), ctx.caller().clone(), prompt);
+        let resp = self
+            .sub_pipeline
+            .execute(req)
+            .await
+            .map_err(|e| e.to_string())?;
+        let text = resp
+            .result
+            .content
+            .iter()
+            .filter_map(|c| match c {
+                Content::Text { text, .. } => Some(text.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("");
+        Ok(NestedOutcome {
+            model: request.model,
+            text,
+            usage: resp.result.usage.unwrap_or_default(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::language_model::types::ResponseFormat;
+
+    fn assert_send_sync<T: Send + Sync>() {}
+
+    #[test]
+    fn seam_types_are_send_sync_and_carry_response_format() {
+        assert_send_sync::<NestedRequest>();
+        assert_send_sync::<NestedOutcome>();
+        let req = NestedRequest {
+            model: "test/model".into(),
+            system: None,
+            user: "hi".into(),
+            tools: vec![],
+            response_format: Some(ResponseFormat::JsonSchema {
+                name: Some("analysis".into()),
+                description: None,
+                strict: Some(true),
+                schema: serde_json::json!({ "type": "object" }),
+            }),
+        };
+        assert!(req.response_format.is_some());
+    }
+}

--- a/crates/bitrouter-sdk/src/language_model/server_tools/nested.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/nested.rs
@@ -4,8 +4,8 @@
 //! `run` receives the per-request [`ToolContext`] so a deployment that needs
 //! identity or billing can read it off the context — this crate never models
 //! either. The plain [`PipelineNestedRunner`] below uses only the caller carried
-//! on the context; a hosted deployment supplies its own [`NestedRunner`] that
-//! layers on metering.
+//! on the context; a deployment that needs metering supplies its own
+//! [`NestedRunner`] (or wires a settlement recorder onto the sub-pipeline).
 
 use std::sync::Arc;
 
@@ -59,7 +59,8 @@ pub trait NestedRunner: Send + Sync {
 
 /// The plain runner: runs the nested completion through a sub-pipeline, using
 /// the caller carried on the [`ToolContext`]. It carries no identity or billing
-/// — those are layered by a custom [`NestedRunner`] in a hosted deployment.
+/// of its own; metering is whatever the sub-pipeline's settlement recorders do
+/// (a custom [`NestedRunner`] can add more).
 pub struct PipelineNestedRunner {
     sub_pipeline: Arc<Pipeline>,
 }

--- a/crates/bitrouter-sdk/src/language_model/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/tests.rs
@@ -1160,6 +1160,88 @@ async fn server_tool_loop_resolves_a_router_tool_call() {
 }
 
 #[tokio::test]
+async fn fusion_declaration_is_advertised_and_executed_end_to_end() {
+    // Exercises the full metadata-threading path: the declaration hook parses a
+    // bitrouter:fusion declaration and stashes the resolved config; the loop
+    // snapshots it into the ToolContext; the FusionToolset advertises + runs the
+    // engine; the analysis feeds back and the model writes the final answer.
+    use crate::language_model::server_tools::approval::AllowAll;
+    use crate::language_model::server_tools::config::ServerToolLoopConfig;
+    use crate::language_model::server_tools::fusion::FusionToolset;
+    use crate::language_model::server_tools::fusion::declarations::FusionDeclarationsHook;
+    use crate::language_model::server_tools::loop_controller::ServerToolLoop;
+    use crate::language_model::server_tools::nested::{NestedOutcome, NestedRequest, NestedRunner};
+    use crate::language_model::server_tools::toolset::{ToolContext, ToolsetRegistry};
+
+    // Scripted nested runner: the judge (response_format set) returns analysis
+    // JSON; a panel member returns a plain answer.
+    struct ScriptedRunner;
+    #[async_trait]
+    impl NestedRunner for ScriptedRunner {
+        async fn run(
+            &self,
+            req: NestedRequest,
+            _c: &ToolContext,
+        ) -> std::result::Result<NestedOutcome, String> {
+            let text = if req.response_format.is_some() {
+                "{\"consensus\":[\"agreed point\"]}".to_string()
+            } else {
+                "panel answer".to_string()
+            };
+            Ok(NestedOutcome {
+                model: req.model,
+                text,
+                usage: Default::default(),
+            })
+        }
+    }
+
+    // A bare bitrouter:fusion declaration, named `fusion` so the loop strips it
+    // before upstream (empty args → single-member panel on the request model).
+    let mut req = request();
+    req.prompt.tools.push(Tool::ProviderDefined {
+        id: "bitrouter.fusion".to_string(),
+        name: "fusion".to_string(),
+        args: serde_json::json!({}),
+        provider_metadata: Default::default(),
+    });
+
+    let server_loop = Arc::new(ServerToolLoop::new(
+        ToolsetRegistry::new(vec![Arc::new(FusionToolset::new(Arc::new(ScriptedRunner)))]),
+        ServerToolLoopConfig::default(),
+        Arc::new(AllowAll),
+    ));
+
+    // Upstream: turn 1 calls the `fusion` tool; turn 2 writes the final answer.
+    let executor = Arc::new(MockExecutor::new(vec![
+        MockResponse::Generate(gen_result(vec![Content::ToolCall {
+            id: "c1".to_string(),
+            name: "fusion".to_string(),
+            arguments: "{\"prompt\":\"deliberate this\"}".to_string(),
+            provider_executed: false,
+            dynamic: false,
+            provider_metadata: Default::default(),
+        }])),
+        MockResponse::Generate(gen_result(vec![Content::Text {
+            text: "final answer".to_string(),
+            provider_metadata: Default::default(),
+        }])),
+    ]));
+
+    let pipeline = pipeline_with(routing_table(&["openai"]), executor, |b| {
+        b.pre_request_hook(FusionDeclarationsHook);
+        b.server_tool_loop(server_loop);
+    });
+
+    let resp = pipeline.execute(req).await.expect("request succeeds");
+    assert!(
+        matches!(&resp.result.content[0], Content::Text { text, .. } if text == "final answer")
+    );
+    // Two upstream turns ran (the fusion tool was executed and fed back).
+    assert_eq!(resp.result.usage.unwrap().prompt_tokens, 6);
+}
+
+#[tokio::test]
 async fn without_loop_a_tool_call_turn_is_returned_unchanged() {
     // No server_tool_loop configured: the pipeline stays single-shot and hands
     // the model's tool-call turn straight back to the caller (only one upstream

--- a/crates/bitrouter-sdk/src/lib.rs
+++ b/crates/bitrouter-sdk/src/lib.rs
@@ -136,7 +136,7 @@ pub mod acp;
 pub mod language_model;
 pub mod mcp;
 
-pub use app::{App, AppBuilder, Plugin};
+pub use app::{App, AppBuilder, Plugin, PromptTransform};
 pub use caller::CallerContext;
 pub use error::{BitrouterError, Result};
 pub use event::{EventBus, PipelineEvent};

--- a/crates/bitrouter-sdk/src/server.rs
+++ b/crates/bitrouter-sdk/src/server.rs
@@ -46,6 +46,10 @@ pub struct AppState {
     pub skip_auth: bool,
     /// Optional Prometheus-style metrics renderer; `GET /metrics` reads this.
     pub metrics_renderer: Option<Arc<dyn MetricsRenderer>>,
+    /// Ingress-time prompt transforms, applied in order after protocol parsing
+    /// and before a request enters the pipeline (e.g. the `bitrouter/fusion`
+    /// model alias).
+    pub prompt_transforms: Vec<Arc<dyn crate::app::PromptTransform>>,
 }
 
 impl App {
@@ -76,6 +80,7 @@ impl App {
             mcp: self.mcp().cloned(),
             skip_auth: self.skip_auth(),
             metrics_renderer: self.metrics_renderer().cloned(),
+            prompt_transforms: self.prompt_transforms().to_vec(),
         };
         let options = RouterOptions {
             omit_v1_models: false,
@@ -638,6 +643,12 @@ async fn handle(
                 p.model = model;
             }
             p.model = sanitize_model_name(&p.model);
+            // Ingress-time prompt transforms (e.g. the bitrouter/fusion model
+            // alias): the prompt body is freely mutable here, before it enters
+            // the pipeline that exposes it read-only downstream.
+            for transform in &state.prompt_transforms {
+                transform.apply(&mut p);
+            }
             p
         }
         Err(e) => return e.into_response(),


### PR DESCRIPTION
## Summary

Adds **Fusion** — a multi-model deliberation server tool. A panel of models answers a prompt in parallel, a judge model compares (not merges) their answers into structured analysis, and the calling model writes the final answer from it. Behavior is modeled after [OpenRouter Fusion](https://openrouter.ai/docs/guides/features/server-tools/fusion).

Three interchangeable surfaces, one engine:
- **Server tool** `bitrouter:fusion` — a `RouterToolset` on the existing server-tool loop.
- **Declaration config** — panel / judge / synthesizer carried on the tool's `args`, parsed by a pre-request hook into the request context.
- **Model alias** `bitrouter/fusion` — an ingress prompt transform that resolves the alias to a real outer model and attaches the declaration.

## How it works

1. The panel — up to 8 models — answers the prompt in parallel.
2. A judge compares the answers into structured JSON: `consensus`, `contradictions`, `partial_coverage`, `unique_insights`, `blind_spots`. It *compares*; it does not merge or majority-vote.
3. The calling model receives that analysis and writes the final answer (or an optional `synthesizer` model does).

## Notable pieces

- New generic **`NestedRunner`** interface (`server_tools/nested.rs`): run one nested completion through a pipeline, given the per-request `ToolContext`. The Fusion engine is generic over it; the binary supplies a plain pipeline-backed runner.
- New **`PromptTransform`** App seam: an ingress-time prompt rewrite applied by the HTTP server before the request enters the pipeline (the pipeline context exposes the prompt read-only downstream). The `bitrouter/fusion` alias is the first consumer; it advertises + nudges via the system prompt rather than forcing `tool_choice` (which the loop reuses across turns).
- `inject()` now strips a caller-declared provider-defined tool by **registry ownership** rather than exact advertised name, so a namespaced `{"type":"bitrouter:fusion"}` declaration never leaks to an upstream as an unknown server tool.
- Observability: `tracing` spans (`fusion.deliberation` / `fusion.panel` / `fusion.judge`) plus aggregated token usage.
- Config: a `[server_tools.fusion]` section enables the tool and the alias. The panel/judge run on a **loop-less** sub-pipeline (a panel member cannot recursively invoke Fusion), metered like top-level requests.

## Testing

- `cargo test -p bitrouter-sdk --all-features --lib` — **504 passing**.
- `cargo test -p bitrouter --lib` — **123 passing**.
- clippy clean across the SDK and the binary.
- Includes an end-to-end integration test (declaration → hook → loop → engine → final answer) plus unit coverage for config parsing, the judge schema/parser, the engine (parallel fan-out, partial-failure resilience, synthesizer fallback), the toolset, the alias, and the namespaced-declaration strip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)