### PR TITLE
feat(server-tools): add Tavily web_search backend, drop Perplexity

### DIFF
--- a/apps/bitrouter/src/assemble.rs
+++ b/apps/bitrouter/src/assemble.rs
@@ -662,22 +662,23 @@ fn build_server_tool_loop(
 /// preference/failover order. HTTP backends resolve their BYOK key from the
 /// explicit `api_key` (with `${VAR}` already substituted at config load) or the
 /// engine's conventional environment variable; one whose key cannot be resolved
-/// is skipped with a warning. The Perplexity / native backends reuse the shared
-/// nested runner (so they are skipped when none was built).
+/// is skipped with a warning. The native backend reuses the shared nested runner
+/// (so it is skipped when none was built).
 fn build_web_search_backends(
     settings: &WebSearchSettings,
     nested_runner: &Option<Arc<dyn NestedRunner>>,
 ) -> Vec<Arc<dyn WebSearchBackend>> {
     // A shared HTTP client for the BYOK search APIs, built only when an HTTP
-    // backend is configured so a config with only nested (Perplexity / native)
-    // backends pays nothing. The request timeout sits below the loop's per-tool
-    // budget so a stuck call fails over promptly.
+    // backend is configured so a config with only the nested (native) backend
+    // pays nothing. The request timeout sits below the loop's per-tool budget so
+    // a stuck call fails over promptly.
     let needs_http = settings.backends.iter().any(|b| {
         matches!(
             b,
             WebSearchBackendConfig::Parallel { .. }
                 | WebSearchBackendConfig::Exa { .. }
                 | WebSearchBackendConfig::Firecrawl { .. }
+                | WebSearchBackendConfig::Tavily { .. }
         )
     });
     let http = needs_http.then(|| {
@@ -690,14 +691,16 @@ fn build_web_search_backends(
     let mut backends: Vec<Arc<dyn WebSearchBackend>> = Vec::new();
     for entry in &settings.backends {
         match entry {
-            // The three HTTP engines share one construction path, differing only
-            // in the engine tag (which also names the conventional key env var).
+            // The HTTP engines share one construction path, differing only in
+            // the engine tag (which also names the conventional key env var).
             WebSearchBackendConfig::Parallel { api_key, api_base }
             | WebSearchBackendConfig::Exa { api_key, api_base }
-            | WebSearchBackendConfig::Firecrawl { api_key, api_base } => {
+            | WebSearchBackendConfig::Firecrawl { api_key, api_base }
+            | WebSearchBackendConfig::Tavily { api_key, api_base } => {
                 let engine = match entry {
                     WebSearchBackendConfig::Exa { .. } => HttpEngine::Exa,
                     WebSearchBackendConfig::Firecrawl { .. } => HttpEngine::Firecrawl,
+                    WebSearchBackendConfig::Tavily { .. } => HttpEngine::Tavily,
                     _ => HttpEngine::Parallel,
                 };
                 if let (Some(client), Some(key)) = (
@@ -710,20 +713,6 @@ fn build_web_search_backends(
                         api_base.clone(),
                         client.clone(),
                     )));
-                }
-            }
-            WebSearchBackendConfig::Perplexity { model } => {
-                if let Some(runner) = nested_runner {
-                    backends.push(Arc::new(NestedSearchBackend::new(
-                        "perplexity".to_string(),
-                        runner.clone(),
-                        model
-                            .clone()
-                            .unwrap_or_else(|| "perplexity/sonar".to_string()),
-                        Vec::new(),
-                    )));
-                } else {
-                    tracing::warn!("web_search perplexity backend needs a nested runner; skipping");
                 }
             }
             WebSearchBackendConfig::Native { name, model, tool } => {
@@ -1560,10 +1549,14 @@ mod server_tools_tests {
         use bitrouter_sdk::language_model::server_tools::web_search::config::{
             WebSearchBackendConfig, WebSearchSettings,
         };
-        // A Perplexity (nested) backend resolves over the runner and builds the loop.
+        // A native (nested) backend resolves over the runner and builds the loop.
         let mut cfg = Config::default();
         cfg.server_tools.web_search = Some(WebSearchSettings {
-            backends: vec![WebSearchBackendConfig::Perplexity { model: None }],
+            backends: vec![WebSearchBackendConfig::Native {
+                name: None,
+                model: "anthropic/claude-opus-4.8".to_string(),
+                tool: serde_json::json!({ "type": "anthropic:web_search_20250305" }),
+            }],
             max_results: None,
         });
         let runner: Arc<dyn NestedRunner> = Arc::new(NoopRunner);

--- a/crates/bitrouter-sdk/src/language_model/server_tools/web_search/backend.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/web_search/backend.rs
@@ -2,8 +2,8 @@
 //! `web_search` server tool returns to the calling model.
 //!
 //! A backend is the *engine* behind one `web_search` call — a BYOK HTTP search
-//! API (Parallel / Exa / Firecrawl) or a nested model completion (Perplexity, or
-//! a provider's native web search reused for every model). The toolset composes
+//! API (Parallel / Exa / Firecrawl / Tavily) or a nested model completion (a
+//! provider's native web search reused for every model). The toolset composes
 //! several backends as an ordered preference/failover list and selects one per
 //! call. The result schema is deliberately minimal and stable: every per-result
 //! field is optional because no single engine fills them all, and a future
@@ -23,8 +23,8 @@ pub struct SearchOptions {
 }
 
 /// One normalized search hit. Every field beyond `url` is optional because the
-/// backends disagree on what they return (Perplexity citations carry only a
-/// URL; Exa adds a score and highlights; Firecrawl a description; …).
+/// backends disagree on what they return (Exa and Tavily add a score; Firecrawl
+/// a description; Parallel excerpts; …).
 #[derive(Clone, Debug, Default, PartialEq, Serialize)]
 pub struct WebSearchResult {
     /// The result URL.
@@ -48,8 +48,8 @@ pub struct WebSearchResult {
 }
 
 /// The normalized output of one `web_search` call. `answer` is the synthesized
-/// text an *answer engine* (Perplexity / native provider search) returns; pure
-/// search engines leave it `None` and populate `results` only.
+/// text an *answer engine* (the native provider search) returns; pure search
+/// engines leave it `None` and populate `results` only.
 #[derive(Clone, Debug, Default, PartialEq, Serialize)]
 pub struct WebSearchResults {
     /// Which backend served this call (failover/observability transparency).

--- a/crates/bitrouter-sdk/src/language_model/server_tools/web_search/config.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/web_search/config.rs
@@ -57,13 +57,14 @@ pub enum WebSearchBackendConfig {
         #[serde(default)]
         api_base: Option<String>,
     },
-    /// A search-grounded model (e.g. `perplexity/sonar`) reached through a
-    /// nested completion. BYOK rides the normal provider mechanism (the model's
-    /// provider key), so no key lives here.
-    Perplexity {
-        /// Nested model (defaults to `perplexity/sonar`).
+    /// tavily.com — key `api_key` or `TAVILY_API_KEY`.
+    Tavily {
+        /// Explicit API key (else `TAVILY_API_KEY`).
         #[serde(default)]
-        model: Option<String>,
+        api_key: Option<String>,
+        /// Endpoint override (else the engine default).
+        #[serde(default)]
+        api_base: Option<String>,
     },
     /// A web-search-capable model whose *native* search tool is forwarded, made
     /// available to every model routed through BitRouter.

--- a/crates/bitrouter-sdk/src/language_model/server_tools/web_search/http.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/web_search/http.rs
@@ -1,4 +1,4 @@
-//! BYOK HTTP search backends: Parallel, Exa, and Firecrawl. Each maps the
+//! BYOK HTTP search backends: Parallel, Exa, Firecrawl, and Tavily. Each maps the
 //! shared [`WebSearchBackend`] call onto the provider's REST search endpoint and
 //! normalizes its response into [`WebSearchResults`]. Responses are parsed
 //! defensively through [`serde_json::Value`] so a provider adding or renaming a
@@ -85,12 +85,13 @@ impl HttpSearchBackend {
     fn request_body(&self, query: &str, opts: &SearchOptions) -> Value {
         let n = opts.max_results;
         match self.engine {
-            // Parallel takes a natural-language `objective` plus keyword queries;
-            // we mirror the user query into both and ask for excerpts.
+            // Parallel takes a natural-language `objective` plus keyword queries
+            // and returns excerpted results. Its `/v1/search` rejects extra body
+            // fields (`max_results` and friends), so the cap is applied to the
+            // response instead (see `search`).
             HttpEngine::Parallel => json!({
                 "objective": query,
                 "search_queries": [query],
-                "max_results": n,
             }),
             // Exa: ask for highlights (short excerpts) rather than full `text`,
             // keeping the tool result within budget.
@@ -174,7 +175,11 @@ impl WebSearchBackend for HttpSearchBackend {
         }
         let parsed: Value = serde_json::from_str(&text)
             .map_err(|e| format!("{} returned non-JSON: {e}", self.engine.name()))?;
-        Ok(self.parse_response(&parsed))
+        let mut results = self.parse_response(&parsed);
+        // Enforce the cap on the response too: some engines (Parallel) take no
+        // result-count parameter, so trim to what the caller asked for.
+        results.results.truncate(opts.max_results as usize);
+        Ok(results)
     }
 }
 
@@ -259,7 +264,7 @@ mod tests {
         let p = backend(HttpEngine::Parallel).request_body("rust async", &opts);
         assert_eq!(p["objective"], "rust async");
         assert_eq!(p["search_queries"][0], "rust async");
-        assert_eq!(p["max_results"], 5);
+        assert!(p.get("max_results").is_none()); // Parallel rejects extra fields
 
         let e = backend(HttpEngine::Exa).request_body("rust async", &opts);
         assert_eq!(e["query"], "rust async");
@@ -346,5 +351,72 @@ mod tests {
     fn missing_arrays_yield_no_results() {
         let out = backend(HttpEngine::Exa).parse_response(&json!({}));
         assert!(out.results.is_empty());
+    }
+
+    /// Live smoke test against the real search APIs. Ignored by default; run
+    /// explicitly with the BYOK keys in the environment:
+    ///   PARALLEL_API_KEY=… EXA_API_KEY=… FIRECRAWL_API_KEY=… TAVILY_API_KEY=… \
+    ///   cargo test -p bitrouter-sdk --all-features live_search_smoke -- --ignored --nocapture
+    #[tokio::test]
+    #[ignore = "hits live search APIs; requires BYOK keys in env"]
+    async fn live_search_smoke() {
+        use crate::caller::CallerContext;
+
+        let ctx = ToolContext::new(CallerContext::local(), Default::default());
+        let opts = SearchOptions { max_results: 3 };
+        let client = reqwest::Client::new();
+        let query = "latest stable Rust programming language release";
+
+        let mut failures = Vec::new();
+        for engine in [
+            HttpEngine::Parallel,
+            HttpEngine::Exa,
+            HttpEngine::Firecrawl,
+            HttpEngine::Tavily,
+        ] {
+            let key = std::env::var(engine.env_var())
+                .ok()
+                .filter(|k| !k.is_empty());
+            let Some(key) = key else {
+                println!("SKIP {:<10} (no {})", engine.name(), engine.env_var());
+                continue;
+            };
+            let backend = HttpSearchBackend::new(engine, key, None, client.clone());
+            match backend.search(query, &opts, &ctx).await {
+                Ok(r) => {
+                    println!(
+                        "\nOK   {:<10} {} result(s){}",
+                        r.backend,
+                        r.results.len(),
+                        r.answer
+                            .as_deref()
+                            .map(|a| format!(
+                                "  answer: {}…",
+                                &a.chars().take(60).collect::<String>()
+                            ))
+                            .unwrap_or_default(),
+                    );
+                    for (i, res) in r.results.iter().take(3).enumerate() {
+                        println!(
+                            "  [{i}] {}  ({})  score={:?}",
+                            res.title.as_deref().unwrap_or("—"),
+                            res.url,
+                            res.score
+                        );
+                        if let Some(s) = &res.snippet {
+                            println!("      {}", s.chars().take(120).collect::<String>());
+                        }
+                    }
+                    if r.results.is_empty() && r.answer.is_none() {
+                        failures.push(format!("{}: empty response", engine.name()));
+                    }
+                }
+                Err(e) => {
+                    println!("\nFAIL {:<10} {e}", engine.name());
+                    failures.push(format!("{}: {e}", engine.name()));
+                }
+            }
+        }
+        assert!(failures.is_empty(), "live search failures: {failures:?}");
     }
 }

--- a/crates/bitrouter-sdk/src/language_model/server_tools/web_search/http.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/web_search/http.rs
@@ -20,6 +20,8 @@ pub enum HttpEngine {
     Exa,
     /// firecrawl.dev — `POST /v2/search`, bearer auth, results under `data.web`.
     Firecrawl,
+    /// tavily.com — `POST /search`, bearer auth, results under `results`.
+    Tavily,
 }
 
 impl HttpEngine {
@@ -29,6 +31,7 @@ impl HttpEngine {
             Self::Parallel => "parallel",
             Self::Exa => "exa",
             Self::Firecrawl => "firecrawl",
+            Self::Tavily => "tavily",
         }
     }
 
@@ -38,6 +41,7 @@ impl HttpEngine {
             Self::Parallel => "PARALLEL_API_KEY",
             Self::Exa => "EXA_API_KEY",
             Self::Firecrawl => "FIRECRAWL_API_KEY",
+            Self::Tavily => "TAVILY_API_KEY",
         }
     }
 
@@ -47,6 +51,7 @@ impl HttpEngine {
             Self::Parallel => "https://api.parallel.ai/v1/search",
             Self::Exa => "https://api.exa.ai/search",
             Self::Firecrawl => "https://api.firecrawl.dev/v2/search",
+            Self::Tavily => "https://api.tavily.com/search",
         }
     }
 }
@@ -100,6 +105,12 @@ impl HttpSearchBackend {
                 "query": query,
                 "limit": n,
             }),
+            // Tavily: a basic search; `content` carries the relevant snippet per
+            // result, so no answer or raw content is requested.
+            HttpEngine::Tavily => json!({
+                "query": query,
+                "max_results": n,
+            }),
         }
     }
 
@@ -107,7 +118,7 @@ impl HttpSearchBackend {
     fn authorize(&self, req: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
         match self.engine {
             HttpEngine::Parallel | HttpEngine::Exa => req.header("x-api-key", &self.api_key),
-            HttpEngine::Firecrawl => req.bearer_auth(&self.api_key),
+            HttpEngine::Firecrawl | HttpEngine::Tavily => req.bearer_auth(&self.api_key),
         }
     }
 
@@ -120,6 +131,7 @@ impl HttpSearchBackend {
                 body.get("data").and_then(|d| d.get("web")),
                 firecrawl_result,
             ),
+            HttpEngine::Tavily => map_array(body.get("results"), tavily_result),
         };
         WebSearchResults {
             backend: self.engine.name().to_string(),
@@ -221,6 +233,18 @@ fn firecrawl_result(v: &Value) -> WebSearchResult {
     }
 }
 
+fn tavily_result(v: &Value) -> WebSearchResult {
+    WebSearchResult {
+        url: str_at(v, "url").unwrap_or_default(),
+        title: str_at(v, "title"),
+        // Tavily's `content` is the relevant snippet, not the full page.
+        snippet: str_at(v, "content"),
+        content: None,
+        published: str_at(v, "published_date"),
+        score: v.get("score").and_then(|s| s.as_f64()),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -245,6 +269,10 @@ mod tests {
         let f = backend(HttpEngine::Firecrawl).request_body("rust async", &opts);
         assert_eq!(f["query"], "rust async");
         assert_eq!(f["limit"], 5);
+
+        let t = backend(HttpEngine::Tavily).request_body("rust async", &opts);
+        assert_eq!(t["query"], "rust async");
+        assert_eq!(t["max_results"], 5);
     }
 
     #[test]
@@ -290,6 +318,28 @@ mod tests {
         let out = backend(HttpEngine::Firecrawl).parse_response(&body);
         assert_eq!(out.results[0].snippet.as_deref(), Some("desc"));
         assert_eq!(out.results[0].content.as_deref(), Some("# Y"));
+    }
+
+    #[test]
+    fn parses_tavily_results_with_score() {
+        let body = json!({
+            "query": "rust",
+            "results": [
+                { "url": "https://t", "title": "T", "content": "snippet",
+                  "score": 0.42, "published_date": "2025-03-03" },
+                { "missing": "url and the rest" }
+            ]
+        });
+        let out = backend(HttpEngine::Tavily).parse_response(&body);
+        assert_eq!(out.backend, "tavily");
+        assert!(out.answer.is_none());
+        assert_eq!(out.results.len(), 2);
+        assert_eq!(out.results[0].url, "https://t");
+        assert_eq!(out.results[0].title.as_deref(), Some("T"));
+        assert_eq!(out.results[0].snippet.as_deref(), Some("snippet"));
+        assert_eq!(out.results[0].published.as_deref(), Some("2025-03-03"));
+        assert_eq!(out.results[0].score, Some(0.42));
+        assert!(out.results[0].content.is_none());
     }
 
     #[test]

--- a/crates/bitrouter-sdk/src/language_model/server_tools/web_search/mod.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/web_search/mod.rs
@@ -8,8 +8,9 @@
 //!
 //! Backends come in two flavors behind one [`backend::WebSearchBackend`] seam:
 //! BYOK HTTP search APIs ([`http::HttpSearchBackend`] — Parallel / Exa /
-//! Firecrawl) and nested model completions ([`nested::NestedSearchBackend`] —
-//! Perplexity, or a provider's native search reused for every model).
+//! Firecrawl / Tavily) and a nested model completion
+//! ([`nested::NestedSearchBackend`] — a provider's native search reused for
+//! every model).
 //!
 //! Per crate guideline 2, this module does not `pub use` from its submodules;
 //! downstream reaches types directly (e.g. `web_search::toolset::WebSearchToolset`).

--- a/crates/bitrouter-sdk/src/language_model/server_tools/web_search/nested.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/web_search/nested.rs
@@ -1,13 +1,14 @@
 //! The nested-completion web-search backend: turns a *model* into a search
-//! engine for the `web_search` tool. Two configurations share this one impl:
+//! engine for the `web_search` tool, used by the **native** config —
 //!
-//! * **Perplexity** — route a nested completion to a search-grounded model
-//!   (e.g. `perplexity/sonar`); the model searches and synthesizes the answer.
 //! * **Native provider search** — pin a web-search-capable model and forward
 //!   its native server tool (e.g. `anthropic:web_search_20250305`). This is how
 //!   one provider's native search becomes usable by *every* model routed through
 //!   BitRouter: a model with no web search of its own calls `bitrouter:web_search`
 //!   and BitRouter serves it from the configured search-capable model.
+//!
+//! The impl is engine-agnostic — it runs any nested model, with or without a
+//! forwarded tool — so a search-grounded model could be wired in the same way.
 //!
 //! This first cut follows "option A": the synthesized text is returned as
 //! [`WebSearchResults::answer`] with an empty `results` list (the answer already
@@ -33,7 +34,7 @@ pub struct NestedSearchBackend {
     runner: Arc<dyn NestedRunner>,
     model: String,
     /// Native server tools forwarded to the nested completion. Empty for a
-    /// search-grounded model (e.g. Perplexity) that searches on its own.
+    /// search-grounded model that searches on its own.
     tools: Vec<Tool>,
 }
 
@@ -120,9 +121,9 @@ mod tests {
             seen: Mutex::new(Vec::new()),
         });
         let backend = NestedSearchBackend::new(
-            "perplexity".into(),
+            "native".into(),
             runner.clone(),
-            "perplexity/sonar".into(),
+            "anthropic/claude-opus-4.8".into(),
             Vec::new(),
         );
         let out = backend
@@ -133,11 +134,11 @@ mod tests {
             )
             .await
             .unwrap();
-        assert_eq!(out.backend, "perplexity");
+        assert_eq!(out.backend, "native");
         assert_eq!(out.answer.as_deref(), Some("the synthesized answer"));
         assert!(out.results.is_empty());
         let seen = runner.seen.lock().unwrap();
-        assert_eq!(seen[0].model, "perplexity/sonar");
+        assert_eq!(seen[0].model, "anthropic/claude-opus-4.8");
         assert_eq!(seen[0].user, "latest rust release");
     }
 

--- a/schemas/bitrouter.config.schema.json
+++ b/schemas/bitrouter.config.schema.json
@@ -995,19 +995,27 @@
           "type": "object"
         },
         {
-          "description": "A search-grounded model (e.g. `perplexity/sonar`) reached through a\nnested completion. BYOK rides the normal provider mechanism (the model's\nprovider key), so no key lives here.",
+          "description": "tavily.com — key `api_key` or `TAVILY_API_KEY`.",
           "properties": {
-            "kind": {
-              "const": "perplexity",
-              "type": "string"
-            },
-            "model": {
+            "api_base": {
               "default": null,
-              "description": "Nested model (defaults to `perplexity/sonar`).",
+              "description": "Endpoint override (else the engine default).",
               "type": [
                 "string",
                 "null"
               ]
+            },
+            "api_key": {
+              "default": null,
+              "description": "Explicit API key (else `TAVILY_API_KEY`).",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "kind": {
+              "const": "tavily",
+              "type": "string"
             }
           },
           "required": [

--- a/skills/bitrouter/references/providers.md
+++ b/skills/bitrouter/references/providers.md
@@ -253,7 +253,7 @@ Setting `fusion:` also enables the `bitrouter/fusion` model alias, which expands
 
 ### Built-in web search (BYOK)
 
-The `web_search` server tool gives *any* model routed through BitRouter a web search, served by a search backend you bring keys for. Advertised only when the caller declares `{"type":"bitrouter:web_search"}` (optionally with `backend` / `max_results` overrides). The model calls `web_search` with a `query`; BitRouter runs it and returns `{backend, answer?, results:[{url,title?,snippet?,content?,published?,score?}]}` — `answer` is present only for answer-engine backends (Perplexity / native).
+The `web_search` server tool gives *any* model routed through BitRouter a web search, served by a search backend you bring keys for. Advertised only when the caller declares `{"type":"bitrouter:web_search"}` (optionally with `backend` / `max_results` overrides). The model calls `web_search` with a `query`; BitRouter runs it and returns `{backend, answer?, results:[{url,title?,snippet?,content?,published?,score?}]}` — `answer` is present only for the answer-engine `native` backend.
 
 ```yaml
 server_tools:
@@ -263,15 +263,14 @@ server_tools:
       - kind: parallel         # HTTP, key from api_key or PARALLEL_API_KEY
       - kind: exa              # HTTP, key from api_key or EXA_API_KEY
       - kind: firecrawl        # HTTP, key from api_key or FIRECRAWL_API_KEY
-      - kind: perplexity       # nested completion; model defaults to perplexity/sonar (BYOK via provider key)
-        model: perplexity/sonar
+      - kind: tavily           # HTTP, key from api_key or TAVILY_API_KEY
       - kind: native           # reuse a provider's NATIVE search for every model
         name: native           # backend id a caller pins (default "native")
         model: anthropic/claude-opus-4.8
         tool: { type: "anthropic:web_search_20250305" }
 ```
 
-HTTP backends (`parallel` / `exa` / `firecrawl`) take an optional `api_key` (supports `${VAR}`) and `api_base`; a backend with no resolvable key is skipped. The `perplexity` and `native` backends run a nested completion (so they need a routable model) — `native` forwards a provider's own search tool, making one provider's native web search usable from models that lack it.
+HTTP backends (`parallel` / `exa` / `firecrawl` / `tavily`) take an optional `api_key` (supports `${VAR}`) and `api_base`; a backend with no resolvable key is skipped. The `native` backend runs a nested completion (so it needs a routable model) — it forwards a provider's own search tool, making one provider's native web search usable from models that lack it.
 
 ## ACP agents
 


### PR DESCRIPTION
## Summary

Adds **Tavily** as a fourth BYOK HTTP backend for the built-in `web_search` server tool (PR #603), alongside Parallel / Exa / Firecrawl, and **drops the Perplexity** backend.

Tavily is a REST search engine in the same shape as the other HTTP engines, so it slots into `HttpSearchBackend`:
- `POST https://api.tavily.com/search`, bearer auth
- key from `api_key` (supports `${VAR}`) or `TAVILY_API_KEY`
- results mapped from `results[]` — `content` → snippet, plus `score` and `published_date`

```yaml
server_tools:
  web_search:
    backends:
      - kind: tavily        # key from api_key or TAVILY_API_KEY
```

Perplexity is removed (config variant + assembly arm). The shared `NestedSearchBackend` stays — it still backs the `native` answer-engine.

## Changes

- `config.rs` — `+ Tavily { api_key, api_base }`, `− Perplexity`
- `http.rs` — `HttpEngine::Tavily` (name/env_var/default_base, request body, bearer auth, `tavily_result` mapping) + 2 tests
- `assemble.rs` — wire Tavily into the shared HTTP construction path + `needs_http`; drop the Perplexity arm; nested-backend test now uses `native`
- regenerated `schemas/bitrouter.config.schema.json`
- updated `skills/bitrouter/references/providers.md`

## Tests / checks

- `cargo test -p bitrouter-sdk --all-features web_search` — 25 pass, incl. new `parses_tavily_results_with_score`
- assemble `web_search_*` tests pass
- `cargo fmt --check` clean; `cargo clippy -p bitrouter-sdk -p bitrouter --all-features` clean

## Note for reviewers

Tavily's request/response mapping is coded to the current `/search` API but, like the other HTTP engines in #603, is best smoke-tested against a live `TAVILY_API_KEY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)