### PR TITLE
feat(telemetry): account-authenticated exports + anonymous opt-out

### DIFF
--- a/apps/bitrouter/src/assemble.rs
+++ b/apps/bitrouter/src/assemble.rs
@@ -751,7 +751,15 @@ fn build_otel_config(config: &Config) -> Result<Option<OtelConfig>> {
             let install_id = crate::paths::install_id()
                 .map_err(|e| tracing::warn!("telemetry: could not resolve install id: {e:#}"))
                 .ok();
-            return Ok(Some(build_telemetry_otel_config(opt_in, install_id)));
+            // The signed-in account token is resolved and attached below (the
+            // `account_bearer` argument) so `attribution: auto`/`account` can
+            // authenticate the export when the user is logged in.
+            let account_bearer = telemetry_account_bearer(opt_in.attribution);
+            return Ok(Some(build_telemetry_otel_config(
+                opt_in,
+                install_id,
+                account_bearer,
+            )));
         }
     }
 
@@ -803,6 +811,26 @@ enum TelemetryLevel {
     Full,
 }
 
+/// How an enabled telemetry export attributes itself.
+#[derive(Debug, Clone, Copy, serde::Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum TelemetryAttribution {
+    /// Account-attributed when a `bitrouter cloud login` session (or an explicit
+    /// `bearer_token`) is available; anonymous otherwise. The default — signing
+    /// in upgrades attribution automatically, with no config change.
+    #[default]
+    Auto,
+    /// Require account attribution: use the signed-in session / explicit bearer.
+    /// If neither is available the export still proceeds **anonymously** (it is
+    /// best-effort and must never be dropped for want of a token), but a warning
+    /// is logged so the misconfiguration is visible.
+    Account,
+    /// Always anonymous — never attach a bearer, even when signed in or a
+    /// `bearer_token` is configured. The opt-out for users who want telemetry
+    /// without tying it to their account.
+    Anonymous,
+}
+
 /// The `plugins.bitrouter-observe.telemetry` opt-in block — a thin wrapper over
 /// [`OtelConfig`] that defaults the endpoint and selects a capture level. Off
 /// by default; nothing is exported unless `enabled` is `true`.
@@ -818,6 +846,10 @@ struct TelemetryOptIn {
     /// Optional bearer token authenticating the export to an account. Falls
     /// back to the `BITROUTER_TELEMETRY_TOKEN` env var when unset.
     bearer_token: Option<String>,
+    /// How to attribute the export: `auto` (default — account when signed in,
+    /// else anonymous), `account` (require the account), or `anonymous` (force
+    /// anonymous even when signed in).
+    attribution: TelemetryAttribution,
 }
 
 /// Ensure an OTLP/HTTP endpoint targets the per-signal **traces** path.
@@ -844,14 +876,30 @@ fn otlp_traces_endpoint(endpoint: &str) -> String {
 ///
 /// Telemetry is **traces-only**: metrics export is disabled so the opt-in never
 /// POSTs a metrics payload to a traces ingest.
-fn build_telemetry_otel_config(opt_in: TelemetryOptIn, install_id: Option<String>) -> OtelConfig {
+fn build_telemetry_otel_config(
+    opt_in: TelemetryOptIn,
+    install_id: Option<String>,
+    account_bearer: Option<String>,
+) -> OtelConfig {
     let content_capture = match opt_in.level {
         TelemetryLevel::Metadata => ContentCaptureMode::Off,
         TelemetryLevel::Full => ContentCaptureMode::Full,
     };
-    let bearer_token = opt_in
+    // Explicit token (config / env) takes precedence; the signed-in account
+    // token (`account_bearer`) is the auto-attached fallback. `attribution`
+    // gates the whole thing — `anonymous` forces no bearer regardless.
+    let explicit = opt_in
         .bearer_token
+        .clone()
         .or_else(|| std::env::var("BITROUTER_TELEMETRY_TOKEN").ok());
+    let (bearer_token, account_requested_but_unmet) =
+        resolve_telemetry_bearer(opt_in.attribution, explicit, account_bearer);
+    if account_requested_but_unmet {
+        tracing::warn!(
+            "telemetry: attribution=account but no signed-in session or bearer token is \
+             available — exporting anonymously (sign in with `bitrouter cloud login`)"
+        );
+    }
     let mut resource_attributes = std::collections::HashMap::new();
     if let Some(id) = install_id {
         resource_attributes.insert("bitrouter.install_id".to_string(), id);
@@ -876,6 +924,49 @@ fn build_telemetry_otel_config(opt_in: TelemetryOptIn, install_id: Option<String
     }
 }
 
+/// Decide the telemetry export bearer from the attribution mode and the
+/// available credentials. Pure (no I/O / env) so the attribution policy is
+/// unit-testable in isolation.
+///
+/// - `anonymous` → never authenticate (no bearer), even if one is available.
+/// - `auto` / `account` → prefer the `explicit` token (config / env), else the
+///   signed-in `account` token.
+///
+/// Returns `(bearer, account_requested_but_unmet)`: `bearer == None` means the
+/// export stays anonymous, and the bool is `true` only when `account` was asked
+/// for but no credential was available (so the caller can warn — the export
+/// still proceeds anonymously, since telemetry is best-effort).
+fn resolve_telemetry_bearer(
+    attribution: TelemetryAttribution,
+    explicit: Option<String>,
+    account: Option<String>,
+) -> (Option<String>, bool) {
+    match attribution {
+        TelemetryAttribution::Anonymous => (None, false),
+        TelemetryAttribution::Auto => (explicit.or(account), false),
+        TelemetryAttribution::Account => {
+            let bearer = explicit.or(account);
+            let unmet = bearer.is_none();
+            (bearer, unmet)
+        }
+    }
+}
+
+/// Resolve the signed-in account's bearer for telemetry attribution, or `None`
+/// when not signed in (or when `attribution` is `anonymous`, in which case the
+/// credential store is never touched). Best-effort: any failure to read the
+/// store yields `None` (anonymous), never an error — telemetry must not break
+/// startup.
+fn telemetry_account_bearer(attribution: TelemetryAttribution) -> Option<String> {
+    if attribution == TelemetryAttribution::Anonymous {
+        return None;
+    }
+    // Phase 2 reads the signed-in account token from the cloud credential store
+    // (`crate::cloud::current_account_bearer`); until then this is a no-op so the
+    // attribution policy + config can land and be reviewed on their own.
+    None
+}
+
 #[cfg(test)]
 mod telemetry_opt_in_tests {
     use super::*;
@@ -887,8 +978,9 @@ mod telemetry_opt_in_tests {
             endpoint: None,
             level: TelemetryLevel::Full,
             bearer_token: Some("bra_x".to_string()),
+            attribution: TelemetryAttribution::Auto,
         };
-        let cfg = build_telemetry_otel_config(opt_in, Some("inst-1".to_string()));
+        let cfg = build_telemetry_otel_config(opt_in, Some("inst-1".to_string()), None);
         // The default base is normalized to the OTLP traces path — the exporter
         // does not append `/v1/traces` for us.
         assert_eq!(
@@ -914,8 +1006,9 @@ mod telemetry_opt_in_tests {
             endpoint: Some("https://otel.example".to_string()),
             level: TelemetryLevel::Metadata,
             bearer_token: None,
+            attribution: TelemetryAttribution::Auto,
         };
-        let cfg = build_telemetry_otel_config(opt_in, None);
+        let cfg = build_telemetry_otel_config(opt_in, None, None);
         // A bare override host is normalized to the traces path too.
         assert_eq!(cfg.endpoint, "https://otel.example/v1/traces");
         assert_eq!(cfg.content_capture, ContentCaptureMode::Off);
@@ -956,6 +1049,93 @@ mod telemetry_opt_in_tests {
         let empty: TelemetryOptIn = serde_json::from_value(serde_json::json!({})).unwrap();
         assert!(!empty.enabled);
         assert_eq!(empty.level, TelemetryLevel::Metadata);
+    }
+
+    #[test]
+    fn attribution_defaults_to_auto_and_parses_variants() {
+        let auto: TelemetryOptIn =
+            serde_json::from_value(serde_json::json!({"enabled": true})).unwrap();
+        assert_eq!(auto.attribution, TelemetryAttribution::Auto);
+        let anon: TelemetryOptIn = serde_json::from_value(
+            serde_json::json!({"enabled": true, "attribution": "anonymous"}),
+        )
+        .unwrap();
+        assert_eq!(anon.attribution, TelemetryAttribution::Anonymous);
+        let acct: TelemetryOptIn =
+            serde_json::from_value(serde_json::json!({"enabled": true, "attribution": "account"}))
+                .unwrap();
+        assert_eq!(acct.attribution, TelemetryAttribution::Account);
+    }
+
+    #[test]
+    fn resolve_bearer_anonymous_never_authenticates() {
+        // Even with both an explicit token and a signed-in account token.
+        assert_eq!(
+            resolve_telemetry_bearer(
+                TelemetryAttribution::Anonymous,
+                Some("explicit".into()),
+                Some("account".into())
+            ),
+            (None, false)
+        );
+    }
+
+    #[test]
+    fn resolve_bearer_auto_prefers_explicit_then_account_then_anonymous() {
+        assert_eq!(
+            resolve_telemetry_bearer(TelemetryAttribution::Auto, Some("e".into()), Some("a".into())),
+            (Some("e".into()), false)
+        );
+        assert_eq!(
+            resolve_telemetry_bearer(TelemetryAttribution::Auto, None, Some("a".into())),
+            (Some("a".into()), false)
+        );
+        // Not signed in, no explicit token → anonymous, no warning.
+        assert_eq!(
+            resolve_telemetry_bearer(TelemetryAttribution::Auto, None, None),
+            (None, false)
+        );
+    }
+
+    #[test]
+    fn resolve_bearer_account_warns_only_when_no_credential() {
+        assert_eq!(
+            resolve_telemetry_bearer(TelemetryAttribution::Account, None, Some("a".into())),
+            (Some("a".into()), false)
+        );
+        // account requested but nothing available → anonymous + warn flag set.
+        assert_eq!(
+            resolve_telemetry_bearer(TelemetryAttribution::Account, None, None),
+            (None, true)
+        );
+    }
+
+    #[test]
+    fn build_config_attaches_account_bearer_under_auto() {
+        let opt_in = TelemetryOptIn {
+            enabled: true,
+            endpoint: None,
+            level: TelemetryLevel::Full,
+            bearer_token: None,
+            attribution: TelemetryAttribution::Auto,
+        };
+        let cfg = build_telemetry_otel_config(opt_in, None, Some("acct-token".into()));
+        assert_eq!(cfg.bearer_token.as_deref(), Some("acct-token"));
+    }
+
+    #[test]
+    fn build_config_anonymous_drops_bearer_even_when_signed_in() {
+        // Both an explicit token and a signed-in account token are present, yet
+        // `anonymous` must export with no bearer — the opt-out guarantee.
+        let opt_in = TelemetryOptIn {
+            enabled: true,
+            endpoint: None,
+            level: TelemetryLevel::Full,
+            bearer_token: Some("explicit".into()),
+            attribution: TelemetryAttribution::Anonymous,
+        };
+        let cfg = build_telemetry_otel_config(opt_in, None, Some("acct".into()));
+        assert!(cfg.bearer_token.is_none());
     }
 }
 

--- a/apps/bitrouter/src/assemble.rs
+++ b/apps/bitrouter/src/assemble.rs
@@ -959,12 +959,11 @@ fn resolve_telemetry_bearer(
 /// startup.
 fn telemetry_account_bearer(attribution: TelemetryAttribution) -> Option<String> {
     if attribution == TelemetryAttribution::Anonymous {
+        // Never touch the credential store when the user has opted out of
+        // account attribution.
         return None;
     }
-    // Phase 2 reads the signed-in account token from the cloud credential store
-    // (`crate::cloud::current_account_bearer`); until then this is a no-op so the
-    // attribution policy + config can land and be reviewed on their own.
-    None
+    crate::cloud::current_account_bearer()
 }
 
 #[cfg(test)]

--- a/apps/bitrouter/src/assemble.rs
+++ b/apps/bitrouter/src/assemble.rs
@@ -890,7 +890,6 @@ fn build_telemetry_otel_config(
     // gates the whole thing — `anonymous` forces no bearer regardless.
     let explicit = opt_in
         .bearer_token
-        .clone()
         .or_else(|| std::env::var("BITROUTER_TELEMETRY_TOKEN").ok());
     let (bearer_token, account_requested_but_unmet) =
         resolve_telemetry_bearer(opt_in.attribution, explicit, account_bearer);
@@ -1082,7 +1081,11 @@ mod telemetry_opt_in_tests {
     #[test]
     fn resolve_bearer_auto_prefers_explicit_then_account_then_anonymous() {
         assert_eq!(
-            resolve_telemetry_bearer(TelemetryAttribution::Auto, Some("e".into()), Some("a".into())),
+            resolve_telemetry_bearer(
+                TelemetryAttribution::Auto,
+                Some("e".into()),
+                Some("a".into())
+            ),
             (Some("e".into()), false)
         );
         assert_eq!(
@@ -1135,6 +1138,44 @@ mod telemetry_opt_in_tests {
         };
         let cfg = build_telemetry_otel_config(opt_in, None, Some("acct".into()));
         assert!(cfg.bearer_token.is_none());
+    }
+
+    #[test]
+    fn build_config_explicit_token_wins_over_account() {
+        // An operator-set `bearer_token` takes precedence over the signed-in
+        // account token.
+        let opt_in = TelemetryOptIn {
+            enabled: true,
+            endpoint: None,
+            level: TelemetryLevel::Full,
+            bearer_token: Some("explicit".into()),
+            attribution: TelemetryAttribution::Auto,
+        };
+        let cfg = build_telemetry_otel_config(opt_in, None, Some("acct".into()));
+        assert_eq!(cfg.bearer_token.as_deref(), Some("explicit"));
+    }
+
+    #[test]
+    fn build_config_account_required_but_unmet_exports_anonymously() {
+        // `attribution: account` with no explicit token and no signed-in
+        // account must still produce a config (best-effort) — just with no
+        // bearer. The warning is a side effect we don't assert here.
+        let opt_in = TelemetryOptIn {
+            enabled: true,
+            endpoint: None,
+            level: TelemetryLevel::Full,
+            bearer_token: None,
+            attribution: TelemetryAttribution::Account,
+        };
+        let cfg = build_telemetry_otel_config(opt_in, None, None);
+        assert!(cfg.bearer_token.is_none());
+    }
+
+    #[test]
+    fn telemetry_account_bearer_anonymous_never_reads_store() {
+        // The opt-out short-circuits before the credential store is ever
+        // consulted, so this is hermetic regardless of the host's login state.
+        assert!(telemetry_account_bearer(TelemetryAttribution::Anonymous).is_none());
     }
 }
 

--- a/apps/bitrouter/src/cloud/mod.rs
+++ b/apps/bitrouter/src/cloud/mod.rs
@@ -28,7 +28,7 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use bitrouter_cloud_sdk::BitrouterCloudAuthApplier;
-use bitrouter_cloud_sdk::auth::credentials::default_credentials_path;
+use bitrouter_cloud_sdk::auth::credentials::{CredentialsStore, default_credentials_path};
 use bitrouter_cloud_sdk::provider::PROVIDER_ID;
 use bitrouter_sdk::config::{Config, ProviderConfig};
 use bitrouter_sdk::language_model::{AuthApplier, auth::AuthAppliers};
@@ -84,6 +84,34 @@ pub fn register_if_configured(config: &Config, appliers: &mut AuthAppliers) -> R
     let applier = build_auth_applier()?;
     appliers.register(PROVIDER_ID, applier);
     Ok(())
+}
+
+/// The signed-in account's access token, for attributing telemetry exports to
+/// the account that ran `bitrouter cloud login`. `None` when not signed in.
+///
+/// Best-effort: a missing or unreadable credential store, or no stored session,
+/// yields `None` (the export stays anonymous) rather than an error — resolving
+/// the bearer must never break daemon startup.
+///
+/// This reads the **stored** token without refreshing — a synchronous snapshot
+/// taken once at config-assembly time. An expired stored token is treated as
+/// "not signed in" (returns `None`); live re-attachment with auto-refresh on
+/// each export is a documented follow-up. In practice the token is minted fresh
+/// at `bitrouter cloud login` and long-lived, so the snapshot is valid for the
+/// daemon's session.
+pub fn current_account_bearer() -> Option<String> {
+    let store = CredentialsStore::default_path().ok()?;
+    account_bearer_from_store(&store)
+}
+
+/// Pure form of [`current_account_bearer`]: extract a still-valid access token
+/// from an already-loaded store. Factored out so the validity gate is
+/// unit-testable without touching the default credentials path.
+fn account_bearer_from_store(store: &CredentialsStore) -> Option<String> {
+    let creds = store.current()?;
+    creds
+        .access_token_valid()
+        .then(|| creds.access_token.clone())
 }
 
 #[cfg(test)]
@@ -149,5 +177,45 @@ mod tests {
             "https://example.invalid",
             "existing entry must not be overwritten"
         );
+    }
+
+    /// Write a credentials JSON file with the given access token and RFC 3339
+    /// `expires_at`, then load it into a store. The remaining required fields
+    /// are filled with placeholders — only the token + expiry matter here.
+    fn store_with_token(label: &str, access_token: &str, expires_at: &str) -> CredentialsStore {
+        let path = fresh_tmp_creds_path(label);
+        let json = serde_json::json!({
+            "access_token": access_token,
+            "expires_at": expires_at,
+            "token_type": "Bearer",
+            "scope": "telemetry:write",
+            "client_id": "bitrouter-cli",
+            "authorization_server": "https://api.bitrouter.ai",
+        });
+        fs::write(&path, serde_json::to_vec(&json).unwrap()).unwrap();
+        CredentialsStore::load(&path).unwrap()
+    }
+
+    #[test]
+    fn account_bearer_returns_valid_stored_token() {
+        let store = store_with_token("valid", "bra_live", "2999-01-01T00:00:00Z");
+        assert_eq!(account_bearer_from_store(&store).as_deref(), Some("bra_live"));
+    }
+
+    #[test]
+    fn account_bearer_none_when_token_expired() {
+        let store = store_with_token("expired", "bra_old", "2000-01-01T00:00:00Z");
+        assert!(
+            account_bearer_from_store(&store).is_none(),
+            "an expired stored token must be treated as not signed in"
+        );
+    }
+
+    #[test]
+    fn account_bearer_none_when_not_signed_in() {
+        // Empty store (no credentials file) → no bearer.
+        let path = fresh_tmp_creds_path("absent");
+        let store = CredentialsStore::load(&path).unwrap();
+        assert!(account_bearer_from_store(&store).is_none());
     }
 }

--- a/apps/bitrouter/src/cloud/mod.rs
+++ b/apps/bitrouter/src/cloud/mod.rs
@@ -199,7 +199,10 @@ mod tests {
     #[test]
     fn account_bearer_returns_valid_stored_token() {
         let store = store_with_token("valid", "bra_live", "2999-01-01T00:00:00Z");
-        assert_eq!(account_bearer_from_store(&store).as_deref(), Some("bra_live"));
+        assert_eq!(
+            account_bearer_from_store(&store).as_deref(),
+            Some("bra_live")
+        );
     }
 
     #[test]

--- a/apps/bitrouter/src/cloud/mod.rs
+++ b/apps/bitrouter/src/cloud/mod.rs
@@ -99,6 +99,12 @@ pub fn register_if_configured(config: &Config, appliers: &mut AuthAppliers) -> R
 /// each export is a documented follow-up. In practice the token is minted fresh
 /// at `bitrouter cloud login` and long-lived, so the snapshot is valid for the
 /// daemon's session.
+///
+/// Note the snapshot is baked into a *static* `Authorization` header on the OTLP
+/// exporter: if the token expires mid-session the exporter keeps sending the now
+/// stale bearer (the ingest rejects it; telemetry is best-effort) until the
+/// daemon restarts and re-evaluates validity — it does not silently fall back to
+/// anonymous. This is the trade-off the deferred auto-refresh follow-up removes.
 pub fn current_account_bearer() -> Option<String> {
     let store = CredentialsStore::default_path().ok()?;
     account_bearer_from_store(&store)
@@ -220,5 +226,21 @@ mod tests {
         let path = fresh_tmp_creds_path("absent");
         let store = CredentialsStore::load(&path).unwrap();
         assert!(account_bearer_from_store(&store).is_none());
+    }
+
+    #[test]
+    fn malformed_credentials_file_is_swallowed_as_anonymous() {
+        // A corrupt credentials file makes `CredentialsStore::load` error; the
+        // `default_path().ok()?` in `current_account_bearer` swallows that into
+        // `None` so a broken file degrades to anonymous telemetry rather than
+        // breaking daemon startup. We can't drive the real default path here, so
+        // assert the load error that the `?` consumes.
+        let path = fresh_tmp_creds_path("malformed");
+        fs::write(&path, "{ not valid json").unwrap();
+        assert!(
+            CredentialsStore::load(&path).is_err(),
+            "a malformed credentials file must surface as a load error for \
+             `current_account_bearer` to swallow into anonymous"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Once a user signs in with `bitrouter cloud login`, their telemetry exports are now **account-attributed automatically** — the signed-in account's bearer token is attached to the OTLP export instead of the anonymous `bitrouter.install_id` resource attribute alone. A new `attribution` config option governs this, including an explicit **opt-out** so a signed-in user can still emit anonymous telemetry.

Telemetry stays **off by default** and **best-effort**: nothing here can break daemon startup or drop an export for want of a token.

## Motivation

Telemetry already exported anonymously (keyed on a generated `bitrouter.install_id`), and an operator could hand-set a `bearer_token`. But a user who had already run `bitrouter cloud login` got no benefit from it — their export stayed anonymous unless they manually copied a token into config. This wires the existing sign-in session straight through to telemetry attribution, with a clear knob to decline it.

## The `attribution` option

New field on `plugins.bitrouter-observe.telemetry`:

```yaml
plugins:
  bitrouter-observe:
    telemetry:
      enabled: true
      level: full            # or `metadata`
      attribution: auto      # auto (default) | account | anonymous
```

| Mode | Behavior |
| --- | --- |
| `auto` *(default)* | Account-attributed when a `bitrouter cloud login` session (or an explicit `bearer_token`) is available; anonymous otherwise. **Signing in upgrades attribution with no config change.** |
| `account` | Require account attribution. If no credential is available the export still proceeds **anonymously** (telemetry is best-effort and must never be dropped), but a `tracing::warn!` makes the misconfiguration visible. |
| `anonymous` | **Force anonymous.** Never attach a bearer — even when signed in, even when `bearer_token` / `BITROUTER_TELEMETRY_TOKEN` is set. The credential store is never read. The opt-out. |

### Bearer precedence (`auto` / `account`)

`explicit` over `account`: an operator-set token wins, then the signed-in session, else anonymous.

1. `plugins.bitrouter-observe.telemetry.bearer_token` (config)
2. `BITROUTER_TELEMETRY_TOKEN` (env)
3. the signed-in `bitrouter cloud login` access token
4. anonymous (no `Authorization` header)

`anonymous` short-circuits the whole chain to "no bearer".

## Design

- **Pure decision policy.** `resolve_telemetry_bearer(attribution, explicit, account) -> (Option<String>, bool)` (`apps/bitrouter/src/assemble.rs`) holds the entire policy with no I/O, so the matrix is unit-tested in isolation. The `bool` is `account_requested_but_unmet` — `true` only when `account` was asked for but no credential existed, so the caller can warn while still exporting anonymously.
- **Snapshot, not live refresh.** `cloud::current_account_bearer()` (`apps/bitrouter/src/cloud/mod.rs`) reads the *stored* access token once at config-assembly time, validity-gated (`access_token_valid()`); expired or absent → `None`. The bearer is then baked into a static `Authorization` header on the OTLP exporter. **Live per-export auto-refresh is a deliberate follow-up** — the cloud SDK already has the refresh-aware `current_token`, but plumbing it per-export needs a custom `opentelemetry_http::HttpClient`, out of scope here. Consequence (documented at the call site): if the token expires mid-session the exporter keeps sending the now-stale bearer until daemon restart, rather than silently reverting to anonymous.
- **Layering.** `current_account_bearer` lives in `apps/bitrouter/src/cloud/mod.rs` (the only place that imports `CredentialsStore`), keeping the cloud-SDK dependency out of `bitrouter-providers`. `assemble.rs` reaches it via `crate::cloud`.

## Guarantees

- **Best-effort.** No panic/unwrap on the resolution path. A missing, unreadable, or malformed credential store degrades to anonymous (`default_path().ok()?`), never an error. `account`-unmet only logs a warning. Telemetry never breaks startup.
- **Opt-out is absolute (within the documented surface).** `anonymous` is double-gated: `telemetry_account_bearer` early-returns before touching the store, and `resolve_telemetry_bearer` independently returns `(None, false)`.
- **No token leakage.** The new code logs nothing; the SDK's `Credentials` `Debug` impl already redacts the token as a backstop.
- **Fail-closed config.** Unknown `attribution` strings have no `#[serde(other)]` arm, so a typo is a hard, clearly-messaged startup error rather than a silent fallback on a privacy control.

## Testing

- `resolve_telemetry_bearer` decision matrix (all three modes; precedence; the warn-only-when-unmet flag).
- `build_telemetry_otel_config` integration: account bearer attached under `auto`; `anonymous` drops the bearer even with explicit + account present; explicit wins over account; `account`-unmet still exports anonymously.
- serde: `attribution` defaults to `auto`, parses `account` / `anonymous`.
- `account_bearer_from_store`: valid → `Some`, expired → `None`, absent → `None`; malformed file surfaces as a load error (swallowed into anonymous).
- Full workspace suite green (`cargo nextest run --workspace --all-features`: 1137 passed), clippy clean, fmt clean.

## Follow-ups (out of scope)

- Live per-export auto-refresh of the account token (via `current_token` + a custom OTLP `HttpClient`), removing the stale-header-after-mid-session-expiry trade-off.
- Document `attribution` in the telemetry Quick Start once that section lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
