### PR TITLE
fix(claude-code): detect subscription traffic by the agent-profile beta

### DIFF
--- a/apps/bitrouter/src/claude_code.rs
+++ b/apps/bitrouter/src/claude_code.rs
@@ -2,21 +2,23 @@
 //! (`claude-code`).
 //!
 //! Two daemon-side responsibilities, both keyed on the `claude-code` provider
-//! id and the Claude Code identity system prompt:
+//! id and the Claude Code agent-profile beta:
 //!
 //! - [`ClaudeCodeRouter`] — an ingress [`PromptTransform`] that detects genuine
-//!   Claude Code traffic by its system prompt and routes it to the subscription
-//!   provider by provider-prefixing the model (`claude-code:<model>`).
+//!   Claude Code traffic by its `anthropic-beta: claude-code-…` header and
+//!   routes it to the subscription provider by provider-prefixing the model
+//!   (`claude-code:<model>`).
 //! - [`enable_if_logged_in`] — auto-add the `claude-code` provider to the
 //!   in-memory `providers:` map when the OAuth credential store holds a
 //!   `claude-code` credential (mirrors [`crate::cloud::enable_in_zero_config`]).
 //!
 //! These live in the app layer (not `bitrouter-providers`) because the routing
-//! decision reads the parsed canonical [`Prompt`],
-//! which only exists above the SDK ingress seam, and because the enable step
-//! mutates the assembled [`Config`].
+//! decision needs the ingress request (the parsed [`Prompt`] plus the inbound
+//! headers), which only exists above the SDK ingress seam, and because the
+//! enable step mutates the assembled [`Config`].
 
 use bitrouter_providers::oauth::credential_store::{Credential, CredentialStore, DEFAULT_LABEL};
+use bitrouter_sdk::HeaderMap;
 use bitrouter_sdk::PromptTransform;
 use bitrouter_sdk::config::{Config, ProviderConfig};
 use bitrouter_sdk::language_model::types::Prompt;
@@ -29,13 +31,12 @@ const PROVIDER_ID: &str = "claude-code";
 /// Ingress [`PromptTransform`] that routes genuine Claude Code traffic to the
 /// Claude Pro/Max **subscription** provider.
 ///
-/// Genuine Claude Code traffic carries the Claude Code identity as its first
-/// system block: the SDK's Messages decoder flattens the inbound `system`
-/// blocks into one `\n`-joined string (identity first), so the canonical
-/// [`Prompt::system`] *starts with* [`CLAUDE_CODE_SYSTEM_PROMPT`]
-/// (`bitrouter_providers::anthropic::headers::CLAUDE_CODE_SYSTEM_PROMPT`). Such
-/// a request also targets a bare Claude model id (e.g.
-/// `claude-sonnet-4-5-20250929`).
+/// Genuine Claude Code traffic carries the Claude Code agent-profile beta —
+/// `anthropic-beta: claude-code-…` — the same marker the Pro/Max subscription
+/// endpoint keys on. It's sent identically by the CLI, the Agent SDK, and
+/// `bitrouter spawn`, and is stable across releases (unlike the
+/// version-dependent system-prompt text the older detection relied on). Such a
+/// request also targets a bare Claude model id (e.g. `claude-opus-4-8`).
 ///
 /// When both hold, the transform rewrites `prompt.model` to
 /// `claude-code:<model>`, which sends the request to the subscription provider
@@ -44,25 +45,46 @@ const PROVIDER_ID: &str = "claude-code";
 /// route wherever they already pointed (the pay-as-you-go `anthropic` provider
 /// for bare Claude models, or the explicit provider).
 ///
-/// The transform **only reads** the identity — it never adds it. The
-/// subscription applier separately *requires* the identity to be present and
-/// refuses to fabricate it, so this transform cannot be used to spoof arbitrary
-/// traffic as Claude Code.
-///
-/// [`CLAUDE_CODE_SYSTEM_PROMPT`]: bitrouter_providers::anthropic::headers::CLAUDE_CODE_SYSTEM_PROMPT
+/// The transform **only reads** the marker — it never adds it. The subscription
+/// applier separately *requires* the beta to be present and refuses to
+/// fabricate it, so this transform cannot be used to spoof arbitrary traffic as
+/// Claude Code.
 pub struct ClaudeCodeRouter;
 
 impl PromptTransform for ClaudeCodeRouter {
-    fn apply(&self, prompt: &mut Prompt) {
-        let is_cc = prompt.system.as_deref().is_some_and(|s| {
-            s.trim_start()
-                .starts_with(bitrouter_providers::anthropic::headers::CLAUDE_CODE_SYSTEM_PROMPT)
-        });
+    fn apply(&self, _prompt: &mut Prompt) {
+        // Detection needs the inbound `anthropic-beta` header, so all the work
+        // is in `apply_with_headers` (which the HTTP server always calls). With
+        // no headers there is nothing to decide, so this is a no-op.
+    }
+
+    fn apply_with_headers(&self, prompt: &mut Prompt, headers: &HeaderMap) {
+        // Genuine Claude Code carries the agent-profile beta
+        // (`anthropic-beta: claude-code-…`) — the same marker the subscription
+        // endpoint keys on, stable across Claude Code's CLI / Agent-SDK /
+        // `bitrouter spawn` shapes (unlike the version-dependent system prompt
+        // text). When it's present and the request targets a bare `claude-*`
+        // model, route to the subscription provider by prefixing the model.
+        // Non-Claude-Code traffic is left untouched (it falls to the
+        // pay-as-you-go `anthropic` provider). The transform only READS the
+        // marker — it never adds it, so it can't be used to spoof.
+        let is_cc = headers_indicate_claude_code(headers);
         if is_cc && prompt.model.starts_with("claude") && !prompt.model.starts_with("claude-code:")
         {
             prompt.model = format!("claude-code:{}", prompt.model);
         }
     }
+}
+
+/// Whether the inbound headers carry the Claude Code agent-profile beta. The
+/// `anthropic-beta` header is a comma-joined list; any token whose name starts
+/// with `claude-code` counts, so the match is stable across the dated suffix.
+fn headers_indicate_claude_code(headers: &HeaderMap) -> bool {
+    headers
+        .get_all("anthropic-beta")
+        .iter()
+        .filter_map(|v| v.to_str().ok())
+        .any(|v| v.split(',').any(|b| b.trim().starts_with("claude-code")))
 }
 
 /// Insert the `claude-code` provider into `config.providers` when the OAuth
@@ -182,14 +204,17 @@ fn enable_if_logged_in_with_store(config: &mut Config, store: &CredentialStore) 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bitrouter_providers::anthropic::headers::CLAUDE_CODE_SYSTEM_PROMPT;
     use bitrouter_providers::oauth::credential_store::Credential;
     use bitrouter_sdk::language_model::types::{GenerationParams, ProviderMetadata};
 
-    fn prompt(model: &str, system: Option<&str>) -> Prompt {
+    /// A representative `anthropic-beta` value as genuine Claude Code sends it:
+    /// the agent-profile beta first, then feature betas.
+    const CC_BETA: &str = "claude-code-20250219,oauth-2025-04-20,context-1m-2025-08-07";
+
+    fn prompt(model: &str) -> Prompt {
         Prompt {
             model: model.to_string(),
-            system: system.map(str::to_string),
+            system: None,
             system_provider_metadata: ProviderMetadata::new(),
             messages: Vec::new(),
             tools: Vec::new(),
@@ -200,58 +225,71 @@ mod tests {
         }
     }
 
-    fn route(model: &str, system: Option<&str>) -> String {
-        let mut p = prompt(model, system);
-        ClaudeCodeRouter.apply(&mut p);
+    /// Drive the router with an optional inbound `anthropic-beta` header value,
+    /// returning the (possibly rewritten) model.
+    fn route(model: &str, anthropic_beta: Option<&str>) -> String {
+        let mut p = prompt(model);
+        let mut headers = HeaderMap::new();
+        if let Some(beta) = anthropic_beta {
+            headers.insert("anthropic-beta", beta.parse().unwrap());
+        }
+        ClaudeCodeRouter.apply_with_headers(&mut p, &headers);
         p.model
     }
 
     #[test]
-    fn cc_system_and_bare_claude_model_is_prefixed() {
-        let system = format!("{CLAUDE_CODE_SYSTEM_PROMPT}\nbe terse");
+    fn claude_code_beta_and_bare_claude_model_is_prefixed() {
         assert_eq!(
-            route("claude-sonnet-4-5-20250929", Some(&system)),
-            "claude-code:claude-sonnet-4-5-20250929"
+            route("claude-opus-4-8", Some(CC_BETA)),
+            "claude-code:claude-opus-4-8"
         );
     }
 
     #[test]
-    fn cc_system_and_non_claude_model_is_untouched() {
-        let system = format!("{CLAUDE_CODE_SYSTEM_PROMPT}\nbe terse");
-        assert_eq!(route("gpt-5", Some(&system)), "gpt-5");
+    fn claude_code_beta_and_non_claude_model_is_untouched() {
+        assert_eq!(route("gpt-5", Some(CC_BETA)), "gpt-5");
     }
 
     #[test]
-    fn non_cc_system_with_claude_model_is_untouched() {
-        // No system prompt at all.
+    fn no_claude_code_beta_leaves_claude_model_for_payg() {
+        // The key guarantee: non-Claude-Code traffic for a Claude model is NOT
+        // routed to the subscription — it falls to the pay-as-you-go provider.
+        assert_eq!(route("claude-opus-4-8", None), "claude-opus-4-8");
+        // A beta header that lacks the claude-code agent profile also doesn't route.
         assert_eq!(
-            route("claude-sonnet-4-5-20250929", None),
-            "claude-sonnet-4-5-20250929"
-        );
-        // A system prompt that is not the Claude Code identity.
-        assert_eq!(
-            route("claude-sonnet-4-5-20250929", Some("be terse")),
-            "claude-sonnet-4-5-20250929"
+            route(
+                "claude-opus-4-8",
+                Some("oauth-2025-04-20,context-1m-2025-08-07")
+            ),
+            "claude-opus-4-8"
         );
     }
 
     #[test]
     fn already_prefixed_claude_model_is_untouched() {
-        let system = format!("{CLAUDE_CODE_SYSTEM_PROMPT}\nbe terse");
         assert_eq!(
-            route("claude-code:claude-sonnet-4-5-20250929", Some(&system)),
-            "claude-code:claude-sonnet-4-5-20250929"
+            route("claude-code:claude-opus-4-8", Some(CC_BETA)),
+            "claude-code:claude-opus-4-8"
         );
     }
 
     #[test]
     fn idempotent_on_already_claude_code_prefixed_model() {
         // Running the transform twice must not double-prefix.
-        let system = format!("{CLAUDE_CODE_SYSTEM_PROMPT}\nbe terse");
-        let mut p = prompt("claude-sonnet-4-5-20250929", Some(&system));
+        let mut p = prompt("claude-opus-4-8");
+        let mut headers = HeaderMap::new();
+        headers.insert("anthropic-beta", CC_BETA.parse().unwrap());
+        ClaudeCodeRouter.apply_with_headers(&mut p, &headers);
+        ClaudeCodeRouter.apply_with_headers(&mut p, &headers);
+        assert_eq!(p.model, "claude-code:claude-opus-4-8");
+    }
+
+    #[test]
+    fn apply_without_headers_is_noop() {
+        // The header-less path can't detect Claude Code, so it must not route.
+        let mut p = prompt("claude-opus-4-8");
         ClaudeCodeRouter.apply(&mut p);
-        ClaudeCodeRouter.apply(&mut p);
-        assert_eq!(p.model, "claude-code:claude-sonnet-4-5-20250929");
+        assert_eq!(p.model, "claude-opus-4-8");
     }
 
     fn fresh_tmp_store() -> CredentialStore {

--- a/crates/bitrouter-providers/src/claude_code.rs
+++ b/crates/bitrouter-providers/src/claude_code.rs
@@ -17,15 +17,18 @@
 //! back to the store, and caches it in memory to avoid hammering the
 //! refresh endpoint under load.
 //!
-//! ## Body shape — require, never inject
+//! ## Gate on the agent-profile beta — detect, never inject
 //!
-//! The Claude Pro/Max subscription endpoint admits requests under the Claude
-//! Code agent profile: the first `system` block has to be Claude Code's
-//! identity string. [`ClaudeCodeAuthApplier::prepare_body`] **gates** on that
-//! — it rejects (`400`) any request whose first `system` block is not the
-//! identity, and it **never fabricates** the identity. Enabling correct Claude
-//! Code use is the contract; the applier does not spoof arbitrary traffic as
-//! Claude Code.
+//! Only genuine Claude Code traffic may spend the subscription. [`ClaudeCodeAuthApplier::apply`]
+//! **gates** on the Claude Code agent-profile beta the client itself sent
+//! (`anthropic-beta: claude-code-…`) — the same marker the Pro/Max subscription
+//! endpoint keys on — and rejects (`400`) any request that reaches this provider
+//! without it. It **never fabricates** the marker: enabling correct Claude Code
+//! use is the contract; the applier does not spoof arbitrary traffic as Claude
+//! Code. The body is forwarded faithfully ([`ClaudeCodeAuthApplier::prepare_body`]
+//! is a no-op) — current Claude Code (CLI, Agent SDK, `bitrouter spawn`) does
+//! not lead its `system` with a fixed identity string, but always carries the
+//! agent-profile beta, and the subscription accepts its own system blocks as-is.
 //!
 //! ## Two distinct ids
 //!
@@ -371,6 +374,23 @@ impl AuthApplier for ClaudeCodeAuthApplier {
         mut request: reqwest::Request,
         target: &RoutingTarget,
     ) -> Result<reqwest::Request> {
+        // Gate: only genuine Claude Code traffic may spend the subscription.
+        // We detect it by the Claude Code agent-profile beta the client itself
+        // sent (`anthropic-beta: claude-code-…`) — the same marker the Pro/Max
+        // subscription endpoint keys on — and NEVER fabricate it. A request that
+        // reaches this provider without it (e.g. a hand-typed `claude-code:<model>`
+        // that bypassed the ingress router) is refused. This replaces the older,
+        // version-brittle check on the system-prompt identity string: current
+        // Claude Code (CLI, Agent SDK, `bitrouter spawn`) no longer leads its
+        // system with that exact text, but always carries the agent-profile beta.
+        if !request_has_claude_code_beta(&request) {
+            return Err(BitrouterError::Upstream {
+                status: 400,
+                message: "the claude-code subscription provider only accepts Claude Code requests \
+                          (missing the Claude Code agent-profile beta)"
+                    .into(),
+            });
+        }
         let label = self.label_for(target);
         let resolved = self.resolve_credential(label).await?;
         // `anthropic-version` is mandatory regardless of credential type.
@@ -431,32 +451,16 @@ impl AuthApplier for ClaudeCodeAuthApplier {
 
     async fn prepare_body(
         &self,
-        body: &mut serde_json::Value,
+        _body: &mut serde_json::Value,
         _target: &RoutingTarget,
     ) -> Result<()> {
-        // Require — never inject. The Claude Pro/Max subscription endpoint
-        // admits requests under the Claude Code agent profile, whose system
-        // prompt must begin with Claude Code's identity string. This applier
-        // gates on that being already present (a genuine Claude Code request)
-        // and refuses to fabricate it: enabling correct use is the contract,
-        // policing/spoofing arbitrary traffic is not.
-        //
-        // bitrouter decodes the inbound request and re-encodes it, so by the
-        // time the body reaches this applier the Messages codec has collapsed
-        // the inbound `system` blocks into one `\n`-joined text (the identity
-        // first) and re-emitted it as a plain string — or, when a prompt-cache
-        // breakpoint is set, a single text block carrying that whole text. The
-        // gate therefore checks that the effective system text *starts with*
-        // the identity, accepting both shapes. A missing `system`, or one whose
-        // text doesn't lead with the identity, fails the gate.
-        if !system_starts_with_identity(body) {
-            return Err(BitrouterError::Upstream {
-                status: 400,
-                message: "the claude-code subscription provider only accepts Claude Code requests \
-                          (missing the Claude Code system prompt)"
-                    .into(),
-            });
-        }
+        // Faithful passthrough. The request is gated in `apply` on the Claude
+        // Code agent-profile beta (`anthropic-beta: claude-code-…`), and the
+        // Pro/Max subscription endpoint accepts genuine Claude Code's own
+        // system blocks as-is (verified: a stock `claude -p` round-trips on the
+        // subscription). So this applier neither requires a specific system
+        // prompt nor rewrites the body — it forwards exactly what Claude Code
+        // sent and lets the upstream be the authority.
         Ok(())
     }
 }
@@ -482,28 +486,28 @@ fn merged_beta_value<'a>(client_betas: impl Iterator<Item = &'a str>) -> String 
     out.join(",")
 }
 
-/// Whether the request body's `system` begins with Claude Code's identity
-/// string. Accepts a plain-string `system` (its text) or a content-block array
-/// (the first block's `text`), and matches on a `starts_with` prefix because
-/// bitrouter's Messages codec flattens the inbound `system` blocks into one
-/// `\n`-joined text (identity first) before re-encoding, so the identity is a
-/// prefix of the effective system text rather than a standalone first block.
-fn system_starts_with_identity(body: &serde_json::Value) -> bool {
-    let Some(system) = body.as_object().and_then(|obj| obj.get("system")) else {
-        return false;
-    };
-    let text = match system {
-        serde_json::Value::String(s) => Some(s.as_str()),
-        serde_json::Value::Array(blocks) => blocks
-            .first()
-            .and_then(|b| b.get("text"))
-            .and_then(|t| t.as_str()),
-        _ => None,
-    };
-    text.is_some_and(|t| {
-        t.trim_start()
-            .starts_with(headers::CLAUDE_CODE_SYSTEM_PROMPT)
-    })
+/// Whether the request carries the Claude Code agent-profile beta — the
+/// `anthropic-beta: claude-code-…` value genuine Claude Code sends (and the
+/// Pro/Max subscription endpoint keys on). The beta header is a comma-joined
+/// list; any token whose name starts with `claude-code` counts, so the check is
+/// stable across the dated suffix (`claude-code-20250219`, future dates).
+/// Matching the protocol marker — not the version-dependent system-prompt text —
+/// is what makes detection robust across Claude Code's CLI / Agent-SDK shapes.
+fn request_has_claude_code_beta(request: &reqwest::Request) -> bool {
+    request
+        .headers()
+        .get_all("anthropic-beta")
+        .iter()
+        .filter_map(|v| v.to_str().ok())
+        .any(beta_value_has_claude_code)
+}
+
+/// Whether a single (possibly comma-joined) `anthropic-beta` header value
+/// contains the Claude Code agent-profile beta.
+pub(crate) fn beta_value_has_claude_code(value: &str) -> bool {
+    value
+        .split(',')
+        .any(|b| b.trim().starts_with("claude-code"))
 }
 
 #[cfg(test)]
@@ -543,14 +547,50 @@ mod tests {
         }
     }
 
+    /// A request as it reaches the applier: it carries the Claude Code
+    /// agent-profile beta, which the `apply` gate requires — like genuine
+    /// Claude Code traffic. Tests of the post-gate behaviour start from this.
+    fn cc_request() -> reqwest::Request {
+        let mut req = reqwest::Client::new()
+            .post("https://api.anthropic.com/v1/messages")
+            .build()
+            .unwrap();
+        req.headers_mut().insert(
+            "anthropic-beta",
+            HeaderValue::from_static("claude-code-20250219"),
+        );
+        req
+    }
+
     #[tokio::test]
-    async fn errors_when_no_session() {
+    async fn apply_rejects_request_without_agent_profile_beta() {
+        // The gate: a request that reaches the subscription provider without the
+        // Claude Code agent-profile beta (e.g. a hand-typed `claude-code:<model>`
+        // that bypassed the ingress router) is refused, before any credential is
+        // spent. Genuine Claude Code always carries the beta.
         let path = tmp_store_path();
+        seed_marker(&path);
         let applier = ClaudeCodeAuthApplier::new(&path).unwrap();
         let req = reqwest::Client::new()
             .post("https://api.anthropic.com/v1/messages")
             .build()
-            .unwrap();
+            .unwrap(); // no anthropic-beta
+        let err = applier.apply(req, &cc_target(None)).await.unwrap_err();
+        assert!(
+            matches!(err, BitrouterError::Upstream { status: 400, .. }),
+            "expected a 400 gate rejection, got: {err}"
+        );
+        assert!(
+            err.to_string().contains("agent-profile beta"),
+            "expected the gate message, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn errors_when_no_session() {
+        let path = tmp_store_path();
+        let applier = ClaudeCodeAuthApplier::new(&path).unwrap();
+        let req = cc_request();
         let err = applier.apply(req, &cc_target(None)).await.unwrap_err();
         let msg = err.to_string();
         assert!(
@@ -577,10 +617,7 @@ mod tests {
                 .unwrap();
         }
         let applier = ClaudeCodeAuthApplier::new(&path).unwrap();
-        let mut req = reqwest::Client::new()
-            .post("https://api.anthropic.com/v1/messages")
-            .build()
-            .unwrap();
+        let mut req = cc_request();
         // Pretend the protocol adapter already set x-api-key; the OAuth
         // path must strip it.
         req.headers_mut()
@@ -633,14 +670,11 @@ mod tests {
                 .unwrap();
         }
         let applier = ClaudeCodeAuthApplier::new(&path).unwrap();
-        let mut req = reqwest::Client::new()
-            .post("https://api.anthropic.com/v1/messages")
-            .build()
-            .unwrap();
+        let mut req = cc_request();
         req.headers_mut().insert(
             "anthropic-beta",
             HeaderValue::from_static(
-                "context-management-2025-06-27,interleaved-thinking-2025-05-14",
+                "claude-code-20250219,context-management-2025-06-27,interleaved-thinking-2025-05-14",
             ),
         );
         let authed = applier.apply(req, &cc_target(None)).await.unwrap();
@@ -702,10 +736,7 @@ mod tests {
             format!("{}/oauth/token", server.uri()),
             None,
         );
-        let req = reqwest::Client::new()
-            .post("https://api.anthropic.com/v1/messages")
-            .build()
-            .unwrap();
+        let req = cc_request();
         let authed = applier.apply(req, &cc_target(None)).await.unwrap();
         assert_eq!(
             authed
@@ -717,35 +748,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn prepare_body_gates_on_the_claude_code_identity_prefix() {
-        // The subscription provider requires the system prompt to BEGIN with the
-        // Claude Code identity. It must never fabricate it: a body that doesn't
-        // lead with the identity is rejected (400) and left untouched; one that
-        // does passes through unchanged. Both the plain-string and content-block
-        // shapes the Messages codec can emit are accepted.
+    async fn prepare_body_is_faithful_passthrough() {
+        // The body gate moved to `apply` (keyed on the agent-profile beta);
+        // `prepare_body` now forwards the body untouched regardless of the
+        // system prompt — it neither requires a specific identity nor rewrites
+        // anything, so genuine Claude Code's own system blocks pass through.
         let path = tmp_store_path();
         let applier = ClaudeCodeAuthApplier::new(&path).unwrap();
-        let id = headers::CLAUDE_CODE_SYSTEM_PROMPT;
-
-        let reject = |body: serde_json::Value| {
-            let applier = &applier;
-            async move {
-                let mut b = body.clone();
-                let err = applier
-                    .prepare_body(&mut b, &cc_target(None))
-                    .await
-                    .unwrap_err();
-                assert!(
-                    matches!(err, BitrouterError::Upstream { status: 400, .. }),
-                    "expected 400 for {body}"
-                );
-                assert_eq!(
-                    b, body,
-                    "a rejected body must be left untouched (no injection)"
-                );
-            }
-        };
-        let accept = |body: serde_json::Value| {
+        let unchanged = |body: serde_json::Value| {
             let applier = &applier;
             async move {
                 let mut b = body.clone();
@@ -753,30 +763,16 @@ mod tests {
                     .prepare_body(&mut b, &cc_target(None))
                     .await
                     .unwrap();
-                assert_eq!(b, body, "an accepted body must be left untouched");
+                assert_eq!(b, body, "prepare_body must not touch the body");
             }
         };
-
-        // Missing / non-leading-identity → reject.
-        reject(serde_json::json!({ "model": "claude", "messages": [] })).await;
-        reject(serde_json::json!({ "system": "be terse", "messages": [] })).await;
-        reject(serde_json::json!({
-            "system": [{ "type": "text", "text": "not the identity" }], "messages": []
-        }))
-        .await;
-
-        // Leads with the identity → accept. This covers exactly what bitrouter's
-        // Messages codec re-emits for genuine Claude Code traffic: a plain string
-        // (with or without the caller's prompt appended after a newline) and a
-        // single flattened content block, plus a raw identity-first block array.
-        accept(serde_json::json!({ "system": id, "messages": [] })).await;
-        accept(serde_json::json!({ "system": format!("{id}\nbe terse"), "messages": [] })).await;
-        accept(serde_json::json!({
-            "system": [{ "type": "text", "text": format!("{id}\nbe terse") }], "messages": []
-        }))
-        .await;
-        accept(serde_json::json!({
-            "system": [{ "type": "text", "text": id }], "messages": []
+        // No system, an arbitrary system, and the real Claude Code shape all
+        // pass through unchanged.
+        unchanged(serde_json::json!({ "model": "claude", "messages": [] })).await;
+        unchanged(serde_json::json!({ "system": "be terse", "messages": [] })).await;
+        unchanged(serde_json::json!({
+            "system": [{ "type": "text", "text": "You are a Claude agent, built on Anthropic's Claude Agent SDK." }],
+            "messages": []
         }))
         .await;
     }
@@ -821,10 +817,7 @@ mod tests {
             "https://example.com/oauth/token",
             Some(ClaudeCodeStore::file_only(&creds)),
         );
-        let mut req = reqwest::Client::new()
-            .post("https://api.anthropic.com/v1/messages")
-            .build()
-            .unwrap();
+        let mut req = cc_request();
         req.headers_mut()
             .insert("x-api-key", HeaderValue::from_static("stale"));
         let authed = applier.apply(req, &cc_target(None)).await.unwrap();
@@ -857,10 +850,7 @@ mod tests {
             "https://example.com/oauth/token",
             Some(ClaudeCodeStore::file_only(&absent)),
         );
-        let req = reqwest::Client::new()
-            .post("https://api.anthropic.com/v1/messages")
-            .build()
-            .unwrap();
+        let req = cc_request();
         let err = applier.apply(req, &cc_target(None)).await.unwrap_err();
         assert!(
             err.to_string().contains("claude auth login"),
@@ -889,10 +879,7 @@ mod tests {
             "http://insecure.example.com/oauth/token",
             Some(ClaudeCodeStore::file_only(&creds)),
         );
-        let req = reqwest::Client::new()
-            .post("https://api.anthropic.com/v1/messages")
-            .build()
-            .unwrap();
+        let req = cc_request();
         let err = applier.apply(req, &cc_target(None)).await.unwrap_err();
         assert!(
             err.to_string().contains("refresh"),
@@ -923,16 +910,7 @@ mod tests {
                 .and_then(|v| v.to_str().ok())
                 .map(str::to_string)
         };
-        let first = applier
-            .apply(
-                reqwest::Client::new()
-                    .post("https://api.anthropic.com/v1/messages")
-                    .build()
-                    .unwrap(),
-                &cc_target(None),
-            )
-            .await
-            .unwrap();
+        let first = applier.apply(cc_request(), &cc_target(None)).await.unwrap();
         assert_eq!(bearer(first).as_deref(), Some("Bearer first"));
         // Claude Code rotates its stored token.
         std::fs::write(
@@ -940,16 +918,7 @@ mod tests {
             r#"{"claudeAiOauth":{"accessToken":"second","refreshToken":"r"}}"#,
         )
         .unwrap();
-        let second = applier
-            .apply(
-                reqwest::Client::new()
-                    .post("https://api.anthropic.com/v1/messages")
-                    .build()
-                    .unwrap(),
-                &cc_target(None),
-            )
-            .await
-            .unwrap();
+        let second = applier.apply(cc_request(), &cc_target(None)).await.unwrap();
         assert_eq!(
             bearer(second).as_deref(),
             Some("Bearer second"),

--- a/crates/bitrouter-sdk/src/app.rs
+++ b/crates/bitrouter-sdk/src/app.rs
@@ -71,6 +71,20 @@ pub trait PromptTransform: Send + Sync {
     /// Rewrite the prompt in place. A transform that does not apply to this
     /// request leaves it untouched.
     fn apply(&self, prompt: &mut language_model::types::Prompt);
+
+    /// Like [`apply`](Self::apply), but with the inbound request headers
+    /// available. The default delegates to [`apply`](Self::apply), ignoring the
+    /// headers; transforms whose routing decision depends on a header the
+    /// client sent (e.g. detecting genuine Claude Code traffic by its
+    /// `anthropic-beta` agent-profile marker) override this instead. The HTTP
+    /// server always calls this method.
+    fn apply_with_headers(
+        &self,
+        prompt: &mut language_model::types::Prompt,
+        _headers: &http::HeaderMap,
+    ) {
+        self.apply(prompt);
+    }
 }
 
 /// A fully assembled application: one pipeline per enabled protocol, plus the

--- a/crates/bitrouter-sdk/src/lib.rs
+++ b/crates/bitrouter-sdk/src/lib.rs
@@ -137,9 +137,12 @@ pub mod language_model;
 pub mod mcp;
 
 pub use app::{App, AppBuilder, Plugin, PromptTransform};
+// Re-exported so downstream `PromptTransform` impls can name the header map
+// passed to `apply_with_headers` without taking a direct `http` dependency.
 pub use caller::CallerContext;
 pub use error::{BitrouterError, Result};
 pub use event::{EventBus, PipelineEvent};
+pub use http::HeaderMap;
 pub use language_model::{
     FallbackPolicy, HookDecision, PreRequestHook, RoutingTable, RoutingTarget,
 };

--- a/crates/bitrouter-sdk/src/server.rs
+++ b/crates/bitrouter-sdk/src/server.rs
@@ -647,7 +647,7 @@ async fn handle(
             // alias): the prompt body is freely mutable here, before it enters
             // the pipeline that exposes it read-only downstream.
             for transform in &state.prompt_transforms {
-                transform.apply(&mut p);
+                transform.apply_with_headers(&mut p, &headers);
             }
             p
         }


### PR DESCRIPTION
## Problem
`bitrouter spawn -a claude` (and any current Claude Code) never reached the `claude-code` subscription provider. #593 detects/gates Claude Code by the exact system-prompt prefix `"You are Claude Code, Anthropic's official CLI for Claude."`, but current Claude Code (v2.1.185 — CLI, Agent SDK, spawn) sends an `x-anthropic-billing-header` block first and a `"You are a Claude agent, built on Anthropic's Claude Agent SDK."` identity. The exact prefix never matched, so:
- the ingress router never rewrote `claude-*` → `claude-code:<model>` (request failed routing), and
- a direct `claude-code:` route 400'd at the applier gate.

## Fix
Detect genuine Claude Code by the **`anthropic-beta: claude-code-…` agent-profile marker** the client always sends — the same marker the Pro/Max subscription endpoint keys on, stable across releases and identical for the CLI / Agent SDK / `bitrouter spawn`.

- New additive `PromptTransform::apply_with_headers` (default delegates to `apply`); the HTTP server passes the inbound headers. `ClaudeCodeRouter` uses it to rewrite bare `claude-*` → `claude-code:<model>` only when the marker is present.
- `ClaudeCodeAuthApplier::apply` gates on the marker (400 without it); `prepare_body` is now a faithful passthrough (Anthropic accepts genuine Claude Code's own system as-is — verified a stock `claude -p` round-trips on the subscription). No identity is required or injected — "detect, never fabricate" is preserved.

## Verification
- `bitrouter spawn -a claude` → daemon → `claude-code` subscription: multi-turn agent completes, all requests 200, thinking-block signatures round-trip.
- Workspace tests: 1125 pass; clippy/fmt/doctest clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)