### PR TITLE
ci(release-plz): bump schema $id after release PR is created/updated

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -59,8 +59,27 @@ jobs:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Run release-plz
+        id: release-plz
         uses: release-plz/action@v0.5
         with:
           command: release-pr
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+
+      - name: Bump schema $id to match release version
+        if: steps.release-plz.outputs.pr != ''
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          RELEASE_PR: ${{ steps.release-plz.outputs.pr }}
+        run: |
+          branch=$(echo "$RELEASE_PR" | jq -r '.head_branch')
+          git fetch origin "$branch"
+          git checkout "$branch"
+          cargo xtask generate-schema
+          git diff --quiet schemas/ && exit 0
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add schemas/bitrouter.config.schema.json
+          git commit -m "chore: update config schema \$id for release"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+          git push origin "$branch"


### PR DESCRIPTION
## Summary

release-plz has no hook mechanism (`pre_release_hook` doesn't exist). The alternative is a follow-up step in the `release-plz-pr` job that runs immediately after the action.

The step:
1. Reads the release PR branch from the action's `pr` output (`steps.release-plz.outputs.pr`)
2. Checks out that branch and runs `cargo xtask generate-schema`
3. Commits the updated `schemas/bitrouter.config.schema.json` (with the new `$id` version) and pushes it back to the release PR branch
4. Is a no-op if the schema is already up to date (`git diff --quiet`)

This supersedes #581 (which removed `$id` from the schema entirely as a workaround).

## Test plan

- [ ] Merge to main and verify the next release-plz run produces a PR whose schema `$id` matches the bumped version
- [ ] Verify `cargo xtask generate-schema --check` passes on that PR's branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)