### PR TITLE
chore(release): bump workspace to v1.0.0-alpha.17

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -11,6 +11,9 @@ jobs:
   release-plz-release:
     name: Release-plz release
     runs-on: ubuntu-latest
+    concurrency:
+      group: release-plz-release-${{ github.ref }}
+      cancel-in-progress: false
     permissions:
       contents: write
       pull-requests: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0-alpha.16](https://github.com/bitrouter/bitrouter/compare/v1.0.0-alpha.15...v1.0.0-alpha.16)
+## [1.0.0-alpha.17](https://github.com/bitrouter/bitrouter/compare/v1.0.0-alpha.15...v1.0.0-alpha.17)
 
 
 ### ⛰️ Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "bitrouter"
-version = "1.0.0-alpha.16"
+version = "1.0.0-alpha.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -783,7 +783,7 @@ dependencies = [
 
 [[package]]
 name = "bitrouter-attestation"
-version = "1.0.0-alpha.16"
+version = "1.0.0-alpha.17"
 dependencies = [
  "async-trait",
  "dcap-qvl",
@@ -802,7 +802,7 @@ dependencies = [
 
 [[package]]
 name = "bitrouter-attestation-plugin"
-version = "1.0.0-alpha.16"
+version = "1.0.0-alpha.17"
 dependencies = [
  "async-trait",
  "bitrouter-attestation",
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "bitrouter-bedrock"
-version = "1.0.0-alpha.16"
+version = "1.0.0-alpha.17"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -828,7 +828,7 @@ dependencies = [
 
 [[package]]
 name = "bitrouter-cloud-sdk"
-version = "1.0.0-alpha.16"
+version = "1.0.0-alpha.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "bitrouter-guardrails"
-version = "1.0.0-alpha.16"
+version = "1.0.0-alpha.17"
 dependencies = [
  "async-trait",
  "bitrouter-sdk",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "bitrouter-mcp"
-version = "1.0.0-alpha.16"
+version = "1.0.0-alpha.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -884,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "bitrouter-observe"
-version = "1.0.0-alpha.16"
+version = "1.0.0-alpha.17"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -908,7 +908,7 @@ dependencies = [
 
 [[package]]
 name = "bitrouter-providers"
-version = "1.0.0-alpha.16"
+version = "1.0.0-alpha.17"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "bitrouter-sdk"
-version = "1.0.0-alpha.16"
+version = "1.0.0-alpha.17"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "bitrouter-skills"
-version = "1.0.0-alpha.16"
+version = "1.0.0-alpha.17"
 dependencies = [
  "reqwest 0.12.28",
  "serde",
@@ -6327,7 +6327,7 @@ checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "xtask"
-version = "1.0.0-alpha.16"
+version = "1.0.0-alpha.17"
 dependencies = [
  "anyhow",
  "bitrouter-sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*", "plugins/*", "apps/*", "mcp", "xtask"]
 
 [workspace.package]
-version = "1.0.0-alpha.16"
+version = "1.0.0-alpha.17"
 edition = "2024"
 license = "Apache-2.0"
 authors = ["Archer <archer@bitrouter.ai>"]
@@ -15,15 +15,15 @@ rust-version = "1.88"
 
 [workspace.dependencies]
 # internal crates
-bitrouter-sdk = { path = "crates/bitrouter-sdk", version = "1.0.0-alpha.16", default-features = false }
-bitrouter-attestation = { path = "crates/bitrouter-attestation", version = "1.0.0-alpha.16" }
-bitrouter-bedrock = { path = "crates/bitrouter-bedrock", version = "1.0.0-alpha.16" }
-bitrouter-cloud-sdk = { path = "crates/bitrouter-cloud-sdk", version = "1.0.0-alpha.16" }
-bitrouter-providers = { path = "crates/bitrouter-providers", version = "1.0.0-alpha.16" }
-bitrouter-skills = { path = "crates/bitrouter-skills", version = "1.0.0-alpha.16" }
-bitrouter-guardrails = { path = "plugins/bitrouter-guardrails", version = "1.0.0-alpha.16" }
-bitrouter-attestation-plugin = { path = "plugins/bitrouter-attestation", version = "1.0.0-alpha.16" }
-bitrouter-observe = { path = "plugins/bitrouter-observe", version = "1.0.0-alpha.16", default-features = false }
+bitrouter-sdk = { path = "crates/bitrouter-sdk", version = "1.0.0-alpha.17", default-features = false }
+bitrouter-attestation = { path = "crates/bitrouter-attestation", version = "1.0.0-alpha.17" }
+bitrouter-bedrock = { path = "crates/bitrouter-bedrock", version = "1.0.0-alpha.17" }
+bitrouter-cloud-sdk = { path = "crates/bitrouter-cloud-sdk", version = "1.0.0-alpha.17" }
+bitrouter-providers = { path = "crates/bitrouter-providers", version = "1.0.0-alpha.17" }
+bitrouter-skills = { path = "crates/bitrouter-skills", version = "1.0.0-alpha.17" }
+bitrouter-guardrails = { path = "plugins/bitrouter-guardrails", version = "1.0.0-alpha.17" }
+bitrouter-attestation-plugin = { path = "plugins/bitrouter-attestation", version = "1.0.0-alpha.17" }
+bitrouter-observe = { path = "plugins/bitrouter-observe", version = "1.0.0-alpha.17", default-features = false }
 
 # shared third-party
 anyhow = "1"

--- a/apps/bitrouter/Cargo.toml
+++ b/apps/bitrouter/Cargo.toml
@@ -24,7 +24,7 @@ bitrouter-providers = { workspace = true, features = ["pkce"] }
 bitrouter-skills.workspace = true
 bitrouter-guardrails.workspace = true
 bitrouter-observe = { workspace = true, features = ["otel-http"] }
-bitrouter-mcp = { path = "../../mcp", version = "1.0.0-alpha.16" }
+bitrouter-mcp = { path = "../../mcp", version = "1.0.0-alpha.17" }
 chrono.workspace = true
 sha2.workspace = true
 base64.workspace = true

--- a/schemas/bitrouter.config.schema.json
+++ b/schemas/bitrouter.config.schema.json
@@ -813,7 +813,7 @@
       ]
     }
   },
-  "$id": "https://bitrouter.dev/schema/v1.0.0-alpha.16/config.schema.json",
+  "$id": "https://bitrouter.dev/schema/v1.0.0-alpha.17/config.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "The top-level configuration.",
   "properties": {


### PR DESCRIPTION
## Summary

- `bitrouter-attestation v1.0.0-alpha.16` was published to crates.io with stale code (pre-#573/#578 attestation API changes). Since crates.io versions are immutable, `cargo publish` for `bitrouter v1.0.0-alpha.16` failed because it fetched the stale crate and hit missing fields/methods.
- Bumping the workspace to `v1.0.0-alpha.17` lets release-plz publish all crates fresh with the correct code.
- Also adds a `concurrency` guard to the `release-plz-release` job so parallel workflow runs queue rather than race to publish the same version (structural fix for the root cause).

**Changes:**
- Bump all workspace versions `1.0.0-alpha.16` → `1.0.0-alpha.17` (`Cargo.toml`, `apps/bitrouter/Cargo.toml`, `Cargo.lock`)
- Rename `CHANGELOG.md` alpha.16 section → alpha.17 (the alpha.16 tag was never created, so release-plz compares from alpha.15 — this keeps the history accurate)
- Update `schemas/bitrouter.config.schema.json` `$id` to `v1.0.0-alpha.17`
- Add `concurrency: group: release-plz-release-${{ github.ref }}` to the release job

## Test plan

- [ ] CI passes on this PR
- [ ] Merge to main → release-plz-release workflow publishes all crates at alpha.17 successfully