### PR TITLE
feat(claude-code): route Claude Code traffic to a dedicated subscription provider

### DIFF
--- a/apps/bitrouter/src/assemble.rs
+++ b/apps/bitrouter/src/assemble.rs
@@ -443,6 +443,15 @@ pub async fn build_app_with_path(
         Some(transform) => app.prompt_transform(transform),
         None => app,
     };
+    // The Claude Code subscription router: an ingress prompt transform that
+    // rewrites genuine Claude Code traffic (identity system prompt + a bare
+    // Claude model) onto the explicit `claude-code:<model>` route, sending it to
+    // the subscription provider. Registered unconditionally — it reads the
+    // prompt and no-ops on everything else. Transform order is irrelevant here
+    // (it and the fusion alias touch unrelated requests).
+    let app = app.prompt_transform(
+        Arc::new(crate::claude_code::ClaudeCodeRouter) as Arc<dyn PromptTransform>
+    );
     // Apply the optional MCP pipeline configuration in a second builder step
     // so the language_model configuration above stays the same shape it has
     // had since v0.
@@ -636,9 +645,8 @@ fn build_auth_appliers(config: &Config) -> Result<AuthAppliers> {
     // session). Registered under `claude-code`, distinct from the
     // Platform-API `anthropic` provider above.
     if config.providers.contains_key("claude-code") {
-        let applier =
-            bitrouter_providers::claude_code::ClaudeCodeAuthApplier::new(&store_path)
-                .context("building the claude-code AuthApplier")?;
+        let applier = bitrouter_providers::claude_code::ClaudeCodeAuthApplier::new(&store_path)
+            .context("building the claude-code AuthApplier")?;
         appliers.register("claude-code", Arc::new(applier));
     }
     if config.providers.contains_key("openai-codex") {

--- a/apps/bitrouter/src/assemble.rs
+++ b/apps/bitrouter/src/assemble.rs
@@ -605,8 +605,9 @@ fn build_server_tool_loop(
 /// `Transport::authorise` default — today: `bitrouter` (the official
 /// hosted gateway; OAuth from `bitrouter cloud login` with a
 /// `BITROUTER_API_KEY` fallback), GitHub Copilot (device-code OAuth +
-/// token exchange), Anthropic (dual API-key / Pro/Max subscription
-/// OAuth), OpenAI Codex (ChatGPT-subscription OAuth).
+/// token exchange), Anthropic Platform API (`x-api-key`), the Claude
+/// Pro/Max subscription (`claude-code`, OAuth / live `~/.claude` session),
+/// OpenAI Codex (ChatGPT-subscription OAuth).
 fn build_auth_appliers(config: &Config) -> Result<AuthAppliers> {
     let mut appliers = AuthAppliers::new();
     let store_path = bitrouter_providers::oauth::credential_store::CredentialStore::default_path()
@@ -621,14 +622,24 @@ fn build_auth_appliers(config: &Config) -> Result<AuthAppliers> {
             .context("building the github-copilot AuthApplier")?;
         appliers.register("github-copilot", Arc::new(applier));
     }
-    // The Anthropic applier is registered unconditionally when the
-    // provider is configured, so an existing `${ANTHROPIC_API_KEY}` user
-    // gets the same fallthrough behaviour as before — the applier
-    // forwards the inline key when no OAuth credential is in the store.
+    // The Anthropic Platform-API applier is registered when the provider is
+    // configured, so an existing `${ANTHROPIC_API_KEY}` user gets the same
+    // fallthrough behaviour as before — the applier forwards the inline key
+    // when no stored key is present. It is `x-api-key`-only; the Claude
+    // Pro/Max subscription lives in the separate `claude-code` provider below.
     if config.providers.contains_key("anthropic") {
-        let applier = bitrouter_providers::anthropic::AnthropicOAuthApplier::new(&store_path)
+        let applier = bitrouter_providers::anthropic::AnthropicApiKeyApplier::new(&store_path)
             .context("building the anthropic AuthApplier")?;
         appliers.register("anthropic", Arc::new(applier));
+    }
+    // The Claude Pro/Max subscription applier (OAuth / live `~/.claude`
+    // session). Registered under `claude-code`, distinct from the
+    // Platform-API `anthropic` provider above.
+    if config.providers.contains_key("claude-code") {
+        let applier =
+            bitrouter_providers::claude_code::ClaudeCodeAuthApplier::new(&store_path)
+                .context("building the claude-code AuthApplier")?;
+        appliers.register("claude-code", Arc::new(applier));
     }
     if config.providers.contains_key("openai-codex") {
         let applier = bitrouter_providers::codex::OpenAiCodexAuthApplier::new(&store_path)

--- a/apps/bitrouter/src/claude_code.rs
+++ b/apps/bitrouter/src/claude_code.rs
@@ -16,7 +16,7 @@
 //! which only exists above the SDK ingress seam, and because the enable step
 //! mutates the assembled [`Config`](bitrouter_sdk::config::Config).
 
-use bitrouter_providers::oauth::credential_store::{CredentialStore, DEFAULT_LABEL};
+use bitrouter_providers::oauth::credential_store::{Credential, CredentialStore, DEFAULT_LABEL};
 use bitrouter_sdk::PromptTransform;
 use bitrouter_sdk::config::{Config, ProviderConfig};
 use bitrouter_sdk::language_model::types::Prompt;
@@ -80,10 +80,87 @@ impl PromptTransform for ClaudeCodeRouter {
 /// hasn't signed in to their Claude subscription yet. Mirrors
 /// [`crate::cloud::enable_in_zero_config`].
 pub fn enable_if_logged_in(config: &mut Config) {
+    // Adopt any legacy #590 subscription marker (stored under `anthropic`)
+    // before reading the store, so a running daemon picks up the move to
+    // `claude-code` on a serve / reload config-build pass.
+    migrate_legacy_anthropic_marker_default();
     let Ok(store) = CredentialStore::default_path() else {
         return;
     };
     enable_if_logged_in_with_store(config, &store);
+}
+
+/// Provider id of the legacy platform / pay-as-you-go Anthropic provider. A
+/// pre-split (#590) user signed in to their Claude subscription stored the
+/// [`Credential::ClaudeCodeCli`] marker here; the migration moves it to
+/// [`PROVIDER_ID`].
+const LEGACY_PROVIDER_ID: &str = "anthropic";
+
+/// Move a pre-split (#590) Claude subscription marker from the legacy
+/// `anthropic` provider to the dedicated `claude-code` provider, using the
+/// default credential-store path. Best-effort: an unresolvable / unreadable
+/// store is a silent no-op. See [`migrate_legacy_anthropic_marker`].
+pub fn migrate_legacy_anthropic_marker_default() {
+    let Ok(store) = CredentialStore::default_path() else {
+        return;
+    };
+    let _ = migrate_legacy_anthropic_marker(store.path().to_path_buf());
+}
+
+/// Move a pre-split (#590) Claude subscription marker from the legacy
+/// `anthropic` provider to the dedicated `claude-code` provider.
+///
+/// #590 stored the [`Credential::ClaudeCodeCli`] subscription marker under
+/// `anthropic`. Now that `anthropic` is platform / pay-as-you-go (`x-api-key`)
+/// and the subscription is its own `claude-code` provider, an existing user
+/// would otherwise be stranded. For every label under `anthropic` whose
+/// credential is the `ClaudeCodeCli` marker, this re-keys it to `claude-code`
+/// (set under `claude-code`, removed from `anthropic`).
+///
+/// Strictly scoped to the marker:
+/// - A pasted [`Credential::ApiKey`] (or any OAuth credential) under `anthropic`
+///   is **left untouched** — that is `anthropic`'s own platform key.
+/// - If `claude-code` already holds a credential for that label, the `anthropic`
+///   marker is left as-is (no clobber).
+///
+/// Best-effort: an unreadable store is a silent no-op. Takes the store path so
+/// callers / tests can inject it.
+pub fn migrate_legacy_anthropic_marker(store_path: std::path::PathBuf) -> bool {
+    let Ok(mut store) = CredentialStore::load(store_path) else {
+        return false;
+    };
+    // Snapshot the labels first — the move mutates the store as it goes.
+    let labels: Vec<String> = store
+        .labels(LEGACY_PROVIDER_ID)
+        .into_iter()
+        .map(str::to_string)
+        .collect();
+    let mut moved_any = false;
+    for label in labels {
+        // Only the tokenless subscription marker migrates; an `ApiKey` or any
+        // other credential is anthropic's platform credential and stays put.
+        if !matches!(
+            store.get_any(LEGACY_PROVIDER_ID, &label),
+            Some(Credential::ClaudeCodeCli)
+        ) {
+            continue;
+        }
+        // Don't clobber an existing `claude-code` credential for this label.
+        if store.get_any(PROVIDER_ID, &label).is_some() {
+            continue;
+        }
+        if store
+            .set(PROVIDER_ID, &label, Credential::ClaudeCodeCli)
+            .is_err()
+        {
+            // A failed write leaves the legacy marker in place; try again next
+            // time rather than removing the only copy.
+            continue;
+        }
+        let _ = store.remove(LEGACY_PROVIDER_ID, &label);
+        moved_any = true;
+    }
+    moved_any
 }
 
 /// Inner form taking the credential store explicitly so unit tests can drive
@@ -213,6 +290,116 @@ mod tests {
             !config.providers.contains_key(PROVIDER_ID),
             "no credential → no provider inserted"
         );
+    }
+
+    #[test]
+    fn migration_moves_marker_from_anthropic_to_claude_code() {
+        let mut store = fresh_tmp_store();
+        let path = store.path().to_path_buf();
+        // A pre-split (#590) user: the subscription marker lives under
+        // `anthropic`, and `claude-code` has nothing yet.
+        store
+            .set(LEGACY_PROVIDER_ID, DEFAULT_LABEL, Credential::ClaudeCodeCli)
+            .unwrap();
+        drop(store);
+
+        assert!(migrate_legacy_anthropic_marker(path.clone()));
+
+        let reloaded = CredentialStore::load(&path).unwrap();
+        assert!(
+            matches!(
+                reloaded.get_any(PROVIDER_ID, DEFAULT_LABEL),
+                Some(Credential::ClaudeCodeCli)
+            ),
+            "the marker must now live under `claude-code`"
+        );
+        assert!(
+            reloaded
+                .get_any(LEGACY_PROVIDER_ID, DEFAULT_LABEL)
+                .is_none(),
+            "the legacy `anthropic` marker must be removed"
+        );
+    }
+
+    #[test]
+    fn migration_leaves_anthropic_api_key_untouched() {
+        let mut store = fresh_tmp_store();
+        let path = store.path().to_path_buf();
+        // An `anthropic` platform key must stay put — it is not a subscription
+        // marker.
+        store
+            .set(
+                LEGACY_PROVIDER_ID,
+                DEFAULT_LABEL,
+                Credential::api_key("sk-ant-api03-platform"),
+            )
+            .unwrap();
+        drop(store);
+
+        assert!(!migrate_legacy_anthropic_marker(path.clone()));
+
+        let reloaded = CredentialStore::load(&path).unwrap();
+        assert_eq!(
+            reloaded
+                .get_any(LEGACY_PROVIDER_ID, DEFAULT_LABEL)
+                .and_then(Credential::as_api_key),
+            Some("sk-ant-api03-platform"),
+            "the anthropic platform API key must be left in place"
+        );
+        assert!(
+            reloaded.get_any(PROVIDER_ID, DEFAULT_LABEL).is_none(),
+            "no claude-code credential should be created for an API key"
+        );
+    }
+
+    #[test]
+    fn migration_does_not_clobber_existing_claude_code_credential() {
+        let mut store = fresh_tmp_store();
+        let path = store.path().to_path_buf();
+        // Both providers already hold a marker for this label (e.g. the user
+        // already logged in to `claude-code`). The legacy entry must be left
+        // as-is rather than overwriting the existing `claude-code` credential.
+        store
+            .set(LEGACY_PROVIDER_ID, DEFAULT_LABEL, Credential::ClaudeCodeCli)
+            .unwrap();
+        store
+            .set(
+                PROVIDER_ID,
+                DEFAULT_LABEL,
+                Credential::api_key("sk-ant-oat-existing"),
+            )
+            .unwrap();
+        drop(store);
+
+        assert!(!migrate_legacy_anthropic_marker(path.clone()));
+
+        let reloaded = CredentialStore::load(&path).unwrap();
+        assert!(
+            matches!(
+                reloaded.get_any(LEGACY_PROVIDER_ID, DEFAULT_LABEL),
+                Some(Credential::ClaudeCodeCli)
+            ),
+            "the anthropic marker must be left as-is when claude-code already has a credential"
+        );
+        assert_eq!(
+            reloaded
+                .get_any(PROVIDER_ID, DEFAULT_LABEL)
+                .and_then(Credential::as_api_key),
+            Some("sk-ant-oat-existing"),
+            "the pre-existing claude-code credential must not be clobbered"
+        );
+    }
+
+    #[test]
+    fn migration_noop_on_unreadable_store() {
+        // A path that cannot be loaded as a store (it's a directory) is a
+        // silent no-op, never a panic.
+        let dir =
+            std::env::temp_dir().join(format!("bitrouter-cc-migrate-bad-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        assert!(!migrate_legacy_anthropic_marker(dir.clone()));
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/apps/bitrouter/src/claude_code.rs
+++ b/apps/bitrouter/src/claude_code.rs
@@ -1,0 +1,241 @@
+//! App-layer routing glue for the Claude Code **subscription** provider
+//! (`claude-code`).
+//!
+//! Two daemon-side responsibilities, both keyed on the `claude-code` provider
+//! id and the Claude Code identity system prompt:
+//!
+//! - [`ClaudeCodeRouter`] — an ingress [`PromptTransform`] that detects genuine
+//!   Claude Code traffic by its system prompt and routes it to the subscription
+//!   provider by provider-prefixing the model (`claude-code:<model>`).
+//! - [`enable_if_logged_in`] — auto-add the `claude-code` provider to the
+//!   in-memory `providers:` map when the OAuth credential store holds a
+//!   `claude-code` credential (mirrors [`crate::cloud::enable_in_zero_config`]).
+//!
+//! These live in the app layer (not `bitrouter-providers`) because the routing
+//! decision reads the parsed canonical [`Prompt`](bitrouter_sdk::language_model::types::Prompt),
+//! which only exists above the SDK ingress seam, and because the enable step
+//! mutates the assembled [`Config`](bitrouter_sdk::config::Config).
+
+use bitrouter_providers::oauth::credential_store::{CredentialStore, DEFAULT_LABEL};
+use bitrouter_sdk::PromptTransform;
+use bitrouter_sdk::config::{Config, ProviderConfig};
+use bitrouter_sdk::language_model::types::Prompt;
+
+/// Provider id of the Claude Pro/Max subscription provider. Must match the id
+/// the [`bitrouter_providers::claude_code::ClaudeCodeAuthApplier`] is registered
+/// under and the id used in the explicit-provider route prefix below.
+const PROVIDER_ID: &str = "claude-code";
+
+/// Ingress [`PromptTransform`] that routes genuine Claude Code traffic to the
+/// Claude Pro/Max **subscription** provider.
+///
+/// Genuine Claude Code traffic carries the Claude Code identity as its first
+/// system block: the SDK's Messages decoder flattens the inbound `system`
+/// blocks into one `\n`-joined string (identity first), so the canonical
+/// [`Prompt::system`] *starts with* [`CLAUDE_CODE_SYSTEM_PROMPT`]
+/// (`bitrouter_providers::anthropic::headers::CLAUDE_CODE_SYSTEM_PROMPT`). Such
+/// a request also targets a bare Claude model id (e.g.
+/// `claude-sonnet-4-5-20250929`).
+///
+/// When both hold, the transform rewrites `prompt.model` to
+/// `claude-code:<model>`, which sends the request to the subscription provider
+/// via the explicit-provider route. Everything else is left untouched:
+/// non-Claude-Code traffic, non-Claude models, and already-prefixed models all
+/// route wherever they already pointed (the pay-as-you-go `anthropic` provider
+/// for bare Claude models, or the explicit provider).
+///
+/// The transform **only reads** the identity — it never adds it. The
+/// subscription applier separately *requires* the identity to be present and
+/// refuses to fabricate it, so this transform cannot be used to spoof arbitrary
+/// traffic as Claude Code.
+///
+/// [`CLAUDE_CODE_SYSTEM_PROMPT`]: bitrouter_providers::anthropic::headers::CLAUDE_CODE_SYSTEM_PROMPT
+pub struct ClaudeCodeRouter;
+
+impl PromptTransform for ClaudeCodeRouter {
+    fn apply(&self, prompt: &mut Prompt) {
+        let is_cc = prompt.system.as_deref().is_some_and(|s| {
+            s.trim_start()
+                .starts_with(bitrouter_providers::anthropic::headers::CLAUDE_CODE_SYSTEM_PROMPT)
+        });
+        if is_cc && prompt.model.starts_with("claude") && !prompt.model.starts_with("claude-code:")
+        {
+            prompt.model = format!("claude-code:{}", prompt.model);
+        }
+    }
+}
+
+/// Insert the `claude-code` provider into `config.providers` when the OAuth
+/// credential store holds a `claude-code` credential (subscription marker or
+/// stored OAuth token) and the entry is not already present.
+///
+/// The inserted entry is an empty [`ProviderConfig::default()`]; the registry
+/// merge fills its `api_base` / `api_protocol` / auth from the fetched
+/// `claude-code` registry entry, the
+/// [`bitrouter_providers::claude_code::ClaudeCodeAuthApplier`] authenticates it,
+/// and `claude-code`'s `access: local_oauth` keeps it active even though it
+/// declares no canonical models.
+///
+/// Best-effort: a missing or unreadable store is a no-op — the user simply
+/// hasn't signed in to their Claude subscription yet. Mirrors
+/// [`crate::cloud::enable_in_zero_config`].
+pub fn enable_if_logged_in(config: &mut Config) {
+    let Ok(store) = CredentialStore::default_path() else {
+        return;
+    };
+    enable_if_logged_in_with_store(config, &store);
+}
+
+/// Inner form taking the credential store explicitly so unit tests can drive
+/// the logic without touching the user's real store.
+fn enable_if_logged_in_with_store(config: &mut Config, store: &CredentialStore) {
+    if config.providers.contains_key(PROVIDER_ID) {
+        return;
+    }
+    let logged_in = !store.labels(PROVIDER_ID).is_empty()
+        || store.get_any(PROVIDER_ID, DEFAULT_LABEL).is_some();
+    if !logged_in {
+        return;
+    }
+    config
+        .providers
+        .insert(PROVIDER_ID.to_string(), ProviderConfig::default());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bitrouter_providers::anthropic::headers::CLAUDE_CODE_SYSTEM_PROMPT;
+    use bitrouter_providers::oauth::credential_store::Credential;
+    use bitrouter_sdk::language_model::types::{GenerationParams, ProviderMetadata};
+
+    fn prompt(model: &str, system: Option<&str>) -> Prompt {
+        Prompt {
+            model: model.to_string(),
+            system: system.map(str::to_string),
+            system_provider_metadata: ProviderMetadata::new(),
+            messages: Vec::new(),
+            tools: Vec::new(),
+            params: GenerationParams::default(),
+            response_format: None,
+            tool_choice: None,
+            stream: false,
+        }
+    }
+
+    fn route(model: &str, system: Option<&str>) -> String {
+        let mut p = prompt(model, system);
+        ClaudeCodeRouter.apply(&mut p);
+        p.model
+    }
+
+    #[test]
+    fn cc_system_and_bare_claude_model_is_prefixed() {
+        let system = format!("{CLAUDE_CODE_SYSTEM_PROMPT}\nbe terse");
+        assert_eq!(
+            route("claude-sonnet-4-5-20250929", Some(&system)),
+            "claude-code:claude-sonnet-4-5-20250929"
+        );
+    }
+
+    #[test]
+    fn cc_system_and_non_claude_model_is_untouched() {
+        let system = format!("{CLAUDE_CODE_SYSTEM_PROMPT}\nbe terse");
+        assert_eq!(route("gpt-5", Some(&system)), "gpt-5");
+    }
+
+    #[test]
+    fn non_cc_system_with_claude_model_is_untouched() {
+        // No system prompt at all.
+        assert_eq!(
+            route("claude-sonnet-4-5-20250929", None),
+            "claude-sonnet-4-5-20250929"
+        );
+        // A system prompt that is not the Claude Code identity.
+        assert_eq!(
+            route("claude-sonnet-4-5-20250929", Some("be terse")),
+            "claude-sonnet-4-5-20250929"
+        );
+    }
+
+    #[test]
+    fn already_prefixed_claude_model_is_untouched() {
+        let system = format!("{CLAUDE_CODE_SYSTEM_PROMPT}\nbe terse");
+        assert_eq!(
+            route("claude-code:claude-sonnet-4-5-20250929", Some(&system)),
+            "claude-code:claude-sonnet-4-5-20250929"
+        );
+    }
+
+    #[test]
+    fn idempotent_on_already_claude_code_prefixed_model() {
+        // Running the transform twice must not double-prefix.
+        let system = format!("{CLAUDE_CODE_SYSTEM_PROMPT}\nbe terse");
+        let mut p = prompt("claude-sonnet-4-5-20250929", Some(&system));
+        ClaudeCodeRouter.apply(&mut p);
+        ClaudeCodeRouter.apply(&mut p);
+        assert_eq!(p.model, "claude-code:claude-sonnet-4-5-20250929");
+    }
+
+    fn fresh_tmp_store() -> CredentialStore {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "bitrouter-cc-router-test-{}-{id}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        CredentialStore::load(dir.join("creds.json")).unwrap()
+    }
+
+    #[test]
+    fn enable_inserts_when_marker_present() {
+        let mut store = fresh_tmp_store();
+        store
+            .set(PROVIDER_ID, DEFAULT_LABEL, Credential::ClaudeCodeCli)
+            .unwrap();
+        let mut config = Config::default();
+        enable_if_logged_in_with_store(&mut config, &store);
+        assert!(
+            config.providers.contains_key(PROVIDER_ID),
+            "`claude-code` provider should be auto-enabled when a credential is stored"
+        );
+    }
+
+    #[test]
+    fn enable_noop_when_no_credential() {
+        let store = fresh_tmp_store();
+        let mut config = Config::default();
+        enable_if_logged_in_with_store(&mut config, &store);
+        assert!(
+            !config.providers.contains_key(PROVIDER_ID),
+            "no credential → no provider inserted"
+        );
+    }
+
+    #[test]
+    fn enable_noop_when_already_present() {
+        let mut store = fresh_tmp_store();
+        store
+            .set(PROVIDER_ID, DEFAULT_LABEL, Credential::ClaudeCodeCli)
+            .unwrap();
+        let mut config = Config::default();
+        // Pre-populate with a sentinel `api_base` to prove the existing entry
+        // is not overwritten.
+        config.providers.insert(
+            PROVIDER_ID.to_string(),
+            ProviderConfig {
+                api_base: "https://example.invalid".to_string(),
+                ..ProviderConfig::default()
+            },
+        );
+        enable_if_logged_in_with_store(&mut config, &store);
+        assert_eq!(
+            config.providers.get(PROVIDER_ID).unwrap().api_base,
+            "https://example.invalid",
+            "existing entry must not be overwritten"
+        );
+    }
+}

--- a/apps/bitrouter/src/claude_code.rs
+++ b/apps/bitrouter/src/claude_code.rs
@@ -12,9 +12,9 @@
 //!   `claude-code` credential (mirrors [`crate::cloud::enable_in_zero_config`]).
 //!
 //! These live in the app layer (not `bitrouter-providers`) because the routing
-//! decision reads the parsed canonical [`Prompt`](bitrouter_sdk::language_model::types::Prompt),
+//! decision reads the parsed canonical [`Prompt`],
 //! which only exists above the SDK ingress seam, and because the enable step
-//! mutates the assembled [`Config`](bitrouter_sdk::config::Config).
+//! mutates the assembled [`Config`].
 
 use bitrouter_providers::oauth::credential_store::{Credential, CredentialStore, DEFAULT_LABEL};
 use bitrouter_sdk::PromptTransform;

--- a/apps/bitrouter/src/commands.rs
+++ b/apps/bitrouter/src/commands.rs
@@ -325,11 +325,16 @@ impl AuthMethod {
 }
 
 /// The vendor CLI bitrouter can adopt an existing OAuth session from, for
-/// providers that ship one — `Claude Code` for `anthropic`, `Codex` for
-/// `openai-codex`. `None` for every other provider.
+/// providers that ship one — `Codex` for `openai-codex`. `None` for every
+/// other provider.
+///
+/// `anthropic` is **not** listed: it is now the platform / pay-as-you-go
+/// provider (`x-api-key` only). Adopting a Claude Code session is the
+/// `claude-code` subscription provider's job, handled by
+/// [`AuthMethod::ClaudeCodeSession`] (a *live* session read, not a one-shot
+/// token copy), so there is no vendor-CLI import for `anthropic`.
 fn import_cli_for(provider_id: &str) -> Option<&'static str> {
     match provider_id {
-        bitrouter_providers::anthropic::PROVIDER_ID => Some("Claude Code"),
         bitrouter_providers::codex::PROVIDER_ID => Some("Codex"),
         _ => None,
     }
@@ -340,22 +345,30 @@ fn import_cli_for(provider_id: &str) -> Option<&'static str> {
 fn available_methods(entry: &bitrouter_providers::ProviderEntry) -> Vec<AuthMethod> {
     use bitrouter_providers::AuthScheme;
     let mut methods = Vec::new();
-    // Anthropic's preferred path: read the user's live Claude Code session and
-    // let the `claude` CLI own login. Listed first so it's the default on
-    // <enter> / non-interactive runs.
-    let is_anthropic = entry.id == bitrouter_providers::anthropic::PROVIDER_ID;
-    if is_anthropic {
+    // The Claude subscription's preferred (and only) path: read the user's live
+    // Claude Code session and let the `claude` CLI own login. It belongs to the
+    // dedicated `claude-code` subscription provider — `anthropic` is now the
+    // platform / pay-as-you-go provider and offers the API-key path only.
+    // Listed first so it's the default on <enter> / non-interactive runs.
+    let is_claude_code = entry.id == bitrouter_providers::claude_code::PROVIDER_ID;
+    if is_claude_code {
         methods.push(AuthMethod::ClaudeCodeSession);
     }
-    let has_pkce = bitrouter_providers::oauth::registry::has_pkce_flow(&entry.id);
+    // `anthropic` is platform / pay-as-you-go: offer the API-key path only. The
+    // PKCE registry still carries an `anthropic` entry (the Claude subscription
+    // browser flow), but that subscription path now belongs to the dedicated
+    // `claude-code` provider, so it must not be offered under `anthropic`.
+    let is_anthropic = entry.id == bitrouter_providers::anthropic::PROVIDER_ID;
+    let has_pkce = !is_anthropic && bitrouter_providers::oauth::registry::has_pkce_flow(&entry.id);
     if has_pkce {
         methods.push(AuthMethod::PkceSubscription);
     }
     // Providers with a sibling vendor CLI can adopt its existing session as a
-    // one-shot copy. For anthropic this is superseded by the live
-    // `ClaudeCodeSession` above (the copy is what risked the family-revoke), so
-    // it's offered only for the other CLI providers (Codex).
-    if import_cli_for(&entry.id).is_some() && !is_anthropic {
+    // one-shot copy — currently only Codex (`openai-codex`). `anthropic` has no
+    // such import: subscription sign-in moved to the `claude-code` provider via
+    // the live `ClaudeCodeSession` above (the one-shot copy is what risked the
+    // family-revoke), and `import_cli_for` no longer maps `anthropic`.
+    if import_cli_for(&entry.id).is_some() {
         methods.push(AuthMethod::ImportFromCli);
     }
     match &entry.auth {
@@ -502,7 +515,7 @@ pub async fn login_provider(provider_id: &str, label: &str) -> Result<()> {
 }
 
 /// Adopt the user's existing Claude Code session as the live credential source
-/// for `anthropic`.
+/// for the `claude-code` subscription provider.
 ///
 /// Resolution order, mirroring how Claude Code users actually authenticate:
 /// 1. If a Claude Code session already exists in `~/.claude` (macOS Keychain /
@@ -514,13 +527,20 @@ pub async fn login_provider(provider_id: &str, label: &str) -> Result<()> {
 ///
 /// Returns a [`Credential::ClaudeCodeCli`] marker — no token is copied into
 /// bitrouter's own store, so bitrouter and Claude Code share one credential and
-/// can't refresh-rotate each other out (RFC 6749 §6).
+/// can't refresh-rotate each other out (RFC 6749 §6). `login_provider` stores
+/// this marker under the `provider_id` it was invoked with, so
+/// `bitrouter providers login claude-code` lands it under `claude-code`.
 async fn run_claude_code_session()
 -> Result<bitrouter_providers::oauth::credential_store::Credential> {
     use std::io::IsTerminal;
 
     use bitrouter_providers::import::claude_code::ClaudeCodeStore;
     use bitrouter_providers::oauth::credential_store::Credential;
+
+    // Adopt a legacy #590 marker stored under `anthropic` before checking the
+    // live session, so a returning user's existing sign-in is recognised under
+    // the new `claude-code` provider.
+    crate::claude_code::migrate_legacy_anthropic_marker_default();
 
     let store = ClaudeCodeStore::system().ok_or_else(|| {
         anyhow::anyhow!(
@@ -545,7 +565,7 @@ async fn run_claude_code_session()
         anyhow::bail!(
             "not signed in to Claude Code. Run `claude auth login` (install the CLI first with \
              `curl -fsSL https://claude.ai/install.sh | bash`), then re-run \
-             `bitrouter login anthropic`."
+             `bitrouter providers login claude-code`."
         );
     }
 
@@ -563,7 +583,8 @@ async fn run_claude_code_session()
         .context("running `claude auth login`")?;
     if !status.success() {
         anyhow::bail!(
-            "`claude auth login` didn't complete — sign in, then re-run `bitrouter login anthropic`."
+            "`claude auth login` didn't complete — sign in, then re-run \
+             `bitrouter providers login claude-code`."
         );
     }
 
@@ -693,15 +714,17 @@ async fn run_device_code(
 }
 
 /// Adopt an existing OAuth session from the provider's sibling vendor CLI
-/// (Claude Code for `anthropic`, Codex for `openai-codex`) by reading its
-/// on-disk / Keychain credential. Errors when no such session is found.
+/// (Codex for `openai-codex`) by reading its on-disk / Keychain credential.
+/// Errors when no such session is found.
+///
+/// `anthropic` is intentionally absent: it is the platform / pay-as-you-go
+/// provider now, and the Claude Code session is adopted *live* by the
+/// `claude-code` provider via [`run_claude_code_session`] — not copied in here
+/// (the one-shot copy is what risked the RFC 6749 §6 family-revoke).
 fn run_cli_import(
     provider_id: &str,
 ) -> Result<bitrouter_providers::oauth::credential_store::Credential> {
     let imported = match provider_id {
-        bitrouter_providers::anthropic::PROVIDER_ID => {
-            bitrouter_providers::import::claude_code::import()
-        }
         bitrouter_providers::codex::PROVIDER_ID => bitrouter_providers::import::codex::import(),
         other => anyhow::bail!("no vendor-CLI import is available for provider '{other}'"),
     }
@@ -1113,7 +1136,33 @@ mod tests {
     }
 
     #[test]
-    fn anthropic_prefers_claude_code_session_first() {
+    fn claude_code_prefers_claude_code_session_first() {
+        // The `claude-code` subscription provider — the live Claude Code session
+        // is its default (and the marker lands under `claude-code`).
+        let entry = entry_for(serde_json::json!({
+            "name": "claude-code",
+            "api_base": "https://api.anthropic.com/v1",
+            "status": "active",
+            "auth": { "kind": "oauth", "handler": "claude-code" },
+            "models": []
+        }));
+        let methods = available_methods(&entry);
+        assert_eq!(
+            methods.first(),
+            Some(&AuthMethod::ClaudeCodeSession),
+            "the live Claude Code session must be the default for claude-code"
+        );
+        assert!(
+            !methods.contains(&AuthMethod::ImportFromCli),
+            "claude-code uses the live session, not the one-shot copy that can family-revoke"
+        );
+    }
+
+    #[test]
+    fn anthropic_offers_api_key_only() {
+        // `anthropic` is now platform / pay-as-you-go: API-key paste only — no
+        // Claude Code session, no subscription PKCE, no vendor-CLI import. The
+        // subscription path moved to the `claude-code` provider.
         let entry = entry_for(serde_json::json!({
             "name": "anthropic",
             "api_base": "https://api.anthropic.com/v1",
@@ -1123,18 +1172,13 @@ mod tests {
         }));
         let methods = available_methods(&entry);
         assert_eq!(
-            methods.first(),
-            Some(&AuthMethod::ClaudeCodeSession),
-            "the live Claude Code session must be the default for anthropic"
+            methods,
+            vec![AuthMethod::ApiKey],
+            "anthropic must offer the API-key path only"
         );
-        assert!(
-            !methods.contains(&AuthMethod::ImportFromCli),
-            "anthropic uses the live session, not the one-shot copy that can family-revoke"
-        );
-        assert!(
-            methods.contains(&AuthMethod::PkceSubscription),
-            "PKCE stays available as an explicit fallback"
-        );
+        assert!(!methods.contains(&AuthMethod::ClaudeCodeSession));
+        assert!(!methods.contains(&AuthMethod::PkceSubscription));
+        assert!(!methods.contains(&AuthMethod::ImportFromCli));
     }
 
     #[test]

--- a/apps/bitrouter/src/lib.rs
+++ b/apps/bitrouter/src/lib.rs
@@ -14,6 +14,7 @@ pub mod agent_proxy;
 pub mod agents;
 pub mod assemble;
 pub mod auth;
+pub mod claude_code;
 pub mod cloud;
 pub mod commands;
 pub mod daemon;

--- a/apps/bitrouter/src/main.rs
+++ b/apps/bitrouter/src/main.rs
@@ -855,6 +855,11 @@ async fn serve(source: &bitrouter::paths::ConfigSource) -> Result<()> {
         .with_context(|| format!("chdir to bitrouter home {}", home.display()))?;
 
     let mut cfg = bitrouter::paths::load_config(source).await?;
+    // Auto-enable the `claude-code` subscription provider when the user has
+    // signed in (a `claude-code` credential is in the OAuth store). Runs before
+    // the registry merge so the merge fills the inserted provider's
+    // `api_base` / `api_protocol` / auth from the fetched registry entry.
+    bitrouter::claude_code::enable_if_logged_in(&mut cfg);
     // Fetch + merge the provider registry (BYOK providers + the canonical model
     // catalog) before assembly, so the daemon routes every credentialed
     // provider's canonical models. Best-effort and cache-backed; a no-op when

--- a/apps/bitrouter/src/reload.rs
+++ b/apps/bitrouter/src/reload.rs
@@ -91,6 +91,10 @@ impl DaemonReloader for AppReloader {
             ReloadSource::File(path) => match bitrouter_sdk::config::load(path).await {
                 Ok(mut fresh) => {
                     bitrouter_providers::apply_builtin_defaults(&mut fresh);
+                    // Auto-enable the `claude-code` subscription provider when a
+                    // credential is in the OAuth store, before the registry merge
+                    // fills its fields — so a sign-in survives a hot-reload.
+                    crate::claude_code::enable_if_logged_in(&mut fresh);
                     // Re-merge the registry too, so a reload picks up newly-set
                     // credentials (a `bitrouter reload --env` that exports a
                     // provider key activates that provider's canonical models).
@@ -119,6 +123,10 @@ impl DaemonReloader for AppReloader {
                 // `$BITROUTER_API_KEY` is in the daemon's env-override map.
                 crate::cloud::enable_in_zero_config(&mut fresh);
                 bitrouter_providers::apply_builtin_defaults(&mut fresh);
+                // Auto-enable the `claude-code` subscription provider when a
+                // credential is in the OAuth store, before the registry merge
+                // fills its fields — so a sign-in survives a hot-reload.
+                crate::claude_code::enable_if_logged_in(&mut fresh);
                 // Merge the registry so the canonical catalog + every
                 // credentialed BYOK provider is routable after a reload too.
                 crate::assemble::merge_registry_into(&mut fresh).await;

--- a/crates/bitrouter-providers/src/anthropic/headers.rs
+++ b/crates/bitrouter-providers/src/anthropic/headers.rs
@@ -28,11 +28,11 @@ pub const OAUTH_BETA_VALUES: &[&str] = &["claude-code-20250219", "oauth-2025-04-
 ///
 /// The subscription endpoint admits requests under the Claude Code agent
 /// profile; the first `system` block has to be this exact identity string or
-/// the upstream rejects the request. The caller's own system prompt is
-/// preserved — appended after this block by
-/// [`crate::anthropic::AnthropicOAuthApplier`]'s body shaper. Mirrors the
-/// request shape of Claude Code itself (see the OpenClaw reference,
-/// `src/llm/providers/anthropic.ts`, at <https://github.com/openclaw/openclaw>).
+/// the upstream rejects the request. The subscription applier
+/// [`crate::claude_code::ClaudeCodeAuthApplier`] *gates* on this block being
+/// present (it never fabricates it). Mirrors the request shape of Claude Code
+/// itself (see the OpenClaw reference, `src/llm/providers/anthropic.ts`, at
+/// <https://github.com/openclaw/openclaw>).
 pub const CLAUDE_CODE_SYSTEM_PROMPT: &str =
     "You are Claude Code, Anthropic's official CLI for Claude.";
 

--- a/crates/bitrouter-providers/src/anthropic/mod.rs
+++ b/crates/bitrouter-providers/src/anthropic/mod.rs
@@ -1,469 +1,120 @@
-//! Anthropic — dual-mode `AuthApplier` covering both API-key auth and the
-//! Claude Pro/Max OAuth subscription path.
+//! Anthropic — the Platform-API `AuthApplier` (`x-api-key`).
 //!
-//! Same provider id (`"anthropic"`) for both modes: at request time the
-//! applier looks up `(anthropic, target.account_label)` in the
-//! [`crate::oauth::credential_store::CredentialStore`] and branches on the
-//! credential type.
+//! Registered under the provider id `"anthropic"`. This applier covers the
+//! Anthropic **Platform API** (pay-as-you-go) only: it resolves a static API
+//! key and sets `x-api-key` + `anthropic-version`. It does **no** OAuth, no
+//! `ClaudeCodeCli` marker resolution, and no body shaping — the Claude Pro/Max
+//! subscription path lives in the separate [`crate::claude_code`] applier
+//! (provider id `"claude-code"`).
 //!
-//! | Stored credential | Outbound headers |
+//! | Source of the key | Outbound headers |
 //! |---|---|
-//! | `Credential::Oauth` (Claude Pro/Max)  | `Authorization: Bearer sk-ant-oat…`, `anthropic-beta: claude-code-20250219,oauth-2025-04-20`, `anthropic-version: 2023-06-01`, `user-agent: claude-cli/…`, `x-app: cli`. **No `x-api-key`** — the upstream rejects OAuth requests that also carry `x-api-key`. The request body is shaped by [`AnthropicOAuthApplier::prepare_body`] so Claude Code's identity is the first `system` block. |
-//! | `Credential::ApiKey`                  | `x-api-key: <value>`, `anthropic-version: 2023-06-01`. |
-//! | _no credential in store_              | Fall back to the routing target's `api_key` field (the env-var path). Existing `${ANTHROPIC_API_KEY}` setups behave exactly as before. |
+//! | `Credential::ApiKey` stored under `"anthropic"` | `x-api-key: <value>`, `anthropic-version: 2023-06-01`. |
+//! | _no stored key_ | Fall back to the routing target's inline `api_key` (the `${ANTHROPIC_API_KEY}` env path). |
+//! | _neither_ | `401` pointing at `ANTHROPIC_API_KEY` / `bitrouter providers login anthropic`. |
 //!
-//! The OAuth branch refreshes the access token via
-//! [`crate::oauth::refresh::refresh`] if it's within
-//! [`crate::oauth::refresh::REFRESH_WINDOW`] of expiry, writes the new token
-//! back to the store, and caches it in memory to avoid hammering the
-//! refresh endpoint under load.
+//! [`AnthropicApiKeyApplier::prepare_body`] is a no-op: the Platform API takes
+//! the caller's body verbatim.
 //!
-//! ## Body shape
-//!
-//! The Claude Pro/Max subscription endpoint admits requests under the Claude
-//! Code agent profile: the first `system` block has to be Claude Code's
-//! identity string. [`AnthropicOAuthApplier::prepare_body`] enforces that at
-//! render time (when the body is still a `serde_json::Value`), prepending the
-//! identity block and preserving the caller's own system prompt after it.
-//! API-key requests pass the body through unchanged.
-//!
-//! Authoritative reference for the OAuth client + headers: Claude Code's
-//! published OAuth client (client_id `9d1c250a-…`), as reused by
-//! [`@earendil-works/pi-ai`](https://github.com/openclaw/openclaw)'s
-//! Anthropic login and OpenCode's auth registry.
+//! The shared header constants (`anthropic-version`, and the Claude Code
+//! constants reused by [`crate::claude_code`]) live in [`headers`].
 
 pub mod headers;
 
-use std::sync::Arc;
-use std::sync::Mutex;
-use std::time::Duration;
-
 use async_trait::async_trait;
-use reqwest::header::{HeaderName, HeaderValue};
+use reqwest::header::HeaderValue;
 
 use bitrouter_sdk::language_model::AuthApplier;
 use bitrouter_sdk::language_model::types::RoutingTarget;
 use bitrouter_sdk::{BitrouterError, Result};
 
-use crate::import::claude_code::ClaudeCodeStore;
-use crate::oauth::auth_code::AuthCodeError;
-use crate::oauth::credential_store::{Credential, CredentialStore, DEFAULT_LABEL, OAuthToken};
-use crate::oauth::refresh::{needs_refresh, refresh};
+use crate::oauth::credential_store::{Credential, CredentialStore, DEFAULT_LABEL};
 
 /// Provider id this applier is registered under.
 pub const PROVIDER_ID: &str = "anthropic";
 
-/// `AuthApplier` for `provider_name == "anthropic"`.
+/// `AuthApplier` for `provider_name == "anthropic"` — the Anthropic Platform
+/// API (`x-api-key`).
 ///
-/// The applier owns:
-/// - the credential-store path so it can read + refresh-write back; and
-/// - the OAuth client id + token endpoint pulled from
-///   [`crate::oauth::registry::find`] at construction.
-///
-/// In-memory the applier caches the freshly-refreshed `OAuthToken` keyed
-/// by `account_label` so concurrent requests don't all hit the refresh
-/// endpoint.
-pub struct AnthropicOAuthApplier {
+/// The applier owns the credential-store path so it can read a stored API key.
+/// When no key is stored it falls through to the routing target's inline
+/// `api_key` (the `${ANTHROPIC_API_KEY}` env path), preserving existing setups.
+pub struct AnthropicApiKeyApplier {
     store_path: std::path::PathBuf,
-    refresh_client: reqwest::Client,
-    /// OAuth client id used for the refresh grant. Mirrors what the
-    /// `bitrouter login anthropic` flow wrote.
-    client_id: String,
-    /// Token endpoint used for the refresh grant.
-    token_endpoint: String,
-    /// `account_label -> freshest OAuthToken` cache. Populated on first
-    /// refresh; subsequent requests within the validity window reuse it
-    /// without touching disk or the refresh endpoint.
-    cache: Arc<Mutex<std::collections::HashMap<String, OAuthToken>>>,
-    /// Per-label single-flight gate around the disk-read → refresh →
-    /// persist sequence. RFC 6749 §6 lets the server invalidate older
-    /// refresh tokens once a new one is minted, so two concurrent refreshes
-    /// of the same label can silently log the user out. Holding this
-    /// `tokio::sync::Mutex` across the refresh `await` serialises them;
-    /// the second waiter re-checks the cache after acquiring the lock
-    /// (double-checked locking) and skips the refresh if the first one
-    /// already populated it.
-    refresh_gates: Arc<Mutex<std::collections::HashMap<String, Arc<tokio::sync::Mutex<()>>>>>,
-    /// Live view of Claude Code's own credential store (`~/.claude`). Used to
-    /// resolve a [`Credential::ClaudeCodeCli`] marker: read the token live and
-    /// write any refresh back to the same source, so bitrouter and Claude Code
-    /// share one credential. `None` only when no home directory resolves.
-    claude_code: Option<ClaudeCodeStore>,
 }
 
-impl AnthropicOAuthApplier {
-    /// Build an applier that reads + writes the credential store at
-    /// `store_path` and refreshes tokens using the registry's default
-    /// Anthropic OAuth client + token endpoint.
+impl AnthropicApiKeyApplier {
+    /// Build an applier that reads the credential store at `store_path`.
     pub fn new(store_path: impl Into<std::path::PathBuf>) -> Result<Self> {
-        let registry = crate::oauth::registry::find(PROVIDER_ID).ok_or_else(|| {
-            BitrouterError::internal(
-                "anthropic PKCE registry entry is missing — this is a build-time bug".to_string(),
-            )
-        })?;
-        let refresh_client = reqwest::Client::builder()
-            .user_agent(concat!("bitrouter-providers/", env!("CARGO_PKG_VERSION")))
-            .timeout(Duration::from_secs(30))
-            .build()
-            .map_err(|e| {
-                BitrouterError::internal(format!(
-                    "building Anthropic OAuth refresh HTTP client: {e}"
-                ))
-            })?;
         Ok(Self {
             store_path: store_path.into(),
-            refresh_client,
-            client_id: registry.auth.client_id,
-            token_endpoint: registry.auth.token_endpoint,
-            cache: Arc::new(Mutex::new(std::collections::HashMap::new())),
-            refresh_gates: Arc::new(Mutex::new(std::collections::HashMap::new())),
-            claude_code: ClaudeCodeStore::system(),
         })
     }
 
-    /// Override the refresh client + token endpoint (tests use this against
-    /// `wiremock`).
-    #[cfg(test)]
-    pub(crate) fn with_client_and_endpoint(
-        store_path: impl Into<std::path::PathBuf>,
-        refresh_client: reqwest::Client,
-        client_id: impl Into<String>,
-        token_endpoint: impl Into<String>,
-        claude_code: Option<ClaudeCodeStore>,
-    ) -> Self {
-        Self {
-            store_path: store_path.into(),
-            refresh_client,
-            client_id: client_id.into(),
-            token_endpoint: token_endpoint.into(),
-            cache: Arc::new(Mutex::new(std::collections::HashMap::new())),
-            refresh_gates: Arc::new(Mutex::new(std::collections::HashMap::new())),
-            claude_code,
-        }
+    fn label_for<'a>(&self, target: &'a RoutingTarget) -> &'a str {
+        target.account_label.as_deref().unwrap_or(DEFAULT_LABEL)
     }
 
-    /// Per-label single-flight gate. Cloned out under the std mutex (no
-    /// awaits held); the returned `tokio::sync::Mutex` serialises the
-    /// disk-read → refresh → persist sequence for that label.
-    fn refresh_gate(&self, label: &str) -> Arc<tokio::sync::Mutex<()>> {
-        let mut guard = self
-            .refresh_gates
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        guard
-            .entry(label.to_string())
-            .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
-            .clone()
-    }
-
-    fn cached_fresh(&self, label: &str) -> Option<OAuthToken> {
-        let guard = self.cache.lock().ok()?;
-        let token = guard.get(label)?;
-        (!needs_refresh(token)).then(|| token.clone())
-    }
-
-    fn store_in_cache(&self, label: &str, token: &OAuthToken) {
-        if let Ok(mut guard) = self.cache.lock() {
-            guard.insert(label.to_string(), token.clone());
-        }
-    }
-
-    /// Load the stored credential for the given account label, refreshing
-    /// the inner OAuth access token if it's within the refresh window.
-    /// Returns `None` when no credential is stored under that label —
-    /// callers fall through to the routing-target's inline `api_key`.
-    ///
-    /// Concurrency: cache hits are lock-free. The disk-read → refresh →
-    /// persist sequence is single-flighted per label via
-    /// [`Self::refresh_gate`] so concurrent requests don't both POST to
-    /// the token endpoint (and risk having the server invalidate the
-    /// older refresh token, per RFC 6749 §6).
-    async fn resolve_credential(&self, label: &str) -> Result<Option<ResolvedCredential>> {
-        // 1. Cheap in-memory cache check — no locks held across awaits.
-        if let Some(cached) = self.cached_fresh(label) {
-            return Ok(Some(ResolvedCredential::Oauth(cached)));
-        }
-        // 2. Acquire the per-label single-flight gate before any disk
-        //    read or refresh POST. If another task is mid-refresh for
-        //    this label, we wait here and then short-circuit on the
-        //    cache.
-        let gate = self.refresh_gate(label);
-        let _guard = gate.lock().await;
-        // 3. Double-checked locking — another task may have just
-        //    refreshed and populated the cache while we were waiting on
-        //    the gate.
-        if let Some(cached) = self.cached_fresh(label) {
-            return Ok(Some(ResolvedCredential::Oauth(cached)));
-        }
-        // 4. Disk read.
+    /// Resolve a stored API key for the given account label, if one is present.
+    /// Only [`Credential::ApiKey`] is honoured — any other shape (e.g. a stray
+    /// OAuth credential) is ignored, leaving the caller to fall through to the
+    /// routing target's inline key.
+    fn stored_api_key(&self, label: &str) -> Result<Option<String>> {
         let store = CredentialStore::load(&self.store_path).map_err(|e| {
             BitrouterError::internal(format!(
                 "reading credential store at {}: {e}",
                 self.store_path.display()
             ))
         })?;
-        let cred = match store.get_any(PROVIDER_ID, label) {
-            Some(c) => c.clone(),
-            None => return Ok(None),
-        };
-        // 5. ApiKey: no refresh logic, return as-is. Marker: resolve live from
-        //    the Claude Code store (read + refresh-write-back there).
-        let token = match cred {
-            Credential::ApiKey { value } => {
-                return Ok(Some(ResolvedCredential::ApiKey(value)));
-            }
-            Credential::ClaudeCodeCli => {
-                return self.resolve_claude_code_session(label).await;
-            }
-            Credential::Oauth(t) => t,
-        };
-        // 6. OAuth: refresh if expiring.
-        if needs_refresh(&token) {
-            let refreshed = refresh(
-                &self.refresh_client,
-                &self.token_endpoint,
-                &self.client_id,
-                &token,
-            )
-            .await
-            .map_err(refresh_to_bitrouter_error)?;
-            // Persist back to disk so other processes / reloads see it.
-            self.persist_refreshed(label, refreshed.clone())?;
-            self.store_in_cache(label, &refreshed);
-            return Ok(Some(ResolvedCredential::Oauth(refreshed)));
+        match store.get_any(PROVIDER_ID, label) {
+            Some(Credential::ApiKey { value }) => Ok(Some(value.clone())),
+            _ => Ok(None),
         }
-        self.store_in_cache(label, &token);
-        Ok(Some(ResolvedCredential::Oauth(token)))
-    }
-
-    /// Resolve a [`Credential::ClaudeCodeCli`] marker: read the live token from
-    /// Claude Code's own store (`~/.claude`), refreshing it in place when it is
-    /// within the refresh window and **writing the rotated token back to that
-    /// same store** so bitrouter and Claude Code never diverge (RFC 6749 §6
-    /// refresh-token rotation would otherwise family-revoke one of them).
-    ///
-    /// Called under the per-label single-flight gate, so the read → refresh →
-    /// write-back is serialised; the live read also picks up any refresh the
-    /// `claude` CLI performed in the meantime, avoiding a redundant rotation.
-    async fn resolve_claude_code_session(&self, label: &str) -> Result<Option<ResolvedCredential>> {
-        let store = self
-            .claude_code
-            .as_ref()
-            .ok_or_else(|| BitrouterError::Upstream {
-                status: 401,
-                message: "cannot locate the Claude Code session (no home directory) — set HOME \
-                      or run `bitrouter login anthropic`"
-                    .into(),
-            })?;
-        let live = store
-            .read()
-            .map_err(|e| BitrouterError::internal(format!("reading Claude Code session: {e}")))?;
-        let Some(live) = live else {
-            return Err(BitrouterError::Upstream {
-                status: 401,
-                message: "no Claude Code session found — run `claude auth login` (or \
-                          `bitrouter login anthropic`) to sign in to your Claude subscription"
-                    .into(),
-            });
-        };
-        let token = if needs_refresh(&live.token) {
-            let refreshed = refresh(
-                &self.refresh_client,
-                &self.token_endpoint,
-                &self.client_id,
-                &live.token,
-            )
-            .await
-            .map_err(refresh_to_bitrouter_error)?;
-            // Single source of truth: write the rotation back where we read it.
-            store.write_back(&refreshed, &live.source).map_err(|e| {
-                BitrouterError::internal(format!(
-                    "writing refreshed token back to the Claude Code store: {e}"
-                ))
-            })?;
-            refreshed
-        } else {
-            live.token
-        };
-        // Cache the resolved token to collapse the in-request double resolution
-        // (`apply` + `prepare_body`) and avoid a `security`/file read per
-        // request. The cache self-invalidates at the refresh window, so a
-        // `claude`-side rotation is picked up by the next refresh. A
-        // non-expiring token (`expires_at == 0`) is deliberately NOT cached: it
-        // would otherwise be served for the whole process lifetime without ever
-        // re-reading the live store, defeating the marker's "single source of
-        // truth" intent — so we re-read it live on each request instead.
-        if token.expires_at > 0 {
-            self.store_in_cache(label, &token);
-        }
-        Ok(Some(ResolvedCredential::Oauth(token)))
-    }
-
-    fn persist_refreshed(&self, label: &str, token: OAuthToken) -> Result<()> {
-        let mut store = CredentialStore::load(&self.store_path).map_err(|e| {
-            BitrouterError::internal(format!(
-                "reloading credential store before refresh write-back at {}: {e}",
-                self.store_path.display()
-            ))
-        })?;
-        store
-            .set(PROVIDER_ID, label, Credential::from_oauth_token(token))
-            .map_err(|e| {
-                BitrouterError::internal(format!("persisting refreshed anthropic OAuth token: {e}"))
-            })?;
-        Ok(())
-    }
-
-    fn label_for<'a>(&self, target: &'a RoutingTarget) -> &'a str {
-        target.account_label.as_deref().unwrap_or(DEFAULT_LABEL)
-    }
-}
-
-enum ResolvedCredential {
-    Oauth(OAuthToken),
-    ApiKey(String),
-}
-
-fn refresh_to_bitrouter_error(e: AuthCodeError) -> BitrouterError {
-    match e {
-        AuthCodeError::OAuthError { error, description } => BitrouterError::Upstream {
-            status: 401,
-            message: format!(
-                "anthropic OAuth refresh failed ({error}{}). Re-run `bitrouter login anthropic`.",
-                description.map(|d| format!(": {d}")).unwrap_or_default()
-            ),
-        },
-        other => BitrouterError::Upstream {
-            status: 502,
-            message: format!("anthropic OAuth refresh transport error: {other}"),
-        },
     }
 }
 
 #[async_trait]
-impl AuthApplier for AnthropicOAuthApplier {
+impl AuthApplier for AnthropicApiKeyApplier {
     async fn apply(
         &self,
         mut request: reqwest::Request,
         target: &RoutingTarget,
     ) -> Result<reqwest::Request> {
         let label = self.label_for(target);
-        let resolved = self.resolve_credential(label).await?;
-        // `anthropic-version` is mandatory regardless of credential type.
+        // `anthropic-version` is mandatory.
         request.headers_mut().insert(
             "anthropic-version",
             HeaderValue::from_static(headers::ANTHROPIC_VERSION),
         );
-        match resolved {
-            Some(ResolvedCredential::Oauth(token)) => {
-                let bearer = format!("Bearer {}", token.access_token);
-                let auth = HeaderValue::from_str(&bearer).map_err(|e| {
-                    BitrouterError::internal(format!(
-                        "invalid anthropic OAuth bearer for Authorization: {e}"
-                    ))
-                })?;
-                let headers_mut = request.headers_mut();
-                headers_mut.insert(reqwest::header::AUTHORIZATION, auth);
-                // OAuth requests must NOT carry x-api-key — the upstream
-                // returns 401 when both auth schemes are present.
-                headers_mut.remove("x-api-key");
-                // Merge — never overwrite — the OAuth-required betas with any
-                // the client already sent. Claude Code appends feature betas
-                // (e.g. `context-management-2025-06-27`, interleaved thinking,
-                // prompt caching) alongside the matching request-body fields;
-                // clobbering the header would leave those fields with no
-                // enabling beta and the upstream 400s ("Extra inputs are not
-                // permitted").
-                let client_betas: Vec<String> = headers_mut
-                    .get_all("anthropic-beta")
-                    .iter()
-                    .filter_map(|v| v.to_str().ok())
-                    .map(str::to_string)
-                    .collect();
-                let beta_value = merged_beta_value(client_betas.iter().map(String::as_str));
-                let beta_header = HeaderValue::from_str(&beta_value).map_err(|e| {
-                    BitrouterError::internal(format!("invalid anthropic-beta header: {e}"))
-                })?;
-                headers_mut.insert(HeaderName::from_static("anthropic-beta"), beta_header);
-                // The subscription endpoint expects first-party-CLI-shaped
-                // requests; mirror Claude Code's user-agent + x-app so the
-                // OAuth credential is admitted. (Reference: OpenClaw
-                // `src/llm/providers/anthropic.ts`.)
-                headers_mut.insert(
-                    reqwest::header::USER_AGENT,
-                    HeaderValue::from_static(headers::CLAUDE_CODE_USER_AGENT),
-                );
-                headers_mut.insert(
-                    HeaderName::from_static("x-app"),
-                    HeaderValue::from_static(headers::CLAUDE_CODE_X_APP),
-                );
-                Ok(request)
-            }
-            Some(ResolvedCredential::ApiKey(value)) => {
-                apply_api_key_header(&mut request, &value)?;
-                Ok(request)
-            }
+        // Prefer a key stored under "anthropic"; otherwise fall through to the
+        // routing target's inline key (the env-var path).
+        let key = match self.stored_api_key(label)? {
+            Some(stored) => stored,
             None => {
-                // No store entry — fall through to the routing-target's
-                // configured key (env-var path). Mirrors what
-                // `MessagesTransport::authorise` would have done.
-                let key = target.effective_api_key();
-                if key.is_empty() {
+                let inline = target.effective_api_key();
+                if inline.is_empty() {
                     return Err(BitrouterError::Upstream {
                         status: 401,
                         message: "no anthropic credential — set ANTHROPIC_API_KEY or run \
-                             `bitrouter login anthropic`"
+                             `bitrouter providers login anthropic`"
                             .into(),
                     });
                 }
-                apply_api_key_header(&mut request, key)?;
-                Ok(request)
+                inline.to_string()
             }
-        }
+        };
+        apply_api_key_header(&mut request, &key)?;
+        Ok(request)
     }
 
     async fn prepare_body(
         &self,
-        body: &mut serde_json::Value,
-        target: &RoutingTarget,
+        _body: &mut serde_json::Value,
+        _target: &RoutingTarget,
     ) -> Result<()> {
-        // Only the OAuth (Claude Pro/Max) path needs the Claude Code identity
-        // block; API-key and env-var requests pass the caller's body through
-        // unchanged. For an OAuth credential the resolution is cached and
-        // shared with `apply`; the non-OAuth paths re-read the store (cheap)
-        // instead of caching, so a credential added between requests is picked
-        // up without a restart.
-        let label = self.label_for(target);
-        if !matches!(
-            self.resolve_credential(label).await?,
-            Some(ResolvedCredential::Oauth(_))
-        ) {
-            return Ok(());
-        }
-        inject_claude_code_identity(body);
+        // The Platform API takes the caller's body verbatim — never shaped.
         Ok(())
     }
-}
-
-/// Merge the OAuth-required `anthropic-beta` values (which the Claude Pro/Max
-/// subscription endpoint demands) with any the client already sent, deduping
-/// while keeping the required values first. Real Claude Code traffic carries
-/// feature betas next to matching request-body fields, so the union — not an
-/// overwrite — is what keeps those requests valid upstream.
-fn merged_beta_value<'a>(client_betas: impl Iterator<Item = &'a str>) -> String {
-    let mut out: Vec<String> = headers::OAUTH_BETA_VALUES
-        .iter()
-        .map(|s| (*s).to_string())
-        .collect();
-    for raw in client_betas {
-        for beta in raw.split(',') {
-            let beta = beta.trim();
-            if !beta.is_empty() && !out.iter().any(|x| x == beta) {
-                out.push(beta.to_string());
-            }
-        }
-    }
-    out.join(",")
 }
 
 fn apply_api_key_header(request: &mut reqwest::Request, key: &str) -> Result<()> {
@@ -471,62 +122,10 @@ fn apply_api_key_header(request: &mut reqwest::Request, key: &str) -> Result<()>
         BitrouterError::internal(format!("invalid api key for x-api-key header: {e}"))
     })?;
     request.headers_mut().insert("x-api-key", value);
-    // OAuth and API-key paths must not both be set; clear any stale
-    // Bearer the protocol layer might have added.
+    // Clear any stale Bearer the protocol layer might have added — the
+    // Platform API authenticates via x-api-key only.
     request.headers_mut().remove(reqwest::header::AUTHORIZATION);
     Ok(())
-}
-
-/// Ensure the first Anthropic `system` block is Claude Code's identity string,
-/// preserving the caller's own system prompt after it. Idempotent — a body
-/// whose first block is already the identity is left unchanged.
-///
-/// Required by the Claude Pro/Max subscription endpoint, which admits requests
-/// under the Claude Code agent profile (reference: OpenClaw
-/// `src/llm/providers/anthropic.ts`). The caller's system prompt is never
-/// dropped; it follows the identity block.
-fn inject_claude_code_identity(body: &mut serde_json::Value) {
-    use serde_json::Value;
-    let Some(obj) = body.as_object_mut() else {
-        return;
-    };
-    let identity_block = serde_json::json!({
-        "type": "text",
-        "text": headers::CLAUDE_CODE_SYSTEM_PROMPT,
-    });
-    let new_system = match obj.remove("system") {
-        // No system yet → the identity as a single content block, matching
-        // Claude Code's own wire shape (it always sends `system` as an array).
-        None => Value::Array(vec![identity_block]),
-        // Already correct → leave it.
-        Some(Value::String(s)) if s == headers::CLAUDE_CODE_SYSTEM_PROMPT => Value::String(s),
-        // A plain-string system prompt → [identity, caller's prompt].
-        Some(Value::String(s)) => Value::Array(vec![
-            identity_block,
-            serde_json::json!({ "type": "text", "text": s }),
-        ]),
-        // A content-block array → prepend the identity unless already present.
-        Some(Value::Array(mut blocks)) => {
-            if !first_block_is_identity(&blocks) {
-                blocks.insert(0, identity_block);
-            }
-            Value::Array(blocks)
-        }
-        // Any other shape (not valid for Messages) → wrap defensively so the
-        // identity still leads.
-        Some(other) => Value::Array(vec![identity_block, other]),
-    };
-    obj.insert("system".to_string(), new_system);
-}
-
-/// Whether the first element of an Anthropic `system` content-block array is
-/// already Claude Code's identity string.
-fn first_block_is_identity(blocks: &[serde_json::Value]) -> bool {
-    blocks
-        .first()
-        .and_then(|b| b.get("text"))
-        .and_then(|t| t.as_str())
-        == Some(headers::CLAUDE_CODE_SYSTEM_PROMPT)
 }
 
 #[cfg(test)]
@@ -534,10 +133,8 @@ mod tests {
     use std::path::PathBuf;
 
     use bitrouter_sdk::language_model::types::ApiProtocol;
-    use wiremock::MockServer;
 
     use super::*;
-    use crate::oauth::credential_store::OAuthToken;
 
     fn tmp_store_path() -> PathBuf {
         use std::sync::atomic::{AtomicU64, Ordering};
@@ -575,7 +172,7 @@ mod tests {
     #[tokio::test]
     async fn fallthrough_uses_target_api_key_when_store_is_empty() {
         let path = tmp_store_path();
-        let applier = AnthropicOAuthApplier::new(&path).unwrap();
+        let applier = AnthropicApiKeyApplier::new(&path).unwrap();
         let req = reqwest::Client::new()
             .post("https://api.anthropic.com/v1/messages")
             .build()
@@ -597,7 +194,7 @@ mod tests {
     #[tokio::test]
     async fn errors_when_no_credential_anywhere() {
         let path = tmp_store_path();
-        let applier = AnthropicOAuthApplier::new(&path).unwrap();
+        let applier = AnthropicApiKeyApplier::new(&path).unwrap();
         let req = reqwest::Client::new()
             .post("https://api.anthropic.com/v1/messages")
             .build()
@@ -608,7 +205,7 @@ mod tests {
             .unwrap_err();
         let msg = err.to_string();
         assert!(
-            msg.contains("bitrouter login anthropic"),
+            msg.contains("bitrouter providers login anthropic"),
             "expected helpful hint, got: {msg}"
         );
     }
@@ -627,7 +224,7 @@ mod tests {
                 )
                 .unwrap();
         }
-        let applier = AnthropicOAuthApplier::new(&path).unwrap();
+        let applier = AnthropicApiKeyApplier::new(&path).unwrap();
         let req = reqwest::Client::new()
             .post("https://api.anthropic.com/v1/messages")
             .build()
@@ -646,163 +243,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn stored_oauth_token_applies_bearer_and_strips_x_api_key() {
-        let path = tmp_store_path();
-        {
-            let mut store = CredentialStore::load(&path).unwrap();
-            store
-                .set(
-                    PROVIDER_ID,
-                    DEFAULT_LABEL,
-                    Credential::from_oauth_token(OAuthToken {
-                        access_token: "sk-ant-oat-fresh".into(),
-                        expires_at: 0, // non-expiring → no refresh attempt
-                        refresh_token: Some("r".into()),
-                    }),
-                )
-                .unwrap();
-        }
-        let applier = AnthropicOAuthApplier::new(&path).unwrap();
-        let mut req = reqwest::Client::new()
-            .post("https://api.anthropic.com/v1/messages")
-            .build()
-            .unwrap();
-        // Pretend the protocol adapter already set x-api-key; the OAuth
-        // path must strip it.
-        req.headers_mut()
-            .insert("x-api-key", HeaderValue::from_static("stale-key"));
-        let authed = applier.apply(req, &anthropic_target(None)).await.unwrap();
-        let h = authed.headers();
-        assert_eq!(
-            h.get(reqwest::header::AUTHORIZATION)
-                .and_then(|v| v.to_str().ok()),
-            Some("Bearer sk-ant-oat-fresh")
-        );
-        assert!(h.get("x-api-key").is_none());
-        let beta = h
-            .get("anthropic-beta")
-            .and_then(|v| v.to_str().ok())
-            .unwrap();
-        assert!(beta.contains("oauth-2025-04-20"));
-        assert!(beta.contains("claude-code-20250219"));
-        assert_eq!(
-            h.get(reqwest::header::USER_AGENT)
-                .and_then(|v| v.to_str().ok()),
-            Some(headers::CLAUDE_CODE_USER_AGENT)
-        );
-        assert_eq!(
-            h.get("x-app").and_then(|v| v.to_str().ok()),
-            Some(headers::CLAUDE_CODE_X_APP)
-        );
-    }
-
-    #[tokio::test]
-    async fn oauth_merges_client_anthropic_beta_instead_of_overwriting() {
-        // Real Claude Code traffic appends feature betas
-        // (`context-management-…`, interleaved-thinking) next to the matching
-        // request-body fields. The applier must keep them while adding the
-        // OAuth-required betas — overwriting strips them and the upstream 400s
-        // ("Extra inputs are not permitted") on the now-orphaned body field.
-        let path = tmp_store_path();
-        {
-            let mut store = CredentialStore::load(&path).unwrap();
-            store
-                .set(
-                    PROVIDER_ID,
-                    DEFAULT_LABEL,
-                    Credential::from_oauth_token(OAuthToken {
-                        access_token: "sk-ant-oat".into(),
-                        expires_at: 0,
-                        refresh_token: Some("r".into()),
-                    }),
-                )
-                .unwrap();
-        }
-        let applier = AnthropicOAuthApplier::new(&path).unwrap();
-        let mut req = reqwest::Client::new()
-            .post("https://api.anthropic.com/v1/messages")
-            .build()
-            .unwrap();
-        req.headers_mut().insert(
-            "anthropic-beta",
-            HeaderValue::from_static(
-                "context-management-2025-06-27,interleaved-thinking-2025-05-14",
-            ),
-        );
-        let authed = applier.apply(req, &anthropic_target(None)).await.unwrap();
-        let beta = authed
-            .headers()
-            .get("anthropic-beta")
-            .and_then(|v| v.to_str().ok())
-            .unwrap();
-        assert!(
-            beta.contains("oauth-2025-04-20"),
-            "required beta dropped: {beta}"
-        );
-        assert!(
-            beta.contains("claude-code-20250219"),
-            "required beta dropped: {beta}"
-        );
-        assert!(
-            beta.contains("context-management-2025-06-27"),
-            "client beta dropped: {beta}"
-        );
-        assert!(
-            beta.contains("interleaved-thinking-2025-05-14"),
-            "client beta dropped: {beta}"
-        );
-    }
-
-    #[tokio::test]
-    async fn fresh_oauth_token_skips_refresh() {
-        // Sanity check on the cache-hit path: a long-lived token (1h
-        // ahead of the 60s refresh window) is reused directly. The end-
-        // to-end refresh round-trip is covered in
-        // `oauth::refresh::tests::refresh_returns_new_access_token`.
-        let path = tmp_store_path();
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
-        {
-            let mut store = CredentialStore::load(&path).unwrap();
-            store
-                .set(
-                    PROVIDER_ID,
-                    DEFAULT_LABEL,
-                    Credential::from_oauth_token(OAuthToken {
-                        access_token: "still-fresh".into(),
-                        expires_at: now + 3600,
-                        refresh_token: Some("ignored".into()),
-                    }),
-                )
-                .unwrap();
-        }
-        // Point the refresh endpoint at a wiremock that fails the test
-        // if it's hit at all (no mounted responder → wiremock 404s).
-        let server = MockServer::start().await;
-        let applier = AnthropicOAuthApplier::with_client_and_endpoint(
-            &path,
-            reqwest::Client::new(),
-            "client-1",
-            format!("{}/oauth/token", server.uri()),
-            None,
-        );
-        let req = reqwest::Client::new()
-            .post("https://api.anthropic.com/v1/messages")
-            .build()
-            .unwrap();
-        let authed = applier.apply(req, &anthropic_target(None)).await.unwrap();
-        assert_eq!(
-            authed
-                .headers()
-                .get(reqwest::header::AUTHORIZATION)
-                .and_then(|v| v.to_str().ok()),
-            Some("Bearer still-fresh")
-        );
-    }
-
-    #[tokio::test]
     async fn multi_account_lookup_uses_target_label() {
         let path = tmp_store_path();
         {
@@ -814,7 +254,7 @@ mod tests {
                 .set(PROVIDER_ID, "work-key", Credential::api_key("for-work"))
                 .unwrap();
         }
-        let applier = AnthropicOAuthApplier::new(&path).unwrap();
+        let applier = AnthropicApiKeyApplier::new(&path).unwrap();
         let req = reqwest::Client::new()
             .post("https://api.anthropic.com/v1/messages")
             .build()
@@ -848,232 +288,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn oauth_prepare_body_injects_claude_code_identity() {
-        let path = tmp_store_path();
-        {
-            let mut store = CredentialStore::load(&path).unwrap();
-            store
-                .set(
-                    PROVIDER_ID,
-                    DEFAULT_LABEL,
-                    Credential::from_oauth_token(OAuthToken {
-                        access_token: "sk-ant-oat-x".into(),
-                        expires_at: 0,
-                        refresh_token: Some("r".into()),
-                    }),
-                )
-                .unwrap();
-        }
-        let applier = AnthropicOAuthApplier::new(&path).unwrap();
-        // No system field → identity as a single-element content-block array.
-        let mut body = serde_json::json!({ "model": "claude", "messages": [] });
-        applier
-            .prepare_body(&mut body, &anthropic_target(None))
-            .await
-            .unwrap();
-        let only = body["system"].as_array().unwrap();
-        assert_eq!(only.len(), 1);
-        assert_eq!(only[0]["text"], headers::CLAUDE_CODE_SYSTEM_PROMPT);
-        // String system → array: identity first, caller's prompt preserved.
-        let mut body2 = serde_json::json!({ "system": "be terse", "messages": [] });
-        applier
-            .prepare_body(&mut body2, &anthropic_target(None))
-            .await
-            .unwrap();
-        let arr = body2["system"].as_array().unwrap();
-        assert_eq!(arr[0]["text"], headers::CLAUDE_CODE_SYSTEM_PROMPT);
-        assert_eq!(arr[1]["text"], "be terse");
-        // Idempotent — a second pass doesn't double-prepend.
-        applier
-            .prepare_body(&mut body2, &anthropic_target(None))
-            .await
-            .unwrap();
-        assert_eq!(body2["system"].as_array().unwrap().len(), 2);
-    }
-
-    /// Write a `.credentials.json` in a fresh temp dir and return its path.
-    fn tmp_claude_creds(contents: &str) -> PathBuf {
-        use std::sync::atomic::{AtomicU64, Ordering};
-        static COUNTER: AtomicU64 = AtomicU64::new(0);
-        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
-        let dir = std::env::temp_dir().join(format!(
-            "bitrouter-anthropic-cc-{}-{id}",
-            std::process::id()
-        ));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).unwrap();
-        let path = dir.join(".credentials.json");
-        std::fs::write(&path, contents).unwrap();
-        path
-    }
-
-    fn seed_marker(store_path: &std::path::Path) {
-        let mut store = CredentialStore::load(store_path).unwrap();
-        store
-            .set(PROVIDER_ID, DEFAULT_LABEL, Credential::ClaudeCodeCli)
-            .unwrap();
-    }
-
-    #[tokio::test]
-    async fn claude_code_cli_marker_applies_bearer_from_live_store() {
-        // Marker in bitrouter's store + a non-expiring live Claude Code session
-        // (no `expiresAt` → never refreshed) → the live access token is applied
-        // as a Bearer and any stale x-api-key is stripped.
-        let path = tmp_store_path();
-        seed_marker(&path);
-        let creds = tmp_claude_creds(
-            r#"{"claudeAiOauth":{"accessToken":"sk-ant-oat-live","refreshToken":"r"}}"#,
-        );
-        let applier = AnthropicOAuthApplier::with_client_and_endpoint(
-            &path,
-            reqwest::Client::new(),
-            "client-1",
-            "https://example.com/oauth/token",
-            Some(ClaudeCodeStore::file_only(&creds)),
-        );
-        let mut req = reqwest::Client::new()
-            .post("https://api.anthropic.com/v1/messages")
-            .build()
-            .unwrap();
-        req.headers_mut()
-            .insert("x-api-key", HeaderValue::from_static("stale"));
-        let authed = applier.apply(req, &anthropic_target(None)).await.unwrap();
-        let h = authed.headers();
-        assert_eq!(
-            h.get(reqwest::header::AUTHORIZATION)
-                .and_then(|v| v.to_str().ok()),
-            Some("Bearer sk-ant-oat-live")
-        );
-        assert!(h.get("x-api-key").is_none());
-        assert!(
-            h.get("anthropic-beta")
-                .and_then(|v| v.to_str().ok())
-                .unwrap()
-                .contains("oauth-2025-04-20")
-        );
-    }
-
-    #[tokio::test]
-    async fn claude_code_cli_marker_missing_session_errors() {
-        // Marker present but no live Claude Code session → a helpful 401 that
-        // points the user at `claude auth login`, not a silent fall-through.
-        let path = tmp_store_path();
-        seed_marker(&path);
-        let absent = std::env::temp_dir().join("bitrouter-anthropic-cc-absent/none.json");
-        let applier = AnthropicOAuthApplier::with_client_and_endpoint(
-            &path,
-            reqwest::Client::new(),
-            "client-1",
-            "https://example.com/oauth/token",
-            Some(ClaudeCodeStore::file_only(&absent)),
-        );
-        let req = reqwest::Client::new()
-            .post("https://api.anthropic.com/v1/messages")
-            .build()
-            .unwrap();
-        let err = applier
-            .apply(req, &anthropic_target(None))
-            .await
-            .unwrap_err();
-        assert!(
-            err.to_string().contains("claude auth login"),
-            "expected a login hint, got: {err}"
-        );
-    }
-
-    #[tokio::test]
-    async fn claude_code_cli_marker_expiring_token_triggers_refresh() {
-        // An expiring live token must drive a refresh attempt rather than serve
-        // the stale token. Pointing the endpoint at an insecure (http) URL makes
-        // `refresh` fail fast with a typed error, proving the needs_refresh
-        // branch is taken. (The happy-path refresh and write-back are covered by
-        // `oauth::refresh::tests` and `import::claude_code::tests` respectively;
-        // an http MockServer can't exercise them because `refresh` requires
-        // https.)
-        let path = tmp_store_path();
-        seed_marker(&path);
-        let creds = tmp_claude_creds(
-            r#"{"claudeAiOauth":{"accessToken":"old","refreshToken":"RT","expiresAt":1000}}"#,
-        );
-        let applier = AnthropicOAuthApplier::with_client_and_endpoint(
-            &path,
-            reqwest::Client::new(),
-            "client-1",
-            "http://insecure.example.com/oauth/token",
-            Some(ClaudeCodeStore::file_only(&creds)),
-        );
-        let req = reqwest::Client::new()
-            .post("https://api.anthropic.com/v1/messages")
-            .build()
-            .unwrap();
-        let err = applier
-            .apply(req, &anthropic_target(None))
-            .await
-            .unwrap_err();
-        assert!(
-            err.to_string().contains("refresh"),
-            "expected a refresh error proving the refresh path ran, got: {err}"
-        );
-    }
-
-    #[tokio::test]
-    async fn claude_code_cli_marker_non_expiring_is_reread_live_each_request() {
-        // A non-expiring live token must NOT be cached for the process lifetime:
-        // when `claude` rotates the on-disk token, the next request must see the
-        // new value, keeping bitrouter in lockstep with the single source of
-        // truth.
-        let path = tmp_store_path();
-        seed_marker(&path);
-        let creds =
-            tmp_claude_creds(r#"{"claudeAiOauth":{"accessToken":"first","refreshToken":"r"}}"#);
-        let applier = AnthropicOAuthApplier::with_client_and_endpoint(
-            &path,
-            reqwest::Client::new(),
-            "client-1",
-            "https://example.com/oauth/token",
-            Some(ClaudeCodeStore::file_only(&creds)),
-        );
-        let bearer = |req: reqwest::Request| {
-            req.headers()
-                .get(reqwest::header::AUTHORIZATION)
-                .and_then(|v| v.to_str().ok())
-                .map(str::to_string)
-        };
-        let first = applier
-            .apply(
-                reqwest::Client::new()
-                    .post("https://api.anthropic.com/v1/messages")
-                    .build()
-                    .unwrap(),
-                &anthropic_target(None),
-            )
-            .await
-            .unwrap();
-        assert_eq!(bearer(first).as_deref(), Some("Bearer first"));
-        // Claude Code rotates its stored token.
-        std::fs::write(
-            &creds,
-            r#"{"claudeAiOauth":{"accessToken":"second","refreshToken":"r"}}"#,
-        )
-        .unwrap();
-        let second = applier
-            .apply(
-                reqwest::Client::new()
-                    .post("https://api.anthropic.com/v1/messages")
-                    .build()
-                    .unwrap(),
-                &anthropic_target(None),
-            )
-            .await
-            .unwrap();
-        assert_eq!(
-            bearer(second).as_deref(),
-            Some("Bearer second"),
-            "a non-expiring marker token must be re-read live, not served from a stale cache"
-        );
-    }
-
-    #[tokio::test]
     async fn api_key_prepare_body_leaves_system_untouched() {
         let path = tmp_store_path();
         {
@@ -1086,7 +300,7 @@ mod tests {
                 )
                 .unwrap();
         }
-        let applier = AnthropicOAuthApplier::new(&path).unwrap();
+        let applier = AnthropicApiKeyApplier::new(&path).unwrap();
         let mut body = serde_json::json!({ "system": "user prompt", "messages": [] });
         applier
             .prepare_body(&mut body, &anthropic_target(None))

--- a/crates/bitrouter-providers/src/claude_code.rs
+++ b/crates/bitrouter-providers/src/claude_code.rs
@@ -115,7 +115,7 @@ impl ClaudeCodeAuthApplier {
     ///
     /// Note the asymmetry: the credential store is keyed by [`PROVIDER_ID`]
     /// (`"claude-code"`), but the OAuth client config is resolved under
-    /// [`OAUTH_CLIENT_ID`] (`"anthropic"`).
+    /// `OAUTH_CLIENT_ID` (`"anthropic"`).
     pub fn new(store_path: impl Into<std::path::PathBuf>) -> Result<Self> {
         let registry = crate::oauth::registry::find(OAUTH_CLIENT_ID).ok_or_else(|| {
             BitrouterError::internal(

--- a/crates/bitrouter-providers/src/claude_code.rs
+++ b/crates/bitrouter-providers/src/claude_code.rs
@@ -1,0 +1,959 @@
+//! `claude-code` — the Claude Pro/Max **subscription** `AuthApplier`.
+//!
+//! Registered under the provider id `"claude-code"`. This applier resolves an
+//! OAuth credential (or a [`Credential::ClaudeCodeCli`] marker pointing at the
+//! live `~/.claude` session) and shapes the request as a first-party Claude
+//! Code call:
+//!
+//! | Stored credential | Outbound headers |
+//! |---|---|
+//! | `Credential::Oauth` (Claude Pro/Max)  | `Authorization: Bearer sk-ant-oat…`, `anthropic-beta: claude-code-20250219,oauth-2025-04-20`, `anthropic-version: 2023-06-01`, `user-agent: claude-cli/…`, `x-app: cli`. **No `x-api-key`** — the upstream rejects OAuth requests that also carry `x-api-key`. |
+//! | `Credential::ClaudeCodeCli`           | Same as above, but the token is read live from Claude Code's own store (`~/.claude`) and any refresh is written back there. |
+//! | _no credential in store_              | `401` — there is no API-key fallback on the subscription path. |
+//!
+//! The OAuth branch refreshes the access token via
+//! [`crate::oauth::refresh::refresh`] if it's within
+//! [`crate::oauth::refresh::REFRESH_WINDOW`] of expiry, writes the new token
+//! back to the store, and caches it in memory to avoid hammering the
+//! refresh endpoint under load.
+//!
+//! ## Body shape — require, never inject
+//!
+//! The Claude Pro/Max subscription endpoint admits requests under the Claude
+//! Code agent profile: the first `system` block has to be Claude Code's
+//! identity string. [`ClaudeCodeAuthApplier::prepare_body`] **gates** on that
+//! — it rejects (`400`) any request whose first `system` block is not the
+//! identity, and it **never fabricates** the identity. Enabling correct Claude
+//! Code use is the contract; the applier does not spoof arbitrary traffic as
+//! Claude Code.
+//!
+//! ## Two distinct ids
+//!
+//! The credential-store lookup uses the provider id `"claude-code"`
+//! ([`PROVIDER_ID`]), but the OAuth client config (client_id + token endpoint)
+//! is still looked up under `"anthropic"` in
+//! [`crate::oauth::registry::find`] — that's where the Anthropic OAuth client
+//! lives. Keep the two ids distinct.
+//!
+//! Authoritative reference for the OAuth client + headers: Claude Code's
+//! published OAuth client (client_id `9d1c250a-…`), as reused by
+//! [`@earendil-works/pi-ai`](https://github.com/openclaw/openclaw)'s
+//! Anthropic login and OpenCode's auth registry.
+
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use reqwest::header::{HeaderName, HeaderValue};
+
+use bitrouter_sdk::language_model::AuthApplier;
+use bitrouter_sdk::language_model::types::RoutingTarget;
+use bitrouter_sdk::{BitrouterError, Result};
+
+use crate::anthropic::headers;
+use crate::import::claude_code::ClaudeCodeStore;
+use crate::oauth::auth_code::AuthCodeError;
+use crate::oauth::credential_store::{Credential, CredentialStore, DEFAULT_LABEL, OAuthToken};
+use crate::oauth::refresh::{needs_refresh, refresh};
+
+/// Provider id this applier is registered under.
+///
+/// Distinct from the OAuth-client id used in [`ClaudeCodeAuthApplier::new`],
+/// which stays `"anthropic"` (that's where the Anthropic OAuth client config
+/// lives in [`crate::oauth::registry`]).
+pub const PROVIDER_ID: &str = "claude-code";
+
+/// The OAuth-client id used to look up the client_id + token endpoint in
+/// [`crate::oauth::registry::find`]. The Anthropic OAuth client config lives
+/// under `"anthropic"`, not under [`PROVIDER_ID`].
+const OAUTH_CLIENT_ID: &str = "anthropic";
+
+/// `AuthApplier` for the Claude Pro/Max subscription (`provider_name ==
+/// "claude-code"`).
+///
+/// The applier owns:
+/// - the credential-store path so it can read + refresh-write back; and
+/// - the OAuth client id + token endpoint pulled from
+///   [`crate::oauth::registry::find`] (under `"anthropic"`) at construction.
+///
+/// In-memory the applier caches the freshly-refreshed `OAuthToken` keyed
+/// by `account_label` so concurrent requests don't all hit the refresh
+/// endpoint.
+pub struct ClaudeCodeAuthApplier {
+    store_path: std::path::PathBuf,
+    refresh_client: reqwest::Client,
+    /// OAuth client id used for the refresh grant. Mirrors what the
+    /// `bitrouter providers login claude-code` flow wrote.
+    client_id: String,
+    /// Token endpoint used for the refresh grant.
+    token_endpoint: String,
+    /// `account_label -> freshest OAuthToken` cache. Populated on first
+    /// refresh; subsequent requests within the validity window reuse it
+    /// without touching disk or the refresh endpoint.
+    cache: Arc<Mutex<std::collections::HashMap<String, OAuthToken>>>,
+    /// Per-label single-flight gate around the disk-read → refresh →
+    /// persist sequence. RFC 6749 §6 lets the server invalidate older
+    /// refresh tokens once a new one is minted, so two concurrent refreshes
+    /// of the same label can silently log the user out. Holding this
+    /// `tokio::sync::Mutex` across the refresh `await` serialises them;
+    /// the second waiter re-checks the cache after acquiring the lock
+    /// (double-checked locking) and skips the refresh if the first one
+    /// already populated it.
+    refresh_gates: Arc<Mutex<std::collections::HashMap<String, Arc<tokio::sync::Mutex<()>>>>>,
+    /// Live view of Claude Code's own credential store (`~/.claude`). Used to
+    /// resolve a [`Credential::ClaudeCodeCli`] marker: read the token live and
+    /// write any refresh back to the same source, so bitrouter and Claude Code
+    /// share one credential. `None` only when no home directory resolves.
+    claude_code: Option<ClaudeCodeStore>,
+}
+
+impl ClaudeCodeAuthApplier {
+    /// Build an applier that reads + writes the credential store at
+    /// `store_path` and refreshes tokens using the registry's default
+    /// Anthropic OAuth client + token endpoint.
+    ///
+    /// Note the asymmetry: the credential store is keyed by [`PROVIDER_ID`]
+    /// (`"claude-code"`), but the OAuth client config is resolved under
+    /// [`OAUTH_CLIENT_ID`] (`"anthropic"`).
+    pub fn new(store_path: impl Into<std::path::PathBuf>) -> Result<Self> {
+        let registry = crate::oauth::registry::find(OAUTH_CLIENT_ID).ok_or_else(|| {
+            BitrouterError::internal(
+                "anthropic PKCE registry entry is missing — this is a build-time bug".to_string(),
+            )
+        })?;
+        let refresh_client = reqwest::Client::builder()
+            .user_agent(concat!("bitrouter-providers/", env!("CARGO_PKG_VERSION")))
+            .timeout(Duration::from_secs(30))
+            .build()
+            .map_err(|e| {
+                BitrouterError::internal(format!(
+                    "building Claude Code OAuth refresh HTTP client: {e}"
+                ))
+            })?;
+        Ok(Self {
+            store_path: store_path.into(),
+            refresh_client,
+            client_id: registry.auth.client_id,
+            token_endpoint: registry.auth.token_endpoint,
+            cache: Arc::new(Mutex::new(std::collections::HashMap::new())),
+            refresh_gates: Arc::new(Mutex::new(std::collections::HashMap::new())),
+            claude_code: ClaudeCodeStore::system(),
+        })
+    }
+
+    /// Override the refresh client + token endpoint (tests use this against
+    /// `wiremock`).
+    #[cfg(test)]
+    pub(crate) fn with_client_and_endpoint(
+        store_path: impl Into<std::path::PathBuf>,
+        refresh_client: reqwest::Client,
+        client_id: impl Into<String>,
+        token_endpoint: impl Into<String>,
+        claude_code: Option<ClaudeCodeStore>,
+    ) -> Self {
+        Self {
+            store_path: store_path.into(),
+            refresh_client,
+            client_id: client_id.into(),
+            token_endpoint: token_endpoint.into(),
+            cache: Arc::new(Mutex::new(std::collections::HashMap::new())),
+            refresh_gates: Arc::new(Mutex::new(std::collections::HashMap::new())),
+            claude_code,
+        }
+    }
+
+    /// Per-label single-flight gate. Cloned out under the std mutex (no
+    /// awaits held); the returned `tokio::sync::Mutex` serialises the
+    /// disk-read → refresh → persist sequence for that label.
+    fn refresh_gate(&self, label: &str) -> Arc<tokio::sync::Mutex<()>> {
+        let mut guard = self
+            .refresh_gates
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        guard
+            .entry(label.to_string())
+            .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+            .clone()
+    }
+
+    fn cached_fresh(&self, label: &str) -> Option<OAuthToken> {
+        let guard = self.cache.lock().ok()?;
+        let token = guard.get(label)?;
+        (!needs_refresh(token)).then(|| token.clone())
+    }
+
+    fn store_in_cache(&self, label: &str, token: &OAuthToken) {
+        if let Ok(mut guard) = self.cache.lock() {
+            guard.insert(label.to_string(), token.clone());
+        }
+    }
+
+    /// Load the stored subscription credential for the given account label,
+    /// refreshing the inner OAuth access token if it's within the refresh
+    /// window. Returns `None` when no credential is stored under that label.
+    ///
+    /// The subscription path only knows two credential shapes:
+    /// [`Credential::Oauth`] and the [`Credential::ClaudeCodeCli`] marker.
+    /// There is no API-key arm — a stored API key (or any other shape) is
+    /// ignored.
+    ///
+    /// Concurrency: cache hits are lock-free. The disk-read → refresh →
+    /// persist sequence is single-flighted per label via
+    /// [`Self::refresh_gate`] so concurrent requests don't both POST to
+    /// the token endpoint (and risk having the server invalidate the
+    /// older refresh token, per RFC 6749 §6).
+    async fn resolve_credential(&self, label: &str) -> Result<Option<OAuthToken>> {
+        // 1. Cheap in-memory cache check — no locks held across awaits.
+        if let Some(cached) = self.cached_fresh(label) {
+            return Ok(Some(cached));
+        }
+        // 2. Acquire the per-label single-flight gate before any disk
+        //    read or refresh POST. If another task is mid-refresh for
+        //    this label, we wait here and then short-circuit on the
+        //    cache.
+        let gate = self.refresh_gate(label);
+        let _guard = gate.lock().await;
+        // 3. Double-checked locking — another task may have just
+        //    refreshed and populated the cache while we were waiting on
+        //    the gate.
+        if let Some(cached) = self.cached_fresh(label) {
+            return Ok(Some(cached));
+        }
+        // 4. Disk read.
+        let store = CredentialStore::load(&self.store_path).map_err(|e| {
+            BitrouterError::internal(format!(
+                "reading credential store at {}: {e}",
+                self.store_path.display()
+            ))
+        })?;
+        let cred = match store.get_any(PROVIDER_ID, label) {
+            Some(c) => c.clone(),
+            None => return Ok(None),
+        };
+        // 5. Marker: resolve live from the Claude Code store (read +
+        //    refresh-write-back there). OAuth: refresh if expiring. Any
+        //    other shape (e.g. an API key) has no place on the subscription
+        //    path — ignore it.
+        let token = match cred {
+            Credential::ClaudeCodeCli => {
+                return self.resolve_claude_code_session(label).await;
+            }
+            Credential::Oauth(t) => t,
+            _ => return Ok(None),
+        };
+        // 6. OAuth: refresh if expiring.
+        if needs_refresh(&token) {
+            let refreshed = refresh(
+                &self.refresh_client,
+                &self.token_endpoint,
+                &self.client_id,
+                &token,
+            )
+            .await
+            .map_err(refresh_to_bitrouter_error)?;
+            // Persist back to disk so other processes / reloads see it.
+            self.persist_refreshed(label, refreshed.clone())?;
+            self.store_in_cache(label, &refreshed);
+            return Ok(Some(refreshed));
+        }
+        self.store_in_cache(label, &token);
+        Ok(Some(token))
+    }
+
+    /// Resolve a [`Credential::ClaudeCodeCli`] marker: read the live token from
+    /// Claude Code's own store (`~/.claude`), refreshing it in place when it is
+    /// within the refresh window and **writing the rotated token back to that
+    /// same store** so bitrouter and Claude Code never diverge (RFC 6749 §6
+    /// refresh-token rotation would otherwise family-revoke one of them).
+    ///
+    /// Called under the per-label single-flight gate, so the read → refresh →
+    /// write-back is serialised; the live read also picks up any refresh the
+    /// `claude` CLI performed in the meantime, avoiding a redundant rotation.
+    async fn resolve_claude_code_session(&self, label: &str) -> Result<Option<OAuthToken>> {
+        let store = self
+            .claude_code
+            .as_ref()
+            .ok_or_else(|| BitrouterError::Upstream {
+                status: 401,
+                message: "cannot locate the Claude Code session (no home directory) — set HOME \
+                      or run `bitrouter providers login claude-code`"
+                    .into(),
+            })?;
+        let live = store
+            .read()
+            .map_err(|e| BitrouterError::internal(format!("reading Claude Code session: {e}")))?;
+        let Some(live) = live else {
+            return Err(BitrouterError::Upstream {
+                status: 401,
+                message: "no Claude Code session found — run `claude auth login` (or \
+                          `bitrouter providers login claude-code`) to sign in to your Claude \
+                          subscription"
+                    .into(),
+            });
+        };
+        let token = if needs_refresh(&live.token) {
+            let refreshed = refresh(
+                &self.refresh_client,
+                &self.token_endpoint,
+                &self.client_id,
+                &live.token,
+            )
+            .await
+            .map_err(refresh_to_bitrouter_error)?;
+            // Single source of truth: write the rotation back where we read it.
+            store.write_back(&refreshed, &live.source).map_err(|e| {
+                BitrouterError::internal(format!(
+                    "writing refreshed token back to the Claude Code store: {e}"
+                ))
+            })?;
+            refreshed
+        } else {
+            live.token
+        };
+        // Cache the resolved token to collapse the in-request double resolution
+        // (`apply` + `prepare_body`) and avoid a `security`/file read per
+        // request. The cache self-invalidates at the refresh window, so a
+        // `claude`-side rotation is picked up by the next refresh. A
+        // non-expiring token (`expires_at == 0`) is deliberately NOT cached: it
+        // would otherwise be served for the whole process lifetime without ever
+        // re-reading the live store, defeating the marker's "single source of
+        // truth" intent — so we re-read it live on each request instead.
+        if token.expires_at > 0 {
+            self.store_in_cache(label, &token);
+        }
+        Ok(Some(token))
+    }
+
+    fn persist_refreshed(&self, label: &str, token: OAuthToken) -> Result<()> {
+        let mut store = CredentialStore::load(&self.store_path).map_err(|e| {
+            BitrouterError::internal(format!(
+                "reloading credential store before refresh write-back at {}: {e}",
+                self.store_path.display()
+            ))
+        })?;
+        store
+            .set(PROVIDER_ID, label, Credential::from_oauth_token(token))
+            .map_err(|e| {
+                BitrouterError::internal(format!(
+                    "persisting refreshed claude-code OAuth token: {e}"
+                ))
+            })?;
+        Ok(())
+    }
+
+    fn label_for<'a>(&self, target: &'a RoutingTarget) -> &'a str {
+        target.account_label.as_deref().unwrap_or(DEFAULT_LABEL)
+    }
+}
+
+fn refresh_to_bitrouter_error(e: AuthCodeError) -> BitrouterError {
+    match e {
+        AuthCodeError::OAuthError { error, description } => BitrouterError::Upstream {
+            status: 401,
+            message: format!(
+                "claude-code OAuth refresh failed ({error}{}). Re-run `bitrouter providers login \
+                 claude-code`.",
+                description.map(|d| format!(": {d}")).unwrap_or_default()
+            ),
+        },
+        other => BitrouterError::Upstream {
+            status: 502,
+            message: format!("claude-code OAuth refresh transport error: {other}"),
+        },
+    }
+}
+
+#[async_trait]
+impl AuthApplier for ClaudeCodeAuthApplier {
+    async fn apply(
+        &self,
+        mut request: reqwest::Request,
+        target: &RoutingTarget,
+    ) -> Result<reqwest::Request> {
+        let label = self.label_for(target);
+        let resolved = self.resolve_credential(label).await?;
+        // `anthropic-version` is mandatory regardless of credential type.
+        request.headers_mut().insert(
+            "anthropic-version",
+            HeaderValue::from_static(headers::ANTHROPIC_VERSION),
+        );
+        let Some(token) = resolved else {
+            // No subscription credential — there is no API-key fallback here.
+            return Err(BitrouterError::Upstream {
+                status: 401,
+                message: "no Claude Code session — run `bitrouter providers login claude-code`"
+                    .into(),
+            });
+        };
+        let bearer = format!("Bearer {}", token.access_token);
+        let auth = HeaderValue::from_str(&bearer).map_err(|e| {
+            BitrouterError::internal(format!(
+                "invalid claude-code OAuth bearer for Authorization: {e}"
+            ))
+        })?;
+        let headers_mut = request.headers_mut();
+        headers_mut.insert(reqwest::header::AUTHORIZATION, auth);
+        // OAuth requests must NOT carry x-api-key — the upstream
+        // returns 401 when both auth schemes are present.
+        headers_mut.remove("x-api-key");
+        // Merge — never overwrite — the OAuth-required betas with any
+        // the client already sent. Claude Code appends feature betas
+        // (e.g. `context-management-2025-06-27`, interleaved thinking,
+        // prompt caching) alongside the matching request-body fields;
+        // clobbering the header would leave those fields with no
+        // enabling beta and the upstream 400s ("Extra inputs are not
+        // permitted").
+        let client_betas: Vec<String> = headers_mut
+            .get_all("anthropic-beta")
+            .iter()
+            .filter_map(|v| v.to_str().ok())
+            .map(str::to_string)
+            .collect();
+        let beta_value = merged_beta_value(client_betas.iter().map(String::as_str));
+        let beta_header = HeaderValue::from_str(&beta_value)
+            .map_err(|e| BitrouterError::internal(format!("invalid anthropic-beta header: {e}")))?;
+        headers_mut.insert(HeaderName::from_static("anthropic-beta"), beta_header);
+        // The subscription endpoint expects first-party-CLI-shaped
+        // requests; mirror Claude Code's user-agent + x-app so the
+        // OAuth credential is admitted. (Reference: OpenClaw
+        // `src/llm/providers/anthropic.ts`.)
+        headers_mut.insert(
+            reqwest::header::USER_AGENT,
+            HeaderValue::from_static(headers::CLAUDE_CODE_USER_AGENT),
+        );
+        headers_mut.insert(
+            HeaderName::from_static("x-app"),
+            HeaderValue::from_static(headers::CLAUDE_CODE_X_APP),
+        );
+        Ok(request)
+    }
+
+    async fn prepare_body(
+        &self,
+        body: &mut serde_json::Value,
+        _target: &RoutingTarget,
+    ) -> Result<()> {
+        // Require — never inject. The Claude Pro/Max subscription endpoint
+        // admits requests under the Claude Code agent profile, whose system
+        // prompt must begin with Claude Code's identity string. This applier
+        // gates on that being already present (a genuine Claude Code request)
+        // and refuses to fabricate it: enabling correct use is the contract,
+        // policing/spoofing arbitrary traffic is not.
+        //
+        // bitrouter decodes the inbound request and re-encodes it, so by the
+        // time the body reaches this applier the Messages codec has collapsed
+        // the inbound `system` blocks into one `\n`-joined text (the identity
+        // first) and re-emitted it as a plain string — or, when a prompt-cache
+        // breakpoint is set, a single text block carrying that whole text. The
+        // gate therefore checks that the effective system text *starts with*
+        // the identity, accepting both shapes. A missing `system`, or one whose
+        // text doesn't lead with the identity, fails the gate.
+        if !system_starts_with_identity(body) {
+            return Err(BitrouterError::Upstream {
+                status: 400,
+                message: "the claude-code subscription provider only accepts Claude Code requests \
+                          (missing the Claude Code system prompt)"
+                    .into(),
+            });
+        }
+        Ok(())
+    }
+}
+
+/// Merge the OAuth-required `anthropic-beta` values (which the Claude Pro/Max
+/// subscription endpoint demands) with any the client already sent, deduping
+/// while keeping the required values first. Real Claude Code traffic carries
+/// feature betas next to matching request-body fields, so the union — not an
+/// overwrite — is what keeps those requests valid upstream.
+fn merged_beta_value<'a>(client_betas: impl Iterator<Item = &'a str>) -> String {
+    let mut out: Vec<String> = headers::OAUTH_BETA_VALUES
+        .iter()
+        .map(|s| (*s).to_string())
+        .collect();
+    for raw in client_betas {
+        for beta in raw.split(',') {
+            let beta = beta.trim();
+            if !beta.is_empty() && !out.iter().any(|x| x == beta) {
+                out.push(beta.to_string());
+            }
+        }
+    }
+    out.join(",")
+}
+
+/// Whether the request body's `system` begins with Claude Code's identity
+/// string. Accepts a plain-string `system` (its text) or a content-block array
+/// (the first block's `text`), and matches on a `starts_with` prefix because
+/// bitrouter's Messages codec flattens the inbound `system` blocks into one
+/// `\n`-joined text (identity first) before re-encoding, so the identity is a
+/// prefix of the effective system text rather than a standalone first block.
+fn system_starts_with_identity(body: &serde_json::Value) -> bool {
+    let Some(system) = body.as_object().and_then(|obj| obj.get("system")) else {
+        return false;
+    };
+    let text = match system {
+        serde_json::Value::String(s) => Some(s.as_str()),
+        serde_json::Value::Array(blocks) => blocks
+            .first()
+            .and_then(|b| b.get("text"))
+            .and_then(|t| t.as_str()),
+        _ => None,
+    };
+    text.is_some_and(|t| {
+        t.trim_start()
+            .starts_with(headers::CLAUDE_CODE_SYSTEM_PROMPT)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use bitrouter_sdk::language_model::types::ApiProtocol;
+    use wiremock::MockServer;
+
+    use super::*;
+    use crate::oauth::credential_store::OAuthToken;
+
+    fn tmp_store_path() -> PathBuf {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "bitrouter-claude-code-test-{}-{id}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir.join("creds.json")
+    }
+
+    fn cc_target(label: Option<&str>) -> RoutingTarget {
+        RoutingTarget {
+            provider_name: PROVIDER_ID.to_string(),
+            service_id: "claude-opus-4-7".to_string(),
+            api_base: "https://api.anthropic.com/v1".to_string(),
+            api_key: String::new(),
+            api_protocol: ApiProtocol::Messages,
+            account_label: label.map(String::from),
+            api_key_override: None,
+            api_base_override: None,
+            auth_scheme: Default::default(),
+        }
+    }
+
+    #[tokio::test]
+    async fn errors_when_no_session() {
+        let path = tmp_store_path();
+        let applier = ClaudeCodeAuthApplier::new(&path).unwrap();
+        let req = reqwest::Client::new()
+            .post("https://api.anthropic.com/v1/messages")
+            .build()
+            .unwrap();
+        let err = applier.apply(req, &cc_target(None)).await.unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("bitrouter providers login claude-code"),
+            "expected helpful hint, got: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn stored_oauth_token_applies_bearer_and_strips_x_api_key() {
+        let path = tmp_store_path();
+        {
+            let mut store = CredentialStore::load(&path).unwrap();
+            store
+                .set(
+                    PROVIDER_ID,
+                    DEFAULT_LABEL,
+                    Credential::from_oauth_token(OAuthToken {
+                        access_token: "sk-ant-oat-fresh".into(),
+                        expires_at: 0, // non-expiring → no refresh attempt
+                        refresh_token: Some("r".into()),
+                    }),
+                )
+                .unwrap();
+        }
+        let applier = ClaudeCodeAuthApplier::new(&path).unwrap();
+        let mut req = reqwest::Client::new()
+            .post("https://api.anthropic.com/v1/messages")
+            .build()
+            .unwrap();
+        // Pretend the protocol adapter already set x-api-key; the OAuth
+        // path must strip it.
+        req.headers_mut()
+            .insert("x-api-key", HeaderValue::from_static("stale-key"));
+        let authed = applier.apply(req, &cc_target(None)).await.unwrap();
+        let h = authed.headers();
+        assert_eq!(
+            h.get(reqwest::header::AUTHORIZATION)
+                .and_then(|v| v.to_str().ok()),
+            Some("Bearer sk-ant-oat-fresh")
+        );
+        assert!(h.get("x-api-key").is_none());
+        let beta = h
+            .get("anthropic-beta")
+            .and_then(|v| v.to_str().ok())
+            .unwrap();
+        assert!(beta.contains("oauth-2025-04-20"));
+        assert!(beta.contains("claude-code-20250219"));
+        assert_eq!(
+            h.get(reqwest::header::USER_AGENT)
+                .and_then(|v| v.to_str().ok()),
+            Some(headers::CLAUDE_CODE_USER_AGENT)
+        );
+        assert_eq!(
+            h.get("x-app").and_then(|v| v.to_str().ok()),
+            Some(headers::CLAUDE_CODE_X_APP)
+        );
+    }
+
+    #[tokio::test]
+    async fn oauth_merges_client_anthropic_beta_instead_of_overwriting() {
+        // Real Claude Code traffic appends feature betas
+        // (`context-management-…`, interleaved-thinking) next to the matching
+        // request-body fields. The applier must keep them while adding the
+        // OAuth-required betas — overwriting strips them and the upstream 400s
+        // ("Extra inputs are not permitted") on the now-orphaned body field.
+        let path = tmp_store_path();
+        {
+            let mut store = CredentialStore::load(&path).unwrap();
+            store
+                .set(
+                    PROVIDER_ID,
+                    DEFAULT_LABEL,
+                    Credential::from_oauth_token(OAuthToken {
+                        access_token: "sk-ant-oat".into(),
+                        expires_at: 0,
+                        refresh_token: Some("r".into()),
+                    }),
+                )
+                .unwrap();
+        }
+        let applier = ClaudeCodeAuthApplier::new(&path).unwrap();
+        let mut req = reqwest::Client::new()
+            .post("https://api.anthropic.com/v1/messages")
+            .build()
+            .unwrap();
+        req.headers_mut().insert(
+            "anthropic-beta",
+            HeaderValue::from_static(
+                "context-management-2025-06-27,interleaved-thinking-2025-05-14",
+            ),
+        );
+        let authed = applier.apply(req, &cc_target(None)).await.unwrap();
+        let beta = authed
+            .headers()
+            .get("anthropic-beta")
+            .and_then(|v| v.to_str().ok())
+            .unwrap();
+        assert!(
+            beta.contains("oauth-2025-04-20"),
+            "required beta dropped: {beta}"
+        );
+        assert!(
+            beta.contains("claude-code-20250219"),
+            "required beta dropped: {beta}"
+        );
+        assert!(
+            beta.contains("context-management-2025-06-27"),
+            "client beta dropped: {beta}"
+        );
+        assert!(
+            beta.contains("interleaved-thinking-2025-05-14"),
+            "client beta dropped: {beta}"
+        );
+    }
+
+    #[tokio::test]
+    async fn fresh_oauth_token_skips_refresh() {
+        // Sanity check on the cache-hit path: a long-lived token (1h
+        // ahead of the 60s refresh window) is reused directly. The end-
+        // to-end refresh round-trip is covered in
+        // `oauth::refresh::tests::refresh_returns_new_access_token`.
+        let path = tmp_store_path();
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        {
+            let mut store = CredentialStore::load(&path).unwrap();
+            store
+                .set(
+                    PROVIDER_ID,
+                    DEFAULT_LABEL,
+                    Credential::from_oauth_token(OAuthToken {
+                        access_token: "still-fresh".into(),
+                        expires_at: now + 3600,
+                        refresh_token: Some("ignored".into()),
+                    }),
+                )
+                .unwrap();
+        }
+        // Point the refresh endpoint at a wiremock that fails the test
+        // if it's hit at all (no mounted responder → wiremock 404s).
+        let server = MockServer::start().await;
+        let applier = ClaudeCodeAuthApplier::with_client_and_endpoint(
+            &path,
+            reqwest::Client::new(),
+            "client-1",
+            format!("{}/oauth/token", server.uri()),
+            None,
+        );
+        let req = reqwest::Client::new()
+            .post("https://api.anthropic.com/v1/messages")
+            .build()
+            .unwrap();
+        let authed = applier.apply(req, &cc_target(None)).await.unwrap();
+        assert_eq!(
+            authed
+                .headers()
+                .get(reqwest::header::AUTHORIZATION)
+                .and_then(|v| v.to_str().ok()),
+            Some("Bearer still-fresh")
+        );
+    }
+
+    #[tokio::test]
+    async fn prepare_body_gates_on_the_claude_code_identity_prefix() {
+        // The subscription provider requires the system prompt to BEGIN with the
+        // Claude Code identity. It must never fabricate it: a body that doesn't
+        // lead with the identity is rejected (400) and left untouched; one that
+        // does passes through unchanged. Both the plain-string and content-block
+        // shapes the Messages codec can emit are accepted.
+        let path = tmp_store_path();
+        let applier = ClaudeCodeAuthApplier::new(&path).unwrap();
+        let id = headers::CLAUDE_CODE_SYSTEM_PROMPT;
+
+        let reject = |body: serde_json::Value| {
+            let applier = &applier;
+            async move {
+                let mut b = body.clone();
+                let err = applier
+                    .prepare_body(&mut b, &cc_target(None))
+                    .await
+                    .unwrap_err();
+                assert!(
+                    matches!(err, BitrouterError::Upstream { status: 400, .. }),
+                    "expected 400 for {body}"
+                );
+                assert_eq!(
+                    b, body,
+                    "a rejected body must be left untouched (no injection)"
+                );
+            }
+        };
+        let accept = |body: serde_json::Value| {
+            let applier = &applier;
+            async move {
+                let mut b = body.clone();
+                applier
+                    .prepare_body(&mut b, &cc_target(None))
+                    .await
+                    .unwrap();
+                assert_eq!(b, body, "an accepted body must be left untouched");
+            }
+        };
+
+        // Missing / non-leading-identity → reject.
+        reject(serde_json::json!({ "model": "claude", "messages": [] })).await;
+        reject(serde_json::json!({ "system": "be terse", "messages": [] })).await;
+        reject(serde_json::json!({
+            "system": [{ "type": "text", "text": "not the identity" }], "messages": []
+        }))
+        .await;
+
+        // Leads with the identity → accept. This covers exactly what bitrouter's
+        // Messages codec re-emits for genuine Claude Code traffic: a plain string
+        // (with or without the caller's prompt appended after a newline) and a
+        // single flattened content block, plus a raw identity-first block array.
+        accept(serde_json::json!({ "system": id, "messages": [] })).await;
+        accept(serde_json::json!({ "system": format!("{id}\nbe terse"), "messages": [] })).await;
+        accept(serde_json::json!({
+            "system": [{ "type": "text", "text": format!("{id}\nbe terse") }], "messages": []
+        }))
+        .await;
+        accept(serde_json::json!({
+            "system": [{ "type": "text", "text": id }], "messages": []
+        }))
+        .await;
+    }
+
+    /// Write a `.credentials.json` in a fresh temp dir and return its path.
+    fn tmp_claude_creds(contents: &str) -> PathBuf {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "bitrouter-claude-code-cc-{}-{id}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(".credentials.json");
+        std::fs::write(&path, contents).unwrap();
+        path
+    }
+
+    fn seed_marker(store_path: &std::path::Path) {
+        let mut store = CredentialStore::load(store_path).unwrap();
+        store
+            .set(PROVIDER_ID, DEFAULT_LABEL, Credential::ClaudeCodeCli)
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn claude_code_cli_marker_applies_bearer_from_live_store() {
+        // Marker in bitrouter's store + a non-expiring live Claude Code session
+        // (no `expiresAt` → never refreshed) → the live access token is applied
+        // as a Bearer and any stale x-api-key is stripped.
+        let path = tmp_store_path();
+        seed_marker(&path);
+        let creds = tmp_claude_creds(
+            r#"{"claudeAiOauth":{"accessToken":"sk-ant-oat-live","refreshToken":"r"}}"#,
+        );
+        let applier = ClaudeCodeAuthApplier::with_client_and_endpoint(
+            &path,
+            reqwest::Client::new(),
+            "client-1",
+            "https://example.com/oauth/token",
+            Some(ClaudeCodeStore::file_only(&creds)),
+        );
+        let mut req = reqwest::Client::new()
+            .post("https://api.anthropic.com/v1/messages")
+            .build()
+            .unwrap();
+        req.headers_mut()
+            .insert("x-api-key", HeaderValue::from_static("stale"));
+        let authed = applier.apply(req, &cc_target(None)).await.unwrap();
+        let h = authed.headers();
+        assert_eq!(
+            h.get(reqwest::header::AUTHORIZATION)
+                .and_then(|v| v.to_str().ok()),
+            Some("Bearer sk-ant-oat-live")
+        );
+        assert!(h.get("x-api-key").is_none());
+        assert!(
+            h.get("anthropic-beta")
+                .and_then(|v| v.to_str().ok())
+                .unwrap()
+                .contains("oauth-2025-04-20")
+        );
+    }
+
+    #[tokio::test]
+    async fn claude_code_cli_marker_missing_session_errors() {
+        // Marker present but no live Claude Code session → a helpful 401 that
+        // points the user at `claude auth login`, not a silent fall-through.
+        let path = tmp_store_path();
+        seed_marker(&path);
+        let absent = std::env::temp_dir().join("bitrouter-claude-code-cc-absent/none.json");
+        let applier = ClaudeCodeAuthApplier::with_client_and_endpoint(
+            &path,
+            reqwest::Client::new(),
+            "client-1",
+            "https://example.com/oauth/token",
+            Some(ClaudeCodeStore::file_only(&absent)),
+        );
+        let req = reqwest::Client::new()
+            .post("https://api.anthropic.com/v1/messages")
+            .build()
+            .unwrap();
+        let err = applier.apply(req, &cc_target(None)).await.unwrap_err();
+        assert!(
+            err.to_string().contains("claude auth login"),
+            "expected a login hint, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn claude_code_cli_marker_expiring_token_triggers_refresh() {
+        // An expiring live token must drive a refresh attempt rather than serve
+        // the stale token. Pointing the endpoint at an insecure (http) URL makes
+        // `refresh` fail fast with a typed error, proving the needs_refresh
+        // branch is taken. (The happy-path refresh and write-back are covered by
+        // `oauth::refresh::tests` and `import::claude_code::tests` respectively;
+        // an http MockServer can't exercise them because `refresh` requires
+        // https.)
+        let path = tmp_store_path();
+        seed_marker(&path);
+        let creds = tmp_claude_creds(
+            r#"{"claudeAiOauth":{"accessToken":"old","refreshToken":"RT","expiresAt":1000}}"#,
+        );
+        let applier = ClaudeCodeAuthApplier::with_client_and_endpoint(
+            &path,
+            reqwest::Client::new(),
+            "client-1",
+            "http://insecure.example.com/oauth/token",
+            Some(ClaudeCodeStore::file_only(&creds)),
+        );
+        let req = reqwest::Client::new()
+            .post("https://api.anthropic.com/v1/messages")
+            .build()
+            .unwrap();
+        let err = applier.apply(req, &cc_target(None)).await.unwrap_err();
+        assert!(
+            err.to_string().contains("refresh"),
+            "expected a refresh error proving the refresh path ran, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn claude_code_cli_marker_non_expiring_is_reread_live_each_request() {
+        // A non-expiring live token must NOT be cached for the process lifetime:
+        // when `claude` rotates the on-disk token, the next request must see the
+        // new value, keeping bitrouter in lockstep with the single source of
+        // truth.
+        let path = tmp_store_path();
+        seed_marker(&path);
+        let creds =
+            tmp_claude_creds(r#"{"claudeAiOauth":{"accessToken":"first","refreshToken":"r"}}"#);
+        let applier = ClaudeCodeAuthApplier::with_client_and_endpoint(
+            &path,
+            reqwest::Client::new(),
+            "client-1",
+            "https://example.com/oauth/token",
+            Some(ClaudeCodeStore::file_only(&creds)),
+        );
+        let bearer = |req: reqwest::Request| {
+            req.headers()
+                .get(reqwest::header::AUTHORIZATION)
+                .and_then(|v| v.to_str().ok())
+                .map(str::to_string)
+        };
+        let first = applier
+            .apply(
+                reqwest::Client::new()
+                    .post("https://api.anthropic.com/v1/messages")
+                    .build()
+                    .unwrap(),
+                &cc_target(None),
+            )
+            .await
+            .unwrap();
+        assert_eq!(bearer(first).as_deref(), Some("Bearer first"));
+        // Claude Code rotates its stored token.
+        std::fs::write(
+            &creds,
+            r#"{"claudeAiOauth":{"accessToken":"second","refreshToken":"r"}}"#,
+        )
+        .unwrap();
+        let second = applier
+            .apply(
+                reqwest::Client::new()
+                    .post("https://api.anthropic.com/v1/messages")
+                    .build()
+                    .unwrap(),
+                &cc_target(None),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            bearer(second).as_deref(),
+            Some("Bearer second"),
+            "a non-expiring marker token must be re-read live, not served from a stale cache"
+        );
+    }
+}

--- a/crates/bitrouter-providers/src/codex/mod.rs
+++ b/crates/bitrouter-providers/src/codex/mod.rs
@@ -55,7 +55,7 @@ pub struct OpenAiCodexAuthApplier {
     token_endpoint: String,
     cache: Arc<Mutex<std::collections::HashMap<String, OAuthToken>>>,
     /// Per-label single-flight gate around disk-read → refresh →
-    /// persist. See [`crate::anthropic::AnthropicOAuthApplier`] for the
+    /// persist. See [`crate::claude_code::ClaudeCodeAuthApplier`] for the
     /// rationale (concurrent refreshes can have the older refresh_token
     /// invalidated per RFC 6749 §6).
     refresh_gates: Arc<Mutex<std::collections::HashMap<String, Arc<tokio::sync::Mutex<()>>>>>,

--- a/crates/bitrouter-providers/src/lib.rs
+++ b/crates/bitrouter-providers/src/lib.rs
@@ -78,6 +78,8 @@ mod apply;
 pub mod builtin;
 pub mod catalog;
 #[cfg(feature = "pkce")]
+pub mod claude_code;
+#[cfg(feature = "pkce")]
 pub mod codex;
 pub mod copilot;
 mod entry;

--- a/crates/bitrouter-sdk/src/config/routing_table.rs
+++ b/crates/bitrouter-sdk/src/config/routing_table.rs
@@ -363,6 +363,25 @@ pub fn resolve_route_chain(
         if !provider_matches_tags(provider, &prefs.require_tags) {
             continue;
         }
+        // Subscription providers (a caller's own plan, reached by a local OAuth
+        // login) are explicit-route-only: a `provider:model` route (Strategy 1)
+        // or an explicit `only` preference reaches them, but they never join the
+        // canonical auto-cascade — so a plain canonical request never silently
+        // bills a personal subscription. In particular the Claude Code
+        // subscription serves only genuine Claude Code traffic, which the ingress
+        // transform routes explicitly to `claude-code:<model>`; a non-Claude-Code
+        // request for the same canonical model must fall to the pay-as-you-go
+        // provider (or 404), never the subscription.
+        if matches!(
+            provider.class,
+            Some(
+                crate::config::ProviderClass::FirstPartySubscription
+                    | crate::config::ProviderClass::GatewaySubscription
+            )
+        ) && !prefs.only.contains(provider_id)
+        {
+            continue;
+        }
         if provider.models.iter().any(|m| m.id == clean) {
             chain.push((
                 provider_rank(provider, order),
@@ -604,6 +623,82 @@ providers:
         assert_eq!(chain.len(), 2);
         assert_eq!(chain[0].provider_name, "anthropic");
         assert_eq!(chain[1].provider_name, "openai");
+    }
+
+    // `shared-model` is served by a pay-as-you-go provider (`anthropic`,
+    // first-party-api) and a subscription provider (`claude-code`,
+    // first-party-subscription). The subscription must stay out of the
+    // auto-cascade.
+    const SUBSCRIPTION_CASCADE: &str = r#"
+providers:
+  anthropic:
+    api_base: https://api.anthropic.com/v1
+    api_key: k-anthropic
+    class: first-party-api
+    models: [{ id: shared-model }]
+  claude-code:
+    api_base: https://api.anthropic.com/v1
+    api_key: k-cc
+    class: first-party-subscription
+    models: [{ id: shared-model }]
+"#;
+
+    #[tokio::test]
+    async fn strategy_3_excludes_subscription_providers_from_cascade() {
+        // A bare canonical request must NOT cascade onto the subscription
+        // provider — only the pay-as-you-go one answers.
+        let t = table(SUBSCRIPTION_CASCADE);
+        let chain = t
+            .route_chain(
+                "shared-model",
+                &RoutingPrefs::default(),
+                &CallerContext::local(),
+            )
+            .await
+            .unwrap();
+        let order: Vec<&str> = chain.iter().map(|h| h.provider_name.as_str()).collect();
+        assert_eq!(
+            order,
+            vec!["anthropic"],
+            "a subscription provider must not join the canonical auto-cascade"
+        );
+    }
+
+    #[tokio::test]
+    async fn subscription_provider_reachable_by_explicit_route_and_only() {
+        let t = table(SUBSCRIPTION_CASCADE);
+        // Strategy-1 `provider:model` reaches it directly (the transform's path).
+        let direct = t
+            .route_chain(
+                "claude-code:shared-model",
+                &RoutingPrefs::default(),
+                &CallerContext::local(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            direct
+                .iter()
+                .map(|h| h.provider_name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["claude-code"]
+        );
+        // An explicit `only` preference also reaches it in the cascade.
+        let only = RoutingPrefs {
+            only: vec!["claude-code".to_string()],
+            ..Default::default()
+        };
+        let chain = t
+            .route_chain("shared-model", &only, &CallerContext::local())
+            .await
+            .unwrap();
+        assert_eq!(
+            chain
+                .iter()
+                .map(|h| h.provider_name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["claude-code"]
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

Split the Claude subscription out of the `anthropic` provider into a dedicated **`claude-code`** provider, and route only genuine Claude Code traffic to it — so bitrouter never uses a user's Claude subscription for non-Claude-Code requests, and never *fabricates* the Claude Code identity.

Builds on #590 (which read the live `~/.claude` session under `anthropic`). Lock-step with provider-registry#53, which adds the `claude-code` registry entry (`access: local_oauth`, `auth.kind: oauth`).

## Behavior

| Request | Routes to | Auth |
|---|---|---|
| Claude Code (system prompt leads with the Claude Code identity) + a `claude-*` model | `claude-code` | subscription Bearer (live `~/.claude`) |
| everything else | `anthropic` | `x-api-key` (platform / pay-as-you-go) |
| `claude-code:<model>` with a non-Claude-Code body | rejected `400` | — |

## How

- **`claude_code::ClaudeCodeAuthApplier`** (registered under `claude-code`): resolves the live `~/.claude` OAuth session (`ClaudeCodeCli` marker, refresh + write-back), attaches the Bearer + claude-code/oauth betas + Claude Code `user-agent`/`x-app`. Its `prepare_body` **gates** on the system prompt already beginning with the Claude Code identity (matching the prefix of the effective system text the Messages codec produces) and **never injects** it. No API-key fallback.
- **`anthropic`** is now platform-only (`AnthropicApiKeyApplier`): `x-api-key`, no body shaping, no OAuth, no identity injection (the old spoofing is gone).
- **`ClaudeCodeRouter`** (ingress `PromptTransform`): rewrites a Claude Code request's `claude-*` model to `claude-code:<model>`; reads the identity, never writes it. Non-CC / non-Claude / already-prefixed requests are untouched.
- **`enable_if_logged_in`**: inserts `claude-code` into the config when the OAuth store holds a session; the registry merge fills its fields. Wired on the serve + reload paths.
- **Onboarding**: `bitrouter providers login claude-code` (resolved from the registry) stores the marker under `claude-code`; `anthropic` login is API-key-only. **Migrates** any #590 `ClaudeCodeCli` marker from `anthropic` to `claude-code`.

## Testing

Unit: applier gate (require, never inject; prefix match across string/array forms), transform detection/rewrite, enable + migration, `available_methods`. `bitrouter-providers` (pkce) 151, `bitrouter` 150 — green; clippy clean. Verified end-to-end on macOS against a real Claude subscription (no API key): Claude Code traffic → `claude-code` → 200; a `claude-code:` request without the identity → 400; a non-Claude-Code request → `anthropic`.

## Follow-up (not in this PR)

`login_provider` resolves registry providers via `RegistryConfig::default()` (the default registry URL) rather than the config's `registry.url`, so `login claude-code` ignores a custom `registry.url`. Pre-existing; worth aligning later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
