### PR TITLE
feat(cli): wait for daemon readiness on start; auto-start it on spawn

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -37,6 +37,8 @@ bitrouter start [-c <path>] [--log <path>]
 
 Logs default to `bitrouter.log` next to the config file (e.g. `~/.bitrouter/bitrouter.log` when the config resolved to `~/.bitrouter/bitrouter.yaml`). Refuses to start if a daemon is already running.
 
+Waits until the daemon answers on its control socket before reporting `✓ … started` (up to 15s), then prints the listen address and routable-model count — so a follow-up command can rely on the daemon being up. If the daemon crashes during startup, the tail of its log is printed and the command exits non-zero; if it is alive but still not ready after 15s, a note is printed and the command exits 0 (the daemon keeps coming up).
+
 ### `bitrouter stop`
 
 ```
@@ -173,9 +175,17 @@ bitrouter agent-proxy claude-code [-c <path>]
 
 Stdio bridge between an ACP-aware editor and a configured upstream agent. The editor spawns this as a child process; `agent-proxy` routes JSON-RPC over the `acp` pipeline and relays notifications back.
 
----
+### `bitrouter spawn`
 
-## Auth and keys
+```
+bitrouter spawn -a <agent> [-c <path>] [--base-url <url>] [--no-install] [--no-start] -- <agent args…>
+```
+
+Launches a coding-agent harness (`-a claude` for Claude Code) as a child process with its gateway base URL pointed at BitRouter, so the agent's traffic routes through the router **without touching the agent's own config files** — only the child process environment is set (`ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN`). Following `cargo run`'s convention, everything after `--` is forwarded to the agent verbatim, e.g. `bitrouter spawn -a claude -- -p "summarize" --dangerously-skip-permissions`.
+
+The agent authenticates to BitRouter with `BITROUTER_API_KEY` when set; otherwise a local placeholder is used (fine under the `skip_auth` default written by `bitrouter init`). A missing agent binary is offered for install via its official native installer (`--no-install`, or a non-TTY stdin, declines).
+
+When the target is the local daemon (a derived base URL on a loopback/wildcard bind) and none is running, `spawn` **auto-starts it** — printing a hint, launching a detached `serve`, and waiting for readiness before handing off to the agent. Pass `--no-start` to skip this (a reachability warning is printed instead). An explicit `--base-url` or a non-local bind is never auto-started — BitRouter can't start someone else's daemon — and only gets a warning if it looks unreachable.
 
 ### `bitrouter key sign`
 

--- a/apps/bitrouter/src/daemon.rs
+++ b/apps/bitrouter/src/daemon.rs
@@ -794,6 +794,169 @@ pub async fn remove_pid_file(path: &Path) {
     let _ = tokio::fs::remove_file(path).await;
 }
 
+// ===== launch + readiness wait =====
+
+/// How long [`start_and_wait`] polls for readiness before giving up. Sized for
+/// a cold registry fetch + DB migrations on first run; the daemon keeps running
+/// past this — the timeout only bounds how long the launcher blocks.
+pub const DAEMON_READY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
+
+/// Poll cadence for the readiness loop.
+const READY_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
+
+/// The result of launching a detached daemon and waiting for it to come up.
+#[derive(Debug)]
+pub enum DaemonStartOutcome {
+    /// The daemon answered `Status` within the timeout. Carries its self-report.
+    Ready(ReadyInfo),
+    /// The process is alive but did not become ready before the deadline.
+    NotReadyInTime {
+        /// The launched child's process id.
+        pid: u32,
+    },
+    /// The process exited during startup. Carries the exit-status string and
+    /// the fresh tail of the daemon log (this run's output only).
+    Exited {
+        /// Rendered `ExitStatus`.
+        status: String,
+        /// Daemon log content written since launch.
+        log_tail: String,
+    },
+}
+
+/// Spawn `bitrouter serve` as a detached background process writing to
+/// `log_path` (append). Returns the child handle and the log's pre-spawn byte
+/// length so the caller can quote only this run's output on early death.
+///
+/// Detach rationale: a new process group on Unix so the launcher shell's
+/// SIGHUP (terminal close) does not propagate; DETACHED_PROCESS +
+/// CREATE_NEW_PROCESS_GROUP on Windows so a console Ctrl-C is not delivered.
+/// <https://doc.rust-lang.org/std/os/unix/process/trait.CommandExt.html#tymethod.process_group>
+fn spawn_detached_serve(
+    source: &crate::paths::ConfigSource,
+    log_path: &Path,
+) -> Result<(std::process::Child, u64)> {
+    let exe = std::env::current_exe().context("locating current bitrouter binary")?;
+    // Capture the log's pre-spawn size so we can quote *this run's* output back
+    // to the user on early death instead of slurping stale content from prior
+    // runs (the log is opened append-only).
+    let log_size_before = std::fs::metadata(log_path).map(|m| m.len()).unwrap_or(0);
+    let log = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(log_path)
+        .with_context(|| format!("opening daemon log {}", log_path.display()))?;
+    let log_err = log
+        .try_clone()
+        .context("duplicating log handle for stderr")?;
+
+    let mut cmd = std::process::Command::new(&exe);
+    cmd.arg("serve");
+    // For a `File` source pass `--config <abs path>` so the child loads the same
+    // file even though it'll chdir to the home. For `Default` (zero-config) skip
+    // the flag — the child re-runs `resolve_config` and lands on the same state.
+    if let crate::paths::ConfigSource::File(path) = source {
+        cmd.arg("--config").arg(path);
+    }
+    cmd.stdout(std::process::Stdio::from(log))
+        .stderr(std::process::Stdio::from(log_err))
+        .stdin(std::process::Stdio::null());
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        cmd.process_group(0);
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        // Winbase.h constants — avoid pulling in a `windows`/`winapi` crate.
+        const DETACHED_PROCESS: u32 = 0x0000_0008;
+        const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
+        cmd.creation_flags(DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP);
+    }
+    let child = cmd.spawn().context("spawning detached `bitrouter serve`")?;
+    Ok((child, log_size_before))
+}
+
+/// Read the daemon log from `offset` to end. Returns "" on any read failure so
+/// callers can fall back to a path-only hint. The pre-spawn `offset` ensures
+/// only this run's content is quoted even though the log is append-only.
+async fn read_log_tail(path: &Path, offset: u64) -> String {
+    let bytes = match tokio::fs::read(path).await {
+        Ok(b) => b,
+        Err(_) => return String::new(),
+    };
+    let start = (offset as usize).min(bytes.len());
+    String::from_utf8_lossy(&bytes[start..]).into_owned()
+}
+
+/// Print the daemon's tail-of-log to stderr as an indented, captioned block so
+/// the user sees the actual failure inline instead of being pointed at a log
+/// file they have to open separately. No-op when there is nothing useful to
+/// show. Shared by `start` and `spawn`.
+pub fn eprint_failure_log(log_path: &Path, content: &str) {
+    let trimmed = content.trim_end();
+    if trimmed.is_empty() {
+        return;
+    }
+    let p = crate::style::Palette::for_stderr();
+    eprintln!(
+        "{dim}daemon log ({path}):{reset}",
+        dim = p.dim,
+        path = log_path.display(),
+        reset = p.reset,
+    );
+    for line in trimmed.lines() {
+        eprintln!("  {line}");
+    }
+    eprintln!();
+}
+
+/// Launch a detached `bitrouter serve` and poll the control socket until it
+/// answers `Status`, the process dies, or `timeout` elapses. The daemon keeps
+/// running regardless of the outcome — this only reports what the launcher
+/// observed. `socket` is the control-socket path to poll; pass `None` when it
+/// could not be resolved (then only process-death is detectable).
+///
+/// Ensures the bitrouter home exists (the log lives inside it) but never chdirs
+/// the calling process — only the child `serve` chdirs into the home.
+pub async fn start_and_wait(
+    source: &crate::paths::ConfigSource,
+    log_path: &Path,
+    socket: Option<&Path>,
+    timeout: std::time::Duration,
+) -> Result<DaemonStartOutcome> {
+    crate::paths::ensure_home_directory(source.home())?;
+    let (mut child, log_size_before) = spawn_detached_serve(source, log_path)?;
+
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        // Early-death: a bad config / port-in-use kills the child fast; surface
+        // it with the log tail rather than waiting out the whole timeout. Any
+        // exit before readiness means the daemon isn't serving, so the status
+        // code is reported verbatim and treated as a startup failure by callers
+        // (`serve` never exits 0 before it binds the control socket).
+        if let Ok(Some(status)) = child.try_wait() {
+            let log_tail = read_log_tail(log_path, log_size_before).await;
+            return Ok(DaemonStartOutcome::Exited {
+                status: status.to_string(),
+                log_tail,
+            });
+        }
+        if let Some(socket) = socket {
+            match probe_status(socket).await {
+                Ok(Some(info)) => return Ok(DaemonStartOutcome::Ready(info)),
+                Ok(None) => {}
+                Err(e) => tracing::debug!(error = %e, "readiness probe failed; retrying"),
+            }
+        }
+        if std::time::Instant::now() >= deadline {
+            return Ok(DaemonStartOutcome::NotReadyInTime { pid: child.id() });
+        }
+        tokio::time::sleep(READY_POLL_INTERVAL).await;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/apps/bitrouter/src/daemon.rs
+++ b/apps/bitrouter/src/daemon.rs
@@ -274,6 +274,59 @@ pub fn is_not_reachable(err: &anyhow::Error) -> bool {
     })
 }
 
+/// The daemon's self-reported readiness snapshot, returned by
+/// [`probe_status`]. A successful probe means the control socket is bound
+/// and the app is assembled (the model count is populated), which is exactly
+/// the signal `bitrouter status` reports.
+#[derive(Debug, Clone)]
+pub struct ReadyInfo {
+    /// The daemon's process id.
+    pub pid: u32,
+    /// The HTTP listen address.
+    pub listen: String,
+    /// Count of routable models.
+    pub models: usize,
+}
+
+/// Resolve the control-socket path for a `(source, cfg)` pair. For a `File`
+/// source the configured `server.control_socket` is resolved against the
+/// config file's directory; for a `Default` source the socket lives at
+/// `<home>/bitrouter.sock`. Single source of truth shared by `serve`,
+/// `start`, and `spawn`.
+pub fn socket_path_for(
+    source: &crate::paths::ConfigSource,
+    cfg: &bitrouter_sdk::config::Config,
+) -> PathBuf {
+    match source {
+        crate::paths::ConfigSource::File(path) => {
+            resolve_socket_path(path, &cfg.server.control_socket)
+        }
+        crate::paths::ConfigSource::Default { home } => home.join("bitrouter.sock"),
+    }
+}
+
+/// One-shot readiness probe: send `Status` and classify the reply.
+/// `Ok(Some(_))` = the daemon answered (it is up); `Ok(None)` = nothing is
+/// listening yet (not reachable — keep waiting); `Err` = a daemon is there but
+/// the exchange failed (a real error worth surfacing).
+pub async fn probe_status(socket: &Path) -> Result<Option<ReadyInfo>> {
+    match send_command(socket, &DaemonCommand::Status).await {
+        Ok(DaemonResponse::Status {
+            pid,
+            listen,
+            models,
+        }) => Ok(Some(ReadyInfo {
+            pid,
+            listen,
+            models,
+        })),
+        Ok(DaemonResponse::Error { message }) => Err(anyhow::anyhow!(message)),
+        Ok(other) => Err(anyhow::anyhow!("unexpected response: {other:?}")),
+        Err(e) if is_not_reachable(&e) => Ok(None),
+        Err(e) => Err(e),
+    }
+}
+
 // ===== server side =====
 
 /// Run the control listener until a `Stop` command is received (then it

--- a/apps/bitrouter/src/main.rs
+++ b/apps/bitrouter/src/main.rs
@@ -868,15 +868,10 @@ async fn serve(source: &bitrouter::paths::ConfigSource) -> Result<()> {
     announce_zero_config(source, &cfg);
     maybe_announce_telemetry(home);
     let listen = cfg.server.listen.clone();
-    // For a `File` source we resolve the socket against the config
-    // file's directory (preserves any user override). For `Default`
-    // the socket lives at `<home>/bitrouter.sock` directly.
-    let socket_path = match source {
-        bitrouter::paths::ConfigSource::File(path) => {
-            daemon::resolve_socket_path(path, &cfg.server.control_socket)
-        }
-        bitrouter::paths::ConfigSource::Default { home } => home.join("bitrouter.sock"),
-    };
+    // For a `File` source the socket is resolved against the config file's
+    // directory (preserves any user override); for `Default` it lives at
+    // `<home>/bitrouter.sock`. Shared with `start`/`spawn` via `socket_path_for`.
+    let socket_path = daemon::socket_path_for(source, &cfg);
     let pid_path = pid_path_for(&socket_path);
 
     let config_path_for_reload = match source {

--- a/apps/bitrouter/src/main.rs
+++ b/apps/bitrouter/src/main.rs
@@ -228,6 +228,11 @@ enum Command {
         /// command instead. (Auto-implied when stdin is not a TTY.)
         #[arg(long)]
         no_install: bool,
+        /// Never auto-start a local BitRouter daemon when none is running —
+        /// just warn. (A `--base-url` or non-local target is never auto-started
+        /// regardless.)
+        #[arg(long)]
+        no_start: bool,
         /// Arguments forwarded verbatim to the agent binary. Everything after
         /// `--` lands here.
         #[arg(last = true, allow_hyphen_values = true)]
@@ -593,17 +598,20 @@ async fn run() -> Result<()> {
             config,
             base_url,
             no_install,
+            no_start,
             agent_args,
         } => {
             let source = bitrouter::paths::resolve_config(config.as_deref())?;
             let cfg = bitrouter::paths::load_config(&source).await?;
             bitrouter::spawn::run(
+                &source,
                 &cfg,
                 bitrouter::spawn::SpawnOptions {
                     agent,
                     agent_args,
                     base_url,
                     no_install,
+                    no_start,
                 },
             )
             .await

--- a/apps/bitrouter/src/main.rs
+++ b/apps/bitrouter/src/main.rs
@@ -1041,10 +1041,10 @@ async fn start(source: &bitrouter::paths::ConfigSource, log_path: &Path) -> Resu
     // log file (the user wouldn't see it).
     let cfg_socket_path: Option<PathBuf> = match source {
         bitrouter::paths::ConfigSource::File(path) => match config::load(path).await {
-            Ok(cfg) => Some(daemon::resolve_socket_path(
-                path,
-                &cfg.server.control_socket,
-            )),
+            Ok(cfg) => Some(daemon::socket_path_for(source, &cfg)),
+            // Best-effort: a broken/env-incomplete config can't locate the
+            // socket, but `serve` would fail the same way → the child-death
+            // check below still surfaces it.
             Err(_) => None,
         },
         bitrouter::paths::ConfigSource::Default { home } => Some(home.join("bitrouter.sock")),
@@ -1062,71 +1062,51 @@ async fn start(source: &bitrouter::paths::ConfigSource, log_path: &Path) -> Resu
         }
     }
 
-    let exe = std::env::current_exe().context("locating current bitrouter binary")?;
-    // Capture the log's pre-spawn size so we can quote *this run's*
-    // output back to the user on early death instead of slurping
-    // stale content from prior runs (the log is opened append-only).
-    let log_size_before = std::fs::metadata(log_path).map(|m| m.len()).unwrap_or(0);
-    let log = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(log_path)
-        .with_context(|| format!("opening daemon log {}", log_path.display()))?;
-    let log_err = log
-        .try_clone()
-        .context("duplicating log handle for stderr")?;
+    // Launch the detached `serve` and poll its control socket until it is
+    // actually serving — so "started" only prints once the daemon can answer
+    // (config load + DB migrations + registry fetch all complete first).
+    let outcome = daemon::start_and_wait(
+        source,
+        log_path,
+        cfg_socket_path.as_deref(),
+        daemon::DAEMON_READY_TIMEOUT,
+    )
+    .await?;
 
-    // Detach the child so the launcher's console / terminal lifecycle does not
-    // take the daemon down with it. On Unix that means a new process group so
-    // the parent shell's SIGHUP (terminal close) does not propagate — otherwise
-    // closing the tab would kill the daemon. Pattern from
-    // https://doc.rust-lang.org/std/os/unix/process/trait.CommandExt.html#tymethod.process_group
-    // On Windows the equivalent is DETACHED_PROCESS (the child gets no inherited
-    // console) plus CREATE_NEW_PROCESS_GROUP (a Ctrl-C / Ctrl-Break in the
-    // launcher's console is not delivered to the daemon).
-    let mut cmd = std::process::Command::new(&exe);
-    cmd.arg("serve");
-    // For a `File` source pass `--config <abs path>` so the child
-    // loads the same file even though it'll chdir to the home. For
-    // `Default` (zero-config) skip the flag — the child re-runs
-    // `resolve_config`, finds no file, and arrives at the same
-    // zero-config state.
-    if let bitrouter::paths::ConfigSource::File(path) = source {
-        cmd.arg("--config").arg(path);
+    match outcome {
+        daemon::DaemonStartOutcome::Ready(info) => {
+            let p = bitrouter::style::Palette::for_stdout();
+            println!(
+                "{green}✓{reset} bitrouter daemon started (pid {pid}) — \
+                 listening on {listen}, {models} models — logs at {log}",
+                green = p.green,
+                reset = p.reset,
+                pid = info.pid,
+                listen = info.listen,
+                models = info.models,
+                log = log_path.display(),
+            );
+            Ok(())
+        }
+        // The process is alive but slow to answer — don't kill it; the daemon
+        // may still be migrating / fetching the registry. Report and exit 0.
+        daemon::DaemonStartOutcome::NotReadyInTime { pid } => {
+            let p = bitrouter::style::Palette::for_stderr();
+            eprintln!(
+                "{cyan}note:{reset} bitrouter daemon started (pid {pid}) but has not become \
+                 ready after {secs}s — check logs at {log}",
+                cyan = p.cyan,
+                reset = p.reset,
+                secs = daemon::DAEMON_READY_TIMEOUT.as_secs(),
+                log = log_path.display(),
+            );
+            Ok(())
+        }
+        daemon::DaemonStartOutcome::Exited { status, log_tail } => {
+            daemon::eprint_failure_log(log_path, &log_tail);
+            anyhow::bail!("daemon exited during startup ({status})")
+        }
     }
-    cmd.stdout(std::process::Stdio::from(log))
-        .stderr(std::process::Stdio::from(log_err))
-        .stdin(std::process::Stdio::null());
-    #[cfg(unix)]
-    {
-        use std::os::unix::process::CommandExt;
-        cmd.process_group(0);
-    }
-    #[cfg(windows)]
-    {
-        use std::os::windows::process::CommandExt;
-        // Winbase.h constants — avoid pulling in a `windows`/`winapi` crate.
-        const DETACHED_PROCESS: u32 = 0x0000_0008;
-        const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
-        cmd.creation_flags(DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP);
-    }
-    let mut child = cmd.spawn().context("spawning detached `bitrouter serve`")?;
-
-    // Liveness grace period: if the child explodes immediately (bad config,
-    // port already in use, …) we want the user to know now, not in the log.
-    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
-    if let Ok(Some(status)) = child.try_wait() {
-        let tail = read_log_since(log_path, log_size_before).await;
-        eprint_failure_log(log_path, &tail);
-        anyhow::bail!("daemon exited immediately ({status})");
-    }
-
-    println!(
-        "bitrouter daemon started (pid {}) — logs at {}",
-        child.id(),
-        log_path.display()
-    );
-    Ok(())
 }
 
 /// Tell the operator they're running zero-config — and exactly which
@@ -1243,46 +1223,6 @@ fn other_provider_env_var_hints() -> Vec<String> {
     vars.sort();
     vars.dedup();
     vars
-}
-
-/// Read the daemon log from `offset` to end. Used to recover the
-/// freshly-written failure output when the spawned child dies during
-/// the liveness grace period — the pre-spawn offset captured by
-/// [`start`] ensures we only quote *this* run's content even though
-/// the log is opened append-only and may carry history.
-///
-/// Returns an empty string on any read failure (missing file, permission
-/// error, decode hiccup) so the caller can fall back to a path-only
-/// hint without panicking on the user's worst day.
-async fn read_log_since(path: &Path, offset: u64) -> String {
-    let bytes = match tokio::fs::read(path).await {
-        Ok(b) => b,
-        Err(_) => return String::new(),
-    };
-    let start = (offset as usize).min(bytes.len());
-    String::from_utf8_lossy(&bytes[start..]).into_owned()
-}
-
-/// Print the daemon's tail-of-log to stderr as an indented, captioned
-/// block so the user sees the actual failure inline instead of being
-/// pointed at a log file they have to open separately. Silent no-op
-/// when there is nothing useful to show.
-fn eprint_failure_log(log_path: &Path, content: &str) {
-    let trimmed = content.trim_end();
-    if trimmed.is_empty() {
-        return;
-    }
-    let p = bitrouter::style::Palette::for_stderr();
-    eprintln!(
-        "{dim}daemon log ({path}):{reset}",
-        dim = p.dim,
-        path = log_path.display(),
-        reset = p.reset,
-    );
-    for line in trimmed.lines() {
-        eprintln!("  {line}");
-    }
-    eprintln!();
 }
 
 async fn stop(socket: &Path) -> Result<()> {

--- a/apps/bitrouter/src/spawn.rs
+++ b/apps/bitrouter/src/spawn.rs
@@ -113,14 +113,23 @@ pub struct SpawnOptions {
     /// When true, never offer to install a missing agent — error instead.
     /// (Set by `--no-install`, or implied when stdin is not a TTY.)
     pub no_install: bool,
+    /// When true, never auto-start a local daemon when none is running — just
+    /// warn. (Set by `--no-start`.) Has no effect for a non-local / `--base-url`
+    /// target, which is never auto-started regardless.
+    pub no_start: bool,
 }
 
 /// Run `bitrouter spawn`. Resolves the base URL from `cfg`, locates the agent
-/// binary (offering to install it if missing and permitted), then execs the
-/// agent with the routing environment injected. On success this **does not
-/// return** — it exits the process with the agent's exit code, the way a
-/// launcher like `git <subcommand>` propagates its child's status.
-pub async fn run(cfg: &bitrouter_sdk::config::Config, opts: SpawnOptions) -> Result<()> {
+/// binary (offering to install it if missing and permitted), ensures the local
+/// daemon is up (auto-starting it when down), then execs the agent with the
+/// routing environment injected. On success this **does not return** — it exits
+/// the process with the agent's exit code, the way a launcher like
+/// `git <subcommand>` propagates its child's status.
+pub async fn run(
+    source: &crate::paths::ConfigSource,
+    cfg: &bitrouter_sdk::config::Config,
+    opts: SpawnOptions,
+) -> Result<()> {
     let spec = opts.agent.spec();
 
     let base_url = match &opts.base_url {
@@ -131,10 +140,20 @@ pub async fn run(cfg: &bitrouter_sdk::config::Config, opts: SpawnOptions) -> Res
     // Locate the binary; prompt-to-install when it's missing.
     let binary = ensure_agent_installed(opts.agent, opts.no_install).await?;
 
-    // Best-effort reachability note — never blocks the launch. The agent
-    // would fail on its own if the daemon is down; surfacing it up front is
-    // friendlier than a wall of HTTP errors inside the agent.
-    warn_if_daemon_unreachable(&cfg.server.listen);
+    // Make sure the daemon the agent will talk to is up. For the local daemon
+    // we own (derived base URL + a loopback/wildcard bind), probe its control
+    // socket and auto-start it when down; for an explicit `--base-url` or a
+    // non-local bind we can only warn — we can't start someone else's daemon.
+    if opts.base_url.is_none() && listen_is_local(&cfg.server.listen) {
+        ensure_local_daemon(source, cfg, opts.no_start).await;
+    } else {
+        let target = opts
+            .base_url
+            .as_deref()
+            .and_then(listen_from_base_url)
+            .unwrap_or_else(|| cfg.server.listen.clone());
+        warn_if_daemon_unreachable(&target);
+    }
 
     // Auth-token precedence (highest first): an auth token the user already
     // exported for this agent → the BitRouter API key → a local placeholder.
@@ -244,6 +263,109 @@ fn rewrite_host(host: &str) -> &str {
         "0.0.0.0" | "" => "127.0.0.1",
         "::" | "[::]" => "[::1]",
         other => other,
+    }
+}
+
+/// True when `listen` binds a loopback / wildcard address — i.e. a daemon on
+/// *this* host that `bitrouter spawn` may auto-start. A remote or LAN host is
+/// someone else's daemon, which we can only warn about. Exact-match only:
+/// `127.0.0.0/8` aliases (e.g. `127.0.0.2`) and IPv4-mapped IPv6 fall through to
+/// the warn path — the fail-safe direction (never a wrong auto-start).
+fn listen_is_local(listen: &str) -> bool {
+    let (host, _port) = split_listen(listen);
+    matches!(
+        host,
+        "127.0.0.1" | "0.0.0.0" | "" | "::1" | "[::1]" | "::" | "[::]" | "localhost"
+    )
+}
+
+/// Extract the `host[:port]` authority from a base URL for a best-effort
+/// reachability note. Returns `None` when there is no authority to probe.
+fn listen_from_base_url(url: &str) -> Option<String> {
+    let rest = url
+        .strip_prefix("http://")
+        .or_else(|| url.strip_prefix("https://"))
+        .unwrap_or(url);
+    let authority = rest.split('/').next().unwrap_or(rest);
+    (!authority.is_empty()).then(|| authority.to_string())
+}
+
+/// Ensure the local BitRouter daemon is up before launching the agent. Probes
+/// the control socket; when nothing is listening (and `--no-start` was not
+/// given) it prints a hint and auto-starts a detached `serve`, waiting for
+/// readiness. Best-effort throughout: on any failure it warns and returns so
+/// the agent still launches (and surfaces its own connection error) — matching
+/// spawn's "never block the launch" stance.
+async fn ensure_local_daemon(
+    source: &crate::paths::ConfigSource,
+    cfg: &bitrouter_sdk::config::Config,
+    no_start: bool,
+) {
+    let socket = crate::daemon::socket_path_for(source, cfg);
+    match crate::daemon::probe_status(&socket).await {
+        // Already running — nothing to do.
+        Ok(Some(_)) => {}
+        // Definitively not reachable — auto-start unless opted out.
+        Ok(None) => {
+            let p = Palette::for_stderr();
+            if no_start {
+                warn_if_daemon_unreachable(&cfg.server.listen);
+                return;
+            }
+            eprintln!(
+                "{cyan}note:{reset} no BitRouter daemon is running — starting one…",
+                cyan = p.cyan,
+                reset = p.reset,
+            );
+            let log_path = source.home().join("bitrouter.log");
+            match crate::daemon::start_and_wait(
+                source,
+                &log_path,
+                Some(&socket),
+                crate::daemon::DAEMON_READY_TIMEOUT,
+            )
+            .await
+            {
+                Ok(crate::daemon::DaemonStartOutcome::Ready(info)) => {
+                    eprintln!(
+                        "{cyan}note:{reset} BitRouter daemon ready (pid {})",
+                        info.pid,
+                        cyan = p.cyan,
+                        reset = p.reset,
+                    );
+                }
+                Ok(crate::daemon::DaemonStartOutcome::NotReadyInTime { pid }) => {
+                    eprintln!(
+                        "{cyan}note:{reset} daemon started (pid {pid}) but is not ready yet — \
+                         the agent may need a moment; logs at {}",
+                        log_path.display(),
+                        cyan = p.cyan,
+                        reset = p.reset,
+                    );
+                }
+                Ok(crate::daemon::DaemonStartOutcome::Exited { status, log_tail }) => {
+                    eprintln!(
+                        "{cyan}note:{reset} daemon exited during startup ({status}) — \
+                         launching the agent anyway",
+                        cyan = p.cyan,
+                        reset = p.reset,
+                    );
+                    crate::daemon::eprint_failure_log(&log_path, &log_tail);
+                }
+                Err(e) => {
+                    eprintln!(
+                        "{cyan}note:{reset} could not start the daemon ({e:#}) — \
+                         launching the agent anyway",
+                        cyan = p.cyan,
+                        reset = p.reset,
+                    );
+                }
+            }
+        }
+        // Reachable but the exchange errored — assume it's up; don't double-start.
+        Err(e) => {
+            tracing::debug!(error = %e, "daemon status probe errored; assuming up");
+        }
     }
 }
 
@@ -521,6 +643,46 @@ impl InstallCommand {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn listen_is_local_classifies_loopback_and_wildcard() {
+        for local in [
+            "127.0.0.1:4356",
+            "0.0.0.0:4356",
+            "[::1]:4356",
+            "[::]:4356",
+            "localhost:4356",
+            "127.0.0.1",
+        ] {
+            assert!(listen_is_local(local), "{local} should be local");
+        }
+        for remote in [
+            "router.internal:8080",
+            "192.168.1.5:4356",
+            "10.0.0.3:4356",
+            "example.com:443",
+        ] {
+            assert!(!listen_is_local(remote), "{remote} should be remote");
+        }
+    }
+
+    #[test]
+    fn listen_from_base_url_extracts_authority() {
+        assert_eq!(
+            listen_from_base_url("http://127.0.0.1:4356").as_deref(),
+            Some("127.0.0.1:4356")
+        );
+        assert_eq!(
+            listen_from_base_url("https://router.example.com/v1").as_deref(),
+            Some("router.example.com")
+        );
+        // No scheme → treated as a bare authority.
+        assert_eq!(
+            listen_from_base_url("127.0.0.1:4356").as_deref(),
+            Some("127.0.0.1:4356")
+        );
+        assert_eq!(listen_from_base_url(""), None);
+    }
 
     #[test]
     fn base_url_rewrites_wildcard_bind_to_loopback() {

--- a/apps/bitrouter/tests/daemon.rs
+++ b/apps/bitrouter/tests/daemon.rs
@@ -178,6 +178,50 @@ async fn status_route_and_stop_roundtrip_over_the_control_socket() {
 }
 
 #[tokio::test]
+async fn probe_status_reports_ready_when_daemon_is_up() {
+    let dir = tempdir("probe-up");
+    let cfg_path = write_config(&dir, "sqlite::memory:").await;
+    let cfg = config::load(&cfg_path).await.unwrap();
+    let assembled = build_app_with_path(&cfg, Some(&cfg_path)).await.unwrap();
+    let app = Arc::new(assembled.app);
+
+    let socket = dir.join("bitrouter.sock");
+    let server = tokio::spawn(daemon::run_control_socket(
+        socket.clone(),
+        app.clone(),
+        "127.0.0.1:1234".to_string(),
+        Arc::new(NoopReloader),
+        Arc::new(NoopObserveStatus { compiled_in: false }),
+    ));
+    wait_until_ready(&socket).await;
+
+    // A daemon is up → the probe returns its self-report.
+    let info = daemon::probe_status(&socket)
+        .await
+        .unwrap()
+        .expect("probe should see the running daemon");
+    assert_eq!(info.listen, "127.0.0.1:1234");
+    assert_eq!(info.models, 2, "gpt-5 + shared");
+
+    let stop = daemon::send_command(&socket, &DaemonCommand::Stop)
+        .await
+        .unwrap();
+    assert!(matches!(stop, DaemonResponse::Ok));
+    server.await.unwrap().unwrap();
+    let _ = tokio::fs::remove_dir_all(&dir).await;
+}
+
+#[tokio::test]
+async fn probe_status_reports_none_when_nothing_listens() {
+    let dir = tempdir("probe-down");
+    // The socket path is never bound — the probe must classify this as
+    // "not reachable" (Ok(None)), not an error.
+    let socket = dir.join("bitrouter.sock");
+    assert!(daemon::probe_status(&socket).await.unwrap().is_none());
+    let _ = tokio::fs::remove_dir_all(&dir).await;
+}
+
+#[tokio::test]
 async fn reload_re_reads_the_config_file() {
     let dir = tempdir("reload");
     let cfg_path = write_config(&dir, "sqlite::memory:").await;


### PR DESCRIPTION
## What & why

Two rough edges in the daemon CLI:

1. **`bitrouter start` reported success before the daemon was actually up.** `serve` binds its control socket only after `load_config` → `merge_registry_into` (a best-effort network fetch) → `build_app_with_path`. `start` slept a fixed **250 ms**, checked only that the child hadn't crashed, and printed `bitrouter daemon started …` — so a follow-up `status`/request could race a not-yet-listening daemon.
2. **`bitrouter spawn` didn't help start the daemon.** When the daemon was down it printed a note and launched the agent anyway, which then failed with connection errors.

## Changes

**`start` now waits for readiness.** It polls the control socket until it answers `Status` (the same oracle `bitrouter status` uses) instead of sleeping a fixed interval, then prints the daemon's facts:

```
✓ bitrouter daemon started (pid 40864) — listening on 127.0.0.1:14357, 7 models — logs at ~/.bitrouter/bitrouter.log
```

- Crash during startup → the daemon log tail is printed and `start` exits non-zero (preserved).
- Alive but not ready after the 15 s budget → a note is printed and `start` exits 0 (the daemon keeps coming up; killing it would be wrong). 15 s covers a cold registry fetch + DB migrations.

**`spawn` auto-starts the local daemon.** When the target is the local daemon (a derived base URL on a loopback/wildcard bind) and its control socket doesn't answer, `spawn` prints a hint, launches a detached `serve`, and waits for readiness before handing off to the agent:

```
note: no BitRouter daemon is running — starting one…
note: BitRouter daemon ready (pid 40955)
spawn: launching claude via BitRouter (http://127.0.0.1:14357)
```

- Best-effort: if auto-start times out or the daemon crashes, `spawn` warns (with the log tail) and still launches the agent — matching spawn's existing "never block the launch" stance.
- `--no-start` opts out (a reachability warning is printed instead).
- An explicit `--base-url` or a non-local bind is **never** auto-started — BitRouter can't start someone else's daemon — and only gets a reachability warning against the effective target.

## Shared primitives (DRY)

The launch + readiness logic is factored into the `daemon` lib module so `start` (binary) and `spawn` (lib) share one implementation:

- `socket_path_for(source, cfg)` — single source of truth for the control-socket path (was duplicated in `serve`/`start`).
- `probe_status(socket) -> Result<Option<ReadyInfo>>` — one-shot readiness oracle.
- `start_and_wait(source, log_path, socket, timeout) -> Result<DaemonStartOutcome>` — launches a detached `serve` and polls until `Ready` / `NotReadyInTime` / `Exited{status, log_tail}`. Ensures the home dir exists but never chdirs the calling process.
- `eprint_failure_log` relocated from `main.rs` so both callers reuse it.

`main.rs::start` is now a thin orchestrator; the old inline detached-spawn block and `read_log_since` are removed.

## Tests

- `tests/daemon.rs`: `probe_status` returns the self-report against a live control socket, and `None` when nothing is listening.
- `spawn.rs` unit tests: `listen_is_local` (loopback/wildcard vs LAN/public) and `listen_from_base_url` (scheme/path/empty).
- Manually smoke-tested on a dedicated port: start blocks until ready then prints the model count; spawn auto-starts when down, reuses a running daemon, warns under `--no-start`, and warns about the override target for `--base-url`.

`cargo test -p bitrouter`, `cargo clippy -p bitrouter --all-targets`, and `cargo build -p bitrouter --all-targets` are all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
