### PR TITLE
fix(server-tools): address web_search review follow-ups

### DIFF
--- a/crates/bitrouter-sdk/src/language_model/server_tools/declarations.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/declarations.rs
@@ -160,13 +160,31 @@ enum Kind {
 
 /// Recognise an advisor / sub-agent / web-search declaration by tool name: the
 /// bare name or a namespaced form whose final `:`/`.` segment is the name.
+///
+/// `web_search` is the exception. Unlike the bitrouter-invented
+/// `advisor` / `subagent` / `fusion` names, `web_search` is also a real
+/// *native* tool name on several providers (e.g. OpenAI's Responses
+/// `web_search`). Matching it bare would hijack a caller's genuine native tool,
+/// so it is recognised only under the explicit `bitrouter` namespace
+/// (`{"type":"bitrouter:web_search"}`, the documented declaration form); a bare
+/// or foreign-namespaced `web_search` is left untouched for the upstream.
 fn server_tool_kind(name: &str) -> Option<Kind> {
     match name.rsplit([':', '.']).next().unwrap_or(name) {
         ADVISOR_TOOL => Some(Kind::Advisor),
         SUBAGENT_TOOL => Some(Kind::SubAgent),
-        WEB_SEARCH_TOOL => Some(Kind::WebSearch),
+        WEB_SEARCH_TOOL if is_bitrouter_namespaced(name) => Some(Kind::WebSearch),
         _ => None,
     }
+}
+
+/// Whether `name` carries the explicit `bitrouter:` / `bitrouter.` namespace —
+/// the documented `{"type":"bitrouter:<tool>"}` declaration form, as opposed to
+/// a bare or foreign-namespaced tool a provider defines itself. The inbound
+/// decoders keep the namespace in the canonical tool `name` (a typeless tool
+/// defaults its `name` to the full `type`), so the prefix is visible here.
+fn is_bitrouter_namespaced(name: &str) -> bool {
+    name.split_once([':', '.'])
+        .is_some_and(|(namespace, _)| namespace == "bitrouter")
 }
 
 /// Read a string field from a config object, tolerating an OpenRouter-style
@@ -319,6 +337,31 @@ mod tests {
         let ws = decls.web_search.expect("web_search parsed");
         assert_eq!(ws.backend.as_deref(), Some("exa"));
         assert_eq!(ws.max_results, Some(3));
+    }
+
+    #[test]
+    fn bare_web_search_is_a_native_tool_not_a_declaration() {
+        // A provider's own native `web_search` (no `bitrouter` namespace) must
+        // NOT be taken over by the built-in tool — otherwise the caller silently
+        // loses their model's native search.
+        let decls = ServerToolDeclarations::from_prompt(&prompt_with(vec![provider_tool(
+            "web_search",
+            serde_json::json!({}),
+        )]));
+        assert!(decls.web_search.is_none());
+        assert!(decls.is_empty());
+    }
+
+    #[test]
+    fn foreign_namespaced_web_search_is_not_a_declaration() {
+        // Only the explicit `bitrouter` namespace declares the built-in tool;
+        // another provider's namespaced `web_search` is left for the upstream.
+        let decls = ServerToolDeclarations::from_prompt(&prompt_with(vec![provider_tool(
+            "openai:web_search",
+            serde_json::json!({}),
+        )]));
+        assert!(decls.web_search.is_none());
+        assert!(decls.is_empty());
     }
 
     #[test]

--- a/crates/bitrouter-sdk/src/language_model/server_tools/loop_controller.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/loop_controller.rs
@@ -249,8 +249,6 @@ impl ServerToolLoop {
     }
 }
 
-/// Append the model's tool-call turn and the tool-result turn to the working
-/// prompt so the next upstream call sees the results.
 /// The bare tail of a (possibly namespaced) tool name: the final `:`/`.`
 /// segment. Matches a `bitrouter:fusion` declaration against the advertised
 /// bare `fusion`, while leaving an unrelated provider tail (e.g.
@@ -259,6 +257,8 @@ fn tool_tail(name: &str) -> &str {
     name.rsplit([':', '.']).next().unwrap_or(name)
 }
 
+/// Append the model's tool-call turn and the tool-result turn to the working
+/// prompt so the next upstream call sees the results.
 fn append_turn(working: &mut Prompt, assistant_content: Vec<Content>, tool_results: Vec<Content>) {
     working.messages.push(Message {
         role: Role::Assistant,

--- a/crates/bitrouter-sdk/src/language_model/server_tools/web_search/toolset.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/web_search/toolset.rs
@@ -38,15 +38,20 @@ impl WebSearchToolset {
     /// Candidate backends for a call, honoring a `backend` override: the named
     /// backend first (if configured), then the rest in configured order. An
     /// unknown name is ignored, falling back to the configured order.
+    ///
+    /// The pinned entry is excluded from the tail by *index*, not by name, so
+    /// two backends that happen to share a name (e.g. two `native` backends
+    /// left at the default name) both stay in the failover chain instead of
+    /// collapsing to the first.
     fn candidates(&self, override_name: Option<&str>) -> Vec<&Arc<dyn WebSearchBackend>> {
+        let pinned =
+            override_name.and_then(|name| self.backends.iter().position(|b| b.name() == name));
         let mut ordered: Vec<&Arc<dyn WebSearchBackend>> = Vec::with_capacity(self.backends.len());
-        if let Some(name) = override_name
-            && let Some(pinned) = self.backends.iter().find(|b| b.name() == name)
-        {
-            ordered.push(pinned);
+        if let Some(i) = pinned {
+            ordered.push(&self.backends[i]);
         }
-        for b in &self.backends {
-            if !ordered.iter().any(|o| o.name() == b.name()) {
+        for (i, b) in self.backends.iter().enumerate() {
+            if Some(i) != pinned {
                 ordered.push(b);
             }
         }
@@ -104,13 +109,18 @@ impl RouterToolset for WebSearchToolset {
         let Some(query) = args.get("query").and_then(|v| v.as_str()) else {
             return Ok(error_output("web_search call is missing required `query`"));
         };
-        // Result cap precedence: call arg → declaration → deployment default.
+        // Result cap, narrowing from the deployment default through the
+        // declaration to this call's argument: each layer may only *lower* the
+        // cap, never raise it above what the deployment configured. The
+        // deployment `default_max_results` is the hard ceiling so a model can't
+        // inflate cost by requesting more than the operator allowed.
+        let ceiling = self.default_max_results;
+        let ceiling = decl.max_results.map_or(ceiling, |d| d.min(ceiling));
         let max_results = args
             .get("max_results")
             .and_then(|v| v.as_u64())
-            .map(|n| n.min(u32::MAX as u64) as u32)
-            .or(decl.max_results)
-            .unwrap_or(self.default_max_results)
+            .map(|n| (n.min(ceiling as u64)) as u32)
+            .unwrap_or(ceiling)
             .max(1);
         let opts = SearchOptions { max_results };
 
@@ -188,6 +198,48 @@ mod tests {
                 Err(format!("{} failed", self.name))
             }
         }
+    }
+
+    /// A backend that records the `max_results` it was handed, so a test can
+    /// assert the cap that actually reaches the engine.
+    struct CapturingBackend {
+        name: String,
+        seen_max_results: std::sync::Mutex<Option<u32>>,
+    }
+    #[async_trait]
+    impl WebSearchBackend for CapturingBackend {
+        fn name(&self) -> &str {
+            &self.name
+        }
+        async fn search(
+            &self,
+            _query: &str,
+            opts: &SearchOptions,
+            _ctx: &ToolContext,
+        ) -> std::result::Result<WebSearchResults, String> {
+            *self.seen_max_results.lock().unwrap() = Some(opts.max_results);
+            Ok(WebSearchResults {
+                backend: self.name.clone(),
+                answer: None,
+                results: Vec::new(),
+            })
+        }
+    }
+
+    /// Run one call through a `CapturingBackend` and return the `max_results`
+    /// the backend saw.
+    async fn capped_max_results(default_max: u32, decl: WebSearchDeclaration, args: &str) -> u32 {
+        let backend = Arc::new(CapturingBackend {
+            name: "cap".to_string(),
+            seen_max_results: std::sync::Mutex::new(None),
+        });
+        let backends: Vec<Arc<dyn WebSearchBackend>> = vec![backend.clone()];
+        let ts = WebSearchToolset::new(backends, default_max);
+        ts.call_tool("web_search", args, &ctx_with(Some(decl)))
+            .await
+            .unwrap();
+        let seen = *backend.seen_max_results.lock().unwrap();
+        seen.expect("backend was called")
     }
 
     fn ctx_with(decl: Option<WebSearchDeclaration>) -> ToolContext {
@@ -315,5 +367,64 @@ mod tests {
             .await
             .unwrap();
         assert!(matches!(&out, ToolResultOutput::Json { value } if value["status"] == "error"));
+    }
+
+    #[tokio::test]
+    async fn max_results_clamps_to_the_deployment_ceiling() {
+        // A call arg above the deployment default is clamped down to it (the
+        // model can't inflate the cap past what the operator configured).
+        assert_eq!(
+            capped_max_results(
+                5,
+                WebSearchDeclaration::default(),
+                r#"{"query":"q","max_results":100}"#
+            )
+            .await,
+            5
+        );
+        // A lower call arg is honored.
+        assert_eq!(
+            capped_max_results(
+                5,
+                WebSearchDeclaration::default(),
+                r#"{"query":"q","max_results":2}"#
+            )
+            .await,
+            2
+        );
+        // The declaration only lowers the ceiling, and the call arg cannot
+        // exceed that (now lower) declaration cap.
+        let decl = WebSearchDeclaration {
+            backend: None,
+            max_results: Some(2),
+        };
+        assert_eq!(
+            capped_max_results(5, decl.clone(), r#"{"query":"q","max_results":100}"#).await,
+            2
+        );
+        // The declaration cap also applies when the call omits `max_results`.
+        assert_eq!(capped_max_results(5, decl, r#"{"query":"q"}"#).await, 2);
+    }
+
+    #[tokio::test]
+    async fn same_named_backends_stay_in_the_failover_chain() {
+        // Two backends share the name "dup"; the first errors. Failover must
+        // still reach the second instead of the two collapsing by name.
+        let ts = WebSearchToolset::new(
+            vec![
+                Arc::new(StubBackend::err("dup")),
+                Arc::new(StubBackend::ok("dup")),
+            ],
+            5,
+        );
+        let out = ts
+            .call_tool(
+                "web_search",
+                r#"{"query":"q"}"#,
+                &ctx_with(Some(WebSearchDeclaration::default())),
+            )
+            .await
+            .unwrap();
+        assert!(matches!(&out, ToolResultOutput::Json { value } if value["status"] == "ok"));
     }
 }


### PR DESCRIPTION
## Summary

Follow-ups to the built-in `web_search` server tool, addressing the inline review on this PR. Targets `claude/web-search-server-tools-74j5li` so it merges **into** the feature branch (not `main`).

## Fixes

1. **Gate the `web_search` declaration on the `bitrouter` namespace.** Unlike the bitrouter-invented `advisor` / `subagent` / `fusion` names, `web_search` is also a real *native* tool name on several providers (e.g. OpenAI's Responses `web_search`). `server_tool_kind` matched the bare tail, so a caller's native `web_search` was parsed as a `bitrouter:web_search` declaration, advertised, and then **stripped from the upstream prompt** by the loop's `inject` step — silently replacing the model's native search with the BYOK backend. Now only `{"type":"bitrouter:web_search"}` declares the built-in tool; a bare or foreign-namespaced `web_search` is left for the upstream. This also makes the existing `loop_controller` comment ("a caller's native `web_search` … is left untouched") actually true.

2. **Clamp `max_results` to the configured ceiling.** The per-call argument could exceed both the per-request declaration cap and the deployment `default_max_results`, despite the docs describing those as caps the caller "may lower". Now each layer can only *lower* the cap: deployment default is the hard ceiling ≥ declaration ≥ call argument. Prevents a model from inflating result count / cost past what the operator allowed.

3. **Keep same-named backends in the failover chain.** `candidates` deduped by `name()`, so two backends sharing a name (e.g. two `native` backends left at the default name, or two `perplexity`) collapsed to the first and the rest were unreachable via failover/override. Now the pinned backend is excluded by **index**, not name.

4. **Restore `append_turn`'s doc comment**, which had become attached to `tool_tail` when that helper was inserted.

## Tests / checks

Adds tests for each fix (namespace gating accepts `bitrouter:web_search` and rejects bare / foreign `web_search`; `max_results` clamps to the ceiling; same-named backends both stay reachable on failover). Locally green:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-features --tests -- -D warnings`
- `cargo nextest run --workspace --all-features` (1169 passed)
- `cargo xtask generate-schema --check` (schema unchanged — no config struct changes)
- `cargo test --doc`

No config-schema or public-API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
