### PR TITLE
fix(schema): don't embed workspace version in committed schema $id

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -10,6 +10,7 @@ pr_labels = ["release"]           # add the `release` label to the release Pull 
 [[package]]
 name = "xtask"
 release = false
+publish = false
 
 # Only the main binary package gets a tag, release, and changelog entry.
 [[package]]

--- a/schemas/bitrouter.config.schema.json
+++ b/schemas/bitrouter.config.schema.json
@@ -813,7 +813,6 @@
       ]
     }
   },
-  "$id": "https://bitrouter.dev/schema/v1.0.0-alpha.15/config.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "The top-level configuration.",
   "properties": {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -12,10 +12,6 @@ use std::process::ExitCode;
 
 use anyhow::{Context, Result, bail};
 
-/// Workspace version, stamped into the schema `$id`. Every workspace crate
-/// shares `version.workspace`, so xtask's own version is the workspace version.
-const VERSION: &str = env!("CARGO_PKG_VERSION");
-
 fn main() -> ExitCode {
     let args: Vec<String> = std::env::args().skip(1).collect();
     // The task is the first non-flag argument, so flag order doesn't matter
@@ -53,15 +49,11 @@ fn schema_path() -> PathBuf {
 fn render_schema() -> Result<String> {
     let mut root = serde_json::to_value(schemars::schema_for!(bitrouter_sdk::config::Config))
         .context("serializing generated schema")?;
-    // Stamp identity onto the root so a published copy is self-describing and
-    // tools (SchemaStore, IDEs) can pin a version.
+    // Add a stable, version-independent title. $id is intentionally omitted
+    // from the committed snapshot — it couples the file to the workspace
+    // version and breaks the drift check on every release-plz PR. A versioned
+    // $id should be injected at publish time, not stored in the repo.
     if let Some(obj) = root.as_object_mut() {
-        obj.insert(
-            "$id".to_string(),
-            serde_json::Value::String(format!(
-                "https://bitrouter.dev/schema/v{VERSION}/config.schema.json"
-            )),
-        );
         obj.insert(
             "title".to_string(),
             serde_json::Value::String("BitRouter config".to_string()),


### PR DESCRIPTION
## Root cause

`render_schema()` in `xtask/src/main.rs` stamped `CARGO_PKG_VERSION` into the schema's `$id` field:

```
"$id": "https://bitrouter.dev/schema/v1.0.0-alpha.15/config.schema.json"
```

When release-plz bumps the version to `alpha.16`, `cargo xtask generate-schema --check` regenerates the schema with `alpha.16` in `$id` — but the committed file still says `alpha.15`. String comparison fails, so the schema CI job fails on every release PR even though the schema structs haven't changed.

## Fix

Strip `$id` from the committed snapshot. The committed schema is a structural contract (do the serde structs match the file?), not a versioned artifact. A versioned URL belongs in the published/distributed schema; inject it at publish time, not at commit time. The `title` field is version-independent and is kept.

Regenerate the snapshot to drop the one `$id` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)