### PR TITLE
feat: read the existing Claude Code session for Claude subscription auth

### DIFF
--- a/apps/bitrouter/src/assemble.rs
+++ b/apps/bitrouter/src/assemble.rs
@@ -174,6 +174,14 @@ pub async fn build_app_with_path(
     // (api_base / api_protocol / api_key-from-env). No-op when
     // `inherit_defaults: false`, and never overrides user-set fields.
     bitrouter_providers::apply_builtin_defaults(&mut resolved);
+    // Subscription / "use your Claude Code session" logins persist their
+    // credential in the store (not the config), so apply_builtin_defaults would
+    // mark a keyless provider like `anthropic` inactive. Re-activate any
+    // provider that has a stored credential so it stays routable.
+    if let Ok(store) = bitrouter_providers::oauth::credential_store::CredentialStore::default_path()
+    {
+        bitrouter_providers::activate_stored_credential_providers(&mut resolved, &store);
+    }
     bitrouter_sdk::config::discover_models(&mut resolved).await;
     let routing_table = Arc::new(match config_path {
         Some(path) => ConfigRoutingTable::from_config_with_path(resolved, path),

--- a/apps/bitrouter/src/commands.rs
+++ b/apps/bitrouter/src/commands.rs
@@ -292,6 +292,12 @@ pub async fn create_policy(policy_dir: &std::path::Path, id: &str) -> Result<std
 /// actually supports.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum AuthMethod {
+    /// Use the user's existing Claude Code session: read its OAuth credential
+    /// live from `~/.claude` (Keychain / `.credentials.json`), or sign in via
+    /// the `claude` CLI when not yet logged in. The preferred path for
+    /// `anthropic` — no second token copy, so it can't refresh-rotate Claude
+    /// Code out (RFC 6749 §6).
+    ClaudeCodeSession,
     /// Browser-based PKCE Authorization Code flow — Anthropic Claude
     /// Pro/Max, OpenAI Codex / ChatGPT.
     PkceSubscription,
@@ -307,6 +313,9 @@ enum AuthMethod {
 impl AuthMethod {
     fn label(self) -> &'static str {
         match self {
+            AuthMethod::ClaudeCodeSession => {
+                "Use your Claude Code session (read ~/.claude, or sign in via the claude CLI)"
+            }
             AuthMethod::PkceSubscription => "Subscription (browser sign-in)",
             AuthMethod::ImportFromCli => "Import an existing session from the vendor CLI",
             AuthMethod::DeviceCode => "Device-code OAuth (show a code in browser)",
@@ -331,12 +340,22 @@ fn import_cli_for(provider_id: &str) -> Option<&'static str> {
 fn available_methods(entry: &bitrouter_providers::ProviderEntry) -> Vec<AuthMethod> {
     use bitrouter_providers::AuthScheme;
     let mut methods = Vec::new();
+    // Anthropic's preferred path: read the user's live Claude Code session and
+    // let the `claude` CLI own login. Listed first so it's the default on
+    // <enter> / non-interactive runs.
+    let is_anthropic = entry.id == bitrouter_providers::anthropic::PROVIDER_ID;
+    if is_anthropic {
+        methods.push(AuthMethod::ClaudeCodeSession);
+    }
     let has_pkce = bitrouter_providers::oauth::registry::has_pkce_flow(&entry.id);
     if has_pkce {
         methods.push(AuthMethod::PkceSubscription);
     }
-    // Providers with a sibling vendor CLI can adopt its existing session.
-    if import_cli_for(&entry.id).is_some() {
+    // Providers with a sibling vendor CLI can adopt its existing session as a
+    // one-shot copy. For anthropic this is superseded by the live
+    // `ClaudeCodeSession` above (the copy is what risked the family-revoke), so
+    // it's offered only for the other CLI providers (Codex).
+    if import_cli_for(&entry.id).is_some() && !is_anthropic {
         methods.push(AuthMethod::ImportFromCli);
     }
     match &entry.auth {
@@ -436,6 +455,7 @@ pub async fn login_provider(provider_id: &str, label: &str) -> Result<()> {
     );
 
     let credential = match chosen {
+        AuthMethod::ClaudeCodeSession => run_claude_code_session().await?,
         AuthMethod::PkceSubscription => run_pkce_subscription(provider_id).await?,
         AuthMethod::ImportFromCli => run_cli_import(provider_id)?,
         AuthMethod::DeviceCode => run_device_code(provider_id, entry).await?,
@@ -454,6 +474,90 @@ pub async fn login_provider(provider_id: &str, label: &str) -> Result<()> {
     );
     eprintln!();
     Ok(())
+}
+
+/// Adopt the user's existing Claude Code session as the live credential source
+/// for `anthropic`.
+///
+/// Resolution order, mirroring how Claude Code users actually authenticate:
+/// 1. If a Claude Code session already exists in `~/.claude` (macOS Keychain /
+///    `.credentials.json`), use it as-is — the daemon reads it live and
+///    refreshes in place.
+/// 2. Otherwise sign the user in with the `claude` CLI itself (`claude auth
+///    login --claudeai`), installing it first (the same native installer
+///    `bitrouter spawn` uses) when it's missing, then re-read.
+///
+/// Returns a [`Credential::ClaudeCodeCli`] marker — no token is copied into
+/// bitrouter's own store, so bitrouter and Claude Code share one credential and
+/// can't refresh-rotate each other out (RFC 6749 §6).
+async fn run_claude_code_session()
+-> Result<bitrouter_providers::oauth::credential_store::Credential> {
+    use std::io::IsTerminal;
+
+    use bitrouter_providers::import::claude_code::ClaudeCodeStore;
+    use bitrouter_providers::oauth::credential_store::Credential;
+
+    let store = ClaudeCodeStore::system().ok_or_else(|| {
+        anyhow::anyhow!(
+            "could not resolve your home directory (set HOME) to find the Claude Code session"
+        )
+    })?;
+
+    // 1. Already signed in to Claude Code?
+    if let Some(live) = store
+        .read()
+        .context("reading your existing Claude Code session")?
+    {
+        eprintln!(
+            "  Found your Claude Code session ({}) — bitrouter will read it live.",
+            live.source
+        );
+        return Ok(Credential::ClaudeCodeCli);
+    }
+
+    // 2. Not signed in — drive the `claude` CLI's own login.
+    if !std::io::stdin().is_terminal() {
+        anyhow::bail!(
+            "not signed in to Claude Code. Run `claude auth login` (install the CLI first with \
+             `curl -fsSL https://claude.ai/install.sh | bash`), then re-run \
+             `bitrouter login anthropic`."
+        );
+    }
+
+    let claude = crate::spawn::ensure_agent_installed(crate::spawn::SpawnAgent::Claude, false)
+        .await
+        .context("locating the claude CLI to sign you in")?;
+
+    eprintln!("  You're not signed in to Claude Code yet — launching `claude auth login`.");
+    let status = tokio::process::Command::new(&claude)
+        .arg("auth")
+        .arg("login")
+        .arg("--claudeai")
+        .status()
+        .await
+        .context("running `claude auth login`")?;
+    if !status.success() {
+        anyhow::bail!(
+            "`claude auth login` didn't complete — sign in, then re-run `bitrouter login anthropic`."
+        );
+    }
+
+    match store
+        .read()
+        .context("re-reading your Claude Code session after sign-in")?
+    {
+        Some(live) => {
+            eprintln!(
+                "  Signed in — bitrouter will read your session live from {}.",
+                live.source
+            );
+            Ok(Credential::ClaudeCodeCli)
+        }
+        None => anyhow::bail!(
+            "still no Claude Code session after `claude auth login` — run `claude auth status` \
+             to check, then retry."
+        ),
+    }
 }
 
 /// Run the browser-based PKCE Authorization Code flow against the
@@ -972,6 +1076,33 @@ mod tests {
             "agents block should land as parsed entries; got: {:?}",
             cfg.agents.keys().collect::<Vec<_>>()
         );
+    }
+
+    #[test]
+    fn anthropic_prefers_claude_code_session_first() {
+        let entry = bitrouter_providers::builtin::find("anthropic").unwrap();
+        let methods = available_methods(entry);
+        assert_eq!(
+            methods.first(),
+            Some(&AuthMethod::ClaudeCodeSession),
+            "the live Claude Code session must be the default for anthropic"
+        );
+        assert!(
+            !methods.contains(&AuthMethod::ImportFromCli),
+            "anthropic uses the live session, not the one-shot copy that can family-revoke"
+        );
+        assert!(
+            methods.contains(&AuthMethod::PkceSubscription),
+            "PKCE stays available as an explicit fallback"
+        );
+    }
+
+    #[test]
+    fn codex_keeps_oneshot_import_and_offers_no_claude_code_session() {
+        let entry = bitrouter_providers::builtin::find("openai-codex").unwrap();
+        let methods = available_methods(entry);
+        assert!(methods.contains(&AuthMethod::ImportFromCli));
+        assert!(!methods.contains(&AuthMethod::ClaudeCodeSession));
     }
 
     fn sample_config() -> Config {

--- a/apps/bitrouter/src/reload.rs
+++ b/apps/bitrouter/src/reload.rs
@@ -19,6 +19,17 @@ use std::sync::Arc;
 use crate::daemon::DaemonReloader;
 use crate::policy::PolicyStore;
 
+/// Re-activate providers that have a credential in the OAuth store, loading the
+/// default store. Best-effort: an unreadable store is a no-op. Mirrors the
+/// startup pass in `assemble.rs` so a subscription / Claude Code session
+/// provider survives a hot-reload instead of dropping out of routing.
+fn activate_stored_credential_providers(config: &mut bitrouter_sdk::config::Config) {
+    if let Ok(store) = bitrouter_providers::oauth::credential_store::CredentialStore::default_path()
+    {
+        bitrouter_providers::activate_stored_credential_providers(config, &store);
+    }
+}
+
 /// Whether the daemon is running against a `bitrouter.yaml` on disk
 /// (re-readable on reload) or a zero-config in-memory default
 /// (rebuilt by re-running [`bitrouter_providers::zero_config`]).
@@ -84,6 +95,12 @@ impl DaemonReloader for AppReloader {
                     // credentials (a `bitrouter reload --env` that exports a
                     // provider key activates that provider's canonical models).
                     crate::assemble::merge_registry_into(&mut fresh).await;
+                    // Then re-activate any provider that has an OAuth /
+                    // subscription credential in the store — those live outside
+                    // the config, so the registry's credential gate can't see
+                    // them and the merge's `apply_builtin_defaults` would leave a
+                    // keyless provider inactive. Runs after the merge.
+                    activate_stored_credential_providers(&mut fresh);
                     self.routing_table.replace_config(fresh).await
                 }
                 Err(e) => Err(e),
@@ -105,6 +122,10 @@ impl DaemonReloader for AppReloader {
                 // Merge the registry so the canonical catalog + every
                 // credentialed BYOK provider is routable after a reload too.
                 crate::assemble::merge_registry_into(&mut fresh).await;
+                // Then re-activate any provider with a stored OAuth / subscription
+                // credential (invisible to the registry's config/env credential
+                // gate), after the merge re-applies builtin defaults.
+                activate_stored_credential_providers(&mut fresh);
                 self.routing_table.replace_config(fresh).await
             }
         };

--- a/apps/bitrouter/src/spawn.rs
+++ b/apps/bitrouter/src/spawn.rs
@@ -129,10 +129,7 @@ pub async fn run(cfg: &bitrouter_sdk::config::Config, opts: SpawnOptions) -> Res
     };
 
     // Locate the binary; prompt-to-install when it's missing.
-    let binary = match resolve_binary(spec.binary) {
-        Some(path) => path,
-        None => ensure_installed(&spec, opts.no_install).await?,
-    };
+    let binary = ensure_agent_installed(opts.agent, opts.no_install).await?;
 
     // Best-effort reachability note — never blocks the launch. The agent
     // would fail on its own if the daemon is down; surfacing it up front is
@@ -330,6 +327,19 @@ fn home_dir() -> Option<PathBuf> {
     #[cfg(not(windows))]
     {
         std::env::var_os("HOME").map(PathBuf::from)
+    }
+}
+
+/// Ensure `agent`'s binary is installed — locating it on `PATH` (+
+/// `~/.local/bin`) and offering the official native installer when permitted —
+/// and return its path. Shared by `bitrouter spawn` and `bitrouter login
+/// anthropic` (which needs the `claude` CLI to sign the user in) so both go
+/// through one detect-and-install path.
+pub(crate) async fn ensure_agent_installed(agent: SpawnAgent, no_install: bool) -> Result<PathBuf> {
+    let spec = agent.spec();
+    match resolve_binary(spec.binary) {
+        Some(path) => Ok(path),
+        None => ensure_installed(&spec, no_install).await,
     }
 }
 

--- a/crates/bitrouter-providers/src/anthropic/mod.rs
+++ b/crates/bitrouter-providers/src/anthropic/mod.rs
@@ -367,12 +367,24 @@ impl AuthApplier for AnthropicOAuthApplier {
                 // OAuth requests must NOT carry x-api-key — the upstream
                 // returns 401 when both auth schemes are present.
                 headers_mut.remove("x-api-key");
-                let beta_value = headers::OAUTH_BETA_VALUES.join(",");
+                // Merge — never overwrite — the OAuth-required betas with any
+                // the client already sent. Claude Code appends feature betas
+                // (e.g. `context-management-2025-06-27`, interleaved thinking,
+                // prompt caching) alongside the matching request-body fields;
+                // clobbering the header would leave those fields with no
+                // enabling beta and the upstream 400s ("Extra inputs are not
+                // permitted").
+                let client_betas: Vec<String> = headers_mut
+                    .get_all("anthropic-beta")
+                    .iter()
+                    .filter_map(|v| v.to_str().ok())
+                    .map(str::to_string)
+                    .collect();
+                let beta_value = merged_beta_value(client_betas.iter().map(String::as_str));
                 let beta_header = HeaderValue::from_str(&beta_value).map_err(|e| {
                     BitrouterError::internal(format!("invalid anthropic-beta header: {e}"))
                 })?;
-                let beta_name = HeaderName::from_static("anthropic-beta");
-                headers_mut.insert(beta_name, beta_header);
+                headers_mut.insert(HeaderName::from_static("anthropic-beta"), beta_header);
                 // The subscription endpoint expects first-party-CLI-shaped
                 // requests; mirror Claude Code's user-agent + x-app so the
                 // OAuth credential is admitted. (Reference: OpenClaw
@@ -431,6 +443,27 @@ impl AuthApplier for AnthropicOAuthApplier {
         inject_claude_code_identity(body);
         Ok(())
     }
+}
+
+/// Merge the OAuth-required `anthropic-beta` values (which the Claude Pro/Max
+/// subscription endpoint demands) with any the client already sent, deduping
+/// while keeping the required values first. Real Claude Code traffic carries
+/// feature betas next to matching request-body fields, so the union — not an
+/// overwrite — is what keeps those requests valid upstream.
+fn merged_beta_value<'a>(client_betas: impl Iterator<Item = &'a str>) -> String {
+    let mut out: Vec<String> = headers::OAUTH_BETA_VALUES
+        .iter()
+        .map(|s| (*s).to_string())
+        .collect();
+    for raw in client_betas {
+        for beta in raw.split(',') {
+            let beta = beta.trim();
+            if !beta.is_empty() && !out.iter().any(|x| x == beta) {
+                out.push(beta.to_string());
+            }
+        }
+    }
+    out.join(",")
 }
 
 fn apply_api_key_header(request: &mut reqwest::Request, key: &str) -> Result<()> {
@@ -660,6 +693,63 @@ mod tests {
         assert_eq!(
             h.get("x-app").and_then(|v| v.to_str().ok()),
             Some(headers::CLAUDE_CODE_X_APP)
+        );
+    }
+
+    #[tokio::test]
+    async fn oauth_merges_client_anthropic_beta_instead_of_overwriting() {
+        // Real Claude Code traffic appends feature betas
+        // (`context-management-…`, interleaved-thinking) next to the matching
+        // request-body fields. The applier must keep them while adding the
+        // OAuth-required betas — overwriting strips them and the upstream 400s
+        // ("Extra inputs are not permitted") on the now-orphaned body field.
+        let path = tmp_store_path();
+        {
+            let mut store = CredentialStore::load(&path).unwrap();
+            store
+                .set(
+                    PROVIDER_ID,
+                    DEFAULT_LABEL,
+                    Credential::from_oauth_token(OAuthToken {
+                        access_token: "sk-ant-oat".into(),
+                        expires_at: 0,
+                        refresh_token: Some("r".into()),
+                    }),
+                )
+                .unwrap();
+        }
+        let applier = AnthropicOAuthApplier::new(&path).unwrap();
+        let mut req = reqwest::Client::new()
+            .post("https://api.anthropic.com/v1/messages")
+            .build()
+            .unwrap();
+        req.headers_mut().insert(
+            "anthropic-beta",
+            HeaderValue::from_static(
+                "context-management-2025-06-27,interleaved-thinking-2025-05-14",
+            ),
+        );
+        let authed = applier.apply(req, &anthropic_target(None)).await.unwrap();
+        let beta = authed
+            .headers()
+            .get("anthropic-beta")
+            .and_then(|v| v.to_str().ok())
+            .unwrap();
+        assert!(
+            beta.contains("oauth-2025-04-20"),
+            "required beta dropped: {beta}"
+        );
+        assert!(
+            beta.contains("claude-code-20250219"),
+            "required beta dropped: {beta}"
+        );
+        assert!(
+            beta.contains("context-management-2025-06-27"),
+            "client beta dropped: {beta}"
+        );
+        assert!(
+            beta.contains("interleaved-thinking-2025-05-14"),
+            "client beta dropped: {beta}"
         );
     }
 

--- a/crates/bitrouter-providers/src/anthropic/mod.rs
+++ b/crates/bitrouter-providers/src/anthropic/mod.rs
@@ -285,7 +285,17 @@ impl AnthropicOAuthApplier {
         } else {
             live.token
         };
-        self.store_in_cache(label, &token);
+        // Cache the resolved token to collapse the in-request double resolution
+        // (`apply` + `prepare_body`) and avoid a `security`/file read per
+        // request. The cache self-invalidates at the refresh window, so a
+        // `claude`-side rotation is picked up by the next refresh. A
+        // non-expiring token (`expires_at == 0`) is deliberately NOT cached: it
+        // would otherwise be served for the whole process lifetime without ever
+        // re-reading the live store, defeating the marker's "single source of
+        // truth" intent — so we re-read it live on each request instead.
+        if token.expires_at > 0 {
+            self.store_in_cache(label, &token);
+        }
         Ok(Some(ResolvedCredential::Oauth(token)))
     }
 
@@ -913,6 +923,63 @@ mod tests {
         assert!(
             err.to_string().contains("refresh"),
             "expected a refresh error proving the refresh path ran, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn claude_code_cli_marker_non_expiring_is_reread_live_each_request() {
+        // A non-expiring live token must NOT be cached for the process lifetime:
+        // when `claude` rotates the on-disk token, the next request must see the
+        // new value, keeping bitrouter in lockstep with the single source of
+        // truth.
+        let path = tmp_store_path();
+        seed_marker(&path);
+        let creds =
+            tmp_claude_creds(r#"{"claudeAiOauth":{"accessToken":"first","refreshToken":"r"}}"#);
+        let applier = AnthropicOAuthApplier::with_client_and_endpoint(
+            &path,
+            reqwest::Client::new(),
+            "client-1",
+            "https://example.com/oauth/token",
+            Some(ClaudeCodeStore::file_only(&creds)),
+        );
+        let bearer = |req: reqwest::Request| {
+            req.headers()
+                .get(reqwest::header::AUTHORIZATION)
+                .and_then(|v| v.to_str().ok())
+                .map(str::to_string)
+        };
+        let first = applier
+            .apply(
+                reqwest::Client::new()
+                    .post("https://api.anthropic.com/v1/messages")
+                    .build()
+                    .unwrap(),
+                &anthropic_target(None),
+            )
+            .await
+            .unwrap();
+        assert_eq!(bearer(first).as_deref(), Some("Bearer first"));
+        // Claude Code rotates its stored token.
+        std::fs::write(
+            &creds,
+            r#"{"claudeAiOauth":{"accessToken":"second","refreshToken":"r"}}"#,
+        )
+        .unwrap();
+        let second = applier
+            .apply(
+                reqwest::Client::new()
+                    .post("https://api.anthropic.com/v1/messages")
+                    .build()
+                    .unwrap(),
+                &anthropic_target(None),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            bearer(second).as_deref(),
+            Some("Bearer second"),
+            "a non-expiring marker token must be re-read live, not served from a stale cache"
         );
     }
 

--- a/crates/bitrouter-providers/src/anthropic/mod.rs
+++ b/crates/bitrouter-providers/src/anthropic/mod.rs
@@ -45,6 +45,7 @@ use bitrouter_sdk::language_model::AuthApplier;
 use bitrouter_sdk::language_model::types::RoutingTarget;
 use bitrouter_sdk::{BitrouterError, Result};
 
+use crate::import::claude_code::ClaudeCodeStore;
 use crate::oauth::auth_code::AuthCodeError;
 use crate::oauth::credential_store::{Credential, CredentialStore, DEFAULT_LABEL, OAuthToken};
 use crate::oauth::refresh::{needs_refresh, refresh};
@@ -83,6 +84,11 @@ pub struct AnthropicOAuthApplier {
     /// (double-checked locking) and skips the refresh if the first one
     /// already populated it.
     refresh_gates: Arc<Mutex<std::collections::HashMap<String, Arc<tokio::sync::Mutex<()>>>>>,
+    /// Live view of Claude Code's own credential store (`~/.claude`). Used to
+    /// resolve a [`Credential::ClaudeCodeCli`] marker: read the token live and
+    /// write any refresh back to the same source, so bitrouter and Claude Code
+    /// share one credential. `None` only when no home directory resolves.
+    claude_code: Option<ClaudeCodeStore>,
 }
 
 impl AnthropicOAuthApplier {
@@ -111,6 +117,7 @@ impl AnthropicOAuthApplier {
             token_endpoint: registry.auth.token_endpoint,
             cache: Arc::new(Mutex::new(std::collections::HashMap::new())),
             refresh_gates: Arc::new(Mutex::new(std::collections::HashMap::new())),
+            claude_code: ClaudeCodeStore::system(),
         })
     }
 
@@ -122,6 +129,7 @@ impl AnthropicOAuthApplier {
         refresh_client: reqwest::Client,
         client_id: impl Into<String>,
         token_endpoint: impl Into<String>,
+        claude_code: Option<ClaudeCodeStore>,
     ) -> Self {
         Self {
             store_path: store_path.into(),
@@ -130,6 +138,7 @@ impl AnthropicOAuthApplier {
             token_endpoint: token_endpoint.into(),
             cache: Arc::new(Mutex::new(std::collections::HashMap::new())),
             refresh_gates: Arc::new(Mutex::new(std::collections::HashMap::new())),
+            claude_code,
         }
     }
 
@@ -197,10 +206,14 @@ impl AnthropicOAuthApplier {
             Some(c) => c.clone(),
             None => return Ok(None),
         };
-        // 5. ApiKey: no refresh logic, return as-is.
+        // 5. ApiKey: no refresh logic, return as-is. Marker: resolve live from
+        //    the Claude Code store (read + refresh-write-back there).
         let token = match cred {
             Credential::ApiKey { value } => {
                 return Ok(Some(ResolvedCredential::ApiKey(value)));
+            }
+            Credential::ClaudeCodeCli => {
+                return self.resolve_claude_code_session(label).await;
             }
             Credential::Oauth(t) => t,
         };
@@ -219,6 +232,59 @@ impl AnthropicOAuthApplier {
             self.store_in_cache(label, &refreshed);
             return Ok(Some(ResolvedCredential::Oauth(refreshed)));
         }
+        self.store_in_cache(label, &token);
+        Ok(Some(ResolvedCredential::Oauth(token)))
+    }
+
+    /// Resolve a [`Credential::ClaudeCodeCli`] marker: read the live token from
+    /// Claude Code's own store (`~/.claude`), refreshing it in place when it is
+    /// within the refresh window and **writing the rotated token back to that
+    /// same store** so bitrouter and Claude Code never diverge (RFC 6749 §6
+    /// refresh-token rotation would otherwise family-revoke one of them).
+    ///
+    /// Called under the per-label single-flight gate, so the read → refresh →
+    /// write-back is serialised; the live read also picks up any refresh the
+    /// `claude` CLI performed in the meantime, avoiding a redundant rotation.
+    async fn resolve_claude_code_session(&self, label: &str) -> Result<Option<ResolvedCredential>> {
+        let store = self
+            .claude_code
+            .as_ref()
+            .ok_or_else(|| BitrouterError::Upstream {
+                status: 401,
+                message: "cannot locate the Claude Code session (no home directory) — set HOME \
+                      or run `bitrouter login anthropic`"
+                    .into(),
+            })?;
+        let live = store
+            .read()
+            .map_err(|e| BitrouterError::internal(format!("reading Claude Code session: {e}")))?;
+        let Some(live) = live else {
+            return Err(BitrouterError::Upstream {
+                status: 401,
+                message: "no Claude Code session found — run `claude auth login` (or \
+                          `bitrouter login anthropic`) to sign in to your Claude subscription"
+                    .into(),
+            });
+        };
+        let token = if needs_refresh(&live.token) {
+            let refreshed = refresh(
+                &self.refresh_client,
+                &self.token_endpoint,
+                &self.client_id,
+                &live.token,
+            )
+            .await
+            .map_err(refresh_to_bitrouter_error)?;
+            // Single source of truth: write the rotation back where we read it.
+            store.write_back(&refreshed, &live.source).map_err(|e| {
+                BitrouterError::internal(format!(
+                    "writing refreshed token back to the Claude Code store: {e}"
+                ))
+            })?;
+            refreshed
+        } else {
+            live.token
+        };
         self.store_in_cache(label, &token);
         Ok(Some(ResolvedCredential::Oauth(token)))
     }
@@ -620,6 +686,7 @@ mod tests {
             reqwest::Client::new(),
             "client-1",
             format!("{}/oauth/token", server.uri()),
+            None,
         );
         let req = reqwest::Client::new()
             .post("https://api.anthropic.com/v1/messages")
@@ -722,6 +789,131 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(body2["system"].as_array().unwrap().len(), 2);
+    }
+
+    /// Write a `.credentials.json` in a fresh temp dir and return its path.
+    fn tmp_claude_creds(contents: &str) -> PathBuf {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "bitrouter-anthropic-cc-{}-{id}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(".credentials.json");
+        std::fs::write(&path, contents).unwrap();
+        path
+    }
+
+    fn seed_marker(store_path: &std::path::Path) {
+        let mut store = CredentialStore::load(store_path).unwrap();
+        store
+            .set(PROVIDER_ID, DEFAULT_LABEL, Credential::ClaudeCodeCli)
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn claude_code_cli_marker_applies_bearer_from_live_store() {
+        // Marker in bitrouter's store + a non-expiring live Claude Code session
+        // (no `expiresAt` → never refreshed) → the live access token is applied
+        // as a Bearer and any stale x-api-key is stripped.
+        let path = tmp_store_path();
+        seed_marker(&path);
+        let creds = tmp_claude_creds(
+            r#"{"claudeAiOauth":{"accessToken":"sk-ant-oat-live","refreshToken":"r"}}"#,
+        );
+        let applier = AnthropicOAuthApplier::with_client_and_endpoint(
+            &path,
+            reqwest::Client::new(),
+            "client-1",
+            "https://example.com/oauth/token",
+            Some(ClaudeCodeStore::file_only(&creds)),
+        );
+        let mut req = reqwest::Client::new()
+            .post("https://api.anthropic.com/v1/messages")
+            .build()
+            .unwrap();
+        req.headers_mut()
+            .insert("x-api-key", HeaderValue::from_static("stale"));
+        let authed = applier.apply(req, &anthropic_target(None)).await.unwrap();
+        let h = authed.headers();
+        assert_eq!(
+            h.get(reqwest::header::AUTHORIZATION)
+                .and_then(|v| v.to_str().ok()),
+            Some("Bearer sk-ant-oat-live")
+        );
+        assert!(h.get("x-api-key").is_none());
+        assert!(
+            h.get("anthropic-beta")
+                .and_then(|v| v.to_str().ok())
+                .unwrap()
+                .contains("oauth-2025-04-20")
+        );
+    }
+
+    #[tokio::test]
+    async fn claude_code_cli_marker_missing_session_errors() {
+        // Marker present but no live Claude Code session → a helpful 401 that
+        // points the user at `claude auth login`, not a silent fall-through.
+        let path = tmp_store_path();
+        seed_marker(&path);
+        let absent = std::env::temp_dir().join("bitrouter-anthropic-cc-absent/none.json");
+        let applier = AnthropicOAuthApplier::with_client_and_endpoint(
+            &path,
+            reqwest::Client::new(),
+            "client-1",
+            "https://example.com/oauth/token",
+            Some(ClaudeCodeStore::file_only(&absent)),
+        );
+        let req = reqwest::Client::new()
+            .post("https://api.anthropic.com/v1/messages")
+            .build()
+            .unwrap();
+        let err = applier
+            .apply(req, &anthropic_target(None))
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("claude auth login"),
+            "expected a login hint, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn claude_code_cli_marker_expiring_token_triggers_refresh() {
+        // An expiring live token must drive a refresh attempt rather than serve
+        // the stale token. Pointing the endpoint at an insecure (http) URL makes
+        // `refresh` fail fast with a typed error, proving the needs_refresh
+        // branch is taken. (The happy-path refresh and write-back are covered by
+        // `oauth::refresh::tests` and `import::claude_code::tests` respectively;
+        // an http MockServer can't exercise them because `refresh` requires
+        // https.)
+        let path = tmp_store_path();
+        seed_marker(&path);
+        let creds = tmp_claude_creds(
+            r#"{"claudeAiOauth":{"accessToken":"old","refreshToken":"RT","expiresAt":1000}}"#,
+        );
+        let applier = AnthropicOAuthApplier::with_client_and_endpoint(
+            &path,
+            reqwest::Client::new(),
+            "client-1",
+            "http://insecure.example.com/oauth/token",
+            Some(ClaudeCodeStore::file_only(&creds)),
+        );
+        let req = reqwest::Client::new()
+            .post("https://api.anthropic.com/v1/messages")
+            .build()
+            .unwrap();
+        let err = applier
+            .apply(req, &anthropic_target(None))
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("refresh"),
+            "expected a refresh error proving the refresh path ran, got: {err}"
+        );
     }
 
     #[tokio::test]

--- a/crates/bitrouter-providers/src/apply.rs
+++ b/crates/bitrouter-providers/src/apply.rs
@@ -12,6 +12,7 @@ use bitrouter_sdk::language_model::types::ProtocolList;
 
 use crate::builtin;
 use crate::entry::ProtocolMapping;
+use crate::oauth::credential_store::CredentialStore;
 
 /// Build the in-memory **zero-config** [`Config`] used when the user
 /// runs `bitrouter serve` with no `bitrouter.yaml` anywhere on the
@@ -140,6 +141,27 @@ pub fn apply_builtin_defaults(config: &mut Config) {
         // (no `env_var`), so this guard doesn't touch it.
         if provider.api_key.is_empty() && builtin.auth.env_var().is_some() {
             provider.active = false;
+        }
+    }
+}
+
+/// Re-activate providers that hold a credential in the OAuth credential `store`
+/// even though they carry no inline / env-var api key.
+///
+/// Subscription (OAuth) and "use your Claude Code session" logins persist their
+/// credential in the store (`oauth-tokens.json`), not in the config — so
+/// [`apply_builtin_defaults`] marks a provider whose only catalog auth is an
+/// env-var key (e.g. `anthropic` with `ANTHROPIC_API_KEY`) inactive and drops it
+/// from the routing table. This pass restores it: a provider with at least one
+/// stored credential is usable, because the matching `AuthApplier` resolves that
+/// credential (the live Claude Code session, a stored OAuth token, or a pasted
+/// key) at request time. Idempotent; already-active providers are untouched, and
+/// providers with no stored credential stay as `apply_builtin_defaults` left
+/// them.
+pub fn activate_stored_credential_providers(config: &mut Config, store: &CredentialStore) {
+    for (id, provider) in config.providers.iter_mut() {
+        if !provider.active && !store.labels(id).is_empty() {
+            provider.active = true;
         }
     }
 }
@@ -340,6 +362,45 @@ mod tests {
             apply_builtin_defaults(&mut config);
             assert!(config.providers["openai"].active);
         });
+    }
+
+    #[test]
+    fn stored_credential_reactivates_keyless_provider() {
+        use crate::oauth::credential_store::{Credential, CredentialStore, DEFAULT_LABEL};
+        let dir = std::env::temp_dir().join(format!("br-activate-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let mut store = CredentialStore::load(dir.join("oauth-tokens.json")).unwrap();
+        // A "use your Claude Code session" login persists this marker.
+        store
+            .set("anthropic", DEFAULT_LABEL, Credential::ClaudeCodeCli)
+            .unwrap();
+
+        let mut config = Config::default();
+        config.providers.insert(
+            "anthropic".to_string(),
+            ProviderConfig {
+                active: false, // as apply_builtin_defaults would leave a keyless Bearer provider
+                ..ProviderConfig::default()
+            },
+        );
+        config.providers.insert(
+            "openai".to_string(),
+            ProviderConfig {
+                active: false,
+                ..ProviderConfig::default()
+            },
+        );
+
+        activate_stored_credential_providers(&mut config, &store);
+        assert!(
+            config.providers["anthropic"].active,
+            "a stored credential must re-activate the provider for routing"
+        );
+        assert!(
+            !config.providers["openai"].active,
+            "a provider with no stored credential stays inactive"
+        );
     }
 
     #[test]

--- a/crates/bitrouter-providers/src/import/claude_code.rs
+++ b/crates/bitrouter-providers/src/import/claude_code.rs
@@ -9,9 +9,10 @@
 //! Reference: OpenClaw `src/agents/cli-credentials.ts`
 //! (<https://github.com/openclaw/openclaw>).
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
+use serde_json::{Value, json};
 
 use crate::import::{ImportError, ImportSource, Imported, home_dir, keychain};
 use crate::oauth::credential_store::OAuthToken;
@@ -109,10 +110,232 @@ fn parse_blob(blob: &str, origin: &str) -> Result<Option<OAuthToken>, ImportErro
     }))
 }
 
+/// Where a live Claude Code credential was read from — so a refresh write-back
+/// can target the *same* place rather than diverging into a second store.
+#[derive(Debug, Clone)]
+pub enum ClaudeCodeSource {
+    /// The macOS login Keychain generic-password item.
+    Keychain {
+        /// The generic-password service (`Claude Code-credentials`).
+        service: &'static str,
+        /// The account the item is keyed under — required for an in-place
+        /// upsert so we update Claude Code's item, not a duplicate.
+        account: String,
+    },
+    /// A JSON file on disk (`~/.claude/.credentials.json`).
+    File(PathBuf),
+}
+
+impl std::fmt::Display for ClaudeCodeSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ClaudeCodeSource::Keychain { service, .. } => {
+                write!(f, "macOS Keychain ({service})")
+            }
+            ClaudeCodeSource::File(path) => write!(f, "{}", path.display()),
+        }
+    }
+}
+
+/// A live Claude Code OAuth credential plus the source it was read from.
+#[derive(Debug, Clone)]
+pub struct LiveCredential {
+    /// The current OAuth token (`expires_at` in seconds).
+    pub token: OAuthToken,
+    /// Where it came from — the write-back target.
+    pub source: ClaudeCodeSource,
+}
+
+/// A live, read-write view of Claude Code's own Claude Pro/Max OAuth credential.
+///
+/// This is the single source of truth shared with the `claude` CLI: bitrouter
+/// *reads* the current token and, when it must refresh, *writes the rotated
+/// token back to the same place Claude Code stores it* — so the two never
+/// diverge and Anthropic's refresh-token rotation (RFC 6749 §6) can't
+/// family-revoke the user out of Claude Code. (Contrast tools that copy the
+/// token into a private store and refresh independently, e.g. OpenClaw issue
+/// #71026; the correct write-back pattern is griffinmartin/opencode-claude-auth.)
+///
+/// Locations mirror Claude Code: macOS Keychain generic password
+/// `Claude Code-credentials`, else `~/.claude/.credentials.json`. Envelope:
+/// `{ "claudeAiOauth": { accessToken, refreshToken, expiresAt(ms), … } }`,
+/// with any other fields (`scopes`, `subscriptionType`, …) preserved verbatim
+/// across a write-back.
+#[derive(Debug, Clone)]
+pub struct ClaudeCodeStore {
+    /// `Some` on macOS (try the Keychain first); `None` elsewhere or in tests.
+    keychain_service: Option<&'static str>,
+    /// The on-disk credential file (used when the Keychain has no item).
+    file_path: PathBuf,
+}
+
+impl ClaudeCodeStore {
+    /// The store at Claude Code's default system locations: the macOS Keychain
+    /// (`Claude Code-credentials`) plus `~/.claude/.credentials.json`. `None`
+    /// when no home directory can be resolved.
+    pub fn system() -> Option<Self> {
+        let file_path = home_dir()?.join(".claude").join(".credentials.json");
+        #[cfg(target_os = "macos")]
+        let keychain_service = Some(KEYCHAIN_SERVICE);
+        #[cfg(not(target_os = "macos"))]
+        let keychain_service = None;
+        Some(Self {
+            keychain_service,
+            file_path,
+        })
+    }
+
+    /// A file-only store at `path`, never touching the Keychain. Used on
+    /// non-macOS hosts and in tests so a real Keychain is never read/written.
+    pub fn file_only(path: impl Into<PathBuf>) -> Self {
+        Self {
+            keychain_service: None,
+            file_path: path.into(),
+        }
+    }
+
+    /// Read the current credential, Keychain first (macOS) then the file.
+    /// `Ok(None)` when neither source carries a Claude Code OAuth credential.
+    pub fn read(&self) -> Result<Option<LiveCredential>, ImportError> {
+        if let Some(service) = self.keychain_service
+            && let Some(blob) = keychain::read_generic_password(service, None)
+            && let Some(token) = parse_blob(&blob, "keychain")?
+        {
+            // The account is needed to write the rotated token back in place.
+            // Fall back to an empty account rather than failing the read — a
+            // write-back would then create the item under that account.
+            let account = keychain::find_account(service).unwrap_or_default();
+            return Ok(Some(LiveCredential {
+                token,
+                source: ClaudeCodeSource::Keychain { service, account },
+            }));
+        }
+        match from_file(&self.file_path)? {
+            Some(imported) => Ok(Some(LiveCredential {
+                token: imported.token,
+                source: ClaudeCodeSource::File(self.file_path.clone()),
+            })),
+            None => Ok(None),
+        }
+    }
+
+    /// Persist a refreshed `token` back to `source`, preserving every other
+    /// field Claude Code wrote. File writes are atomic and `0600`; Keychain
+    /// writes upsert the existing `(service, account)` item.
+    pub fn write_back(
+        &self,
+        token: &OAuthToken,
+        source: &ClaudeCodeSource,
+    ) -> Result<(), ImportError> {
+        match source {
+            ClaudeCodeSource::File(path) => {
+                let existing = std::fs::read(path).ok();
+                let bytes = updated_envelope_bytes(existing.as_deref(), token)?;
+                write_file_atomic_0600(path, &bytes)
+            }
+            ClaudeCodeSource::Keychain { service, account } => {
+                let existing = keychain::read_generic_password(service, Some(account))
+                    .or_else(|| keychain::read_generic_password(service, None));
+                let bytes = updated_envelope_bytes(existing.as_deref().map(str::as_bytes), token)?;
+                // `to_vec_pretty` always emits valid UTF-8, so the lossy
+                // conversion is exact here.
+                let value = String::from_utf8_lossy(&bytes).into_owned();
+                if keychain::write_generic_password(service, account, &value) {
+                    Ok(())
+                } else {
+                    Err(ImportError::Io {
+                        path: PathBuf::from(format!("keychain:{service}")),
+                        source: std::io::Error::other("security add-generic-password failed"),
+                    })
+                }
+            }
+        }
+    }
+}
+
+/// Merge a refreshed `token` into Claude Code's credential envelope, preserving
+/// every other field. `existing` is the current raw blob (file bytes or
+/// Keychain value); when absent or unparseable a fresh `{ "claudeAiOauth": {} }`
+/// envelope is built. `expiresAt` is written back in **milliseconds**.
+fn updated_envelope_bytes(
+    existing: Option<&[u8]>,
+    token: &OAuthToken,
+) -> Result<Vec<u8>, ImportError> {
+    let mut root: Value = match existing {
+        Some(b) if !b.is_empty() => serde_json::from_slice(b).unwrap_or_else(|_| json!({})),
+        _ => json!({}),
+    };
+    if !root.is_object() {
+        root = json!({});
+    }
+    let obj = root.as_object_mut().expect("root is an object");
+    let entry = obj.entry("claudeAiOauth").or_insert_with(|| json!({}));
+    if !entry.is_object() {
+        *entry = json!({});
+    }
+    let oauth = entry.as_object_mut().expect("claudeAiOauth is an object");
+    oauth.insert("accessToken".to_string(), json!(token.access_token));
+    if let Some(rt) = &token.refresh_token {
+        oauth.insert("refreshToken".to_string(), json!(rt));
+    }
+    // Seconds → milliseconds. A non-expiring (`0`) token leaves any existing
+    // `expiresAt` untouched rather than writing a misleading `0`.
+    if token.expires_at > 0 {
+        oauth.insert("expiresAt".to_string(), json!(token.expires_at * 1000));
+    }
+    serde_json::to_vec_pretty(&root).map_err(|source| ImportError::Json {
+        origin: "claude code credentials write-back".to_string(),
+        source,
+    })
+}
+
+/// Write `bytes` to `path` atomically with `0600` permissions (Unix), mirroring
+/// the credential store's flush so the token never sits on a world-readable
+/// file even for the width of the write.
+fn write_file_atomic_0600(path: &Path, bytes: &[u8]) -> Result<(), ImportError> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|source| ImportError::Io {
+            path: parent.to_path_buf(),
+            source,
+        })?;
+    }
+    let mut tmp = path.as_os_str().to_owned();
+    tmp.push(".tmp");
+    let tmp = PathBuf::from(tmp);
+    #[cfg(unix)]
+    {
+        use std::io::Write as _;
+        use std::os::unix::fs::OpenOptionsExt as _;
+        let _ = std::fs::remove_file(&tmp);
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&tmp)
+            .map_err(|source| ImportError::Io {
+                path: tmp.clone(),
+                source,
+            })?;
+        file.write_all(bytes).map_err(|source| ImportError::Io {
+            path: tmp.clone(),
+            source,
+        })?;
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::write(&tmp, bytes).map_err(|source| ImportError::Io {
+            path: tmp.clone(),
+            source,
+        })?;
+    }
+    std::fs::rename(&tmp, path).map_err(|source| ImportError::Io {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
-
     use super::*;
 
     fn tmp_file(contents: &str) -> PathBuf {
@@ -159,5 +382,87 @@ mod tests {
         let path = tmp_file(r#"{"claudeAiOauth":{"refreshToken":"r1"}}"#);
         let err = from_file(&path).unwrap_err();
         assert!(matches!(err, ImportError::MissingAccessToken { .. }));
+    }
+
+    #[test]
+    fn store_read_file_only_returns_token_and_file_source() {
+        let path = tmp_file(
+            r#"{"claudeAiOauth":{"accessToken":"a","refreshToken":"r","expiresAt":1700000000000}}"#,
+        );
+        let store = ClaudeCodeStore::file_only(&path);
+        let live = store.read().unwrap().unwrap();
+        assert_eq!(live.token.access_token, "a");
+        assert_eq!(live.token.refresh_token.as_deref(), Some("r"));
+        assert_eq!(live.token.expires_at, 1_700_000_000);
+        match &live.source {
+            ClaudeCodeSource::File(p) => assert_eq!(p, &path),
+            other => panic!("expected File source, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn store_read_file_only_absent_is_none() {
+        let path = std::env::temp_dir().join("bitrouter-ccstore-absent/never.json");
+        let store = ClaudeCodeStore::file_only(&path);
+        assert!(store.read().unwrap().is_none());
+    }
+
+    #[test]
+    fn write_back_preserves_unknown_keys_and_updates_token() {
+        let path = tmp_file(
+            r#"{"claudeAiOauth":{"accessToken":"old","refreshToken":"oldr","expiresAt":1700000000000,"scopes":["user:inference"],"subscriptionType":"max"},"otherTop":42}"#,
+        );
+        let store = ClaudeCodeStore::file_only(&path);
+        store
+            .write_back(
+                &OAuthToken {
+                    access_token: "new".into(),
+                    expires_at: 1_700_000_500,
+                    refresh_token: Some("newr".into()),
+                },
+                &ClaudeCodeSource::File(path.clone()),
+            )
+            .unwrap();
+        let raw: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        let o = &raw["claudeAiOauth"];
+        assert_eq!(o["accessToken"], "new");
+        assert_eq!(o["refreshToken"], "newr");
+        // seconds → milliseconds on write-back.
+        assert_eq!(o["expiresAt"], 1_700_000_500_000u64);
+        // Unknown fields Claude Code wrote must survive the round-trip.
+        assert_eq!(o["subscriptionType"], "max");
+        assert_eq!(o["scopes"][0], "user:inference");
+        assert_eq!(raw["otherTop"], 42);
+        // And the rotated token reads back through the store.
+        let live = store.read().unwrap().unwrap();
+        assert_eq!(live.token.access_token, "new");
+        assert_eq!(live.token.refresh_token.as_deref(), Some("newr"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_back_creates_fresh_file_0600() {
+        use std::os::unix::fs::PermissionsExt;
+        // Start from a unique path that does NOT yet exist (macOS Keychain-only
+        // machines have no file until something writes one).
+        let path = tmp_file("{}");
+        std::fs::remove_file(&path).unwrap();
+        let store = ClaudeCodeStore::file_only(&path);
+        store
+            .write_back(
+                &OAuthToken {
+                    access_token: "a".into(),
+                    expires_at: 1_700_000_000,
+                    refresh_token: Some("r".into()),
+                },
+                &ClaudeCodeSource::File(path.clone()),
+            )
+            .unwrap();
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "expected 0600, got {mode:o}");
+        // A freshly-created file is still a valid, readable credential.
+        let live = store.read().unwrap().unwrap();
+        assert_eq!(live.token.access_token, "a");
     }
 }

--- a/crates/bitrouter-providers/src/import/keychain.rs
+++ b/crates/bitrouter-providers/src/import/keychain.rs
@@ -41,3 +41,100 @@ pub(crate) fn read_generic_password(service: &str, account: Option<&str>) -> Opt
 pub(crate) fn read_generic_password(_service: &str, _account: Option<&str>) -> Option<String> {
     None
 }
+
+/// Parse the account (`"acct"`) attribute out of `security find-generic-password
+/// -s <service>` attribute output. The attribute dump prints one
+/// `"key"<blob>="value"` line per attribute; the generic-password item Claude
+/// Code writes carries the macOS login account name under `acct`. Pure so it is
+/// testable without touching a real Keychain.
+pub(crate) fn parse_account(attributes_output: &str) -> Option<String> {
+    for line in attributes_output.lines() {
+        let line = line.trim();
+        if let Some(rest) = line.strip_prefix("\"acct\"<blob>=\"")
+            && let Some(value) = rest.strip_suffix('"')
+        {
+            return Some(value.to_string());
+        }
+    }
+    None
+}
+
+/// Discover the account name of the generic-password item stored under
+/// `service`. Needed for an upsert write-back: a Keychain generic password is
+/// keyed by `(service, account)`, so writing without the original account would
+/// create a *second* item rather than update Claude Code's. Returns `None` when
+/// the item is absent or the platform isn't macOS.
+#[cfg(target_os = "macos")]
+pub(crate) fn find_account(service: &str) -> Option<String> {
+    // Without `-w` the command prints the item's attributes (incl. `acct`).
+    let output = std::process::Command::new("security")
+        .arg("find-generic-password")
+        .arg("-s")
+        .arg(service)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    // `security` prints the attribute dump to stdout; some versions mirror it
+    // to stderr. Check both.
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    parse_account(&stdout).or_else(|| {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        parse_account(&stderr)
+    })
+}
+
+/// Non-macOS stub.
+#[cfg(not(target_os = "macos"))]
+pub(crate) fn find_account(_service: &str) -> Option<String> {
+    None
+}
+
+/// Upsert a generic-password value for `(service, account)`. `-U` updates the
+/// existing item in place (or creates it if absent) — exactly the write-back
+/// semantics needed so Claude Code's own item is updated rather than shadowed
+/// by a duplicate. Returns `true` on success.
+///
+/// `security(1)` reference:
+/// <https://ss64.com/osx/security.html> (`add-generic-password -U`).
+#[cfg(target_os = "macos")]
+pub(crate) fn write_generic_password(service: &str, account: &str, value: &str) -> bool {
+    std::process::Command::new("security")
+        .arg("add-generic-password")
+        .arg("-U")
+        .arg("-s")
+        .arg(service)
+        .arg("-a")
+        .arg(account)
+        .arg("-w")
+        .arg(value)
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Non-macOS stub — write-back targets the on-disk credential file there.
+#[cfg(not(target_os = "macos"))]
+pub(crate) fn write_generic_password(_service: &str, _account: &str, _value: &str) -> bool {
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_account_extracts_acct_field() {
+        let out = "keychain: \"/Users/x/Library/Keychains/login.keychain-db\"\n    \
+                   0x00000007 <blob>=\"Claude Code-credentials\"\n    \
+                   \"acct\"<blob>=\"archer\"\n    \
+                   \"svce\"<blob>=\"Claude Code-credentials\"\n";
+        assert_eq!(parse_account(out).as_deref(), Some("archer"));
+    }
+
+    #[test]
+    fn parse_account_none_when_absent() {
+        assert_eq!(parse_account("nothing here\n  \"svce\"<blob>=\"x\""), None);
+    }
+}

--- a/crates/bitrouter-providers/src/import/keychain.rs
+++ b/crates/bitrouter-providers/src/import/keychain.rs
@@ -66,6 +66,9 @@ pub(crate) fn parse_account(attributes_output: &str) -> Option<String> {
 /// the item is absent or the platform isn't macOS.
 #[cfg(target_os = "macos")]
 pub(crate) fn find_account(service: &str) -> Option<String> {
+    // `find-generic-password -s <service>` (no `-a`) returns the *first*
+    // matching item, so this assumes a single item per service — true for
+    // Claude Code, which writes exactly one `Claude Code-credentials` item.
     // Without `-w` the command prints the item's attributes (incl. `acct`).
     let output = std::process::Command::new("security")
         .arg("find-generic-password")

--- a/crates/bitrouter-providers/src/import/keychain.rs
+++ b/crates/bitrouter-providers/src/import/keychain.rs
@@ -47,6 +47,10 @@ pub(crate) fn read_generic_password(_service: &str, _account: Option<&str>) -> O
 /// `"key"<blob>="value"` line per attribute; the generic-password item Claude
 /// Code writes carries the macOS login account name under `acct`. Pure so it is
 /// testable without touching a real Keychain.
+///
+/// macOS-only: it parses `security(1)` output and is only called by
+/// [`find_account`], so compiling it elsewhere would be dead code.
+#[cfg(target_os = "macos")]
 pub(crate) fn parse_account(attributes_output: &str) -> Option<String> {
     for line in attributes_output.lines() {
         let line = line.trim();
@@ -123,7 +127,8 @@ pub(crate) fn write_generic_password(_service: &str, _account: &str, _value: &st
     false
 }
 
-#[cfg(test)]
+// macOS-only: the only tests here exercise the macOS-gated `parse_account`.
+#[cfg(all(test, target_os = "macos"))]
 mod tests {
     use super::*;
 

--- a/crates/bitrouter-providers/src/lib.rs
+++ b/crates/bitrouter-providers/src/lib.rs
@@ -83,7 +83,10 @@ pub mod import;
 pub mod oauth;
 pub mod registry;
 
-pub use apply::{apply_builtin_defaults, zero_config, zero_config_env_var_providers};
+pub use apply::{
+    activate_stored_credential_providers, apply_builtin_defaults, zero_config,
+    zero_config_env_var_providers,
+};
 pub use entry::{AuthScheme, ProtocolMapping, ProviderEntry};
 
 /// Errors raised while loading the compile-time registry.

--- a/crates/bitrouter-providers/src/oauth/credential_store.rs
+++ b/crates/bitrouter-providers/src/oauth/credential_store.rs
@@ -111,6 +111,14 @@ pub enum Credential {
     },
     /// An OAuth credential plus optional refresh metadata.
     Oauth(OAuthToken),
+    /// A tokenless marker meaning "resolve the credential live from the Claude
+    /// Code CLI's own store (`~/.claude`) at request time, and write any
+    /// refresh back there". No token is copied into this store, so bitrouter
+    /// and Claude Code share one credential and can't refresh-rotate each other
+    /// out (RFC 6749 §6). Set by `bitrouter login anthropic`; consumed by the
+    /// Anthropic `AuthApplier`. Serialized as the unit-variant `{"type":
+    /// "claude_code_cli"}`.
+    ClaudeCodeCli,
 }
 
 impl std::fmt::Debug for Credential {
@@ -128,6 +136,7 @@ impl std::fmt::Debug for Credential {
                 )
                 .finish(),
             Credential::Oauth(token) => f.debug_tuple("Oauth").field(token).finish(),
+            Credential::ClaudeCodeCli => f.write_str("ClaudeCodeCli"),
         }
     }
 }
@@ -139,6 +148,9 @@ impl Credential {
         match self {
             Credential::ApiKey { .. } => true,
             Credential::Oauth(t) => t.is_valid(),
+            // Liveness is resolved at request time from the Claude Code store;
+            // the marker is never itself "expired".
+            Credential::ClaudeCodeCli => true,
         }
     }
 
@@ -158,7 +170,7 @@ impl Credential {
     pub fn as_oauth(&self) -> Option<&OAuthToken> {
         match self {
             Credential::Oauth(t) => Some(t),
-            Credential::ApiKey { .. } => None,
+            Credential::ApiKey { .. } | Credential::ClaudeCodeCli => None,
         }
     }
 
@@ -166,7 +178,7 @@ impl Credential {
     pub fn as_api_key(&self) -> Option<&str> {
         match self {
             Credential::ApiKey { value } => Some(value.as_str()),
-            Credential::Oauth(_) => None,
+            Credential::Oauth(_) | Credential::ClaudeCodeCli => None,
         }
     }
 
@@ -176,6 +188,7 @@ impl Credential {
         match self {
             Credential::ApiKey { .. } => "API key",
             Credential::Oauth(_) => "OAuth",
+            Credential::ClaudeCodeCli => "Claude Code session",
         }
     }
 }
@@ -489,6 +502,31 @@ mod tests {
         let reloaded = CredentialStore::load(&path).unwrap();
         let got = reloaded.get("anthropic", "work").unwrap();
         assert_eq!(got.as_api_key(), Some("sk-ant-api03-secret"));
+    }
+
+    #[test]
+    fn round_trip_claude_code_cli_marker() {
+        let dir = tmp_dir();
+        let path = dir.join("oauth-tokens.json");
+        {
+            let mut store = CredentialStore::load(&path).unwrap();
+            store
+                .set("anthropic", DEFAULT_LABEL, Credential::ClaudeCodeCli)
+                .unwrap();
+        }
+        let reloaded = CredentialStore::load(&path).unwrap();
+        let got = reloaded.get_any("anthropic", DEFAULT_LABEL).unwrap();
+        assert!(matches!(got, Credential::ClaudeCodeCli));
+        assert_eq!(got.kind_label(), "Claude Code session");
+        assert!(got.as_oauth().is_none());
+        assert!(got.as_api_key().is_none());
+        // The marker itself is always "valid"; whether a live session exists is
+        // decided at request time by the applier.
+        assert!(got.is_valid());
+        assert!(reloaded.get("anthropic", DEFAULT_LABEL).is_some());
+        // Serialized as the adjacently-tagged unit variant, no `data` payload.
+        let raw = std::fs::read_to_string(&path).unwrap();
+        assert!(raw.contains("claude_code_cli"), "got: {raw}");
     }
 
     #[test]

--- a/crates/bitrouter-sdk/src/language_model/executor.rs
+++ b/crates/bitrouter-sdk/src/language_model/executor.rs
@@ -364,6 +364,37 @@ fn merge_outbound_trace_headers(request: &mut reqwest::Request, ctx: &PipelineCo
     }
 }
 
+/// Forward the inbound `anthropic-beta` header(s) to a Messages-protocol
+/// upstream.
+///
+/// Anthropic clients (notably Claude Code) gate request-*body* features —
+/// `context_management`, interleaved thinking, fine-grained tool streaming — on
+/// `anthropic-beta` values. The canonical decode→re-encode preserves those body
+/// fields (they ride through `extra`), but builds a fresh outbound request with
+/// no beta header, so without this forward the upstream rejects the now-orphaned
+/// field with a 400 ("Extra inputs are not permitted"). Scoped to Messages
+/// upstreams because the header is meaningless to other wire protocols; the
+/// provider's `AuthApplier` runs afterwards and may merge in any
+/// credential-required betas (e.g. the Claude Pro/Max OAuth ones).
+fn forward_inbound_anthropic_beta(
+    request: &mut reqwest::Request,
+    target: &RoutingTarget,
+    ctx: &PipelineContext,
+) {
+    if target.api_protocol != ApiProtocol::Messages {
+        return;
+    }
+    let inbound: Vec<_> = ctx
+        .headers()
+        .get_all("anthropic-beta")
+        .iter()
+        .cloned()
+        .collect();
+    for value in inbound {
+        request.headers_mut().append("anthropic-beta", value);
+    }
+}
+
 #[async_trait]
 impl Executor for HttpExecutor {
     async fn execute(
@@ -387,12 +418,13 @@ impl Executor for HttpExecutor {
         let url = transport.endpoint_url(target, false);
 
         let started = Instant::now();
-        let request = self
+        let mut request = self
             .client
             .post(&url)
             .json(&body)
             .build()
             .map_err(|e| BitrouterError::internal(format!("building request: {e}")))?;
+        forward_inbound_anthropic_beta(&mut request, target, ctx);
         let mut request = self.apply_auth(request, target, transport).await?;
         merge_outbound_trace_headers(&mut request, ctx);
         let response = self.client.execute(request).await.map_err(|e| {
@@ -458,12 +490,13 @@ impl Executor for HttpExecutor {
         self.shape_request_body(&mut body, target).await?;
         let url = transport.endpoint_url(target, true);
 
-        let request = self
+        let mut request = self
             .client
             .post(&url)
             .json(&body)
             .build()
             .map_err(|e| BitrouterError::internal(format!("building request: {e}")))?;
+        forward_inbound_anthropic_beta(&mut request, target, ctx);
         let mut request = self.apply_auth(request, target, transport).await?;
         merge_outbound_trace_headers(&mut request, ctx);
         let response = self.client.execute(request).await.map_err(|e| {
@@ -695,5 +728,103 @@ mod error_classification_tests {
             r#"{"error":{"type":"CreditsError"}}"#
         ));
         assert!(!looks_like_credit_exhaustion("invalid request: bad model"));
+    }
+}
+
+#[cfg(test)]
+mod beta_forward_tests {
+    use super::*;
+    use crate::caller::CallerContext;
+    use crate::language_model::types::Prompt;
+    use crate::language_model::{Message, PipelineRequest, Role};
+
+    fn ctx_with_beta(beta: Option<&str>) -> PipelineContext {
+        let mut headers = http::HeaderMap::new();
+        if let Some(b) = beta {
+            headers.insert("anthropic-beta", http::HeaderValue::from_str(b).unwrap());
+        }
+        let prompt = Prompt {
+            model: "claude".into(),
+            system: None,
+            system_provider_metadata: Default::default(),
+            messages: vec![Message {
+                role: Role::User,
+                content: vec![],
+            }],
+            tools: vec![],
+            params: Default::default(),
+            response_format: None,
+            tool_choice: None,
+            stream: false,
+        };
+        PipelineContext::new(PipelineRequest {
+            request_id: "t".into(),
+            model: "claude".into(),
+            caller: CallerContext::local(),
+            headers,
+            prompt,
+            inbound_protocol: None,
+        })
+    }
+
+    fn target(proto: ApiProtocol) -> RoutingTarget {
+        RoutingTarget {
+            provider_name: "anthropic".into(),
+            service_id: "claude-haiku".into(),
+            api_base: "https://api.anthropic.com/v1".into(),
+            api_key: String::new(),
+            api_protocol: proto,
+            account_label: None,
+            api_key_override: None,
+            api_base_override: None,
+            auth_scheme: Default::default(),
+        }
+    }
+
+    fn fresh_request() -> reqwest::Request {
+        reqwest::Client::new()
+            .post("https://api.anthropic.com/v1/messages")
+            .build()
+            .unwrap()
+    }
+
+    #[test]
+    fn forwards_anthropic_beta_to_messages_upstream() {
+        let mut request = fresh_request();
+        forward_inbound_anthropic_beta(
+            &mut request,
+            &target(ApiProtocol::Messages),
+            &ctx_with_beta(Some("context-management-2025-06-27")),
+        );
+        let got: Vec<_> = request
+            .headers()
+            .get_all("anthropic-beta")
+            .iter()
+            .filter_map(|v| v.to_str().ok())
+            .collect();
+        assert_eq!(got, vec!["context-management-2025-06-27"]);
+    }
+
+    #[test]
+    fn does_not_forward_to_non_messages_upstream() {
+        // A messages→chat translation must not leak the Anthropic-only header.
+        let mut request = fresh_request();
+        forward_inbound_anthropic_beta(
+            &mut request,
+            &target(ApiProtocol::ChatCompletions),
+            &ctx_with_beta(Some("context-management-2025-06-27")),
+        );
+        assert!(request.headers().get("anthropic-beta").is_none());
+    }
+
+    #[test]
+    fn no_inbound_beta_is_a_noop() {
+        let mut request = fresh_request();
+        forward_inbound_anthropic_beta(
+            &mut request,
+            &target(ApiProtocol::Messages),
+            &ctx_with_beta(None),
+        );
+        assert!(request.headers().get("anthropic-beta").is_none());
     }
 }


### PR DESCRIPTION
## What

Switches bitrouter's Claude Pro/Max **subscription** onboarding from a hand-written browser OAuth flow to reading the user's **existing Claude Code session** from `~/.claude`, and makes the local daemon proxy Claude Code traffic to the subscription correctly.

`bitrouter providers login anthropic` now, by default:
1. reads an existing Claude Code session (macOS Keychain `Claude Code-credentials`, else `~/.claude/.credentials.json`), or
2. if not signed in, runs the `claude` CLI's own login (`claude auth login --claudeai`), installing the CLI first via the same native installer `bitrouter spawn` uses.

The browser PKCE flow is kept as an explicit fallback.

## Why "read live" instead of "copy the token"

Copying Claude Code's token into bitrouter's own store and refreshing it independently makes two refreshers race on the same token family. Anthropic rotates refresh tokens (RFC 6749 §6), so the two invalidate each other and the user gets logged out of Claude Code. Instead, `~/.claude` stays the single source of truth: bitrouter reads it live and, when it must refresh, writes the rotated token **back to the same source** (file mode `0600` / Keychain upsert), preserving the full envelope (`scopes`, `subscriptionType`, …).

A tokenless `Credential::ClaudeCodeCli` marker records the intent; the daemon resolves it live per request (read → refresh-if-needed → write back).

## Making real Claude Code traffic actually proxy

Two latent gaps surfaced when running real `claude` traffic through the daemon — both fixed here:

- **Provider activation.** A keyless Bearer provider (the subscription credential lives in the store, not the config) was marked inactive by `apply_builtin_defaults` and dropped out of routing. A stored credential now re-activates its provider, on startup and on hot-reload.
- **`anthropic-beta` passthrough.** Claude Code gates request-body features (`context_management`, interleaved thinking, fine-grained tool streaming) on `anthropic-beta` values. The canonical decode→re-encode preserved the body fields but built a fresh request without the header, so the upstream rejected the orphaned field with a `400 "Extra inputs are not permitted"`. The inbound `anthropic-beta` is now forwarded to Messages upstreams, and the OAuth applier **merges** (rather than overwrites) the subscription-required betas.

## Cross-platform

macOS uses the Keychain; Linux/Windows use `~/.claude/.credentials.json` (`%USERPROFILE%` on Windows). File write-back is `0600` + atomic on Unix.

## Testing

- Unit tests across the new live store, the marker, applier resolution, the beta merge/forward, and the activation pass. Suites green: `bitrouter-providers` (`pkce`), `bitrouter-sdk` (`config_file`), and the `bitrouter` app; clippy clean.
- Verified end-to-end on macOS against a real Claude subscription with **no API key configured**: `bitrouter providers login anthropic` adopts the live Keychain session; the daemon returns `200` for a direct request, for a `context_management` request, and for real `claude -p` routed through `bitrouter spawn`.

References: Claude Code's published OAuth client; the read + refresh-write-back pattern follows [griffinmartin/opencode-claude-auth](https://github.com/griffinmartin/opencode-claude-auth) and avoids the refresh-divergence logout described in OpenClaw issue #71026.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
