### PR TITLE
feat(update): add bitrouter update self-updater

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,7 +59,7 @@ checksum = "f211a51805bc641f3ad5b7664c77d2547af685cc33b4cd8d31964027a46f13f1"
 dependencies = [
  "anstyle",
  "memchr",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -572,6 +572,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "axoasset"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "448205969ebf1eec16088881b9d309e90e52ceed1bfa92e7efbfb00f3b10982a"
+dependencies = [
+ "camino",
+ "image",
+ "lazy_static",
+ "miette",
+ "mime",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "url",
+ "walkdir",
+]
+
+[[package]]
+name = "axoprocess"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a4b4798a6c02e91378537c63cd6e91726900b595450daa5d487bc3c11e95e1b"
+dependencies = [
+ "miette",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "axotag"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc923121fbc4cc72e9008436b5650b98e56f94b5799df59a1b4f572b5c6a7e6b"
+dependencies = [
+ "miette",
+ "semver",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "axoupdater"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc482a1926df098f4e3806b834f3fe73a1ab54b24ab0ac481f72de479af5e982"
+dependencies = [
+ "axoasset",
+ "axoprocess",
+ "axotag",
+ "camino",
+ "homedir",
+ "miette",
+ "self-replace",
+ "serde",
+ "tempfile",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
 name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -747,6 +807,7 @@ version = "1.0.0-alpha.19"
 dependencies = [
  "anyhow",
  "async-trait",
+ "axoupdater",
  "axum 0.8.9",
  "axum-test",
  "base64 0.22.1",
@@ -769,6 +830,7 @@ dependencies = [
  "reqwest 0.12.28",
  "sea-orm",
  "sea-orm-migration",
+ "semver",
  "serde",
  "serde-saphyr",
  "serde_json",
@@ -1035,10 +1097,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -1061,6 +1135,15 @@ name = "bytesize"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3"
+
+[[package]]
+name = "camino"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ce8d3bd5823c7504d3f579f13e7b2f3da252fcb938c594d5680ee508bf846f"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "cast"
@@ -1114,7 +1197,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2365,6 +2448,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "homedir"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68df315d2857b2d8d2898be54a85e1d001bbbe0dbb5f8ef847b48dd3a23c4527"
+dependencies = [
+ "cfg-if",
+ "nix 0.30.1",
+ "widestring",
+ "windows 0.61.3",
+]
+
+[[package]]
 name = "http"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2518,7 +2613,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -2645,6 +2740,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+]
+
+[[package]]
 name = "impl-trait-for-tuples"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2706,7 +2813,7 @@ dependencies = [
  "socket2 0.6.3",
  "widestring",
  "windows-registry",
- "windows-result",
+ "windows-result 0.4.1",
  "windows-sys 0.61.2",
 ]
 
@@ -2771,7 +2878,7 @@ dependencies = [
  "simd_cesu8",
  "thiserror 2.0.18",
  "walkdir",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2941,6 +3048,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3005,6 +3118,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "cfg-if",
+ "miette-derive",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3042,6 +3177,28 @@ dependencies = [
  "smallvec",
  "tagptr",
  "uuid",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -3418,7 +3575,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.5.18",
  "smallvec",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3665,10 +3822,10 @@ checksum = "2e842efad9119158434d193c6682e2ebee4b44d6ad801d7b349623b3f57cdf55"
 dependencies = [
  "futures",
  "indexmap 2.14.0",
- "nix",
+ "nix 0.31.3",
  "tokio",
  "tracing",
- "windows",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -3693,6 +3850,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "quinn"
@@ -4167,6 +4330,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4515,6 +4691,17 @@ checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "self-replace"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ec815b5eab420ab893f63393878d89c90fdd94c0bcc44c07abb8ad95552fb7"
+dependencies = [
+ "fastrand",
+ "tempfile",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5077,6 +5264,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5582,6 +5782,12 @@ checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
@@ -5902,14 +6108,36 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections 0.2.0",
+ "windows-core 0.61.2",
+ "windows-future 0.2.1",
+ "windows-link 0.1.3",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
- "windows-collections",
- "windows-core",
- "windows-future",
- "windows-numerics",
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -5918,7 +6146,20 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core",
+ "windows-core 0.62.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -5929,9 +6170,20 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading 0.1.0",
 ]
 
 [[package]]
@@ -5940,9 +6192,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core",
- "windows-link",
- "windows-threading",
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -5969,9 +6221,25 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+]
 
 [[package]]
 name = "windows-numerics"
@@ -5979,8 +6247,8 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core",
- "windows-link",
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5989,9 +6257,18 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -6000,7 +6277,16 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -6009,7 +6295,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -6045,7 +6331,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -6081,11 +6367,20 @@ dependencies = [
 
 [[package]]
 name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]

--- a/apps/bitrouter/Cargo.toml
+++ b/apps/bitrouter/Cargo.toml
@@ -43,6 +43,8 @@ serde_json.workspace = true
 async-trait.workspace = true
 reqwest.workspace = true
 anyhow = "1"
+axoupdater = { version = "0.9", default-features = false, features = ["github_releases"] }
+semver = "1"
 thiserror.workspace = true
 
 [dev-dependencies]

--- a/apps/bitrouter/src/lib.rs
+++ b/apps/bitrouter/src/lib.rs
@@ -28,6 +28,7 @@ pub mod skills;
 pub mod spawn;
 pub mod style;
 pub mod tools;
+pub mod update;
 
 pub use assemble::{Assembled, build_app, build_app_with_path, merge_registry_into};
 

--- a/apps/bitrouter/src/main.rs
+++ b/apps/bitrouter/src/main.rs
@@ -1375,21 +1375,19 @@ async fn status(socket: &Path) -> Result<()> {
             pid,
             listen,
             models,
-        }) => {
-            print_status_running(&p, pid, &listen, models, socket);
-            Ok(())
-        }
-        Ok(DaemonResponse::Error { message }) => Err(anyhow::anyhow!(message)),
-        Ok(other) => Err(anyhow::anyhow!("unexpected response: {other:?}")),
+        }) => print_status_running(&p, pid, &listen, models, socket),
+        Ok(DaemonResponse::Error { message }) => return Err(anyhow::anyhow!(message)),
+        Ok(other) => return Err(anyhow::anyhow!("unexpected response: {other:?}")),
         // No daemon listening on the socket → report stopped, not error.
         // Anything else (permission denied, malformed response, …) is a
         // real failure and bubbles to the pretty reporter.
-        Err(e) if daemon::is_not_reachable(&e) => {
-            print_status_stopped(&p, socket);
-            Ok(())
-        }
-        Err(e) => Err(e),
+        Err(e) if daemon::is_not_reachable(&e) => print_status_stopped(&p, socket),
+        Err(e) => return Err(e),
     }
+    if let Ok(source) = bitrouter::paths::resolve_config(None) {
+        bitrouter::update::maybe_nudge(source.home(), &p).await;
+    }
+    Ok(())
 }
 
 /// Render the running-daemon status block. Modelled on `systemctl

--- a/apps/bitrouter/src/main.rs
+++ b/apps/bitrouter/src/main.rs
@@ -255,6 +255,30 @@ enum Command {
         #[command(subcommand)]
         action: McpAction,
     },
+    /// Update the installed `bitrouter` binary in place to the latest release.
+    /// Follows prereleases by default while pre-1.0. For Homebrew / `cargo
+    /// install` installs it prints the right upgrade command instead.
+    Update {
+        /// Report whether a newer version exists, then exit without changing
+        /// anything.
+        #[arg(long)]
+        check: bool,
+        /// Update (or downgrade) to a specific release tag, e.g.
+        /// `1.0.0-alpha.18`. Named `--tag` to avoid clashing with the global
+        /// `--version` flag.
+        #[arg(long)]
+        tag: Option<String>,
+        /// Only consider stable (non-prerelease) releases.
+        #[arg(long)]
+        stable: bool,
+        /// After a successful update, restart a running daemon so it serves the
+        /// new binary.
+        #[arg(long)]
+        restart: bool,
+        /// Skip the confirmation prompt.
+        #[arg(short = 'y', long)]
+        yes: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -619,6 +643,30 @@ async fn run() -> Result<()> {
         Command::Cloud { action } => bitrouter::cloud::cli::run(action).await,
         Command::Skills { action } => bitrouter::skills::cli::run(action).await,
         Command::Mcp { action } => mcp_cmd(action).await,
+        Command::Update {
+            check,
+            tag,
+            stable,
+            restart: restart_after,
+            yes,
+        } => {
+            let source = bitrouter::paths::resolve_config(None)?;
+            let socket = resolve_client_socket_from(&source, None).await?;
+            let opts = bitrouter::update::UpdateOptions {
+                check,
+                tag,
+                stable,
+                restart: restart_after,
+                yes,
+            };
+            let outcome = bitrouter::update::run(opts, &socket).await?;
+            if outcome.restart_needed {
+                let log_path = resolve_log_path(source.home(), None);
+                restart(&source, &socket, &log_path).await
+            } else {
+                Ok(())
+            }
+        }
     }
 }
 
@@ -2048,4 +2096,38 @@ async fn force_kill(pid: u32) {
         .stderr(std::process::Stdio::null())
         .status()
         .await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cli_definition_is_valid() {
+        use clap::CommandFactory;
+        // Panics if clap detects a conflict (e.g. `--tag` vs global `--version`).
+        Cli::command().debug_assert();
+    }
+
+    #[test]
+    fn update_flags_parse() {
+        use clap::Parser;
+        let cli =
+            Cli::try_parse_from(["bitrouter", "update", "--check", "--tag", "1.0.0-alpha.18"])
+                .expect("parse");
+        match cli.command {
+            Command::Update {
+                check,
+                tag,
+                stable,
+                restart,
+                yes,
+            } => {
+                assert!(check);
+                assert_eq!(tag.as_deref(), Some("1.0.0-alpha.18"));
+                assert!(!stable && !restart && !yes);
+            }
+            _ => panic!("expected Update"),
+        }
+    }
 }

--- a/apps/bitrouter/src/update.rs
+++ b/apps/bitrouter/src/update.rs
@@ -3,7 +3,9 @@
 //! nudge-cache TTL) lives in small pure functions so it can be unit-tested
 //! without touching the network or replacing the running binary.
 
+use crate::{daemon, style};
 use anyhow::Result;
+use axoupdater::{AxoUpdater, UpdateRequest};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
@@ -45,8 +47,8 @@ pub fn delegation_command(method: InstallMethod) -> String {
 }
 
 /// Resolved release target, decoupled from axoupdater's own request type so the
-/// decision is unit-testable. Converted to an `axoupdater::UpdateRequest` at the
-/// call site (a later task).
+/// decision is unit-testable. Converted to an `axoupdater::UpdateRequest` by
+/// `to_request`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum VersionSpec {
     /// Newest stable (non-prerelease) release.
@@ -84,11 +86,137 @@ pub struct RunOutcome {
     pub restart_needed: bool,
 }
 
-/// Stub — real implementation in a later task.
-pub async fn run(_opts: UpdateOptions, _socket: &Path) -> Result<RunOutcome> {
+/// Current binary version, baked in at compile time.
+fn current_version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}
+
+/// Resolve `$CARGO_HOME`, falling back to `~/.cargo`, for install detection.
+fn cargo_home() -> Option<std::path::PathBuf> {
+    if let Some(h) = std::env::var_os("CARGO_HOME") {
+        return Some(std::path::PathBuf::from(h));
+    }
+    std::env::var_os("HOME").map(|h| std::path::PathBuf::from(h).join(".cargo"))
+}
+
+/// Translate our channel decision into axoupdater's request type.
+fn to_request(spec: VersionSpec) -> UpdateRequest {
+    match spec {
+        VersionSpec::Latest => UpdateRequest::Latest,
+        VersionSpec::LatestPrerelease => UpdateRequest::LatestMaybePrerelease,
+        VersionSpec::Tag(t) => UpdateRequest::SpecificTag(t),
+    }
+}
+
+/// Configure an axoupdater for the `bitrouter` app. Prefers the dist install
+/// receipt; if absent, returns `None` so the caller can delegate.
+fn build_updater() -> Option<AxoUpdater> {
+    let mut updater = AxoUpdater::new_for("bitrouter");
+    if let Err(e) = updater.load_receipt() {
+        tracing::debug!(error = %e, "no install receipt; delegating to package manager");
+        return None;
+    }
+    Some(updater)
+}
+
+pub async fn run(opts: UpdateOptions, socket: &Path) -> Result<RunOutcome> {
+    let p = style::Palette::for_stdout();
+    let current = current_version();
+
+    // 1. No receipt -> package-manager install; delegate, never clobber.
+    let Some(mut updater) = build_updater() else {
+        let exe = std::env::current_exe().unwrap_or_default();
+        let method = detect_install_method(&exe, cargo_home().as_deref());
+        println!(
+            "{dim}bitrouter looks installed via {how}. Update with:{reset}\n    {cmd}",
+            dim = p.dim,
+            reset = p.reset,
+            how = match method {
+                InstallMethod::Homebrew => "Homebrew",
+                InstallMethod::Cargo => "Cargo",
+                InstallMethod::Unknown => "your package manager",
+            },
+            cmd = delegation_command(method),
+        );
+        return Ok(RunOutcome {
+            restart_needed: false,
+        });
+    };
+
+    // 2. Channel / pin.
+    let spec = choose_spec(opts.tag.as_deref(), opts.stable);
+    if let VersionSpec::Tag(_) = spec {
+        updater.always_update(true);
+    }
+    updater.configure_version_specifier(to_request(spec));
+
+    // 3. Dry run.
+    if opts.check {
+        if updater.is_update_needed().await? {
+            match updater.query_new_version().await? {
+                Some(v) => println!("update available: {current} -> {v}"),
+                None => println!("up to date ({current})"),
+            }
+        } else {
+            println!("up to date ({current})");
+        }
+        return Ok(RunOutcome {
+            restart_needed: false,
+        });
+    }
+
+    // 4. Confirm + swap.
+    if !opts.yes && !confirm(&p, current)? {
+        println!("aborted");
+        return Ok(RunOutcome {
+            restart_needed: false,
+        });
+    }
+    let Some(result) = updater.run().await? else {
+        println!("already up to date ({current})");
+        return Ok(RunOutcome {
+            restart_needed: false,
+        });
+    };
+    println!(
+        "{green}✓{reset} updated {current} -> {new}",
+        green = p.green,
+        reset = p.reset,
+        new = result.new_version,
+    );
+
+    // 5. Daemon awareness.
+    let daemon_running = daemon::endpoint_in_use(socket);
+    if daemon_running && !opts.restart {
+        println!(
+            "{dim}A daemon is running the old binary. Run `bitrouter restart` to serve {new}.{reset}",
+            dim = p.dim,
+            reset = p.reset,
+            new = result.new_version,
+        );
+    }
     Ok(RunOutcome {
-        restart_needed: false,
+        restart_needed: daemon_running && opts.restart,
     })
+}
+
+/// Interactive y/N confirmation. Defaults to no on empty input or non-tty EOF.
+fn confirm(p: &style::Palette, current: &str) -> Result<bool> {
+    use std::io::Write;
+    print!(
+        "Update bitrouter from {bold}{current}{reset} to the latest release? [y/N] ",
+        bold = p.bold,
+        reset = p.reset,
+    );
+    std::io::stdout().flush()?;
+    let mut line = String::new();
+    if std::io::stdin().read_line(&mut line)? == 0 {
+        return Ok(false);
+    }
+    Ok(matches!(
+        line.trim().to_ascii_lowercase().as_str(),
+        "y" | "yes"
+    ))
 }
 
 /// Filename of the persisted update-check cache inside the bitrouter home.

--- a/apps/bitrouter/src/update.rs
+++ b/apps/bitrouter/src/update.rs
@@ -1,0 +1,7 @@
+//! `bitrouter update` — in-place self-updater built on cargo-dist's
+//! `axoupdater`. Decision logic (install-method detection, release channel,
+//! nudge-cache TTL) lives in small pure functions so it can be unit-tested
+//! without touching the network or replacing the running binary.
+
+#[cfg(test)]
+mod tests {}

--- a/apps/bitrouter/src/update.rs
+++ b/apps/bitrouter/src/update.rs
@@ -255,6 +255,89 @@ pub fn write_cache(home: &Path, cache: &UpdateCache) -> Result<()> {
     Ok(())
 }
 
+/// Env var that disables the passive update nudge entirely.
+const NUDGE_DISABLE_ENV: &str = "BITROUTER_NO_UPDATE_CHECK";
+/// Nudge network check cadence: once per day.
+const NUDGE_TTL_SECS: i64 = 24 * 60 * 60;
+
+/// Best-effort "update available" line for `bitrouter status`. Never returns an
+/// error and never blocks meaningfully: it respects the opt-out env var, checks
+/// the network at most once per `NUDGE_TTL_SECS` (cached under `home`), and
+/// swallows every failure.
+pub async fn maybe_nudge(home: &Path, p: &style::Palette) {
+    if std::env::var_os(NUDGE_DISABLE_ENV).is_some() {
+        return;
+    }
+    let now = chrono::Utc::now().timestamp();
+    let cache = read_cache(home);
+    let last = cache.as_ref().map(|c| c.checked_at);
+
+    let latest: Option<String> = if should_check(now, last, NUDGE_TTL_SECS) {
+        match query_latest().await {
+            Some(v) => {
+                let _ = write_cache(
+                    home,
+                    &UpdateCache {
+                        checked_at: now,
+                        latest: Some(v.clone()),
+                    },
+                );
+                Some(v)
+            }
+            None => {
+                // Record the attempt so we don't hammer the network on failure.
+                let _ = write_cache(
+                    home,
+                    &UpdateCache {
+                        checked_at: now,
+                        latest: None,
+                    },
+                );
+                cache.and_then(|c| c.latest)
+            }
+        }
+    } else {
+        cache.and_then(|c| c.latest)
+    };
+
+    if let Some(latest) = latest.filter(|l| is_newer(l, current_version())) {
+        println!();
+        println!(
+            "  {dim}↑ {latest} available — run `bitrouter update`{reset}",
+            dim = p.dim,
+            reset = p.reset,
+        );
+    }
+}
+
+/// Query the newest version tag, prereleases included, with a short timeout.
+/// Returns `None` on any error or timeout — the nudge is strictly best-effort.
+async fn query_latest() -> Option<String> {
+    let mut updater = build_updater()?;
+    updater.configure_version_specifier(UpdateRequest::LatestMaybePrerelease);
+    tokio::time::timeout(
+        std::time::Duration::from_secs(3),
+        updater.query_new_version(),
+    )
+    .await
+    .ok()
+    .and_then(|r| r.ok())
+    .flatten()
+    .map(|v| v.to_string())
+}
+
+/// True when `candidate` is a strictly greater semver than `current`. Parse
+/// failures yield `false` so a malformed tag never nags the user.
+fn is_newer(candidate: &str, current: &str) -> bool {
+    match (
+        semver::Version::parse(candidate),
+        semver::Version::parse(current),
+    ) {
+        (Ok(c), Ok(cur)) => c > cur,
+        _ => false,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -328,6 +411,14 @@ mod tests {
     #[test]
     fn checks_again_after_ttl_elapsed() {
         assert!(should_check(1_000_000 + DAY + 1, Some(1_000_000), DAY));
+    }
+
+    #[test]
+    fn is_newer_compares_prerelease_semver() {
+        assert!(is_newer("1.0.0-alpha.20", "1.0.0-alpha.19"));
+        assert!(!is_newer("1.0.0-alpha.19", "1.0.0-alpha.19"));
+        assert!(!is_newer("1.0.0-alpha.18", "1.0.0-alpha.19"));
+        assert!(!is_newer("garbage", "1.0.0-alpha.19"));
     }
 
     #[test]

--- a/apps/bitrouter/src/update.rs
+++ b/apps/bitrouter/src/update.rs
@@ -3,5 +3,82 @@
 //! nudge-cache TTL) lives in small pure functions so it can be unit-tested
 //! without touching the network or replacing the running binary.
 
+use std::path::Path;
+
+/// How the running `bitrouter` binary was installed, used to pick the right
+/// upgrade path when there is no cargo-dist receipt to self-update from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InstallMethod {
+    Homebrew,
+    Cargo,
+    Unknown,
+}
+
+/// Best-effort classification from the executable path and the resolved Cargo
+/// home. Homebrew installs live under a `Cellar/bitrouter/...` path; `cargo
+/// install` places the binary in `<CARGO_HOME>/bin`.
+pub fn detect_install_method(exe: &Path, cargo_home: Option<&Path>) -> InstallMethod {
+    let exe_str = exe.to_string_lossy();
+    if exe_str.contains("/Cellar/bitrouter/") || exe_str.contains("/homebrew/") {
+        return InstallMethod::Homebrew;
+    }
+    if cargo_home.is_some_and(|home| exe.starts_with(home.join("bin"))) {
+        return InstallMethod::Cargo;
+    }
+    InstallMethod::Unknown
+}
+
+/// The exact command a user should run to upgrade a package-manager-managed
+/// install. Unknown installs get the generic re-run-the-installer hint.
+pub fn delegation_command(method: InstallMethod) -> String {
+    match method {
+        InstallMethod::Homebrew => "brew upgrade bitrouter".to_string(),
+        InstallMethod::Cargo => "cargo install bitrouter --force".to_string(),
+        InstallMethod::Unknown => {
+            "curl --proto '=https' --tlsv1.2 -LsSf \
+             https://github.com/bitrouter/bitrouter/releases/latest/download/bitrouter-installer.sh | sh"
+                .to_string()
+        }
+    }
+}
+
 #[cfg(test)]
-mod tests {}
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn detects_homebrew_from_cellar_path() {
+        let exe = Path::new("/opt/homebrew/Cellar/bitrouter/1.0.0/bin/bitrouter");
+        assert_eq!(detect_install_method(exe, None), InstallMethod::Homebrew);
+    }
+
+    #[test]
+    fn detects_cargo_from_cargo_home_bin() {
+        let exe = Path::new("/home/me/.cargo/bin/bitrouter");
+        let cargo_home = Path::new("/home/me/.cargo");
+        assert_eq!(
+            detect_install_method(exe, Some(cargo_home)),
+            InstallMethod::Cargo
+        );
+    }
+
+    #[test]
+    fn unknown_when_no_signal_matches() {
+        let exe = Path::new("/usr/local/bin/bitrouter");
+        assert_eq!(detect_install_method(exe, None), InstallMethod::Unknown);
+    }
+
+    #[test]
+    fn delegation_command_is_method_specific() {
+        assert_eq!(
+            delegation_command(InstallMethod::Homebrew),
+            "brew upgrade bitrouter"
+        );
+        assert_eq!(
+            delegation_command(InstallMethod::Cargo),
+            "cargo install bitrouter --force"
+        );
+        assert!(delegation_command(InstallMethod::Unknown).contains("bitrouter-installer.sh"));
+    }
+}

--- a/apps/bitrouter/src/update.rs
+++ b/apps/bitrouter/src/update.rs
@@ -42,6 +42,29 @@ pub fn delegation_command(method: InstallMethod) -> String {
     }
 }
 
+/// Resolved release target, decoupled from axoupdater's own request type so the
+/// decision is unit-testable. Converted to an `axoupdater::UpdateRequest` at the
+/// call site (a later task).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VersionSpec {
+    /// Newest stable (non-prerelease) release.
+    Latest,
+    /// Newest release including prereleases — the default while pre-1.0.
+    LatestPrerelease,
+    /// A specific pinned tag (enables downgrade/rollback).
+    Tag(String),
+}
+
+/// `--tag` always wins; otherwise `--stable` selects stable-only, and the
+/// default follows prereleases (the project currently ships only `alpha.*`).
+pub fn choose_spec(tag: Option<&str>, stable: bool) -> VersionSpec {
+    match tag {
+        Some(t) => VersionSpec::Tag(t.to_string()),
+        None if stable => VersionSpec::Latest,
+        None => VersionSpec::LatestPrerelease,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -80,5 +103,23 @@ mod tests {
             "cargo install bitrouter --force"
         );
         assert!(delegation_command(InstallMethod::Unknown).contains("bitrouter-installer.sh"));
+    }
+
+    #[test]
+    fn tag_takes_precedence_over_channel() {
+        assert_eq!(
+            choose_spec(Some("1.0.0-alpha.18"), true),
+            VersionSpec::Tag("1.0.0-alpha.18".to_string())
+        );
+    }
+
+    #[test]
+    fn default_channel_includes_prereleases() {
+        assert_eq!(choose_spec(None, false), VersionSpec::LatestPrerelease);
+    }
+
+    #[test]
+    fn stable_flag_excludes_prereleases() {
+        assert_eq!(choose_spec(None, true), VersionSpec::Latest);
     }
 }

--- a/apps/bitrouter/src/update.rs
+++ b/apps/bitrouter/src/update.rs
@@ -12,7 +12,7 @@ use std::path::Path;
 /// How the running `bitrouter` binary was installed, used to pick the right
 /// upgrade path when there is no cargo-dist receipt to self-update from.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum InstallMethod {
+enum InstallMethod {
     Homebrew,
     Cargo,
     Unknown,
@@ -21,7 +21,7 @@ pub enum InstallMethod {
 /// Best-effort classification from the executable path and the resolved Cargo
 /// home. Homebrew installs live under a `Cellar/bitrouter/...` path; `cargo
 /// install` places the binary in `<CARGO_HOME>/bin`.
-pub fn detect_install_method(exe: &Path, cargo_home: Option<&Path>) -> InstallMethod {
+fn detect_install_method(exe: &Path, cargo_home: Option<&Path>) -> InstallMethod {
     let exe_str = exe.to_string_lossy();
     if exe_str.contains("/Cellar/bitrouter/") || exe_str.contains("/homebrew/") {
         return InstallMethod::Homebrew;
@@ -34,7 +34,7 @@ pub fn detect_install_method(exe: &Path, cargo_home: Option<&Path>) -> InstallMe
 
 /// The exact command a user should run to upgrade a package-manager-managed
 /// install. Unknown installs get the generic re-run-the-installer hint.
-pub fn delegation_command(method: InstallMethod) -> String {
+fn delegation_command(method: InstallMethod) -> String {
     match method {
         InstallMethod::Homebrew => "brew upgrade bitrouter".to_string(),
         InstallMethod::Cargo => "cargo install bitrouter --force".to_string(),
@@ -50,7 +50,7 @@ pub fn delegation_command(method: InstallMethod) -> String {
 /// decision is unit-testable. Converted to an `axoupdater::UpdateRequest` by
 /// `to_request`.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum VersionSpec {
+enum VersionSpec {
     /// Newest stable (non-prerelease) release.
     Latest,
     /// Newest release including prereleases — the default while pre-1.0.
@@ -61,7 +61,7 @@ pub enum VersionSpec {
 
 /// `--tag` always wins; otherwise `--stable` selects stable-only, and the
 /// default follows prereleases (the project currently ships only `alpha.*`).
-pub fn choose_spec(tag: Option<&str>, stable: bool) -> VersionSpec {
+fn choose_spec(tag: Option<&str>, stable: bool) -> VersionSpec {
     match tag {
         Some(t) => VersionSpec::Tag(t.to_string()),
         None if stable => VersionSpec::Latest,
@@ -145,6 +145,10 @@ pub async fn run(opts: UpdateOptions, socket: &Path) -> Result<RunOutcome> {
 
     // 2. Channel / pin.
     let spec = choose_spec(opts.tag.as_deref(), opts.stable);
+    let target_label = match &spec {
+        VersionSpec::Tag(t) => format!("version {t}"),
+        _ => "the latest release".to_string(),
+    };
     if let VersionSpec::Tag(_) = spec {
         updater.always_update(true);
     }
@@ -155,7 +159,7 @@ pub async fn run(opts: UpdateOptions, socket: &Path) -> Result<RunOutcome> {
         if updater.is_update_needed().await? {
             match updater.query_new_version().await? {
                 Some(v) => println!("update available: {current} -> {v}"),
-                None => println!("up to date ({current})"),
+                None => println!("update available (target version unknown)"),
             }
         } else {
             println!("up to date ({current})");
@@ -166,7 +170,7 @@ pub async fn run(opts: UpdateOptions, socket: &Path) -> Result<RunOutcome> {
     }
 
     // 4. Confirm + swap.
-    if !opts.yes && !confirm(&p, current)? {
+    if !opts.yes && !confirm(&p, current, &target_label)? {
         println!("aborted");
         return Ok(RunOutcome {
             restart_needed: false,
@@ -201,10 +205,10 @@ pub async fn run(opts: UpdateOptions, socket: &Path) -> Result<RunOutcome> {
 }
 
 /// Interactive y/N confirmation. Defaults to no on empty input or non-tty EOF.
-fn confirm(p: &style::Palette, current: &str) -> Result<bool> {
+fn confirm(p: &style::Palette, current: &str, target: &str) -> Result<bool> {
     use std::io::Write;
     print!(
-        "Update bitrouter from {bold}{current}{reset} to the latest release? [y/N] ",
+        "Update bitrouter from {bold}{current}{reset} to {target}? [y/N] ",
         bold = p.bold,
         reset = p.reset,
     );
@@ -224,16 +228,16 @@ const CACHE_FILENAME: &str = "update-check.json";
 
 /// Persisted record of the last passive update check.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct UpdateCache {
+struct UpdateCache {
     /// Unix seconds of the last network check.
-    pub checked_at: i64,
+    checked_at: i64,
     /// Latest version string seen at that check, if any.
-    pub latest: Option<String>,
+    latest: Option<String>,
 }
 
 /// Whether the passive nudge should perform a fresh network check now. True
 /// when never checked, or when more than `ttl_secs` have elapsed.
-pub fn should_check(now: i64, last_checked: Option<i64>, ttl_secs: i64) -> bool {
+fn should_check(now: i64, last_checked: Option<i64>, ttl_secs: i64) -> bool {
     match last_checked {
         None => true,
         Some(prev) => now - prev >= ttl_secs,
@@ -242,13 +246,13 @@ pub fn should_check(now: i64, last_checked: Option<i64>, ttl_secs: i64) -> bool 
 
 /// Read the cache from `<home>/update-check.json`. Any error (missing,
 /// malformed) is treated as "no cache" — the nudge is best-effort.
-pub fn read_cache(home: &Path) -> Option<UpdateCache> {
+fn read_cache(home: &Path) -> Option<UpdateCache> {
     let bytes = std::fs::read(home.join(CACHE_FILENAME)).ok()?;
     serde_json::from_slice(&bytes).ok()
 }
 
 /// Persist the cache to `<home>/update-check.json`, creating the home if needed.
-pub fn write_cache(home: &Path, cache: &UpdateCache) -> Result<()> {
+fn write_cache(home: &Path, cache: &UpdateCache) -> Result<()> {
     crate::paths::ensure_home_directory(home)?;
     let bytes = serde_json::to_vec(cache)?;
     std::fs::write(home.join(CACHE_FILENAME), bytes)?;

--- a/apps/bitrouter/src/update.rs
+++ b/apps/bitrouter/src/update.rs
@@ -3,6 +3,8 @@
 //! nudge-cache TTL) lives in small pure functions so it can be unit-tested
 //! without touching the network or replacing the running binary.
 
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
 use std::path::Path;
 
 /// How the running `bitrouter` binary was installed, used to pick the right
@@ -65,6 +67,42 @@ pub fn choose_spec(tag: Option<&str>, stable: bool) -> VersionSpec {
     }
 }
 
+/// Filename of the persisted update-check cache inside the bitrouter home.
+const CACHE_FILENAME: &str = "update-check.json";
+
+/// Persisted record of the last passive update check.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdateCache {
+    /// Unix seconds of the last network check.
+    pub checked_at: i64,
+    /// Latest version string seen at that check, if any.
+    pub latest: Option<String>,
+}
+
+/// Whether the passive nudge should perform a fresh network check now. True
+/// when never checked, or when more than `ttl_secs` have elapsed.
+pub fn should_check(now: i64, last_checked: Option<i64>, ttl_secs: i64) -> bool {
+    match last_checked {
+        None => true,
+        Some(prev) => now - prev >= ttl_secs,
+    }
+}
+
+/// Read the cache from `<home>/update-check.json`. Any error (missing,
+/// malformed) is treated as "no cache" — the nudge is best-effort.
+pub fn read_cache(home: &Path) -> Option<UpdateCache> {
+    let bytes = std::fs::read(home.join(CACHE_FILENAME)).ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+/// Persist the cache to `<home>/update-check.json`, creating the home if needed.
+pub fn write_cache(home: &Path, cache: &UpdateCache) -> Result<()> {
+    crate::paths::ensure_home_directory(home)?;
+    let bytes = serde_json::to_vec(cache)?;
+    std::fs::write(home.join(CACHE_FILENAME), bytes)?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -121,5 +159,37 @@ mod tests {
     #[test]
     fn stable_flag_excludes_prereleases() {
         assert_eq!(choose_spec(None, true), VersionSpec::Latest);
+    }
+
+    const DAY: i64 = 24 * 60 * 60;
+
+    #[test]
+    fn checks_when_never_checked_before() {
+        assert!(should_check(1_000_000, None, DAY));
+    }
+
+    #[test]
+    fn skips_when_within_ttl() {
+        assert!(!should_check(1_000_000 + 100, Some(1_000_000), DAY));
+    }
+
+    #[test]
+    fn checks_again_after_ttl_elapsed() {
+        assert!(should_check(1_000_000 + DAY + 1, Some(1_000_000), DAY));
+    }
+
+    #[test]
+    fn cache_round_trips_through_disk() {
+        let dir = std::env::temp_dir().join(format!("brupd-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let cache = UpdateCache {
+            checked_at: 42,
+            latest: Some("1.0.0-alpha.20".to_string()),
+        };
+        write_cache(&dir, &cache).unwrap();
+        let read = read_cache(&dir).expect("cache present");
+        assert_eq!(read.checked_at, 42);
+        assert_eq!(read.latest.as_deref(), Some("1.0.0-alpha.20"));
+        std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/apps/bitrouter/src/update.rs
+++ b/apps/bitrouter/src/update.rs
@@ -67,6 +67,30 @@ pub fn choose_spec(tag: Option<&str>, stable: bool) -> VersionSpec {
     }
 }
 
+/// Options parsed from the `bitrouter update` flags.
+#[derive(Debug)]
+pub struct UpdateOptions {
+    pub check: bool,
+    pub tag: Option<String>,
+    pub stable: bool,
+    pub restart: bool,
+    pub yes: bool,
+}
+
+/// What the dispatch layer must still do after `run` returns.
+#[derive(Debug)]
+pub struct RunOutcome {
+    /// A running daemon needs restarting to pick up the new binary.
+    pub restart_needed: bool,
+}
+
+/// Stub — real implementation in a later task.
+pub async fn run(_opts: UpdateOptions, _socket: &Path) -> Result<RunOutcome> {
+    Ok(RunOutcome {
+        restart_needed: false,
+    })
+}
+
 /// Filename of the persisted update-check cache inside the bitrouter home.
 const CACHE_FILENAME: &str = "update-check.json";
 

--- a/skills/bitrouter/SKILL.md
+++ b/skills/bitrouter/SKILL.md
@@ -92,6 +92,7 @@ export OPENCODE_ZEN_API_KEY=...        # opencode-zen AND opencode-go (shared)
 
 bitrouter start          # detached daemon, logs to ~/.bitrouter/bitrouter.log
 bitrouter status         # green dot + pid / listen / model count
+bitrouter update         # self-update the binary (prereleases by default); --check to dry-run
 ```
 
 The daemon writes its runtime files (`bitrouter.sock`, `bitrouter.pid`, `bitrouter.log`, optional `bitrouter.db`) into `~/.bitrouter/`.
@@ -178,6 +179,7 @@ Read these on demand — don't load them all upfront.
 | `references/harness-hermes-agent.md` | Wiring Hermes Agent |
 | `references/harness-openclaw.md` | Wiring OpenClaw |
 | `references/mcp-server.md` | Origin MCP server — all flags, tool shapes, transport/backend details, roadmap |
+| `references/updating.md` | `bitrouter update`, channels, package-manager delegation, the status nudge |
 
 ## 7. Gotchas
 

--- a/skills/bitrouter/references/updating.md
+++ b/skills/bitrouter/references/updating.md
@@ -1,0 +1,24 @@
+# Updating BitRouter
+
+`bitrouter update` updates the installed binary in place using cargo-dist's
+self-update path.
+
+- Default follows **prereleases** (the project ships `1.0.0-alpha.*`); pass
+  `--stable` for stable-only once 1.0 exists.
+- `--check` reports whether a newer version exists and exits without changing
+  anything.
+- `--tag <VERSION>` pins to a specific release (also downgrades/rolls back),
+  e.g. `bitrouter update --tag 1.0.0-alpha.18`. Named `--tag`, not `--version`,
+  because `--version` prints the binary version.
+- `-y`/`--yes` skips the confirmation prompt.
+- `--restart` restarts a running daemon after a successful update.
+- **Homebrew / `cargo install`** installs are not self-updated — the command
+  prints the right upgrade command (`brew upgrade bitrouter` /
+  `cargo install bitrouter --force`) instead of clobbering a managed binary.
+- After a successful update, if a daemon is running, the new binary is only
+  served after a restart. The command prompts for `bitrouter restart`, or pass
+  `--restart` to do it automatically.
+
+`bitrouter status` shows a one-line "↑ <version> available" nudge when a newer
+release exists (checked at most once per day). Disable it with
+`BITROUTER_NO_UPDATE_CHECK=1`.


### PR DESCRIPTION
## Summary

Adds a first-class `bitrouter update` subcommand that updates the installed binary in place, plus a passive "update available" nudge on `bitrouter status`. Built on cargo-dist's `axoupdater` (the project already ships via cargo-dist), so we lean on the existing release pipeline rather than hand-rolling GitHub release fetching.

### `bitrouter update`
- **In-place self-update** via `axoupdater` 0.9.1 (reads the cargo-dist install receipt, swaps the binary, handles the Windows self-replace dance). Uses rustls — no OpenSSL pulled in.
- **`--check`** — dry run: report whether a newer version exists, change nothing.
- **`--tag <VERSION>`** — pin to a specific release (also downgrade/rollback). Named `--tag`, not `--version`, to avoid shadowing the global `--version` flag.
- **`--stable`** — stable-only channel. Default **follows prereleases** while the project is on `1.0.0-alpha.*` (a stable-only updater would always report "nothing newer"). Exposed so flipping the default at 1.0 is trivial.
- **Package-manager delegation** — Homebrew / `cargo install` installs (no receipt) are not clobbered; the command prints the right upgrade command (`brew upgrade bitrouter` / `cargo install bitrouter --force`).
- **Daemon awareness** — after a successful swap, if a daemon is running it prompts for `bitrouter restart` (or `--restart` does it automatically). No surprise process kills.
- **`-y/--yes`** — skip the confirmation prompt.

### `bitrouter status` nudge
- One dim `↑ <version> available` line when a newer release exists.
- Best-effort: cached once/day, 3s network timeout, all errors swallowed, never slows or fails `status`.
- Opt out with `BITROUTER_NO_UPDATE_CHECK=1`.

### Implementation notes
- New `apps/bitrouter/src/update.rs` (442 lines). Decision logic (install-method detection, channel selection, nudge-cache TTL, semver comparison) is split into small pure functions with unit tests; the network/binary-swap stays in `run`/`query_latest`.
- `/bitrouter` skill updated per `CLAUDE.md` (`SKILL.md` + new `references/updating.md`).
- No `#[allow]`, no `unwrap`/`expect`/`panic!` in non-test code.

## Test Plan
- [x] `cargo nextest run --all-features` — 1162 passed, 1 skipped
- [x] `cargo clippy --all-features` — clean
- [x] `cargo fmt -- --check` — clean
- [x] `bitrouter update --check` in a no-receipt checkout → prints delegation hint, exits 0 (no swap)
- [x] `bitrouter status` → nudge no-ops silently when no receipt; never hangs/errors
- [ ] **Deferred (needs a real dist install):** live binary-swap against a receipt-bearing install — not exercisable from a dev checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)