### PR TITLE
feat(spawn): model overrides, presets, and a generic IR

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -178,12 +178,21 @@ Stdio bridge between an ACP-aware editor and a configured upstream agent. The ed
 ### `bitrouter spawn`
 
 ```
-bitrouter spawn -a <agent> [-c <path>] [--base-url <url>] [--no-install] [--no-start] -- <agent args…>
+bitrouter spawn -a <agent> [-c <path>] [--base-url <url>] [--no-install] [--no-start] [--preset <name>] [--model <spec>]… -- <agent args…>
 ```
 
-Launches a coding-agent harness (`-a claude` for Claude Code) as a child process with its gateway base URL pointed at BitRouter, so the agent's traffic routes through the router **without touching the agent's own config files** — only the child process environment is set (`ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN`). Following `cargo run`'s convention, everything after `--` is forwarded to the agent verbatim, e.g. `bitrouter spawn -a claude -- -p "summarize" --dangerously-skip-permissions`.
+Launches a coding-agent harness (`-a claude` for Claude Code) as a child process with its gateway base URL pointed at BitRouter, so the agent's traffic routes through the router **without touching the agent's own config files** — only the child process environment is set (`ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN`, plus any model overrides). Following `cargo run`'s convention, everything after `--` is forwarded to the agent verbatim, e.g. `bitrouter spawn -a claude -- -p "summarize" --dangerously-skip-permissions`.
 
 The agent authenticates to BitRouter with `BITROUTER_API_KEY` when set; otherwise a local placeholder is used (fine under the `skip_auth` default written by `bitrouter init`). A missing agent binary is offered for install via its official native installer (`--no-install`, or a non-TTY stdin, declines).
+
+**Model overrides.** By default the harness uses its own default models (Claude Code's bare `claude-*` ids, which the daemon routes to the subscription). To run it on other BitRouter models — e.g. cheaper open-weight ones — supply a model plan over three generic capability tiers, `high` / `mid` / `low` (for Claude these map to the `opus` / `sonnet` / `haiku` slots; those names are accepted as aliases):
+
+- `--model <id>` sets **every** tier to `<id>`; `--model <tier>=<id>` sets one tier (repeatable), e.g. `--model low=opencode-go/glm-5.1-air`.
+- `--preset <name>` applies a named tier→model map from the `spawn.presets` config block.
+- Environment: `BITROUTER_SPAWN_PRESET` (a preset name) and `BITROUTER_SPAWN_MODEL` (a bare id → every tier).
+- Config: a `spawn.model` default plan and `spawn.presets` named maps in `bitrouter.yaml`.
+
+Sources merge **per tier**, lowest priority first: `spawn.model` → `BITROUTER_SPAWN_PRESET` → `BITROUTER_SPAWN_MODEL` → `--preset` → `--model`. With nothing set, no model env vars are injected and routing is unchanged. For Claude these become `ANTHROPIC_DEFAULT_{OPUS,SONNET,HAIKU}_MODEL`, which remap what each alias and the picker's Default resolve to (see <https://code.claude.com/docs/en/model-config#environment-variables>).
 
 When the target is the local daemon (a derived base URL on a loopback/wildcard bind) and none is running, `spawn` **auto-starts it** — printing a hint, launching a detached `serve`, and waiting for readiness before handing off to the agent. Pass `--no-start` to skip this (a reachability warning is printed instead). An explicit `--base-url` or a non-local bind is never auto-started — BitRouter can't start someone else's daemon — and only gets a warning if it looks unreachable.
 

--- a/apps/bitrouter/src/commands.rs
+++ b/apps/bitrouter/src/commands.rs
@@ -569,9 +569,10 @@ async fn run_claude_code_session()
         );
     }
 
-    let claude = crate::spawn::ensure_agent_installed(crate::spawn::SpawnAgent::Claude, false)
-        .await
-        .context("locating the claude CLI to sign you in")?;
+    let claude =
+        crate::spawn::agent::ensure_agent_installed(crate::spawn::agent::SpawnAgent::Claude, false)
+            .await
+            .context("locating the claude CLI to sign you in")?;
 
     eprintln!("  You're not signed in to Claude Code yet — launching `claude auth login`.");
     let status = tokio::process::Command::new(&claude)

--- a/apps/bitrouter/src/main.rs
+++ b/apps/bitrouter/src/main.rs
@@ -212,7 +212,7 @@ enum Command {
     Spawn {
         /// Which agent harness to launch.
         #[arg(short, long, value_enum)]
-        agent: bitrouter::spawn::SpawnAgent,
+        agent: bitrouter::spawn::agent::SpawnAgent,
         /// Path to `bitrouter.yaml` (used to derive the daemon base URL).
         /// When omitted, the binary resolves in this order: `./bitrouter.yaml`
         /// → `$BITROUTER_HOME/bitrouter.yaml` → `~/.bitrouter/bitrouter.yaml`
@@ -233,6 +233,19 @@ enum Command {
         /// regardless.)
         #[arg(long)]
         no_start: bool,
+        /// Apply a named preset from the `spawn.presets` config block, e.g.
+        /// `--preset cheap`. A preset is a tier→model combination; individual
+        /// `--model` flags override it per tier. Overrides the config default
+        /// plan and `BITROUTER_SPAWN_PRESET`.
+        #[arg(long)]
+        preset: Option<String>,
+        /// Override the agent's model for one or all capability tiers
+        /// (repeatable, highest priority). `--model <id>` sets every tier to
+        /// `<id>`; `--model <tier>=<id>` sets one tier — `high`/`mid`/`low`, or
+        /// the Claude aliases `opus`/`sonnet`/`haiku` — e.g.
+        /// `--model low=opencode-go/glm-5.1-air`.
+        #[arg(short = 'm', long = "model", value_name = "SPEC")]
+        models: Vec<String>,
         /// Arguments forwarded verbatim to the agent binary. Everything after
         /// `--` lands here.
         #[arg(last = true, allow_hyphen_values = true)]
@@ -599,6 +612,8 @@ async fn run() -> Result<()> {
             base_url,
             no_install,
             no_start,
+            preset,
+            models,
             agent_args,
         } => {
             let source = bitrouter::paths::resolve_config(config.as_deref())?;
@@ -612,6 +627,8 @@ async fn run() -> Result<()> {
                     base_url,
                     no_install,
                     no_start,
+                    preset,
+                    models,
                 },
             )
             .await

--- a/apps/bitrouter/src/spawn/agent.rs
+++ b/apps/bitrouter/src/spawn/agent.rs
@@ -1,0 +1,473 @@
+//! Per-agent static facts and install machinery for `bitrouter spawn`.
+//!
+//! [`SpawnAgent`] is the set of coding-agent harnesses `spawn` can launch (v1
+//! ships Claude Code only); [`AgentSpec`] is the resolved per-agent metadata the
+//! launcher drives — the binary name, the routing env vars, and the
+//! [agent-model IR](super::model_plan) tier → env-var mapping. The dispatch,
+//! env-injection, and install code is written against this metadata rather than
+//! hard-coded to one agent, so adding `codex` / `gemini` later is a matter of
+//! extending the per-agent matches here.
+
+use std::ffi::OsString;
+use std::io::IsTerminal;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use clap::ValueEnum;
+
+use crate::spawn::model_plan::ModelTier;
+use crate::style::Palette;
+
+/// The coding-agent harnesses `bitrouter spawn` can launch. v1 ships Claude
+/// Code only; the enum is the extension point for `codex` / `gemini` later, so
+/// the dispatch, env-injection, and install machinery is written against the
+/// [`AgentSpec`] metadata rather than hard-coded to one agent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum SpawnAgent {
+    /// Anthropic's Claude Code CLI (`claude`).
+    Claude,
+}
+
+impl SpawnAgent {
+    /// Static metadata describing how to find, route, and install this agent.
+    pub fn spec(self) -> AgentSpec {
+        match self {
+            SpawnAgent::Claude => AgentSpec {
+                agent: self,
+                // The display id matches the `--agent` value.
+                id: "claude",
+                // The executable name looked up on `PATH`.
+                binary: "claude",
+                // Claude Code reads its gateway endpoint from
+                // `ANTHROPIC_BASE_URL`, and authenticates to that gateway with
+                // `ANTHROPIC_AUTH_TOKEN` (sent as the `Authorization: Bearer`
+                // header) — this is the documented way to route Claude Code
+                // through a custom LLM gateway, and `Authorization: Bearer` is
+                // exactly the inbound credential BitRouter expects (`brk_…`).
+                // `ANTHROPIC_API_KEY` would instead be sent as `x-api-key`, the
+                // first-party Anthropic header, which is not BitRouter's inbound
+                // scheme — so we deliberately set the auth token, not the API key.
+                // https://code.claude.com/docs/en/llm-gateway#authentication-methods
+                base_url_env: "ANTHROPIC_BASE_URL",
+                auth_token_env: "ANTHROPIC_AUTH_TOKEN",
+            },
+        }
+    }
+
+    /// Parse a user-facing model-tier label into a generic [`ModelTier`].
+    ///
+    /// The canonical, agent-neutral labels are `high` / `mid` / `low`; each
+    /// agent may also accept its own familiar aliases. Claude Code maps the
+    /// three Anthropic capability names onto the tiers: `opus` → high,
+    /// `sonnet` → mid, `haiku` → low. Matching is case-insensitive and trims
+    /// surrounding whitespace. Returns `None` for an unrecognised label.
+    pub fn parse_tier(self, label: &str) -> Option<ModelTier> {
+        let label = label.trim().to_ascii_lowercase();
+        match self {
+            SpawnAgent::Claude => match label.as_str() {
+                "high" | "opus" => Some(ModelTier::High),
+                "mid" | "sonnet" => Some(ModelTier::Mid),
+                "low" | "haiku" => Some(ModelTier::Low),
+                _ => None,
+            },
+        }
+    }
+
+    /// A human-readable list of the tier labels this agent accepts, for error
+    /// messages.
+    pub fn tier_labels(self) -> &'static str {
+        match self {
+            SpawnAgent::Claude => "high|mid|low (aliases: opus|sonnet|haiku)",
+        }
+    }
+}
+
+/// Resolved, per-agent static facts used by the spawn machinery.
+#[derive(Debug, Clone, Copy)]
+pub struct AgentSpec {
+    /// Which agent this describes.
+    pub agent: SpawnAgent,
+    /// Catalog id / `--agent` value.
+    pub id: &'static str,
+    /// Executable name searched for on `PATH`.
+    pub binary: &'static str,
+    /// Env var the agent reads its gateway base URL from.
+    pub base_url_env: &'static str,
+    /// Env var the agent reads its gateway bearer token from (sent as
+    /// `Authorization: Bearer`), which is BitRouter's inbound auth scheme.
+    pub auth_token_env: &'static str,
+}
+
+impl AgentSpec {
+    /// The environment variable this agent reads the model for `tier` from, or
+    /// `None` when the agent does not model that tier.
+    ///
+    /// Claude Code remaps what each capability alias — and the picker's
+    /// `Default` option — resolves to via the `ANTHROPIC_DEFAULT_*_MODEL`
+    /// variables, so setting all three redirects the whole agent while
+    /// preserving its tiered behaviour (heavy reasoning → opus slot, default
+    /// work → sonnet slot, background → haiku slot). See the Claude Code model
+    /// configuration reference:
+    /// <https://code.claude.com/docs/en/model-config#environment-variables>.
+    pub fn tier_env(&self, tier: ModelTier) -> Option<&'static str> {
+        match self.agent {
+            SpawnAgent::Claude => Some(match tier {
+                ModelTier::High => "ANTHROPIC_DEFAULT_OPUS_MODEL",
+                ModelTier::Mid => "ANTHROPIC_DEFAULT_SONNET_MODEL",
+                ModelTier::Low => "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+            }),
+        }
+    }
+}
+
+/// Locate an executable on `PATH`. Pure-`std` (no `which` crate) so the
+/// `#![forbid(unsafe_code)]` lib stays dependency-light: split `$PATH` and
+/// probe each entry. Returns the first match.
+fn resolve_binary(name: &str) -> Option<PathBuf> {
+    find_on_path(name, std::env::var_os("PATH"), &extra_search_dirs())
+}
+
+/// Core of [`resolve_binary`], factored out for testing. Searches `path` (an
+/// `OsString` of `PATH`-separated dirs) followed by `extra` directories —
+/// the latter covers the native installer's target (`~/.local/bin`), which is
+/// often not yet on `PATH` in the shell that just ran the install.
+fn find_on_path(name: &str, path: Option<OsString>, extra: &[PathBuf]) -> Option<PathBuf> {
+    let mut dirs: Vec<PathBuf> = Vec::new();
+    if let Some(path) = path {
+        dirs.extend(std::env::split_paths(&path));
+    }
+    dirs.extend(extra.iter().cloned());
+    for dir in dirs {
+        let candidate = dir.join(name);
+        if is_executable_file(&candidate) {
+            return Some(candidate);
+        }
+        // On Windows, executables carry an extension. We probe the common
+        // launcher extensions rather than parsing the full `%PATHEXT%` set —
+        // agent CLIs ship as `.exe` or an npm `.cmd`/`.bat` shim, which these
+        // cover; an exotic `%PATHEXT%` entry (`.com`, `.ps1`) would be missed.
+        #[cfg(windows)]
+        {
+            for ext in ["exe", "cmd", "bat"] {
+                let with_ext = dir.join(format!("{name}.{ext}"));
+                if is_executable_file(&with_ext) {
+                    return Some(with_ext);
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Directories to probe in addition to `PATH`. The Claude Code native
+/// installer drops the binary in `~/.local/bin`, which a freshly-installed
+/// shell session may not have on `PATH` yet.
+fn extra_search_dirs() -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+    if let Some(home) = home_dir() {
+        dirs.push(home.join(".local").join("bin"));
+    }
+    dirs
+}
+
+/// True when `path` is a regular file we can plausibly execute. On Unix this
+/// checks the executable permission bit; on other platforms, file existence.
+fn is_executable_file(path: &std::path::Path) -> bool {
+    let Ok(meta) = std::fs::metadata(path) else {
+        return false;
+    };
+    if !meta.is_file() {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        meta.permissions().mode() & 0o111 != 0
+    }
+    #[cfg(not(unix))]
+    {
+        true
+    }
+}
+
+/// Resolve the user's home directory without pulling in a crate: `$HOME` on
+/// Unix, `%USERPROFILE%` on Windows.
+fn home_dir() -> Option<PathBuf> {
+    #[cfg(windows)]
+    {
+        std::env::var_os("USERPROFILE").map(PathBuf::from)
+    }
+    #[cfg(not(windows))]
+    {
+        std::env::var_os("HOME").map(PathBuf::from)
+    }
+}
+
+/// Ensure `agent`'s binary is installed — locating it on `PATH` (+
+/// `~/.local/bin`) and offering the official native installer when permitted —
+/// and return its path. Shared by `bitrouter spawn` and `bitrouter login
+/// anthropic` (which needs the `claude` CLI to sign the user in) so both go
+/// through one detect-and-install path.
+pub(crate) async fn ensure_agent_installed(agent: SpawnAgent, no_install: bool) -> Result<PathBuf> {
+    let spec = agent.spec();
+    match resolve_binary(spec.binary) {
+        Some(path) => Ok(path),
+        None => ensure_installed(&spec, no_install).await,
+    }
+}
+
+/// The agent binary is missing. Offer to install it via the official native
+/// installer when stdin is interactive and `--no-install` was not set;
+/// otherwise return an actionable error listing the install command.
+async fn ensure_installed(spec: &AgentSpec, no_install: bool) -> Result<PathBuf> {
+    let install = InstallCommand::for_agent(spec.agent);
+
+    let may_prompt = !no_install && std::io::stdin().is_terminal();
+    if !may_prompt {
+        anyhow::bail!(
+            "agent '{}' is not installed (no `{}` on PATH).\n  Install it with:\n    {}",
+            spec.id,
+            spec.binary,
+            install.display(),
+        );
+    }
+
+    if !confirm_install(spec, &install)? {
+        anyhow::bail!("aborted — '{}' was not installed", spec.id);
+    }
+
+    install.run().await?;
+
+    // Re-resolve after install. The installer may have landed the binary in
+    // `~/.local/bin` (covered by `extra_search_dirs`) even when that dir is
+    // not on the current shell's `PATH`.
+    resolve_binary(spec.binary).ok_or_else(|| {
+        anyhow::anyhow!(
+            "installed '{}' but still cannot find `{}` on PATH or in ~/.local/bin — \
+             open a new shell (or add the install dir to PATH) and re-run",
+            spec.id,
+            spec.binary,
+        )
+    })
+}
+
+/// Print the install prompt and read a Y/n answer. Defaults to yes on a bare
+/// <enter>. A closed stdin (EOF) is treated as "no" so we never hang.
+fn confirm_install(spec: &AgentSpec, install: &InstallCommand) -> Result<bool> {
+    use std::io::{BufRead, Write};
+    let p = Palette::for_stderr();
+    eprintln!(
+        "{cyan}{bold}info:{reset} agent `{}` is not installed on this machine.",
+        spec.id,
+        cyan = p.cyan,
+        bold = p.bold,
+        reset = p.reset,
+    );
+    eprintln!("  Installer: {}", install.display());
+    eprint!("Proceed to install? [Y/n]: ");
+    std::io::stderr().flush().ok();
+
+    let stdin = std::io::stdin();
+    let mut line = String::new();
+    let n = stdin
+        .lock()
+        .read_line(&mut line)
+        .context("reading install confirmation from stdin")?;
+    if n == 0 {
+        // EOF — non-interactive; decline rather than block.
+        eprintln!();
+        return Ok(false);
+    }
+    let answer = line.trim().to_ascii_lowercase();
+    Ok(answer.is_empty() || answer == "y" || answer == "yes")
+}
+
+/// A platform-specific install command for an agent. Conditional compilation
+/// makes exactly one variant visible per platform, so the help text and the
+/// executed command never disagree with the host.
+#[derive(Debug, Clone)]
+pub struct InstallCommand {
+    /// Program to run (`bash` / `powershell`).
+    program: &'static str,
+    /// Arguments to that program.
+    args: Vec<String>,
+    /// Human-readable one-liner, e.g. `curl -fsSL … | bash`.
+    human: String,
+}
+
+impl InstallCommand {
+    /// The official native installer for `agent` on the *current* platform.
+    ///
+    /// Sources (Claude Code quickstart, "Native Install"):
+    /// <https://code.claude.com/docs/en/quickstart>
+    /// - macOS / Linux: `curl -fsSL https://claude.ai/install.sh | bash`
+    /// - Windows:       `irm https://claude.ai/install.ps1 | iex`
+    pub fn for_agent(agent: SpawnAgent) -> Self {
+        match agent {
+            SpawnAgent::Claude => Self::claude(),
+        }
+    }
+
+    #[cfg(not(windows))]
+    fn claude() -> Self {
+        let human = "curl -fsSL https://claude.ai/install.sh | bash".to_string();
+        Self {
+            program: "bash",
+            args: vec![
+                "-c".to_string(),
+                "curl -fsSL https://claude.ai/install.sh | bash".to_string(),
+            ],
+            human,
+        }
+    }
+
+    #[cfg(windows)]
+    fn claude() -> Self {
+        let human = "irm https://claude.ai/install.ps1 | iex".to_string();
+        Self {
+            program: "powershell",
+            args: vec![
+                "-NoProfile".to_string(),
+                "-Command".to_string(),
+                "irm https://claude.ai/install.ps1 | iex".to_string(),
+            ],
+            human,
+        }
+    }
+
+    /// The human-readable one-liner shown in prompts and error messages.
+    pub fn display(&self) -> &str {
+        &self.human
+    }
+
+    /// Execute the installer, inheriting stdio so the user sees its progress.
+    /// Errors when the installer exits non-zero.
+    async fn run(&self) -> Result<()> {
+        let p = Palette::for_stderr();
+        eprintln!(
+            "{cyan}spawn:{reset} installing — {}",
+            self.human,
+            cyan = p.cyan,
+            reset = p.reset,
+        );
+        let status = tokio::process::Command::new(self.program)
+            .args(&self.args)
+            .status()
+            .await
+            .with_context(|| format!("running installer: {}", self.human))?;
+        if !status.success() {
+            anyhow::bail!("installer exited with {status}: {}", self.human);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn claude_spec_uses_anthropic_env_vars() {
+        let spec = SpawnAgent::Claude.spec();
+        assert_eq!(spec.binary, "claude");
+        assert_eq!(spec.base_url_env, "ANTHROPIC_BASE_URL");
+        assert_eq!(spec.auth_token_env, "ANTHROPIC_AUTH_TOKEN");
+    }
+
+    #[test]
+    fn parse_tier_accepts_canonical_and_anthropic_aliases() {
+        let a = SpawnAgent::Claude;
+        // Canonical, agent-neutral labels.
+        assert_eq!(a.parse_tier("high"), Some(ModelTier::High));
+        assert_eq!(a.parse_tier("mid"), Some(ModelTier::Mid));
+        assert_eq!(a.parse_tier("low"), Some(ModelTier::Low));
+        // Anthropic-name aliases.
+        assert_eq!(a.parse_tier("opus"), Some(ModelTier::High));
+        assert_eq!(a.parse_tier("sonnet"), Some(ModelTier::Mid));
+        assert_eq!(a.parse_tier("haiku"), Some(ModelTier::Low));
+        // Case-insensitive + whitespace-trimmed.
+        assert_eq!(a.parse_tier("  OPUS "), Some(ModelTier::High));
+    }
+
+    #[test]
+    fn parse_tier_rejects_unknown_label() {
+        assert_eq!(SpawnAgent::Claude.parse_tier("turbo"), None);
+        assert_eq!(SpawnAgent::Claude.parse_tier(""), None);
+    }
+
+    #[test]
+    fn tier_env_maps_claude_tiers_to_default_model_vars() {
+        let spec = SpawnAgent::Claude.spec();
+        assert_eq!(
+            spec.tier_env(ModelTier::High),
+            Some("ANTHROPIC_DEFAULT_OPUS_MODEL")
+        );
+        assert_eq!(
+            spec.tier_env(ModelTier::Mid),
+            Some("ANTHROPIC_DEFAULT_SONNET_MODEL")
+        );
+        assert_eq!(
+            spec.tier_env(ModelTier::Low),
+            Some("ANTHROPIC_DEFAULT_HAIKU_MODEL")
+        );
+    }
+
+    #[test]
+    fn install_command_is_the_official_native_installer() {
+        let cmd = InstallCommand::for_agent(SpawnAgent::Claude);
+        // Same canonical URL on every platform; the transport differs.
+        assert!(cmd.display().contains("claude.ai/install"));
+        #[cfg(not(windows))]
+        {
+            assert!(cmd.display().contains("install.sh"));
+            assert!(cmd.display().contains("| bash"));
+        }
+        #[cfg(windows)]
+        {
+            assert!(cmd.display().contains("install.ps1"));
+        }
+    }
+
+    #[test]
+    fn find_on_path_locates_executable_in_listed_dir() {
+        let dir = std::env::temp_dir().join(format!("bitrouter-spawn-path-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let bin = dir.join("fake-agent");
+        std::fs::write(&bin, b"#!/bin/sh\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        let path = std::env::join_paths([dir.as_os_str()]).unwrap();
+        let found = find_on_path("fake-agent", Some(path), &[]);
+        assert_eq!(found.as_deref(), Some(bin.as_path()));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn find_on_path_returns_none_when_absent() {
+        let path = std::env::join_paths([std::env::temp_dir().as_os_str()]).unwrap();
+        assert!(find_on_path("definitely-not-a-real-binary-xyz", Some(path), &[]).is_none());
+    }
+
+    #[test]
+    fn find_on_path_falls_back_to_extra_dirs() {
+        // The post-install re-resolution relies on `extra` (e.g. ~/.local/bin)
+        // even when PATH is empty — exercise that path explicitly.
+        let dir =
+            std::env::temp_dir().join(format!("bitrouter-spawn-extra-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let bin = dir.join("fake-agent");
+        std::fs::write(&bin, b"#!/bin/sh\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        // PATH is None entirely; the binary is only reachable via `extra`.
+        let found = find_on_path("fake-agent", None, std::slice::from_ref(&dir));
+        assert_eq!(found.as_deref(), Some(bin.as_path()));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/apps/bitrouter/src/spawn/mod.rs
+++ b/apps/bitrouter/src/spawn/mod.rs
@@ -17,6 +17,17 @@
 //!
 //! Everything after `--` is handed to the agent binary verbatim.
 //!
+//! ## Model overrides
+//!
+//! By default the launched agent uses its own default models (for Claude Code,
+//! the bare `claude-*` ids that the daemon routes to the subscription). A user
+//! can instead point the agent at arbitrary BitRouter models — expressed as
+//! generic capability tiers ([`model_plan::ModelTier`]) and supplied via the
+//! config file, environment variables, or `--preset` / `--model` flags. The
+//! selection (the [`model_plan`] IR) is resolved independently of how it reaches
+//! a given harness ([`agent::AgentSpec::tier_env`]), so the feature is generic
+//! across agents.
+//!
 //! ## Claude Code integration
 //!
 //! - `ANTHROPIC_BASE_URL` redirects the Anthropic SDK Claude Code uses to an
@@ -25,72 +36,27 @@
 //! - Install commands are the official native installers documented in the
 //!   Claude Code quickstart: <https://code.claude.com/docs/en/quickstart>.
 
-use std::ffi::OsString;
-use std::io::IsTerminal;
-use std::path::PathBuf;
+pub mod agent;
+pub mod model_plan;
 
 use anyhow::{Context, Result};
-use clap::ValueEnum;
 
+use crate::spawn::agent::{AgentSpec, SpawnAgent, ensure_agent_installed};
+use crate::spawn::model_plan::ModelPlan;
 use crate::style::Palette;
-
-/// The coding-agent harnesses `bitrouter spawn` can launch. v1 ships Claude
-/// Code only; the enum is the extension point for `codex` / `gemini` later, so
-/// the dispatch, env-injection, and install machinery is written against the
-/// [`AgentSpec`] metadata rather than hard-coded to one agent.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
-pub enum SpawnAgent {
-    /// Anthropic's Claude Code CLI (`claude`).
-    Claude,
-}
-
-impl SpawnAgent {
-    /// Static metadata describing how to find, route, and install this agent.
-    pub fn spec(self) -> AgentSpec {
-        match self {
-            SpawnAgent::Claude => AgentSpec {
-                agent: self,
-                // The display id matches the `--agent` value.
-                id: "claude",
-                // The executable name looked up on `PATH`.
-                binary: "claude",
-                // Claude Code reads its gateway endpoint from
-                // `ANTHROPIC_BASE_URL`, and authenticates to that gateway with
-                // `ANTHROPIC_AUTH_TOKEN` (sent as the `Authorization: Bearer`
-                // header) — this is the documented way to route Claude Code
-                // through a custom LLM gateway, and `Authorization: Bearer` is
-                // exactly the inbound credential BitRouter expects (`brk_…`).
-                // `ANTHROPIC_API_KEY` would instead be sent as `x-api-key`, the
-                // first-party Anthropic header, which is not BitRouter's inbound
-                // scheme — so we deliberately set the auth token, not the API key.
-                // https://code.claude.com/docs/en/llm-gateway#authentication-methods
-                base_url_env: "ANTHROPIC_BASE_URL",
-                auth_token_env: "ANTHROPIC_AUTH_TOKEN",
-            },
-        }
-    }
-}
-
-/// Resolved, per-agent static facts used by the spawn machinery.
-#[derive(Debug, Clone, Copy)]
-pub struct AgentSpec {
-    /// Which agent this describes.
-    pub agent: SpawnAgent,
-    /// Catalog id / `--agent` value.
-    pub id: &'static str,
-    /// Executable name searched for on `PATH`.
-    pub binary: &'static str,
-    /// Env var the agent reads its gateway base URL from.
-    pub base_url_env: &'static str,
-    /// Env var the agent reads its gateway bearer token from (sent as
-    /// `Authorization: Bearer`), which is BitRouter's inbound auth scheme.
-    pub auth_token_env: &'static str,
-}
 
 /// BitRouter's own API-key env var (`brk_…`). When set, we forward it to the
 /// agent as the gateway bearer token so the agent authenticates to BitRouter
 /// with the user's real credential instead of the placeholder.
 const BITROUTER_API_KEY_ENV: &str = "BITROUTER_API_KEY";
+
+/// Environment variable naming a `spawn.presets` entry to apply (overrides the
+/// config default plan, overridden by the `--preset` flag).
+const SPAWN_PRESET_ENV: &str = "BITROUTER_SPAWN_PRESET";
+
+/// Environment variable holding a single model id applied to every tier
+/// (overrides a preset, overridden by `--model`).
+const SPAWN_MODEL_ENV: &str = "BITROUTER_SPAWN_MODEL";
 
 /// A sentinel placeholder credential, injected into the agent's environment
 /// only when the user has neither set the agent's auth-token var nor exported a
@@ -117,13 +83,19 @@ pub struct SpawnOptions {
     /// warn. (Set by `--no-start`.) Has no effect for a non-local / `--base-url`
     /// target, which is never auto-started regardless.
     pub no_start: bool,
+    /// `--preset <name>`: a `spawn.presets` entry to apply on top of the config
+    /// default plan / environment overrides. `None` when not given.
+    pub preset: Option<String>,
+    /// `--model <SPEC>` flags (repeatable): a bare `<id>` sets every tier; a
+    /// `<tier>=<id>` sets one tier. Applied last (highest priority).
+    pub models: Vec<String>,
 }
 
-/// Run `bitrouter spawn`. Resolves the base URL from `cfg`, locates the agent
-/// binary (offering to install it if missing and permitted), ensures the local
-/// daemon is up (auto-starting it when down), then execs the agent with the
-/// routing environment injected. On success this **does not return** — it exits
-/// the process with the agent's exit code, the way a launcher like
+/// Run `bitrouter spawn`. Resolves the base URL and the model plan, locates the
+/// agent binary (offering to install it if missing and permitted), ensures the
+/// local daemon is up (auto-starting it when down), then execs the agent with
+/// the routing environment injected. On success this **does not return** — it
+/// exits the process with the agent's exit code, the way a launcher like
 /// `git <subcommand>` propagates its child's status.
 pub async fn run(
     source: &crate::paths::ConfigSource,
@@ -136,6 +108,17 @@ pub async fn run(
         Some(explicit) => explicit.clone(),
         None => derive_base_url(&cfg.server.listen),
     };
+
+    // Resolve the model plan before anything with side effects (install /
+    // daemon start), so a typo in a preset name or `--model` flag fails fast.
+    let plan = model_plan::resolve(
+        opts.agent,
+        &cfg.spawn,
+        nonempty_env(SPAWN_PRESET_ENV),
+        nonempty_env(SPAWN_MODEL_ENV),
+        opts.preset.as_deref(),
+        &opts.models,
+    )?;
 
     // Locate the binary; prompt-to-install when it's missing.
     let binary = ensure_agent_installed(opts.agent, opts.no_install).await?;
@@ -159,7 +142,7 @@ pub async fn run(
     // exported for this agent → the BitRouter API key → a local placeholder.
     let parent_auth = nonempty_env(spec.auth_token_env);
     let bitrouter_key = nonempty_env(BITROUTER_API_KEY_ENV);
-    let env = build_child_env(&spec, &base_url, parent_auth, bitrouter_key);
+    let env = build_child_env(&spec, &base_url, parent_auth, bitrouter_key, &plan);
 
     let p = Palette::for_stderr();
     eprintln!(
@@ -170,6 +153,15 @@ pub async fn run(
         bold = p.bold,
         reset = p.reset,
     );
+    if !plan.is_empty() {
+        let overrides: Vec<String> = plan.iter().map(|(t, m)| format!("{t}={m}")).collect();
+        eprintln!(
+            "{cyan}spawn:{reset} model overrides — {}",
+            overrides.join(", "),
+            cyan = p.cyan,
+            reset = p.reset,
+        );
+    }
 
     let mut cmd = tokio::process::Command::new(&binary);
     cmd.args(&opts.agent_args);
@@ -194,30 +186,41 @@ pub async fn run(
 }
 
 /// Build the environment overrides layered on top of the inherited parent
-/// environment: always force the routing base URL, and resolve the gateway
-/// bearer token by precedence.
+/// environment: always force the routing base URL, resolve the gateway bearer
+/// token by precedence, and append any model-plan tier overrides.
 ///
 /// Returned as an explicit list (rather than mutating the global env) so the
 /// logic is unit-testable. `parent_auth` is any auth token the user already
 /// exported for the agent; `bitrouter_key` is the value of `BITROUTER_API_KEY`.
-/// Precedence: `parent_auth` → `bitrouter_key` → placeholder. We always set the
-/// auth token (never just inherit) so that an inherited `ANTHROPIC_API_KEY`
+/// Auth precedence: `parent_auth` → `bitrouter_key` → placeholder. We always set
+/// the auth token (never just inherit) so that an inherited `ANTHROPIC_API_KEY`
 /// (which in this repo is the *upstream* Anthropic provider key, not a valid
-/// BitRouter inbound credential) cannot accidentally become the auth Claude
-/// Code sends to the router.
+/// BitRouter inbound credential) cannot accidentally become the auth Claude Code
+/// sends to the router. An empty `plan` adds no model vars — the harness then
+/// uses its own default models.
 fn build_child_env(
     spec: &AgentSpec,
     base_url: &str,
     parent_auth: Option<String>,
     bitrouter_key: Option<String>,
+    plan: &ModelPlan,
 ) -> Vec<(&'static str, String)> {
     let token = parent_auth
         .or(bitrouter_key)
         .unwrap_or_else(|| PLACEHOLDER_API_KEY.to_string());
-    vec![
+    let mut env = vec![
         (spec.base_url_env, base_url.to_string()),
         (spec.auth_token_env, token),
-    ]
+    ];
+    // Layer the resolved model plan on top: each selected tier becomes the
+    // agent's corresponding model env var. A tier the agent does not model
+    // (tier_env → None) is skipped.
+    for (tier, model) in plan.iter() {
+        if let Some(var) = spec.tier_env(tier) {
+            env.push((var, model.to_string()));
+        }
+    }
+    env
 }
 
 /// Read an environment variable, treating an unset *or empty* value as absent.
@@ -369,168 +372,6 @@ async fn ensure_local_daemon(
     }
 }
 
-/// Locate an executable on `PATH`. Pure-`std` (no `which` crate) so the
-/// `#![forbid(unsafe_code)]` lib stays dependency-light: split `$PATH` and
-/// probe each entry. Returns the first match.
-fn resolve_binary(name: &str) -> Option<PathBuf> {
-    find_on_path(name, std::env::var_os("PATH"), &extra_search_dirs())
-}
-
-/// Core of [`resolve_binary`], factored out for testing. Searches `path` (an
-/// `OsString` of `PATH`-separated dirs) followed by `extra` directories —
-/// the latter covers the native installer's target (`~/.local/bin`), which is
-/// often not yet on `PATH` in the shell that just ran the install.
-fn find_on_path(name: &str, path: Option<OsString>, extra: &[PathBuf]) -> Option<PathBuf> {
-    let mut dirs: Vec<PathBuf> = Vec::new();
-    if let Some(path) = path {
-        dirs.extend(std::env::split_paths(&path));
-    }
-    dirs.extend(extra.iter().cloned());
-    for dir in dirs {
-        let candidate = dir.join(name);
-        if is_executable_file(&candidate) {
-            return Some(candidate);
-        }
-        // On Windows, executables carry an extension. We probe the common
-        // launcher extensions rather than parsing the full `%PATHEXT%` set —
-        // agent CLIs ship as `.exe` or an npm `.cmd`/`.bat` shim, which these
-        // cover; an exotic `%PATHEXT%` entry (`.com`, `.ps1`) would be missed.
-        #[cfg(windows)]
-        {
-            for ext in ["exe", "cmd", "bat"] {
-                let with_ext = dir.join(format!("{name}.{ext}"));
-                if is_executable_file(&with_ext) {
-                    return Some(with_ext);
-                }
-            }
-        }
-    }
-    None
-}
-
-/// Directories to probe in addition to `PATH`. The Claude Code native
-/// installer drops the binary in `~/.local/bin`, which a freshly-installed
-/// shell session may not have on `PATH` yet.
-fn extra_search_dirs() -> Vec<PathBuf> {
-    let mut dirs = Vec::new();
-    if let Some(home) = home_dir() {
-        dirs.push(home.join(".local").join("bin"));
-    }
-    dirs
-}
-
-/// True when `path` is a regular file we can plausibly execute. On Unix this
-/// checks the executable permission bit; on other platforms, file existence.
-fn is_executable_file(path: &std::path::Path) -> bool {
-    let Ok(meta) = std::fs::metadata(path) else {
-        return false;
-    };
-    if !meta.is_file() {
-        return false;
-    }
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        meta.permissions().mode() & 0o111 != 0
-    }
-    #[cfg(not(unix))]
-    {
-        true
-    }
-}
-
-/// Resolve the user's home directory without pulling in a crate: `$HOME` on
-/// Unix, `%USERPROFILE%` on Windows.
-fn home_dir() -> Option<PathBuf> {
-    #[cfg(windows)]
-    {
-        std::env::var_os("USERPROFILE").map(PathBuf::from)
-    }
-    #[cfg(not(windows))]
-    {
-        std::env::var_os("HOME").map(PathBuf::from)
-    }
-}
-
-/// Ensure `agent`'s binary is installed — locating it on `PATH` (+
-/// `~/.local/bin`) and offering the official native installer when permitted —
-/// and return its path. Shared by `bitrouter spawn` and `bitrouter login
-/// anthropic` (which needs the `claude` CLI to sign the user in) so both go
-/// through one detect-and-install path.
-pub(crate) async fn ensure_agent_installed(agent: SpawnAgent, no_install: bool) -> Result<PathBuf> {
-    let spec = agent.spec();
-    match resolve_binary(spec.binary) {
-        Some(path) => Ok(path),
-        None => ensure_installed(&spec, no_install).await,
-    }
-}
-
-/// The agent binary is missing. Offer to install it via the official native
-/// installer when stdin is interactive and `--no-install` was not set;
-/// otherwise return an actionable error listing the install command.
-async fn ensure_installed(spec: &AgentSpec, no_install: bool) -> Result<PathBuf> {
-    let install = InstallCommand::for_agent(spec.agent);
-
-    let may_prompt = !no_install && std::io::stdin().is_terminal();
-    if !may_prompt {
-        anyhow::bail!(
-            "agent '{}' is not installed (no `{}` on PATH).\n  Install it with:\n    {}",
-            spec.id,
-            spec.binary,
-            install.display(),
-        );
-    }
-
-    if !confirm_install(spec, &install)? {
-        anyhow::bail!("aborted — '{}' was not installed", spec.id);
-    }
-
-    install.run().await?;
-
-    // Re-resolve after install. The installer may have landed the binary in
-    // `~/.local/bin` (covered by `extra_search_dirs`) even when that dir is
-    // not on the current shell's `PATH`.
-    resolve_binary(spec.binary).ok_or_else(|| {
-        anyhow::anyhow!(
-            "installed '{}' but still cannot find `{}` on PATH or in ~/.local/bin — \
-             open a new shell (or add the install dir to PATH) and re-run",
-            spec.id,
-            spec.binary,
-        )
-    })
-}
-
-/// Print the install prompt and read a Y/n answer. Defaults to yes on a bare
-/// <enter>. A closed stdin (EOF) is treated as "no" so we never hang.
-fn confirm_install(spec: &AgentSpec, install: &InstallCommand) -> Result<bool> {
-    use std::io::{BufRead, Write};
-    let p = Palette::for_stderr();
-    eprintln!(
-        "{cyan}{bold}info:{reset} agent `{}` is not installed on this machine.",
-        spec.id,
-        cyan = p.cyan,
-        bold = p.bold,
-        reset = p.reset,
-    );
-    eprintln!("  Installer: {}", install.display());
-    eprint!("Proceed to install? [Y/n]: ");
-    std::io::stderr().flush().ok();
-
-    let stdin = std::io::stdin();
-    let mut line = String::new();
-    let n = stdin
-        .lock()
-        .read_line(&mut line)
-        .context("reading install confirmation from stdin")?;
-    if n == 0 {
-        // EOF — non-interactive; decline rather than block.
-        eprintln!();
-        return Ok(false);
-    }
-    let answer = line.trim().to_ascii_lowercase();
-    Ok(answer.is_empty() || answer == "y" || answer == "yes")
-}
-
 /// Best-effort TCP reachability probe against the daemon's listen address.
 /// Prints a one-line warning when nothing is listening; never errors.
 fn warn_if_daemon_unreachable(listen: &str) {
@@ -557,86 +398,6 @@ fn warn_if_daemon_unreachable(listen: &str) {
             cyan = p.cyan,
             reset = p.reset,
         );
-    }
-}
-
-/// A platform-specific install command for an agent. Conditional compilation
-/// makes exactly one variant visible per platform, so the help text and the
-/// executed command never disagree with the host.
-#[derive(Debug, Clone)]
-pub struct InstallCommand {
-    /// Program to run (`bash` / `powershell`).
-    program: &'static str,
-    /// Arguments to that program.
-    args: Vec<String>,
-    /// Human-readable one-liner, e.g. `curl -fsSL … | bash`.
-    human: String,
-}
-
-impl InstallCommand {
-    /// The official native installer for `agent` on the *current* platform.
-    ///
-    /// Sources (Claude Code quickstart, "Native Install"):
-    /// <https://code.claude.com/docs/en/quickstart>
-    /// - macOS / Linux: `curl -fsSL https://claude.ai/install.sh | bash`
-    /// - Windows:       `irm https://claude.ai/install.ps1 | iex`
-    pub fn for_agent(agent: SpawnAgent) -> Self {
-        match agent {
-            SpawnAgent::Claude => Self::claude(),
-        }
-    }
-
-    #[cfg(not(windows))]
-    fn claude() -> Self {
-        let human = "curl -fsSL https://claude.ai/install.sh | bash".to_string();
-        Self {
-            program: "bash",
-            args: vec![
-                "-c".to_string(),
-                "curl -fsSL https://claude.ai/install.sh | bash".to_string(),
-            ],
-            human,
-        }
-    }
-
-    #[cfg(windows)]
-    fn claude() -> Self {
-        let human = "irm https://claude.ai/install.ps1 | iex".to_string();
-        Self {
-            program: "powershell",
-            args: vec![
-                "-NoProfile".to_string(),
-                "-Command".to_string(),
-                "irm https://claude.ai/install.ps1 | iex".to_string(),
-            ],
-            human,
-        }
-    }
-
-    /// The human-readable one-liner shown in prompts and error messages.
-    pub fn display(&self) -> &str {
-        &self.human
-    }
-
-    /// Execute the installer, inheriting stdio so the user sees its progress.
-    /// Errors when the installer exits non-zero.
-    async fn run(&self) -> Result<()> {
-        let p = Palette::for_stderr();
-        eprintln!(
-            "{cyan}spawn:{reset} installing — {}",
-            self.human,
-            cyan = p.cyan,
-            reset = p.reset,
-        );
-        let status = tokio::process::Command::new(self.program)
-            .args(&self.args)
-            .status()
-            .await
-            .with_context(|| format!("running installer: {}", self.human))?;
-        if !status.success() {
-            anyhow::bail!("installer exited with {status}: {}", self.human);
-        }
-        Ok(())
     }
 }
 
@@ -708,10 +469,15 @@ mod tests {
         assert_eq!(derive_base_url("[::1]"), "http://[::1]:4356");
     }
 
+    /// A default (empty) model plan — the common case where no override is set.
+    fn empty_plan() -> ModelPlan {
+        ModelPlan::default()
+    }
+
     #[test]
     fn child_env_always_sets_base_url() {
         let spec = SpawnAgent::Claude.spec();
-        let env = build_child_env(&spec, "http://127.0.0.1:4356", None, None);
+        let env = build_child_env(&spec, "http://127.0.0.1:4356", None, None, &empty_plan());
         assert!(
             env.iter()
                 .any(|(k, v)| *k == "ANTHROPIC_BASE_URL" && v == "http://127.0.0.1:4356")
@@ -735,15 +501,22 @@ mod tests {
             "http://x:1",
             Some("user-token".into()),
             Some("brk_key".into()),
+            &empty_plan(),
         );
         assert_eq!(auth_token(&explicit).as_deref(), Some("user-token"));
 
         // No explicit token → fall back to the BitRouter API key.
-        let from_key = build_child_env(&spec, "http://x:1", None, Some("brk_key".into()));
+        let from_key = build_child_env(
+            &spec,
+            "http://x:1",
+            None,
+            Some("brk_key".into()),
+            &empty_plan(),
+        );
         assert_eq!(auth_token(&from_key).as_deref(), Some("brk_key"));
 
         // Neither set → the local placeholder so the harness still starts.
-        let placeholder = build_child_env(&spec, "http://x:1", None, None);
+        let placeholder = build_child_env(&spec, "http://x:1", None, None, &empty_plan());
         assert_eq!(
             auth_token(&placeholder).as_deref(),
             Some(PLACEHOLDER_API_KEY)
@@ -755,75 +528,43 @@ mod tests {
         // The auth token is ALWAYS set explicitly, so a stray inherited
         // ANTHROPIC_API_KEY can never silently become the inbound credential.
         let spec = SpawnAgent::Claude.spec();
-        let env = build_child_env(&spec, "http://x:1", None, None);
+        let env = build_child_env(&spec, "http://x:1", None, None, &empty_plan());
         assert!(env.iter().any(|(k, _)| *k == "ANTHROPIC_AUTH_TOKEN"));
         assert!(env.iter().all(|(k, _)| *k != "ANTHROPIC_API_KEY"));
     }
 
     #[test]
-    fn claude_spec_uses_anthropic_env_vars() {
+    fn empty_plan_adds_only_base_url_and_auth() {
         let spec = SpawnAgent::Claude.spec();
-        assert_eq!(spec.binary, "claude");
-        assert_eq!(spec.base_url_env, "ANTHROPIC_BASE_URL");
-        assert_eq!(spec.auth_token_env, "ANTHROPIC_AUTH_TOKEN");
+        let env = build_child_env(&spec, "http://x:1", None, None, &empty_plan());
+        assert_eq!(env.len(), 2, "no model vars for an empty plan");
     }
 
     #[test]
-    fn install_command_is_the_official_native_installer() {
-        let cmd = InstallCommand::for_agent(SpawnAgent::Claude);
-        // Same canonical URL on every platform; the transport differs.
-        assert!(cmd.display().contains("claude.ai/install"));
-        #[cfg(not(windows))]
-        {
-            assert!(cmd.display().contains("install.sh"));
-            assert!(cmd.display().contains("| bash"));
-        }
-        #[cfg(windows)]
-        {
-            assert!(cmd.display().contains("install.ps1"));
-        }
-    }
-
-    #[test]
-    fn find_on_path_locates_executable_in_listed_dir() {
-        let dir = std::env::temp_dir().join(format!("bitrouter-spawn-path-{}", std::process::id()));
-        std::fs::create_dir_all(&dir).unwrap();
-        let bin = dir.join("fake-agent");
-        std::fs::write(&bin, b"#!/bin/sh\n").unwrap();
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
-        }
-        let path = std::env::join_paths([dir.as_os_str()]).unwrap();
-        let found = find_on_path("fake-agent", Some(path), &[]);
-        assert_eq!(found.as_deref(), Some(bin.as_path()));
-        let _ = std::fs::remove_dir_all(&dir);
-    }
-
-    #[test]
-    fn find_on_path_returns_none_when_absent() {
-        let path = std::env::join_paths([std::env::temp_dir().as_os_str()]).unwrap();
-        assert!(find_on_path("definitely-not-a-real-binary-xyz", Some(path), &[]).is_none());
-    }
-
-    #[test]
-    fn find_on_path_falls_back_to_extra_dirs() {
-        // The post-install re-resolution relies on `extra` (e.g. ~/.local/bin)
-        // even when PATH is empty — exercise that path explicitly.
-        let dir =
-            std::env::temp_dir().join(format!("bitrouter-spawn-extra-{}", std::process::id()));
-        std::fs::create_dir_all(&dir).unwrap();
-        let bin = dir.join("fake-agent");
-        std::fs::write(&bin, b"#!/bin/sh\n").unwrap();
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
-        }
-        // PATH is None entirely; the binary is only reachable via `extra`.
-        let found = find_on_path("fake-agent", None, std::slice::from_ref(&dir));
-        assert_eq!(found.as_deref(), Some(bin.as_path()));
-        let _ = std::fs::remove_dir_all(&dir);
+    fn child_env_appends_resolved_model_plan() {
+        let spec = SpawnAgent::Claude.spec();
+        let plan = model_plan::resolve(
+            SpawnAgent::Claude,
+            &bitrouter_sdk::config::SpawnConfig::default(),
+            None,
+            None,
+            None,
+            &["low=prov/air".to_string(), "high=prov/big".to_string()],
+        )
+        .unwrap();
+        let env = build_child_env(&spec, "http://x:1", None, None, &plan);
+        assert!(
+            env.iter()
+                .any(|(k, v)| *k == "ANTHROPIC_DEFAULT_HAIKU_MODEL" && v == "prov/air")
+        );
+        assert!(
+            env.iter()
+                .any(|(k, v)| *k == "ANTHROPIC_DEFAULT_OPUS_MODEL" && v == "prov/big")
+        );
+        // The unset `mid` tier must not produce a sonnet var.
+        assert!(
+            env.iter()
+                .all(|(k, _)| *k != "ANTHROPIC_DEFAULT_SONNET_MODEL")
+        );
     }
 }

--- a/apps/bitrouter/src/spawn/model_plan.rs
+++ b/apps/bitrouter/src/spawn/model_plan.rs
@@ -1,0 +1,449 @@
+//! The agent-agnostic model-selection IR for `bitrouter spawn`.
+//!
+//! A [`ModelPlan`] is a partial map from a generic capability [`ModelTier`] to a
+//! BitRouter model id. [`resolve`] builds one by merging, low-priority first:
+//!
+//! 1. the configured default plan (`spawn.model`),
+//! 2. the `BITROUTER_SPAWN_PRESET` environment preset,
+//! 3. the `BITROUTER_SPAWN_MODEL` environment model (a bare id → every tier),
+//! 4. the `--preset` CLI preset, and
+//! 5. the `--model` CLI flags (`<id>` → every tier, `<tier>=<id>` → one tier).
+//!
+//! Later layers override earlier ones **per tier**. The resulting plan is then
+//! translated into a specific harness's model environment variables by that
+//! agent's binding ([`AgentSpec::tier_env`](super::agent::AgentSpec::tier_env)).
+//!
+//! Keeping the tier vocabulary here — distinct from both the config layer (which
+//! stores raw `label → model` strings) and the per-agent env-var mapping — is
+//! what makes the override feature generic across harnesses even though only
+//! Claude Code exists today.
+
+use std::collections::{BTreeMap, HashMap};
+
+use anyhow::{Result, anyhow, bail};
+use bitrouter_sdk::config::SpawnConfig;
+
+use crate::spawn::agent::SpawnAgent;
+
+/// A generic capability tier, ordered most→least capable. Agent-agnostic: each
+/// agent maps a tier to its own concrete model env var (see
+/// [`AgentSpec::tier_env`](super::agent::AgentSpec::tier_env)).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ModelTier {
+    /// Most capable / heaviest tier. Claude Code: the `opus` slot.
+    High,
+    /// Default working tier. Claude Code: the `sonnet` slot.
+    Mid,
+    /// Cheapest / background tier. Claude Code: the `haiku` slot.
+    Low,
+}
+
+impl ModelTier {
+    /// Every tier, high→low. Used when a single bare model id applies to all
+    /// tiers.
+    pub const ALL: [ModelTier; 3] = [ModelTier::High, ModelTier::Mid, ModelTier::Low];
+
+    /// The canonical, agent-neutral label for this tier.
+    pub fn canonical(self) -> &'static str {
+        match self {
+            ModelTier::High => "high",
+            ModelTier::Mid => "mid",
+            ModelTier::Low => "low",
+        }
+    }
+}
+
+impl std::fmt::Display for ModelTier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.canonical())
+    }
+}
+
+/// A resolved model selection: tier → BitRouter model id. Partial — unset tiers
+/// fall through to the harness's own defaults.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ModelPlan {
+    tiers: BTreeMap<ModelTier, String>,
+}
+
+impl ModelPlan {
+    /// True when no tier is set — the launcher then injects no model env vars,
+    /// reproducing the harness's default model behaviour.
+    pub fn is_empty(&self) -> bool {
+        self.tiers.is_empty()
+    }
+
+    /// Iterate `(tier, model)` pairs, high→low.
+    pub fn iter(&self) -> impl Iterator<Item = (ModelTier, &str)> {
+        self.tiers.iter().map(|(t, m)| (*t, m.as_str()))
+    }
+
+    /// Set one tier, overwriting any previous value (later layers win).
+    fn set(&mut self, tier: ModelTier, model: String) {
+        self.tiers.insert(tier, model);
+    }
+}
+
+/// Build the final [`ModelPlan`] for one `bitrouter spawn` invocation by merging
+/// all override sources in precedence order (see the module docs). `env_preset`
+/// / `env_model` are the values of `BITROUTER_SPAWN_PRESET` /
+/// `BITROUTER_SPAWN_MODEL` (passed in rather than read here so the resolver is
+/// pure and unit-testable); `cli_preset` / `cli_models` are the `--preset` and
+/// `--model` flags.
+pub fn resolve(
+    agent: SpawnAgent,
+    spawn_cfg: &SpawnConfig,
+    env_preset: Option<String>,
+    env_model: Option<String>,
+    cli_preset: Option<&str>,
+    cli_models: &[String],
+) -> Result<ModelPlan> {
+    let mut plan = ModelPlan::default();
+
+    // 1. Config default plan (lowest priority).
+    apply_label_map(&mut plan, agent, &spawn_cfg.model, "spawn.model")?;
+
+    // 2. Environment preset.
+    if let Some(name) = env_preset.as_deref() {
+        apply_preset(&mut plan, agent, spawn_cfg, name, "BITROUTER_SPAWN_PRESET")?;
+    }
+
+    // 3. Environment bare model → every tier.
+    if let Some(model) = env_model.as_deref() {
+        let model = model.trim();
+        if model.is_empty() {
+            bail!("BITROUTER_SPAWN_MODEL is set but empty");
+        }
+        apply_bare(&mut plan, model);
+    }
+
+    // 4. CLI preset.
+    if let Some(name) = cli_preset {
+        apply_preset(&mut plan, agent, spawn_cfg, name, "--preset")?;
+    }
+
+    // 5. CLI `--model` flags (highest priority).
+    for spec in cli_models {
+        apply_model_spec(&mut plan, agent, spec)?;
+    }
+
+    Ok(plan)
+}
+
+/// Apply a raw `tier-label → model-id` map (a config default plan or a preset
+/// body) onto `plan`. Labels are validated against the agent; an unknown label,
+/// an empty model id, or two labels resolving to the same tier are all hard
+/// errors. Entries are processed in sorted-label order so error messages are
+/// deterministic.
+fn apply_label_map(
+    plan: &mut ModelPlan,
+    agent: SpawnAgent,
+    map: &HashMap<String, String>,
+    source: &str,
+) -> Result<()> {
+    let mut entries: Vec<(&String, &String)> = map.iter().collect();
+    entries.sort_by(|a, b| a.0.cmp(b.0));
+
+    // Track tiers set *within this source* to catch e.g. both `high:` and
+    // `opus:` (which collide on the same tier) instead of silently picking one.
+    let mut seen: BTreeMap<ModelTier, &str> = BTreeMap::new();
+    for (label, model) in entries {
+        let tier = agent.parse_tier(label).ok_or_else(|| {
+            anyhow!(
+                "unknown model tier '{label}' in {source}; valid tiers: {}",
+                agent.tier_labels()
+            )
+        })?;
+        let model = model.trim();
+        if model.is_empty() {
+            bail!("empty model id for tier '{label}' in {source}");
+        }
+        if let Some(prev) = seen.insert(tier, label) {
+            bail!(
+                "tier '{tier}' set twice in {source} (labels '{prev}' and '{label}' both map to it)"
+            );
+        }
+        plan.set(tier, model.to_string());
+    }
+    Ok(())
+}
+
+/// Look up a named preset in `spawn_cfg.presets` and apply its body. An unknown
+/// name is a hard error listing the defined presets.
+fn apply_preset(
+    plan: &mut ModelPlan,
+    agent: SpawnAgent,
+    spawn_cfg: &SpawnConfig,
+    name: &str,
+    source: &str,
+) -> Result<()> {
+    let body = spawn_cfg.presets.get(name).ok_or_else(|| {
+        let mut names: Vec<&str> = spawn_cfg.presets.keys().map(String::as_str).collect();
+        names.sort_unstable();
+        let defined = if names.is_empty() {
+            "(none defined under spawn.presets)".to_string()
+        } else {
+            names.join(", ")
+        };
+        anyhow!("unknown spawn preset '{name}' (from {source}); defined presets: {defined}")
+    })?;
+    apply_label_map(plan, agent, body, &format!("preset '{name}'"))
+}
+
+/// Apply one `--model` flag: `tier=id` sets a single tier; a bare `id` sets
+/// every tier.
+fn apply_model_spec(plan: &mut ModelPlan, agent: SpawnAgent, spec: &str) -> Result<()> {
+    match spec.split_once('=') {
+        Some((label, id)) => {
+            let tier = agent.parse_tier(label).ok_or_else(|| {
+                anyhow!(
+                    "unknown model tier '{}' in --model '{spec}'; valid tiers: {}",
+                    label.trim(),
+                    agent.tier_labels()
+                )
+            })?;
+            let id = id.trim();
+            if id.is_empty() {
+                bail!("empty model id in --model '{spec}'");
+            }
+            plan.set(tier, id.to_string());
+        }
+        None => {
+            let id = spec.trim();
+            if id.is_empty() {
+                bail!("empty --model value");
+            }
+            apply_bare(plan, id);
+        }
+    }
+    Ok(())
+}
+
+/// Set every tier to `model` (the bare-single-model override).
+fn apply_bare(plan: &mut ModelPlan, model: &str) {
+    for tier in ModelTier::ALL {
+        plan.set(tier, model.to_string());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CLAUDE: SpawnAgent = SpawnAgent::Claude;
+
+    /// Build a `SpawnConfig` from `(name, [(tier, model)])` preset specs and an
+    /// optional default-plan spec.
+    fn cfg(default_plan: &[(&str, &str)], presets: &[(&str, &[(&str, &str)])]) -> SpawnConfig {
+        let mut c = SpawnConfig::default();
+        for (k, v) in default_plan {
+            c.model.insert((*k).to_string(), (*v).to_string());
+        }
+        for (name, body) in presets {
+            let map = body
+                .iter()
+                .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+                .collect();
+            c.presets.insert((*name).to_string(), map);
+        }
+        c
+    }
+
+    /// Collect a plan into a sorted `Vec<(tier, model)>` for easy assertions.
+    fn pairs(plan: &ModelPlan) -> Vec<(ModelTier, String)> {
+        plan.iter().map(|(t, m)| (t, m.to_string())).collect()
+    }
+
+    fn resolve_ok(
+        c: &SpawnConfig,
+        env_preset: Option<&str>,
+        env_model: Option<&str>,
+        cli_preset: Option<&str>,
+        cli_models: &[&str],
+    ) -> ModelPlan {
+        let cli: Vec<String> = cli_models.iter().map(|s| s.to_string()).collect();
+        resolve(
+            CLAUDE,
+            c,
+            env_preset.map(str::to_string),
+            env_model.map(str::to_string),
+            cli_preset,
+            &cli,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn empty_when_nothing_set() {
+        let plan = resolve_ok(&SpawnConfig::default(), None, None, None, &[]);
+        assert!(plan.is_empty());
+    }
+
+    #[test]
+    fn bare_cli_model_sets_all_tiers() {
+        let plan = resolve_ok(&SpawnConfig::default(), None, None, None, &["prov/glm"]);
+        assert_eq!(
+            pairs(&plan),
+            vec![
+                (ModelTier::High, "prov/glm".into()),
+                (ModelTier::Mid, "prov/glm".into()),
+                (ModelTier::Low, "prov/glm".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn tier_cli_model_sets_one_tier() {
+        let plan = resolve_ok(&SpawnConfig::default(), None, None, None, &["low=prov/air"]);
+        assert_eq!(pairs(&plan), vec![(ModelTier::Low, "prov/air".into())]);
+    }
+
+    #[test]
+    fn cli_model_overrides_cli_preset_per_tier() {
+        let c = cfg(
+            &[],
+            &[("cheap", &[("high", "p/a"), ("mid", "p/a"), ("low", "p/b")])],
+        );
+        // Preset sets all three; the explicit --model overrides only `high`.
+        let plan = resolve_ok(&c, None, None, Some("cheap"), &["high=p/premium"]);
+        assert_eq!(
+            pairs(&plan),
+            vec![
+                (ModelTier::High, "p/premium".into()),
+                (ModelTier::Mid, "p/a".into()),
+                (ModelTier::Low, "p/b".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn full_precedence_chain() {
+        // Each layer touches `mid` so we can see which one wins, plus a unique
+        // tier so we can confirm earlier layers still contribute.
+        let c = cfg(
+            &[("high", "cfg/high"), ("mid", "cfg/mid")],
+            &[
+                ("envp", &[("mid", "envp/mid")]),
+                ("clip", &[("mid", "clip/mid")]),
+            ],
+        );
+        let plan = resolve_ok(
+            &c,
+            Some("envp"),      // env preset
+            Some("env/model"), // env bare model → all tiers
+            Some("clip"),      // cli preset
+            &["mid=cli/mid"],  // cli flag (highest)
+        );
+        // `mid` resolves to the highest layer that set it: the CLI flag.
+        let mids: Vec<_> = plan
+            .iter()
+            .filter(|(t, _)| *t == ModelTier::Mid)
+            .map(|(_, m)| m.to_string())
+            .collect();
+        assert_eq!(mids, vec!["cli/mid".to_string()]);
+        // `high`/`low` were last set by the env bare model (it set all tiers,
+        // overriding cfg/high, and nothing later touched them).
+        let high: Vec<_> = plan
+            .iter()
+            .filter(|(t, _)| *t == ModelTier::High)
+            .map(|(_, m)| m.to_string())
+            .collect();
+        assert_eq!(high, vec!["env/model".to_string()]);
+        let low: Vec<_> = plan
+            .iter()
+            .filter(|(t, _)| *t == ModelTier::Low)
+            .map(|(_, m)| m.to_string())
+            .collect();
+        assert_eq!(low, vec!["env/model".to_string()]);
+    }
+
+    #[test]
+    fn env_model_overrides_env_preset() {
+        let c = cfg(&[], &[("envp", &[("mid", "envp/mid")])]);
+        let plan = resolve_ok(&c, Some("envp"), Some("env/all"), None, &[]);
+        // env bare model (layer 3) beats env preset (layer 2).
+        assert!(plan.iter().all(|(_, m)| m == "env/all"));
+    }
+
+    #[test]
+    fn config_default_is_lowest_priority() {
+        let c = cfg(&[("mid", "cfg/mid")], &[]);
+        let plan = resolve_ok(&c, None, None, None, &["mid=cli/mid"]);
+        assert_eq!(pairs(&plan), vec![(ModelTier::Mid, "cli/mid".into())]);
+    }
+
+    #[test]
+    fn partial_preset_leaves_other_tiers_unset() {
+        let c = cfg(&[], &[("hi", &[("high", "p/h")])]);
+        let plan = resolve_ok(&c, None, None, Some("hi"), &[]);
+        assert_eq!(pairs(&plan), vec![(ModelTier::High, "p/h".into())]);
+    }
+
+    #[test]
+    fn unknown_preset_errors_with_available_list() {
+        let c = cfg(&[], &[("cheap", &[("mid", "p/a")])]);
+        let err = resolve(CLAUDE, &c, None, None, Some("nope"), &[]).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("unknown spawn preset 'nope'"), "{msg}");
+        assert!(msg.contains("cheap"), "should list defined presets: {msg}");
+    }
+
+    #[test]
+    fn unknown_env_preset_errors() {
+        let err = resolve(
+            CLAUDE,
+            &SpawnConfig::default(),
+            Some("ghost".to_string()),
+            None,
+            None,
+            &[],
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("BITROUTER_SPAWN_PRESET"));
+    }
+
+    #[test]
+    fn unknown_tier_in_model_spec_errors() {
+        let err = resolve(
+            CLAUDE,
+            &SpawnConfig::default(),
+            None,
+            None,
+            None,
+            &["turbo=p/x".to_string()],
+        )
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("unknown model tier 'turbo'"), "{msg}");
+        assert!(msg.contains("valid tiers"), "{msg}");
+    }
+
+    #[test]
+    fn unknown_tier_in_config_errors() {
+        let c = cfg(&[("ultra", "p/x")], &[]);
+        let err = resolve(CLAUDE, &c, None, None, None, &[]).unwrap_err();
+        assert!(err.to_string().contains("spawn.model"));
+    }
+
+    #[test]
+    fn empty_model_id_errors() {
+        let err = resolve(
+            CLAUDE,
+            &SpawnConfig::default(),
+            None,
+            None,
+            None,
+            &["mid=".to_string()],
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("empty model id"));
+    }
+
+    #[test]
+    fn duplicate_tier_via_alias_in_one_source_errors() {
+        // `high` and `opus` both map to the High tier — ambiguous within one map.
+        let c = cfg(&[("high", "p/a"), ("opus", "p/b")], &[]);
+        let err = resolve(CLAUDE, &c, None, None, None, &[]).unwrap_err();
+        assert!(err.to_string().contains("set twice"), "{}", err);
+    }
+}

--- a/crates/bitrouter-sdk/src/config/mod.rs
+++ b/crates/bitrouter-sdk/src/config/mod.rs
@@ -77,6 +77,10 @@ pub struct Config {
     /// BYOK providers, where to fetch it from, and the provider-class priority
     /// ladder used to order the auto-cascade.
     pub registry: RegistryConfig,
+    /// `bitrouter spawn` model overrides: a default tier→model plan and named
+    /// presets fed to a launched coding-agent harness. Consumed by the `spawn`
+    /// CLI; empty by default (the harness then uses its own default models).
+    pub spawn: SpawnConfig,
 }
 
 impl Default for Config {
@@ -95,8 +99,29 @@ impl Default for Config {
             agents: HashMap::new(),
             inherit_defaults: true,
             registry: RegistryConfig::default(),
+            spawn: SpawnConfig::default(),
         }
     }
+}
+
+/// `bitrouter spawn` model-override configuration — the top-level `spawn:`
+/// block in `bitrouter.yaml`.
+///
+/// Holds only raw `tier-label → model-id` string maps. The tier vocabulary and
+/// its mapping to a harness's concrete model env vars (the agent-model IR) live
+/// in the `spawn` CLI (`apps/bitrouter`), so the SDK config layer stays free of
+/// agent-specific knowledge. Both fields default to empty — `spawn:` is
+/// optional, and an empty block reproduces the historical spawn behavior (no
+/// model env vars injected, the harness uses its own defaults).
+#[derive(Debug, Clone, Default, Deserialize, schemars::JsonSchema)]
+#[serde(default)]
+pub struct SpawnConfig {
+    /// Default tier→model plan applied to every `bitrouter spawn`, keyed by
+    /// tier label (e.g. `high` / `mid` / `low`). Empty ⇒ no default plan.
+    pub model: HashMap<String, String>,
+    /// Named presets: preset name → (tier label → model id). Selected with
+    /// `--preset <name>` or `BITROUTER_SPAWN_PRESET`. Empty ⇒ no presets.
+    pub presets: HashMap<String, HashMap<String, String>>,
 }
 
 /// Default base URL for the provider-registry `dist/` artifacts — the raw files

--- a/crates/bitrouter-sdk/src/config/tests.rs
+++ b/crates/bitrouter-sdk/src/config/tests.rs
@@ -456,3 +456,57 @@ fn primary_api_key_prefers_top_level_then_first_account() {
     };
     assert_eq!(p2.primary_api_key(), "second");
 }
+
+#[test]
+fn spawn_config_defaults_empty() {
+    // The `spawn:` block is optional; a config without it parses with empty
+    // model + presets maps, so spawn injects no model env vars (historical
+    // behavior).
+    let cfg = Config::default();
+    assert!(cfg.spawn.model.is_empty());
+    assert!(cfg.spawn.presets.is_empty());
+
+    let cfg = parse("providers: {}\n").unwrap();
+    assert!(cfg.spawn.model.is_empty());
+    assert!(cfg.spawn.presets.is_empty());
+}
+
+#[test]
+fn parses_spawn_model_and_presets() {
+    let yaml = r#"
+spawn:
+  model:
+    mid: opencode-go/glm-5.1
+    low: opencode-go/glm-5.1-air
+  presets:
+    cheap:
+      high: opencode-go/glm-5.1
+      mid: opencode-go/glm-5.1
+      low: opencode-go/glm-5.1-air
+    powerful:
+      high: anthropic/claude-opus-4-8
+"#;
+    let cfg = parse(yaml).unwrap();
+    // Default tier→model plan.
+    assert_eq!(
+        cfg.spawn.model.get("mid").map(String::as_str),
+        Some("opencode-go/glm-5.1")
+    );
+    assert_eq!(
+        cfg.spawn.model.get("low").map(String::as_str),
+        Some("opencode-go/glm-5.1-air")
+    );
+    // Named presets, including a partial one.
+    let cheap = cfg.spawn.presets.get("cheap").unwrap();
+    assert_eq!(
+        cheap.get("high").map(String::as_str),
+        Some("opencode-go/glm-5.1")
+    );
+    assert_eq!(cheap.len(), 3);
+    let powerful = cfg.spawn.presets.get("powerful").unwrap();
+    assert_eq!(
+        powerful.get("high").map(String::as_str),
+        Some("anthropic/claude-opus-4-8")
+    );
+    assert_eq!(powerful.len(), 1, "partial presets are allowed");
+}

--- a/examples/bitrouter.yaml
+++ b/examples/bitrouter.yaml
@@ -47,3 +47,16 @@ models:
         service_id: claude-sonnet-4-6
       - provider: openai
         service_id: gpt-4o
+
+# `bitrouter spawn` model overrides. Maps generic capability tiers
+# (`high`/`mid`/`low`) to BitRouter model ids; for Claude Code these become the
+# opus/sonnet/haiku slots. Optional — omit `spawn:` to keep each harness's own
+# default models. CLI flags (`--preset`, `--model`) override these per tier.
+# spawn:
+#   model:                      # default plan applied to every `bitrouter spawn`
+#     low: openai/gpt-4o-mini
+#   presets:                    # named tier→model maps, selected with --preset
+#     powerful:
+#       high: anthropic/claude-sonnet-4-6
+#       mid: anthropic/claude-sonnet-4-6
+#       low: openai/gpt-4o

--- a/schemas/bitrouter.config.schema.json
+++ b/schemas/bitrouter.config.schema.json
@@ -819,6 +819,31 @@
         }
       ]
     },
+    "SpawnConfig": {
+      "description": "`bitrouter spawn` model-override configuration — the top-level `spawn:`\nblock in `bitrouter.yaml`.\n\nHolds only raw `tier-label → model-id` string maps. The tier vocabulary and\nits mapping to a harness's concrete model env vars (the agent-model IR) live\nin the `spawn` CLI (`apps/bitrouter`), so the SDK config layer stays free of\nagent-specific knowledge. Both fields default to empty — `spawn:` is\noptional, and an empty block reproduces the historical spawn behavior (no\nmodel env vars injected, the harness uses its own defaults).",
+      "properties": {
+        "model": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {},
+          "description": "Default tier→model plan applied to every `bitrouter spawn`, keyed by\ntier label (e.g. `high` / `mid` / `low`). Empty ⇒ no default plan.",
+          "type": "object"
+        },
+        "presets": {
+          "additionalProperties": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "default": {},
+          "description": "Named presets: preset name → (tier label → model id). Selected with\n`--preset <name>` or `BITROUTER_SPAWN_PRESET`. Empty ⇒ no presets.",
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
     "VariantConfig": {
       "description": "A `:variant` definition — a routing modifier only.",
       "properties": {
@@ -965,6 +990,10 @@
     "server_tools": {
       "$ref": "#/$defs/ServerToolsConfig",
       "description": "Server-side tool loop: MCP server ids whose tools BitRouter injects into\nLLM requests and executes itself. Empty by default — the pipeline stays\nsingle-shot."
+    },
+    "spawn": {
+      "$ref": "#/$defs/SpawnConfig",
+      "description": "`bitrouter spawn` model overrides: a default tier→model plan and named\npresets fed to a launched coding-agent harness. Consumed by the `spawn`\nCLI; empty by default (the harness then uses its own default models)."
     },
     "variants": {
       "additionalProperties": {

--- a/skills/bitrouter/references/cli.md
+++ b/skills/bitrouter/references/cli.md
@@ -85,6 +85,21 @@ Typed wrappers over the `/v1/*` management API on the cloud. Requires `bitrouter
 |---|---|
 | `bitrouter agent-proxy <agent> [--config PATH]` | Stdio bridge between an ACP-aware editor and an upstream agent declared under `agents:`. Editor spawns this binary as a subprocess. Routes JSON-RPC newline-framed over stdio. |
 
+## Harness launcher (`bitrouter spawn`)
+
+| Command | Effect |
+|---|---|
+| `bitrouter spawn -a <agent> [--config PATH] [--base-url URL] [--no-install] [--no-start] [--preset NAME] [--model SPEC]… -- <agent args…>` | Launch a coding-agent harness (`-a claude` for Claude Code) as a child process with its gateway env pointed at BitRouter (`ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN`) — the agent's own config files are untouched. Everything after `--` is forwarded to the agent verbatim. Auto-starts a local daemon when one isn't running (`--no-start` opts out). |
+
+**Model overrides.** By default Claude Code uses its bare `claude-*` models (routed to the subscription). Override them across three generic tiers — `high` / `mid` / `low` (Claude aliases: `opus` / `sonnet` / `haiku`):
+
+- `--model <id>` → every tier; `--model <tier>=<id>` → one tier (repeatable), e.g. `--model low=opencode-go/glm-5.1-air`.
+- `--preset <name>` → a named tier→model map from the `spawn.presets` config block.
+- Env: `BITROUTER_SPAWN_PRESET` (preset name), `BITROUTER_SPAWN_MODEL` (bare id → every tier).
+- Config: `spawn.model` (default plan) + `spawn.presets` (named maps) in `bitrouter.yaml`.
+
+Sources merge per tier, lowest first: `spawn.model` → `BITROUTER_SPAWN_PRESET` → `BITROUTER_SPAWN_MODEL` → `--preset` → `--model`. For Claude these become `ANTHROPIC_DEFAULT_{OPUS,SONNET,HAIKU}_MODEL`. Model ids pass through faithfully (no client-side validation); use the `provider/model` form from `bitrouter models`.
+
 ## Unimplemented in v1.0
 
 These print `not implemented in v1.0` today and are unlikely to land in the proxy binary:

--- a/skills/bitrouter/references/harness-claude-code.md
+++ b/skills/bitrouter/references/harness-claude-code.md
@@ -37,6 +37,46 @@ models:
     upstream_id: "anthropic/claude-haiku-4-5"
 ```
 
+### Override models with `bitrouter spawn`
+
+When launching Claude Code through `bitrouter spawn`, you can point it at other
+BitRouter models without editing `~/.claude`. The selection is expressed over
+three generic capability tiers — `high` / `mid` / `low`, which map to Claude's
+`opus` / `sonnet` / `haiku` slots (those names also work as aliases) — and
+delivered as `ANTHROPIC_DEFAULT_{OPUS,SONNET,HAIKU}_MODEL`, so the whole alias
+ladder (and the picker's Default) is remapped while Claude keeps its tiered
+behaviour (heavy work → high, default → mid, background → low). Use the
+`provider/model` ids from `bitrouter models`.
+
+```bash
+# Everything on one cheap model:
+bitrouter spawn -a claude -m opencode-go/glm-5.1 -- -p "summarize"
+
+# Per-tier: keep a strong main model, cheap background:
+bitrouter spawn -a claude -m mid=anthropic/claude-sonnet-4-6 \
+  -m low=opencode-go/glm-5.1-air -- -p "refactor"
+
+# A named preset from bitrouter.yaml:
+bitrouter spawn -a claude --preset cheap -- -p "tidy imports"
+```
+
+```yaml
+# bitrouter.yaml — a default plan applied to every spawn, plus named presets.
+spawn:
+  model:                       # default tier→model plan (optional)
+    low: opencode-go/glm-5.1-air
+  presets:
+    cheap:
+      high: opencode-go/glm-5.1
+      mid: opencode-go/glm-5.1
+      low: opencode-go/glm-5.1-air
+```
+
+Sources merge per tier, lowest priority first: `spawn.model` →
+`BITROUTER_SPAWN_PRESET` → `BITROUTER_SPAWN_MODEL` (a bare id → every tier) →
+`--preset` → `--model`. With none set, Claude Code's own default models are used.
+See `references/cli.md` for the full flag/env reference.
+
 ## Verify
 
 ```bash


### PR DESCRIPTION
## Summary

Adds a model-override layer to `bitrouter spawn`. Today the launcher injects only `ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN`, so a spawned Claude Code session uses its default `claude-*` models (which the daemon routes to the subscription). This lets a user point the harness at arbitrary BitRouter models — e.g. cheaper open-weight ones — via the **config file, environment variables, or CLI flags**, plus user-defined **presets** for named model combinations.

The *model selection* is decoupled from the *delivery mechanism* through a small agent-agnostic **IR**, so the feature is generic across harnesses even though only `claude` exists today.

## Design

- **Generic 3-tier IR** (`apps/bitrouter/src/spawn/model_plan.rs`): `ModelTier` (`high`/`mid`/`low`) + `ModelPlan` (tier → BitRouter model id). The resolver has zero agent-specific branching.
- **Per-agent binding** (`apps/bitrouter/src/spawn/agent.rs`): `SpawnAgent::parse_tier` (labels incl. the Claude aliases `opus`/`sonnet`/`haiku`) and `AgentSpec::tier_env`. Claude Code maps the tiers to `ANTHROPIC_DEFAULT_{OPUS,SONNET,HAIKU}_MODEL`, which remap what each alias and the picker's Default resolve to ([docs](https://code.claude.com/docs/en/model-config#environment-variables)) while preserving tiered behavior. Adding `codex`/`gemini` later touches only `agent.rs`.
- **SDK config stays dumb**: the new `spawn:` block (`spawn.model` default plan + `spawn.presets`) holds only raw `tier-label → model-id` string maps — no tier/agent vocabulary in the SDK.

### Surface

- `--model <id>` sets every tier; `--model <tier>=<id>` sets one (repeatable), e.g. `--model low=opencode-go/glm-5.1-air`.
- `--preset <name>` applies a user-defined `spawn.presets` entry.
- Env: `BITROUTER_SPAWN_PRESET`, `BITROUTER_SPAWN_MODEL` (bare id → every tier).
- Precedence, merged per tier (lowest → highest): `spawn.model` → `BITROUTER_SPAWN_PRESET` → `BITROUTER_SPAWN_MODEL` → `--preset` → `--model`.

**No behavior change when unset** — an empty plan injects no model env vars, so the historical subscription routing is preserved exactly. A non-`claude-*` override id passes through the daemon's `ClaudeCodeRouter` to normal routing.

## Commits

1. `feat(config)` — `spawn:` block on the SDK `Config` (+ regenerated JSON-Schema golden).
2. `feat(spawn)` — split `spawn.rs` into `spawn/{mod,agent,model_plan}.rs`; the IR, resolver, per-agent binding, `build_child_env` fold, and `--preset`/`--model` flags.
3. `docs(spawn)` — CLI.md, the `/bitrouter` skill (`references/cli.md` + `harness-claude-code.md`), and a commented `examples/bitrouter.yaml` stanza.

## Testing

- `cargo nextest run --all-features` → **1169 passed, 1 skipped**.
- `cargo clippy --all-features` clean; `cargo fmt --check` clean; `cargo xtask generate-schema --check` in sync.
- New unit tests cover precedence across all 5 layers, bare-vs-tier parsing, alias handling, duplicate-tier-in-one-source / unknown-preset / unknown-tier / empty-id errors, and empty-plan ⇒ unchanged env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)