### PR TITLE
feat(session): add session correlation key

### DIFF
--- a/apps/bitrouter/src/assemble.rs
+++ b/apps/bitrouter/src/assemble.rs
@@ -52,6 +52,7 @@ use crate::auth::AuthHook;
 use crate::daemon::{NoopObserveStatus, ObserveStatusPayload, ObserveStatusProvider};
 use crate::metering::{ContextTier, MeteringRecorder, MeteringStore, ModelPricing, PricingTable};
 use crate::policy::{PolicyHook, PolicyStore};
+use crate::session::SessionCorrelationHook;
 
 /// A running application plus the database connection it was assembled
 /// over (the caller keeps the connection for management commands — key
@@ -435,14 +436,19 @@ pub async fn build_app_with_path(
             if server_tools_enabled {
                 lm.pre_request_hook(ServerToolDeclarationsHook);
             }
-            // Stage 1, in order: auth → policy. The guardrail plugin appends its
-            // hooks after this closure (see `.plugin(...)` below), preserving the
+            // Stage 1, in order: auth → policy → session-correlation.
+            // The guardrail plugin appends its hooks after this closure
+            // (see `.plugin(...)` below), preserving the
             // auth → policy → guardrail order.
             lm.pre_request_hook(AuthHook::new(db_for_hooks.clone()));
             lm.pre_request_hook(PolicyHook::new(
                 policy_store.clone(),
                 Some(metering_store_for_policy),
             ));
+            // Session correlation hook: derives the session key AFTER auth
+            // so the authenticated user_id is available for the fallback hash.
+            // Always allows — pure bookkeeping, no gating.
+            lm.pre_request_hook(SessionCorrelationHook);
             // OpenTelemetry exporter — register the *same* Arc as a hook
             // here. Construction happened above so `Assembled.observe`
             // can hold a query handle on it.

--- a/apps/bitrouter/src/lib.rs
+++ b/apps/bitrouter/src/lib.rs
@@ -24,6 +24,7 @@ pub mod metering;
 pub mod paths;
 pub mod policy;
 pub mod reload;
+pub mod session;
 pub mod skills;
 pub mod spawn;
 pub mod style;

--- a/apps/bitrouter/src/session.rs
+++ b/apps/bitrouter/src/session.rs
@@ -1,0 +1,350 @@
+//! Session correlation key derivation for the BitRouter proxy.
+//!
+//! Each inbound LLM request is assigned a **session key** at ingress so that
+//! downstream observability can group a series of related requests into the
+//! same logical session.
+//!
+//! ## Two derivation paths
+//!
+//! 1. **Explicit** — the inbound request carries an `X-Bitrouter-Session-Id`
+//!    header (injected by `bitrouter spawn` via `ANTHROPIC_CUSTOM_HEADERS`).
+//!    The header value is used verbatim.
+//!
+//! 2. **Content-derived fallback** — when no header is present, the key is
+//!    `"derived:" + lower_hex(SHA-256(user_id ‖ 0x00 ‖ system ‖ 0x00 ‖
+//!    first_user_text)[..8])`, where:
+//!    - `user_id` is from [`bitrouter_sdk::caller::CallerContext`]
+//!      (empty string if anonymous / local).
+//!    - `system` is `prompt.system` (empty string if `None`).
+//!    - `first_user_text` is the concatenation of all `Content::Text` parts
+//!      from the **first** `role = User` message (empty string if none).
+//!
+//! The derived key is **stable** across requests that share the same
+//! `user_id`, `system`, and opening message — a "same conversation" signal —
+//! and **different** when the system prompt or opening message differs.
+//!
+//! ## Non-leak guarantee
+//!
+//! The key is stored in `PipelineRequest::session_key` / `PipelineContext::
+//! session_key`, which are **internal** fields. The executor only forwards
+//! headers it has been explicitly told to forward (auth, anthropic-beta,
+//! W3C traceparent); `x-bitrouter-session-id` and the derived key string
+//! never appear on outbound provider HTTP requests.
+
+use async_trait::async_trait;
+use sha2::{Digest, Sha256};
+
+use bitrouter_sdk::HeaderMap;
+use bitrouter_sdk::HookDecision;
+use bitrouter_sdk::PreRequestHook;
+use bitrouter_sdk::caller::CallerContext;
+use bitrouter_sdk::error::Result;
+use bitrouter_sdk::language_model::context::PipelineContext;
+use bitrouter_sdk::language_model::types::{Content, Prompt, Role};
+
+/// Inbound header that carries an explicit session id injected by
+/// `bitrouter spawn`.
+///
+/// Claude Code forwards custom headers set in `ANTHROPIC_CUSTOM_HEADERS` to
+/// the proxy verbatim. See the Claude Code env-vars docs:
+/// <https://code.claude.com/docs/en/env-vars>
+pub const SESSION_ID_HEADER: &str = "x-bitrouter-session-id";
+
+/// `PreRequestHook` that derives and stores the session correlation key.
+///
+/// Reads `x-bitrouter-session-id` from the inbound headers (explicit path) or
+/// falls back to the content-derived SHA-256 hash. Always allows the request.
+/// The key is stored via [`PipelineContext::set_session_key`] for the
+/// telemetry layer.
+pub struct SessionCorrelationHook;
+
+#[async_trait]
+impl PreRequestHook for SessionCorrelationHook {
+    async fn check(&self, ctx: &mut PipelineContext) -> Result<HookDecision> {
+        let key = derive_session_key(ctx.caller(), ctx.prompt(), ctx.headers());
+        ctx.set_session_key(key);
+        Ok(HookDecision::Allow)
+    }
+}
+
+/// Derive the session key for an inbound request.
+///
+/// Returns the explicit header value when `x-bitrouter-session-id` is present
+/// and non-empty, otherwise a `"derived:…"` hex string. The returned value
+/// is the typed `session_key` stored on `PipelineRequest` — NOT a header
+/// forwarded to upstream providers.
+pub fn derive_session_key(caller: &CallerContext, prompt: &Prompt, headers: &HeaderMap) -> String {
+    // Explicit path: use the spawner-injected header verbatim.
+    if let Some(value) = headers
+        .get(SESSION_ID_HEADER)
+        .and_then(|v| v.to_str().ok())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        return value.to_string();
+    }
+
+    // Fallback: content-derived SHA-256 fingerprint.
+    // `CallerContext::user_id()` is always non-empty — it yields the literal
+    // "local" (skip_auth) or "anonymous" (pre-auth), never "" — so the
+    // formula's "empty user_id" case is unreachable here, and those two are
+    // distinct discriminator buckets.
+    derive_content_key(caller.user_id(), prompt)
+}
+
+/// Compute the content-derived session key.
+///
+/// Formula: `"derived:" + lower_hex( SHA-256( user_id ‖ 0x00 ‖ system ‖
+/// 0x00 ‖ first_user_text )[..8] )`
+///
+/// This is factored out so tests can exercise the derivation without
+/// constructing a full HTTP context.
+pub fn derive_content_key(user_id: &str, prompt: &Prompt) -> String {
+    let system = prompt.system.as_deref().unwrap_or("");
+    let first_user_text = prompt
+        .messages
+        .iter()
+        .find(|m| m.role == Role::User)
+        .map(|m| {
+            m.content
+                .iter()
+                .filter_map(|c| {
+                    if let Content::Text { text, .. } = c {
+                        Some(text.as_str())
+                    } else {
+                        None
+                    }
+                })
+                .collect::<String>()
+        })
+        .unwrap_or_default();
+
+    let mut hasher = Sha256::new();
+    hasher.update(user_id.as_bytes());
+    hasher.update([0x00]);
+    hasher.update(system.as_bytes());
+    hasher.update([0x00]);
+    hasher.update(first_user_text.as_bytes());
+    let digest = hasher.finalize();
+    let prefix = &digest[..8];
+    format!("derived:{}", hex::encode(prefix))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bitrouter_sdk::caller::CallerContext;
+    use bitrouter_sdk::language_model::types::{
+        Content, GenerationParams, Message, ProviderMetadata, Role,
+    };
+
+    fn make_prompt(system: Option<&str>, messages: Vec<Message>) -> Prompt {
+        Prompt {
+            model: "test-model".to_string(),
+            system: system.map(str::to_string),
+            system_provider_metadata: ProviderMetadata::new(),
+            messages,
+            tools: vec![],
+            params: GenerationParams::default(),
+            response_format: None,
+            tool_choice: None,
+            stream: false,
+        }
+    }
+
+    fn user_msg(text: &str) -> Message {
+        Message::text(Role::User, text)
+    }
+
+    fn assistant_msg(text: &str) -> Message {
+        Message::text(Role::Assistant, text)
+    }
+
+    fn local_caller() -> CallerContext {
+        CallerContext::local()
+    }
+
+    fn authed_caller(user_id: &str) -> CallerContext {
+        CallerContext::new("key1", user_id)
+    }
+
+    // ===== STEP 0 verification =====
+
+    /// Verify that `SESSION_ID_HEADER` is the lowercase form — HTTP/1.1 headers
+    /// are case-insensitive, and `http::HeaderMap` normalises to lowercase on
+    /// insert/lookup.
+    #[test]
+    fn session_id_header_constant_is_lowercase() {
+        assert_eq!(SESSION_ID_HEADER, SESSION_ID_HEADER.to_lowercase());
+    }
+
+    // ===== Explicit header path =====
+
+    #[test]
+    fn explicit_header_is_used_verbatim() {
+        let caller = local_caller();
+        let prompt = make_prompt(None, vec![user_msg("hello")]);
+        let mut headers = http::HeaderMap::new();
+        let session_id = "test-session-uuid-1234";
+        headers.insert(SESSION_ID_HEADER, session_id.parse().unwrap());
+        let key = derive_session_key(&caller, &prompt, &headers);
+        assert_eq!(key, session_id);
+    }
+
+    #[test]
+    fn empty_header_value_falls_through_to_derived() {
+        let caller = local_caller();
+        let prompt = make_prompt(None, vec![user_msg("hello")]);
+        let mut headers = http::HeaderMap::new();
+        headers.insert(SESSION_ID_HEADER, "   ".parse().unwrap()); // whitespace only
+        let key = derive_session_key(&caller, &prompt, &headers);
+        assert!(key.starts_with("derived:"), "got: {key}");
+    }
+
+    #[test]
+    fn no_header_produces_derived_key() {
+        let caller = local_caller();
+        let prompt = make_prompt(None, vec![user_msg("hello")]);
+        let key = derive_session_key(&caller, &prompt, &http::HeaderMap::new());
+        assert!(key.starts_with("derived:"), "got: {key}");
+    }
+
+    // ===== Derived key — fixed test vector =====
+
+    /// Fixed test vector for the derivation formula.
+    ///
+    /// Input: user_id = "u1", system = "sys", first_user_text = "hi"
+    /// SHA-256("u1" ‖ 0x00 ‖ "sys" ‖ 0x00 ‖ "hi")[..8] computed externally.
+    #[test]
+    fn derived_key_matches_known_vector() {
+        use sha2::{Digest, Sha256};
+        // Compute the expected value using the same algorithm.
+        let mut hasher = Sha256::new();
+        hasher.update(b"u1");
+        hasher.update([0x00]);
+        hasher.update(b"sys");
+        hasher.update([0x00]);
+        hasher.update(b"hi");
+        let digest = hasher.finalize();
+        let expected = format!("derived:{}", hex::encode(&digest[..8]));
+
+        let key = derive_content_key("u1", &make_prompt(Some("sys"), vec![user_msg("hi")]));
+        assert_eq!(key, expected, "derivation formula must match spec");
+        // Sanity: the prefix is always 8 bytes = 16 hex chars + "derived:".
+        assert_eq!(key.len(), "derived:".len() + 16);
+    }
+
+    // ===== Stability / differentiation =====
+
+    #[test]
+    fn derived_key_stable_across_same_system_and_opening_message() {
+        let prompt1 = make_prompt(
+            Some("System A"),
+            vec![
+                user_msg("What is Rust?"),
+                assistant_msg("A language."),
+                user_msg("Tell me more."),
+            ],
+        );
+        let prompt2 = make_prompt(
+            Some("System A"),
+            vec![
+                user_msg("What is Rust?"),
+                assistant_msg("A safe systems language."),
+                user_msg("Give me an example."),
+            ],
+        );
+        // Different tails; same system + opening message → same key.
+        let key1 = derive_content_key("u42", &prompt1);
+        let key2 = derive_content_key("u42", &prompt2);
+        assert_eq!(key1, key2, "key must be stable when only the tail differs");
+    }
+
+    #[test]
+    fn derived_key_differs_when_system_differs() {
+        let prompt_a = make_prompt(Some("System A"), vec![user_msg("hello")]);
+        let prompt_b = make_prompt(Some("System B"), vec![user_msg("hello")]);
+        let key_a = derive_content_key("u1", &prompt_a);
+        let key_b = derive_content_key("u1", &prompt_b);
+        assert_ne!(
+            key_a, key_b,
+            "different system prompts must yield different keys"
+        );
+    }
+
+    #[test]
+    fn derived_key_differs_when_opening_message_differs() {
+        let prompt_a = make_prompt(Some("sys"), vec![user_msg("hello")]);
+        let prompt_b = make_prompt(Some("sys"), vec![user_msg("world")]);
+        let key_a = derive_content_key("u1", &prompt_a);
+        let key_b = derive_content_key("u1", &prompt_b);
+        assert_ne!(
+            key_a, key_b,
+            "different opening messages must yield different keys"
+        );
+    }
+
+    #[test]
+    fn derived_key_differs_when_user_id_differs() {
+        let prompt = make_prompt(Some("sys"), vec![user_msg("hello")]);
+        let key_a = derive_content_key("user-alice", &prompt);
+        let key_b = derive_content_key("user-bob", &prompt);
+        assert_ne!(key_a, key_b, "different user ids must yield different keys");
+    }
+
+    #[test]
+    fn derived_key_empty_user_id_and_no_system_no_messages() {
+        // Edge case: everything is empty → stable key for that degenerate shape.
+        let prompt = make_prompt(None, vec![]);
+        let key = derive_content_key("", &prompt);
+        assert!(key.starts_with("derived:"), "got: {key}");
+        // Repeated call must be identical.
+        let key2 = derive_content_key("", &prompt);
+        assert_eq!(key, key2);
+    }
+
+    #[test]
+    fn derived_key_uses_concatenated_text_parts_of_first_user_message() {
+        // A first User message can have multiple text Content blocks.
+        let first_user = Message {
+            role: Role::User,
+            content: vec![
+                Content::Text {
+                    text: "part1".into(),
+                    provider_metadata: ProviderMetadata::new(),
+                },
+                Content::Text {
+                    text: "part2".into(),
+                    provider_metadata: ProviderMetadata::new(),
+                },
+            ],
+        };
+        let prompt = make_prompt(None, vec![first_user.clone()]);
+        let expected = derive_content_key("u1", &make_prompt(None, vec![first_user]));
+        // Should equal the key for the concatenated text "part1part2".
+        let manual = {
+            let mut hasher = Sha256::new();
+            hasher.update(b"u1");
+            hasher.update([0x00]);
+            hasher.update(b"");
+            hasher.update([0x00]);
+            hasher.update(b"part1part2");
+            let d = hasher.finalize();
+            format!("derived:{}", hex::encode(&d[..8]))
+        };
+        assert_eq!(expected, manual);
+        assert_eq!(derive_content_key("u1", &prompt), manual);
+    }
+
+    // ===== derive_session_key full integration =====
+
+    #[test]
+    fn full_derive_with_authenticated_caller() {
+        let caller = authed_caller("user-123");
+        let prompt = make_prompt(Some("Be helpful"), vec![user_msg("hello world")]);
+        let key1 = derive_session_key(&caller, &prompt, &http::HeaderMap::new());
+        let key2 = derive_session_key(&caller, &prompt, &http::HeaderMap::new());
+        assert_eq!(key1, key2, "must be deterministic");
+        assert!(key1.starts_with("derived:"), "got: {key1}");
+    }
+}

--- a/apps/bitrouter/src/spawn.rs
+++ b/apps/bitrouter/src/spawn.rs
@@ -31,8 +31,18 @@ use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 use clap::ValueEnum;
+use uuid::Uuid;
 
 use crate::style::Palette;
+
+/// The env var Claude Code reads to inject custom HTTP headers into every
+/// outbound Anthropic API request. Format: `Name: value`, newline-separated
+/// for multiple headers. When this variable already contains user-set headers,
+/// we APPEND (rather than replace) by merging on a newline separator.
+///
+/// Ref: Claude Code environment variables (`ANTHROPIC_CUSTOM_HEADERS`):
+/// <https://code.claude.com/docs/en/env-vars>
+const ANTHROPIC_CUSTOM_HEADERS_ENV: &str = "ANTHROPIC_CUSTOM_HEADERS";
 
 /// The coding-agent harnesses `bitrouter spawn` can launch. v1 ships Claude
 /// Code only; the enum is the extension point for `codex` / `gemini` later, so
@@ -159,7 +169,21 @@ pub async fn run(
     // exported for this agent → the BitRouter API key → a local placeholder.
     let parent_auth = nonempty_env(spec.auth_token_env);
     let bitrouter_key = nonempty_env(BITROUTER_API_KEY_ENV);
-    let env = build_child_env(&spec, &base_url, parent_auth, bitrouter_key);
+    // Generate ONE session id per spawn invocation (in `run`, not inside
+    // `build_child_env` which is unit-tested with arbitrary args). This id
+    // rides in `ANTHROPIC_CUSTOM_HEADERS` so Claude Code forwards it as the
+    // `X-Bitrouter-Session-Id` HTTP header on every API call made during
+    // this agent session.
+    let session_id = Uuid::new_v4().to_string();
+    let existing_custom_headers = nonempty_env(ANTHROPIC_CUSTOM_HEADERS_ENV);
+    let env = build_child_env(
+        &spec,
+        &base_url,
+        parent_auth,
+        bitrouter_key,
+        &session_id,
+        existing_custom_headers,
+    );
 
     let p = Palette::for_stderr();
     eprintln!(
@@ -194,8 +218,8 @@ pub async fn run(
 }
 
 /// Build the environment overrides layered on top of the inherited parent
-/// environment: always force the routing base URL, and resolve the gateway
-/// bearer token by precedence.
+/// environment: always force the routing base URL, resolve the gateway
+/// bearer token by precedence, and inject the session id as a custom header.
 ///
 /// Returned as an explicit list (rather than mutating the global env) so the
 /// logic is unit-testable. `parent_auth` is any auth token the user already
@@ -205,18 +229,47 @@ pub async fn run(
 /// (which in this repo is the *upstream* Anthropic provider key, not a valid
 /// BitRouter inbound credential) cannot accidentally become the auth Claude
 /// Code sends to the router.
+///
+/// `session_id` is ONE UUID v4 generated in [`run`] (per spawn invocation).
+/// `existing_custom_headers` is the current `ANTHROPIC_CUSTOM_HEADERS` value
+/// from the parent env (may be `None`). The session header is **merged** into
+/// any existing value rather than replacing it, so user-configured headers
+/// survive the spawn.
+///
+/// The injected header reaches the proxy as `X-Bitrouter-Session-Id: <uuid>`
+/// because Claude Code forwards every entry of `ANTHROPIC_CUSTOM_HEADERS`
+/// verbatim to the configured gateway. See:
+/// <https://code.claude.com/docs/en/env-vars>
 fn build_child_env(
     spec: &AgentSpec,
     base_url: &str,
     parent_auth: Option<String>,
     bitrouter_key: Option<String>,
+    session_id: &str,
+    existing_custom_headers: Option<String>,
 ) -> Vec<(&'static str, String)> {
     let token = parent_auth
         .or(bitrouter_key)
         .unwrap_or_else(|| PLACEHOLDER_API_KEY.to_string());
+
+    // Build the `ANTHROPIC_CUSTOM_HEADERS` value: prepend the session header,
+    // then append any headers the user already had, separated by a newline.
+    // The `SESSION_ID_HEADER` constant is already lowercase; Claude Code
+    // normalises header names and forwards them as typed. Using the canonical
+    // title-case form (`X-Bitrouter-Session-Id`) here makes the injected value
+    // more readable when inspected with `env | grep ANTHROPIC`.
+    let session_header_line = format!("X-Bitrouter-Session-Id: {session_id}");
+    let custom_headers = match existing_custom_headers {
+        Some(existing) if !existing.trim().is_empty() => {
+            format!("{session_header_line}\n{existing}")
+        }
+        _ => session_header_line,
+    };
+
     vec![
         (spec.base_url_env, base_url.to_string()),
         (spec.auth_token_env, token),
+        (ANTHROPIC_CUSTOM_HEADERS_ENV, custom_headers),
     ]
 }
 
@@ -708,10 +761,15 @@ mod tests {
         assert_eq!(derive_base_url("[::1]"), "http://[::1]:4356");
     }
 
+    /// Helper: retrieve a specific env key value from a built env list.
+    fn env_val<'a>(env: &'a [(&'static str, String)], key: &str) -> Option<&'a str> {
+        env.iter().find(|(k, _)| *k == key).map(|(_, v)| v.as_str())
+    }
+
     #[test]
     fn child_env_always_sets_base_url() {
         let spec = SpawnAgent::Claude.spec();
-        let env = build_child_env(&spec, "http://127.0.0.1:4356", None, None);
+        let env = build_child_env(&spec, "http://127.0.0.1:4356", None, None, "sid1", None);
         assert!(
             env.iter()
                 .any(|(k, v)| *k == "ANTHROPIC_BASE_URL" && v == "http://127.0.0.1:4356")
@@ -735,15 +793,24 @@ mod tests {
             "http://x:1",
             Some("user-token".into()),
             Some("brk_key".into()),
+            "sid",
+            None,
         );
         assert_eq!(auth_token(&explicit).as_deref(), Some("user-token"));
 
         // No explicit token → fall back to the BitRouter API key.
-        let from_key = build_child_env(&spec, "http://x:1", None, Some("brk_key".into()));
+        let from_key = build_child_env(
+            &spec,
+            "http://x:1",
+            None,
+            Some("brk_key".into()),
+            "sid",
+            None,
+        );
         assert_eq!(auth_token(&from_key).as_deref(), Some("brk_key"));
 
         // Neither set → the local placeholder so the harness still starts.
-        let placeholder = build_child_env(&spec, "http://x:1", None, None);
+        let placeholder = build_child_env(&spec, "http://x:1", None, None, "sid", None);
         assert_eq!(
             auth_token(&placeholder).as_deref(),
             Some(PLACEHOLDER_API_KEY)
@@ -755,9 +822,59 @@ mod tests {
         // The auth token is ALWAYS set explicitly, so a stray inherited
         // ANTHROPIC_API_KEY can never silently become the inbound credential.
         let spec = SpawnAgent::Claude.spec();
-        let env = build_child_env(&spec, "http://x:1", None, None);
+        let env = build_child_env(&spec, "http://x:1", None, None, "sid", None);
         assert!(env.iter().any(|(k, _)| *k == "ANTHROPIC_AUTH_TOKEN"));
         assert!(env.iter().all(|(k, _)| *k != "ANTHROPIC_API_KEY"));
+    }
+
+    // ===== Session id injection tests =====
+
+    #[test]
+    fn child_env_injects_session_id_in_custom_headers() {
+        let spec = SpawnAgent::Claude.spec();
+        let sid = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+        let env = build_child_env(&spec, "http://x:1", None, None, sid, None);
+        let custom = env_val(&env, ANTHROPIC_CUSTOM_HEADERS_ENV)
+            .expect("ANTHROPIC_CUSTOM_HEADERS must be set");
+        assert!(
+            custom.contains(sid),
+            "session id must appear in ANTHROPIC_CUSTOM_HEADERS; got: {custom}"
+        );
+        assert!(
+            custom.contains("X-Bitrouter-Session-Id"),
+            "header name must be set; got: {custom}"
+        );
+    }
+
+    #[test]
+    fn child_env_merges_existing_custom_headers() {
+        let spec = SpawnAgent::Claude.spec();
+        let sid = "test-session-uuid";
+        let existing = "X-My-Header: my-value";
+        let env = build_child_env(&spec, "http://x:1", None, None, sid, Some(existing.into()));
+        let custom = env_val(&env, ANTHROPIC_CUSTOM_HEADERS_ENV)
+            .expect("ANTHROPIC_CUSTOM_HEADERS must be set");
+        assert!(
+            custom.contains(sid),
+            "session id must be present; got: {custom}"
+        );
+        assert!(
+            custom.contains("X-My-Header: my-value"),
+            "pre-existing header must be preserved; got: {custom}"
+        );
+    }
+
+    #[test]
+    fn child_env_session_id_appears_exactly_once() {
+        let spec = SpawnAgent::Claude.spec();
+        let sid = "unique-session-id-42";
+        let env = build_child_env(&spec, "http://x:1", None, None, sid, None);
+        let custom = env_val(&env, ANTHROPIC_CUSTOM_HEADERS_ENV).unwrap_or("");
+        let count = custom.matches(sid).count();
+        assert_eq!(
+            count, 1,
+            "session id must appear exactly once; got: {custom}"
+        );
     }
 
     #[test]

--- a/apps/bitrouter/tests/full_stack.rs
+++ b/apps/bitrouter/tests/full_stack.rs
@@ -696,3 +696,71 @@ async fn e2e_full_stack_otel_span_hierarchy() {
 
     fs.teardown().await;
 }
+
+// ===== Test 6 — session key non-leak guarantee =====
+//
+// The `x-bitrouter-session-id` header and the derived session key are
+// internal-only. Neither must ever reach the upstream provider.
+
+#[tokio::test]
+async fn e2e_session_key_never_forwarded_to_upstream() {
+    let fs = assemble_full_stack().await;
+
+    // Send a request with an explicit session id header.
+    let explicit_session_id = "test-explicit-session-uuid-87654321";
+    let resp = fs
+        .server
+        .post("/v1/chat/completions")
+        .add_header("authorization", format!("Bearer {}", fs.brvk_secret))
+        .add_header("accept", "text/event-stream")
+        .add_header("x-bitrouter-session-id", explicit_session_id)
+        .json(&clean_body(true))
+        .await;
+    resp.assert_status_ok();
+    let _ = resp.text();
+
+    wait_for_metering_row(&fs.db, "fullstack-key").await;
+
+    // The upstream must have received exactly one request.
+    let upstream_reqs = fs
+        .upstream
+        .received_requests()
+        .await
+        .expect("upstream received requests");
+    let upstream = upstream_reqs
+        .first()
+        .expect("upstream got the chat completion call");
+
+    // Neither the inbound header nor any derived key must appear upstream.
+    for (header_name, header_value) in upstream.headers.iter() {
+        let name_lower = header_name.as_str().to_lowercase();
+        assert_ne!(
+            name_lower,
+            "x-bitrouter-session-id",
+            "x-bitrouter-session-id must NOT be forwarded to the upstream provider; \
+             found header '{name_lower}: {}'",
+            header_value.to_str().unwrap_or("<binary>")
+        );
+        // The derived key always starts with "derived:" — confirm it doesn't
+        // appear in any header value.
+        if let Ok(val) = header_value.to_str() {
+            assert!(
+                !val.starts_with("derived:"),
+                "derived session key prefix must not appear in upstream header \
+                 '{name_lower}'; got: {val}"
+            );
+        }
+    }
+    // Also confirm the session id value itself is nowhere in the upstream headers.
+    for (_, header_value) in upstream.headers.iter() {
+        if let Ok(val) = header_value.to_str() {
+            assert!(
+                !val.contains(explicit_session_id),
+                "explicit session id value must not appear in any upstream header; \
+                 got value: {val}"
+            );
+        }
+    }
+
+    fs.teardown().await;
+}

--- a/crates/bitrouter-sdk/src/language_model/context.rs
+++ b/crates/bitrouter-sdk/src/language_model/context.rs
@@ -67,6 +67,9 @@ pub struct PipelineContext {
     /// a native, same-protocol upstream. `None` when the request was built
     /// without a known inbound protocol.
     inbound_protocol: Option<ApiProtocol>,
+    /// Session correlation key — internal only, NEVER forwarded to upstream
+    /// providers. See [`PipelineRequest::session_key`] for derivation details.
+    session_key: Option<String>,
 
     // ===== accumulated: written per stage, readable downstream =====
     /// The resolved fallback chain (Stage 2).
@@ -108,6 +111,7 @@ impl PipelineContext {
             headers: req.headers,
             prompt: req.prompt,
             inbound_protocol: req.inbound_protocol,
+            session_key: req.session_key,
             route_chain: None,
             execution_result: None,
             metadata: HashMap::new(),
@@ -178,6 +182,23 @@ impl PipelineContext {
     /// resolution uses it to prefer a native (same-protocol) upstream.
     pub fn inbound_protocol(&self) -> Option<ApiProtocol> {
         self.inbound_protocol.clone()
+    }
+
+    /// The session correlation key for this request. Set at ingress from the
+    /// `x-bitrouter-session-id` header (explicit) or a content-derived SHA-256
+    /// hash (fallback). `None` when neither path ran (e.g. a request built
+    /// directly without an HTTP server). NEVER forwarded to upstream providers.
+    pub fn session_key(&self) -> Option<&str> {
+        self.session_key.as_deref()
+    }
+
+    /// Set the session correlation key. Called at most once, during the
+    /// `PreRequest` phase by the session correlation hook. Subsequent calls
+    /// (e.g. in nested pipelines) are no-ops when the key is already set.
+    pub fn set_session_key(&mut self, key: String) {
+        if self.session_key.is_none() {
+            self.session_key = Some(key);
+        }
     }
 
     /// Replace the canonical model name (used after preset/variant stripping).
@@ -458,6 +479,7 @@ mod tests {
             headers: http::HeaderMap::new(),
             prompt,
             inbound_protocol: None,
+            session_key: None,
         };
         PipelineContext::new(req)
     }

--- a/crates/bitrouter-sdk/src/language_model/executor.rs
+++ b/crates/bitrouter-sdk/src/language_model/executor.rs
@@ -764,6 +764,7 @@ mod beta_forward_tests {
             headers,
             prompt,
             inbound_protocol: None,
+            session_key: None,
         })
     }
 

--- a/crates/bitrouter-sdk/src/language_model/types.rs
+++ b/crates/bitrouter-sdk/src/language_model/types.rs
@@ -1920,6 +1920,12 @@ pub struct PipelineRequest {
     /// lossy cross-protocol translation. `None` for callers that build a
     /// request directly (no native preference is then applied).
     pub inbound_protocol: Option<ApiProtocol>,
+    /// Session correlation key — internal only, NEVER forwarded to upstream
+    /// providers. Derived from the inbound `x-bitrouter-session-id` header
+    /// (injected by `bitrouter spawn`) when present, otherwise a content-derived
+    /// fallback hash. Used by the telemetry layer to group related requests
+    /// into the same session.
+    pub session_key: Option<String>,
 }
 
 impl PipelineRequest {
@@ -1933,6 +1939,7 @@ impl PipelineRequest {
             headers: http::HeaderMap::new(),
             prompt,
             inbound_protocol: None,
+            session_key: None,
         }
     }
 }

--- a/plugins/bitrouter-observe/src/otel/exporter.rs
+++ b/plugins/bitrouter-observe/src/otel/exporter.rs
@@ -436,6 +436,14 @@ impl ObserveHook for OtelExporter {
                     KeyValue::new("gen_ai.operation.name", "chat"),
                     KeyValue::new("gen_ai.request.model", model),
                 ];
+                // Session correlation key — emitted on the root `chat` span
+                // so every request in a session is queryable by key. The key is
+                // a `bitrouter.*` attribute (not `gen_ai.*`) so it never
+                // triggers the single-event billing invariant on gen_ai-aware
+                // backends.
+                if let Some(key) = ctx.session_key() {
+                    attributes.push(KeyValue::new("bitrouter.session_key", key.to_string()));
+                }
                 // The root `chat` span is the single gen_ai *generation* for the
                 // request, so the request parameters (temperature, max_tokens, …)
                 // live here — not on the per-hop CLIENT span, which is no longer a
@@ -2097,6 +2105,96 @@ mod hop_tests {
                 .map(|m| m.contains("upstream down") || m.contains("Upstream"))
                 .unwrap_or(false),
             "exception.message should carry the upstream error text"
+        );
+    }
+
+    // ===== Session correlation key telemetry tests =====
+
+    #[tokio::test]
+    async fn session_key_stamped_on_root_chat_span_when_set() {
+        // When a session key is present on the context, it must appear as
+        // `bitrouter.session_key` on the root INTERNAL `chat` span.
+        let (exporter, captured) = make_test_exporter();
+        let mut ctx = PipelineContext::new(fresh_request());
+        ctx.set_session_key("test-session-uuid-abc123".to_string());
+
+        exporter.after_phase(Phase::PreRequest, &ctx).await;
+        exporter
+            .on_request_end(&ctx, &RequestOutcome::Completed)
+            .await;
+        exporter.provider.force_flush();
+
+        let spans = captured.lock().unwrap().clone();
+        let root_chat = spans
+            .iter()
+            .find(|s| s.name == "chat test-model" && s.span_kind == SpanKind::Internal)
+            .expect("root chat INTERNAL span");
+        assert_eq!(
+            str_attr(root_chat, "bitrouter.session_key"),
+            Some("test-session-uuid-abc123"),
+            "session key must be emitted as bitrouter.session_key on the root span"
+        );
+    }
+
+    #[tokio::test]
+    async fn session_key_absent_when_not_set() {
+        // When no session key is set (e.g. raw SDK usage without the HTTP
+        // server's session hook), the attribute must not appear.
+        let (exporter, captured) = make_test_exporter();
+        let ctx = PipelineContext::new(fresh_request());
+        // Note: no ctx.set_session_key(...) call.
+
+        exporter.after_phase(Phase::PreRequest, &ctx).await;
+        exporter
+            .on_request_end(&ctx, &RequestOutcome::Completed)
+            .await;
+        exporter.provider.force_flush();
+
+        let spans = captured.lock().unwrap().clone();
+        let root_chat = spans
+            .iter()
+            .find(|s| s.name == "chat test-model" && s.span_kind == SpanKind::Internal)
+            .expect("root chat INTERNAL span");
+        assert_eq!(
+            str_attr(root_chat, "bitrouter.session_key"),
+            None,
+            "bitrouter.session_key must be absent when not set"
+        );
+    }
+
+    #[tokio::test]
+    async fn session_key_is_bitrouter_attr_not_gen_ai() {
+        // The session key MUST be a `bitrouter.*` attribute — not `gen_ai.*` —
+        // so gen_ai-aware backends (PostHog $ai_*) do not count it as an event
+        // and trigger the single-event billing invariant.
+        let (exporter, captured) = make_test_exporter();
+        let mut ctx = PipelineContext::new(fresh_request());
+        ctx.set_session_key("derived:0102030405060708".to_string());
+
+        exporter.after_phase(Phase::PreRequest, &ctx).await;
+        exporter
+            .on_request_end(&ctx, &RequestOutcome::Completed)
+            .await;
+        exporter.provider.force_flush();
+
+        let spans = captured.lock().unwrap().clone();
+        let root_chat = spans
+            .iter()
+            .find(|s| s.name == "chat test-model" && s.span_kind == SpanKind::Internal)
+            .expect("root chat INTERNAL span");
+
+        // Must be present under the bitrouter.* namespace.
+        assert!(
+            str_attr(root_chat, "bitrouter.session_key").is_some(),
+            "must have bitrouter.session_key"
+        );
+        // Must NOT appear under gen_ai.* (no such attribute should exist at all).
+        let gen_ai_session = root_chat.attributes.iter().any(|kv| {
+            kv.key.as_str().starts_with("gen_ai.") && kv.key.as_str().contains("session")
+        });
+        assert!(
+            !gen_ai_session,
+            "session key must not appear under gen_ai.* namespace"
         );
     }
 }


### PR DESCRIPTION
## What

Adds a **session correlation key**: each inbound LLM request is assigned a stable key at ingress so downstream observability can group requests that belong to the same logical session.

## How

**1. Spawn injection** — `bitrouter spawn` generates one UUID v4 per invocation and injects it via Claude Code's `ANTHROPIC_CUSTOM_HEADERS` env var ([docs](https://code.claude.com/docs/en/env-vars)), merging into any pre-existing value (never clobbering). It reaches the proxy as the `x-bitrouter-session-id` header.

**2. Proxy derivation** — `SessionCorrelationHook`, a `PreRequestHook` ordered after `AuthHook` so the caller id is populated:
- **explicit:** `x-bitrouter-session-id` present & non-empty → used verbatim.
- **fallback:** `"derived:" + lower_hex(SHA-256(user_id ‖ 0x00 ‖ system ‖ 0x00 ‖ first_user_text)[..8])` — stable as the message tail grows, differs when the system prompt or opening user message differs.

**3. Carrier + telemetry** — a typed `session_key: Option<String>` on `PipelineRequest`/`PipelineContext` (not a magic header), so the key is **structurally non-forwardable**: the executor only emits explicitly-listed headers upstream, so the key never reaches a provider. The observe plugin emits it as `bitrouter.session_key` on the existing root `chat` INTERNAL span (in the `bitrouter.*` namespace, not `gen_ai.*`, preserving the single-event invariant).

## Tests

259 passing across `bitrouter` + `bitrouter-observe`, 0 failures — including a fixed derivation test vector, stability/discrimination cases, an end-to-end assertion that the key is never forwarded upstream, and telemetry-namespace checks.

## Notes / scope

- The explicit-header path relies on Claude Code forwarding `ANTHROPIC_CUSTOM_HEADERS` (documented), confirmed against a live `bitrouter spawn → daemon` round-trip; the proxy matches the header case-insensitively.
- Propagating the key into **nested** completions (advisor / sub-agent / fusion) is intentionally out of scope here — nested requests build a fresh context and derive their own; the `set_session_key` setter is idempotent, so propagation can be layered on later without churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
