### PR TITLE
feat(cli): JSON output layer with a uniform error envelope

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -227,36 +227,36 @@ Mints a scoped `brvk_` virtual key for a user. The plaintext secret is printed o
 | `--db` | `sqlite://./bitrouter.db` | Database URL — `sqlite://`, `postgres://`, or `mysql://` |
 | `--policy` | *(none)* | Policy id to bind to the key |
 
-### `bitrouter login <provider>`
+### `bitrouter providers login <provider>`
 
 ```
-bitrouter login anthropic            # Claude Pro/Max subscription PKCE flow
-bitrouter login openai-codex         # ChatGPT subscription PKCE flow
-bitrouter login github-copilot       # GitHub device-code flow
+bitrouter providers login anthropic       # Claude Pro/Max subscription PKCE flow
+bitrouter providers login openai-codex    # ChatGPT subscription PKCE flow
+bitrouter providers login github-copilot  # GitHub device-code flow
 ```
 
 Runs the provider's OAuth flow (PKCE in a browser or device-code, depending on provider) and stores the token in `$XDG_DATA_HOME/bitrouter/oauth-tokens.json`. The slot is keyed by `(provider_id, label)` — pass `--label <name>` (defaults to `default`) to keep multiple accounts of the same provider side by side. Other providers fall back to a pasted API key.
 
 For `anthropic` and `openai-codex`, the login menu also offers **"Import an existing session from the vendor CLI"** — bitrouter reads the credential the matching first-party CLI already stored (Claude Code from the macOS Keychain or `~/.claude/.credentials.json`; Codex from the macOS Keychain or `$CODEX_HOME/auth.json`) and adopts it, with no fresh browser sign-in. The imported token refreshes automatically like any other.
 
-For cloud sign-in (signing into your BitRouter Cloud account, not an upstream LLM provider), see [`bitrouter auth login`](#bitrouter-auth-login--logout--whoami) below.
+For cloud sign-in (signing into your BitRouter Cloud account, not an upstream LLM provider), see [`bitrouter cloud login`](#bitrouter-cloud-login--logout--whoami) below.
 
-### `bitrouter logout <provider>`
+### `bitrouter providers logout <provider>`
 
 ```
-bitrouter logout github-copilot
+bitrouter providers logout github-copilot
 ```
 
 Removes every stored credential for the provider (subscription OAuth tokens and pasted API keys alike).
 
-### `bitrouter auth login` / `logout` / `whoami`
+### `bitrouter cloud login` / `logout` / `whoami`
 
-Cloud sign-in, distinct from the per-provider `bitrouter login` flow above. Signs the CLI into your BitRouter Cloud account via the RFC 8628 OAuth Device Authorization Grant. The browser approval page asks you to pick which workspace to grant the CLI access to — the resulting credential is **namespace-baked** (workspace-baked), and all subsequent `bitrouter cloud` calls target that workspace implicitly. To switch workspaces, re-run `bitrouter auth login`. The credential is auto-refreshed on use; rotation preserves the namespace binding.
+Cloud sign-in, distinct from the per-provider `bitrouter providers login` flow above. Signs the CLI into your BitRouter Cloud account via the RFC 8628 OAuth Device Authorization Grant. The browser approval page asks you to pick which workspace to grant the CLI access to — the resulting credential is **namespace-baked** (workspace-baked), and all subsequent `bitrouter cloud` calls target that workspace implicitly. To switch workspaces, re-run `bitrouter cloud login`. The credential is auto-refreshed on use; rotation preserves the namespace binding.
 
 ```
-bitrouter auth login [--oauth-as <URL>] [--client-id <ID>] [--scope <SCOPE>]
-bitrouter auth logout [--oauth-as <URL>] [--client-id <ID>]
-bitrouter auth whoami
+bitrouter cloud login [--oauth-as <URL>] [--client-id <ID>] [--scope <SCOPE>]
+bitrouter cloud logout [--oauth-as <URL>] [--client-id <ID>]
+bitrouter cloud whoami
 ```
 
 | Flag | Default | Description |

--- a/CLI.md
+++ b/CLI.md
@@ -2,6 +2,32 @@
 
 `bitrouter <subcommand> [flags]`
 
+## Output format
+
+Every command prints a single **formatted JSON object** to **stdout** — success or failure — so output is machine-parseable by default (agent-native first). Global flags, accepted on any subcommand:
+
+- `-j`, `--json` — force JSON (the default).
+- `-H`, `--human` — render a human-readable view to stdout instead of JSON.
+- `-h`, `--help` — unchanged (`-h` is **not** human output; that's `-H`).
+
+All diagnostics — progress, warnings, internal logs, and a human echo of errors — go to **stderr** (colored when stderr is a TTY; honors `NO_COLOR`). So:
+
+```
+bitrouter <cmd> 2>/dev/null | jq .
+```
+
+always yields one clean JSON value. A failed command emits a uniform error envelope to stdout and exits non-zero:
+
+```json
+{ "error": { "kind": "not_found", "message": "…", "context": ["…"], "hint": "…" } }
+```
+
+`kind` is a stable taxonomy (`bad_request` / `unauthorized` / `forbidden` / `not_found` / `upstream` / `internal` / …). Under `--human`, the result (success object or error block) is rendered to stdout in the human form and no JSON is printed.
+
+> Non-CLI commands are exempt: `serve` and `mcp serve` are long-running servers, `agent-proxy` is a stdio JSON-RPC bridge, and `spawn` hands its streams to the child agent. Their stdout is a wire protocol or the child's terminal, not a JSON result.
+
+Per-provider credential commands are under `bitrouter providers (login|logout)`; BitRouter Cloud sign-in is `bitrouter cloud (login|logout|whoami)`.
+
 ## Config resolution
 
 All subcommands accept an optional `-c / --config <path>` flag. When omitted the binary walks this order:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -760,6 +760,7 @@ dependencies = [
  "bitrouter-skills",
  "chrono",
  "clap",
+ "erased-serde",
  "futures",
  "hex",
  "http 1.4.0",

--- a/apps/bitrouter/Cargo.toml
+++ b/apps/bitrouter/Cargo.toml
@@ -40,6 +40,7 @@ tracing-subscriber.workspace = true
 clap.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+erased-serde = "0.4"
 async-trait.workspace = true
 reqwest.workspace = true
 anyhow = "1"

--- a/apps/bitrouter/src/cloud/cli.rs
+++ b/apps/bitrouter/src/cloud/cli.rs
@@ -654,9 +654,16 @@ async fn run_inner(action: CloudAction) -> std::result::Result<(), SdkError> {
             })
             .await
             .map_err(SdkError::Auth)?;
-            emit(false, &serde_json::json!({ "signed_in": true }), |_| {
-                "signed in".to_string()
-            })
+            let client = client()?;
+            let store = CredentialsStore::default_path().map_err(SdkError::Auth)?;
+            let body = serde_json::json!({
+                "signed_in": true,
+                "namespace": client.namespace_id(),
+                "subject": store.current().and_then(|c| c.subject.clone()),
+                "scope": store.current().map(|c| c.scope.clone()),
+                "credentials_path": store.path().display().to_string(),
+            });
+            emit(false, &body, |_| "signed in".to_string())
         }
         CloudAction::Logout {
             authorization_server,

--- a/apps/bitrouter/src/cloud/cli.rs
+++ b/apps/bitrouter/src/cloud/cli.rs
@@ -627,7 +627,8 @@ pub struct JsonFlag {
 // =====================================================================
 
 /// Entry point dispatched by `apps/bitrouter/src/main.rs`.
-pub async fn run(action: CloudAction) -> Result<()> {
+pub async fn run(action: CloudAction, format: crate::output::Format) -> Result<()> {
+    let _ = CLOUD_FORMAT.set(format);
     let result = run_inner(action).await;
     match result {
         Ok(()) => Ok(()),
@@ -645,24 +646,33 @@ async fn run_inner(action: CloudAction) -> std::result::Result<(), SdkError> {
             authorization_server,
             client_id,
             scope,
-        } => login(LoginInputs {
-            authorization_server,
-            client_id,
-            scope,
-        })
-        .await
-        .map(|_| ())
-        .map_err(SdkError::Auth),
+        } => {
+            login(LoginInputs {
+                authorization_server,
+                client_id,
+                scope,
+            })
+            .await
+            .map_err(SdkError::Auth)?;
+            emit(false, &serde_json::json!({ "signed_in": true }), |_| {
+                "signed in".to_string()
+            })
+        }
         CloudAction::Logout {
             authorization_server,
             client_id,
-        } => logout(LoginInputs {
-            authorization_server,
-            client_id,
-            scope: None,
-        })
-        .await
-        .map_err(SdkError::Auth),
+        } => {
+            logout(LoginInputs {
+                authorization_server,
+                client_id,
+                scope: None,
+            })
+            .await
+            .map_err(SdkError::Auth)?;
+            emit(false, &serde_json::json!({ "signed_out": true }), |_| {
+                "signed out".to_string()
+            })
+        }
         CloudAction::Namespace { action } => run_namespace(action).await,
         CloudAction::Keys { action } => run_keys(action).await,
         CloudAction::Usage(args) => run_usage(args).await,
@@ -681,26 +691,39 @@ fn client() -> std::result::Result<ManagementClient, SdkError> {
 }
 
 async fn whoami() -> std::result::Result<(), SdkError> {
-    // Doesn't hit the network — reads the local credentials file so
-    // it works offline. Mirrors `bitrouter cloud whoami` but adds the
-    // base URL `bitrouter cloud …` will target.
+    // Offline — reads the local credentials file (works without network).
     let client = client()?;
-    println!("cloud base URL: {}", client.base_url());
-    println!(
-        "namespace:      {}",
-        client.namespace_id().unwrap_or("(none)")
-    );
     let store = CredentialsStore::default_path().map_err(SdkError::Auth)?;
-    if let Some(creds) = store.current() {
-        println!("scope:          {}", creds.scope);
-        if let Some(sub) = creds.subject.as_deref() {
-            println!("subject:        {sub}");
+    let scope = store.current().map(|c| c.scope.clone());
+    let subject = store.current().and_then(|c| c.subject.clone());
+    let signed_in = store.current().is_some();
+    let body = serde_json::json!({
+        "signed_in": signed_in,
+        "base_url": client.base_url(),
+        "namespace": client.namespace_id(),
+        "scope": scope.clone(),
+        "subject": subject.clone(),
+        "credentials_path": store.path().display().to_string(),
+    });
+    emit(false, &body, |_| {
+        let mut out = format!(
+            "cloud base URL: {}\nnamespace:      {}",
+            client.base_url(),
+            client.namespace_id().unwrap_or("(none)")
+        );
+        if signed_in {
+            if let Some(s) = &scope {
+                out.push_str(&format!("\nscope:          {s}"));
+            }
+            if let Some(sub) = &subject {
+                out.push_str(&format!("\nsubject:        {sub}"));
+            }
+            out.push_str(&format!("\ncredentials:    {}", store.path().display()));
+        } else {
+            out.push_str("\n(not signed in — run `bitrouter cloud login`)");
         }
-        println!("credentials:    {}", store.path().display());
-    } else {
-        println!("(not signed in — run `bitrouter cloud login`)");
-    }
-    Ok(())
+        out
+    })
 }
 
 // ----- Namespace -----
@@ -718,7 +741,7 @@ async fn run_namespace(action: NamespaceAction) -> std::result::Result<(), SdkEr
         NamespaceAction::Current(flag) => {
             // Offline — the namespace is baked into the local credential.
             let nsid = client.namespace_id();
-            if flag.json {
+            if effective_json(flag.json) {
                 let body = serde_json::json!({ "namespace_id": nsid });
                 println!("{}", serde_json::to_string_pretty(&body)?);
             } else {
@@ -1381,12 +1404,27 @@ fn format_oauth_client_register(c: &oauth_clients::RegisterOauthClientResponse) 
 // Output + error helpers
 // =====================================================================
 
-fn emit<T, F>(json: bool, value: &T, fmt: F) -> std::result::Result<(), SdkError>
+/// The global output format, set once at the start of [`run`]. `emit` consults
+/// it so cloud leaves default to JSON (agent-native) and switch to the human
+/// formatter only under the global `--human` flag.
+static CLOUD_FORMAT: std::sync::OnceLock<crate::output::Format> = std::sync::OnceLock::new();
+
+/// Whether a cloud leaf should print JSON. JSON by default; the global
+/// `--human` flag selects the human formatter; a per-leaf `--json` still forces
+/// JSON.
+fn effective_json(leaf_json: bool) -> bool {
+    if leaf_json {
+        return true;
+    }
+    !matches!(CLOUD_FORMAT.get(), Some(crate::output::Format::Human))
+}
+
+fn emit<T, F>(leaf_json: bool, value: &T, fmt: F) -> std::result::Result<(), SdkError>
 where
     T: serde::Serialize,
     F: FnOnce(&T) -> String,
 {
-    if json {
+    if effective_json(leaf_json) {
         let pretty = serde_json::to_string_pretty(value)?;
         println!("{pretty}");
     } else {

--- a/apps/bitrouter/src/commands.rs
+++ b/apps/bitrouter/src/commands.rs
@@ -439,7 +439,16 @@ fn prompt_method_choice(provider: &str, options: &[AuthMethod]) -> Result<AuthMe
 /// there's more than one, runs the chosen flow, and persists the
 /// resulting [`bitrouter_providers::oauth::credential_store::Credential`]
 /// under `(provider_id, label)`.
-pub async fn login_provider(provider_id: &str, label: &str) -> Result<()> {
+/// What `login_provider` accomplished — surfaced as the CLI's JSON result while
+/// the interactive prompts and confirmation go to stderr.
+pub struct LoginOutcome {
+    pub provider: String,
+    pub label: String,
+    pub method: String,
+    pub path: String,
+}
+
+pub async fn login_provider(provider_id: &str, label: &str) -> Result<LoginOutcome> {
     use bitrouter_providers::builtin;
 
     // The `bitrouter` cloud gateway is compiled in; every other provider's
@@ -511,7 +520,12 @@ pub async fn login_provider(provider_id: &str, label: &str) -> Result<()> {
         store.path().display()
     );
     eprintln!();
-    Ok(())
+    Ok(LoginOutcome {
+        provider: provider_id.to_string(),
+        label: label.to_string(),
+        method: kind.to_string(),
+        path: store.path().display().to_string(),
+    })
 }
 
 /// Adopt the user's existing Claude Code session as the live credential source
@@ -811,7 +825,7 @@ impl bitrouter_providers::oauth::login::LoginUx for StderrLoginUx {
 
 /// `bitrouter logout <provider>` — drop every stored credential for the
 /// provider (subscription OAuth or pasted API key), if any.
-pub async fn logout_provider(provider_id: &str) -> Result<()> {
+pub async fn logout_provider(provider_id: &str) -> Result<usize> {
     let mut store = bitrouter_providers::oauth::credential_store::CredentialStore::default_path()
         .context("opening credential store")?;
     let removed = store
@@ -821,7 +835,7 @@ pub async fn logout_provider(provider_id: &str) -> Result<()> {
         0 => eprintln!("  No stored credentials for {provider_id}; nothing to remove."),
         n => eprintln!("  ✓ Removed {n} stored credential(s) for {provider_id}."),
     }
-    Ok(())
+    Ok(removed)
 }
 
 // ===== skills (client installer) =====

--- a/apps/bitrouter/src/commands.rs
+++ b/apps/bitrouter/src/commands.rs
@@ -10,6 +10,10 @@ use bitrouter_sdk::language_model::{RoutingPrefs, RoutingTable};
 
 use crate::auth::{NewApiKey, db as auth_db, generate};
 use crate::daemon::RouteHop;
+use crate::output::reports::skills::{
+    FailedSkill, SkillAddReport, SkillEntry, SkillHit, SkillInitReport, SkillRemoveReport,
+    SkillsFindReport, SkillsListReport, SkillsUpdateReport, SkippedSkill, UpdatedSkill,
+};
 
 /// The starter `bitrouter.yaml` written by `bitrouter init`. Mirrors
 /// the zero-config in-memory default so a user who runs `init` and
@@ -898,7 +902,7 @@ pub async fn skills_add(
     overwrite: bool,
     registry: Option<&str>,
     namespace: Option<&str>,
-) -> Result<()> {
+) -> Result<SkillAddReport> {
     use bitrouter_skills::{install, source as skill_source};
 
     if source.trim().is_empty() {
@@ -916,37 +920,41 @@ pub async fn skills_add(
         skill_source::parse_source(source)?
     };
     let outcome = install::install(&parsed, &target, overwrite, select, None).await?;
-    let verb = if outcome.was_updated {
-        "updated"
-    } else {
-        "installed"
-    };
-    println!("{verb} {} → {}", outcome.name, outcome.dest.display());
-    Ok(())
+    Ok(SkillAddReport {
+        action: if outcome.was_updated {
+            "updated"
+        } else {
+            "installed"
+        },
+        name: outcome.name,
+        dest: outcome.dest.display().to_string(),
+    })
 }
 
 /// `bitrouter skills list` — show installed skills.
-pub fn skills_list(global: bool) -> Result<()> {
+pub fn skills_list(global: bool) -> Result<SkillsListReport> {
     use bitrouter_skills::install;
     let target = skills_target(global)?;
-    let installed = install::list_installed(&target)?;
-    if installed.is_empty() {
-        println!("no skills installed");
-        return Ok(());
-    }
-    for (name, path) in installed {
-        println!("{name}\t{}", path.display());
-    }
-    Ok(())
+    let skills = install::list_installed(&target)?
+        .into_iter()
+        .map(|(name, path)| SkillEntry {
+            name,
+            path: path.display().to_string(),
+        })
+        .collect();
+    Ok(SkillsListReport { skills })
 }
 
 /// `bitrouter skills remove` — uninstall a skill by name.
-pub fn skills_remove(name: &str, global: bool) -> Result<()> {
+pub fn skills_remove(name: &str, global: bool) -> Result<SkillRemoveReport> {
     use bitrouter_skills::install;
     let target = skills_target(global)?;
     let dir = install::remove(name, &target)?;
-    println!("removed {name} ({})", dir.display());
-    Ok(())
+    Ok(SkillRemoveReport {
+        name: name.to_string(),
+        path: dir.display().to_string(),
+        removed: true,
+    })
 }
 
 /// `bitrouter skills find` — search a registry.
@@ -954,28 +962,31 @@ pub async fn skills_find(
     query: &str,
     registry: Option<&str>,
     namespace: Option<&str>,
-) -> Result<()> {
+) -> Result<SkillsFindReport> {
     use bitrouter_skills::marketplace;
     let base = registry.unwrap_or(DEFAULT_SKILLS_REGISTRY);
     let nsid = namespace
         .ok_or_else(|| anyhow::anyhow!("--namespace <nsid> is required to query a registry"))?;
     let client = skills_http_client()?;
     let market = marketplace::fetch_marketplace(&client, base, nsid).await?;
-    let hits = market.search(query);
-    if hits.is_empty() {
-        println!("no skills matching {query:?} in {base}");
-        return Ok(());
-    }
-    for entry in hits {
-        let version = entry.version.as_deref().unwrap_or("-");
-        let description = entry.description.as_deref().unwrap_or("");
-        println!("{}\t{version}\t{description}", entry.name);
-    }
-    Ok(())
+    let results = market
+        .search(query)
+        .into_iter()
+        .map(|entry| SkillHit {
+            name: entry.name.clone(),
+            version: entry.version.clone().unwrap_or_else(|| "-".to_string()),
+            description: entry.description.clone().unwrap_or_default(),
+        })
+        .collect();
+    Ok(SkillsFindReport {
+        query: query.to_string(),
+        registry: base.to_string(),
+        results,
+    })
 }
 
 /// `bitrouter skills init` — scaffold a SKILL.md.
-pub fn skills_init(name: &str, output: &std::path::Path) -> Result<()> {
+pub fn skills_init(name: &str, output: &std::path::Path) -> Result<SkillInitReport> {
     bitrouter_skills::install::validate_skill_name(name)?;
     if output.exists() {
         anyhow::bail!("{} already exists; refusing to overwrite", output.display());
@@ -984,8 +995,10 @@ pub fn skills_init(name: &str, output: &std::path::Path) -> Result<()> {
         "---\nname: {name}\ndescription: TODO — one line on what this skill does and when to use it.\n---\n\n# {name}\n\nTODO: instructions for the agent.\n\n## When to use\n\n## Steps\n"
     );
     std::fs::write(output, body).with_context(|| format!("writing {}", output.display()))?;
-    println!("wrote {}", output.display());
-    Ok(())
+    Ok(SkillInitReport {
+        path: output.display().to_string(),
+        created: true,
+    })
 }
 
 /// `bitrouter skills update` — re-install installed skills from the registry.
@@ -994,7 +1007,7 @@ pub async fn skills_update(
     global: bool,
     registry: Option<&str>,
     namespace: Option<&str>,
-) -> Result<()> {
+) -> Result<SkillsUpdateReport> {
     use bitrouter_skills::install;
     use bitrouter_skills::marketplace;
     use bitrouter_skills::source::SkillSource;
@@ -1018,8 +1031,11 @@ pub async fn skills_update(
         None => installed,
     };
     if names.is_empty() {
-        println!("no skills installed to update");
-        return Ok(());
+        return Ok(SkillsUpdateReport {
+            updated: Vec::new(),
+            skipped: Vec::new(),
+            failed: Vec::new(),
+        });
     }
 
     let nsid = namespace
@@ -1028,9 +1044,14 @@ pub async fn skills_update(
     let market = marketplace::fetch_marketplace(&client, base, nsid).await?;
 
     // Update each skill independently: one failure must not abort the rest.
-    // Re-install into the same directory (`install_as`) so a skill stays put
-    // even if its upstream frontmatter name has drifted.
-    let mut failures = 0u32;
+    // Re-install into the same directory so a skill stays put even if its
+    // upstream frontmatter name has drifted. Per-skill outcomes are collected
+    // into the report, which exits non-zero when any skill failed.
+    let mut report = SkillsUpdateReport {
+        updated: Vec::new(),
+        skipped: Vec::new(),
+        failed: Vec::new(),
+    };
     for skill_name in names {
         match market.find(&skill_name) {
             Some(entry) => {
@@ -1041,22 +1062,23 @@ pub async fn skills_update(
                     Err(e) => Err(e),
                 };
                 match result {
-                    Ok(outcome) => {
-                        println!("updated {} → {}", outcome.name, outcome.dest.display())
-                    }
-                    Err(e) => {
-                        failures += 1;
-                        eprintln!("failed to update {skill_name}: {e}");
-                    }
+                    Ok(outcome) => report.updated.push(UpdatedSkill {
+                        name: outcome.name,
+                        dest: outcome.dest.display().to_string(),
+                    }),
+                    Err(e) => report.failed.push(FailedSkill {
+                        name: skill_name,
+                        error: e.to_string(),
+                    }),
                 }
             }
-            None => println!("skipped {skill_name} (not in registry {base})"),
+            None => report.skipped.push(SkippedSkill {
+                name: skill_name,
+                reason: format!("not in registry {base}"),
+            }),
         }
     }
-    if failures > 0 {
-        anyhow::bail!("{failures} skill(s) failed to update");
-    }
-    Ok(())
+    Ok(report)
 }
 
 #[cfg(test)]

--- a/apps/bitrouter/src/error_report.rs
+++ b/apps/bitrouter/src/error_report.rs
@@ -124,7 +124,7 @@ fn write_info(
 /// `Upstream { status, message }` renders as `"upstream error (502): …"`;
 /// the status is genuine debugging signal so we preserve the whole
 /// string rather than stripping a prefix.
-fn strip_status_prefix(msg: &str) -> &str {
+pub(crate) fn strip_status_prefix(msg: &str) -> &str {
     const PREFIXES: &[&str] = &[
         "bad request: ",
         "internal error: ",
@@ -145,7 +145,7 @@ fn strip_status_prefix(msg: &str) -> &str {
 /// next-step hint. Matches by anchored prefix or specific substring
 /// against the *stripped* root message so display-prefix churn doesn't
 /// break the table.
-fn hint_for(root: &str) -> Option<String> {
+pub(crate) fn hint_for(root: &str) -> Option<String> {
     // Undefined config env-var. Pull the var name out so the hint can
     // name it explicitly.
     if let Some(rest) = root.strip_prefix("config references undefined environment variable '")

--- a/apps/bitrouter/src/lib.rs
+++ b/apps/bitrouter/src/lib.rs
@@ -21,6 +21,7 @@ pub mod daemon;
 pub mod db;
 pub mod error_report;
 pub mod metering;
+pub mod output;
 pub mod paths;
 pub mod policy;
 pub mod reload;

--- a/apps/bitrouter/src/main.rs
+++ b/apps/bitrouter/src/main.rs
@@ -667,7 +667,7 @@ async fn run(cli: Cli, output: &bitrouter::output::Output) -> Result<()> {
             )
             .await
         }
-        Command::Cloud { action } => bitrouter::cloud::cli::run(action).await,
+        Command::Cloud { action } => bitrouter::cloud::cli::run(action, output.format()).await,
         Command::Skills { action } => bitrouter::skills::cli::run(action, output).await,
         Command::Mcp { action } => mcp_cmd(action).await,
     }
@@ -1648,11 +1648,14 @@ async fn providers(action: ProviderAction, output: &Output) -> Result<()> {
             // OAuth credential, so logging into it IS the cloud sign-in
             // (`cloud login`); other providers use the per-provider store.
             if provider == "bitrouter" {
-                bitrouter::cloud::cli::run(bitrouter::cloud::cli::CloudAction::Login {
-                    authorization_server: None,
-                    client_id: None,
-                    scope: None,
-                })
+                bitrouter::cloud::cli::run(
+                    bitrouter::cloud::cli::CloudAction::Login {
+                        authorization_server: None,
+                        client_id: None,
+                        scope: None,
+                    },
+                    output.format(),
+                )
                 .await
             } else {
                 let outcome = bitrouter::commands::login_provider(&provider, &label).await?;
@@ -1668,10 +1671,13 @@ async fn providers(action: ProviderAction, output: &Output) -> Result<()> {
         }
         ProviderAction::Logout { provider } => {
             if provider == "bitrouter" {
-                bitrouter::cloud::cli::run(bitrouter::cloud::cli::CloudAction::Logout {
-                    authorization_server: None,
-                    client_id: None,
-                })
+                bitrouter::cloud::cli::run(
+                    bitrouter::cloud::cli::CloudAction::Logout {
+                        authorization_server: None,
+                        client_id: None,
+                    },
+                    output.format(),
+                )
                 .await
             } else {
                 let removed = bitrouter::commands::logout_provider(&provider).await?;

--- a/apps/bitrouter/src/main.rs
+++ b/apps/bitrouter/src/main.rs
@@ -32,11 +32,13 @@ use bitrouter::output::reports::config::{InitReport, UnsetVar, ValidateReport};
 use bitrouter::output::reports::daemon::{
     DaemonActionReport, RouteHopView, RouteReport, StatusReport,
 };
+use bitrouter::output::reports::observe::ObserveStatusReport;
 use bitrouter::output::reports::routing::{ModelRow, ModelsReport, ProviderRow, ProvidersReport};
 use bitrouter::output::reports::tools::{
     ServerStatusView, ServerToolsView, ToolInfo, ToolsDiscoverReport, ToolsListReport,
     ToolsStatusReport,
 };
+use bitrouter::output::reports::verify::{Check, VerifyReport};
 use bitrouter_sdk::config;
 
 /// BitRouter — an LLM API router.
@@ -422,9 +424,6 @@ enum ObserveAction {
         /// Explicit control socket path. Overrides the config-derived path.
         #[arg(long)]
         socket: Option<PathBuf>,
-        /// Emit the snapshot as JSON instead of the human-readable block.
-        #[arg(long)]
-        json: bool,
     },
 }
 
@@ -629,9 +628,12 @@ async fn run(cli: Cli, output: &bitrouter::output::Output) -> Result<()> {
             output.emit(&models(&source, provider.as_deref()).await?)?;
             Ok(())
         }
-        Command::Verify { model } => verify_attestation(&model).await,
+        Command::Verify { model } => {
+            output.emit(&verify_attestation(&model).await?)?;
+            Ok(())
+        }
         Command::Tools { action } => tools(action, output).await,
-        Command::Observe { action } => observe(action).await,
+        Command::Observe { action } => observe(action, output).await,
         Command::Policy { action } => {
             output.emit(&policy(action).await?)?;
             Ok(())
@@ -1383,17 +1385,6 @@ async fn status(socket: &Path) -> Result<StatusReport> {
     }
 }
 
-/// One indented `label  value` row in a status block. The label column
-/// is left-padded to 8 chars so columns line up for the typical labels
-/// (`pid` / `listen` / `models` / `socket`).
-fn print_status_row(p: &bitrouter::style::Palette, label: &str, value: &str) {
-    println!(
-        "  {dim}{label:<8}{reset}  {value}",
-        dim = p.dim,
-        reset = p.reset,
-    );
-}
-
 async fn route(
     model: &str,
     source: &bitrouter::paths::ConfigSource,
@@ -1458,7 +1449,7 @@ fn route_report(model: &str, resolved_via: &str, chain: Vec<RouteHop>) -> RouteR
 /// - `NEAR_BASE_MEASUREMENTS` — accepted base bundle(s), comma-separated; each
 ///   the hex of `MRTD ‖ RTMR0 ‖ RTMR1 ‖ RTMR2` (192 bytes). Required (issue #567)
 /// - `NVIDIA_EAT_KEY_PEM` — path to NVIDIA's NRAS EAT key (EC public PEM)
-async fn verify_attestation(model: &str) -> Result<()> {
+async fn verify_attestation(model: &str) -> Result<VerifyReport> {
     use std::sync::Arc;
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -1525,83 +1516,61 @@ async fn verify_attestation(model: &str) -> Result<()> {
     let now = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
     let verdict = verifier.attestation_cached(model, now).await?;
 
-    let p = bitrouter::style::Palette::for_stdout();
-    let mark = |ok: bool| {
-        if ok {
-            format!("{}✓{}", p.green, p.reset)
-        } else {
-            format!("{}✗{}", p.red, p.reset)
-        }
-    };
-    let opt_mark = |v: Option<bool>| match v {
-        Some(true) => format!("{}✓{}", p.green, p.reset),
-        Some(false) => format!("{}✗{}", p.red, p.reset),
-        None => format!("{}-{}", p.dim, p.reset),
-    };
-
-    println!(
-        "{bold}{model}{reset}  (trust boundary: {})",
-        if verdict.trust_boundary.is_empty() {
-            "unreachable"
-        } else {
-            &verdict.trust_boundary
-        },
-        bold = p.bold,
-        reset = p.reset,
-    );
     let c = &verdict.checks;
-    println!("  {} GPU NRAS attestation", mark(c.gpu_nras_pass));
-    println!("  {} Intel TDX DCAP quote", mark(c.dcap_quote_valid));
-    println!(
-        "  {} report_data binds key + nonce",
-        mark(c.report_data_binds_key_and_nonce)
-    );
-    println!(
-        "  {} compose matches measured config",
-        mark(c.compose_matches_mr_config)
-    );
-    println!(
-        "  {} event-log RTMR3 anchors policy fields",
-        opt_mark(c.event_log_rtmr_ok)
-    );
-    println!(
-        "  {} base measurements match pin (MRTD/RTMR0-2)",
-        mark(c.base_measurements_match)
-    );
-    println!(
-        "  {} policy accepts (KMS root + image/workload pin)",
-        mark(c.policy_accepts)
-    );
-    println!("  {} TD debug disabled", mark(c.debug_disabled));
-    println!(
-        "  {} TCB level acceptable{}",
-        mark(c.tcb_level_acceptable),
-        match &c.tcb_status {
-            Some(s) => format!(" ({s})"),
-            None => String::new(),
-        }
-    );
-    if !verdict.attested_addresses.is_empty() {
-        println!(
-            "  {dim}attested signer(s): {}{reset}",
-            verdict.attested_addresses.join(", "),
-            dim = p.dim,
-            reset = p.reset,
-        );
-    }
-    println!();
-    if verdict.verified {
-        println!(
-            "{}VERIFIED{} — genuine, policy-pinned TEE",
-            p.green, p.reset
-        );
-    } else {
-        println!(
-            "{}UNVERIFIED{} — not a confirmed legitimate TEE (see failing checks above)",
-            p.red, p.reset
-        );
-    }
-    Ok(())
+    let st = |b: bool| if b { "pass" } else { "fail" };
+    let opt_st = |v: Option<bool>| match v {
+        Some(true) => "pass",
+        Some(false) => "fail",
+        None => "skip",
+    };
+    let checks = vec![
+        Check {
+            name: "GPU NRAS attestation".into(),
+            status: st(c.gpu_nras_pass),
+        },
+        Check {
+            name: "Intel TDX DCAP quote".into(),
+            status: st(c.dcap_quote_valid),
+        },
+        Check {
+            name: "report_data binds key + nonce".into(),
+            status: st(c.report_data_binds_key_and_nonce),
+        },
+        Check {
+            name: "compose matches measured config".into(),
+            status: st(c.compose_matches_mr_config),
+        },
+        Check {
+            name: "event-log RTMR3 anchors policy fields".into(),
+            status: opt_st(c.event_log_rtmr_ok),
+        },
+        Check {
+            name: "base measurements match pin (MRTD/RTMR0-2)".into(),
+            status: st(c.base_measurements_match),
+        },
+        Check {
+            name: "policy accepts (KMS root + image/workload pin)".into(),
+            status: st(c.policy_accepts),
+        },
+        Check {
+            name: "TD debug disabled".into(),
+            status: st(c.debug_disabled),
+        },
+        Check {
+            name: match &c.tcb_status {
+                Some(s) => format!("TCB level acceptable ({s})"),
+                None => "TCB level acceptable".into(),
+            },
+            status: st(c.tcb_level_acceptable),
+        },
+    ];
+    Ok(VerifyReport {
+        model: model.to_string(),
+        trust_boundary: verdict.trust_boundary,
+        verified: verdict.verified,
+        checks,
+        signers: verdict.attested_addresses,
+    })
 }
 
 // ===== management commands =====
@@ -1791,15 +1760,12 @@ async fn agent_proxy_cmd(agent: &str, source: &bitrouter::paths::ConfigSource) -
 
 // ===== observe =====
 
-async fn observe(action: ObserveAction) -> Result<()> {
+async fn observe(action: ObserveAction, output: &Output) -> Result<()> {
     match action {
-        ObserveAction::Status {
-            config,
-            socket,
-            json,
-        } => {
+        ObserveAction::Status { config, socket } => {
             let socket = resolve_client_socket(config.as_deref(), socket.as_deref()).await?;
-            observe_status(&socket, json).await
+            output.emit(&observe_status(&socket).await?)?;
+            Ok(())
         }
     }
 }
@@ -1809,111 +1775,25 @@ async fn observe(action: ObserveAction) -> Result<()> {
 /// daemon is reachable, fall back to a "stopped" report that still
 /// carries the compile-time `OTEL_ENABLED` flag so the user can tell
 /// "feature off" from "daemon down."
-async fn observe_status(socket: &Path, as_json: bool) -> Result<()> {
+async fn observe_status(socket: &Path) -> Result<ObserveStatusReport> {
     use bitrouter_observe::OTEL_ENABLED;
 
-    let payload = match daemon::send_command(socket, &DaemonCommand::ObserveStatus).await {
-        Ok(DaemonResponse::ObserveStatus { payload }) => Some(payload),
-        Ok(DaemonResponse::Error { message }) => return Err(anyhow::anyhow!(message)),
-        Ok(other) => return Err(anyhow::anyhow!("unexpected response: {other:?}")),
-        Err(e) if daemon::is_not_reachable(&e) => None,
-        Err(e) => return Err(e),
-    };
-
-    if as_json {
-        let snapshot =
-            payload.unwrap_or_else(|| daemon::ObserveStatusPayload::unwired(OTEL_ENABLED));
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&snapshot).context("rendering observe status as JSON")?
-        );
-        return Ok(());
-    }
-
-    let p = bitrouter::style::Palette::for_stdout();
-    match payload {
-        Some(s) => print_observe_running(&p, &s, socket),
-        None => print_observe_stopped(&p, socket),
-    }
-    Ok(())
-}
-
-fn print_observe_running(
-    p: &bitrouter::style::Palette,
-    s: &daemon::ObserveStatusPayload,
-    socket: &Path,
-) {
-    let (bullet, headline) = if s.exporter_wired {
-        (
-            format!("{green}●{reset}", green = p.green, reset = p.reset),
-            "OTel exporter is wired",
-        )
-    } else if s.compiled_in {
-        (
-            format!("{dim}○{reset}", dim = p.dim, reset = p.reset),
-            "OTel feature compiled in, exporter not configured",
-        )
-    } else {
-        (
-            format!("{dim}○{reset}", dim = p.dim, reset = p.reset),
-            "OTel feature not compiled in",
-        )
-    };
-    println!(
-        "{bullet} bitrouter observe — {bold}{headline}{reset}",
-        bold = p.bold,
-        reset = p.reset,
-    );
-    println!();
-    print_status_row(p, "compiled", if s.compiled_in { "yes" } else { "no" });
-    print_status_row(p, "wired", if s.exporter_wired { "yes" } else { "no" });
-    if let Some(endpoint) = &s.endpoint {
-        print_status_row(p, "endpoint", endpoint);
-    }
-    if let Some(service) = &s.service_name {
-        print_status_row(p, "service", service);
-    }
-    if let Some(sampler) = &s.sampler {
-        let val = match s.sampler_arg {
-            Some(arg) => format!("{sampler} (arg={arg})"),
-            None => sampler.clone(),
+    let (snapshot, daemon_reachable) =
+        match daemon::send_command(socket, &DaemonCommand::ObserveStatus).await {
+            Ok(DaemonResponse::ObserveStatus { payload }) => (payload, true),
+            Ok(DaemonResponse::Error { message }) => return Err(anyhow::anyhow!(message)),
+            Ok(other) => return Err(anyhow::anyhow!("unexpected response: {other:?}")),
+            Err(e) if daemon::is_not_reachable(&e) => {
+                (daemon::ObserveStatusPayload::unwired(OTEL_ENABLED), false)
+            }
+            Err(e) => return Err(e),
         };
-        print_status_row(p, "sampler", &val);
-    }
-    print_status_row(p, "metrics", if s.metrics_enabled { "on" } else { "off" });
-    print_status_row(p, "headers", &s.header_count.to_string());
-    print_status_row(p, "res-attrs", &s.resource_attribute_count.to_string());
-    print_status_row(
-        p,
-        "api-keys",
-        &format!("{} / {}", s.api_key_count, s.api_key_cap),
-    );
-    print_status_row(
-        p,
-        "users",
-        &format!("{} / {}", s.user_id_count, s.user_id_cap),
-    );
-    print_status_row(p, "in-flight", &s.active_spans.to_string());
-    print_status_row(p, "socket", &socket.display().to_string());
-}
 
-fn print_observe_stopped(p: &bitrouter::style::Palette, socket: &Path) {
-    use bitrouter_observe::OTEL_ENABLED;
-    println!(
-        "{dim}○{reset} bitrouter observe — {bold}daemon stopped{reset}",
-        dim = p.dim,
-        bold = p.bold,
-        reset = p.reset,
-    );
-    println!();
-    print_status_row(p, "compiled", if OTEL_ENABLED { "yes" } else { "no" });
-    print_status_row(p, "socket", &socket.display().to_string());
-    println!();
-    println!(
-        "  {dim}Run `bitrouter start` to launch the daemon, then re-run this command.{reset}",
-        dim = p.dim,
-        reset = p.reset,
-    );
+    Ok(ObserveStatusReport {
+        daemon_reachable,
+        snapshot,
+        socket: socket.display().to_string(),
+    })
 }
 
 async fn agents_cmd(action: AgentsAction, output: &Output) -> Result<()> {

--- a/apps/bitrouter/src/main.rs
+++ b/apps/bitrouter/src/main.rs
@@ -1253,9 +1253,9 @@ fn print_onboarding_hint() {
     eprintln!();
     eprintln!("  3. Or use a provider you already pay for, locally:");
     eprintln!();
-    eprintln!("       bitrouter login anthropic            # Claude Pro/Max subscription");
-    eprintln!("       bitrouter login github-copilot       # GitHub Copilot subscription");
-    eprintln!("       bitrouter login openai-codex         # ChatGPT subscription");
+    eprintln!("       bitrouter providers login anthropic       # Claude Pro/Max subscription");
+    eprintln!("       bitrouter providers login github-copilot  # GitHub Copilot subscription");
+    eprintln!("       bitrouter providers login openai-codex    # ChatGPT subscription");
     eprintln!();
     eprintln!("     …or set an API-key env var:");
     eprintln!();

--- a/apps/bitrouter/src/main.rs
+++ b/apps/bitrouter/src/main.rs
@@ -21,9 +21,12 @@ use clap::{Parser, Subcommand, ValueEnum};
 
 use bitrouter::commands;
 use bitrouter::daemon::{self, DaemonCommand, DaemonResponse, RouteHop};
+use bitrouter::output::Output;
+use bitrouter::output::reports::config::{InitReport, UnsetVar, ValidateReport};
 use bitrouter::output::reports::daemon::{
     DaemonActionReport, RouteHopView, RouteReport, StatusReport,
 };
+use bitrouter::output::reports::routing::{ModelRow, ModelsReport, ProviderRow, ProvidersReport};
 use bitrouter_sdk::config;
 
 /// BitRouter — an LLM API router.
@@ -594,18 +597,30 @@ async fn run(cli: Cli, output: &bitrouter::output::Output) -> Result<()> {
             output.emit(&route(&model, &source, &socket).await?)?;
             Ok(())
         }
-        Command::Init { config } => init(&config).await,
-        Command::Config { action } => config_cmd(action).await,
+        Command::Init { config } => {
+            output.emit(&init(&config).await?)?;
+            Ok(())
+        }
+        Command::Config { action } => {
+            let report = config_cmd(action).await?;
+            output.emit(&report)?;
+            if report.valid {
+                Ok(())
+            } else {
+                std::process::exit(1)
+            }
+        }
         Command::Key { action } => key(action).await,
         Command::Models { config, provider } => {
             let source = bitrouter::paths::resolve_config(config.as_deref())?;
-            models(&source, provider.as_deref()).await
+            output.emit(&models(&source, provider.as_deref()).await?)?;
+            Ok(())
         }
         Command::Verify { model } => verify_attestation(&model).await,
         Command::Tools { action } => tools(action).await,
         Command::Observe { action } => observe(action).await,
         Command::Policy { action } => policy(action).await,
-        Command::Providers { action } => providers(action).await,
+        Command::Providers { action } => providers(action, output).await,
         Command::Agents { action } => agents_cmd(action).await,
         Command::AgentProxy { agent, config } => {
             let source = bitrouter::paths::resolve_config(config.as_deref())?;
@@ -642,7 +657,7 @@ async fn run(cli: Cli, output: &bitrouter::output::Output) -> Result<()> {
 
 // ===== `bitrouter config …` (config tooling) =====
 
-async fn config_cmd(action: ConfigAction) -> Result<()> {
+async fn config_cmd(action: ConfigAction) -> Result<ValidateReport> {
     match action {
         ConfigAction::Validate { config } => {
             let source = bitrouter::paths::resolve_config(config.as_deref())?;
@@ -667,7 +682,7 @@ async fn config_cmd(action: ConfigAction) -> Result<()> {
 /// value is **not authoritative** — it must be re-checked at runtime once the
 /// real value is known. Whole-value `${VAR}` (the common case) is unaffected.
 /// Unresolved variables are listed as warnings.
-async fn validate_config(source: &bitrouter::paths::ConfigSource) -> Result<()> {
+async fn validate_config(source: &bitrouter::paths::ConfigSource) -> Result<ValidateReport> {
     use bitrouter::paths::ConfigSource;
     let path = match source {
         ConfigSource::File(p) => p,
@@ -693,30 +708,21 @@ async fn validate_config(source: &bitrouter::paths::ConfigSource) -> Result<()> 
     let missing = missing.into_inner();
 
     match parsed {
-        Ok(cfg) => {
-            println!("✓ {} is valid", path.display());
-            println!(
-                "  providers: {}  models: {}  presets: {}  variants: {}",
-                cfg.providers.len(),
-                cfg.models.len(),
-                cfg.presets.len(),
-                cfg.variants.len(),
-            );
-            if !missing.is_empty() {
-                println!(
-                    "\n  note: {} unset environment variable(s) substituted with a \
-                     placeholder for validation (a value that embeds one mid-string, \
-                     e.g. an env-composed api_base, is not authoritatively checked — \
-                     re-validate at runtime):",
-                    missing.len()
-                );
-                for name in &missing {
-                    println!("    - ${{{name}}}");
-                }
-            }
-            Ok(())
-        }
-        Err(e) => anyhow::bail!("✗ {} is invalid: {e}", path.display()),
+        Ok(cfg) => Ok(ValidateReport::valid(
+            path.display().to_string(),
+            cfg.providers.len(),
+            cfg.models.len(),
+            cfg.presets.len(),
+            cfg.variants.len(),
+            missing
+                .into_iter()
+                .map(|name| UnsetVar { unset_env: name })
+                .collect(),
+        )),
+        Err(e) => Ok(ValidateReport::invalid(
+            path.display().to_string(),
+            e.to_string(),
+        )),
     }
 }
 
@@ -1581,11 +1587,13 @@ async fn verify_attestation(model: &str) -> Result<()> {
 
 // ===== management commands =====
 
-async fn init(config_path: &Path) -> Result<()> {
+async fn init(config_path: &Path) -> Result<InitReport> {
     commands::init(config_path).await?;
-    println!("wrote starter config to {}", config_path.display());
-    println!("  (skip_auth is on — credential-less local requests are admitted)");
-    Ok(())
+    Ok(InitReport {
+        action: "init",
+        path: config_path.display().to_string(),
+        skip_auth: true,
+    })
 }
 
 async fn key(action: KeyAction) -> Result<()> {
@@ -1602,22 +1610,18 @@ async fn key(action: KeyAction) -> Result<()> {
     }
 }
 
-async fn models(source: &bitrouter::paths::ConfigSource, provider: Option<&str>) -> Result<()> {
+async fn models(
+    source: &bitrouter::paths::ConfigSource,
+    provider: Option<&str>,
+) -> Result<ModelsReport> {
     let cfg = bitrouter::paths::load_config(source).await?;
     let models = commands::list_models(&cfg, provider).await?;
-    if models.is_empty() {
-        match (provider, source.is_default()) {
-            (Some(p), _) => println!("(no routable models for provider '{p}')"),
-            (None, true) => {
-                println!("(no routable models — zero-config mode and no provider env vars are set)")
-            }
-            (None, false) => println!("(no routable models — configure providers in your config)"),
-        }
-    }
-    for (id, providers) in models {
-        println!("{id}\t{}", providers.join(", "));
-    }
-    Ok(())
+    Ok(ModelsReport {
+        models: models
+            .into_iter()
+            .map(|(id, providers)| ModelRow { id, providers })
+            .collect(),
+    })
 }
 
 async fn policy(action: PolicyAction) -> Result<()> {
@@ -1632,31 +1636,21 @@ async fn policy(action: PolicyAction) -> Result<()> {
     }
 }
 
-async fn providers(action: ProviderAction) -> Result<()> {
+async fn providers(action: ProviderAction, output: &Output) -> Result<()> {
     match action {
         ProviderAction::List { config } => {
             let source = bitrouter::paths::resolve_config(config.as_deref())?;
             let cfg = bitrouter::paths::load_config(&source).await?;
-            let providers = commands::list_providers(&cfg);
-            if providers.is_empty() {
-                if source.is_default() {
-                    println!("(no providers — zero-config mode and no provider env vars set)");
-                } else {
-                    println!("(no providers configured)");
-                }
-                return Ok(());
-            }
-            // header
-            println!("{:<20} {:<8} {:<6} API_BASE", "ID", "MODELS", "ACTIVE");
-            for p in providers {
-                println!(
-                    "{:<20} {:<8} {:<6} {}",
-                    p.id,
-                    p.model_count,
-                    if p.active { "yes" } else { "no" },
-                    p.api_base
-                );
-            }
+            let providers = commands::list_providers(&cfg)
+                .into_iter()
+                .map(|p| ProviderRow {
+                    id: p.id,
+                    models: p.model_count,
+                    active: p.active,
+                    api_base: p.api_base,
+                })
+                .collect();
+            output.emit(&ProvidersReport { providers })?;
             Ok(())
         }
         ProviderAction::Login { provider, label } => {

--- a/apps/bitrouter/src/main.rs
+++ b/apps/bitrouter/src/main.rs
@@ -22,11 +22,18 @@ use clap::{Parser, Subcommand, ValueEnum};
 use bitrouter::commands;
 use bitrouter::daemon::{self, DaemonCommand, DaemonResponse, RouteHop};
 use bitrouter::output::Output;
+use bitrouter::output::reports::agents::{
+    AgentCheckRow, AgentInstallReport, AgentRow, AgentsCheckReport, AgentsListReport,
+};
 use bitrouter::output::reports::config::{InitReport, UnsetVar, ValidateReport};
 use bitrouter::output::reports::daemon::{
     DaemonActionReport, RouteHopView, RouteReport, StatusReport,
 };
 use bitrouter::output::reports::routing::{ModelRow, ModelsReport, ProviderRow, ProvidersReport};
+use bitrouter::output::reports::tools::{
+    ServerStatusView, ServerToolsView, ToolInfo, ToolsDiscoverReport, ToolsListReport,
+    ToolsStatusReport,
+};
 use bitrouter_sdk::config;
 
 /// BitRouter — an LLM API router.
@@ -617,11 +624,11 @@ async fn run(cli: Cli, output: &bitrouter::output::Output) -> Result<()> {
             Ok(())
         }
         Command::Verify { model } => verify_attestation(&model).await,
-        Command::Tools { action } => tools(action).await,
+        Command::Tools { action } => tools(action, output).await,
         Command::Observe { action } => observe(action).await,
         Command::Policy { action } => policy(action).await,
         Command::Providers { action } => providers(action, output).await,
-        Command::Agents { action } => agents_cmd(action).await,
+        Command::Agents { action } => agents_cmd(action, output).await,
         Command::AgentProxy { agent, config } => {
             let source = bitrouter::paths::resolve_config(config.as_deref())?;
             agent_proxy_cmd(&agent, &source).await
@@ -1682,68 +1689,61 @@ async fn providers(action: ProviderAction, output: &Output) -> Result<()> {
     }
 }
 
-async fn tools(action: ToolsAction) -> Result<()> {
+async fn tools(action: ToolsAction, output: &Output) -> Result<()> {
     use bitrouter::tools as tools_cmd;
 
     match action {
         ToolsAction::List { config } => {
             let source = bitrouter::paths::resolve_config(config.as_deref())?;
             let cfg = bitrouter::paths::load_config(&source).await?;
-            if cfg.mcp_servers.is_empty() {
-                println!("(no MCP servers configured)");
-                println!("  add an `mcp_servers:` block to your bitrouter.yaml —");
-                println!("  see the commented stub in the starter config written by");
-                println!("  `bitrouter init`.");
-                return Ok(());
-            }
-            let rows = tools_cmd::list(&cfg).await;
-            for row in rows {
-                match row.outcome {
-                    Ok(tools) if tools.is_empty() => {
-                        println!("{} (no tools advertised)", row.server);
-                    }
-                    Ok(tools) => {
-                        println!("{} ({})", row.server, tools.len());
-                        for t in tools {
-                            if t.description.is_empty() {
-                                println!("  {}", t.name);
-                            } else {
-                                println!("  {} — {}", t.name, t.description);
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        eprintln!("{}: ERROR — {e}", row.server);
-                    }
-                }
-            }
+            let servers = tools_cmd::list(&cfg)
+                .await
+                .into_iter()
+                .map(|row| match row.outcome {
+                    Ok(tools) => ServerToolsView {
+                        server: row.server,
+                        tools: Some(
+                            tools
+                                .into_iter()
+                                .map(|t| ToolInfo {
+                                    name: t.name,
+                                    description: t.description,
+                                })
+                                .collect(),
+                        ),
+                        error: None,
+                    },
+                    Err(e) => ServerToolsView {
+                        server: row.server,
+                        tools: None,
+                        error: Some(e),
+                    },
+                })
+                .collect();
+            output.emit(&ToolsListReport { servers })?;
             Ok(())
         }
         ToolsAction::Status { config } => {
             let source = bitrouter::paths::resolve_config(config.as_deref())?;
             let cfg = bitrouter::paths::load_config(&source).await?;
-            if cfg.mcp_servers.is_empty() {
-                println!("(no MCP servers configured)");
-                return Ok(());
-            }
-            let rows = tools_cmd::status(&cfg).await;
-            println!(
-                "{:<24} {:<8} {:<12} TRANSPORT",
-                "SERVER", "STATUS", "LATENCY"
-            );
-            for row in rows {
-                let (status, latency) = match row.outcome {
-                    Ok(d) => ("ok".to_string(), format!("{}ms", d.as_millis())),
-                    Err(_) => ("FAIL".to_string(), "-".to_string()),
-                };
-                println!(
-                    "{:<24} {:<8} {:<12} {}",
-                    row.server, status, latency, row.transport
-                );
-                if let Err(e) = row.outcome.as_ref() {
-                    eprintln!("  ↳ {e}");
-                }
-            }
+            let servers = tools_cmd::status(&cfg)
+                .await
+                .into_iter()
+                .map(|row| {
+                    let (ok, latency_ms, error) = match row.outcome {
+                        Ok(d) => (true, Some(d.as_millis()), None),
+                        Err(e) => (false, None, Some(e)),
+                    };
+                    ServerStatusView {
+                        server: row.server,
+                        ok,
+                        latency_ms,
+                        transport: row.transport,
+                        error,
+                    }
+                })
+                .collect();
+            output.emit(&ToolsStatusReport { servers })?;
             Ok(())
         }
         ToolsAction::Discover { server, config } => {
@@ -1751,7 +1751,7 @@ async fn tools(action: ToolsAction) -> Result<()> {
             let cfg = bitrouter::paths::load_config(&source).await?;
             match tools_cmd::discover(&cfg, &server).await {
                 Ok(yaml) => {
-                    print!("{yaml}");
+                    output.emit(&ToolsDiscoverReport { server, yaml })?;
                     Ok(())
                 }
                 Err(e) => anyhow::bail!("discover '{server}': {e}"),
@@ -1892,53 +1892,50 @@ fn print_observe_stopped(p: &bitrouter::style::Palette, socket: &Path) {
     );
 }
 
-async fn agents_cmd(action: AgentsAction) -> Result<()> {
+async fn agents_cmd(action: AgentsAction, output: &Output) -> Result<()> {
     use bitrouter::agents as agents_cmd;
 
     match action {
         AgentsAction::List { config } => {
             let source = bitrouter::paths::resolve_config(config.as_deref())?;
             let cfg = bitrouter::paths::load_config(&source).await?;
-            let rows = agents_cmd::list(&cfg);
-            println!(
-                "{:<16} {:<12} {:<10} DESCRIPTION",
-                "ID", "CONFIGURED", "CATALOG"
-            );
-            for row in rows {
-                println!(
-                    "{:<16} {:<12} {:<10} {}",
-                    row.id,
-                    if row.configured { "yes" } else { "no" },
-                    if row.in_catalog { "yes" } else { "no" },
-                    row.description,
-                );
-            }
+            let agents = agents_cmd::list(&cfg)
+                .into_iter()
+                .map(|row| AgentRow {
+                    id: row.id,
+                    configured: row.configured,
+                    in_catalog: row.in_catalog,
+                    description: row.description,
+                })
+                .collect();
+            output.emit(&AgentsListReport { agents })?;
             Ok(())
         }
         AgentsAction::Check { config } => {
             let source = bitrouter::paths::resolve_config(config.as_deref())?;
             let cfg = bitrouter::paths::load_config(&source).await?;
-            if cfg.agents.is_empty() {
-                println!("(no agents configured)");
-                println!("  install one with: bitrouter agents install <id>");
-                return Ok(());
-            }
-            let rows = agents_cmd::check(&cfg).await;
-            println!("{:<24} {:<8} LATENCY/ERROR", "AGENT", "STATUS");
-            for row in rows {
-                match row.outcome {
-                    Ok(d) => println!("{:<24} {:<8} {}ms", row.id, "ok", d.as_millis()),
-                    Err(e) => {
-                        println!("{:<24} {:<8} -", row.id, "FAIL");
-                        eprintln!("  ↳ {e}");
+            let agents = agents_cmd::check(&cfg)
+                .await
+                .into_iter()
+                .map(|row| {
+                    let (ok, latency_ms, error) = match row.outcome {
+                        Ok(d) => (true, Some(d.as_millis()), None),
+                        Err(e) => (false, None, Some(e)),
+                    };
+                    AgentCheckRow {
+                        id: row.id,
+                        ok,
+                        latency_ms,
+                        error,
                     }
-                }
-            }
+                })
+                .collect();
+            output.emit(&AgentsCheckReport { agents })?;
             Ok(())
         }
         AgentsAction::Install { id } => match agents_cmd::install(&id) {
             Ok(yaml) => {
-                print!("{yaml}");
+                output.emit(&AgentInstallReport { id, yaml })?;
                 Ok(())
             }
             Err(e) => anyhow::bail!(e),

--- a/apps/bitrouter/src/main.rs
+++ b/apps/bitrouter/src/main.rs
@@ -21,6 +21,9 @@ use clap::{Parser, Subcommand, ValueEnum};
 
 use bitrouter::commands;
 use bitrouter::daemon::{self, DaemonCommand, DaemonResponse, RouteHop};
+use bitrouter::output::reports::daemon::{
+    DaemonActionReport, RouteHopView, RouteReport, StatusReport,
+};
 use bitrouter_sdk::config;
 
 /// BitRouter — an LLM API router.
@@ -520,7 +523,7 @@ async fn main() {
     // `bitrouter <cmd> 2>/dev/null | jq` always sees one clean JSON value.
     let cli = Cli::parse();
     let output = bitrouter::output::Output::from_flags(cli.json, cli.human);
-    match run(cli).await {
+    match run(cli, &output).await {
         Ok(()) => {}
         Err(e) => {
             let _ = output.emit(&bitrouter::output::error::envelope_from_anyhow(&e));
@@ -529,7 +532,7 @@ async fn main() {
     }
 }
 
-async fn run(cli: Cli) -> Result<()> {
+async fn run(cli: Cli, output: &bitrouter::output::Output) -> Result<()> {
     // Subscriber init splits by command: the long-running `serve` defers
     // its init until after the OTel exporter has installed a real tracer
     // provider globally (see `serve` below). Every other command — and
@@ -552,11 +555,13 @@ async fn run(cli: Cli) -> Result<()> {
         Command::Start { config, log } => {
             let source = bitrouter::paths::resolve_config(config.as_deref())?;
             let log_path = resolve_log_path(source.home(), log.as_deref());
-            start(&source, &log_path).await
+            output.emit(&start(&source, &log_path, "start").await?)?;
+            Ok(())
         }
         Command::Stop { config, socket } => {
             let socket = resolve_client_socket(config.as_deref(), socket.as_deref()).await?;
-            stop(&socket).await
+            output.emit(&stop(&socket).await?)?;
+            Ok(())
         }
         Command::Restart {
             config,
@@ -566,15 +571,18 @@ async fn run(cli: Cli) -> Result<()> {
             let source = bitrouter::paths::resolve_config(config.as_deref())?;
             let socket = resolve_client_socket_from(&source, socket.as_deref()).await?;
             let log_path = resolve_log_path(source.home(), log.as_deref());
-            restart(&source, &socket, &log_path).await
+            output.emit(&restart(&source, &socket, &log_path).await?)?;
+            Ok(())
         }
         Command::Reload { config, socket } => {
             let socket = resolve_client_socket(config.as_deref(), socket.as_deref()).await?;
-            reload(&socket).await
+            output.emit(&reload(&socket).await?)?;
+            Ok(())
         }
         Command::Status { config, socket } => {
             let socket = resolve_client_socket(config.as_deref(), socket.as_deref()).await?;
-            status(&socket).await
+            output.emit(&status(&socket).await?)?;
+            Ok(())
         }
         Command::Route {
             model,
@@ -583,7 +591,8 @@ async fn run(cli: Cli) -> Result<()> {
         } => {
             let source = bitrouter::paths::resolve_config(config.as_deref())?;
             let socket = resolve_client_socket_from(&source, socket.as_deref()).await?;
-            route(&model, &source, &socket).await
+            output.emit(&route(&model, &source, &socket).await?)?;
+            Ok(())
         }
         Command::Init { config } => init(&config).await,
         Command::Config { action } => config_cmd(action).await,
@@ -1047,7 +1056,11 @@ async fn serve(source: &bitrouter::paths::ConfigSource) -> Result<()> {
     result
 }
 
-async fn start(source: &bitrouter::paths::ConfigSource, log_path: &Path) -> Result<()> {
+async fn start(
+    source: &bitrouter::paths::ConfigSource,
+    log_path: &Path,
+    action: &'static str,
+) -> Result<DaemonActionReport> {
     // Make sure the bitrouter home exists *before* we open the log
     // file inside it. (Zero-config first-run lands here with the home
     // not yet created on disk.)
@@ -1091,20 +1104,14 @@ async fn start(source: &bitrouter::paths::ConfigSource, log_path: &Path) -> Resu
     .await?;
 
     match outcome {
-        daemon::DaemonStartOutcome::Ready(info) => {
-            let p = bitrouter::style::Palette::for_stdout();
-            println!(
-                "{green}✓{reset} bitrouter daemon started (pid {pid}) — \
-                 listening on {listen}, {models} models — logs at {log}",
-                green = p.green,
-                reset = p.reset,
-                pid = info.pid,
-                listen = info.listen,
-                models = info.models,
-                log = log_path.display(),
-            );
-            Ok(())
-        }
+        daemon::DaemonStartOutcome::Ready(info) => Ok(DaemonActionReport::started(
+            action,
+            "started",
+            info.pid,
+            info.listen,
+            info.models,
+            log_path.display().to_string(),
+        )),
         // The process is alive but slow to answer — don't kill it; the daemon
         // may still be migrating / fetching the registry. Report and exit 0.
         daemon::DaemonStartOutcome::NotReadyInTime { pid } => {
@@ -1117,7 +1124,11 @@ async fn start(source: &bitrouter::paths::ConfigSource, log_path: &Path) -> Resu
                 secs = daemon::DAEMON_READY_TIMEOUT.as_secs(),
                 log = log_path.display(),
             );
-            Ok(())
+            Ok(DaemonActionReport::not_ready(
+                action,
+                pid,
+                log_path.display().to_string(),
+            ))
         }
         daemon::DaemonStartOutcome::Exited { status, log_tail } => {
             daemon::eprint_failure_log(log_path, &log_tail);
@@ -1242,12 +1253,9 @@ fn other_provider_env_var_hints() -> Vec<String> {
     vars
 }
 
-async fn stop(socket: &Path) -> Result<()> {
+async fn stop(socket: &Path) -> Result<DaemonActionReport> {
     match daemon::send_command(socket, &DaemonCommand::Stop).await? {
-        DaemonResponse::Ok => {
-            println!("daemon stopped");
-            Ok(())
-        }
+        DaemonResponse::Ok => Ok(DaemonActionReport::simple("stop", "stopped")),
         DaemonResponse::Error { message } => Err(anyhow::anyhow!(message)),
         other => Err(anyhow::anyhow!("unexpected response: {other:?}")),
     }
@@ -1257,14 +1265,14 @@ async fn restart(
     source: &bitrouter::paths::ConfigSource,
     socket: &Path,
     log_path: &Path,
-) -> Result<()> {
+) -> Result<DaemonActionReport> {
     // Stop is best-effort — a missing daemon is fine, we just go straight to
     // start. Any other error from the running daemon is fatal. `endpoint_in_use`
     // abstracts "is a daemon bound here?" across the Unix socket file and the
     // Windows named pipe.
     if daemon::endpoint_in_use(socket) {
         match daemon::send_command(socket, &DaemonCommand::Stop).await {
-            Ok(DaemonResponse::Ok) => println!("daemon stopped"),
+            Ok(DaemonResponse::Ok) => {}
             Ok(DaemonResponse::Error { message }) => return Err(anyhow::anyhow!(message)),
             Ok(other) => return Err(anyhow::anyhow!("unexpected response: {other:?}")),
             Err(e) => tracing::warn!(error = %e, "stop failed — proceeding to start"),
@@ -1285,7 +1293,7 @@ async fn restart(
             daemon::remove_pid_file(&pid_path).await;
         }
     }
-    start(source, log_path).await
+    start(source, log_path, "restart").await
 }
 
 /// Poll until the control endpoint is released (the old daemon drops the Unix
@@ -1302,7 +1310,7 @@ async fn wait_for_socket_release(socket: &Path, timeout: std::time::Duration) ->
     !daemon::endpoint_in_use(socket)
 }
 
-async fn reload(socket: &Path) -> Result<()> {
+async fn reload(socket: &Path) -> Result<DaemonActionReport> {
     // Snapshot every env-var-credentialed built-in provider's key from
     // *this* (CLI) process and hand them to the daemon along with the
     // reload command, so `export OPENAI_API_KEY=…; bitrouter reload`
@@ -1320,81 +1328,34 @@ async fn reload(socket: &Path) -> Result<()> {
         })
         .collect();
     match daemon::send_command(socket, &DaemonCommand::Reload { env }).await? {
-        DaemonResponse::Ok => {
-            println!("config reloaded");
-            Ok(())
-        }
+        DaemonResponse::Ok => Ok(DaemonActionReport::simple("reload", "reloaded")),
         DaemonResponse::Error { message } => Err(anyhow::anyhow!(message)),
         other => Err(anyhow::anyhow!("unexpected response: {other:?}")),
     }
 }
 
-async fn status(socket: &Path) -> Result<()> {
-    let p = bitrouter::style::Palette::for_stdout();
+async fn status(socket: &Path) -> Result<StatusReport> {
     match daemon::send_command(socket, &DaemonCommand::Status).await {
         Ok(DaemonResponse::Status {
             pid,
             listen,
             models,
-        }) => {
-            print_status_running(&p, pid, &listen, models, socket);
-            Ok(())
-        }
+        }) => Ok(StatusReport::running(
+            pid,
+            listen,
+            models,
+            socket.display().to_string(),
+        )),
         Ok(DaemonResponse::Error { message }) => Err(anyhow::anyhow!(message)),
         Ok(other) => Err(anyhow::anyhow!("unexpected response: {other:?}")),
         // No daemon listening on the socket → report stopped, not error.
         // Anything else (permission denied, malformed response, …) is a
         // real failure and bubbles to the pretty reporter.
         Err(e) if daemon::is_not_reachable(&e) => {
-            print_status_stopped(&p, socket);
-            Ok(())
+            Ok(StatusReport::stopped(socket.display().to_string()))
         }
         Err(e) => Err(e),
     }
-}
-
-/// Render the running-daemon status block. Modelled on `systemctl
-/// status` — a coloured bullet + headline, then a short indented list
-/// of facts. Labels are dim so values are what the eye lands on.
-fn print_status_running(
-    p: &bitrouter::style::Palette,
-    pid: u32,
-    listen: &str,
-    models: usize,
-    socket: &Path,
-) {
-    println!(
-        "{green}●{reset} bitrouter is {bold}running{reset}",
-        green = p.green,
-        bold = p.bold,
-        reset = p.reset,
-    );
-    println!();
-    print_status_row(p, "pid", &pid.to_string());
-    print_status_row(p, "listen", listen);
-    print_status_row(p, "models", &format!("{models} routable"));
-    print_status_row(p, "socket", &socket.display().to_string());
-}
-
-/// Render the stopped-daemon status block. Hollow bullet (dim) +
-/// headline, the socket we *would* connect to, and a one-line next
-/// step. Exit code remains 0 — "stopped" is the answer to the
-/// question, not a failure.
-fn print_status_stopped(p: &bitrouter::style::Palette, socket: &Path) {
-    println!(
-        "{dim}○{reset} bitrouter is {bold}stopped{reset}",
-        dim = p.dim,
-        bold = p.bold,
-        reset = p.reset,
-    );
-    println!();
-    print_status_row(p, "socket", &socket.display().to_string());
-    println!();
-    println!(
-        "  {dim}Run `bitrouter start` to launch the daemon.{reset}",
-        dim = p.dim,
-        reset = p.reset,
-    );
 }
 
 /// One indented `label  value` row in a status block. The label column
@@ -1408,7 +1369,11 @@ fn print_status_row(p: &bitrouter::style::Palette, label: &str, value: &str) {
     );
 }
 
-async fn route(model: &str, source: &bitrouter::paths::ConfigSource, socket: &Path) -> Result<()> {
+async fn route(
+    model: &str,
+    source: &bitrouter::paths::ConfigSource,
+    socket: &Path,
+) -> Result<RouteReport> {
     // Try the running daemon first — its routing table reflects any `reload`s.
     if daemon::endpoint_in_use(socket) {
         match daemon::send_command(
@@ -1420,8 +1385,7 @@ async fn route(model: &str, source: &bitrouter::paths::ConfigSource, socket: &Pa
         .await
         {
             Ok(DaemonResponse::Route { chain }) => {
-                print_route_chain(model, &chain, "live daemon");
-                return Ok(());
+                return Ok(route_report(model, "live daemon", chain));
             }
             Ok(DaemonResponse::Error { message }) => return Err(anyhow::anyhow!(message)),
             Ok(other) => return Err(anyhow::anyhow!("unexpected response: {other:?}")),
@@ -1439,24 +1403,22 @@ async fn route(model: &str, source: &bitrouter::paths::ConfigSource, socket: &Pa
     } else {
         "config"
     };
-    print_route_chain(model, &chain, label);
-    Ok(())
+    Ok(route_report(model, label, chain))
 }
 
-fn print_route_chain(model: &str, chain: &[RouteHop], source: &str) {
-    println!("model: {model}  (resolved via: {source})");
-    if chain.is_empty() {
-        println!("  (empty chain — no provider declares this model)");
-        return;
-    }
-    for (i, hop) in chain.iter().enumerate() {
-        println!(
-            "  {}. {} → {} ({})",
-            i + 1,
-            hop.provider,
-            hop.service_id,
-            hop.api_protocol
-        );
+/// Build a [`RouteReport`] from a resolved hop chain (wire-safe `RouteHop`s).
+fn route_report(model: &str, resolved_via: &str, chain: Vec<RouteHop>) -> RouteReport {
+    RouteReport {
+        model: model.to_string(),
+        resolved_via: resolved_via.to_string(),
+        chain: chain
+            .into_iter()
+            .map(|h| RouteHopView {
+                provider: h.provider,
+                service_id: h.service_id,
+                protocol: h.api_protocol,
+            })
+            .collect(),
     }
 }
 

--- a/apps/bitrouter/src/main.rs
+++ b/apps/bitrouter/src/main.rs
@@ -27,6 +27,12 @@ use bitrouter_sdk::config;
 #[derive(Parser)]
 #[command(name = "bitrouter", version, about)]
 struct Cli {
+    /// Force JSON output (the default; agent-native). Conflicts with `--human`.
+    #[arg(short = 'j', long, global = true, conflicts_with = "human")]
+    json: bool,
+    /// Render the human-readable view to stdout instead of JSON.
+    #[arg(short = 'H', long, global = true)]
+    human: bool,
     #[command(subcommand)]
     command: Command,
 }
@@ -507,20 +513,23 @@ enum ProviderAction {
 
 #[tokio::main]
 async fn main() {
-    // Defer to `run` for the actual dispatch so the entry point can
-    // route the resulting `Result` through `error_report::report` instead
-    // of leaking anyhow's verbose `Debug` formatter to end users.
-    match run().await {
+    // Parse once here so the global `--json` / `--human` flags are available to
+    // render the *result* — a success report or the error envelope — through the
+    // single `Output` driver. Diagnostics during execution go to stderr; the
+    // result (this match) goes to stdout in the selected format, so
+    // `bitrouter <cmd> 2>/dev/null | jq` always sees one clean JSON value.
+    let cli = Cli::parse();
+    let output = bitrouter::output::Output::from_flags(cli.json, cli.human);
+    match run(cli).await {
         Ok(()) => {}
         Err(e) => {
-            bitrouter::error_report::report(&e);
+            let _ = output.emit(&bitrouter::output::error::envelope_from_anyhow(&e));
             std::process::exit(1);
         }
     }
 }
 
-async fn run() -> Result<()> {
-    let cli = Cli::parse();
+async fn run(cli: Cli) -> Result<()> {
     // Subscriber init splits by command: the long-running `serve` defers
     // its init until after the OTel exporter has installed a real tracer
     // provider globally (see `serve` below). Every other command — and

--- a/apps/bitrouter/src/main.rs
+++ b/apps/bitrouter/src/main.rs
@@ -666,7 +666,7 @@ async fn run(cli: Cli, output: &bitrouter::output::Output) -> Result<()> {
             .await
         }
         Command::Cloud { action } => bitrouter::cloud::cli::run(action).await,
-        Command::Skills { action } => bitrouter::skills::cli::run(action).await,
+        Command::Skills { action } => bitrouter::skills::cli::run(action, output).await,
         Command::Mcp { action } => mcp_cmd(action).await,
     }
 }

--- a/apps/bitrouter/src/main.rs
+++ b/apps/bitrouter/src/main.rs
@@ -22,6 +22,9 @@ use clap::{Parser, Subcommand, ValueEnum};
 use bitrouter::commands;
 use bitrouter::daemon::{self, DaemonCommand, DaemonResponse, RouteHop};
 use bitrouter::output::Output;
+use bitrouter::output::reports::admin::{
+    KeySignReport, PolicyCreateReport, ProviderLoginReport, ProviderLogoutReport,
+};
 use bitrouter::output::reports::agents::{
     AgentCheckRow, AgentInstallReport, AgentRow, AgentsCheckReport, AgentsListReport,
 };
@@ -617,7 +620,10 @@ async fn run(cli: Cli, output: &bitrouter::output::Output) -> Result<()> {
                 std::process::exit(1)
             }
         }
-        Command::Key { action } => key(action).await,
+        Command::Key { action } => {
+            output.emit(&key(action).await?)?;
+            Ok(())
+        }
         Command::Models { config, provider } => {
             let source = bitrouter::paths::resolve_config(config.as_deref())?;
             output.emit(&models(&source, provider.as_deref()).await?)?;
@@ -626,7 +632,10 @@ async fn run(cli: Cli, output: &bitrouter::output::Output) -> Result<()> {
         Command::Verify { model } => verify_attestation(&model).await,
         Command::Tools { action } => tools(action, output).await,
         Command::Observe { action } => observe(action).await,
-        Command::Policy { action } => policy(action).await,
+        Command::Policy { action } => {
+            output.emit(&policy(action).await?)?;
+            Ok(())
+        }
         Command::Providers { action } => providers(action, output).await,
         Command::Agents { action } => agents_cmd(action, output).await,
         Command::AgentProxy { agent, config } => {
@@ -812,6 +821,9 @@ async fn resolve_client_socket(config: Option<&Path>, socket: Option<&Path>) -> 
 /// except `serve` — see [`init_serve_tracing_subscriber`].
 fn init_basic_tracing_subscriber() {
     tracing_subscriber::fmt()
+        // Diagnostics MUST go to stderr so stdout stays a pure JSON result
+        // surface (`tracing_subscriber::fmt()` otherwise defaults to stdout).
+        .with_writer(std::io::stderr)
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
@@ -1603,16 +1615,17 @@ async fn init(config_path: &Path) -> Result<InitReport> {
     })
 }
 
-async fn key(action: KeyAction) -> Result<()> {
+async fn key(action: KeyAction) -> Result<KeySignReport> {
     match action {
         KeyAction::Sign { user, db, policy } => {
             let key = commands::key_sign(&db, &user, policy.as_deref()).await?;
-            println!("created virtual key {} for user '{user}'", key.id);
-            println!();
-            println!("  {}", key.secret);
-            println!();
-            println!("This secret is shown ONCE — only its SHA-256 hash is stored.");
-            Ok(())
+            Ok(KeySignReport {
+                id: key.id,
+                user,
+                secret: key.secret,
+                policy,
+                hash_stored: true,
+            })
         }
     }
 }
@@ -1631,14 +1644,15 @@ async fn models(
     })
 }
 
-async fn policy(action: PolicyAction) -> Result<()> {
+async fn policy(action: PolicyAction) -> Result<PolicyCreateReport> {
     match action {
         PolicyAction::Create { id, dir } => {
             let path = commands::create_policy(&dir, &id).await?;
-            println!("wrote starter policy to {}", path.display());
-            println!("  edit, then bind to a key with:");
-            println!("    bitrouter key sign --user <id> --policy {id}");
-            Ok(())
+            Ok(PolicyCreateReport {
+                id,
+                path: path.display().to_string(),
+                created: true,
+            })
         }
     }
 }
@@ -1672,7 +1686,15 @@ async fn providers(action: ProviderAction, output: &Output) -> Result<()> {
                 })
                 .await
             } else {
-                bitrouter::commands::login_provider(&provider, &label).await
+                let outcome = bitrouter::commands::login_provider(&provider, &label).await?;
+                output.emit(&ProviderLoginReport {
+                    provider: outcome.provider,
+                    label: outcome.label,
+                    method: outcome.method,
+                    credential: "saved",
+                    path: outcome.path,
+                })?;
+                Ok(())
             }
         }
         ProviderAction::Logout { provider } => {
@@ -1683,7 +1705,9 @@ async fn providers(action: ProviderAction, output: &Output) -> Result<()> {
                 })
                 .await
             } else {
-                bitrouter::commands::logout_provider(&provider).await
+                let removed = bitrouter::commands::logout_provider(&provider).await?;
+                output.emit(&ProviderLogoutReport { provider, removed })?;
+                Ok(())
             }
         }
     }

--- a/apps/bitrouter/src/output/error.rs
+++ b/apps/bitrouter/src/output/error.rs
@@ -37,7 +37,10 @@ impl CliReport for ErrorEnvelope {
 /// layers → `context` (outermost first), and a recognised remediation `hint`.
 pub fn envelope_from_anyhow(err: &anyhow::Error) -> ErrorEnvelope {
     let chain: Vec<String> = err.chain().map(|e| e.to_string()).collect();
-    let root_raw = chain.last().map(String::as_str).unwrap_or("(unknown error)");
+    let root_raw = chain
+        .last()
+        .map(String::as_str)
+        .unwrap_or("(unknown error)");
     let root = strip_status_prefix(root_raw);
 
     let kind = err
@@ -56,7 +59,12 @@ pub fn envelope_from_anyhow(err: &anyhow::Error) -> ErrorEnvelope {
     };
 
     ErrorEnvelope {
-        error: ErrorBody { kind, message: root.to_string(), context, hint: hint_for(root) },
+        error: ErrorBody {
+            kind,
+            message: root.to_string(),
+            context,
+            hint: hint_for(root),
+        },
     }
 }
 
@@ -74,7 +82,10 @@ mod tests {
             env.error.message,
             "config references undefined environment variable 'FOO'"
         );
-        assert_eq!(env.error.context, vec!["loading /tmp/bitrouter.yaml".to_string()]);
+        assert_eq!(
+            env.error.context,
+            vec!["loading /tmp/bitrouter.yaml".to_string()]
+        );
         assert!(env.error.hint.as_deref().unwrap().contains("export FOO"));
         assert_eq!(env.exit_code(), 1);
     }
@@ -92,6 +103,9 @@ mod tests {
     fn error_envelope_human_block() {
         let env = envelope_from_anyhow(&anyhow::anyhow!("boom").context("doing x"));
         let buf = Output::new(Format::Human).render_to_vec(&env);
-        assert_eq!(String::from_utf8(buf).unwrap(), "error: boom\n  while: doing x\n");
+        assert_eq!(
+            String::from_utf8(buf).unwrap(),
+            "error: boom\n  while: doing x\n"
+        );
     }
 }

--- a/apps/bitrouter/src/output/error.rs
+++ b/apps/bitrouter/src/output/error.rs
@@ -1,7 +1,7 @@
 //! The uniform error envelope as a [`CliReport`], plus normalizers from the
 //! CLI's error sources into it.
 //!
-//! Every failed command renders [`ErrorEnvelope`] through the same [`Output`]
+//! Every failed command renders [`ErrorEnvelope`] through the same [`Output`](super::Output)
 //! driver as a success: JSON `{"error": {"kind", "message", …}}` on stdout by
 //! default, or the human `error:` / `while:` / `hint:` block under `--human`.
 

--- a/apps/bitrouter/src/output/error.rs
+++ b/apps/bitrouter/src/output/error.rs
@@ -1,0 +1,97 @@
+//! The uniform error envelope as a [`CliReport`], plus normalizers from the
+//! CLI's error sources into it.
+//!
+//! Every failed command renders [`ErrorEnvelope`] through the same [`Output`]
+//! driver as a success: JSON `{"error": {"kind", "message", …}}` on stdout by
+//! default, or the human `error:` / `while:` / `hint:` block under `--human`.
+
+use bitrouter_sdk::error::{BitrouterError, ErrorBody, ErrorEnvelope, ErrorKind};
+
+use crate::error_report::{hint_for, strip_status_prefix};
+use crate::output::CliReport;
+use crate::output::human::Human;
+
+impl CliReport for ErrorEnvelope {
+    fn render(&self, h: &mut Human<'_>) -> std::io::Result<()> {
+        h.error_head(&self.error.message)?;
+        for layer in &self.error.context {
+            h.while_line(layer)?;
+        }
+        if let Some(hint) = &self.error.hint {
+            h.blank()?;
+            for line in hint.lines() {
+                h.hint_line(line)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn exit_code(&self) -> i32 {
+        1
+    }
+}
+
+/// Normalize an `anyhow` error chain into the canonical envelope: root cause →
+/// `message` (HTTP status-prefix stripped), the [`BitrouterError`] kind when one
+/// is present in the chain (else [`ErrorKind::Internal`]), the outer chain
+/// layers → `context` (outermost first), and a recognised remediation `hint`.
+pub fn envelope_from_anyhow(err: &anyhow::Error) -> ErrorEnvelope {
+    let chain: Vec<String> = err.chain().map(|e| e.to_string()).collect();
+    let root_raw = chain.last().map(String::as_str).unwrap_or("(unknown error)");
+    let root = strip_status_prefix(root_raw);
+
+    let kind = err
+        .chain()
+        .find_map(|e| e.downcast_ref::<BitrouterError>())
+        .map(BitrouterError::kind)
+        .unwrap_or(ErrorKind::Internal);
+
+    let context = if chain.len() > 1 {
+        chain[..chain.len() - 1]
+            .iter()
+            .map(|layer| strip_status_prefix(layer).to_string())
+            .collect()
+    } else {
+        Vec::new()
+    };
+
+    ErrorEnvelope {
+        error: ErrorBody { kind, message: root.to_string(), context, hint: hint_for(root) },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::output::{Format, Output};
+
+    #[test]
+    fn anyhow_chain_becomes_message_context_hint() {
+        let err = anyhow::anyhow!("config references undefined environment variable 'FOO'")
+            .context("loading /tmp/bitrouter.yaml");
+        let env = envelope_from_anyhow(&err);
+        assert_eq!(
+            env.error.message,
+            "config references undefined environment variable 'FOO'"
+        );
+        assert_eq!(env.error.context, vec!["loading /tmp/bitrouter.yaml".to_string()]);
+        assert!(env.error.hint.as_deref().unwrap().contains("export FOO"));
+        assert_eq!(env.exit_code(), 1);
+    }
+
+    #[test]
+    fn error_envelope_json_shape() {
+        let env = envelope_from_anyhow(&anyhow::anyhow!("boom"));
+        let buf = Output::new(Format::Json).render_to_vec(&env);
+        let v: serde_json::Value = serde_json::from_slice(&buf).unwrap();
+        assert_eq!(v["error"]["kind"], "internal");
+        assert_eq!(v["error"]["message"], "boom");
+    }
+
+    #[test]
+    fn error_envelope_human_block() {
+        let env = envelope_from_anyhow(&anyhow::anyhow!("boom").context("doing x"));
+        let buf = Output::new(Format::Human).render_to_vec(&env);
+        assert_eq!(String::from_utf8(buf).unwrap(), "error: boom\n  while: doing x\n");
+    }
+}

--- a/apps/bitrouter/src/output/human.rs
+++ b/apps/bitrouter/src/output/human.rs
@@ -1,0 +1,268 @@
+//! Human-readable render toolkit for [`CliReport`](super::CliReport)s.
+//!
+//! `render()` implementations compose their human view out of these
+//! primitives — they never `println!` directly. Centralising the palette and
+//! the layout primitives keeps every command's `--human` output consistent and
+//! keeps colour gating (TTY + `NO_COLOR`) in one place.
+
+use std::fmt::Display;
+use std::io::{IsTerminal, Write};
+
+/// ANSI palette, chosen once per render. When colour is suppressed (the target
+/// stream is not a TTY, or `NO_COLOR` is set) every field is `""` so format
+/// strings stay valid but emit nothing. Folded from the former `style.rs`.
+#[derive(Clone, Copy)]
+pub struct Theme {
+    red: &'static str,
+    green: &'static str,
+    cyan: &'static str,
+    bold: &'static str,
+    dim: &'static str,
+    reset: &'static str,
+}
+
+impl Theme {
+    /// Full ANSI palette.
+    pub fn ansi() -> Self {
+        Self {
+            red: "\x1b[31m",
+            green: "\x1b[32m",
+            cyan: "\x1b[36m",
+            bold: "\x1b[1m",
+            dim: "\x1b[2m",
+            reset: "\x1b[0m",
+        }
+    }
+
+    /// Empty palette — every field is `""`. Used for redirected streams,
+    /// `NO_COLOR`, and tests.
+    pub fn none() -> Self {
+        Self { red: "", green: "", cyan: "", bold: "", dim: "", reset: "" }
+    }
+
+    /// Palette for stdout (the human result surface). Plain when piped.
+    pub fn for_stdout() -> Self {
+        if no_color() || !std::io::stdout().is_terminal() { Self::none() } else { Self::ansi() }
+    }
+
+    /// Palette for stderr (diagnostics / error echoes).
+    pub fn for_stderr() -> Self {
+        if no_color() || !std::io::stderr().is_terminal() { Self::none() } else { Self::ansi() }
+    }
+}
+
+/// True when `NO_COLOR` is set to a non-empty value (<https://no-color.org/>).
+fn no_color() -> bool {
+    std::env::var_os("NO_COLOR").is_some_and(|v| !v.is_empty())
+}
+
+/// Health indicator for [`Human::status_block`] — drives the `●` / `○` glyph
+/// and its colour.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum Health {
+    /// Green `●` — the subject is up / healthy.
+    Up,
+    /// Dim `○` — the subject is down / stopped.
+    Down,
+    /// Dim `●` — state could not be determined.
+    Unknown,
+}
+
+/// A fixed-width text table: a header row plus data rows, columns auto-sized to
+/// their widest cell, last column left unpadded.
+#[derive(Default)]
+pub struct Table {
+    headers: Vec<String>,
+    rows: Vec<Vec<String>>,
+}
+
+impl Table {
+    /// Start a table with the given header cells.
+    pub fn new<I, S>(headers: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        Self { headers: headers.into_iter().map(Into::into).collect(), rows: Vec::new() }
+    }
+
+    /// Append a data row (builder form).
+    pub fn row<I, S>(mut self, cells: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.push(cells);
+        self
+    }
+
+    /// Append a data row (mutating form).
+    pub fn push<I, S>(&mut self, cells: I)
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.rows.push(cells.into_iter().map(Into::into).collect());
+    }
+
+    fn widths(&self) -> Vec<usize> {
+        let mut w: Vec<usize> = self.headers.iter().map(|h| h.chars().count()).collect();
+        for row in &self.rows {
+            for (i, cell) in row.iter().enumerate() {
+                if i < w.len() {
+                    w[i] = w[i].max(cell.chars().count());
+                }
+            }
+        }
+        w
+    }
+}
+
+/// A render target wrapping a writer plus a [`Theme`]. Passed to every
+/// [`CliReport::render`](super::CliReport::render).
+pub struct Human<'a> {
+    w: &'a mut dyn Write,
+    theme: Theme,
+}
+
+impl<'a> Human<'a> {
+    /// Wrap a writer with a palette.
+    pub fn new(w: &'a mut dyn Write, theme: Theme) -> Self {
+        Self { w, theme }
+    }
+
+    /// Write one verbatim line.
+    pub fn line(&mut self, s: &str) -> std::io::Result<()> {
+        writeln!(self.w, "{s}")
+    }
+
+    /// Write a blank line.
+    pub fn blank(&mut self) -> std::io::Result<()> {
+        writeln!(self.w)
+    }
+
+    /// A `  label    value` detail row (label dim, left-padded to 8).
+    pub fn field(&mut self, label: &str, value: impl Display) -> std::io::Result<()> {
+        let (dim, reset) = (self.theme.dim, self.theme.reset);
+        writeln!(self.w, "  {dim}{label:<8}{reset}  {value}")
+    }
+
+    /// A `systemctl`-style health headline followed by a blank line.
+    pub fn status_block(&mut self, health: Health, headline: &str) -> std::io::Result<()> {
+        let Theme { green, dim, bold, reset, .. } = self.theme;
+        let glyph = match health {
+            Health::Up => format!("{green}●{reset}"),
+            Health::Down => format!("{dim}○{reset}"),
+            Health::Unknown => format!("{dim}●{reset}"),
+        };
+        writeln!(self.w, "{glyph} {bold}{headline}{reset}")?;
+        self.blank()
+    }
+
+    /// A dim, indented secondary note (e.g. a follow-up suggestion).
+    pub fn note(&mut self, s: &str) -> std::io::Result<()> {
+        let (dim, reset) = (self.theme.dim, self.theme.reset);
+        writeln!(self.w, "  {dim}{s}{reset}")
+    }
+
+    /// The `error:` headline of an error block (red, bold).
+    pub fn error_head(&mut self, s: &str) -> std::io::Result<()> {
+        let (red, bold, reset) = (self.theme.red, self.theme.bold, self.theme.reset);
+        writeln!(self.w, "{red}{bold}error:{reset} {s}")
+    }
+
+    /// A `while:` context layer of an error block (dim).
+    pub fn while_line(&mut self, s: &str) -> std::io::Result<()> {
+        let (dim, reset) = (self.theme.dim, self.theme.reset);
+        writeln!(self.w, "  {dim}while:{reset} {s}")
+    }
+
+    /// A `hint:` remediation line of an error block (cyan).
+    pub fn hint_line(&mut self, s: &str) -> std::io::Result<()> {
+        let (cyan, reset) = (self.theme.cyan, self.theme.reset);
+        writeln!(self.w, "  {cyan}hint:{reset} {s}")
+    }
+
+    /// Render a [`Table`] — header row then data rows, columns auto-sized.
+    pub fn table(&mut self, t: &Table) -> std::io::Result<()> {
+        let widths = t.widths();
+        self.row_cells(&t.headers, &widths)?;
+        for row in &t.rows {
+            self.row_cells(row, &widths)?;
+        }
+        Ok(())
+    }
+
+    fn row_cells(&mut self, cells: &[String], widths: &[usize]) -> std::io::Result<()> {
+        let last = cells.len().saturating_sub(1);
+        let mut line = String::new();
+        for (i, cell) in cells.iter().enumerate() {
+            if i == last {
+                line.push_str(cell);
+            } else {
+                let pad = widths.get(i).copied().unwrap_or(0);
+                line.push_str(&format!("{cell:<pad$}  "));
+            }
+        }
+        writeln!(self.w, "{}", line.trim_end())
+    }
+
+    /// Pretty-print an embedded JSON value, each line indented by two spaces.
+    pub fn embedded_json(&mut self, v: &serde_json::Value) -> std::io::Result<()> {
+        let pretty = serde_json::to_string_pretty(v).unwrap_or_else(|_| v.to_string());
+        for line in pretty.lines() {
+            writeln!(self.w, "  {line}")?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn render(f: impl FnOnce(&mut Human)) -> String {
+        let mut buf: Vec<u8> = Vec::new();
+        {
+            let mut h = Human::new(&mut buf, Theme::none());
+            f(&mut h);
+        }
+        String::from_utf8(buf).unwrap()
+    }
+
+    #[test]
+    fn status_block_up_renders_bullet_headline_and_field() {
+        let s = render(|h| {
+            h.status_block(Health::Up, "bitrouter is running").unwrap();
+            h.field("pid", "123").unwrap();
+        });
+        assert!(s.contains("● bitrouter is running"), "{s:?}");
+        assert!(s.contains("  pid       123"), "{s:?}");
+    }
+
+    #[test]
+    fn status_block_down_uses_hollow_glyph() {
+        let s = render(|h| h.status_block(Health::Down, "bitrouter is stopped").unwrap());
+        assert!(s.contains("○ bitrouter is stopped"), "{s:?}");
+    }
+
+    #[test]
+    fn table_pads_columns_and_trims_last() {
+        let t = Table::new(["ID", "MODELS"]).row(["openai", "42"]).row(["x", "1"]);
+        let s = render(|h| h.table(&t).unwrap());
+        assert!(s.starts_with("ID      MODELS"), "{s:?}");
+        assert!(s.contains("openai  42"), "{s:?}");
+        // last column trimmed — no trailing spaces
+        assert!(s.lines().all(|l| l == l.trim_end()), "{s:?}");
+    }
+
+    #[test]
+    fn error_block_heads() {
+        let s = render(|h| {
+            h.error_head("boom").unwrap();
+            h.while_line("loading x").unwrap();
+            h.hint_line("try y").unwrap();
+        });
+        assert_eq!(s, "error: boom\n  while: loading x\n  hint: try y\n");
+    }
+}

--- a/apps/bitrouter/src/output/human.rs
+++ b/apps/bitrouter/src/output/human.rs
@@ -37,17 +37,32 @@ impl Theme {
     /// Empty palette — every field is `""`. Used for redirected streams,
     /// `NO_COLOR`, and tests.
     pub fn none() -> Self {
-        Self { red: "", green: "", cyan: "", bold: "", dim: "", reset: "" }
+        Self {
+            red: "",
+            green: "",
+            cyan: "",
+            bold: "",
+            dim: "",
+            reset: "",
+        }
     }
 
     /// Palette for stdout (the human result surface). Plain when piped.
     pub fn for_stdout() -> Self {
-        if no_color() || !std::io::stdout().is_terminal() { Self::none() } else { Self::ansi() }
+        if no_color() || !std::io::stdout().is_terminal() {
+            Self::none()
+        } else {
+            Self::ansi()
+        }
     }
 
     /// Palette for stderr (diagnostics / error echoes).
     pub fn for_stderr() -> Self {
-        if no_color() || !std::io::stderr().is_terminal() { Self::none() } else { Self::ansi() }
+        if no_color() || !std::io::stderr().is_terminal() {
+            Self::none()
+        } else {
+            Self::ansi()
+        }
     }
 }
 
@@ -83,7 +98,10 @@ impl Table {
         I: IntoIterator<Item = S>,
         S: Into<String>,
     {
-        Self { headers: headers.into_iter().map(Into::into).collect(), rows: Vec::new() }
+        Self {
+            headers: headers.into_iter().map(Into::into).collect(),
+            rows: Vec::new(),
+        }
     }
 
     /// Append a data row (builder form).
@@ -149,7 +167,13 @@ impl<'a> Human<'a> {
 
     /// A `systemctl`-style health headline followed by a blank line.
     pub fn status_block(&mut self, health: Health, headline: &str) -> std::io::Result<()> {
-        let Theme { green, dim, bold, reset, .. } = self.theme;
+        let Theme {
+            green,
+            dim,
+            bold,
+            reset,
+            ..
+        } = self.theme;
         let glyph = match health {
             Health::Up => format!("{green}●{reset}"),
             Health::Down => format!("{dim}○{reset}"),
@@ -242,13 +266,18 @@ mod tests {
 
     #[test]
     fn status_block_down_uses_hollow_glyph() {
-        let s = render(|h| h.status_block(Health::Down, "bitrouter is stopped").unwrap());
+        let s = render(|h| {
+            h.status_block(Health::Down, "bitrouter is stopped")
+                .unwrap()
+        });
         assert!(s.contains("○ bitrouter is stopped"), "{s:?}");
     }
 
     #[test]
     fn table_pads_columns_and_trims_last() {
-        let t = Table::new(["ID", "MODELS"]).row(["openai", "42"]).row(["x", "1"]);
+        let t = Table::new(["ID", "MODELS"])
+            .row(["openai", "42"])
+            .row(["x", "1"]);
         let s = render(|h| h.table(&t).unwrap());
         assert!(s.starts_with("ID      MODELS"), "{s:?}");
         assert!(s.contains("openai  42"), "{s:?}");

--- a/apps/bitrouter/src/output/mod.rs
+++ b/apps/bitrouter/src/output/mod.rs
@@ -58,9 +58,10 @@ impl Output {
     }
 
     /// Pick the format from the global flags. `--human` selects the human view;
-    /// otherwise (including `--json`) JSON.
-    pub fn from_flags(human: bool) -> Self {
-        Self::new(if human { Format::Human } else { Format::Json })
+    /// `--json` (or neither) is JSON. The two are mutually exclusive at the
+    /// clap layer; the `&& !json` is belt-and-suspenders.
+    pub fn from_flags(json: bool, human: bool) -> Self {
+        Self::new(if human && !json { Format::Human } else { Format::Json })
     }
 
     /// Emit a report to stdout in the active format.

--- a/apps/bitrouter/src/output/mod.rs
+++ b/apps/bitrouter/src/output/mod.rs
@@ -1,0 +1,116 @@
+//! CLI output layer.
+//!
+//! Every CLI command computes a strongly-typed **report** that implements
+//! [`CliReport`] — it is both `Serialize` (the JSON view) and renderable to a
+//! human view via [`Human`](human::Human). The [`Output`] driver is the single
+//! place that writes the result to stdout, picking the format from the global
+//! `--json` / `--human` flags.
+//!
+//! Default is JSON (agent-native). Diagnostics never come through here — they
+//! go to stderr — so `bitrouter <cmd> 2>/dev/null | jq` always sees one clean
+//! JSON value.
+
+pub mod error;
+pub mod human;
+pub mod reports;
+
+use std::io::Write;
+
+use human::{Human, Theme};
+
+/// The output format for a command's result.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Format {
+    /// One pretty-printed JSON value (the default).
+    Json,
+    /// The human-readable rendering.
+    Human,
+}
+
+/// A command result that can be emitted as JSON or as a human view.
+///
+/// The `erased_serde::Serialize` supertrait lets a `&dyn CliReport` be
+/// serialized (via [`serialize_trait_object!`](erased_serde::serialize_trait_object))
+/// while each concrete report just derives `serde::Serialize` — so adding a
+/// command that returns output is impossible without supplying both views.
+pub trait CliReport: erased_serde::Serialize {
+    /// Render the human view using the shared components.
+    fn render(&self, h: &mut Human<'_>) -> std::io::Result<()>;
+
+    /// The process exit code for this result. Defaults to success; a few
+    /// reports (validation failures, error envelopes) override it.
+    fn exit_code(&self) -> i32 {
+        0
+    }
+}
+
+erased_serde::serialize_trait_object!(CliReport);
+
+/// The single stdout writer. Constructed once from the global flags.
+pub struct Output {
+    fmt: Format,
+}
+
+impl Output {
+    /// Construct with an explicit format.
+    pub fn new(fmt: Format) -> Self {
+        Self { fmt }
+    }
+
+    /// Pick the format from the global flags. `--human` selects the human view;
+    /// otherwise (including `--json`) JSON.
+    pub fn from_flags(human: bool) -> Self {
+        Self::new(if human { Format::Human } else { Format::Json })
+    }
+
+    /// Emit a report to stdout in the active format.
+    pub fn emit(&self, r: &dyn CliReport) -> std::io::Result<()> {
+        let mut out = std::io::stdout().lock();
+        self.write(&mut out, Theme::for_stdout(), r)
+    }
+
+    /// Render to a buffer with an empty palette — the testable seam.
+    pub fn render_to_vec(&self, r: &dyn CliReport) -> Vec<u8> {
+        let mut v = Vec::new();
+        self.write(&mut v, Theme::none(), r).expect("render to vec is infallible");
+        v
+    }
+
+    fn write(&self, out: &mut dyn Write, theme: Theme, r: &dyn CliReport) -> std::io::Result<()> {
+        match self.fmt {
+            Format::Json => {
+                serde_json::to_writer_pretty(&mut *out, r).map_err(std::io::Error::other)?;
+                writeln!(out)
+            }
+            Format::Human => r.render(&mut Human::new(&mut *out, theme)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(serde::Serialize)]
+    struct Dummy {
+        ok: bool,
+    }
+
+    impl CliReport for Dummy {
+        fn render(&self, h: &mut Human<'_>) -> std::io::Result<()> {
+            h.line(&format!("ok={}", self.ok))
+        }
+    }
+
+    #[test]
+    fn emit_json_writes_pretty_object() {
+        let buf = Output::new(Format::Json).render_to_vec(&Dummy { ok: true });
+        assert_eq!(String::from_utf8(buf).unwrap(), "{\n  \"ok\": true\n}\n");
+    }
+
+    #[test]
+    fn emit_human_uses_render() {
+        let buf = Output::new(Format::Human).render_to_vec(&Dummy { ok: false });
+        assert_eq!(String::from_utf8(buf).unwrap(), "ok=false\n");
+    }
+}

--- a/apps/bitrouter/src/output/mod.rs
+++ b/apps/bitrouter/src/output/mod.rs
@@ -61,7 +61,16 @@ impl Output {
     /// `--json` (or neither) is JSON. The two are mutually exclusive at the
     /// clap layer; the `&& !json` is belt-and-suspenders.
     pub fn from_flags(json: bool, human: bool) -> Self {
-        Self::new(if human && !json { Format::Human } else { Format::Json })
+        Self::new(if human && !json {
+            Format::Human
+        } else {
+            Format::Json
+        })
+    }
+
+    /// The active output format.
+    pub fn format(&self) -> Format {
+        self.fmt
     }
 
     /// Emit a report to stdout in the active format.
@@ -73,7 +82,8 @@ impl Output {
     /// Render to a buffer with an empty palette — the testable seam.
     pub fn render_to_vec(&self, r: &dyn CliReport) -> Vec<u8> {
         let mut v = Vec::new();
-        self.write(&mut v, Theme::none(), r).expect("render to vec is infallible");
+        self.write(&mut v, Theme::none(), r)
+            .expect("render to vec is infallible");
         v
     }
 

--- a/apps/bitrouter/src/output/mod.rs
+++ b/apps/bitrouter/src/output/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! Every CLI command computes a strongly-typed **report** that implements
 //! [`CliReport`] — it is both `Serialize` (the JSON view) and renderable to a
-//! human view via [`Human`](human::Human). The [`Output`] driver is the single
+//! human view via [`Human`]. The [`Output`] driver is the single
 //! place that writes the result to stdout, picking the format from the global
 //! `--json` / `--human` flags.
 //!

--- a/apps/bitrouter/src/output/reports/admin.rs
+++ b/apps/bitrouter/src/output/reports/admin.rs
@@ -1,0 +1,93 @@
+//! Reports for key minting, policy scaffolding, and per-provider credential
+//! login/logout.
+
+use serde::Serialize;
+
+use crate::output::CliReport;
+use crate::output::human::Human;
+
+/// Result of `bitrouter key sign`. The plaintext `secret` is shown once — only
+/// its SHA-256 hash is stored.
+#[derive(Serialize)]
+pub struct KeySignReport {
+    pub id: String,
+    pub user: String,
+    pub secret: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub policy: Option<String>,
+    pub hash_stored: bool,
+}
+
+impl CliReport for KeySignReport {
+    fn render(&self, h: &mut Human<'_>) -> std::io::Result<()> {
+        h.line(&format!(
+            "created virtual key {} for user '{}'",
+            self.id, self.user
+        ))?;
+        h.blank()?;
+        h.line(&format!("  {}", self.secret))?;
+        h.blank()?;
+        h.line("This secret is shown ONCE — only its SHA-256 hash is stored.")
+    }
+}
+
+/// Result of `bitrouter policy create <id>`.
+#[derive(Serialize)]
+pub struct PolicyCreateReport {
+    pub id: String,
+    pub path: String,
+    pub created: bool,
+}
+
+impl CliReport for PolicyCreateReport {
+    fn render(&self, h: &mut Human<'_>) -> std::io::Result<()> {
+        h.line(&format!("wrote starter policy to {}", self.path))?;
+        h.line("  edit, then bind to a key with:")?;
+        h.line(&format!(
+            "    bitrouter key sign --user <id> --policy {}",
+            self.id
+        ))
+    }
+}
+
+/// Result of `bitrouter providers login <provider>`.
+#[derive(Serialize)]
+pub struct ProviderLoginReport {
+    pub provider: String,
+    pub label: String,
+    pub method: String,
+    pub credential: &'static str,
+    pub path: String,
+}
+
+impl CliReport for ProviderLoginReport {
+    fn render(&self, h: &mut Human<'_>) -> std::io::Result<()> {
+        h.line(&format!(
+            "✓ saved {} credential for {} (label: {}) at {}",
+            self.method, self.provider, self.label, self.path
+        ))
+    }
+}
+
+/// Result of `bitrouter providers logout <provider>`.
+#[derive(Serialize)]
+pub struct ProviderLogoutReport {
+    pub provider: String,
+    pub removed: usize,
+}
+
+impl CliReport for ProviderLogoutReport {
+    fn render(&self, h: &mut Human<'_>) -> std::io::Result<()> {
+        if self.removed == 0 {
+            h.line(&format!(
+                "no stored credentials for {}; nothing to remove",
+                self.provider
+            ))
+        } else {
+            h.line(&format!(
+                "✓ removed {} stored credential(s) for {}",
+                self.removed, self.provider
+            ))
+        }
+    }
+}

--- a/apps/bitrouter/src/output/reports/agents.rs
+++ b/apps/bitrouter/src/output/reports/agents.rs
@@ -1,0 +1,89 @@
+//! Reports for the `agents` commands.
+
+use serde::Serialize;
+
+use crate::output::CliReport;
+use crate::output::human::{Human, Table};
+
+fn yesno(b: bool) -> String {
+    if b { "yes".into() } else { "no".into() }
+}
+
+/// One agent in `agents list`.
+#[derive(Serialize)]
+pub struct AgentRow {
+    pub id: String,
+    pub configured: bool,
+    pub in_catalog: bool,
+    pub description: String,
+}
+
+/// Result of `bitrouter agents list`.
+#[derive(Serialize)]
+pub struct AgentsListReport {
+    pub agents: Vec<AgentRow>,
+}
+
+impl CliReport for AgentsListReport {
+    fn render(&self, h: &mut Human<'_>) -> std::io::Result<()> {
+        let mut t = Table::new(["ID", "CONFIGURED", "CATALOG", "DESCRIPTION"]);
+        for a in &self.agents {
+            t.push([
+                a.id.clone(),
+                yesno(a.configured),
+                yesno(a.in_catalog),
+                a.description.clone(),
+            ]);
+        }
+        h.table(&t)
+    }
+}
+
+/// One agent's `initialize` health in `agents check`.
+#[derive(Serialize)]
+pub struct AgentCheckRow {
+    pub id: String,
+    pub ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub latency_ms: Option<u128>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Result of `bitrouter agents check`.
+#[derive(Serialize)]
+pub struct AgentsCheckReport {
+    pub agents: Vec<AgentCheckRow>,
+}
+
+impl CliReport for AgentsCheckReport {
+    fn render(&self, h: &mut Human<'_>) -> std::io::Result<()> {
+        let mut t = Table::new(["AGENT", "STATUS", "LATENCY"]);
+        for a in &self.agents {
+            t.push([
+                a.id.clone(),
+                if a.ok { "ok".into() } else { "FAIL".into() },
+                a.latency_ms
+                    .map(|ms| format!("{ms}ms"))
+                    .unwrap_or_else(|| "-".into()),
+            ]);
+        }
+        h.table(&t)
+    }
+}
+
+/// Result of `bitrouter agents install <id>` — the paste-able YAML stub.
+#[derive(Serialize)]
+pub struct AgentInstallReport {
+    pub id: String,
+    pub yaml: String,
+}
+
+impl CliReport for AgentInstallReport {
+    fn render(&self, h: &mut Human<'_>) -> std::io::Result<()> {
+        for line in self.yaml.lines() {
+            h.line(line)?;
+        }
+        Ok(())
+    }
+}

--- a/apps/bitrouter/src/output/reports/config.rs
+++ b/apps/bitrouter/src/output/reports/config.rs
@@ -118,3 +118,22 @@ impl CliReport for ValidateReport {
         if self.valid { 0 } else { 1 }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::output::CliReport;
+
+    #[test]
+    fn validate_exit_code_and_shape() {
+        let ok = ValidateReport::valid("p".into(), 1, 2, 0, 0, vec![]);
+        assert_eq!(ok.exit_code(), 0);
+        let bad = ValidateReport::invalid("p".into(), "boom".into());
+        assert_eq!(bad.exit_code(), 1);
+        let v = serde_json::to_value(&bad).unwrap();
+        assert_eq!(v["valid"], false);
+        assert_eq!(v["errors"][0], "boom");
+        // valid report omits the empty errors array.
+        assert!(serde_json::to_value(&ok).unwrap().get("errors").is_none());
+    }
+}

--- a/apps/bitrouter/src/output/reports/config.rs
+++ b/apps/bitrouter/src/output/reports/config.rs
@@ -1,0 +1,120 @@
+//! Reports for `init` and `config validate`.
+
+use serde::Serialize;
+
+use crate::output::CliReport;
+use crate::output::human::Human;
+
+/// Result of `bitrouter init`.
+#[derive(Serialize)]
+pub struct InitReport {
+    pub action: &'static str,
+    pub path: String,
+    pub skip_auth: bool,
+}
+
+impl CliReport for InitReport {
+    fn render(&self, h: &mut Human<'_>) -> std::io::Result<()> {
+        h.line(&format!("wrote starter config to {}", self.path))?;
+        h.note("skip_auth is on — credential-less local requests are admitted")
+    }
+}
+
+/// One unset `${VAR}` substituted with a placeholder during validation.
+#[derive(Serialize)]
+pub struct UnsetVar {
+    pub unset_env: String,
+}
+
+/// Result of `bitrouter config validate`. `valid: false` carries `errors` and
+/// exits non-zero (CI-safe); `valid: true` carries the catalog counts and any
+/// unset-var `warnings`.
+#[derive(Serialize)]
+pub struct ValidateReport {
+    pub valid: bool,
+    pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub providers: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub models: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub presets: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub variants: Option<usize>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<UnsetVar>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub errors: Vec<String>,
+}
+
+impl ValidateReport {
+    pub fn valid(
+        path: String,
+        providers: usize,
+        models: usize,
+        presets: usize,
+        variants: usize,
+        warnings: Vec<UnsetVar>,
+    ) -> Self {
+        Self {
+            valid: true,
+            path,
+            providers: Some(providers),
+            models: Some(models),
+            presets: Some(presets),
+            variants: Some(variants),
+            warnings,
+            errors: Vec::new(),
+        }
+    }
+
+    pub fn invalid(path: String, error: String) -> Self {
+        Self {
+            valid: false,
+            path,
+            providers: None,
+            models: None,
+            presets: None,
+            variants: None,
+            warnings: Vec::new(),
+            errors: vec![error],
+        }
+    }
+}
+
+impl CliReport for ValidateReport {
+    fn render(&self, h: &mut Human<'_>) -> std::io::Result<()> {
+        if self.valid {
+            h.line(&format!("✓ {} is valid", self.path))?;
+            h.line(&format!(
+                "  providers: {}  models: {}  presets: {}  variants: {}",
+                self.providers.unwrap_or(0),
+                self.models.unwrap_or(0),
+                self.presets.unwrap_or(0),
+                self.variants.unwrap_or(0),
+            ))?;
+            if !self.warnings.is_empty() {
+                h.blank()?;
+                h.line(&format!(
+                    "  note: {} unset environment variable(s) substituted with a placeholder \
+                     for validation (re-validate at runtime):",
+                    self.warnings.len()
+                ))?;
+                for w in &self.warnings {
+                    h.line(&format!("    - ${{{}}}", w.unset_env))?;
+                }
+            }
+            Ok(())
+        } else {
+            h.line(&format!("✗ {} is invalid", self.path))?;
+            for e in &self.errors {
+                h.line(&format!("  {e}"))?;
+            }
+            Ok(())
+        }
+    }
+
+    fn exit_code(&self) -> i32 {
+        if self.valid { 0 } else { 1 }
+    }
+}

--- a/apps/bitrouter/src/output/reports/daemon.rs
+++ b/apps/bitrouter/src/output/reports/daemon.rs
@@ -1,0 +1,249 @@
+//! Reports for the daemon-lifecycle (`start` / `stop` / `restart` / `reload` /
+//! `status`) and `route` commands.
+
+use serde::Serialize;
+
+use crate::output::CliReport;
+use crate::output::human::{Health, Human};
+
+/// Result of a daemon lifecycle action (`start` / `stop` / `restart` /
+/// `reload`). `pid`/`listen`/`models`/`log` are present only when the action
+/// produced a live daemon (start / restart).
+#[derive(Serialize)]
+pub struct DaemonActionReport {
+    /// The action performed: `start` | `stop` | `restart` | `reload`.
+    pub action: &'static str,
+    /// The resulting state: `started` | `stopped` | `restarted` | `reloaded` |
+    /// `not_ready`.
+    pub status: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pid: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub listen: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub models: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub log: Option<String>,
+}
+
+impl DaemonActionReport {
+    /// A daemon came up and answered its control socket.
+    pub fn started(
+        action: &'static str,
+        status: &'static str,
+        pid: u32,
+        listen: String,
+        models: usize,
+        log: String,
+    ) -> Self {
+        Self {
+            action,
+            status,
+            pid: Some(pid),
+            listen: Some(listen),
+            models: Some(models),
+            log: Some(log),
+        }
+    }
+
+    /// The daemon is alive but slow to answer (still migrating / fetching).
+    pub fn not_ready(action: &'static str, pid: u32, log: String) -> Self {
+        Self {
+            action,
+            status: "not_ready",
+            pid: Some(pid),
+            listen: None,
+            models: None,
+            log: Some(log),
+        }
+    }
+
+    /// A payload-less outcome (stop / reload).
+    pub fn simple(action: &'static str, status: &'static str) -> Self {
+        Self {
+            action,
+            status,
+            pid: None,
+            listen: None,
+            models: None,
+            log: None,
+        }
+    }
+}
+
+impl CliReport for DaemonActionReport {
+    fn render(&self, h: &mut Human<'_>) -> std::io::Result<()> {
+        match self.pid {
+            Some(pid) => {
+                let health = if self.status == "not_ready" {
+                    Health::Unknown
+                } else {
+                    Health::Up
+                };
+                h.status_block(health, &format!("bitrouter daemon {}", self.status))?;
+                h.field("pid", pid)?;
+                if let Some(listen) = &self.listen {
+                    h.field("listen", listen)?;
+                }
+                if let Some(models) = self.models {
+                    h.field("models", format!("{models} routable"))?;
+                }
+                if let Some(log) = &self.log {
+                    h.field("log", log)?;
+                }
+                Ok(())
+            }
+            None => h.line(&format!("daemon {}", self.status)),
+        }
+    }
+}
+
+/// Result of `bitrouter status`. Exit code stays 0 whether running or stopped —
+/// "stopped" is an answer, not a failure.
+#[derive(Serialize)]
+pub struct StatusReport {
+    pub running: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pid: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub listen: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub models: Option<usize>,
+    pub socket: String,
+}
+
+impl StatusReport {
+    pub fn running(pid: u32, listen: String, models: usize, socket: String) -> Self {
+        Self {
+            running: true,
+            pid: Some(pid),
+            listen: Some(listen),
+            models: Some(models),
+            socket,
+        }
+    }
+    pub fn stopped(socket: String) -> Self {
+        Self {
+            running: false,
+            pid: None,
+            listen: None,
+            models: None,
+            socket,
+        }
+    }
+}
+
+impl CliReport for StatusReport {
+    fn render(&self, h: &mut Human<'_>) -> std::io::Result<()> {
+        if self.running {
+            h.status_block(Health::Up, "bitrouter is running")?;
+            if let Some(pid) = self.pid {
+                h.field("pid", pid)?;
+            }
+            if let Some(listen) = &self.listen {
+                h.field("listen", listen)?;
+            }
+            if let Some(models) = self.models {
+                h.field("models", format!("{models} routable"))?;
+            }
+            h.field("socket", &self.socket)
+        } else {
+            h.status_block(Health::Down, "bitrouter is stopped")?;
+            h.field("socket", &self.socket)?;
+            h.note("Run `bitrouter start` to launch the daemon.")
+        }
+    }
+}
+
+/// One hop of a resolved route chain: provider → upstream service id → protocol.
+#[derive(Serialize)]
+pub struct RouteHopView {
+    pub provider: String,
+    pub service_id: String,
+    pub protocol: String,
+}
+
+/// Result of `bitrouter route <model>`.
+#[derive(Serialize)]
+pub struct RouteReport {
+    pub model: String,
+    /// Where the chain came from: `live daemon` | `config` | `zero-config`.
+    pub resolved_via: String,
+    pub chain: Vec<RouteHopView>,
+}
+
+impl CliReport for RouteReport {
+    fn render(&self, h: &mut Human<'_>) -> std::io::Result<()> {
+        h.line(&format!(
+            "model: {}  (resolved via: {})",
+            self.model, self.resolved_via
+        ))?;
+        if self.chain.is_empty() {
+            return h.line("  (empty chain — no provider declares this model)");
+        }
+        for (i, hop) in self.chain.iter().enumerate() {
+            h.line(&format!(
+                "  {}. {} → {} ({})",
+                i + 1,
+                hop.provider,
+                hop.service_id,
+                hop.protocol
+            ))?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::output::{Format, Output};
+
+    fn json(r: &dyn CliReport) -> serde_json::Value {
+        serde_json::from_slice(&Output::new(Format::Json).render_to_vec(r)).unwrap()
+    }
+
+    #[test]
+    fn status_running_json_and_human() {
+        let r = StatusReport::running(7, "127.0.0.1:4356".into(), 42, "/x.sock".into());
+        assert_eq!(
+            json(&r),
+            serde_json::json!({
+                "running": true, "pid": 7, "listen": "127.0.0.1:4356", "models": 42, "socket": "/x.sock"
+            })
+        );
+        let h = String::from_utf8(Output::new(Format::Human).render_to_vec(&r)).unwrap();
+        assert!(h.contains("● bitrouter is running"), "{h:?}");
+        assert!(h.contains("  models    42 routable"), "{h:?}");
+    }
+
+    #[test]
+    fn status_stopped_omits_optional_fields() {
+        let r = StatusReport::stopped("/x.sock".into());
+        assert_eq!(
+            json(&r),
+            serde_json::json!({"running": false, "socket": "/x.sock"})
+        );
+    }
+
+    #[test]
+    fn route_empty_chain_is_empty_array() {
+        let r = RouteReport {
+            model: "m".into(),
+            resolved_via: "config".into(),
+            chain: vec![],
+        };
+        assert_eq!(json(&r)["chain"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn daemon_action_simple_one_liner() {
+        let r = DaemonActionReport::simple("stop", "stopped");
+        assert_eq!(
+            json(&r),
+            serde_json::json!({"action": "stop", "status": "stopped"})
+        );
+        let h = String::from_utf8(Output::new(Format::Human).render_to_vec(&r)).unwrap();
+        assert_eq!(h, "daemon stopped\n");
+    }
+}

--- a/apps/bitrouter/src/output/reports/mod.rs
+++ b/apps/bitrouter/src/output/reports/mod.rs
@@ -3,3 +3,5 @@
 //! Each command group gets a submodule here holding its `#[derive(Serialize)]`
 //! report structs and their [`CliReport`](crate::output::CliReport)
 //! implementations. Submodules are added as groups are converted.
+
+pub mod daemon;

--- a/apps/bitrouter/src/output/reports/mod.rs
+++ b/apps/bitrouter/src/output/reports/mod.rs
@@ -4,6 +4,7 @@
 //! report structs and their [`CliReport`](crate::output::CliReport)
 //! implementations. Submodules are added as groups are converted.
 
+pub mod admin;
 pub mod agents;
 pub mod config;
 pub mod daemon;

--- a/apps/bitrouter/src/output/reports/mod.rs
+++ b/apps/bitrouter/src/output/reports/mod.rs
@@ -8,6 +8,8 @@ pub mod admin;
 pub mod agents;
 pub mod config;
 pub mod daemon;
+pub mod observe;
 pub mod routing;
 pub mod skills;
 pub mod tools;
+pub mod verify;

--- a/apps/bitrouter/src/output/reports/mod.rs
+++ b/apps/bitrouter/src/output/reports/mod.rs
@@ -4,4 +4,6 @@
 //! report structs and their [`CliReport`](crate::output::CliReport)
 //! implementations. Submodules are added as groups are converted.
 
+pub mod config;
 pub mod daemon;
+pub mod routing;

--- a/apps/bitrouter/src/output/reports/mod.rs
+++ b/apps/bitrouter/src/output/reports/mod.rs
@@ -9,4 +9,5 @@ pub mod agents;
 pub mod config;
 pub mod daemon;
 pub mod routing;
+pub mod skills;
 pub mod tools;

--- a/apps/bitrouter/src/output/reports/mod.rs
+++ b/apps/bitrouter/src/output/reports/mod.rs
@@ -1,0 +1,5 @@
+//! Per-command-group report types.
+//!
+//! Each command group gets a submodule here holding its `#[derive(Serialize)]`
+//! report structs and their [`CliReport`](crate::output::CliReport)
+//! implementations. Submodules are added as groups are converted.

--- a/apps/bitrouter/src/output/reports/mod.rs
+++ b/apps/bitrouter/src/output/reports/mod.rs
@@ -4,6 +4,8 @@
 //! report structs and their [`CliReport`](crate::output::CliReport)
 //! implementations. Submodules are added as groups are converted.
 
+pub mod agents;
 pub mod config;
 pub mod daemon;
 pub mod routing;
+pub mod tools;

--- a/apps/bitrouter/src/output/reports/observe.rs
+++ b/apps/bitrouter/src/output/reports/observe.rs
@@ -14,7 +14,6 @@ pub struct ObserveStatusReport {
     pub daemon_reachable: bool,
     #[serde(flatten)]
     pub snapshot: ObserveStatusPayload,
-    #[serde(skip)]
     pub socket: String,
 }
 

--- a/apps/bitrouter/src/output/reports/observe.rs
+++ b/apps/bitrouter/src/output/reports/observe.rs
@@ -1,0 +1,67 @@
+//! Report for `bitrouter observe status`.
+
+use serde::Serialize;
+
+use crate::daemon::ObserveStatusPayload;
+use crate::output::CliReport;
+use crate::output::human::{Health, Human};
+
+/// Result of `bitrouter observe status` — the OTel exporter snapshot plus
+/// whether the daemon was reachable (so "feature off" is distinguishable from
+/// "daemon down"). The snapshot fields are flattened to the top level.
+#[derive(Serialize)]
+pub struct ObserveStatusReport {
+    pub daemon_reachable: bool,
+    #[serde(flatten)]
+    pub snapshot: ObserveStatusPayload,
+    #[serde(skip)]
+    pub socket: String,
+}
+
+impl CliReport for ObserveStatusReport {
+    fn render(&self, h: &mut Human<'_>) -> std::io::Result<()> {
+        let s = &self.snapshot;
+        if !self.daemon_reachable {
+            h.status_block(Health::Down, "bitrouter observe — daemon stopped")?;
+            h.field("compiled", if s.compiled_in { "yes" } else { "no" })?;
+            h.field("socket", &self.socket)?;
+            return h.note("Run `bitrouter start` to launch the daemon, then re-run this command.");
+        }
+        let (health, headline) = if s.exporter_wired {
+            (Health::Up, "OTel exporter is wired")
+        } else if s.compiled_in {
+            (
+                Health::Down,
+                "OTel feature compiled in, exporter not configured",
+            )
+        } else {
+            (Health::Down, "OTel feature not compiled in")
+        };
+        h.status_block(health, &format!("bitrouter observe — {headline}"))?;
+        h.field("compiled", if s.compiled_in { "yes" } else { "no" })?;
+        h.field("wired", if s.exporter_wired { "yes" } else { "no" })?;
+        if let Some(endpoint) = &s.endpoint {
+            h.field("endpoint", endpoint)?;
+        }
+        if let Some(service) = &s.service_name {
+            h.field("service", service)?;
+        }
+        if let Some(sampler) = &s.sampler {
+            let val = match s.sampler_arg {
+                Some(arg) => format!("{sampler} (arg={arg})"),
+                None => sampler.clone(),
+            };
+            h.field("sampler", val)?;
+        }
+        h.field("metrics", if s.metrics_enabled { "on" } else { "off" })?;
+        h.field("headers", s.header_count)?;
+        h.field("res-attrs", s.resource_attribute_count)?;
+        h.field(
+            "api-keys",
+            format!("{} / {}", s.api_key_count, s.api_key_cap),
+        )?;
+        h.field("users", format!("{} / {}", s.user_id_count, s.user_id_cap))?;
+        h.field("in-flight", s.active_spans)?;
+        h.field("socket", &self.socket)
+    }
+}

--- a/apps/bitrouter/src/output/reports/routing.rs
+++ b/apps/bitrouter/src/output/reports/routing.rs
@@ -1,0 +1,94 @@
+//! Reports for `models` and `providers list`.
+
+use serde::Serialize;
+
+use crate::output::CliReport;
+use crate::output::human::{Human, Table};
+
+/// One routable model and the providers that can serve it.
+#[derive(Serialize)]
+pub struct ModelRow {
+    pub id: String,
+    pub providers: Vec<String>,
+}
+
+/// Result of `bitrouter models`.
+#[derive(Serialize)]
+pub struct ModelsReport {
+    pub models: Vec<ModelRow>,
+}
+
+impl CliReport for ModelsReport {
+    fn render(&self, h: &mut Human<'_>) -> std::io::Result<()> {
+        if self.models.is_empty() {
+            return h.line("(no routable models)");
+        }
+        for m in &self.models {
+            h.line(&format!("{}\t{}", m.id, m.providers.join(", ")))?;
+        }
+        Ok(())
+    }
+}
+
+/// One configured provider.
+#[derive(Serialize)]
+pub struct ProviderRow {
+    pub id: String,
+    pub models: usize,
+    pub active: bool,
+    pub api_base: String,
+}
+
+/// Result of `bitrouter providers list`.
+#[derive(Serialize)]
+pub struct ProvidersReport {
+    pub providers: Vec<ProviderRow>,
+}
+
+impl CliReport for ProvidersReport {
+    fn render(&self, h: &mut Human<'_>) -> std::io::Result<()> {
+        if self.providers.is_empty() {
+            return h.line("(no providers configured)");
+        }
+        let mut t = Table::new(["ID", "MODELS", "ACTIVE", "API_BASE"]);
+        for p in &self.providers {
+            t.push([
+                p.id.clone(),
+                p.models.to_string(),
+                if p.active { "yes".into() } else { "no".into() },
+                p.api_base.clone(),
+            ]);
+        }
+        h.table(&t)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::output::{Format, Output};
+
+    #[test]
+    fn models_empty_is_empty_array() {
+        let r = ModelsReport { models: vec![] };
+        let v: serde_json::Value =
+            serde_json::from_slice(&Output::new(Format::Json).render_to_vec(&r)).unwrap();
+        assert_eq!(v, serde_json::json!({"models": []}));
+    }
+
+    #[test]
+    fn providers_table_human() {
+        let r = ProvidersReport {
+            providers: vec![ProviderRow {
+                id: "openai".into(),
+                models: 42,
+                active: true,
+                api_base: "https://api.openai.com".into(),
+            }],
+        };
+        let h = String::from_utf8(Output::new(Format::Human).render_to_vec(&r)).unwrap();
+        assert!(h.starts_with("ID"), "{h:?}");
+        assert!(h.contains("openai"), "{h:?}");
+        assert!(h.contains("yes"), "{h:?}");
+    }
+}

--- a/apps/bitrouter/src/output/reports/skills.rs
+++ b/apps/bitrouter/src/output/reports/skills.rs
@@ -154,3 +154,28 @@ impl CliReport for SkillsUpdateReport {
         if self.failed.is_empty() { 0 } else { 1 }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::output::CliReport;
+
+    #[test]
+    fn skills_update_exit_code() {
+        let clean = SkillsUpdateReport {
+            updated: vec![],
+            skipped: vec![],
+            failed: vec![],
+        };
+        assert_eq!(clean.exit_code(), 0);
+        let failed = SkillsUpdateReport {
+            updated: vec![],
+            skipped: vec![],
+            failed: vec![FailedSkill {
+                name: "x".into(),
+                error: "e".into(),
+            }],
+        };
+        assert_eq!(failed.exit_code(), 1);
+    }
+}

--- a/apps/bitrouter/src/output/reports/skills.rs
+++ b/apps/bitrouter/src/output/reports/skills.rs
@@ -1,0 +1,156 @@
+//! Reports for the `skills` commands.
+
+use serde::Serialize;
+
+use crate::output::CliReport;
+use crate::output::human::Human;
+
+/// Result of `bitrouter skills add <source>`.
+#[derive(Serialize)]
+pub struct SkillAddReport {
+    /// `installed` or `updated`.
+    pub action: &'static str,
+    pub name: String,
+    pub dest: String,
+}
+
+impl CliReport for SkillAddReport {
+    fn render(&self, h: &mut Human<'_>) -> std::io::Result<()> {
+        h.line(&format!("{} {} → {}", self.action, self.name, self.dest))
+    }
+}
+
+/// One installed skill.
+#[derive(Serialize)]
+pub struct SkillEntry {
+    pub name: String,
+    pub path: String,
+}
+
+/// Result of `bitrouter skills list`.
+#[derive(Serialize)]
+pub struct SkillsListReport {
+    pub skills: Vec<SkillEntry>,
+}
+
+impl CliReport for SkillsListReport {
+    fn render(&self, h: &mut Human<'_>) -> std::io::Result<()> {
+        if self.skills.is_empty() {
+            return h.line("no skills installed");
+        }
+        for s in &self.skills {
+            h.line(&format!("{}\t{}", s.name, s.path))?;
+        }
+        Ok(())
+    }
+}
+
+/// Result of `bitrouter skills remove <name>`.
+#[derive(Serialize)]
+pub struct SkillRemoveReport {
+    pub name: String,
+    pub path: String,
+    pub removed: bool,
+}
+
+impl CliReport for SkillRemoveReport {
+    fn render(&self, h: &mut Human<'_>) -> std::io::Result<()> {
+        h.line(&format!("removed {} ({})", self.name, self.path))
+    }
+}
+
+/// One registry search hit.
+#[derive(Serialize)]
+pub struct SkillHit {
+    pub name: String,
+    pub version: String,
+    pub description: String,
+}
+
+/// Result of `bitrouter skills find <query>`.
+#[derive(Serialize)]
+pub struct SkillsFindReport {
+    pub query: String,
+    pub registry: String,
+    pub results: Vec<SkillHit>,
+}
+
+impl CliReport for SkillsFindReport {
+    fn render(&self, h: &mut Human<'_>) -> std::io::Result<()> {
+        if self.results.is_empty() {
+            return h.line(&format!(
+                "no skills matching {:?} in {}",
+                self.query, self.registry
+            ));
+        }
+        for r in &self.results {
+            h.line(&format!("{}\t{}\t{}", r.name, r.version, r.description))?;
+        }
+        Ok(())
+    }
+}
+
+/// Result of `bitrouter skills init <name>`.
+#[derive(Serialize)]
+pub struct SkillInitReport {
+    pub path: String,
+    pub created: bool,
+}
+
+impl CliReport for SkillInitReport {
+    fn render(&self, h: &mut Human<'_>) -> std::io::Result<()> {
+        h.line(&format!("wrote {}", self.path))
+    }
+}
+
+/// A skill updated in `skills update`.
+#[derive(Serialize)]
+pub struct UpdatedSkill {
+    pub name: String,
+    pub dest: String,
+}
+
+/// A skill skipped in `skills update` (not in the registry).
+#[derive(Serialize)]
+pub struct SkippedSkill {
+    pub name: String,
+    pub reason: String,
+}
+
+/// A skill that failed to update.
+#[derive(Serialize)]
+pub struct FailedSkill {
+    pub name: String,
+    pub error: String,
+}
+
+/// Result of `bitrouter skills update [name]`. Exits non-zero if any skill
+/// failed (parity with the legacy behavior).
+#[derive(Serialize)]
+pub struct SkillsUpdateReport {
+    pub updated: Vec<UpdatedSkill>,
+    pub skipped: Vec<SkippedSkill>,
+    pub failed: Vec<FailedSkill>,
+}
+
+impl CliReport for SkillsUpdateReport {
+    fn render(&self, h: &mut Human<'_>) -> std::io::Result<()> {
+        if self.updated.is_empty() && self.skipped.is_empty() && self.failed.is_empty() {
+            return h.line("no skills installed to update");
+        }
+        for u in &self.updated {
+            h.line(&format!("updated {} → {}", u.name, u.dest))?;
+        }
+        for s in &self.skipped {
+            h.line(&format!("skipped {} ({})", s.name, s.reason))?;
+        }
+        for f in &self.failed {
+            h.line(&format!("failed {}: {}", f.name, f.error))?;
+        }
+        Ok(())
+    }
+
+    fn exit_code(&self) -> i32 {
+        if self.failed.is_empty() { 0 } else { 1 }
+    }
+}

--- a/apps/bitrouter/src/output/reports/tools.rs
+++ b/apps/bitrouter/src/output/reports/tools.rs
@@ -1,0 +1,107 @@
+//! Reports for the `tools` (MCP introspection) commands.
+
+use serde::Serialize;
+
+use crate::output::CliReport;
+use crate::output::human::{Human, Table};
+
+/// One advertised tool.
+#[derive(Serialize)]
+pub struct ToolInfo {
+    pub name: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub description: String,
+}
+
+/// One MCP server in `tools list`: either its advertised tools or the error
+/// reaching it.
+#[derive(Serialize)]
+pub struct ServerToolsView {
+    pub server: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tools: Option<Vec<ToolInfo>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Result of `bitrouter tools list`.
+#[derive(Serialize)]
+pub struct ToolsListReport {
+    pub servers: Vec<ServerToolsView>,
+}
+
+impl CliReport for ToolsListReport {
+    fn render(&self, h: &mut Human<'_>) -> std::io::Result<()> {
+        for s in &self.servers {
+            if let Some(err) = &s.error {
+                h.line(&format!("{} — error: {err}", s.server))?;
+            } else if let Some(tools) = &s.tools {
+                if tools.is_empty() {
+                    h.line(&format!("{} (no tools advertised)", s.server))?;
+                } else {
+                    h.line(&format!("{} ({})", s.server, tools.len()))?;
+                    for t in tools {
+                        if t.description.is_empty() {
+                            h.line(&format!("  {}", t.name))?;
+                        } else {
+                            h.line(&format!("  {} — {}", t.name, t.description))?;
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// One MCP server's health in `tools status`.
+#[derive(Serialize)]
+pub struct ServerStatusView {
+    pub server: String,
+    pub ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub latency_ms: Option<u128>,
+    pub transport: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Result of `bitrouter tools status`.
+#[derive(Serialize)]
+pub struct ToolsStatusReport {
+    pub servers: Vec<ServerStatusView>,
+}
+
+impl CliReport for ToolsStatusReport {
+    fn render(&self, h: &mut Human<'_>) -> std::io::Result<()> {
+        let mut t = Table::new(["SERVER", "STATUS", "LATENCY", "TRANSPORT"]);
+        for s in &self.servers {
+            t.push([
+                s.server.clone(),
+                if s.ok { "ok".into() } else { "FAIL".into() },
+                s.latency_ms
+                    .map(|ms| format!("{ms}ms"))
+                    .unwrap_or_else(|| "-".into()),
+                s.transport.clone(),
+            ]);
+        }
+        h.table(&t)
+    }
+}
+
+/// Result of `bitrouter tools discover <server>` — the paste-able YAML stub,
+/// carried verbatim under `yaml`.
+#[derive(Serialize)]
+pub struct ToolsDiscoverReport {
+    pub server: String,
+    pub yaml: String,
+}
+
+impl CliReport for ToolsDiscoverReport {
+    fn render(&self, h: &mut Human<'_>) -> std::io::Result<()> {
+        for line in self.yaml.lines() {
+            h.line(line)?;
+        }
+        Ok(())
+    }
+}

--- a/apps/bitrouter/src/output/reports/verify.rs
+++ b/apps/bitrouter/src/output/reports/verify.rs
@@ -54,3 +54,46 @@ impl CliReport for VerifyReport {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::output::{Format, Output};
+
+    #[test]
+    fn verify_json_and_glyphs() {
+        let r = VerifyReport {
+            model: "m".into(),
+            trust_boundary: "tb".into(),
+            verified: false,
+            checks: vec![
+                Check {
+                    name: "a".into(),
+                    status: "pass",
+                },
+                Check {
+                    name: "b".into(),
+                    status: "fail",
+                },
+                Check {
+                    name: "c".into(),
+                    status: "skip",
+                },
+            ],
+            signers: vec!["0xabc".into()],
+        };
+        let v: serde_json::Value =
+            serde_json::from_slice(&Output::new(Format::Json).render_to_vec(&r)).unwrap();
+        assert_eq!(v["verified"], false);
+        assert_eq!(v["checks"][1]["status"], "fail");
+        assert_eq!(v["signers"][0], "0xabc");
+        // verify keeps exit 0 even when UNVERIFIED (verdict lives in the JSON).
+        assert_eq!(r.exit_code(), 0);
+
+        let h = String::from_utf8(Output::new(Format::Human).render_to_vec(&r)).unwrap();
+        assert!(h.contains("✓ a"), "{h:?}");
+        assert!(h.contains("✗ b"), "{h:?}");
+        assert!(h.contains("- c"), "{h:?}");
+        assert!(h.contains("UNVERIFIED"), "{h:?}");
+    }
+}

--- a/apps/bitrouter/src/output/reports/verify.rs
+++ b/apps/bitrouter/src/output/reports/verify.rs
@@ -1,0 +1,56 @@
+//! Report for `bitrouter verify <model>` — the L1 TEE-attestation verdict.
+
+use serde::Serialize;
+
+use crate::output::CliReport;
+use crate::output::human::Human;
+
+/// One attestation check. `status` is `pass` / `fail` / `skip` (a check that
+/// did not run, e.g. an optional event-log anchor).
+#[derive(Serialize)]
+pub struct Check {
+    pub name: String,
+    pub status: &'static str,
+}
+
+/// Result of `bitrouter verify <model>`.
+#[derive(Serialize)]
+pub struct VerifyReport {
+    pub model: String,
+    pub trust_boundary: String,
+    pub verified: bool,
+    pub checks: Vec<Check>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub signers: Vec<String>,
+}
+
+impl CliReport for VerifyReport {
+    fn render(&self, h: &mut Human<'_>) -> std::io::Result<()> {
+        let tb = if self.trust_boundary.is_empty() {
+            "unreachable"
+        } else {
+            &self.trust_boundary
+        };
+        h.line(&format!("{}  (trust boundary: {tb})", self.model))?;
+        for c in &self.checks {
+            let mark = match c.status {
+                "pass" => "✓",
+                "fail" => "✗",
+                _ => "-",
+            };
+            h.line(&format!("  {mark} {}", c.name))?;
+        }
+        if !self.signers.is_empty() {
+            h.line(&format!(
+                "  attested signer(s): {}",
+                self.signers.join(", ")
+            ))?;
+        }
+        h.blank()?;
+        if self.verified {
+            h.line("VERIFIED — genuine, policy-pinned TEE")
+        } else {
+            h.line("UNVERIFIED — not a confirmed legitimate TEE (see failing checks above)")
+        }
+    }
+}

--- a/apps/bitrouter/src/skills/cli.rs
+++ b/apps/bitrouter/src/skills/cli.rs
@@ -105,38 +105,59 @@ pub struct UpdateArgs {
 }
 
 /// Entry point dispatched by `apps/bitrouter/src/main.rs`.
-pub async fn run(action: SkillsAction) -> Result<()> {
+pub async fn run(action: SkillsAction, output: &crate::output::Output) -> Result<()> {
     match action {
         SkillsAction::Add(args) => {
-            commands::skills_add(
-                &args.source,
-                args.skill.as_deref(),
-                args.global,
-                args.yes,
-                args.registry.as_deref(),
-                args.namespace.as_deref(),
-            )
-            .await
+            output.emit(
+                &commands::skills_add(
+                    &args.source,
+                    args.skill.as_deref(),
+                    args.global,
+                    args.yes,
+                    args.registry.as_deref(),
+                    args.namespace.as_deref(),
+                )
+                .await?,
+            )?;
+            Ok(())
         }
-        SkillsAction::List(args) => commands::skills_list(args.global),
-        SkillsAction::Remove(args) => commands::skills_remove(&args.name, args.global),
+        SkillsAction::List(args) => {
+            output.emit(&commands::skills_list(args.global)?)?;
+            Ok(())
+        }
+        SkillsAction::Remove(args) => {
+            output.emit(&commands::skills_remove(&args.name, args.global)?)?;
+            Ok(())
+        }
         SkillsAction::Find(args) => {
-            commands::skills_find(
-                &args.query,
-                args.registry.as_deref(),
-                args.namespace.as_deref(),
-            )
-            .await
+            output.emit(
+                &commands::skills_find(
+                    &args.query,
+                    args.registry.as_deref(),
+                    args.namespace.as_deref(),
+                )
+                .await?,
+            )?;
+            Ok(())
         }
-        SkillsAction::Init(args) => commands::skills_init(&args.name, &args.output),
+        SkillsAction::Init(args) => {
+            output.emit(&commands::skills_init(&args.name, &args.output)?)?;
+            Ok(())
+        }
         SkillsAction::Update(args) => {
-            commands::skills_update(
+            let report = commands::skills_update(
                 args.name.as_deref(),
                 args.global,
                 args.registry.as_deref(),
                 args.namespace.as_deref(),
             )
-            .await
+            .await?;
+            output.emit(&report)?;
+            // Parity with the legacy behavior: a partial-failure run exits 1.
+            if !report.failed.is_empty() {
+                std::process::exit(1);
+            }
+            Ok(())
         }
     }
 }

--- a/crates/bitrouter-sdk/src/error.rs
+++ b/crates/bitrouter-sdk/src/error.rs
@@ -6,8 +6,15 @@
 //! without a separate mapping table. The type is `Clone` because the pipeline
 //! hands the same error to several consumers (observe hooks, settlement
 //! recorders, the caller).
+//!
+//! [`BitrouterError::to_envelope`] projects an error into the canonical,
+//! serializable [`ErrorEnvelope`] (`{"error": {"kind": …, "message": …}}`) —
+//! the stable shape the CLI prints on stdout and the daemon/cloud HTTP
+//! surfaces converge on.
 
 use std::fmt;
+
+use serde::{Deserialize, Serialize};
 
 /// Crate-wide result alias.
 pub type Result<T> = std::result::Result<T, BitrouterError>;
@@ -127,6 +134,108 @@ impl BitrouterError {
     pub fn internal(message: impl fmt::Display) -> Self {
         Self::Internal(message.to_string())
     }
+
+    /// The machine-readable [`ErrorKind`] for this error.
+    pub fn kind(&self) -> ErrorKind {
+        match self {
+            Self::BadRequest { .. } => ErrorKind::BadRequest,
+            Self::Unauthorized(_) => ErrorKind::Unauthorized,
+            Self::PaymentRequired(_) => ErrorKind::PaymentRequired,
+            Self::Forbidden(_) => ErrorKind::Forbidden,
+            Self::NotFound(_) => ErrorKind::NotFound,
+            Self::RateLimited { .. } => ErrorKind::RateLimited,
+            Self::Upstream { .. } => ErrorKind::Upstream,
+            Self::UpstreamAuth { .. } => ErrorKind::UpstreamAuth,
+            Self::UpstreamTimeout => ErrorKind::UpstreamTimeout,
+            Self::Internal(_) => ErrorKind::Internal,
+        }
+    }
+
+    /// Project this error into the canonical serializable [`ErrorEnvelope`]
+    /// (kind + detail message). Callers that carry additional context layers or
+    /// a remediation hint populate [`ErrorBody::context`] / [`ErrorBody::hint`]
+    /// themselves — this base projection leaves them empty.
+    pub fn to_envelope(&self) -> ErrorEnvelope {
+        let message = match self {
+            Self::BadRequest { message } => message.clone(),
+            Self::Unauthorized(m)
+            | Self::PaymentRequired(m)
+            | Self::Forbidden(m)
+            | Self::NotFound(m)
+            | Self::Internal(m) => m.clone(),
+            Self::RateLimited { .. } => "rate limited".to_string(),
+            Self::Upstream { status, message } => {
+                format!("upstream error ({status}): {message}")
+            }
+            Self::UpstreamAuth { status, .. } => {
+                format!("upstream auth required ({status})")
+            }
+            Self::UpstreamTimeout => "upstream timeout".to_string(),
+        };
+        ErrorEnvelope {
+            error: ErrorBody {
+                kind: self.kind(),
+                message,
+                context: Vec::new(),
+                hint: None,
+            },
+        }
+    }
+}
+
+/// A machine-readable error category — the stable taxonomy shared across the
+/// CLI, the daemon HTTP API, and (in future) the cloud API. Mirrors the
+/// [`BitrouterError`] variants; serialized in `snake_case`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ErrorKind {
+    /// 400 — malformed request.
+    BadRequest,
+    /// 401 — missing/invalid credentials.
+    Unauthorized,
+    /// 402 — payment required.
+    PaymentRequired,
+    /// 403 — policy violation.
+    Forbidden,
+    /// 404 — no route / resource not found.
+    NotFound,
+    /// 429 — rate limited.
+    RateLimited,
+    /// 502 — upstream provider error.
+    Upstream,
+    /// 401/403 — upstream demanded authorization.
+    UpstreamAuth,
+    /// 504 — upstream timed out.
+    UpstreamTimeout,
+    /// 500 — internal error.
+    Internal,
+}
+
+/// The canonical, serializable error body: a stable [`ErrorKind`], a
+/// human-readable `message`, optional `context` layers (outermost → innermost),
+/// and an optional remediation `hint`. Empty `context` and an absent `hint` are
+/// omitted from the JSON.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ErrorBody {
+    /// Machine-readable category.
+    pub kind: ErrorKind,
+    /// Human-readable root-cause detail.
+    pub message: String,
+    /// Context layers, outermost first. Omitted when empty.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub context: Vec<String>,
+    /// Remediation hint, when one is recognised. Omitted when absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hint: Option<String>,
+}
+
+/// The top-level error envelope emitted on stdout by the CLI (and the shape the
+/// daemon/cloud HTTP surfaces converge on). Wraps a single [`ErrorBody`] under
+/// an `error` key: `{"error": {"kind": …, "message": …}}`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ErrorEnvelope {
+    /// The error detail.
+    pub error: ErrorBody,
 }
 
 #[cfg(test)]
@@ -152,5 +261,35 @@ mod tests {
         };
         assert_eq!(insufficient.status(), 403);
         assert_eq!(insufficient.error_type(), "permission_error");
+    }
+
+    #[test]
+    fn maps_to_envelope_kind_and_message() {
+        let e = BitrouterError::NotFound("route gpt-9".into());
+        let env = e.to_envelope();
+        assert_eq!(env.error.kind, ErrorKind::NotFound);
+        assert_eq!(env.error.message, "route gpt-9");
+        assert!(env.error.context.is_empty());
+        assert_eq!(env.error.hint, None);
+        let v = serde_json::to_value(&env).unwrap();
+        assert_eq!(
+            v,
+            serde_json::json!({"error": {"kind": "not_found", "message": "route gpt-9"}})
+        );
+    }
+
+    #[test]
+    fn envelope_message_strips_status_prefix_for_payload_variants() {
+        assert_eq!(
+            BitrouterError::bad_request("nope").to_envelope().error.message,
+            "nope"
+        );
+        assert_eq!(
+            BitrouterError::Upstream { status: 502, message: "boom".into() }
+                .to_envelope()
+                .error
+                .message,
+            "upstream error (502): boom"
+        );
     }
 }

--- a/crates/bitrouter-sdk/src/error.rs
+++ b/crates/bitrouter-sdk/src/error.rs
@@ -281,14 +281,20 @@ mod tests {
     #[test]
     fn envelope_message_strips_status_prefix_for_payload_variants() {
         assert_eq!(
-            BitrouterError::bad_request("nope").to_envelope().error.message,
-            "nope"
-        );
-        assert_eq!(
-            BitrouterError::Upstream { status: 502, message: "boom".into() }
+            BitrouterError::bad_request("nope")
                 .to_envelope()
                 .error
                 .message,
+            "nope"
+        );
+        assert_eq!(
+            BitrouterError::Upstream {
+                status: 502,
+                message: "boom".into()
+            }
+            .to_envelope()
+            .error
+            .message,
             "upstream error (502): boom"
         );
     }


### PR DESCRIPTION
## What

Every `bitrouter` **CLI** command now prints a single formatted **JSON object to stdout by default** (agent-native first), with a uniform error envelope on failure. A `--human`/`-H` flag renders the old human view; all diagnostics move to stderr.

```
bitrouter status            # {"running":true,"pid":1234,"listen":"127.0.0.1:4356",...}
bitrouter -H status         # ● bitrouter is running  /  pid  1234  ...
bitrouter models 2>/dev/null | jq '.models[].id'   # stdout is always clean JSON
```

## Output contract

| | stdout | stderr |
|---|---|---|
| **JSON (default)** | one JSON value — success object **or** error envelope | diagnostics / progress / colored error echo |
| **Human (`-H`)** | the human rendering (tables, status blocks, hints) | diagnostics |

- Global flags (accepted on any subcommand): `-j/--json` (force JSON, the default), `-H/--human`, `-h/--help` (unchanged — `-h` is **not** human).
- Failures emit `{"error":{"kind","message","context","hint"}}` to stdout and exit non-zero. `kind` is a stable taxonomy projected from the SDK `BitrouterError`.
- `bitrouter <cmd> 2>/dev/null | jq` yields clean JSON for **every** CLI command, including ones that run DB migrations or hit the network (those log to stderr).

## How

- New `apps/bitrouter/src/output/` module:
  - `CliReport` trait — a report is `Serialize` (JSON) **and** renders a human view; the `Output` driver is the single stdout writer and picks the format from the global flags.
  - `human.rs` — reusable render components (`Table`, `status_block`/`field`, `hint`/`note`, `embedded_json`, `Theme`) so every `--human` view is consistent.
  - `reports/*.rs` — one typed report per command group.
- New serializable `ErrorKind` / `ErrorEnvelope` projection of `BitrouterError` in `bitrouter-sdk` (the only SDK change); the CLI normalizes local/daemon/cloud errors into it.
- The basic tracing subscriber now writes to **stderr** so stdout stays pure JSON.

## Converted commands

Daemon lifecycle (`start`/`stop`/`restart`/`reload`/`status`), `route`, `init`, `config validate` (exits 1 on invalid), `models`, `providers list`, `tools` (list/status/discover), `agents` (list/check/install), `key sign`, `policy create`, `providers login`/`logout`, `skills` (add/list/remove/find/init/update), `verify`, `observe status`, and the whole `cloud …` subtree (now JSON by default; per-leaf `--json` still forces JSON).

**Non-CLI commands are intentionally untouched** — `serve` and `mcp serve` are long-running servers, `agent-proxy` is a stdio JSON-RPC bridge, and `spawn` hands its streams to the child agent.

## Follow-ups (not in this PR)

- `mcp install --config <path>` still prints a prose confirmation on its write-path (the default no-`--config` path is already JSON); lives in the `mcp` crate.
- The dispatcher uses per-arm `output.emit(...)`; a later pass can box it to a single emit site for a compile-time "no empty result" guarantee.
- `agents install` / `tools discover` carry the paste-able YAML under a `yaml` field rather than a fully structured object.

## Testing

- `cargo test -p bitrouter`: **193 lib + 11 daemon + 22 e2e + 5 full_stack + 1 observe** — all green.
- `cargo fmt --check` clean; `cargo clippy --all-targets` 0 warnings.
- Each command group smoke-tested end-to-end (JSON default, `-H` human, `2>/dev/null | jq`, error envelope, exit codes).
- An independent review pass verified the stdout contract holds for every converted command; its findings (richer `cloud login` body, `observe.socket` in JSON, CLI.md command-name drift, onboarding-hint fix) are addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
