### PR TITLE
fix(config): don't expand ${VAR} inside YAML comments

### DIFF
--- a/apps/bitrouter/src/commands.rs
+++ b/apps/bitrouter/src/commands.rs
@@ -1078,6 +1078,19 @@ mod tests {
         assert!(key.id.starts_with("brvk_id_"));
     }
 
+    /// Regression for the out-of-the-box `bitrouter init` → `start` failure:
+    /// the starter config ships a *commented* `opencode-go` example that
+    /// references `${OPENCODE_GO_KEY_A/B}`. The loader expands `${VAR}` over the
+    /// raw text before YAML parsing, so it used to error on those unset vars
+    /// even though they live in a comment. With comment-aware substitution the
+    /// starter config must load with **no** environment variables set.
+    #[test]
+    fn starter_config_loads_with_all_env_vars_unset() {
+        let cfg = bitrouter_sdk::config::parse_with(STARTER_CONFIG, |_| None)
+            .expect("starter config must load with no env vars set");
+        assert!(cfg.server.skip_auth);
+    }
+
     /// Regression: the `mcp_servers:` and `agents:` blocks in
     /// `STARTER_CONFIG` are commented out by default, but if a user
     /// uncomments them the result must still parse against the current

--- a/crates/bitrouter-sdk/src/config/mod.rs
+++ b/crates/bitrouter-sdk/src/config/mod.rs
@@ -690,35 +690,102 @@ pub struct VariantConfig {
 
 // ===== `${VAR}` substitution + loader =====
 
-/// Replace every `${VAR}` occurrence with the value resolved by `lookup`. An
-/// unresolved variable is an error (config F8: `${VAR}` substitution).
+/// Replace every `${VAR}` reference with the value resolved by `lookup`, an
+/// unresolved variable being an error (config F8: `${VAR}` substitution).
+///
+/// Substitution is **YAML-comment-aware**: a `${VAR}` that falls inside a `#`
+/// comment is left literal and never looked up — so a commented-out example
+/// (e.g. the `bitrouter init` starter config) that references an unset variable
+/// does not break loading. A `#` begins a comment only when it is at the start
+/// of a line or preceded by whitespace and is not inside a quoted scalar
+/// (matching YAML), so URL fragments (`host/p#x`) and quoted `#` stay literal
+/// value text and any `${VAR}` around them is still substituted. References in
+/// real values — quoted or plain — are substituted exactly as before.
+///
+/// Limitations (acceptable for config files): quoted-scalar state is tracked
+/// per line (reset at each newline), and block scalars (`|` / `>`) are not
+/// modelled, so a `#` inside multi-line block-scalar content could be mistaken
+/// for a comment.
 pub fn substitute_with<F>(input: &str, lookup: F) -> Result<String>
 where
     F: Fn(&str) -> Option<String>,
 {
     let mut out = String::with_capacity(input.len());
-    let mut rest = input;
-    while let Some(start) = rest.find("${") {
-        out.push_str(&rest[..start]);
-        let after = &rest[start + 2..];
-        match after.find('}') {
-            Some(end) => {
-                let name = &after[..end];
-                let value = lookup(name).ok_or_else(|| {
-                    BitrouterError::bad_request(format!(
-                        "config references undefined environment variable '{name}'"
-                    ))
-                })?;
-                out.push_str(&value);
-                rest = &after[end + 1..];
-            }
-            None => {
-                out.push_str("${");
-                rest = after;
+    let mut iter = input.char_indices().peekable();
+    // Whether the previous char was a line break / start-of-input or inline
+    // whitespace — the precondition for a `#` to begin a comment.
+    let mut after_ws = true;
+    let mut in_squote = false;
+    let mut in_dquote = false;
+    let mut in_comment = false;
+
+    while let Some((idx, c)) = iter.next() {
+        // Any line break ends a comment / quoted scalar for this scanner —
+        // `\n`, `\r\n`, and a lone `\r` (old-Mac) all reset state.
+        if c == '\n' || c == '\r' {
+            out.push(c);
+            in_comment = false;
+            in_squote = false;
+            in_dquote = false;
+            after_ws = true;
+            continue;
+        }
+        if in_comment {
+            out.push(c);
+            continue;
+        }
+        // `${...}` reference — substituted everywhere except inside a comment,
+        // including inside quoted scalars. `$` and `{` are ASCII (1 byte each),
+        // so the variable name begins at `idx + 2`.
+        if c == '$' && matches!(iter.peek(), Some((_, '{'))) {
+            let after_brace = &input[idx + 2..];
+            match after_brace.find('}') {
+                Some(rel) => {
+                    let name = &after_brace[..rel];
+                    let value = lookup(name).ok_or_else(|| {
+                        BitrouterError::bad_request(format!(
+                            "config references undefined environment variable '{name}'"
+                        ))
+                    })?;
+                    out.push_str(&value);
+                    // Advance the iterator past `{name}` (up to and including `}`).
+                    let resume = idx + 2 + rel + 1;
+                    while let Some(&(j, _)) = iter.peek() {
+                        if j < resume {
+                            iter.next();
+                        } else {
+                            break;
+                        }
+                    }
+                    after_ws = false;
+                    continue;
+                }
+                None => {
+                    // No closing brace anywhere — emit `$` literally and keep
+                    // scanning (the `{` and following chars copy normally),
+                    // matching the historical passthrough of a dangling `${`.
+                    out.push('$');
+                    after_ws = false;
+                    continue;
+                }
             }
         }
+        // Comment start: `#` at line start / after whitespace, outside quotes.
+        if c == '#' && after_ws && !in_squote && !in_dquote {
+            in_comment = true;
+            out.push(c);
+            continue;
+        }
+        // Track quoted-scalar state so a `#` inside quotes isn't read as a
+        // comment. (Substitution still happens inside quotes — handled above.)
+        if c == '\'' && !in_dquote {
+            in_squote = !in_squote;
+        } else if c == '"' && !in_squote {
+            in_dquote = !in_dquote;
+        }
+        out.push(c);
+        after_ws = matches!(c, ' ' | '\t');
     }
-    out.push_str(rest);
     Ok(out)
 }
 

--- a/crates/bitrouter-sdk/src/config/tests.rs
+++ b/crates/bitrouter-sdk/src/config/tests.rs
@@ -36,6 +36,83 @@ fn env_substitution_handles_multiple_and_literals() {
     assert_eq!(substitute_with("x ${oops", |_| None).unwrap(), "x ${oops");
 }
 
+// ===== comment-aware substitution (a `${VAR}` in a YAML comment must NOT be
+// expanded, and an unset var referenced only from a comment must NOT error) =====
+
+#[test]
+fn env_substitution_skips_full_line_comments() {
+    // The reference is in a `#` comment → left literal, no lookup, no error,
+    // even though the var is unset.
+    let out = substitute_with("# api_key: ${MISSING}\nlisten: x", |_| None).unwrap();
+    assert_eq!(out, "# api_key: ${MISSING}\nlisten: x");
+}
+
+#[test]
+fn env_substitution_skips_indented_comments() {
+    // Mirrors the `bitrouter init` starter config: a commented example deep in
+    // the file referencing an unset var must not break loading.
+    let yaml = "providers:\n  # opencode: { key: \"${OPENCODE_KEY_A}\" }\n  openai: {}";
+    let out = substitute_with(yaml, |_| None).unwrap();
+    assert_eq!(out, yaml);
+}
+
+#[test]
+fn env_substitution_still_runs_before_an_inline_comment() {
+    // The real value is substituted; the `${X}` in the trailing comment is not.
+    let out = substitute_with("api_key: ${REAL}  # fallback ${UNUSED}", |n| {
+        (n == "REAL").then(|| "sk-123".to_string())
+    })
+    .unwrap();
+    assert_eq!(out, "api_key: sk-123  # fallback ${UNUSED}");
+}
+
+#[test]
+fn env_substitution_treats_hash_in_value_as_literal_not_comment() {
+    // A `#` that is NOT preceded by whitespace (e.g. a URL fragment) is part of
+    // the value, so a following `${VAR}` is still substituted.
+    let out = substitute_with("url: https://h/p#x=${TOK}", |n| {
+        (n == "TOK").then(|| "t".to_string())
+    })
+    .unwrap();
+    assert_eq!(out, "url: https://h/p#x=t");
+}
+
+#[test]
+fn env_substitution_handles_crlf_line_endings() {
+    // Windows CRLF: real values on either side of a commented line are still
+    // substituted, and the commented `${C}` is skipped — i.e. comment/quote
+    // state resets across the line break, not just a bare `\n`.
+    let out =
+        substitute_with("a: ${V}\r\n# c ${C}\r\nb: ${W}", |n| Some(format!("<{n}>"))).unwrap();
+    assert_eq!(out, "a: <V>\r\n# c ${C}\r\nb: <W>");
+}
+
+#[test]
+fn env_substitution_inside_quotes_ignores_hash() {
+    // A `#` preceded by a space but *inside* a quoted scalar is literal, so the
+    // `${VAR}` after it is still substituted.
+    let out = substitute_with("note: \"a # b ${V}\"", |n| {
+        (n == "V").then(|| "z".to_string())
+    })
+    .unwrap();
+    assert_eq!(out, "note: \"a # b z\"");
+}
+
+#[test]
+fn env_substitution_in_comment_never_calls_lookup() {
+    // Stronger than "no error": the lookup must not even be consulted for a
+    // commented reference (so validate-style callers don't record it as missing).
+    // `substitute_with` takes `Fn`, so interior mutability is needed to record.
+    let seen = std::cell::RefCell::new(Vec::<String>::new());
+    let out = substitute_with("k: ${REAL} # ${COMMENTED}", |n| {
+        seen.borrow_mut().push(n.to_string());
+        Some(format!("<{n}>"))
+    })
+    .unwrap();
+    assert_eq!(out, "k: <REAL> # ${COMMENTED}");
+    assert_eq!(seen.into_inner(), vec!["REAL".to_string()]);
+}
+
 #[test]
 fn parses_registry_style_provider() {
     let yaml = r#"


### PR DESCRIPTION
## The bug

`bitrouter init` → `bitrouter start` fails out of the box:

```
error: config references undefined environment variable 'OPENCODE_GO_KEY_A'
```

…even though the only reference to that variable is in a **commented-out** example line of the starter config:

```yaml
  # opencode-go: { account_strategy: failover, accounts: [{ api_key: "${OPENCODE_GO_KEY_A}", ... }] }
```

## Root cause

The loader expands `${VAR}` as a **raw-text pass over the whole file, before YAML is parsed** ([`config/mod.rs` `parse_with`](crates/bitrouter-sdk/src/config/mod.rs)):

```rust
let substituted = substitute_with(yaml, lookup)?;          // text substitution FIRST
let mut config: Config = serde_saphyr::from_str(&substituted)?;  // YAML parsed AFTER
```

`substitute_with` just scanned for `${` and errored on any unset variable — with no notion of `#` comments (comments are only recognized later, during parsing). So a `${VAR}` sitting in a comment was treated like a live reference. This isn't only the starter template: commenting out *any* `${VAR}`-bearing line — the natural way to temporarily disable a provider — hit the same failure. (`bitrouter config validate` doesn't catch it because validate substitutes a placeholder for unset vars and only warns, so it disagrees with `serve`/`start`.)

## The fix

Make `substitute_with` **comment- and quote-aware**, a small char-by-char state machine that keeps the existing substitute-before-parse order:

- A `#` begins a comment only at line start or after whitespace **and** outside a quoted scalar (matching YAML). So URL fragments (`host/p#x`) and a `#` inside quotes stay literal value text, and any `${VAR}` around them is still substituted.
- A `${VAR}` inside a comment is left literal and **never looked up** (so it can't error, and validate-style callers don't record it as "missing").
- Comment/quote state resets at any line break (`\n`, `\r\n`, lone `\r`).
- `${VAR}` in real values — quoted or plain — behaves exactly as before; the dangling-`${`-with-no-`}` passthrough and error-on-unset are preserved.

### Why not substitute *after* parsing?

That would be the other "correct" approach, but `serde-saphyr` (0.0.26) is `from_str`-only — no value-tree / `from_value` API — so it would require a new `saphyr` dependency plus a parse→substitute→re-serialize round trip, and would change semantics for a `${VAR}` that expands into non-string YAML. The comment-aware text pass is smaller, dependency-free, and preserves the intended behavior.

## Tests

- Unit tests in [`config/tests.rs`](crates/bitrouter-sdk/src/config/tests.rs): full-line / indented / inline comments, quoted `#`, URL fragments, CRLF line endings, and a lookup-not-called invariant. The four comment tests fail on the old implementation; two over-correction guards (quoted `#`, URL fragment) pass on both old and new.
- End-to-end regression in [`commands.rs`](apps/bitrouter/src/commands.rs): `STARTER_CONFIG` must load with **all** env vars unset.
- Verified by hand: `bitrouter init` → `bitrouter start` with no env vars now starts the daemon cleanly.

`cargo test -p bitrouter-sdk` / `-p bitrouter`, `cargo clippy`, and `cargo fmt --check` are green. Reviewed adversarially (incl. a 400k-input differential fuzz vs. the old implementation — zero divergence on non-comment input, no panics, UTF-8-safe, MSRV 1.88).

🤖 Generated with [Claude Code](https://claude.com/claude-code)