### PR TITLE
feat(server-tools): built-in web_search with BYOK backends

### DIFF
--- a/apps/bitrouter/src/assemble.rs
+++ b/apps/bitrouter/src/assemble.rs
@@ -18,6 +18,7 @@ use bitrouter_sdk::language_model::server_tools::advisor::AdvisorToolset;
 use bitrouter_sdk::language_model::server_tools::approval::AllowAll;
 use bitrouter_sdk::language_model::server_tools::config::ServerToolLoopConfig;
 use bitrouter_sdk::language_model::server_tools::declarations::ServerToolDeclarationsHook;
+use bitrouter_sdk::language_model::server_tools::declarations::forwarded_tools;
 use bitrouter_sdk::language_model::server_tools::fusion::FusionToolset;
 use bitrouter_sdk::language_model::server_tools::fusion::alias::FusionAliasConfig;
 use bitrouter_sdk::language_model::server_tools::loop_controller::ServerToolLoop;
@@ -25,6 +26,15 @@ use bitrouter_sdk::language_model::server_tools::mcp_toolset::McpRouterToolset;
 use bitrouter_sdk::language_model::server_tools::nested::{NestedRunner, PipelineNestedRunner};
 use bitrouter_sdk::language_model::server_tools::sub_agent::SubAgentToolset;
 use bitrouter_sdk::language_model::server_tools::toolset::{RouterToolset, ToolsetRegistry};
+use bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchBackend;
+use bitrouter_sdk::language_model::server_tools::web_search::config::{
+    DEFAULT_MAX_RESULTS, WebSearchBackendConfig, WebSearchSettings,
+};
+use bitrouter_sdk::language_model::server_tools::web_search::http::{
+    HttpEngine, HttpSearchBackend,
+};
+use bitrouter_sdk::language_model::server_tools::web_search::nested::NestedSearchBackend;
+use bitrouter_sdk::language_model::server_tools::web_search::toolset::WebSearchToolset;
 use bitrouter_sdk::language_model::{AuthAppliers, HttpExecutor, HttpTimeouts, PipelineBuilder};
 use bitrouter_sdk::mcp::aggregating_executor::AggregatingExecutor;
 use bitrouter_sdk::mcp::caching_executor::{CacheTtls, CachingExecutor};
@@ -358,7 +368,8 @@ pub async fn build_app_with_path(
     // already-authorised request, and the parent principal rides the caller).
     let server_tools_enabled = config.server_tools.fusion.is_some()
         || config.server_tools.advisor
-        || config.server_tools.subagent;
+        || config.server_tools.subagent
+        || config.server_tools.web_search.is_some();
     let nested_runner: Option<Arc<dyn NestedRunner>> = if server_tools_enabled {
         let mut sub = PipelineBuilder::new();
         sub.routing_table(routing_table.clone())
@@ -606,7 +617,7 @@ fn build_server_tool_loop(
     // Nested server tools (advisor / sub-agent / fusion) over the shared runner.
     // Each toolset advertises only when the request declares it, so it is safe
     // to register every enabled one.
-    if let Some(runner) = nested_runner {
+    if let Some(runner) = &nested_runner {
         if settings.advisor {
             sets.push(Arc::new(AdvisorToolset::new(runner.clone())));
         }
@@ -614,7 +625,22 @@ fn build_server_tool_loop(
             sets.push(Arc::new(SubAgentToolset::new(runner.clone())));
         }
         if settings.fusion.is_some() {
-            sets.push(Arc::new(FusionToolset::new(runner)));
+            sets.push(Arc::new(FusionToolset::new(runner.clone())));
+        }
+    }
+
+    // Built-in web_search server tool, backed by the configured BYOK search
+    // backends. Advertised per-request only when the caller declares it.
+    if let Some(web_search) = &settings.web_search {
+        let backends = build_web_search_backends(web_search, &nested_runner);
+        if backends.is_empty() {
+            tracing::warn!(
+                "server_tools.web_search is set but no backend resolved (missing API keys?); \
+                 web_search is disabled"
+            );
+        } else {
+            let max_results = web_search.max_results.unwrap_or(DEFAULT_MAX_RESULTS);
+            sets.push(Arc::new(WebSearchToolset::new(backends, max_results)));
         }
     }
 
@@ -630,6 +656,106 @@ fn build_server_tool_loop(
         loop_config,
         Arc::new(AllowAll),
     )))
+}
+
+/// Build the live `web_search` backends from `settings`, in the configured
+/// preference/failover order. HTTP backends resolve their BYOK key from the
+/// explicit `api_key` (with `${VAR}` already substituted at config load) or the
+/// engine's conventional environment variable; one whose key cannot be resolved
+/// is skipped with a warning. The Perplexity / native backends reuse the shared
+/// nested runner (so they are skipped when none was built).
+fn build_web_search_backends(
+    settings: &WebSearchSettings,
+    nested_runner: &Option<Arc<dyn NestedRunner>>,
+) -> Vec<Arc<dyn WebSearchBackend>> {
+    // One shared HTTP client for the BYOK search APIs, with a request timeout
+    // below the loop's per-tool budget so a stuck call fails over promptly.
+    let http = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(20))
+        .build()
+        .unwrap_or_default();
+
+    let mut backends: Vec<Arc<dyn WebSearchBackend>> = Vec::new();
+    for entry in &settings.backends {
+        match entry {
+            WebSearchBackendConfig::Parallel { api_key, api_base } => {
+                if let Some(key) = resolve_search_key(api_key, "PARALLEL_API_KEY", "parallel") {
+                    backends.push(Arc::new(HttpSearchBackend::new(
+                        HttpEngine::Parallel,
+                        key,
+                        api_base.clone(),
+                        http.clone(),
+                    )));
+                }
+            }
+            WebSearchBackendConfig::Exa { api_key, api_base } => {
+                if let Some(key) = resolve_search_key(api_key, "EXA_API_KEY", "exa") {
+                    backends.push(Arc::new(HttpSearchBackend::new(
+                        HttpEngine::Exa,
+                        key,
+                        api_base.clone(),
+                        http.clone(),
+                    )));
+                }
+            }
+            WebSearchBackendConfig::Firecrawl { api_key, api_base } => {
+                if let Some(key) = resolve_search_key(api_key, "FIRECRAWL_API_KEY", "firecrawl") {
+                    backends.push(Arc::new(HttpSearchBackend::new(
+                        HttpEngine::Firecrawl,
+                        key,
+                        api_base.clone(),
+                        http.clone(),
+                    )));
+                }
+            }
+            WebSearchBackendConfig::Perplexity { model } => {
+                if let Some(runner) = nested_runner {
+                    backends.push(Arc::new(NestedSearchBackend::new(
+                        "perplexity".to_string(),
+                        runner.clone(),
+                        model
+                            .clone()
+                            .unwrap_or_else(|| "perplexity/sonar".to_string()),
+                        Vec::new(),
+                    )));
+                } else {
+                    tracing::warn!("web_search perplexity backend needs a nested runner; skipping");
+                }
+            }
+            WebSearchBackendConfig::Native { name, model, tool } => {
+                if let Some(runner) = nested_runner {
+                    backends.push(Arc::new(NestedSearchBackend::new(
+                        name.clone().unwrap_or_else(|| "native".to_string()),
+                        runner.clone(),
+                        model.clone(),
+                        forwarded_tools(std::slice::from_ref(tool)),
+                    )));
+                } else {
+                    tracing::warn!("web_search native backend needs a nested runner; skipping");
+                }
+            }
+        }
+    }
+    backends
+}
+
+/// Resolve a search backend's BYOK key: the explicit value if non-empty, else
+/// the conventional environment variable. Logs and returns `None` when unset.
+fn resolve_search_key(explicit: &Option<String>, env_var: &str, backend: &str) -> Option<String> {
+    if let Some(key) = explicit.as_ref().filter(|k| !k.is_empty()) {
+        return Some(key.clone());
+    }
+    match bitrouter_sdk::config::env_lookup(env_var) {
+        Some(key) if !key.is_empty() => Some(key),
+        _ => {
+            tracing::warn!(
+                backend,
+                env_var,
+                "web_search backend has no API key (set the env var or `api_key`); skipping"
+            );
+            None
+        }
+    }
 }
 
 /// Build the per-provider `AuthAppliers` registry. Each entry covers a
@@ -1423,5 +1549,37 @@ mod server_tools_tests {
         let config = Config::default();
         let runner: Arc<dyn NestedRunner> = Arc::new(NoopRunner);
         assert!(build_server_tool_loop(&config, &None, &None, Some(runner)).is_none());
+    }
+
+    #[test]
+    fn web_search_nested_backend_builds_loop() {
+        use bitrouter_sdk::language_model::server_tools::web_search::config::{
+            WebSearchBackendConfig, WebSearchSettings,
+        };
+        // A Perplexity (nested) backend resolves over the runner and builds the loop.
+        let mut cfg = Config::default();
+        cfg.server_tools.web_search = Some(WebSearchSettings {
+            backends: vec![WebSearchBackendConfig::Perplexity { model: None }],
+            max_results: None,
+        });
+        let runner: Arc<dyn NestedRunner> = Arc::new(NoopRunner);
+        assert!(build_server_tool_loop(&cfg, &None, &None, Some(runner)).is_some());
+    }
+
+    #[test]
+    fn web_search_http_backend_with_explicit_key_builds_loop_without_runner() {
+        use bitrouter_sdk::language_model::server_tools::web_search::config::{
+            WebSearchBackendConfig, WebSearchSettings,
+        };
+        // An HTTP backend with an explicit key resolves with no nested runner.
+        let mut cfg = Config::default();
+        cfg.server_tools.web_search = Some(WebSearchSettings {
+            backends: vec![WebSearchBackendConfig::Exa {
+                api_key: Some("explicit-key".to_string()),
+                api_base: None,
+            }],
+            max_results: Some(3),
+        });
+        assert!(build_server_tool_loop(&cfg, &None, &None, None).is_some());
     }
 }

--- a/apps/bitrouter/src/assemble.rs
+++ b/apps/bitrouter/src/assemble.rs
@@ -668,43 +668,47 @@ fn build_web_search_backends(
     settings: &WebSearchSettings,
     nested_runner: &Option<Arc<dyn NestedRunner>>,
 ) -> Vec<Arc<dyn WebSearchBackend>> {
-    // One shared HTTP client for the BYOK search APIs, with a request timeout
-    // below the loop's per-tool budget so a stuck call fails over promptly.
-    let http = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(20))
-        .build()
-        .unwrap_or_default();
+    // A shared HTTP client for the BYOK search APIs, built only when an HTTP
+    // backend is configured so a config with only nested (Perplexity / native)
+    // backends pays nothing. The request timeout sits below the loop's per-tool
+    // budget so a stuck call fails over promptly.
+    let needs_http = settings.backends.iter().any(|b| {
+        matches!(
+            b,
+            WebSearchBackendConfig::Parallel { .. }
+                | WebSearchBackendConfig::Exa { .. }
+                | WebSearchBackendConfig::Firecrawl { .. }
+        )
+    });
+    let http = needs_http.then(|| {
+        reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(20))
+            .build()
+            .unwrap_or_default()
+    });
 
     let mut backends: Vec<Arc<dyn WebSearchBackend>> = Vec::new();
     for entry in &settings.backends {
         match entry {
-            WebSearchBackendConfig::Parallel { api_key, api_base } => {
-                if let Some(key) = resolve_search_key(api_key, "PARALLEL_API_KEY", "parallel") {
+            // The three HTTP engines share one construction path, differing only
+            // in the engine tag (which also names the conventional key env var).
+            WebSearchBackendConfig::Parallel { api_key, api_base }
+            | WebSearchBackendConfig::Exa { api_key, api_base }
+            | WebSearchBackendConfig::Firecrawl { api_key, api_base } => {
+                let engine = match entry {
+                    WebSearchBackendConfig::Exa { .. } => HttpEngine::Exa,
+                    WebSearchBackendConfig::Firecrawl { .. } => HttpEngine::Firecrawl,
+                    _ => HttpEngine::Parallel,
+                };
+                if let (Some(client), Some(key)) = (
+                    &http,
+                    resolve_search_key(api_key, engine.env_var(), engine.name()),
+                ) {
                     backends.push(Arc::new(HttpSearchBackend::new(
-                        HttpEngine::Parallel,
+                        engine,
                         key,
                         api_base.clone(),
-                        http.clone(),
-                    )));
-                }
-            }
-            WebSearchBackendConfig::Exa { api_key, api_base } => {
-                if let Some(key) = resolve_search_key(api_key, "EXA_API_KEY", "exa") {
-                    backends.push(Arc::new(HttpSearchBackend::new(
-                        HttpEngine::Exa,
-                        key,
-                        api_base.clone(),
-                        http.clone(),
-                    )));
-                }
-            }
-            WebSearchBackendConfig::Firecrawl { api_key, api_base } => {
-                if let Some(key) = resolve_search_key(api_key, "FIRECRAWL_API_KEY", "firecrawl") {
-                    backends.push(Arc::new(HttpSearchBackend::new(
-                        HttpEngine::Firecrawl,
-                        key,
-                        api_base.clone(),
-                        http.clone(),
+                        client.clone(),
                     )));
                 }
             }

--- a/crates/bitrouter-sdk/src/language_model/server_tools/config.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/config.rs
@@ -55,4 +55,8 @@ pub struct ServerToolsConfig {
     /// Multi-model deliberation (Fusion). When set, the `bitrouter:fusion`
     /// server tool and the `bitrouter/fusion` model alias are enabled.
     pub fusion: Option<super::fusion::config::FusionSettings>,
+    /// Built-in `web_search` server tool (BYOK). When set, the
+    /// `bitrouter:web_search` tool is enabled, served by the configured search
+    /// backends. Advertised per-request only when the caller declares it.
+    pub web_search: Option<super::web_search::config::WebSearchSettings>,
 }

--- a/crates/bitrouter-sdk/src/language_model/server_tools/declarations.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/declarations.rs
@@ -28,6 +28,8 @@ use crate::plugin::PluginId;
 pub const ADVISOR_TOOL: &str = "advisor";
 /// Router-tool name the model calls to delegate a task to a worker model.
 pub const SUBAGENT_TOOL: &str = "subagent";
+/// Router-tool name the model calls to search the web.
+pub const WEB_SEARCH_TOOL: &str = "web_search";
 
 /// Plugin id under which [`ServerToolDeclarations`] is stashed on the request
 /// context by the pre-request hook, for the toolsets to read back.
@@ -48,6 +50,18 @@ pub struct AdvisorConfig {
     /// form; forwarded to the nested completion (see [`forwarded_tools`]).
     #[serde(default)]
     pub tools: Vec<serde_json::Value>,
+}
+
+/// Per-request Web-search config. Both fields are optional overrides: `backend`
+/// pins one of the configured search backends by name (else the default), and
+/// `max_results` lowers the per-call result cap. The query itself rides the
+/// tool call's arguments, not the declaration.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct WebSearchDeclaration {
+    /// Pin a configured backend by name (else the deployment default).
+    pub backend: Option<String>,
+    /// Cap on results for this request (else the deployment default).
+    pub max_results: Option<u32>,
 }
 
 /// Per-request Sub-agent config (worker model + instructions + tools).
@@ -72,6 +86,8 @@ pub struct ServerToolDeclarations {
     pub subagent: Option<SubAgentConfig>,
     /// The fusion declaration, if any (already resolved against `parent_model`).
     pub fusion: Option<FusionConfig>,
+    /// The web-search declaration, if any.
+    pub web_search: Option<WebSearchDeclaration>,
     /// The outer request model — the default nested model.
     pub parent_model: String,
 }
@@ -108,6 +124,12 @@ impl ServerToolDeclarations {
                         tools: array_field(args, "tools"),
                     });
                 }
+                Some(Kind::WebSearch) => {
+                    decls.web_search = Some(WebSearchDeclaration {
+                        backend: str_field(args, "backend"),
+                        max_results: u32_field(args, "max_results"),
+                    });
+                }
                 None => {}
             }
         }
@@ -123,21 +145,26 @@ impl ServerToolDeclarations {
 
     /// Whether the request declared no server tool.
     pub fn is_empty(&self) -> bool {
-        self.advisor.is_none() && self.subagent.is_none() && self.fusion.is_none()
+        self.advisor.is_none()
+            && self.subagent.is_none()
+            && self.fusion.is_none()
+            && self.web_search.is_none()
     }
 }
 
 enum Kind {
     Advisor,
     SubAgent,
+    WebSearch,
 }
 
-/// Recognise an advisor / sub-agent declaration by tool name: the bare name or a
-/// namespaced form whose final `:`/`.` segment is the name.
+/// Recognise an advisor / sub-agent / web-search declaration by tool name: the
+/// bare name or a namespaced form whose final `:`/`.` segment is the name.
 fn server_tool_kind(name: &str) -> Option<Kind> {
     match name.rsplit([':', '.']).next().unwrap_or(name) {
         ADVISOR_TOOL => Some(Kind::Advisor),
         SUBAGENT_TOOL => Some(Kind::SubAgent),
+        WEB_SEARCH_TOOL => Some(Kind::WebSearch),
         _ => None,
     }
 }
@@ -149,6 +176,15 @@ fn str_field(args: &serde_json::Value, key: &str) -> Option<String> {
         .or_else(|| args.get("parameters").and_then(|p| p.get(key)))
         .and_then(|v| v.as_str())
         .map(str::to_string)
+}
+
+/// Read a `u32` field from a config object (same `parameters`-wrapper tolerance
+/// as [`str_field`]).
+fn u32_field(args: &serde_json::Value, key: &str) -> Option<u32> {
+    args.get(key)
+        .or_else(|| args.get("parameters").and_then(|p| p.get(key)))
+        .and_then(|v| v.as_u64())
+        .map(|n| n.min(u32::MAX as u64) as u32)
 }
 
 /// Read an array field from a config object (same `parameters`-wrapper tolerance
@@ -274,6 +310,18 @@ mod tests {
     }
 
     #[test]
+    fn parses_web_search_declaration() {
+        let decls = ServerToolDeclarations::from_prompt(&prompt_with(vec![provider_tool(
+            "bitrouter:web_search",
+            serde_json::json!({ "backend": "exa", "max_results": 3 }),
+        )]));
+        assert!(!decls.is_empty());
+        let ws = decls.web_search.expect("web_search parsed");
+        assert_eq!(ws.backend.as_deref(), Some("exa"));
+        assert_eq!(ws.max_results, Some(3));
+    }
+
+    #[test]
     fn ignores_function_and_unrelated_tools() {
         let decls = ServerToolDeclarations::from_prompt(&prompt_with(vec![
             Tool::Function {
@@ -283,7 +331,7 @@ mod tests {
                 strict: None,
                 provider_metadata: ProviderMetadata::new(),
             },
-            provider_tool("web_search", serde_json::json!({})),
+            provider_tool("code_interpreter", serde_json::json!({})),
         ]));
         assert!(decls.is_empty());
     }

--- a/crates/bitrouter-sdk/src/language_model/server_tools/declarations.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/declarations.rs
@@ -160,13 +160,31 @@ enum Kind {
 
 /// Recognise an advisor / sub-agent / web-search declaration by tool name: the
 /// bare name or a namespaced form whose final `:`/`.` segment is the name.
+///
+/// `web_search` is the exception. Unlike the bitrouter-invented
+/// `advisor` / `subagent` / `fusion` names, `web_search` is also a real
+/// *native* tool name on several providers (e.g. OpenAI's Responses
+/// `web_search`). Matching it bare would hijack a caller's genuine native tool,
+/// so it is recognised only under the explicit `bitrouter` namespace
+/// (`{"type":"bitrouter:web_search"}`, the documented declaration form); a bare
+/// or foreign-namespaced `web_search` is left untouched for the upstream.
 fn server_tool_kind(name: &str) -> Option<Kind> {
     match name.rsplit([':', '.']).next().unwrap_or(name) {
         ADVISOR_TOOL => Some(Kind::Advisor),
         SUBAGENT_TOOL => Some(Kind::SubAgent),
-        WEB_SEARCH_TOOL => Some(Kind::WebSearch),
+        WEB_SEARCH_TOOL if is_bitrouter_namespaced(name) => Some(Kind::WebSearch),
         _ => None,
     }
+}
+
+/// Whether `name` carries the explicit `bitrouter:` / `bitrouter.` namespace —
+/// the documented `{"type":"bitrouter:<tool>"}` declaration form, as opposed to
+/// a bare or foreign-namespaced tool a provider defines itself. The inbound
+/// decoders keep the namespace in the canonical tool `name` (a typeless tool
+/// defaults its `name` to the full `type`), so the prefix is visible here.
+fn is_bitrouter_namespaced(name: &str) -> bool {
+    name.split_once([':', '.'])
+        .is_some_and(|(namespace, _)| namespace == "bitrouter")
 }
 
 /// Read a string field from a config object, tolerating an OpenRouter-style
@@ -319,6 +337,31 @@ mod tests {
         let ws = decls.web_search.expect("web_search parsed");
         assert_eq!(ws.backend.as_deref(), Some("exa"));
         assert_eq!(ws.max_results, Some(3));
+    }
+
+    #[test]
+    fn bare_web_search_is_a_native_tool_not_a_declaration() {
+        // A provider's own native `web_search` (no `bitrouter` namespace) must
+        // NOT be taken over by the built-in tool — otherwise the caller silently
+        // loses their model's native search.
+        let decls = ServerToolDeclarations::from_prompt(&prompt_with(vec![provider_tool(
+            "web_search",
+            serde_json::json!({}),
+        )]));
+        assert!(decls.web_search.is_none());
+        assert!(decls.is_empty());
+    }
+
+    #[test]
+    fn foreign_namespaced_web_search_is_not_a_declaration() {
+        // Only the explicit `bitrouter` namespace declares the built-in tool;
+        // another provider's namespaced `web_search` is left for the upstream.
+        let decls = ServerToolDeclarations::from_prompt(&prompt_with(vec![provider_tool(
+            "openai:web_search",
+            serde_json::json!({}),
+        )]));
+        assert!(decls.web_search.is_none());
+        assert!(decls.is_empty());
     }
 
     #[test]

--- a/crates/bitrouter-sdk/src/language_model/server_tools/loop_controller.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/loop_controller.rs
@@ -69,16 +69,21 @@ impl ServerToolLoop {
     ///
     /// A caller may *declare* a router tool as a provider-defined tool (e.g. an
     /// `{type: "<provider>:<tool>"}` server-tool entry). Such declarations are
-    /// dropped from the working prompt for any name the registry *owns*: the
-    /// toolset re-advertises that tool as an executable function tool, and the
-    /// raw provider-defined form must not reach the upstream — it has no
-    /// portable wire form and a same-protocol upstream would reject an unknown
-    /// server tool. Dropping them also avoids a spurious self-collision below.
+    /// dropped from the working prompt for any tool the registry is actually
+    /// advertising this request: the toolset re-advertises that tool as an
+    /// executable function tool, and the raw provider-defined form must not reach
+    /// the upstream — it has no portable wire form and a same-protocol upstream
+    /// would reject an unknown server tool. Dropping them also avoids a spurious
+    /// self-collision below.
     ///
-    /// Ownership (`registry.resolve`), not the set of advertised names, is the
-    /// strip predicate: a toolset may own a declaration under a namespaced name
-    /// (e.g. `bitrouter:fusion`) while advertising the bare executable name
-    /// (`fusion`), and the namespaced declaration must still be stripped.
+    /// The strip predicate is membership in the advertised set (`owned`), matched
+    /// by the declaration's tail name: a toolset may own a declaration under a
+    /// namespaced name (e.g. `bitrouter:fusion`) while advertising the bare
+    /// executable (`fusion`), and the namespaced declaration must still be
+    /// stripped. Crucially, a provider-defined tool the registry *could* own but
+    /// is **not** advertising this request (e.g. a caller's native `web_search`
+    /// when `bitrouter:web_search` was not declared) is left untouched, so the
+    /// caller never silently loses a genuine provider tool.
     pub(crate) async fn inject(
         &self,
         base: &Prompt,
@@ -87,8 +92,7 @@ impl ServerToolLoop {
         let (injected, owned) = self.registry.list_all(ctx).await?;
         let mut working = base.clone();
         working.tools.retain(|t| {
-            !(matches!(t, Tool::ProviderDefined { .. })
-                && self.registry.resolve(t.name()).is_some())
+            !(matches!(t, Tool::ProviderDefined { .. }) && owned.contains(tool_tail(t.name())))
         });
         for tool in &injected {
             if working.tools.iter().any(|t| t.name() == tool.name()) {
@@ -247,6 +251,14 @@ impl ServerToolLoop {
 
 /// Append the model's tool-call turn and the tool-result turn to the working
 /// prompt so the next upstream call sees the results.
+/// The bare tail of a (possibly namespaced) tool name: the final `:`/`.`
+/// segment. Matches a `bitrouter:fusion` declaration against the advertised
+/// bare `fusion`, while leaving an unrelated provider tail (e.g.
+/// `web_search_20250305`) distinct from `web_search`.
+fn tool_tail(name: &str) -> &str {
+    name.rsplit([':', '.']).next().unwrap_or(name)
+}
+
 fn append_turn(working: &mut Prompt, assistant_content: Vec<Content>, tool_results: Vec<Content>) {
     working.messages.push(Message {
         role: Role::Assistant,
@@ -532,6 +544,57 @@ mod tests {
         assert!(
             matches!(&working.tools[0], Tool::Function { name, .. } if name == "fusion"),
             "namespaced declaration stripped; executable function advertised"
+        );
+    }
+
+    #[tokio::test]
+    async fn inject_keeps_caller_provider_tool_the_registry_is_not_advertising() {
+        // A toolset that *owns* `search` by tail-match but advertises nothing
+        // this request (e.g. a declaration-gated tool like web_search with no
+        // declaration). A caller's genuine provider-defined `search` must NOT be
+        // stripped — otherwise the caller silently loses a real provider tool.
+        struct SilentOwner;
+        #[async_trait]
+        impl RouterToolset for SilentOwner {
+            async fn list_tools(&self, _c: &ToolContext) -> Result<Vec<Tool>> {
+                Ok(Vec::new())
+            }
+            async fn call_tool(
+                &self,
+                _n: &str,
+                _a: &str,
+                _c: &ToolContext,
+            ) -> Result<ToolResultOutput> {
+                Ok(ToolResultOutput::Text {
+                    value: "x".to_string(),
+                })
+            }
+            fn owns(&self, name: &str) -> bool {
+                name.rsplit([':', '.']).next().unwrap_or(name) == "search"
+            }
+        }
+
+        let loop_ = ServerToolLoop::new(
+            ToolsetRegistry::new(vec![Arc::new(SilentOwner)]),
+            ServerToolLoopConfig::default(),
+            Arc::new(AllowAll),
+        );
+        let mut base = base_prompt();
+        base.tools.push(Tool::ProviderDefined {
+            id: "demo.search".to_string(),
+            name: "search".to_string(),
+            args: serde_json::json!({}),
+            provider_metadata: ProviderMetadata::new(),
+        });
+        let (working, owned) = loop_.inject(&base, &tool_ctx()).await.unwrap();
+        assert!(owned.is_empty(), "nothing advertised this request");
+        assert_eq!(
+            working.tools.len(),
+            1,
+            "caller's provider tool is preserved"
+        );
+        assert!(
+            matches!(&working.tools[0], Tool::ProviderDefined { name, .. } if name == "search")
         );
     }
 

--- a/crates/bitrouter-sdk/src/language_model/server_tools/loop_controller.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/loop_controller.rs
@@ -249,8 +249,6 @@ impl ServerToolLoop {
     }
 }
 
-/// Append the model's tool-call turn and the tool-result turn to the working
-/// prompt so the next upstream call sees the results.
 /// The bare tail of a (possibly namespaced) tool name: the final `:`/`.`
 /// segment. Matches a `bitrouter:fusion` declaration against the advertised
 /// bare `fusion`, while leaving an unrelated provider tail (e.g.
@@ -259,6 +257,8 @@ fn tool_tail(name: &str) -> &str {
     name.rsplit([':', '.']).next().unwrap_or(name)
 }
 
+/// Append the model's tool-call turn and the tool-result turn to the working
+/// prompt so the next upstream call sees the results.
 fn append_turn(working: &mut Prompt, assistant_content: Vec<Content>, tool_results: Vec<Content>) {
     working.messages.push(Message {
         role: Role::Assistant,

--- a/crates/bitrouter-sdk/src/language_model/server_tools/mod.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/mod.rs
@@ -27,3 +27,4 @@ pub mod nested;
 pub mod stream;
 pub mod sub_agent;
 pub mod toolset;
+pub mod web_search;

--- a/crates/bitrouter-sdk/src/language_model/server_tools/web_search/backend.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/web_search/backend.rs
@@ -1,0 +1,84 @@
+//! The [`WebSearchBackend`] executor seam and the normalized result schema the
+//! `web_search` server tool returns to the calling model.
+//!
+//! A backend is the *engine* behind one `web_search` call — a BYOK HTTP search
+//! API (Parallel / Exa / Firecrawl) or a nested model completion (Perplexity, or
+//! a provider's native web search reused for every model). The toolset composes
+//! several backends as an ordered preference/failover list and selects one per
+//! call. The result schema is deliberately minimal and stable: every per-result
+//! field is optional because no single engine fills them all, and a future
+//! backend adds fields additively without breaking the contract with the model.
+
+use async_trait::async_trait;
+use serde::Serialize;
+
+use crate::language_model::server_tools::toolset::ToolContext;
+
+/// Per-call search options the toolset derives from the tool arguments and the
+/// caller's declaration. Kept minimal for the first cut.
+#[derive(Clone, Debug)]
+pub struct SearchOptions {
+    /// Maximum number of results the backend should return.
+    pub max_results: u32,
+}
+
+/// One normalized search hit. Every field beyond `url` is optional because the
+/// backends disagree on what they return (Perplexity citations carry only a
+/// URL; Exa adds a score and highlights; Firecrawl a description; …).
+#[derive(Clone, Debug, Default, PartialEq, Serialize)]
+pub struct WebSearchResult {
+    /// The result URL.
+    pub url: String,
+    /// Page title, when the backend provides one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    /// A short excerpt / highlight / description.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub snippet: Option<String>,
+    /// Full page content (markdown / text), only when the backend was asked for
+    /// it — omitted by default to keep the tool result within budget.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+    /// Publication date as the backend reported it (ISO-ish string).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub published: Option<String>,
+    /// Relevance score in `[0, 1]`, when the backend ranks results.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub score: Option<f64>,
+}
+
+/// The normalized output of one `web_search` call. `answer` is the synthesized
+/// text an *answer engine* (Perplexity / native provider search) returns; pure
+/// search engines leave it `None` and populate `results` only.
+#[derive(Clone, Debug, Default, PartialEq, Serialize)]
+pub struct WebSearchResults {
+    /// Which backend served this call (failover/observability transparency).
+    pub backend: String,
+    /// Synthesized answer text, when the backend is an answer engine.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub answer: Option<String>,
+    /// Ranked results.
+    pub results: Vec<WebSearchResult>,
+}
+
+/// A search engine the `web_search` server tool can dispatch a query to.
+///
+/// `search` returns a human-readable `Err` (not a [`crate::error::Result`]) so
+/// the toolset can fail over to the next configured backend and, if all fail,
+/// surface the message to the model as a `status: "error"` tool result — the
+/// same convention the advisor / sub-agent toolsets use.
+#[async_trait]
+pub trait WebSearchBackend: Send + Sync {
+    /// Stable identifier (e.g. `"parallel"`), used to match a caller's
+    /// per-request backend override and to label the result.
+    fn name(&self) -> &str;
+
+    /// Run one search. `ctx` is the per-request context of the tool call (a
+    /// nested backend forwards it to its runner; HTTP backends ignore it).
+    async fn search(
+        &self,
+        query: &str,
+        opts: &SearchOptions,
+        ctx: &ToolContext,
+    ) -> std::result::Result<WebSearchResults, String>;
+}

--- a/crates/bitrouter-sdk/src/language_model/server_tools/web_search/config.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/web_search/config.rs
@@ -1,0 +1,80 @@
+//! The `server_tools.web_search` deployment config: an ordered list of search
+//! backends (BYOK) the `web_search` server tool may use. Order is preference and
+//! failover; the first resolvable backend is the default, and a caller's
+//! per-request declaration may pin another by name. Plain data — the app
+//! resolves API keys and constructs the live backends from this (see
+//! `apps/bitrouter` assembly).
+
+use serde::Deserialize;
+
+/// Default per-call result cap when neither the caller nor the config sets one.
+pub const DEFAULT_MAX_RESULTS: u32 = 5;
+
+/// The `server_tools.web_search` section. Its presence enables the
+/// `bitrouter:web_search` server tool (advertised only when a request declares
+/// it). An empty `backends` list leaves the tool effectively off.
+#[derive(Debug, Clone, Default, Deserialize, schemars::JsonSchema)]
+#[serde(default)]
+pub struct WebSearchSettings {
+    /// Search backends in preference/failover order; the first that resolves a
+    /// key is the default.
+    pub backends: Vec<WebSearchBackendConfig>,
+    /// Default maximum results per call (caller may lower it). Defaults to
+    /// [`DEFAULT_MAX_RESULTS`].
+    pub max_results: Option<u32>,
+}
+
+/// One configured search backend. The `kind` tag selects the engine; the BYOK
+/// key resolves from `api_key` (supports `${VAR}` substitution) or, when
+/// omitted, the engine's conventional environment variable.
+#[derive(Debug, Clone, Deserialize, schemars::JsonSchema)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum WebSearchBackendConfig {
+    /// parallel.ai — key `api_key` or `PARALLEL_API_KEY`.
+    Parallel {
+        /// Explicit API key (else `PARALLEL_API_KEY`).
+        #[serde(default)]
+        api_key: Option<String>,
+        /// Endpoint override (else the engine default).
+        #[serde(default)]
+        api_base: Option<String>,
+    },
+    /// exa.ai — key `api_key` or `EXA_API_KEY`.
+    Exa {
+        /// Explicit API key (else `EXA_API_KEY`).
+        #[serde(default)]
+        api_key: Option<String>,
+        /// Endpoint override (else the engine default).
+        #[serde(default)]
+        api_base: Option<String>,
+    },
+    /// firecrawl.dev — key `api_key` or `FIRECRAWL_API_KEY`.
+    Firecrawl {
+        /// Explicit API key (else `FIRECRAWL_API_KEY`).
+        #[serde(default)]
+        api_key: Option<String>,
+        /// Endpoint override (else the engine default).
+        #[serde(default)]
+        api_base: Option<String>,
+    },
+    /// A search-grounded model (e.g. `perplexity/sonar`) reached through a
+    /// nested completion. BYOK rides the normal provider mechanism (the model's
+    /// provider key), so no key lives here.
+    Perplexity {
+        /// Nested model (defaults to `perplexity/sonar`).
+        #[serde(default)]
+        model: Option<String>,
+    },
+    /// A web-search-capable model whose *native* search tool is forwarded, made
+    /// available to every model routed through BitRouter.
+    Native {
+        /// Backend id the caller pins (e.g. `"native"`); defaults to `"native"`.
+        #[serde(default)]
+        name: Option<String>,
+        /// The search-capable model serving the call.
+        model: String,
+        /// The provider-defined native search tool, e.g.
+        /// `{ "type": "anthropic:web_search_20250305" }`.
+        tool: serde_json::Value,
+    },
+}

--- a/crates/bitrouter-sdk/src/language_model/server_tools/web_search/http.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/web_search/http.rs
@@ -32,6 +32,15 @@ impl HttpEngine {
         }
     }
 
+    /// The conventional environment variable holding this engine's BYOK key.
+    pub fn env_var(self) -> &'static str {
+        match self {
+            Self::Parallel => "PARALLEL_API_KEY",
+            Self::Exa => "EXA_API_KEY",
+            Self::Firecrawl => "FIRECRAWL_API_KEY",
+        }
+    }
+
     /// The default search endpoint (overridable per backend).
     fn default_base(self) -> &'static str {
         match self {

--- a/crates/bitrouter-sdk/src/language_model/server_tools/web_search/http.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/web_search/http.rs
@@ -1,0 +1,291 @@
+//! BYOK HTTP search backends: Parallel, Exa, and Firecrawl. Each maps the
+//! shared [`WebSearchBackend`] call onto the provider's REST search endpoint and
+//! normalizes its response into [`WebSearchResults`]. Responses are parsed
+//! defensively through [`serde_json::Value`] so a provider adding or renaming a
+//! field never hard-fails the request — a missing field just yields `None`.
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+
+use super::backend::{SearchOptions, WebSearchBackend, WebSearchResult, WebSearchResults};
+use crate::language_model::server_tools::toolset::ToolContext;
+
+/// The HTTP search providers BitRouter speaks natively. Each carries its own
+/// request shape, auth header, and response mapping.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HttpEngine {
+    /// parallel.ai — `POST /v1/search`, `x-api-key`, results with excerpts.
+    Parallel,
+    /// exa.ai — `POST /search`, `x-api-key`, ranked results with highlights.
+    Exa,
+    /// firecrawl.dev — `POST /v2/search`, bearer auth, results under `data.web`.
+    Firecrawl,
+}
+
+impl HttpEngine {
+    /// The stable backend name a caller uses to pin this engine.
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::Parallel => "parallel",
+            Self::Exa => "exa",
+            Self::Firecrawl => "firecrawl",
+        }
+    }
+
+    /// The default search endpoint (overridable per backend).
+    fn default_base(self) -> &'static str {
+        match self {
+            Self::Parallel => "https://api.parallel.ai/v1/search",
+            Self::Exa => "https://api.exa.ai/search",
+            Self::Firecrawl => "https://api.firecrawl.dev/v2/search",
+        }
+    }
+}
+
+/// A BYOK HTTP search backend bound to one [`HttpEngine`] and API key.
+pub struct HttpSearchBackend {
+    engine: HttpEngine,
+    api_key: String,
+    base: String,
+    client: reqwest::Client,
+}
+
+impl HttpSearchBackend {
+    /// Build a backend over a shared HTTP client. `base` overrides the engine's
+    /// default endpoint when `Some` (e.g. a proxy or self-hosted gateway).
+    pub fn new(
+        engine: HttpEngine,
+        api_key: String,
+        base: Option<String>,
+        client: reqwest::Client,
+    ) -> Self {
+        Self {
+            engine,
+            api_key,
+            base: base.unwrap_or_else(|| engine.default_base().to_string()),
+            client,
+        }
+    }
+
+    /// The request body for `query` under `opts`, in the engine's shape.
+    fn request_body(&self, query: &str, opts: &SearchOptions) -> Value {
+        let n = opts.max_results;
+        match self.engine {
+            // Parallel takes a natural-language `objective` plus keyword queries;
+            // we mirror the user query into both and ask for excerpts.
+            HttpEngine::Parallel => json!({
+                "objective": query,
+                "search_queries": [query],
+                "max_results": n,
+            }),
+            // Exa: ask for highlights (short excerpts) rather than full `text`,
+            // keeping the tool result within budget.
+            HttpEngine::Exa => json!({
+                "query": query,
+                "numResults": n,
+                "contents": { "highlights": true },
+            }),
+            // Firecrawl: plain search (no `scrapeOptions`) returns title + URL +
+            // description only, which is what we want by default.
+            HttpEngine::Firecrawl => json!({
+                "query": query,
+                "limit": n,
+            }),
+        }
+    }
+
+    /// Attach the engine's auth header.
+    fn authorize(&self, req: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        match self.engine {
+            HttpEngine::Parallel | HttpEngine::Exa => req.header("x-api-key", &self.api_key),
+            HttpEngine::Firecrawl => req.bearer_auth(&self.api_key),
+        }
+    }
+
+    /// Normalize a parsed JSON response into the shared schema.
+    fn parse_response(&self, body: &Value) -> WebSearchResults {
+        let results = match self.engine {
+            HttpEngine::Parallel => map_array(body.get("results"), parallel_result),
+            HttpEngine::Exa => map_array(body.get("results"), exa_result),
+            HttpEngine::Firecrawl => map_array(
+                body.get("data").and_then(|d| d.get("web")),
+                firecrawl_result,
+            ),
+        };
+        WebSearchResults {
+            backend: self.engine.name().to_string(),
+            answer: None,
+            results,
+        }
+    }
+}
+
+#[async_trait]
+impl WebSearchBackend for HttpSearchBackend {
+    fn name(&self) -> &str {
+        self.engine.name()
+    }
+
+    async fn search(
+        &self,
+        query: &str,
+        opts: &SearchOptions,
+        _ctx: &ToolContext,
+    ) -> std::result::Result<WebSearchResults, String> {
+        let body = self.request_body(query, opts);
+        let resp = self
+            .authorize(self.client.post(&self.base).json(&body))
+            .send()
+            .await
+            .map_err(|e| format!("{} request failed: {e}", self.engine.name()))?;
+        let status = resp.status();
+        let text = resp
+            .text()
+            .await
+            .map_err(|e| format!("{} response read failed: {e}", self.engine.name()))?;
+        if !status.is_success() {
+            return Err(format!(
+                "{} returned {}: {}",
+                self.engine.name(),
+                status.as_u16(),
+                text.chars().take(500).collect::<String>()
+            ));
+        }
+        let parsed: Value = serde_json::from_str(&text)
+            .map_err(|e| format!("{} returned non-JSON: {e}", self.engine.name()))?;
+        Ok(self.parse_response(&parsed))
+    }
+}
+
+/// Map a JSON array field through `f`, dropping entries that aren't objects.
+fn map_array(field: Option<&Value>, f: fn(&Value) -> WebSearchResult) -> Vec<WebSearchResult> {
+    field
+        .and_then(|v| v.as_array())
+        .map(|arr| arr.iter().filter(|v| v.is_object()).map(f).collect())
+        .unwrap_or_default()
+}
+
+fn str_at(v: &Value, key: &str) -> Option<String> {
+    v.get(key).and_then(|x| x.as_str()).map(str::to_string)
+}
+
+/// Join a string array field (e.g. `excerpts` / `highlights`) into one snippet.
+fn join_strings(v: &Value, key: &str) -> Option<String> {
+    let parts: Vec<&str> = v
+        .get(key)
+        .and_then(|x| x.as_array())
+        .map(|arr| arr.iter().filter_map(|s| s.as_str()).collect())
+        .unwrap_or_default();
+    (!parts.is_empty()).then(|| parts.join("\n\n"))
+}
+
+fn parallel_result(v: &Value) -> WebSearchResult {
+    WebSearchResult {
+        url: str_at(v, "url").unwrap_or_default(),
+        title: str_at(v, "title"),
+        snippet: join_strings(v, "excerpts"),
+        content: None,
+        published: str_at(v, "publish_date"),
+        score: None,
+    }
+}
+
+fn exa_result(v: &Value) -> WebSearchResult {
+    WebSearchResult {
+        url: str_at(v, "url").unwrap_or_default(),
+        title: str_at(v, "title"),
+        snippet: join_strings(v, "highlights").or_else(|| str_at(v, "summary")),
+        content: None,
+        published: str_at(v, "publishedDate"),
+        score: v.get("score").and_then(|s| s.as_f64()),
+    }
+}
+
+fn firecrawl_result(v: &Value) -> WebSearchResult {
+    WebSearchResult {
+        url: str_at(v, "url").unwrap_or_default(),
+        title: str_at(v, "title"),
+        snippet: str_at(v, "description"),
+        content: str_at(v, "markdown"),
+        published: None,
+        score: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn backend(engine: HttpEngine) -> HttpSearchBackend {
+        HttpSearchBackend::new(engine, "k".into(), None, reqwest::Client::new())
+    }
+
+    #[test]
+    fn request_bodies_use_each_engines_field_names() {
+        let opts = SearchOptions { max_results: 5 };
+        let p = backend(HttpEngine::Parallel).request_body("rust async", &opts);
+        assert_eq!(p["objective"], "rust async");
+        assert_eq!(p["search_queries"][0], "rust async");
+        assert_eq!(p["max_results"], 5);
+
+        let e = backend(HttpEngine::Exa).request_body("rust async", &opts);
+        assert_eq!(e["query"], "rust async");
+        assert_eq!(e["numResults"], 5);
+        assert_eq!(e["contents"]["highlights"], true);
+
+        let f = backend(HttpEngine::Firecrawl).request_body("rust async", &opts);
+        assert_eq!(f["query"], "rust async");
+        assert_eq!(f["limit"], 5);
+    }
+
+    #[test]
+    fn parses_parallel_results() {
+        let body = json!({
+            "results": [
+                { "url": "https://a", "title": "A", "publish_date": "2024-01-01",
+                  "excerpts": ["one", "two"] },
+                { "not": "an object usable" }
+            ]
+        });
+        let out = backend(HttpEngine::Parallel).parse_response(&body);
+        assert_eq!(out.backend, "parallel");
+        assert!(out.answer.is_none());
+        assert_eq!(out.results.len(), 2);
+        assert_eq!(out.results[0].url, "https://a");
+        assert_eq!(out.results[0].title.as_deref(), Some("A"));
+        assert_eq!(out.results[0].snippet.as_deref(), Some("one\n\ntwo"));
+        assert_eq!(out.results[0].published.as_deref(), Some("2024-01-01"));
+    }
+
+    #[test]
+    fn parses_exa_results_with_score() {
+        let body = json!({
+            "results": [
+                { "url": "https://x", "title": "X", "publishedDate": "2024-02-02",
+                  "score": 0.87, "highlights": ["hl"] }
+            ]
+        });
+        let out = backend(HttpEngine::Exa).parse_response(&body);
+        assert_eq!(out.results[0].score, Some(0.87));
+        assert_eq!(out.results[0].snippet.as_deref(), Some("hl"));
+    }
+
+    #[test]
+    fn parses_firecrawl_web_array() {
+        let body = json!({
+            "data": { "web": [
+                { "url": "https://y", "title": "Y", "description": "desc",
+                  "markdown": "# Y" }
+            ] }
+        });
+        let out = backend(HttpEngine::Firecrawl).parse_response(&body);
+        assert_eq!(out.results[0].snippet.as_deref(), Some("desc"));
+        assert_eq!(out.results[0].content.as_deref(), Some("# Y"));
+    }
+
+    #[test]
+    fn missing_arrays_yield_no_results() {
+        let out = backend(HttpEngine::Exa).parse_response(&json!({}));
+        assert!(out.results.is_empty());
+    }
+}

--- a/crates/bitrouter-sdk/src/language_model/server_tools/web_search/mod.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/web_search/mod.rs
@@ -1,0 +1,21 @@
+//! The built-in `web_search` server tool and its BYOK backends.
+//!
+//! When the deployment configures `server_tools.web_search` and a request
+//! declares `bitrouter:web_search`, BitRouter advertises a single `web_search`
+//! function tool, intercepts the model's calls, runs the query against a
+//! configured search backend, and feeds normalized results back into the loop —
+//! the same server-tool mechanism the advisor / sub-agent / fusion tools use.
+//!
+//! Backends come in two flavors behind one [`backend::WebSearchBackend`] seam:
+//! BYOK HTTP search APIs ([`http::HttpSearchBackend`] — Parallel / Exa /
+//! Firecrawl) and nested model completions ([`nested::NestedSearchBackend`] —
+//! Perplexity, or a provider's native search reused for every model).
+//!
+//! Per crate guideline 2, this module does not `pub use` from its submodules;
+//! downstream reaches types directly (e.g. `web_search::toolset::WebSearchToolset`).
+
+pub mod backend;
+pub mod config;
+pub mod http;
+pub mod nested;
+pub mod toolset;

--- a/crates/bitrouter-sdk/src/language_model/server_tools/web_search/nested.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/web_search/nested.rs
@@ -64,12 +64,16 @@ impl WebSearchBackend for NestedSearchBackend {
     async fn search(
         &self,
         query: &str,
-        _opts: &SearchOptions,
+        opts: &SearchOptions,
         ctx: &ToolContext,
     ) -> std::result::Result<WebSearchResults, String> {
+        // An answer engine returns one synthesized answer, so `max_results`
+        // can't cap a result list; thread it through as a soft cap on how many
+        // sources to consult/cite rather than silently ignoring it.
+        let system = format!("{SEARCH_SYSTEM} Cite up to {} sources.", opts.max_results);
         let request = NestedRequest {
             model: self.model.clone(),
-            system: Some(SEARCH_SYSTEM.to_string()),
+            system: Some(system),
             user: query.to_string(),
             tools: self.tools.clone(),
             response_format: None,

--- a/crates/bitrouter-sdk/src/language_model/server_tools/web_search/nested.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/web_search/nested.rs
@@ -1,0 +1,167 @@
+//! The nested-completion web-search backend: turns a *model* into a search
+//! engine for the `web_search` tool. Two configurations share this one impl:
+//!
+//! * **Perplexity** — route a nested completion to a search-grounded model
+//!   (e.g. `perplexity/sonar`); the model searches and synthesizes the answer.
+//! * **Native provider search** — pin a web-search-capable model and forward
+//!   its native server tool (e.g. `anthropic:web_search_20250305`). This is how
+//!   one provider's native search becomes usable by *every* model routed through
+//!   BitRouter: a model with no web search of its own calls `bitrouter:web_search`
+//!   and BitRouter serves it from the configured search-capable model.
+//!
+//! This first cut follows "option A": the synthesized text is returned as
+//! [`WebSearchResults::answer`] with an empty `results` list (the answer already
+//! embeds its sources). Surfacing structured citations would require extending
+//! the nested-completion seam and is left as a follow-up.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use super::backend::{SearchOptions, WebSearchBackend, WebSearchResults};
+use crate::language_model::server_tools::nested::{NestedRequest, NestedRunner};
+use crate::language_model::server_tools::toolset::ToolContext;
+use crate::language_model::types::Tool;
+
+/// Nudges the nested model to actually search and attribute its answer.
+const SEARCH_SYSTEM: &str = "You are a web-search assistant. Use web search to answer the user's query \
+     with current information, and cite the sources you used.";
+
+/// A [`WebSearchBackend`] backed by a nested model completion.
+pub struct NestedSearchBackend {
+    name: String,
+    runner: Arc<dyn NestedRunner>,
+    model: String,
+    /// Native server tools forwarded to the nested completion. Empty for a
+    /// search-grounded model (e.g. Perplexity) that searches on its own.
+    tools: Vec<Tool>,
+}
+
+impl NestedSearchBackend {
+    /// Build the backend. `name` is the caller-facing backend id, `model` the
+    /// nested model, and `tools` any native search tool to forward.
+    pub fn new(
+        name: String,
+        runner: Arc<dyn NestedRunner>,
+        model: String,
+        tools: Vec<Tool>,
+    ) -> Self {
+        Self {
+            name,
+            runner,
+            model,
+            tools,
+        }
+    }
+}
+
+#[async_trait]
+impl WebSearchBackend for NestedSearchBackend {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    async fn search(
+        &self,
+        query: &str,
+        _opts: &SearchOptions,
+        ctx: &ToolContext,
+    ) -> std::result::Result<WebSearchResults, String> {
+        let request = NestedRequest {
+            model: self.model.clone(),
+            system: Some(SEARCH_SYSTEM.to_string()),
+            user: query.to_string(),
+            tools: self.tools.clone(),
+            response_format: None,
+        };
+        let outcome = self.runner.run(request, ctx).await?;
+        Ok(WebSearchResults {
+            backend: self.name.clone(),
+            answer: Some(outcome.text),
+            results: Vec::new(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::caller::CallerContext;
+    use crate::language_model::server_tools::nested::NestedOutcome;
+    use std::sync::Mutex;
+
+    struct MockRunner {
+        seen: Mutex<Vec<NestedRequest>>,
+    }
+    #[async_trait]
+    impl NestedRunner for MockRunner {
+        async fn run(
+            &self,
+            request: NestedRequest,
+            _ctx: &ToolContext,
+        ) -> std::result::Result<NestedOutcome, String> {
+            let model = request.model.clone();
+            self.seen.lock().unwrap().push(request);
+            Ok(NestedOutcome {
+                model,
+                text: "the synthesized answer".to_string(),
+                usage: Default::default(),
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn returns_answer_with_empty_results() {
+        let runner = Arc::new(MockRunner {
+            seen: Mutex::new(Vec::new()),
+        });
+        let backend = NestedSearchBackend::new(
+            "perplexity".into(),
+            runner.clone(),
+            "perplexity/sonar".into(),
+            Vec::new(),
+        );
+        let out = backend
+            .search(
+                "latest rust release",
+                &SearchOptions { max_results: 5 },
+                &ToolContext::new(CallerContext::local(), Default::default()),
+            )
+            .await
+            .unwrap();
+        assert_eq!(out.backend, "perplexity");
+        assert_eq!(out.answer.as_deref(), Some("the synthesized answer"));
+        assert!(out.results.is_empty());
+        let seen = runner.seen.lock().unwrap();
+        assert_eq!(seen[0].model, "perplexity/sonar");
+        assert_eq!(seen[0].user, "latest rust release");
+    }
+
+    #[tokio::test]
+    async fn forwards_native_tools() {
+        let runner = Arc::new(MockRunner {
+            seen: Mutex::new(Vec::new()),
+        });
+        let tool = Tool::ProviderDefined {
+            id: "anthropic.web_search_20250305".into(),
+            name: "web_search".into(),
+            args: serde_json::json!({}),
+            provider_metadata: crate::language_model::types::ProviderMetadata::new(),
+        };
+        let backend = NestedSearchBackend::new(
+            "native".into(),
+            runner.clone(),
+            "anthropic/claude-opus-4.8".into(),
+            vec![tool],
+        );
+        backend
+            .search(
+                "q",
+                &SearchOptions { max_results: 3 },
+                &ToolContext::new(CallerContext::local(), Default::default()),
+            )
+            .await
+            .unwrap();
+        assert_eq!(runner.seen.lock().unwrap()[0].tools.len(), 1);
+    }
+}

--- a/crates/bitrouter-sdk/src/language_model/server_tools/web_search/toolset.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/web_search/toolset.rs
@@ -38,15 +38,20 @@ impl WebSearchToolset {
     /// Candidate backends for a call, honoring a `backend` override: the named
     /// backend first (if configured), then the rest in configured order. An
     /// unknown name is ignored, falling back to the configured order.
+    ///
+    /// The pinned entry is excluded from the tail by *index*, not by name, so
+    /// two backends that happen to share a name (e.g. two `native` backends
+    /// left at the default name) both stay in the failover chain instead of
+    /// collapsing to the first.
     fn candidates(&self, override_name: Option<&str>) -> Vec<&Arc<dyn WebSearchBackend>> {
+        let pinned =
+            override_name.and_then(|name| self.backends.iter().position(|b| b.name() == name));
         let mut ordered: Vec<&Arc<dyn WebSearchBackend>> = Vec::with_capacity(self.backends.len());
-        if let Some(name) = override_name
-            && let Some(pinned) = self.backends.iter().find(|b| b.name() == name)
-        {
-            ordered.push(pinned);
+        if let Some(i) = pinned {
+            ordered.push(&self.backends[i]);
         }
-        for b in &self.backends {
-            if !ordered.iter().any(|o| o.name() == b.name()) {
+        for (i, b) in self.backends.iter().enumerate() {
+            if Some(i) != pinned {
                 ordered.push(b);
             }
         }
@@ -104,13 +109,18 @@ impl RouterToolset for WebSearchToolset {
         let Some(query) = args.get("query").and_then(|v| v.as_str()) else {
             return Ok(error_output("web_search call is missing required `query`"));
         };
-        // Result cap precedence: call arg → declaration → deployment default.
+        // Result cap, narrowing from the deployment default through the
+        // declaration to this call's argument: each layer may only *lower* the
+        // cap, never raise it above what the deployment configured. The
+        // deployment `default_max_results` is the hard ceiling so a model can't
+        // inflate cost by requesting more than the operator allowed.
+        let ceiling = self.default_max_results;
+        let ceiling = decl.max_results.map_or(ceiling, |d| d.min(ceiling));
         let max_results = args
             .get("max_results")
             .and_then(|v| v.as_u64())
-            .map(|n| n.min(u32::MAX as u64) as u32)
-            .or(decl.max_results)
-            .unwrap_or(self.default_max_results)
+            .map(|n| (n.min(ceiling as u64)) as u32)
+            .unwrap_or(ceiling)
             .max(1);
         let opts = SearchOptions { max_results };
 
@@ -188,6 +198,48 @@ mod tests {
                 Err(format!("{} failed", self.name))
             }
         }
+    }
+
+    /// A backend that records the `max_results` it was handed, so a test can
+    /// assert the cap that actually reaches the engine.
+    struct CapturingBackend {
+        name: String,
+        seen_max_results: std::sync::Mutex<Option<u32>>,
+    }
+    #[async_trait]
+    impl WebSearchBackend for CapturingBackend {
+        fn name(&self) -> &str {
+            &self.name
+        }
+        async fn search(
+            &self,
+            _query: &str,
+            opts: &SearchOptions,
+            _ctx: &ToolContext,
+        ) -> std::result::Result<WebSearchResults, String> {
+            *self.seen_max_results.lock().unwrap() = Some(opts.max_results);
+            Ok(WebSearchResults {
+                backend: self.name.clone(),
+                answer: None,
+                results: Vec::new(),
+            })
+        }
+    }
+
+    /// Run one call through a `CapturingBackend` and return the `max_results`
+    /// the backend saw.
+    async fn capped_max_results(default_max: u32, decl: WebSearchDeclaration, args: &str) -> u32 {
+        let backend = Arc::new(CapturingBackend {
+            name: "cap".to_string(),
+            seen_max_results: std::sync::Mutex::new(None),
+        });
+        let backends: Vec<Arc<dyn WebSearchBackend>> = vec![backend.clone()];
+        let ts = WebSearchToolset::new(backends, default_max);
+        ts.call_tool("web_search", args, &ctx_with(Some(decl)))
+            .await
+            .unwrap();
+        let seen = *backend.seen_max_results.lock().unwrap();
+        seen.expect("backend was called")
     }
 
     fn ctx_with(decl: Option<WebSearchDeclaration>) -> ToolContext {
@@ -315,5 +367,64 @@ mod tests {
             .await
             .unwrap();
         assert!(matches!(&out, ToolResultOutput::Json { value } if value["status"] == "error"));
+    }
+
+    #[tokio::test]
+    async fn max_results_clamps_to_the_deployment_ceiling() {
+        // A call arg above the deployment default is clamped down to it (the
+        // model can't inflate the cap past what the operator configured).
+        assert_eq!(
+            capped_max_results(
+                5,
+                WebSearchDeclaration::default(),
+                r#"{"query":"q","max_results":100}"#
+            )
+            .await,
+            5
+        );
+        // A lower call arg is honored.
+        assert_eq!(
+            capped_max_results(
+                5,
+                WebSearchDeclaration::default(),
+                r#"{"query":"q","max_results":2}"#
+            )
+            .await,
+            2
+        );
+        // The declaration only lowers the ceiling, and the call arg cannot
+        // exceed that (now lower) declaration cap.
+        let decl = WebSearchDeclaration {
+            backend: None,
+            max_results: Some(2),
+        };
+        assert_eq!(
+            capped_max_results(5, decl.clone(), r#"{"query":"q","max_results":100}"#).await,
+            2
+        );
+        // The declaration cap also applies when the call omits `max_results`.
+        assert_eq!(capped_max_results(5, decl, r#"{"query":"q"}"#).await, 2);
+    }
+
+    #[tokio::test]
+    async fn same_named_backends_stay_in_the_failover_chain() {
+        // Two backends share the name "dup"; the first errors. Failover must
+        // still reach the second instead of the two collapsing by name.
+        let ts = WebSearchToolset::new(
+            vec![
+                Arc::new(StubBackend::err("dup")),
+                Arc::new(StubBackend::ok("dup")),
+            ],
+            5,
+        );
+        let out = ts
+            .call_tool(
+                "web_search",
+                r#"{"query":"q"}"#,
+                &ctx_with(Some(WebSearchDeclaration::default())),
+            )
+            .await
+            .unwrap();
+        assert!(matches!(&out, ToolResultOutput::Json { value } if value["status"] == "ok"));
     }
 }

--- a/crates/bitrouter-sdk/src/language_model/server_tools/web_search/toolset.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/web_search/toolset.rs
@@ -1,0 +1,319 @@
+//! The `web_search` [`RouterToolset`]: advertises one `web_search` function tool
+//! (only when the caller declares `bitrouter:web_search`) and dispatches each
+//! call to a configured [`WebSearchBackend`].
+//!
+//! Backend selection mirrors BitRouter's provider model: an ordered preference
+//! list whose first entry is the default, a per-request override that pins one
+//! backend by name, and failover to the next backend when one errors. The chosen
+//! engine is invisible to the calling model — it sees a single `web_search`
+//! tool and a stable result schema regardless of which backend answered.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use super::backend::{SearchOptions, WebSearchBackend};
+use crate::error::Result;
+use crate::language_model::server_tools::declarations::{ServerToolDeclarations, WEB_SEARCH_TOOL};
+use crate::language_model::server_tools::toolset::{RouterToolset, ToolContext};
+use crate::language_model::types::{ProviderMetadata, Tool, ToolResultOutput};
+
+/// A [`RouterToolset`] exposing the `web_search` server tool over one or more
+/// search backends.
+pub struct WebSearchToolset {
+    backends: Vec<Arc<dyn WebSearchBackend>>,
+    default_max_results: u32,
+}
+
+impl WebSearchToolset {
+    /// Build the toolset over an ordered (preference/failover) backend list and
+    /// the deployment default result cap.
+    pub fn new(backends: Vec<Arc<dyn WebSearchBackend>>, default_max_results: u32) -> Self {
+        Self {
+            backends,
+            default_max_results,
+        }
+    }
+
+    /// Candidate backends for a call, honoring a `backend` override: the named
+    /// backend first (if configured), then the rest in configured order. An
+    /// unknown name is ignored, falling back to the configured order.
+    fn candidates(&self, override_name: Option<&str>) -> Vec<&Arc<dyn WebSearchBackend>> {
+        let mut ordered: Vec<&Arc<dyn WebSearchBackend>> = Vec::with_capacity(self.backends.len());
+        if let Some(name) = override_name
+            && let Some(pinned) = self.backends.iter().find(|b| b.name() == name)
+        {
+            ordered.push(pinned);
+        }
+        for b in &self.backends {
+            if !ordered.iter().any(|o| o.name() == b.name()) {
+                ordered.push(b);
+            }
+        }
+        ordered
+    }
+}
+
+fn error_output(message: impl Into<String>) -> ToolResultOutput {
+    ToolResultOutput::Json {
+        value: serde_json::json!({ "status": "error", "error": message.into() }),
+    }
+}
+
+#[async_trait]
+impl RouterToolset for WebSearchToolset {
+    async fn list_tools(&self, ctx: &ToolContext) -> Result<Vec<Tool>> {
+        let advertise =
+            ServerToolDeclarations::from_context(ctx).is_some_and(|d| d.web_search.is_some());
+        if !advertise || self.backends.is_empty() {
+            return Ok(Vec::new());
+        }
+        Ok(vec![Tool::Function {
+            name: WEB_SEARCH_TOOL.to_string(),
+            description: Some(
+                "Search the web for current information. Provide a focused \
+                 `query`; results come back as a list of sources (title, url, \
+                 snippet), and some backends also return a synthesized `answer`."
+                    .to_string(),
+            ),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "query": { "type": "string", "description": "The search query." },
+                    "max_results": { "type": "integer", "description": "Optional cap on the number of results.", "minimum": 1 }
+                },
+                "required": ["query"],
+                "additionalProperties": false
+            }),
+            strict: None,
+            provider_metadata: ProviderMetadata::new(),
+        }])
+    }
+
+    async fn call_tool(
+        &self,
+        _name: &str,
+        arguments: &str,
+        ctx: &ToolContext,
+    ) -> Result<ToolResultOutput> {
+        let decl = ServerToolDeclarations::from_context(ctx)
+            .and_then(|d| d.web_search)
+            .unwrap_or_default();
+        let args: serde_json::Value =
+            serde_json::from_str(arguments).unwrap_or_else(|_| serde_json::json!({}));
+        let Some(query) = args.get("query").and_then(|v| v.as_str()) else {
+            return Ok(error_output("web_search call is missing required `query`"));
+        };
+        // Result cap precedence: call arg → declaration → deployment default.
+        let max_results = args
+            .get("max_results")
+            .and_then(|v| v.as_u64())
+            .map(|n| n.min(u32::MAX as u64) as u32)
+            .or(decl.max_results)
+            .unwrap_or(self.default_max_results)
+            .max(1);
+        let opts = SearchOptions { max_results };
+
+        let candidates = self.candidates(decl.backend.as_deref());
+        let mut last_error = "no web_search backend is configured".to_string();
+        for backend in candidates {
+            match backend.search(query, &opts, ctx).await {
+                Ok(results) => match serde_json::to_value(&results) {
+                    Ok(mut value) => {
+                        if let Some(obj) = value.as_object_mut() {
+                            obj.insert("status".to_string(), serde_json::json!("ok"));
+                        }
+                        return Ok(ToolResultOutput::Json { value });
+                    }
+                    Err(err) => last_error = format!("failed to encode results: {err}"),
+                },
+                Err(err) => last_error = err,
+            }
+        }
+        Ok(error_output(last_error))
+    }
+
+    fn owns(&self, name: &str) -> bool {
+        name.rsplit([':', '.']).next().unwrap_or(name) == WEB_SEARCH_TOOL
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::caller::CallerContext;
+    use crate::language_model::server_tools::declarations::{
+        WebSearchDeclaration, declarations_plugin_id,
+    };
+    use crate::language_model::server_tools::web_search::backend::WebSearchResults;
+    use std::collections::HashMap;
+
+    /// A backend that always returns a labeled result, or always errors.
+    struct StubBackend {
+        name: String,
+        ok: bool,
+    }
+    impl StubBackend {
+        fn ok(name: &str) -> Self {
+            Self {
+                name: name.to_string(),
+                ok: true,
+            }
+        }
+        fn err(name: &str) -> Self {
+            Self {
+                name: name.to_string(),
+                ok: false,
+            }
+        }
+    }
+    #[async_trait]
+    impl WebSearchBackend for StubBackend {
+        fn name(&self) -> &str {
+            &self.name
+        }
+        async fn search(
+            &self,
+            _query: &str,
+            _opts: &SearchOptions,
+            _ctx: &ToolContext,
+        ) -> std::result::Result<WebSearchResults, String> {
+            if self.ok {
+                Ok(WebSearchResults {
+                    backend: self.name.clone(),
+                    answer: None,
+                    results: Vec::new(),
+                })
+            } else {
+                Err(format!("{} failed", self.name))
+            }
+        }
+    }
+
+    fn ctx_with(decl: Option<WebSearchDeclaration>) -> ToolContext {
+        let mut meta: HashMap<_, _> = HashMap::new();
+        if let Some(d) = decl {
+            let decls = ServerToolDeclarations {
+                web_search: Some(d),
+                parent_model: "m".to_string(),
+                ..Default::default()
+            };
+            meta.insert(
+                declarations_plugin_id().clone(),
+                serde_json::to_value(decls).unwrap(),
+            );
+        }
+        ToolContext::new(CallerContext::local(), meta)
+    }
+
+    #[tokio::test]
+    async fn advertises_only_when_declared() {
+        let ts = WebSearchToolset::new(vec![Arc::new(StubBackend::ok("a"))], 5);
+        assert!(ts.list_tools(&ctx_with(None)).await.unwrap().is_empty());
+        let tools = ts
+            .list_tools(&ctx_with(Some(WebSearchDeclaration::default())))
+            .await
+            .unwrap();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].name(), "web_search");
+        assert!(ts.owns("web_search"));
+        assert!(ts.owns("bitrouter:web_search"));
+    }
+
+    #[tokio::test]
+    async fn missing_query_is_an_error_result() {
+        let ts = WebSearchToolset::new(vec![Arc::new(StubBackend::ok("a"))], 5);
+        let out = ts
+            .call_tool(
+                "web_search",
+                "{}",
+                &ctx_with(Some(WebSearchDeclaration::default())),
+            )
+            .await
+            .unwrap();
+        assert!(matches!(&out, ToolResultOutput::Json { value } if value["status"] == "error"));
+    }
+
+    #[tokio::test]
+    async fn dispatches_to_default_backend() {
+        let ts = WebSearchToolset::new(
+            vec![
+                Arc::new(StubBackend::ok("primary")),
+                Arc::new(StubBackend::ok("secondary")),
+            ],
+            5,
+        );
+        let out = ts
+            .call_tool(
+                "web_search",
+                r#"{"query":"q"}"#,
+                &ctx_with(Some(WebSearchDeclaration::default())),
+            )
+            .await
+            .unwrap();
+        assert!(
+            matches!(&out, ToolResultOutput::Json { value } if value["status"] == "ok" && value["backend"] == "primary")
+        );
+    }
+
+    #[tokio::test]
+    async fn backend_override_pins_a_named_backend() {
+        let ts = WebSearchToolset::new(
+            vec![
+                Arc::new(StubBackend::ok("primary")),
+                Arc::new(StubBackend::ok("secondary")),
+            ],
+            5,
+        );
+        let out = ts
+            .call_tool(
+                "web_search",
+                r#"{"query":"q"}"#,
+                &ctx_with(Some(WebSearchDeclaration {
+                    backend: Some("secondary".into()),
+                    max_results: None,
+                })),
+            )
+            .await
+            .unwrap();
+        assert!(
+            matches!(&out, ToolResultOutput::Json { value } if value["backend"] == "secondary")
+        );
+    }
+
+    #[tokio::test]
+    async fn fails_over_to_next_backend_on_error() {
+        let ts = WebSearchToolset::new(
+            vec![
+                Arc::new(StubBackend::err("primary")),
+                Arc::new(StubBackend::ok("secondary")),
+            ],
+            5,
+        );
+        let out = ts
+            .call_tool(
+                "web_search",
+                r#"{"query":"q"}"#,
+                &ctx_with(Some(WebSearchDeclaration::default())),
+            )
+            .await
+            .unwrap();
+        assert!(
+            matches!(&out, ToolResultOutput::Json { value } if value["status"] == "ok" && value["backend"] == "secondary")
+        );
+    }
+
+    #[tokio::test]
+    async fn all_backends_failing_yields_error_result() {
+        let ts = WebSearchToolset::new(vec![Arc::new(StubBackend::err("only"))], 5);
+        let out = ts
+            .call_tool(
+                "web_search",
+                r#"{"query":"q"}"#,
+                &ctx_with(Some(WebSearchDeclaration::default())),
+            )
+            .await
+            .unwrap();
+        assert!(matches!(&out, ToolResultOutput::Json { value } if value["status"] == "error"));
+    }
+}

--- a/schemas/bitrouter.config.schema.json
+++ b/schemas/bitrouter.config.schema.json
@@ -795,6 +795,17 @@
           "default": false,
           "description": "Enable the `subagent` server tool (delegate a task to a worker model).\nAdvertised per-request only when the caller declares `bitrouter:subagent`.",
           "type": "boolean"
+        },
+        "web_search": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WebSearchSettings"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Built-in `web_search` server tool (BYOK). When set, the\n`bitrouter:web_search` tool is enabled, served by the configured search\nbackends. Advertised per-request only when the caller declares it."
         }
       },
       "type": "object"
@@ -892,6 +903,172 @@
           "type": "string"
         }
       ]
+    },
+    "WebSearchBackendConfig": {
+      "description": "One configured search backend. The `kind` tag selects the engine; the BYOK\nkey resolves from `api_key` (supports `${VAR}` substitution) or, when\nomitted, the engine's conventional environment variable.",
+      "oneOf": [
+        {
+          "description": "parallel.ai — key `api_key` or `PARALLEL_API_KEY`.",
+          "properties": {
+            "api_base": {
+              "default": null,
+              "description": "Endpoint override (else the engine default).",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "api_key": {
+              "default": null,
+              "description": "Explicit API key (else `PARALLEL_API_KEY`).",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "kind": {
+              "const": "parallel",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "exa.ai — key `api_key` or `EXA_API_KEY`.",
+          "properties": {
+            "api_base": {
+              "default": null,
+              "description": "Endpoint override (else the engine default).",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "api_key": {
+              "default": null,
+              "description": "Explicit API key (else `EXA_API_KEY`).",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "kind": {
+              "const": "exa",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "firecrawl.dev — key `api_key` or `FIRECRAWL_API_KEY`.",
+          "properties": {
+            "api_base": {
+              "default": null,
+              "description": "Endpoint override (else the engine default).",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "api_key": {
+              "default": null,
+              "description": "Explicit API key (else `FIRECRAWL_API_KEY`).",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "kind": {
+              "const": "firecrawl",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "A search-grounded model (e.g. `perplexity/sonar`) reached through a\nnested completion. BYOK rides the normal provider mechanism (the model's\nprovider key), so no key lives here.",
+          "properties": {
+            "kind": {
+              "const": "perplexity",
+              "type": "string"
+            },
+            "model": {
+              "default": null,
+              "description": "Nested model (defaults to `perplexity/sonar`).",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "kind"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "A web-search-capable model whose *native* search tool is forwarded, made\navailable to every model routed through BitRouter.",
+          "properties": {
+            "kind": {
+              "const": "native",
+              "type": "string"
+            },
+            "model": {
+              "description": "The search-capable model serving the call.",
+              "type": "string"
+            },
+            "name": {
+              "default": null,
+              "description": "Backend id the caller pins (e.g. `\"native\"`); defaults to `\"native\"`.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "tool": {
+              "description": "The provider-defined native search tool, e.g.\n`{ \"type\": \"anthropic:web_search_20250305\" }`."
+            }
+          },
+          "required": [
+            "kind",
+            "model",
+            "tool"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "WebSearchSettings": {
+      "description": "The `server_tools.web_search` section. Its presence enables the\n`bitrouter:web_search` server tool (advertised only when a request declares\nit). An empty `backends` list leaves the tool effectively off.",
+      "properties": {
+        "backends": {
+          "description": "Search backends in preference/failover order; the first that resolves a\nkey is the default.",
+          "items": {
+            "$ref": "#/$defs/WebSearchBackendConfig"
+          },
+          "type": "array"
+        },
+        "max_results": {
+          "default": null,
+          "description": "Default maximum results per call (caller may lower it). Defaults to\n[`DEFAULT_MAX_RESULTS`].",
+          "format": "uint32",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
     }
   },
   "$id": "https://bitrouter.dev/schema/v1.0.0-alpha.19/config.schema.json",

--- a/skills/bitrouter/references/providers.md
+++ b/skills/bitrouter/references/providers.md
@@ -251,6 +251,28 @@ server_tools:
 
 Setting `fusion:` also enables the `bitrouter/fusion` model alias, which expands a request to the configured panel + judge. The judge *compares* the panel's answers (consensus / contradictions / partial coverage / unique insights / blind spots); the calling model writes the final answer from that analysis.
 
+### Built-in web search (BYOK)
+
+The `web_search` server tool gives *any* model routed through BitRouter a web search, served by a search backend you bring keys for. Advertised only when the caller declares `{"type":"bitrouter:web_search"}` (optionally with `backend` / `max_results` overrides). The model calls `web_search` with a `query`; BitRouter runs it and returns `{backend, answer?, results:[{url,title?,snippet?,content?,published?,score?}]}` — `answer` is present only for answer-engine backends (Perplexity / native).
+
+```yaml
+server_tools:
+  web_search:
+    max_results: 5             # optional default cap (caller may lower it)
+    backends:                  # preference + failover order; first that resolves a key is default
+      - kind: parallel         # HTTP, key from api_key or PARALLEL_API_KEY
+      - kind: exa              # HTTP, key from api_key or EXA_API_KEY
+      - kind: firecrawl        # HTTP, key from api_key or FIRECRAWL_API_KEY
+      - kind: perplexity       # nested completion; model defaults to perplexity/sonar (BYOK via provider key)
+        model: perplexity/sonar
+      - kind: native           # reuse a provider's NATIVE search for every model
+        name: native           # backend id a caller pins (default "native")
+        model: anthropic/claude-opus-4.8
+        tool: { type: "anthropic:web_search_20250305" }
+```
+
+HTTP backends (`parallel` / `exa` / `firecrawl`) take an optional `api_key` (supports `${VAR}`) and `api_base`; a backend with no resolvable key is skipped. The `perplexity` and `native` backends run a nested completion (so they need a routable model) — `native` forwards a provider's own search tool, making one provider's native web search usable from models that lack it.
+
 ## ACP agents
 
 ```yaml


### PR DESCRIPTION
## Summary

Adds a built-in `web_search` **router-executed server tool** with bring-your-own-key search backends. It follows the same pattern as advisor / sub-agent / fusion: enabled via `server_tools.web_search` config and advertised per request only when the caller declares `{"type":"bitrouter:web_search"}`. The result is that **any model routed through BitRouter** — even one with no native web search — gains a web search.

## Design

A `WebSearchBackend` trait is the single executor seam, with two implementors covering the four chosen engines plus a native-passthrough path:

- **`HttpSearchBackend`** — BYOK REST engines **Parallel / Exa / Firecrawl**. Keys resolve from an explicit `api_key` (supports `${VAR}`) or the conventional `*_API_KEY` env var; a backend with no resolvable key is skipped. Responses are parsed defensively through `serde_json::Value` so a provider renaming a field yields `None` rather than a hard failure.
- **`NestedSearchBackend`** — model-backed engines over the shared nested-completion runner: **Perplexity** (e.g. `perplexity/sonar`) and a provider's **native** web search (e.g. `anthropic:web_search_20250305`) **reused for every model**. This first cut is "option A": returns the synthesized `answer` with an empty `results` list (the answer embeds its sources).

**Backend selection mirrors BitRouter's provider model:** an ordered preference list (default = first), a per-request override that pins one backend by name, and **failover** to the next backend on error.

**Result schema** is deliberately minimal and stable:

```
{ backend, answer?, results: [ { url, title?, snippet?, content?, published?, score? } ] }
```

Every per-result field is optional (no engine fills them all), so the contract is additive — future backends extend via the trait, not the struct.

## Config

```yaml
server_tools:
  web_search:
    max_results: 5
    backends:                  # preference + failover order
      - kind: parallel         # PARALLEL_API_KEY
      - kind: exa              # EXA_API_KEY
      - kind: firecrawl        # FIRECRAWL_API_KEY
      - kind: perplexity       # nested; defaults to perplexity/sonar
      - kind: native           # reuse a provider's native search for all models
        model: anthropic/claude-opus-4.8
        tool: { type: "anthropic:web_search_20250305" }
```

## Changes

- New `server_tools/web_search/` module (`backend`, `http`, `nested`, `toolset`, `config`).
- `web_search` declaration parsed alongside advisor / sub-agent / fusion; `WebSearchSettings` added to `ServerToolsConfig`; wired in `assemble.rs::build_server_tool_loop` with key resolution + failover.
- Regenerated `schemas/bitrouter.config.schema.json`; documented in `skills/bitrouter/references/providers.md`.

## Tests / checks

21 new tests (request/response mapping per engine, declaration parsing, backend selection + failover, wiring). `cargo test --all-features`, `cargo clippy --all-features`, `cargo fmt --check`, and `xtask generate-schema --check` all pass.

## Notes for reviewers

1. HTTP request/response mappings are coded to the researched 2026 API shapes — most likely to need a tweak against a live key.
2. Nested backends ship as **option A** (answer text, no structured `results[]`); surfacing citations is a follow-up that needs a small `NestedOutcome` extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CCu2nEjnPimbY7atsU6dQ6)_