### PR TITLE
fix(chat): buffer streamed tool call until name arrives

### DIFF
--- a/crates/bitrouter-sdk/src/language_model/protocol/chat_completions.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/chat_completions.rs
@@ -724,7 +724,7 @@ impl InboundAdapter for ChatCompletionsAdapter {
             request_id: request_id.to_string(),
             model: model.to_string(),
             role_sent: false,
-            tool_call_indices: Vec::new(),
+            tool_calls: Vec::new(),
         })
     }
 }
@@ -1533,24 +1533,41 @@ impl StreamDecoder for ChatStreamDecoder {
     }
 }
 
+/// Per tool-call streaming state for the Chat Completions encoder. The slot's
+/// position in [`ChatStreamEncoder::tool_calls`] is its `tool_calls[].index`,
+/// assigned in first-seen order so parallel tool calls stay distinct and stable.
+struct ChatToolCallState {
+    /// Upstream tool-call id, the key used to group continuation deltas.
+    id: String,
+    /// Whether the opening chunk (the one carrying `function.name`) was emitted.
+    opened: bool,
+    /// Argument fragments seen before the name arrived, replayed on the opening
+    /// chunk so nothing is lost while the call is held back.
+    pending_args: String,
+}
+
 /// Encodes canonical stream parts into Chat Completions `data:` SSE chunks.
 struct ChatStreamEncoder {
     request_id: String,
     model: String,
     role_sent: bool,
-    /// Tool-call id → its `tool_calls[].index`, assigned in first-seen order so
-    /// parallel tool calls get distinct, stable indices.
-    tool_call_indices: Vec<String>,
+    /// Per tool-call state, keyed by id and ordered by first sight.
+    tool_calls: Vec<ChatToolCallState>,
 }
 
 impl ChatStreamEncoder {
-    /// Index for a tool-call id, assigning the next free slot on first sight.
+    /// Index (= `tool_calls[].index`) for a tool-call id, creating its state on
+    /// first sight.
     fn tool_call_index(&mut self, id: &str) -> usize {
-        if let Some(pos) = self.tool_call_indices.iter().position(|x| x == id) {
+        if let Some(pos) = self.tool_calls.iter().position(|s| s.id == id) {
             pos
         } else {
-            self.tool_call_indices.push(id.to_string());
-            self.tool_call_indices.len() - 1
+            self.tool_calls.push(ChatToolCallState {
+                id: id.to_string(),
+                opened: false,
+                pending_args: String::new(),
+            });
+            self.tool_calls.len() - 1
         }
     }
 }
@@ -1609,22 +1626,56 @@ impl StreamEncoder for ChatStreamEncoder {
                 arguments,
             } => {
                 let index = self.tool_call_index(id);
-                let mut function = serde_json::Map::new();
-                if let Some(name) = name {
-                    function.insert("name".into(), name.clone().into());
+                let name = name.as_deref().filter(|n| !n.is_empty());
+
+                // The Vercel AI SDK (`@ai-sdk/openai-compatible`) and other
+                // strict clients reject the FIRST streamed `tool_calls` chunk for
+                // a given index unless its `function.name` is a string. Some
+                // OpenAI-compatible upstreams (e.g. DeepSeek / Kimi) send that
+                // first delta with only `id` + partial `arguments` and deliver
+                // `name` in a later delta, so hold the call's opening chunk back
+                // — buffering argument fragments — until the name arrives, then
+                // emit one named opening chunk. Like the Generate Content encoder
+                // buffers a tool call until complete, and consistent with the
+                // Responses / Messages encoders only opening a call on a
+                // non-empty name (both added in #552).
+                // <https://github.com/anomalyco/opencode/issues/24137>
+                let mut opening_name: Option<String> = None;
+                let mut out_args: Option<String> = None;
+                if let Some(state) = self.tool_calls.get_mut(index) {
+                    if state.opened {
+                        if !arguments.is_empty() {
+                            out_args = Some(arguments.clone());
+                        }
+                    } else if let Some(name) = name {
+                        let mut args = std::mem::take(&mut state.pending_args);
+                        args.push_str(arguments);
+                        state.opened = true;
+                        opening_name = Some(name.to_string());
+                        out_args = Some(args);
+                    } else {
+                        state.pending_args.push_str(arguments);
+                    }
                 }
-                function.insert("arguments".into(), arguments.clone().into());
-                let mut delta = self.open_delta();
-                delta.insert(
-                    "tool_calls".into(),
-                    serde_json::json!([{
-                        "index": index,
-                        "id": id,
-                        "type": "function",
-                        "function": serde_json::Value::Object(function),
-                    }]),
-                );
-                frames.push(self.chunk(serde_json::Value::Object(delta), None));
+
+                if opening_name.is_some() || out_args.is_some() {
+                    let mut function = serde_json::Map::new();
+                    if let Some(name) = opening_name {
+                        function.insert("name".into(), name.into());
+                    }
+                    function.insert("arguments".into(), out_args.unwrap_or_default().into());
+                    let mut delta = self.open_delta();
+                    delta.insert(
+                        "tool_calls".into(),
+                        serde_json::json!([{
+                            "index": index,
+                            "id": id,
+                            "type": "function",
+                            "function": serde_json::Value::Object(function),
+                        }]),
+                    );
+                    frames.push(self.chunk(serde_json::Value::Object(delta), None));
+                }
             }
             StreamPart::Usage { .. } => {
                 // usage is attached to the Finish chunk below; nothing here.

--- a/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
@@ -9630,6 +9630,77 @@ fn responses_encodes_mcp_call_output_item() {
     );
 }
 
+/// Regression #560: some OpenAI-compatible upstreams (e.g. DeepSeek / Kimi)
+/// stream a tool call whose FIRST `tool_calls` delta carries only `id` +
+/// partial `arguments`, delivering `function.name` in a LATER delta. The Chat
+/// Completions stream encoder must hold the tool call's opening chunk back until
+/// the name is known, so the first `tool_calls` chunk a client sees always
+/// carries a string `function.name`. Otherwise strict clients (the Vercel AI
+/// SDK `@ai-sdk/openai-compatible` / opencode) abort the stream with
+/// `AI_InvalidResponseDataError: Expected 'function.name' to be a string`.
+/// <https://github.com/anomalyco/opencode/issues/24137>
+#[test]
+fn chat_encode_late_tool_name_first_chunk_carries_name() {
+    let parts = decode_stream(
+        ApiProtocol::ChatCompletions,
+        &[
+            // First delta: id + empty arguments, NO function.name yet.
+            (
+                "",
+                serde_json::json!({"choices":[{"delta":{"tool_calls":[
+                    {"index":0,"id":"call_123","type":"function",
+                     "function":{"arguments":""}}]}}]}),
+            ),
+            // The name arrives only on the second delta, alongside partial args.
+            (
+                "",
+                serde_json::json!({"choices":[{"delta":{"tool_calls":[
+                    {"index":0,"id":"call_123","type":"function",
+                     "function":{"name":"bash","arguments":"{\"cmd\":\""}}]}}]}),
+            ),
+            // Continuation re-sends an empty name (normalized to None upstream).
+            (
+                "",
+                serde_json::json!({"choices":[{"delta":{"tool_calls":[
+                    {"index":0,"id":"call_123","type":"function",
+                     "function":{"name":"","arguments":"ls\"}"}}]}}]}),
+            ),
+            (
+                "",
+                serde_json::json!({"choices":[{"delta":{},"finish_reason":"tool_calls"}]}),
+            ),
+        ],
+    );
+    let events = encode_stream_events(ApiProtocol::ChatCompletions, &parts);
+
+    // Every emitted `tool_calls[]` delta, in wire order.
+    let tool_deltas: Vec<serde_json::Value> = events
+        .iter()
+        .filter_map(|(_, chunk)| chunk["choices"][0]["delta"].get("tool_calls").cloned())
+        .flat_map(|tc| tc.as_array().cloned().unwrap_or_default())
+        .collect();
+
+    // The FIRST tool_calls chunk the client sees must name the function.
+    let first = tool_deltas
+        .first()
+        .expect("at least one tool_calls delta is emitted");
+    assert_eq!(
+        first["function"]["name"], "bash",
+        "first streamed tool_calls chunk must carry a string function.name; got {first}"
+    );
+    assert_eq!(first["id"], "call_123", "tool-call id is preserved");
+
+    // All argument fragments survive the buffering, in order.
+    let args: String = tool_deltas
+        .iter()
+        .filter_map(|d| d["function"]["arguments"].as_str())
+        .collect();
+    assert_eq!(
+        args, "{\"cmd\":\"ls\"}",
+        "argument fragments survive the hold-until-name buffering: {tool_deltas:?}"
+    );
+}
+
 #[test]
 fn coarse_wires_drop_server_tool_activity() {
     // Chat Completions and Generate Content have no server-tool / MCP stream


### PR DESCRIPTION
## Summary

Fixes #560. Streaming chat completions broke tool-calling for Vercel-AI-SDK clients (e.g. opencode) with:

```
AI_InvalidResponseDataError: Expected 'function.name' to be a string.
```

Plain text generation was unaffected — only the streamed `tool_call` path.

## Root cause

Some OpenAI-compatible upstreams (e.g. `deepseek/deepseek-v4-pro`, `moonshotai/kimi-k2.7-code`) stream a tool call whose **first** `tool_calls` delta carries only `id` + partial `arguments`, delivering `function.name` in a **later** delta:

```
data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_123","type":"function","function":{"arguments":""}}]}}]}
data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_123","type":"function","function":{"name":"bash","arguments":"{"}}]}}]}
```

`ChatStreamEncoder` forwarded each delta verbatim, so the first chunk a client saw had no `function.name`. The Vercel AI SDK (`@ai-sdk/openai-compatible`) rejects the first streamed chunk for a new tool-call index unless `function.name` is a string. (Same root cause as [opencode#24137](https://github.com/anomalyco/opencode/issues/24137).)

PR #552 hardened the Responses / Messages / Generate Content encoders and the chat decoder against this upstream quirk, but left the **chat encoder** naive — that gap is this bug.

## Fix

`ChatStreamEncoder` now holds a tool call's opening chunk back — buffering argument fragments per call — until a non-empty `function.name` arrives, then emits one named opening chunk and streams the remaining arguments. A call whose name never arrives is dropped, consistent with the server-tool loop's handling of nameless calls. The change is encoder-only; the decoder and the other encoders are untouched.

## Test

Adds `chat_encode_late_tool_name_first_chunk_carries_name`, which replays the captured wire shape through the real chat decode → encode round trip and asserts the first emitted chunk names the function. It fails on `main` (`function.name` is `null`) and passes with the fix.

## Verification

- `cargo nextest run --all-features` — 985 passed, 1 skipped
- `cargo clippy --all-features` — clean
- `cargo fmt -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)