### PR TITLE
fix(ci): regen config schema; exclude xtask from dist and release-plz

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -6,6 +6,11 @@ pr_branch_prefix = "release-plz/" # PR branch prefix
 pr_name = "chore(release): publish v{{ version }}"
 pr_labels = ["release"]           # add the `release` label to the release Pull Request
 
+# xtask is a workspace-internal automation binary; never release or publish it.
+[[package]]
+name = "xtask"
+release = false
+
 # Only the main binary package gets a tag, release, and changelog entry.
 [[package]]
 name = "bitrouter"

--- a/schemas/bitrouter.config.schema.json
+++ b/schemas/bitrouter.config.schema.json
@@ -676,6 +676,11 @@
     "ServerToolsConfig": {
       "description": "The OSS `server_tools` config section. Names the MCP servers whose tools\nBitRouter attaches to LLM requests and executes inside the loop, with an\noptional override of the loop's iteration cap. An empty `mcp_servers`\nleaves the pipeline strictly single-shot.",
       "properties": {
+        "advisor": {
+          "default": false,
+          "description": "Enable the `advisor` server tool (consult a stronger model mid-task).\nAdvertised per-request only when the caller declares `bitrouter:advisor`.",
+          "type": "boolean"
+        },
         "fusion": {
           "anyOf": [
             {
@@ -704,6 +709,11 @@
             "type": "string"
           },
           "type": "array"
+        },
+        "subagent": {
+          "default": false,
+          "description": "Enable the `subagent` server tool (delegate a task to a worker model).\nAdvertised per-request only when the caller declares `bitrouter:subagent`.",
+          "type": "boolean"
         }
       },
       "type": "object"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 rust-version.workspace = true
 publish = false
 
+[package.metadata.dist]
+dist = false
+
 [dependencies]
 # Config types are the canonical schema definition; the `config_file` feature
 # pulls the module in. `schemars` derives the JSON Schema from them.


### PR DESCRIPTION
## Summary

- **Schema drift**: PR #576 added `advisor` and `subagent` fields to `ServerToolsConfig` after the schema was committed in #575, breaking the CI drift guard (`cargo xtask generate-schema --check`). Regenerated to include both new fields.
- **cargo-dist**: Added `[package.metadata.dist] dist = false` to `xtask/Cargo.toml` so cargo-dist never picks up the workspace-internal `xtask` binary as a distributable artifact.
- **release-plz**: Added an explicit `release = false` entry for `xtask` in `release-plz.toml`, complementing the existing `publish = false` in `Cargo.toml`.

## Test plan

- [x] `cargo xtask generate-schema --check` passes
- [x] `bitrouter config validate -c examples/bitrouter.yaml` exits 0
- [x] `serde_yaml` / `serde_yml` guard: neither crate in the dependency graph

🤖 Generated with [Claude Code](https://claude.com/claude-code)