### PR TITLE
fix(attestation): enable rust_crypto backend for jsonwebtoken

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1445,6 +1445,7 @@ dependencies = [
  "fiat-crypto",
  "rustc_version",
  "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1761,6 +1762,7 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
+ "pkcs8",
  "signature",
 ]
 
@@ -1772,8 +1774,10 @@ checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
+ "serde",
  "sha2",
  "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1797,6 +1801,8 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
+ "hkdf",
+ "pem-rfc7468",
  "pkcs8",
  "rand_core 0.6.4",
  "sec1",
@@ -2819,17 +2825,26 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "9.3.1"
+version = "10.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
  "base64 0.22.1",
+ "ed25519-dalek",
+ "getrandom 0.2.17",
+ "hmac",
  "js-sys",
+ "p256",
+ "p384",
  "pem",
- "ring",
+ "rand 0.8.6",
+ "rsa",
  "serde",
  "serde_json",
+ "sha2",
+ "signature",
  "simple_asn1",
+ "zeroize",
 ]
 
 [[package]]
@@ -6410,6 +6425,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"

--- a/crates/bitrouter-attestation/Cargo.toml
+++ b/crates/bitrouter-attestation/Cargo.toml
@@ -18,7 +18,7 @@ dcap-qvl = { version = "0.3.12", default-features = false, features = [
     "rustcrypto",
 ] }
 hex.workspace = true
-jsonwebtoken = "10"
+jsonwebtoken = { version = "10", features = ["rust_crypto"] }
 # secp256k1 ECDSA recovery for NEAR chat signatures (EIP-191), matching the
 # gateway's k256 usage.
 k256 = { version = "0.13", features = ["ecdsa"] }


### PR DESCRIPTION
## Summary

`jsonwebtoken@10.4.0` changed its `[features]` defaults — `rust_crypto` is no longer included in the `default` feature set (only `use_pem` is). With no crypto backend compiled in, any JWT signature operation panics at runtime:

```
Could not automatically determine the process-level CryptoProvider from jsonwebtoken crate features.
Call CryptoProvider::install_default() before this point to select a provider manually,
or make sure exactly one of the 'rust_crypto' and 'aws_lc_rs' features is enabled.
```

This broke `near::nvidia::tests::accepts_a_passing_signed_eat_with_matching_nonce` on all platforms.

**Fix:** add `features = ["rust_crypto"]` to the `jsonwebtoken` dep in `bitrouter-attestation/Cargo.toml` so the pure-Rust backend is always compiled in.

The Windows clippy failure in the same CI run was an unrelated transient `curl` network reset downloading `k256` from crates.io — not a code issue.

## Test plan

- [x] `cargo nextest run -p bitrouter-attestation` — 66/66 passed locally
- [x] `cargo clippy -p bitrouter-attestation --all-features --tests -- -D warnings` — clean