### PR TITLE
feat(messages): preserve thinking-block signature through the streaming round-trip

### DIFF
--- a/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
@@ -2050,6 +2050,11 @@ struct MessagesStreamDecoder {
     /// for the block that just closed. `None` for an index never opened or for a
     /// block kind that carries no lifecycle marker (tool / web-search results).
     block_kinds: Vec<Option<BlockKind>>,
+    /// per content-block index → the thinking block's `signature`, accumulated
+    /// from its terminal `signature_delta` so `content_block_stop` can attach it
+    /// to the emitted [`StreamPart::ReasoningEnd`] (reasoning continuity — without
+    /// it a replayed thinking block is unsigned and Anthropic rejects it).
+    block_signatures: Vec<Option<String>>,
     usage: Usage,
 }
 
@@ -2213,6 +2218,21 @@ impl StreamDecoder for MessagesStreamDecoder {
                             });
                         }
                     }
+                    Some("signature_delta") => {
+                        // The thinking block's continuity signature, emitted just
+                        // before its `content_block_stop`. Stash it per-index so
+                        // the `ReasoningEnd` for this block can carry it; it does
+                        // not map to a delta part of its own.
+                        if let Some(sig) = delta
+                            .and_then(|d| d.get("signature"))
+                            .and_then(|s| s.as_str())
+                        {
+                            while self.block_signatures.len() <= index {
+                                self.block_signatures.push(None);
+                            }
+                            self.block_signatures[index] = Some(sig.to_string());
+                        }
+                    }
                     // any other delta type: ignore, do not error
                     _ => {}
                 }
@@ -2229,6 +2249,7 @@ impl StreamDecoder for MessagesStreamDecoder {
                     }),
                     Some(BlockKind::Thinking) => parts.push(StreamPart::ReasoningEnd {
                         id: index.to_string(),
+                        signature: self.block_signatures.get(index).cloned().flatten(),
                     }),
                     _ => {}
                 }
@@ -2626,9 +2647,32 @@ impl StreamEncoder for MessagesStreamEncoder {
             StreamPart::ReasoningStart { .. } => {
                 self.open_fresh_block(&mut frames, EncoderBlockKind::Thinking);
             }
-            StreamPart::TextEnd { .. } | StreamPart::ReasoningEnd { .. } => {
+            StreamPart::TextEnd { .. } => {
                 // Close the block the matching start opened; `close_block` is a
                 // no-op if nothing is open, so a stray end is harmless.
+                self.close_block(&mut frames);
+            }
+            StreamPart::ReasoningEnd { signature, .. } => {
+                // Re-emit the thinking block's continuity signature as a
+                // `signature_delta` (Anthropic's wire shape) just before its
+                // `content_block_stop`, so a streamed thinking block re-encodes
+                // signed and a follow-up turn replays it without an
+                // "Invalid `signature`" rejection. Only when a thinking block is
+                // actually open — a stray/empty reasoning-end stays a no-op.
+                // <https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking>
+                if let Some(sig) = signature
+                    && self.block_open
+                    && self.block_kind == Some(EncoderBlockKind::Thinking)
+                {
+                    frames.push(Self::ev(
+                        "content_block_delta",
+                        serde_json::json!({
+                            "type": "content_block_delta",
+                            "index": self.block_index,
+                            "delta": { "type": "signature_delta", "signature": sig },
+                        }),
+                    ));
+                }
                 self.close_block(&mut frames);
             }
             StreamPart::TextDelta { text } => {

--- a/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
@@ -2252,7 +2252,13 @@ impl StreamDecoder for ResponsesStreamDecoder {
                     let item_id = block_marker_id(item, &json);
                     match item_type {
                         "message" => parts.push(StreamPart::TextEnd { id: item_id }),
-                        "reasoning" => parts.push(StreamPart::ReasoningEnd { id: item_id }),
+                        "reasoning" => parts.push(StreamPart::ReasoningEnd {
+                            id: item_id,
+                            // Responses reasoning continuity (encrypted_content) is
+                            // not carried on this slot; only the Anthropic Messages
+                            // wire populates the thinking `signature`.
+                            signature: None,
+                        }),
                         _ => {}
                     }
                 }

--- a/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
@@ -1849,7 +1849,10 @@ fn text_reasoning_text_reencodes_with_three_distinct_blocks() {
         StreamPart::ReasoningDelta {
             text: "ponder".into(),
         },
-        StreamPart::ReasoningEnd { id: "b".into() },
+        StreamPart::ReasoningEnd {
+            id: "b".into(),
+            signature: None,
+        },
         StreamPart::TextStart { id: "c".into() },
         StreamPart::TextDelta {
             text: "outro".into(),
@@ -1906,6 +1909,115 @@ fn text_reasoning_text_reencodes_with_three_distinct_blocks() {
 }
 
 #[test]
+fn anthropic_thinking_signature_survives_stream_roundtrip() {
+    // A streamed Anthropic thinking block carries its `signature` as a
+    // `signature_delta` event before `content_block_stop`. Decoding the upstream
+    // stream and re-encoding it for the client must preserve that signature —
+    // otherwise the client replays an unsigned thinking block on the next turn
+    // and Anthropic rejects it ("Invalid `signature` in `thinking` block").
+    // <https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking>
+    let upstream = [
+        (
+            "content_block_start",
+            serde_json::json!({
+                "type": "content_block_start", "index": 0,
+                "content_block": { "type": "thinking", "thinking": "" }
+            }),
+        ),
+        (
+            "content_block_delta",
+            serde_json::json!({
+                "type": "content_block_delta", "index": 0,
+                "delta": { "type": "thinking_delta", "thinking": "let me think" }
+            }),
+        ),
+        (
+            "content_block_delta",
+            serde_json::json!({
+                "type": "content_block_delta", "index": 0,
+                "delta": { "type": "signature_delta", "signature": "SIG-roundtrip-xyz" }
+            }),
+        ),
+        (
+            "content_block_stop",
+            serde_json::json!({ "type": "content_block_stop", "index": 0 }),
+        ),
+    ];
+    let parts = decode_stream(ApiProtocol::Messages, &upstream);
+    let reencoded = encode_stream_events(ApiProtocol::Messages, &parts);
+    let sig = reencoded.iter().find_map(|(name, data)| {
+        if name == "content_block_delta"
+            && data.pointer("/delta/type").and_then(|t| t.as_str()) == Some("signature_delta")
+        {
+            data.pointer("/delta/signature")
+                .and_then(|s| s.as_str())
+                .map(str::to_string)
+        } else {
+            None
+        }
+    });
+    assert_eq!(
+        sig.as_deref(),
+        Some("SIG-roundtrip-xyz"),
+        "thinking signature must survive decode->encode; got {reencoded:?}"
+    );
+}
+
+#[test]
+fn anthropic_stream_decoder_lifts_thinking_signature_onto_reasoning_end() {
+    // The IR contract: a streamed `signature_delta` is lifted onto the block's
+    // `ReasoningEnd` (not surfaced as a stray part, never merged into the
+    // reasoning text), so downstream re-encoding can replay it.
+    let events = [
+        (
+            "content_block_start",
+            serde_json::json!({
+                "type": "content_block_start", "index": 0,
+                "content_block": { "type": "thinking", "thinking": "" }
+            }),
+        ),
+        (
+            "content_block_delta",
+            serde_json::json!({
+                "type": "content_block_delta", "index": 0,
+                "delta": { "type": "thinking_delta", "thinking": "ponder" }
+            }),
+        ),
+        (
+            "content_block_delta",
+            serde_json::json!({
+                "type": "content_block_delta", "index": 0,
+                "delta": { "type": "signature_delta", "signature": "SIG-decode-1" }
+            }),
+        ),
+        (
+            "content_block_stop",
+            serde_json::json!({ "type": "content_block_stop", "index": 0 }),
+        ),
+    ];
+    let parts = decode_stream(ApiProtocol::Messages, &events);
+    let sig = parts
+        .iter()
+        .find_map(|p| match p {
+            StreamPart::ReasoningEnd { signature, .. } => Some(signature.clone()),
+            _ => None,
+        })
+        .expect("a ReasoningEnd part");
+    assert_eq!(
+        sig.as_deref(),
+        Some("SIG-decode-1"),
+        "decoder must lift signature_delta onto ReasoningEnd; got {parts:?}"
+    );
+    assert!(
+        !parts.iter().any(|p| matches!(
+            p,
+            StreamPart::ReasoningDelta { text } if text.contains("SIG-decode-1")
+        )),
+        "signature must not leak into the reasoning text: {parts:?}"
+    );
+}
+
+#[test]
 fn coarse_wires_drop_block_markers_and_emit_only_deltas() {
     // Chat Completions and Generate Content frame no content blocks, so the
     // block-lifecycle markers re-encode to NOTHING — a bare start/end emits zero
@@ -1921,7 +2033,10 @@ fn coarse_wires_drop_block_markers_and_emit_only_deltas() {
             StreamPart::TextStart { id: "0".into() },
             StreamPart::TextEnd { id: "0".into() },
             StreamPart::ReasoningStart { id: "1".into() },
-            StreamPart::ReasoningEnd { id: "1".into() },
+            StreamPart::ReasoningEnd {
+                id: "1".into(),
+                signature: None,
+            },
         ] {
             assert!(
                 encoder.encode(&marker).unwrap().is_empty(),

--- a/crates/bitrouter-sdk/src/language_model/stream.rs
+++ b/crates/bitrouter-sdk/src/language_model/stream.rs
@@ -474,7 +474,10 @@ mod tests {
             StreamPart::TextStart { id: "0".into() },
             StreamPart::TextEnd { id: "0".into() },
             StreamPart::ReasoningStart { id: "1".into() },
-            StreamPart::ReasoningEnd { id: "1".into() },
+            StreamPart::ReasoningEnd {
+                id: "1".into(),
+                signature: None,
+            },
         ] {
             assert!(
                 !StreamInterest::all().matches(&marker),
@@ -494,7 +497,10 @@ mod tests {
             StreamPart::TextStart { id: "0".into() },
             StreamPart::TextEnd { id: "0".into() },
             StreamPart::ReasoningStart { id: "1".into() },
-            StreamPart::ReasoningEnd { id: "1".into() },
+            StreamPart::ReasoningEnd {
+                id: "1".into(),
+                signature: None,
+            },
         ] {
             acc.observe(&marker);
         }

--- a/crates/bitrouter-sdk/src/language_model/types.rs
+++ b/crates/bitrouter-sdk/src/language_model/types.rs
@@ -1651,6 +1651,14 @@ pub enum StreamPart {
     ReasoningEnd {
         /// Reasoning-block id, matching the opening [`Self::ReasoningStart`].
         id: String,
+        /// The reasoning block's opaque continuity signature, when the upstream
+        /// emitted one — Anthropic's thinking-block `signature`, carried on the
+        /// terminal `signature_delta`. Preserved verbatim so a streamed thinking
+        /// block re-encodes signed and a follow-up turn that replays it validates
+        /// (without it Anthropic rejects the unsigned block). `None` on wires or
+        /// blocks that carry no signature.
+        /// <https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking>
+        signature: Option<String>,
     },
     /// An incremental chunk of a tool call's arguments.
     ToolCallDelta {


### PR DESCRIPTION
## Problem

Multi-turn **extended thinking** through BitRouter breaks on the second turn with:

```
400 invalid_request_error: messages.1.content.0: Invalid `signature` in `thinking` block
```

This blocks **Claude Code on the Claude subscription** (and any streaming client that replays a thinking block): turn 1 succeeds, but when the client sends the assistant's thinking block back on turn 2, the upstream rejects it.

## Root cause

Anthropic streams a thinking block's continuity `signature` as a terminal `signature_delta` event, just before `content_block_stop`. The **streaming** messages decoder ignored it (`// any other delta type: ignore`), and `StreamPart::ReasoningEnd` had **no slot** for a signature — so a streamed thinking block re-encoded to the client **unsigned**. The non-streaming adapter already preserved it (`parse_reasoning_metadata` / `render_reasoning_block`); only the streaming path dropped it. This was the V3-parity A4 "reasoning-continuity" deferral, on the streaming wire.

## Fix

- Add `signature: Option<String>` to `StreamPart::ReasoningEnd`.
- **Decoder:** accumulate `signature_delta` per content-block index and attach it to the `ReasoningEnd` emitted on `content_block_stop`.
- **Encoder:** re-emit the signature as a `signature_delta` (Anthropic's wire shape) just before `content_block_stop`, when a thinking block is open.
- Other wires pass `signature: None` (Responses `encrypted_content` / Gemini `thoughtSignature` continuity are carried elsewhere / remain follow-ups).

Reference: https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking

## Tests

- `anthropic_thinking_signature_survives_stream_roundtrip` — decode upstream SSE → re-encode → the `signature_delta` reappears (RED before the fix).
- `anthropic_stream_decoder_lifts_thinking_signature_onto_reasoning_end` — IR contract: signature rides on `ReasoningEnd`, never leaks into the reasoning text.
- Full workspace `--all-features`: **1095 passed** (incl. the existing non-streaming `messages_reasoning_signature_round_trips` + Gemini `thought_signature` tests); fmt + clippy clean.

## End-to-end

Verified with a real Claude Code agent on the Claude subscription through a local daemon: before this change the agent died on turn 2 with the signature error (only `PLAN.md` written); with the fix it completes a full plan→implement→test workflow (all files created, tests pass), no signature error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)