### PR TITLE
fix(release): add publish = false for xtask in release-plz config

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -10,6 +10,7 @@ pr_labels = ["release"]           # add the `release` label to the release Pull 
 [[package]]
 name = "xtask"
 release = false
+publish = false
 
 # Only the main binary package gets a tag, release, and changelog entry.
 [[package]]


### PR DESCRIPTION
## Summary

Followup to #579. The merged PR added `release = false` for `xtask` in `release-plz.toml` but not `publish = false`. release-plz validates that `publish` must be consistent between `Cargo.toml` and its own config — an explicit `[[package]]` entry defaults `publish` to `true`, conflicting with `publish = false` in `xtask/Cargo.toml` and causing the release job to error:

```
Package `xtask` has `publish = false` or `publish = []` in the Cargo.toml,
but it has `publish = true` in the release-plz configuration.
```

One-line fix: add `publish = false` to the xtask entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)