### PR TITLE
feat(server-tools): built-in web_fetch tool (BYOK)

### DIFF
--- a/apps/bitrouter/src/assemble.rs
+++ b/apps/bitrouter/src/assemble.rs
@@ -810,7 +810,7 @@ fn resolve_byok_key(explicit: &Option<String>, env_var: &str, backend: &str) -> 
             tracing::warn!(
                 backend,
                 env_var,
-                "web_search backend has no API key (set the env var or `api_key`); skipping"
+                "server-tool backend has no API key (set the env var or `api_key`); skipping"
             );
             None
         }

--- a/apps/bitrouter/src/assemble.rs
+++ b/apps/bitrouter/src/assemble.rs
@@ -377,7 +377,8 @@ pub async fn build_app_with_path(
     let server_tools_enabled = config.server_tools.fusion.is_some()
         || config.server_tools.advisor
         || config.server_tools.subagent
-        || config.server_tools.web_search.is_some();
+        || config.server_tools.web_search.is_some()
+        || config.server_tools.web_fetch.is_some();
     let nested_runner: Option<Arc<dyn NestedRunner>> = if server_tools_enabled {
         let mut sub = PipelineBuilder::new();
         sub.routing_table(routing_table.clone())
@@ -1641,6 +1642,26 @@ mod server_tools_tests {
                 api_base: None,
             }],
             max_results: Some(3),
+        });
+        assert!(build_server_tool_loop(&cfg, &None, &None, None).is_some());
+    }
+
+    #[test]
+    fn web_fetch_http_backend_with_explicit_key_builds_loop_without_runner() {
+        use bitrouter_sdk::language_model::server_tools::web_fetch::config::{
+            WebFetchBackendConfig, WebFetchSettings,
+        };
+        // A web_fetch-only config (no advisor/subagent/fusion/web_search) must
+        // still build the server-tool loop, proving server_tools_enabled covers
+        // web_fetch. An HTTP backend with an explicit key resolves without a
+        // nested runner.
+        let mut cfg = Config::default();
+        cfg.server_tools.web_fetch = Some(WebFetchSettings {
+            backends: vec![WebFetchBackendConfig::Exa {
+                api_key: Some("explicit-key".to_string()),
+                api_base: None,
+            }],
+            max_content_tokens: None,
         });
         assert!(build_server_tool_loop(&cfg, &None, &None, None).is_some());
     }

--- a/apps/bitrouter/src/assemble.rs
+++ b/apps/bitrouter/src/assemble.rs
@@ -26,6 +26,14 @@ use bitrouter_sdk::language_model::server_tools::mcp_toolset::McpRouterToolset;
 use bitrouter_sdk::language_model::server_tools::nested::{NestedRunner, PipelineNestedRunner};
 use bitrouter_sdk::language_model::server_tools::sub_agent::SubAgentToolset;
 use bitrouter_sdk::language_model::server_tools::toolset::{RouterToolset, ToolsetRegistry};
+use bitrouter_sdk::language_model::server_tools::web_fetch::backend::WebFetchBackend;
+use bitrouter_sdk::language_model::server_tools::web_fetch::config::{
+    DEFAULT_MAX_CONTENT_TOKENS, WebFetchBackendConfig, WebFetchSettings,
+};
+use bitrouter_sdk::language_model::server_tools::web_fetch::http::{
+    HttpFetchBackend, HttpFetchEngine,
+};
+use bitrouter_sdk::language_model::server_tools::web_fetch::toolset::WebFetchToolset;
 use bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchBackend;
 use bitrouter_sdk::language_model::server_tools::web_search::config::{
     DEFAULT_MAX_RESULTS, WebSearchBackendConfig, WebSearchSettings,
@@ -644,6 +652,22 @@ fn build_server_tool_loop(
         }
     }
 
+    // Built-in web_fetch server tool, backed by the configured BYOK extraction
+    // backends. Advertised per-request only when the caller declares it.
+    if let Some(web_fetch) = &settings.web_fetch {
+        let backends = build_web_fetch_backends(web_fetch);
+        if backends.is_empty() {
+            tracing::warn!(
+                "server_tools.web_fetch is set but no backend resolved (missing API keys?); \
+                 web_fetch is disabled"
+            );
+        } else {
+            let max_content_tokens =
+                web_fetch.max_content_tokens.unwrap_or(DEFAULT_MAX_CONTENT_TOKENS);
+            sets.push(Arc::new(WebFetchToolset::new(backends, max_content_tokens)));
+        }
+    }
+
     if sets.is_empty() {
         return None;
     }
@@ -705,7 +729,7 @@ fn build_web_search_backends(
                 };
                 if let (Some(client), Some(key)) = (
                     &http,
-                    resolve_search_key(api_key, engine.env_var(), engine.name()),
+                    resolve_byok_key(api_key, engine.env_var(), engine.name()),
                 ) {
                     backends.push(Arc::new(HttpSearchBackend::new(
                         engine,
@@ -732,9 +756,50 @@ fn build_web_search_backends(
     backends
 }
 
-/// Resolve a search backend's BYOK key: the explicit value if non-empty, else
+/// Build the live `web_fetch` backends from `settings`, in configured
+/// preference/failover order. Each HTTP backend resolves its BYOK key from the
+/// explicit `api_key` (with `${VAR}` already substituted) or the engine's
+/// conventional environment variable; one whose key cannot be resolved is
+/// skipped with a warning.
+fn build_web_fetch_backends(settings: &WebFetchSettings) -> Vec<Arc<dyn WebFetchBackend>> {
+    if settings.backends.is_empty() {
+        return Vec::new();
+    }
+    // Request timeout sits below the loop's per-tool budget so a stuck fetch
+    // fails over promptly.
+    let http = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(20))
+        .build()
+        .unwrap_or_default();
+
+    let mut backends: Vec<Arc<dyn WebFetchBackend>> = Vec::new();
+    for entry in &settings.backends {
+        let (engine, api_key, api_base) = match entry {
+            WebFetchBackendConfig::Exa { api_key, api_base } => {
+                (HttpFetchEngine::Exa, api_key, api_base)
+            }
+            WebFetchBackendConfig::Firecrawl { api_key, api_base } => {
+                (HttpFetchEngine::Firecrawl, api_key, api_base)
+            }
+            WebFetchBackendConfig::Tavily { api_key, api_base } => {
+                (HttpFetchEngine::Tavily, api_key, api_base)
+            }
+        };
+        if let Some(key) = resolve_byok_key(api_key, engine.env_var(), engine.name()) {
+            backends.push(Arc::new(HttpFetchBackend::new(
+                engine,
+                key,
+                api_base.clone(),
+                http.clone(),
+            )));
+        }
+    }
+    backends
+}
+
+/// Resolve a BYOK backend's API key: the explicit value if non-empty, else
 /// the conventional environment variable. Logs and returns `None` when unset.
-fn resolve_search_key(explicit: &Option<String>, env_var: &str, backend: &str) -> Option<String> {
+fn resolve_byok_key(explicit: &Option<String>, env_var: &str, backend: &str) -> Option<String> {
     if let Some(key) = explicit.as_ref().filter(|k| !k.is_empty()) {
         return Some(key.clone());
     }
@@ -1578,5 +1643,23 @@ mod server_tools_tests {
             max_results: Some(3),
         });
         assert!(build_server_tool_loop(&cfg, &None, &None, None).is_some());
+    }
+
+    #[test]
+    fn assembles_web_fetch_exa_backend_from_explicit_key() {
+        use bitrouter_sdk::language_model::server_tools::web_fetch::config::{
+            WebFetchBackendConfig, WebFetchSettings,
+        };
+        // An HTTP backend with an explicit key resolves without needing an env
+        // var, mirroring the sibling web_search assembly test's approach.
+        let backends = super::build_web_fetch_backends(&WebFetchSettings {
+            backends: vec![WebFetchBackendConfig::Exa {
+                api_key: Some("explicit-key".to_string()),
+                api_base: None,
+            }],
+            max_content_tokens: None,
+        });
+        assert_eq!(backends.len(), 1);
+        assert_eq!(backends[0].name(), "exa");
     }
 }

--- a/apps/bitrouter/src/assemble.rs
+++ b/apps/bitrouter/src/assemble.rs
@@ -663,8 +663,9 @@ fn build_server_tool_loop(
                  web_fetch is disabled"
             );
         } else {
-            let max_content_tokens =
-                web_fetch.max_content_tokens.unwrap_or(DEFAULT_MAX_CONTENT_TOKENS);
+            let max_content_tokens = web_fetch
+                .max_content_tokens
+                .unwrap_or(DEFAULT_MAX_CONTENT_TOKENS);
             sets.push(Arc::new(WebFetchToolset::new(backends, max_content_tokens)));
         }
     }

--- a/crates/bitrouter-sdk/src/language_model/server_tools/config.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/config.rs
@@ -59,4 +59,22 @@ pub struct ServerToolsConfig {
     /// `bitrouter:web_search` tool is enabled, served by the configured search
     /// backends. Advertised per-request only when the caller declares it.
     pub web_search: Option<super::web_search::config::WebSearchSettings>,
+    /// Built-in `web_fetch` server tool (BYOK). When set, the
+    /// `bitrouter:web_fetch` tool is enabled, served by the configured fetch
+    /// backends. Advertised per-request only when the caller declares it.
+    pub web_fetch: Option<super::web_fetch::config::WebFetchSettings>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn server_tools_config_accepts_web_fetch() {
+        let s: ServerToolsConfig = serde_json::from_value(serde_json::json!({
+            "web_fetch": { "backends": [{ "kind": "exa" }] }
+        }))
+        .unwrap();
+        assert!(s.web_fetch.is_some());
+    }
 }

--- a/crates/bitrouter-sdk/src/language_model/server_tools/declarations.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/declarations.rs
@@ -472,4 +472,16 @@ mod tests {
         assert!(decls.web_fetch.is_none());
         assert!(decls.is_empty());
     }
+
+    #[test]
+    fn foreign_namespaced_web_fetch_is_not_a_declaration() {
+        // Only the explicit `bitrouter` namespace declares the built-in tool;
+        // another provider's namespaced `web_fetch` is left for the upstream.
+        let decls = ServerToolDeclarations::from_prompt(&prompt_with(vec![provider_tool(
+            "openai:web_fetch",
+            serde_json::json!({}),
+        )]));
+        assert!(decls.web_fetch.is_none());
+        assert!(decls.is_empty());
+    }
 }

--- a/crates/bitrouter-sdk/src/language_model/server_tools/declarations.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/declarations.rs
@@ -30,6 +30,8 @@ pub const ADVISOR_TOOL: &str = "advisor";
 pub const SUBAGENT_TOOL: &str = "subagent";
 /// Router-tool name the model calls to search the web.
 pub const WEB_SEARCH_TOOL: &str = "web_search";
+/// Router-tool name the model calls to fetch a URL's content.
+pub const WEB_FETCH_TOOL: &str = "web_fetch";
 
 /// Plugin id under which [`ServerToolDeclarations`] is stashed on the request
 /// context by the pre-request hook, for the toolsets to read back.
@@ -64,6 +66,19 @@ pub struct WebSearchDeclaration {
     pub max_results: Option<u32>,
 }
 
+/// Per-request Web-fetch config. Both fields are optional overrides: `backend`
+/// pins one of the configured fetch backends by name (else the default), and
+/// `max_content_tokens` lowers the per-call content cap. The URL itself rides the
+/// tool call's arguments, not the declaration.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct WebFetchDeclaration {
+    /// Pin a configured backend by name (else the deployment default).
+    pub backend: Option<String>,
+    /// Cap on returned content for this request, in tokens (else the deployment
+    /// default).
+    pub max_content_tokens: Option<u32>,
+}
+
 /// Per-request Sub-agent config (worker model + instructions + tools).
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct SubAgentConfig {
@@ -88,6 +103,8 @@ pub struct ServerToolDeclarations {
     pub fusion: Option<FusionConfig>,
     /// The web-search declaration, if any.
     pub web_search: Option<WebSearchDeclaration>,
+    /// The web-fetch declaration, if any.
+    pub web_fetch: Option<WebFetchDeclaration>,
     /// The outer request model — the default nested model.
     pub parent_model: String,
 }
@@ -130,6 +147,12 @@ impl ServerToolDeclarations {
                         max_results: u32_field(args, "max_results"),
                     });
                 }
+                Some(Kind::WebFetch) => {
+                    decls.web_fetch = Some(WebFetchDeclaration {
+                        backend: str_field(args, "backend"),
+                        max_content_tokens: u32_field(args, "max_content_tokens"),
+                    });
+                }
                 None => {}
             }
         }
@@ -149,6 +172,7 @@ impl ServerToolDeclarations {
             && self.subagent.is_none()
             && self.fusion.is_none()
             && self.web_search.is_none()
+            && self.web_fetch.is_none()
     }
 }
 
@@ -156,6 +180,7 @@ enum Kind {
     Advisor,
     SubAgent,
     WebSearch,
+    WebFetch,
 }
 
 /// Recognise an advisor / sub-agent / web-search declaration by tool name: the
@@ -173,6 +198,7 @@ fn server_tool_kind(name: &str) -> Option<Kind> {
         ADVISOR_TOOL => Some(Kind::Advisor),
         SUBAGENT_TOOL => Some(Kind::SubAgent),
         WEB_SEARCH_TOOL if is_bitrouter_namespaced(name) => Some(Kind::WebSearch),
+        WEB_FETCH_TOOL if is_bitrouter_namespaced(name) => Some(Kind::WebFetch),
         _ => None,
     }
 }
@@ -423,5 +449,27 @@ mod tests {
             PipelineContext::new(PipelineRequest::new("m", CallerContext::local(), prompt));
         ServerToolDeclarationsHook.check(&mut ctx).await.unwrap();
         assert!(ctx.get_metadata(declarations_plugin_id()).is_none());
+    }
+
+    #[test]
+    fn parses_web_fetch_declaration() {
+        let decls = ServerToolDeclarations::from_prompt(&prompt_with(vec![provider_tool(
+            "bitrouter:web_fetch",
+            serde_json::json!({ "backend": "exa", "max_content_tokens": 2000 }),
+        )]));
+        assert!(!decls.is_empty());
+        let wf = decls.web_fetch.expect("web_fetch parsed");
+        assert_eq!(wf.backend.as_deref(), Some("exa"));
+        assert_eq!(wf.max_content_tokens, Some(2000));
+    }
+
+    #[test]
+    fn bare_web_fetch_is_not_a_declaration() {
+        let decls = ServerToolDeclarations::from_prompt(&prompt_with(vec![provider_tool(
+            "web_fetch",
+            serde_json::json!({}),
+        )]));
+        assert!(decls.web_fetch.is_none());
+        assert!(decls.is_empty());
     }
 }

--- a/crates/bitrouter-sdk/src/language_model/server_tools/mod.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/mod.rs
@@ -27,4 +27,5 @@ pub mod nested;
 pub mod stream;
 pub mod sub_agent;
 pub mod toolset;
+pub mod web_fetch;
 pub mod web_search;

--- a/crates/bitrouter-sdk/src/language_model/server_tools/web_fetch/backend.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/web_fetch/backend.rs
@@ -11,8 +11,9 @@ use serde::Serialize;
 use crate::language_model::server_tools::toolset::ToolContext;
 
 /// Characters per token, the estimate used to turn a `max_content_tokens` cap
-/// into a character budget. Mirrors the SDK's existing
-/// `CHARS_PER_TOKEN_ESTIMATE` convention (see `language_model::stream`).
+/// into a character budget. This is the first public export of the SDK-internal
+/// value `4` (mirrored privately in `language_model::stream` /
+/// `language_model::context`); prefer importing this constant over hard-coding it.
 pub const CHARS_PER_TOKEN: u64 = 4;
 
 /// Per-call fetch options the toolset derives from the tool arguments and the
@@ -84,5 +85,6 @@ mod tests {
         assert_eq!(v["content"], "hello");
         assert!(v.get("title").is_none());
         assert!(v.get("published").is_none());
+        assert_eq!(v.as_object().unwrap().len(), 3);
     }
 }

--- a/crates/bitrouter-sdk/src/language_model/server_tools/web_fetch/backend.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/web_fetch/backend.rs
@@ -11,9 +11,10 @@ use serde::Serialize;
 use crate::language_model::server_tools::toolset::ToolContext;
 
 /// Characters per token, the estimate used to turn a `max_content_tokens` cap
-/// into a character budget. This is the first public export of the SDK-internal
-/// value `4` (mirrored privately in `language_model::stream` /
-/// `language_model::context`); prefer importing this constant over hard-coding it.
+/// into a character budget. Matches the SDK's `~4 chars/token` heuristic used
+/// privately for usage estimation (`language_model::stream` /
+/// `language_model::context`); those copies are intentionally not coupled to this
+/// one, since they round token *estimates* up while this scales a content *cap*.
 pub const CHARS_PER_TOKEN: u64 = 4;
 
 /// Per-call fetch options the toolset derives from the tool arguments and the

--- a/crates/bitrouter-sdk/src/language_model/server_tools/web_fetch/backend.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/web_fetch/backend.rs
@@ -1,0 +1,88 @@
+//! The [`WebFetchBackend`] executor seam and the normalized result the
+//! `web_fetch` server tool returns. A backend is the *engine* behind one fetch —
+//! a BYOK extraction API. The result schema is deliberately minimal and stable:
+//! `content` is always present (a fetch that yields none is an error), every
+//! other field beyond `url` is optional because the engines disagree on what
+//! they return.
+
+use async_trait::async_trait;
+use serde::Serialize;
+
+use crate::language_model::server_tools::toolset::ToolContext;
+
+/// Characters per token, the estimate used to turn a `max_content_tokens` cap
+/// into a character budget. Mirrors the SDK's existing
+/// `CHARS_PER_TOKEN_ESTIMATE` convention (see `language_model::stream`).
+pub const CHARS_PER_TOKEN: u64 = 4;
+
+/// Per-call fetch options the toolset derives from the tool arguments and the
+/// caller's declaration. Minimal for the first cut.
+#[derive(Clone, Debug)]
+pub struct FetchOptions {
+    /// Approximate cap on returned content, in tokens (enforced as
+    /// `tokens * CHARS_PER_TOKEN` characters).
+    pub max_content_tokens: u32,
+}
+
+/// One normalized fetched page. `content` is required (an empty fetch is treated
+/// as a backend error); `title` and `published` are optional because not every
+/// engine returns them.
+#[derive(Clone, Debug, Default, PartialEq, Serialize)]
+pub struct WebFetchResult {
+    /// Which backend served this call (failover/observability transparency).
+    pub backend: String,
+    /// The fetched URL the backend reports (post-redirect when available, else
+    /// the requested URL).
+    pub url: String,
+    /// Page title, when the backend provides one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    /// Extracted page content (markdown / text), truncated to the content cap.
+    pub content: String,
+    /// Publication date as the backend reported it (ISO-ish string).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub published: Option<String>,
+}
+
+/// An extraction engine the `web_fetch` server tool can dispatch a URL to.
+///
+/// `fetch` returns a human-readable `Err` (not a [`crate::error::Result`]) so the
+/// toolset can fail over to the next configured backend and, if all fail, surface
+/// the message to the model as a `status: "error"` tool result — the same
+/// convention the `web_search` toolset uses.
+#[async_trait]
+pub trait WebFetchBackend: Send + Sync {
+    /// Stable identifier (e.g. `"exa"`), used to match a caller's per-request
+    /// backend override and to label the result.
+    fn name(&self) -> &str;
+
+    /// Fetch one URL. `ctx` is the per-request context (HTTP backends ignore it).
+    async fn fetch(
+        &self,
+        url: &str,
+        opts: &FetchOptions,
+        ctx: &ToolContext,
+    ) -> std::result::Result<WebFetchResult, String>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn result_serializes_skipping_none_fields() {
+        let r = WebFetchResult {
+            backend: "exa".to_string(),
+            url: "https://a".to_string(),
+            title: None,
+            content: "hello".to_string(),
+            published: None,
+        };
+        let v = serde_json::to_value(&r).unwrap();
+        assert_eq!(v["backend"], "exa");
+        assert_eq!(v["url"], "https://a");
+        assert_eq!(v["content"], "hello");
+        assert!(v.get("title").is_none());
+        assert!(v.get("published").is_none());
+    }
+}

--- a/crates/bitrouter-sdk/src/language_model/server_tools/web_fetch/config.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/web_fetch/config.rs
@@ -79,8 +79,14 @@ mod tests {
         assert_eq!(s.backends.len(), 3);
         assert_eq!(s.max_content_tokens, Some(1000));
         assert!(matches!(s.backends[0], WebFetchBackendConfig::Exa { .. }));
-        assert!(matches!(s.backends[1], WebFetchBackendConfig::Firecrawl { .. }));
-        assert!(matches!(s.backends[2], WebFetchBackendConfig::Tavily { .. }));
+        assert!(matches!(
+            s.backends[1],
+            WebFetchBackendConfig::Firecrawl { .. }
+        ));
+        assert!(matches!(
+            s.backends[2],
+            WebFetchBackendConfig::Tavily { .. }
+        ));
     }
 
     #[test]

--- a/crates/bitrouter-sdk/src/language_model/server_tools/web_fetch/config.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/web_fetch/config.rs
@@ -80,6 +80,7 @@ mod tests {
         assert_eq!(s.max_content_tokens, Some(1000));
         assert!(matches!(s.backends[0], WebFetchBackendConfig::Exa { .. }));
         assert!(matches!(s.backends[1], WebFetchBackendConfig::Firecrawl { .. }));
+        assert!(matches!(s.backends[2], WebFetchBackendConfig::Tavily { .. }));
     }
 
     #[test]

--- a/crates/bitrouter-sdk/src/language_model/server_tools/web_fetch/config.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/web_fetch/config.rs
@@ -1,0 +1,91 @@
+//! The `server_tools.web_fetch` deployment config: an ordered list of BYOK
+//! extraction backends the `web_fetch` server tool may use. Order is preference
+//! and failover; the first resolvable backend is the default, and a caller's
+//! per-request declaration may pin another by name. Plain data — the app
+//! resolves API keys and constructs the live backends from this (see
+//! `apps/bitrouter` assembly).
+
+use serde::Deserialize;
+
+/// Default per-call content cap (in tokens) when neither the caller nor the
+/// config sets one.
+pub const DEFAULT_MAX_CONTENT_TOKENS: u32 = 25_000;
+
+/// The `server_tools.web_fetch` section. Its presence enables the
+/// `bitrouter:web_fetch` server tool (advertised only when a request declares
+/// it). An empty `backends` list leaves the tool effectively off.
+#[derive(Debug, Clone, Default, Deserialize, schemars::JsonSchema)]
+#[serde(default)]
+pub struct WebFetchSettings {
+    /// Extraction backends in preference/failover order; the first that resolves
+    /// a key is the default.
+    pub backends: Vec<WebFetchBackendConfig>,
+    /// Default cap on returned content per fetch, in tokens (caller may lower
+    /// it). Defaults to [`DEFAULT_MAX_CONTENT_TOKENS`].
+    pub max_content_tokens: Option<u32>,
+}
+
+/// One configured extraction backend. The `kind` tag selects the engine; the
+/// BYOK key resolves from `api_key` (supports `${VAR}` substitution) or, when
+/// omitted, the engine's conventional environment variable.
+#[derive(Debug, Clone, Deserialize, schemars::JsonSchema)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum WebFetchBackendConfig {
+    /// exa.ai `/contents` — key `api_key` or `EXA_API_KEY`.
+    Exa {
+        /// Explicit API key (else `EXA_API_KEY`).
+        #[serde(default)]
+        api_key: Option<String>,
+        /// Endpoint override (else the engine default).
+        #[serde(default)]
+        api_base: Option<String>,
+    },
+    /// firecrawl.dev `/v2/scrape` — key `api_key` or `FIRECRAWL_API_KEY`.
+    Firecrawl {
+        /// Explicit API key (else `FIRECRAWL_API_KEY`).
+        #[serde(default)]
+        api_key: Option<String>,
+        /// Endpoint override (else the engine default).
+        #[serde(default)]
+        api_base: Option<String>,
+    },
+    /// tavily.com `/extract` — key `api_key` or `TAVILY_API_KEY`.
+    Tavily {
+        /// Explicit API key (else `TAVILY_API_KEY`).
+        #[serde(default)]
+        api_key: Option<String>,
+        /// Endpoint override (else the engine default).
+        #[serde(default)]
+        api_base: Option<String>,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn deserializes_backends_in_order() {
+        let s: WebFetchSettings = serde_json::from_value(json!({
+            "backends": [
+                { "kind": "exa", "api_key": "k" },
+                { "kind": "firecrawl" },
+                { "kind": "tavily", "api_base": "https://example/extract" }
+            ],
+            "max_content_tokens": 1000
+        }))
+        .unwrap();
+        assert_eq!(s.backends.len(), 3);
+        assert_eq!(s.max_content_tokens, Some(1000));
+        assert!(matches!(s.backends[0], WebFetchBackendConfig::Exa { .. }));
+        assert!(matches!(s.backends[1], WebFetchBackendConfig::Firecrawl { .. }));
+    }
+
+    #[test]
+    fn defaults_to_empty() {
+        let s = WebFetchSettings::default();
+        assert!(s.backends.is_empty());
+        assert!(s.max_content_tokens.is_none());
+    }
+}

--- a/crates/bitrouter-sdk/src/language_model/server_tools/web_fetch/http.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/web_fetch/http.rs
@@ -1,0 +1,320 @@
+//! BYOK HTTP extraction backends: Exa, Firecrawl, and Tavily. Each maps the
+//! shared [`WebFetchBackend`] fetch onto the provider's REST extract endpoint and
+//! normalizes its response into a [`WebFetchResult`]. Responses are parsed
+//! defensively through [`serde_json::Value`] so a provider adding or renaming a
+//! field never hard-fails the request — a missing field just yields `None` (or an
+//! empty content string, which the caller treats as a failed fetch).
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+
+use super::backend::{CHARS_PER_TOKEN, FetchOptions, WebFetchBackend, WebFetchResult};
+use crate::language_model::server_tools::toolset::ToolContext;
+
+/// Exa's `/contents` caps `text.maxCharacters` at 10000.
+const EXA_MAX_CHARACTERS: u64 = 10_000;
+
+/// The HTTP extraction providers BitRouter speaks natively.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HttpFetchEngine {
+    /// exa.ai — `POST /contents`, `x-api-key`, content under `results[].text`.
+    Exa,
+    /// firecrawl.dev — `POST /v2/scrape`, bearer, content under `data.markdown`.
+    Firecrawl,
+    /// tavily.com — `POST /extract`, bearer, content under `results[].raw_content`.
+    Tavily,
+}
+
+impl HttpFetchEngine {
+    /// The stable backend name a caller uses to pin this engine.
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::Exa => "exa",
+            Self::Firecrawl => "firecrawl",
+            Self::Tavily => "tavily",
+        }
+    }
+
+    /// The conventional environment variable holding this engine's BYOK key
+    /// (shared with the `web_search` backends of the same provider).
+    pub fn env_var(self) -> &'static str {
+        match self {
+            Self::Exa => "EXA_API_KEY",
+            Self::Firecrawl => "FIRECRAWL_API_KEY",
+            Self::Tavily => "TAVILY_API_KEY",
+        }
+    }
+
+    /// The default extract endpoint (overridable per backend).
+    fn default_base(self) -> &'static str {
+        match self {
+            Self::Exa => "https://api.exa.ai/contents",
+            Self::Firecrawl => "https://api.firecrawl.dev/v2/scrape",
+            Self::Tavily => "https://api.tavily.com/extract",
+        }
+    }
+}
+
+/// A BYOK HTTP extraction backend bound to one [`HttpFetchEngine`] and API key.
+pub struct HttpFetchBackend {
+    engine: HttpFetchEngine,
+    api_key: String,
+    base: String,
+    client: reqwest::Client,
+}
+
+impl HttpFetchBackend {
+    /// Build a backend over a shared HTTP client. `base` overrides the engine's
+    /// default endpoint when `Some`.
+    pub fn new(
+        engine: HttpFetchEngine,
+        api_key: String,
+        base: Option<String>,
+        client: reqwest::Client,
+    ) -> Self {
+        Self {
+            engine,
+            api_key,
+            base: base.unwrap_or_else(|| engine.default_base().to_string()),
+            client,
+        }
+    }
+
+    /// The request body for `url` under `opts`, in the engine's shape.
+    fn request_body(&self, url: &str, opts: &FetchOptions) -> Value {
+        match self.engine {
+            HttpFetchEngine::Exa => {
+                let max_chars =
+                    (opts.max_content_tokens as u64 * CHARS_PER_TOKEN).min(EXA_MAX_CHARACTERS);
+                json!({ "urls": [url], "text": { "maxCharacters": max_chars } })
+            }
+            HttpFetchEngine::Firecrawl => json!({
+                "url": url,
+                "formats": ["markdown"],
+                "onlyMainContent": true,
+            }),
+            HttpFetchEngine::Tavily => json!({ "urls": url, "format": "markdown" }),
+        }
+    }
+
+    /// Attach the engine's auth header.
+    fn authorize(&self, req: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        match self.engine {
+            HttpFetchEngine::Exa => req.header("x-api-key", &self.api_key),
+            HttpFetchEngine::Firecrawl | HttpFetchEngine::Tavily => req.bearer_auth(&self.api_key),
+        }
+    }
+
+    /// Normalize a parsed JSON response into the shared schema. `requested_url`
+    /// is the fallback when the backend doesn't echo a (post-redirect) URL.
+    fn parse_response(&self, body: &Value, requested_url: &str) -> WebFetchResult {
+        match self.engine {
+            HttpFetchEngine::Exa => {
+                let first = first_result(body);
+                WebFetchResult {
+                    backend: "exa".to_string(),
+                    url: first
+                        .and_then(|v| str_at(v, "url"))
+                        .unwrap_or_else(|| requested_url.to_string()),
+                    title: first.and_then(|v| str_at(v, "title")),
+                    content: first.and_then(|v| str_at(v, "text")).unwrap_or_default(),
+                    published: first.and_then(|v| str_at(v, "publishedDate")),
+                }
+            }
+            HttpFetchEngine::Firecrawl => {
+                let data = body.get("data");
+                let meta = data.and_then(|d| d.get("metadata"));
+                WebFetchResult {
+                    backend: "firecrawl".to_string(),
+                    url: meta
+                        .and_then(|m| str_at(m, "url"))
+                        .or_else(|| meta.and_then(|m| str_at(m, "sourceURL")))
+                        .unwrap_or_else(|| requested_url.to_string()),
+                    title: meta.and_then(|m| str_at(m, "title")),
+                    content: data.and_then(|d| str_at(d, "markdown")).unwrap_or_default(),
+                    published: None,
+                }
+            }
+            HttpFetchEngine::Tavily => {
+                let first = first_result(body);
+                WebFetchResult {
+                    backend: "tavily".to_string(),
+                    url: first
+                        .and_then(|v| str_at(v, "url"))
+                        .unwrap_or_else(|| requested_url.to_string()),
+                    title: None,
+                    content: first.and_then(|v| str_at(v, "raw_content")).unwrap_or_default(),
+                    published: None,
+                }
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl WebFetchBackend for HttpFetchBackend {
+    fn name(&self) -> &str {
+        self.engine.name()
+    }
+
+    async fn fetch(
+        &self,
+        url: &str,
+        opts: &FetchOptions,
+        _ctx: &ToolContext,
+    ) -> std::result::Result<WebFetchResult, String> {
+        let body = self.request_body(url, opts);
+        let resp = self
+            .authorize(self.client.post(&self.base).json(&body))
+            .send()
+            .await
+            .map_err(|e| format!("{} request failed: {e}", self.engine.name()))?;
+        let status = resp.status();
+        let text = resp
+            .text()
+            .await
+            .map_err(|e| format!("{} response read failed: {e}", self.engine.name()))?;
+        if !status.is_success() {
+            return Err(format!(
+                "{} returned {}: {}",
+                self.engine.name(),
+                status.as_u16(),
+                text.chars().take(500).collect::<String>()
+            ));
+        }
+        let parsed: Value = serde_json::from_str(&text)
+            .map_err(|e| format!("{} returned non-JSON: {e}", self.engine.name()))?;
+        let mut result = self.parse_response(&parsed, url);
+        if result.content.is_empty() {
+            return Err(format!("{}: no content for {url}", self.engine.name()));
+        }
+        result.content = truncate_content(result.content, opts);
+        Ok(result)
+    }
+}
+
+/// First element of a top-level `results` array, when present and an object.
+fn first_result(body: &Value) -> Option<&Value> {
+    body.get("results")
+        .and_then(|v| v.as_array())
+        .and_then(|a| a.first())
+        .filter(|v| v.is_object())
+}
+
+/// Read a string field from a JSON object.
+fn str_at(v: &Value, key: &str) -> Option<String> {
+    v.get(key).and_then(|x| x.as_str()).map(str::to_string)
+}
+
+/// Trim `content` to the `max_content_tokens` budget, approximated as
+/// `tokens * CHARS_PER_TOKEN` characters. Some engines take no size parameter,
+/// so the cap is always enforced here too.
+fn truncate_content(content: String, opts: &FetchOptions) -> String {
+    let max_chars = opts.max_content_tokens as usize * CHARS_PER_TOKEN as usize;
+    if content.chars().count() > max_chars {
+        content.chars().take(max_chars).collect()
+    } else {
+        content
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn backend(engine: HttpFetchEngine) -> HttpFetchBackend {
+        HttpFetchBackend::new(engine, "k".into(), None, reqwest::Client::new())
+    }
+
+    #[test]
+    fn request_bodies_use_each_engines_field_names() {
+        let opts = FetchOptions { max_content_tokens: 1000 };
+
+        let e = backend(HttpFetchEngine::Exa).request_body("https://a", &opts);
+        assert_eq!(e["urls"][0], "https://a");
+        assert_eq!(e["text"]["maxCharacters"], 4000);
+
+        let f = backend(HttpFetchEngine::Firecrawl).request_body("https://a", &opts);
+        assert_eq!(f["url"], "https://a");
+        assert_eq!(f["formats"][0], "markdown");
+        assert_eq!(f["onlyMainContent"], true);
+
+        let t = backend(HttpFetchEngine::Tavily).request_body("https://a", &opts);
+        assert_eq!(t["urls"], "https://a");
+        assert_eq!(t["format"], "markdown");
+    }
+
+    #[test]
+    fn exa_max_characters_is_capped_at_engine_ceiling() {
+        let opts = FetchOptions { max_content_tokens: 1_000_000 };
+        let e = backend(HttpFetchEngine::Exa).request_body("https://a", &opts);
+        assert_eq!(e["text"]["maxCharacters"], 10_000);
+    }
+
+    #[test]
+    fn parses_exa_contents() {
+        let body = json!({
+            "results": [{
+                "url": "https://a/final", "title": "A",
+                "publishedDate": "2024-01-01", "text": "body text"
+            }]
+        });
+        let r = backend(HttpFetchEngine::Exa).parse_response(&body, "https://a");
+        assert_eq!(r.backend, "exa");
+        assert_eq!(r.url, "https://a/final");
+        assert_eq!(r.title.as_deref(), Some("A"));
+        assert_eq!(r.content, "body text");
+        assert_eq!(r.published.as_deref(), Some("2024-01-01"));
+    }
+
+    #[test]
+    fn parses_firecrawl_scrape() {
+        let body = json!({
+            "success": true,
+            "data": {
+                "markdown": "# Y",
+                "metadata": { "title": "Y", "url": "https://y/final", "sourceURL": "https://y" }
+            }
+        });
+        let r = backend(HttpFetchEngine::Firecrawl).parse_response(&body, "https://y");
+        assert_eq!(r.backend, "firecrawl");
+        assert_eq!(r.url, "https://y/final");
+        assert_eq!(r.title.as_deref(), Some("Y"));
+        assert_eq!(r.content, "# Y");
+        assert!(r.published.is_none());
+    }
+
+    #[test]
+    fn parses_tavily_extract() {
+        let body = json!({
+            "results": [{ "url": "https://t", "raw_content": "raw page" }],
+            "failed_results": []
+        });
+        let r = backend(HttpFetchEngine::Tavily).parse_response(&body, "https://t");
+        assert_eq!(r.backend, "tavily");
+        assert_eq!(r.url, "https://t");
+        assert!(r.title.is_none());
+        assert_eq!(r.content, "raw page");
+    }
+
+    #[test]
+    fn missing_result_falls_back_to_requested_url_and_empty_content() {
+        let r = backend(HttpFetchEngine::Exa).parse_response(&json!({}), "https://req");
+        assert_eq!(r.url, "https://req");
+        assert!(r.content.is_empty());
+    }
+
+    #[test]
+    fn truncate_content_trims_to_char_budget() {
+        let opts = FetchOptions { max_content_tokens: 2 };
+        let trimmed = truncate_content("0123456789".to_string(), &opts);
+        assert_eq!(trimmed, "01234567");
+    }
+
+    #[test]
+    fn truncate_content_leaves_short_content_untouched() {
+        let opts = FetchOptions { max_content_tokens: 2 };
+        assert_eq!(truncate_content("abc".to_string(), &opts), "abc");
+    }
+}

--- a/crates/bitrouter-sdk/src/language_model/server_tools/web_fetch/http.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/web_fetch/http.rs
@@ -143,7 +143,9 @@ impl HttpFetchBackend {
                         .and_then(|v| str_at(v, "url"))
                         .unwrap_or_else(|| requested_url.to_string()),
                     title: None,
-                    content: first.and_then(|v| str_at(v, "raw_content")).unwrap_or_default(),
+                    content: first
+                        .and_then(|v| str_at(v, "raw_content"))
+                        .unwrap_or_default(),
                     published: None,
                 }
             }
@@ -231,7 +233,9 @@ mod tests {
 
     #[test]
     fn request_bodies_use_each_engines_field_names() {
-        let opts = FetchOptions { max_content_tokens: 1000 };
+        let opts = FetchOptions {
+            max_content_tokens: 1000,
+        };
 
         let e = backend(HttpFetchEngine::Exa).request_body("https://a", &opts);
         assert_eq!(e["urls"][0], "https://a");
@@ -249,7 +253,9 @@ mod tests {
 
     #[test]
     fn exa_max_characters_is_capped_at_engine_ceiling() {
-        let opts = FetchOptions { max_content_tokens: 1_000_000 };
+        let opts = FetchOptions {
+            max_content_tokens: 1_000_000,
+        };
         let e = backend(HttpFetchEngine::Exa).request_body("https://a", &opts);
         assert_eq!(e["text"]["maxCharacters"], 10_000);
     }
@@ -309,14 +315,18 @@ mod tests {
 
     #[test]
     fn truncate_content_trims_to_char_budget() {
-        let opts = FetchOptions { max_content_tokens: 2 };
+        let opts = FetchOptions {
+            max_content_tokens: 2,
+        };
         let trimmed = truncate_content("0123456789".to_string(), &opts);
         assert_eq!(trimmed, "01234567");
     }
 
     #[test]
     fn truncate_content_leaves_short_content_untouched() {
-        let opts = FetchOptions { max_content_tokens: 2 };
+        let opts = FetchOptions {
+            max_content_tokens: 2,
+        };
         assert_eq!(truncate_content("abc".to_string(), &opts), "abc");
     }
 }

--- a/crates/bitrouter-sdk/src/language_model/server_tools/web_fetch/http.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/web_fetch/http.rs
@@ -93,7 +93,7 @@ impl HttpFetchBackend {
                 "formats": ["markdown"],
                 "onlyMainContent": true,
             }),
-            HttpFetchEngine::Tavily => json!({ "urls": url, "format": "markdown" }),
+            HttpFetchEngine::Tavily => json!({ "urls": [url], "format": "markdown" }),
         }
     }
 
@@ -185,6 +185,8 @@ impl WebFetchBackend for HttpFetchBackend {
         let parsed: Value = serde_json::from_str(&text)
             .map_err(|e| format!("{} returned non-JSON: {e}", self.engine.name()))?;
         let mut result = self.parse_response(&parsed, url);
+        // A blank extraction is treated as a failed fetch so the toolset fails
+        // over to the next backend (see `WebFetchResult`: content is required).
         if result.content.is_empty() {
             return Err(format!("{}: no content for {url}", self.engine.name()));
         }
@@ -241,7 +243,7 @@ mod tests {
         assert_eq!(f["onlyMainContent"], true);
 
         let t = backend(HttpFetchEngine::Tavily).request_body("https://a", &opts);
-        assert_eq!(t["urls"], "https://a");
+        assert_eq!(t["urls"][0], "https://a");
         assert_eq!(t["format"], "markdown");
     }
 

--- a/crates/bitrouter-sdk/src/language_model/server_tools/web_fetch/http.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/web_fetch/http.rs
@@ -11,17 +11,22 @@ use serde_json::{Value, json};
 use super::backend::{CHARS_PER_TOKEN, FetchOptions, WebFetchBackend, WebFetchResult};
 use crate::language_model::server_tools::toolset::ToolContext;
 
-/// Exa's `/contents` caps `text.maxCharacters` at 10000.
+/// Exa's `/contents` caps `text.maxCharacters` at 10000 (per the API schema's
+/// documented maximum). See <https://docs.exa.ai/reference/get-contents>.
 const EXA_MAX_CHARACTERS: u64 = 10_000;
 
-/// The HTTP extraction providers BitRouter speaks natively.
+/// The HTTP extraction providers BitRouter speaks natively. Each request/response
+/// shape below is mapped from the provider's official extract-endpoint docs.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum HttpFetchEngine {
     /// exa.ai — `POST /contents`, `x-api-key`, content under `results[].text`.
+    /// Docs: <https://docs.exa.ai/reference/get-contents>.
     Exa,
     /// firecrawl.dev — `POST /v2/scrape`, bearer, content under `data.markdown`.
+    /// Docs: <https://docs.firecrawl.dev/api-reference/endpoint/scrape>.
     Firecrawl,
     /// tavily.com — `POST /extract`, bearer, content under `results[].raw_content`.
+    /// Docs: <https://docs.tavily.com/documentation/api-reference/endpoint/extract>.
     Tavily,
 }
 
@@ -112,7 +117,7 @@ impl HttpFetchBackend {
             HttpFetchEngine::Exa => {
                 let first = first_result(body);
                 WebFetchResult {
-                    backend: "exa".to_string(),
+                    backend: self.engine.name().to_string(),
                     url: first
                         .and_then(|v| str_at(v, "url"))
                         .unwrap_or_else(|| requested_url.to_string()),
@@ -125,7 +130,7 @@ impl HttpFetchBackend {
                 let data = body.get("data");
                 let meta = data.and_then(|d| d.get("metadata"));
                 WebFetchResult {
-                    backend: "firecrawl".to_string(),
+                    backend: self.engine.name().to_string(),
                     url: meta
                         .and_then(|m| str_at(m, "url"))
                         .or_else(|| meta.and_then(|m| str_at(m, "sourceURL")))
@@ -138,7 +143,7 @@ impl HttpFetchBackend {
             HttpFetchEngine::Tavily => {
                 let first = first_result(body);
                 WebFetchResult {
-                    backend: "tavily".to_string(),
+                    backend: self.engine.name().to_string(),
                     url: first
                         .and_then(|v| str_at(v, "url"))
                         .unwrap_or_else(|| requested_url.to_string()),
@@ -215,11 +220,13 @@ fn str_at(v: &Value, key: &str) -> Option<String> {
 /// so the cap is always enforced here too.
 fn truncate_content(content: String, opts: &FetchOptions) -> String {
     let max_chars = opts.max_content_tokens as usize * CHARS_PER_TOKEN as usize;
-    if content.chars().count() > max_chars {
-        content.chars().take(max_chars).collect()
-    } else {
-        content
+    // Byte length is an upper bound on the char count, so content that fits the
+    // budget in bytes also fits in chars — skip the full char scan for the common
+    // in-budget case (only over-budget content pays for the counting pass).
+    if content.len() <= max_chars {
+        return content;
     }
+    content.chars().take(max_chars).collect()
 }
 
 #[cfg(test)]

--- a/crates/bitrouter-sdk/src/language_model/server_tools/web_fetch/http.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/web_fetch/http.rs
@@ -329,4 +329,62 @@ mod tests {
         };
         assert_eq!(truncate_content("abc".to_string(), &opts), "abc");
     }
+
+    /// Live smoke test against the real extraction APIs. Ignored by default; run
+    /// explicitly with the BYOK keys in the environment:
+    ///   EXA_API_KEY=… FIRECRAWL_API_KEY=… TAVILY_API_KEY=… \
+    ///   cargo test -p bitrouter-sdk --all-features live_fetch_smoke -- --ignored --nocapture
+    #[tokio::test]
+    #[ignore = "hits live extraction APIs; requires BYOK keys in env"]
+    async fn live_fetch_smoke() {
+        use crate::caller::CallerContext;
+
+        let ctx = ToolContext::new(CallerContext::local(), Default::default());
+        let opts = FetchOptions {
+            max_content_tokens: 2000,
+        };
+        let client = reqwest::Client::new();
+        let url = "https://en.wikipedia.org/wiki/Rust_(programming_language)";
+
+        let mut failures = Vec::new();
+        for engine in [
+            HttpFetchEngine::Exa,
+            HttpFetchEngine::Firecrawl,
+            HttpFetchEngine::Tavily,
+        ] {
+            let key = std::env::var(engine.env_var())
+                .ok()
+                .filter(|k| !k.is_empty());
+            let Some(key) = key else {
+                println!("SKIP {:<10} (no {})", engine.name(), engine.env_var());
+                continue;
+            };
+            let backend = HttpFetchBackend::new(engine, key, None, client.clone());
+            match backend.fetch(url, &opts, &ctx).await {
+                Ok(r) => {
+                    println!(
+                        "\nOK   {:<10} {} chars  title={:?}  url={}",
+                        r.backend,
+                        r.content.chars().count(),
+                        r.title.as_deref().unwrap_or("—"),
+                        r.url,
+                    );
+                    println!("      {}", r.content.chars().take(160).collect::<String>());
+                    // The cap is 2000 tokens ≈ 8000 chars; content must be trimmed
+                    // to that budget and non-empty.
+                    if r.content.is_empty() {
+                        failures.push(format!("{}: empty content", engine.name()));
+                    }
+                    if r.content.chars().count() > 2000 * CHARS_PER_TOKEN as usize {
+                        failures.push(format!("{}: content exceeded the cap", engine.name()));
+                    }
+                }
+                Err(e) => {
+                    println!("\nFAIL {:<10} {e}", engine.name());
+                    failures.push(format!("{}: {e}", engine.name()));
+                }
+            }
+        }
+        assert!(failures.is_empty(), "live fetch failures: {failures:?}");
+    }
 }

--- a/crates/bitrouter-sdk/src/language_model/server_tools/web_fetch/mod.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/web_fetch/mod.rs
@@ -10,3 +10,4 @@
 pub mod backend;
 pub mod config;
 pub mod http;
+pub mod toolset;

--- a/crates/bitrouter-sdk/src/language_model/server_tools/web_fetch/mod.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/web_fetch/mod.rs
@@ -8,3 +8,4 @@
 //! downstream reaches types directly (e.g. `web_fetch::backend::WebFetchBackend`).
 
 pub mod backend;
+pub mod config;

--- a/crates/bitrouter-sdk/src/language_model/server_tools/web_fetch/mod.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/web_fetch/mod.rs
@@ -1,0 +1,7 @@
+//! The built-in `web_fetch` server tool: fetches one URL's content through a
+//! BYOK extraction backend (Exa / Firecrawl / Tavily) and returns normalized
+//! page content. Structurally a sibling of `web_search` — an ordered
+//! preference/failover backend list, declaration-gated advertisement, and a
+//! stable result schema independent of which backend served the call.
+
+pub mod backend;

--- a/crates/bitrouter-sdk/src/language_model/server_tools/web_fetch/mod.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/web_fetch/mod.rs
@@ -9,3 +9,4 @@
 
 pub mod backend;
 pub mod config;
+pub mod http;

--- a/crates/bitrouter-sdk/src/language_model/server_tools/web_fetch/mod.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/web_fetch/mod.rs
@@ -3,5 +3,8 @@
 //! page content. Structurally a sibling of `web_search` — an ordered
 //! preference/failover backend list, declaration-gated advertisement, and a
 //! stable result schema independent of which backend served the call.
+//!
+//! Per crate guideline 2, this module does not `pub use` from its submodules;
+//! downstream reaches types directly (e.g. `web_fetch::backend::WebFetchBackend`).
 
 pub mod backend;

--- a/crates/bitrouter-sdk/src/language_model/server_tools/web_fetch/toolset.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/web_fetch/toolset.rs
@@ -1,0 +1,288 @@
+//! The `web_fetch` [`RouterToolset`]: advertises one `web_fetch` function tool
+//! (only when the caller declares `bitrouter:web_fetch`) and dispatches each call
+//! to a configured [`WebFetchBackend`]. Backend selection mirrors `web_search` —
+//! an ordered preference list, a per-request override that pins one backend by
+//! name, and failover to the next backend when one errors.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use super::backend::{FetchOptions, WebFetchBackend};
+use crate::error::Result;
+use crate::language_model::server_tools::declarations::{ServerToolDeclarations, WEB_FETCH_TOOL};
+use crate::language_model::server_tools::toolset::{RouterToolset, ToolContext};
+use crate::language_model::types::{ProviderMetadata, Tool, ToolResultOutput};
+
+/// A [`RouterToolset`] exposing the `web_fetch` server tool over one or more
+/// extraction backends.
+pub struct WebFetchToolset {
+    backends: Vec<Arc<dyn WebFetchBackend>>,
+    default_max_content_tokens: u32,
+}
+
+impl WebFetchToolset {
+    /// Build the toolset over an ordered (preference/failover) backend list and
+    /// the deployment default content cap.
+    pub fn new(backends: Vec<Arc<dyn WebFetchBackend>>, default_max_content_tokens: u32) -> Self {
+        Self {
+            backends,
+            default_max_content_tokens,
+        }
+    }
+
+    /// Candidate backends for a call, honoring a `backend` override: the named
+    /// backend first (if configured), then the rest in configured order. An
+    /// unknown name is ignored. Excludes the pinned entry from the tail by index
+    /// (not name) so two same-named backends both stay in the failover chain.
+    fn candidates(&self, override_name: Option<&str>) -> Vec<&Arc<dyn WebFetchBackend>> {
+        let pinned =
+            override_name.and_then(|name| self.backends.iter().position(|b| b.name() == name));
+        let mut ordered: Vec<&Arc<dyn WebFetchBackend>> = Vec::with_capacity(self.backends.len());
+        if let Some(i) = pinned {
+            ordered.push(&self.backends[i]);
+        }
+        for (i, b) in self.backends.iter().enumerate() {
+            if Some(i) != pinned {
+                ordered.push(b);
+            }
+        }
+        ordered
+    }
+}
+
+fn error_output(message: impl Into<String>) -> ToolResultOutput {
+    ToolResultOutput::Json {
+        value: serde_json::json!({ "status": "error", "error": message.into() }),
+    }
+}
+
+#[async_trait]
+impl RouterToolset for WebFetchToolset {
+    async fn list_tools(&self, ctx: &ToolContext) -> Result<Vec<Tool>> {
+        let advertise =
+            ServerToolDeclarations::from_context(ctx).is_some_and(|d| d.web_fetch.is_some());
+        if !advertise || self.backends.is_empty() {
+            return Ok(Vec::new());
+        }
+        Ok(vec![Tool::Function {
+            name: WEB_FETCH_TOOL.to_string(),
+            description: Some(
+                "Fetch and read the full content of a specific web page. Provide a \
+                 `url`; the page is returned as `content` (markdown/text) with its \
+                 `title` and `url` when available."
+                    .to_string(),
+            ),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "url": { "type": "string", "description": "The URL to fetch and read." },
+                    "max_content_tokens": { "type": "integer", "description": "Optional cap on returned content size (approx tokens).", "minimum": 1 }
+                },
+                "required": ["url"],
+                "additionalProperties": false
+            }),
+            strict: None,
+            provider_metadata: ProviderMetadata::new(),
+        }])
+    }
+
+    async fn call_tool(
+        &self,
+        _name: &str,
+        arguments: &str,
+        ctx: &ToolContext,
+    ) -> Result<ToolResultOutput> {
+        let decl = ServerToolDeclarations::from_context(ctx)
+            .and_then(|d| d.web_fetch)
+            .unwrap_or_default();
+        let args: serde_json::Value =
+            serde_json::from_str(arguments).unwrap_or_else(|_| serde_json::json!({}));
+        let Some(url) = args.get("url").and_then(|v| v.as_str()) else {
+            return Ok(error_output("web_fetch call is missing required `url`"));
+        };
+        // Content cap, narrowing from the deployment default through the
+        // declaration to this call's argument: each layer may only *lower* the
+        // cap, never raise it above what the deployment configured.
+        let ceiling = self.default_max_content_tokens;
+        let ceiling = decl.max_content_tokens.map_or(ceiling, |d| d.min(ceiling));
+        let max_content_tokens = args
+            .get("max_content_tokens")
+            .and_then(|v| v.as_u64())
+            .map(|n| (n.min(ceiling as u64)) as u32)
+            .unwrap_or(ceiling)
+            .max(1);
+        let opts = FetchOptions { max_content_tokens };
+
+        let candidates = self.candidates(decl.backend.as_deref());
+        let mut last_error = "no web_fetch backend is configured".to_string();
+        for backend in candidates {
+            match backend.fetch(url, &opts, ctx).await {
+                Ok(result) => match serde_json::to_value(&result) {
+                    Ok(mut value) => {
+                        if let Some(obj) = value.as_object_mut() {
+                            obj.insert("status".to_string(), serde_json::json!("ok"));
+                        }
+                        return Ok(ToolResultOutput::Json { value });
+                    }
+                    Err(err) => last_error = format!("failed to encode result: {err}"),
+                },
+                Err(err) => last_error = err,
+            }
+        }
+        Ok(error_output(last_error))
+    }
+
+    fn owns(&self, name: &str) -> bool {
+        name.rsplit([':', '.']).next().unwrap_or(name) == WEB_FETCH_TOOL
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use super::super::backend::WebFetchResult;
+    use crate::caller::CallerContext;
+    use crate::language_model::server_tools::declarations::{
+        WebFetchDeclaration, declarations_plugin_id,
+    };
+    use std::collections::HashMap;
+
+    /// A backend that returns labeled content, or always errors.
+    struct StubBackend {
+        name: String,
+        ok: bool,
+    }
+    #[async_trait]
+    impl WebFetchBackend for StubBackend {
+        fn name(&self) -> &str {
+            &self.name
+        }
+        async fn fetch(
+            &self,
+            url: &str,
+            _opts: &FetchOptions,
+            _ctx: &ToolContext,
+        ) -> std::result::Result<WebFetchResult, String> {
+            if self.ok {
+                Ok(WebFetchResult {
+                    backend: self.name.clone(),
+                    url: url.to_string(),
+                    title: None,
+                    content: "page".to_string(),
+                    published: None,
+                })
+            } else {
+                Err(format!("{} failed", self.name))
+            }
+        }
+    }
+
+    fn ok(name: &str) -> Arc<dyn WebFetchBackend> {
+        Arc::new(StubBackend { name: name.to_string(), ok: true })
+    }
+    fn err(name: &str) -> Arc<dyn WebFetchBackend> {
+        Arc::new(StubBackend { name: name.to_string(), ok: false })
+    }
+
+    fn ctx_with(decl: Option<WebFetchDeclaration>) -> ToolContext {
+        let mut meta: HashMap<_, _> = HashMap::new();
+        if let Some(d) = decl {
+            let decls = ServerToolDeclarations {
+                web_fetch: Some(d),
+                parent_model: "m".to_string(),
+                ..Default::default()
+            };
+            meta.insert(
+                declarations_plugin_id().clone(),
+                serde_json::to_value(decls).unwrap(),
+            );
+        }
+        ToolContext::new(CallerContext::local(), meta)
+    }
+
+    #[tokio::test]
+    async fn advertises_only_when_declared() {
+        let ts = WebFetchToolset::new(vec![ok("exa")], 5);
+        assert!(ts.list_tools(&ctx_with(None)).await.unwrap().is_empty());
+        let tools = ts
+            .list_tools(&ctx_with(Some(WebFetchDeclaration::default())))
+            .await
+            .unwrap();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].name(), "web_fetch");
+        assert!(ts.owns("web_fetch"));
+        assert!(ts.owns("bitrouter:web_fetch"));
+    }
+
+    #[tokio::test]
+    async fn missing_url_is_an_error_result() {
+        let ts = WebFetchToolset::new(vec![ok("exa")], 5);
+        let out = ts
+            .call_tool("web_fetch", "{}", &ctx_with(Some(WebFetchDeclaration::default())))
+            .await
+            .unwrap();
+        assert!(matches!(&out, ToolResultOutput::Json { value } if value["status"] == "error"));
+    }
+
+    #[tokio::test]
+    async fn dispatches_to_default_backend() {
+        let ts = WebFetchToolset::new(vec![ok("primary"), ok("secondary")], 5);
+        let out = ts
+            .call_tool(
+                "web_fetch",
+                r#"{"url":"https://a"}"#,
+                &ctx_with(Some(WebFetchDeclaration::default())),
+            )
+            .await
+            .unwrap();
+        assert!(matches!(&out, ToolResultOutput::Json { value }
+            if value["status"] == "ok" && value["backend"] == "primary" && value["content"] == "page"));
+    }
+
+    #[tokio::test]
+    async fn backend_override_pins_a_named_backend() {
+        let ts = WebFetchToolset::new(vec![ok("primary"), ok("secondary")], 5);
+        let out = ts
+            .call_tool(
+                "web_fetch",
+                r#"{"url":"https://a"}"#,
+                &ctx_with(Some(WebFetchDeclaration {
+                    backend: Some("secondary".into()),
+                    max_content_tokens: None,
+                })),
+            )
+            .await
+            .unwrap();
+        assert!(matches!(&out, ToolResultOutput::Json { value } if value["backend"] == "secondary"));
+    }
+
+    #[tokio::test]
+    async fn fails_over_to_next_backend_on_error() {
+        let ts = WebFetchToolset::new(vec![err("primary"), ok("secondary")], 5);
+        let out = ts
+            .call_tool(
+                "web_fetch",
+                r#"{"url":"https://a"}"#,
+                &ctx_with(Some(WebFetchDeclaration::default())),
+            )
+            .await
+            .unwrap();
+        assert!(matches!(&out, ToolResultOutput::Json { value }
+            if value["status"] == "ok" && value["backend"] == "secondary"));
+    }
+
+    #[tokio::test]
+    async fn all_backends_failing_yields_error_result() {
+        let ts = WebFetchToolset::new(vec![err("only")], 5);
+        let out = ts
+            .call_tool(
+                "web_fetch",
+                r#"{"url":"https://a"}"#,
+                &ctx_with(Some(WebFetchDeclaration::default())),
+            )
+            .await
+            .unwrap();
+        assert!(matches!(&out, ToolResultOutput::Json { value } if value["status"] == "error"));
+    }
+}

--- a/crates/bitrouter-sdk/src/language_model/server_tools/web_fetch/toolset.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/web_fetch/toolset.rs
@@ -32,9 +32,13 @@ impl WebFetchToolset {
     }
 
     /// Candidate backends for a call, honoring a `backend` override: the named
-    /// backend first (if configured), then the rest in configured order. An
-    /// unknown name is ignored. Excludes the pinned entry from the tail by index
-    /// (not name) so two same-named backends both stay in the failover chain.
+    /// backend comes first (if configured), then the rest in configured order.
+    /// An unknown name is ignored, falling back to the configured order.
+    ///
+    /// The pinned entry is excluded from the tail by *index*, not by name, so
+    /// two backends that happen to share a name (e.g. two `native` backends
+    /// left at the default name) both stay in the failover chain instead of
+    /// collapsing to the first.
     fn candidates(&self, override_name: Option<&str>) -> Vec<&Arc<dyn WebFetchBackend>> {
         let pinned =
             override_name.and_then(|name| self.backends.iter().position(|b| b.name() == name));
@@ -140,8 +144,8 @@ impl RouterToolset for WebFetchToolset {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use super::super::backend::WebFetchResult;
+    use super::*;
     use crate::caller::CallerContext;
     use crate::language_model::server_tools::declarations::{
         WebFetchDeclaration, declarations_plugin_id,
@@ -179,10 +183,64 @@ mod tests {
     }
 
     fn ok(name: &str) -> Arc<dyn WebFetchBackend> {
-        Arc::new(StubBackend { name: name.to_string(), ok: true })
+        Arc::new(StubBackend {
+            name: name.to_string(),
+            ok: true,
+        })
     }
     fn err(name: &str) -> Arc<dyn WebFetchBackend> {
-        Arc::new(StubBackend { name: name.to_string(), ok: false })
+        Arc::new(StubBackend {
+            name: name.to_string(),
+            ok: false,
+        })
+    }
+
+    /// A backend that records the `max_content_tokens` it was handed, so a
+    /// test can assert the cap that actually reaches the engine.
+    struct CapturingBackend {
+        name: String,
+        seen_max_content_tokens: std::sync::Mutex<Option<u32>>,
+    }
+    #[async_trait]
+    impl WebFetchBackend for CapturingBackend {
+        fn name(&self) -> &str {
+            &self.name
+        }
+        async fn fetch(
+            &self,
+            url: &str,
+            opts: &FetchOptions,
+            _ctx: &ToolContext,
+        ) -> std::result::Result<WebFetchResult, String> {
+            *self.seen_max_content_tokens.lock().unwrap() = Some(opts.max_content_tokens);
+            Ok(WebFetchResult {
+                backend: self.name.clone(),
+                url: url.to_string(),
+                title: None,
+                content: "page".to_string(),
+                published: None,
+            })
+        }
+    }
+
+    /// Run one call through a `CapturingBackend` and return the
+    /// `max_content_tokens` the backend saw.
+    async fn capped_max_content_tokens(
+        default_max: u32,
+        decl: WebFetchDeclaration,
+        args: &str,
+    ) -> u32 {
+        let backend = Arc::new(CapturingBackend {
+            name: "cap".to_string(),
+            seen_max_content_tokens: std::sync::Mutex::new(None),
+        });
+        let backends: Vec<Arc<dyn WebFetchBackend>> = vec![backend.clone()];
+        let ts = WebFetchToolset::new(backends, default_max);
+        ts.call_tool("web_fetch", args, &ctx_with(Some(decl)))
+            .await
+            .unwrap();
+        let seen = *backend.seen_max_content_tokens.lock().unwrap();
+        seen.expect("backend was called")
     }
 
     fn ctx_with(decl: Option<WebFetchDeclaration>) -> ToolContext {
@@ -219,7 +277,11 @@ mod tests {
     async fn missing_url_is_an_error_result() {
         let ts = WebFetchToolset::new(vec![ok("exa")], 5);
         let out = ts
-            .call_tool("web_fetch", "{}", &ctx_with(Some(WebFetchDeclaration::default())))
+            .call_tool(
+                "web_fetch",
+                "{}",
+                &ctx_with(Some(WebFetchDeclaration::default())),
+            )
             .await
             .unwrap();
         assert!(matches!(&out, ToolResultOutput::Json { value } if value["status"] == "error"));
@@ -254,7 +316,9 @@ mod tests {
             )
             .await
             .unwrap();
-        assert!(matches!(&out, ToolResultOutput::Json { value } if value["backend"] == "secondary"));
+        assert!(
+            matches!(&out, ToolResultOutput::Json { value } if value["backend"] == "secondary")
+        );
     }
 
     #[tokio::test]
@@ -284,5 +348,66 @@ mod tests {
             .await
             .unwrap();
         assert!(matches!(&out, ToolResultOutput::Json { value } if value["status"] == "error"));
+    }
+
+    #[tokio::test]
+    async fn max_content_tokens_clamps_to_the_deployment_ceiling() {
+        // A call arg above the deployment default is clamped down to it (the
+        // model can't inflate the cap past what the operator configured).
+        assert_eq!(
+            capped_max_content_tokens(
+                5,
+                WebFetchDeclaration::default(),
+                r#"{"url":"https://a","max_content_tokens":100}"#
+            )
+            .await,
+            5
+        );
+        // A lower call arg is honored.
+        assert_eq!(
+            capped_max_content_tokens(
+                5,
+                WebFetchDeclaration::default(),
+                r#"{"url":"https://a","max_content_tokens":2}"#
+            )
+            .await,
+            2
+        );
+        // The declaration only lowers the ceiling, and the call arg cannot
+        // exceed that (now lower) declaration cap.
+        let decl = WebFetchDeclaration {
+            backend: None,
+            max_content_tokens: Some(2),
+        };
+        assert_eq!(
+            capped_max_content_tokens(
+                5,
+                decl.clone(),
+                r#"{"url":"https://a","max_content_tokens":100}"#
+            )
+            .await,
+            2
+        );
+        // The declaration cap also applies when the call omits `max_content_tokens`.
+        assert_eq!(
+            capped_max_content_tokens(5, decl, r#"{"url":"https://a"}"#).await,
+            2
+        );
+    }
+
+    #[tokio::test]
+    async fn same_named_backends_stay_in_the_failover_chain() {
+        // Two backends share the name "dup"; the first errors. Failover must
+        // still reach the second instead of the two collapsing by name.
+        let ts = WebFetchToolset::new(vec![err("dup"), ok("dup")], 5);
+        let out = ts
+            .call_tool(
+                "web_fetch",
+                r#"{"url":"https://a"}"#,
+                &ctx_with(Some(WebFetchDeclaration::default())),
+            )
+            .await
+            .unwrap();
+        assert!(matches!(&out, ToolResultOutput::Json { value } if value["status"] == "ok"));
     }
 }

--- a/schemas/bitrouter.config.schema.json
+++ b/schemas/bitrouter.config.schema.json
@@ -796,6 +796,17 @@
           "description": "Enable the `subagent` server tool (delegate a task to a worker model).\nAdvertised per-request only when the caller declares `bitrouter:subagent`.",
           "type": "boolean"
         },
+        "web_fetch": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WebFetchSettings"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Built-in `web_fetch` server tool (BYOK). When set, the\n`bitrouter:web_fetch` tool is enabled, served by the configured fetch\nbackends. Advertised per-request only when the caller declares it."
+        },
         "web_search": {
           "anyOf": [
             {
@@ -903,6 +914,121 @@
           "type": "string"
         }
       ]
+    },
+    "WebFetchBackendConfig": {
+      "description": "One configured extraction backend. The `kind` tag selects the engine; the\nBYOK key resolves from `api_key` (supports `${VAR}` substitution) or, when\nomitted, the engine's conventional environment variable.",
+      "oneOf": [
+        {
+          "description": "exa.ai `/contents` — key `api_key` or `EXA_API_KEY`.",
+          "properties": {
+            "api_base": {
+              "default": null,
+              "description": "Endpoint override (else the engine default).",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "api_key": {
+              "default": null,
+              "description": "Explicit API key (else `EXA_API_KEY`).",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "kind": {
+              "const": "exa",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "firecrawl.dev `/v2/scrape` — key `api_key` or `FIRECRAWL_API_KEY`.",
+          "properties": {
+            "api_base": {
+              "default": null,
+              "description": "Endpoint override (else the engine default).",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "api_key": {
+              "default": null,
+              "description": "Explicit API key (else `FIRECRAWL_API_KEY`).",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "kind": {
+              "const": "firecrawl",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "tavily.com `/extract` — key `api_key` or `TAVILY_API_KEY`.",
+          "properties": {
+            "api_base": {
+              "default": null,
+              "description": "Endpoint override (else the engine default).",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "api_key": {
+              "default": null,
+              "description": "Explicit API key (else `TAVILY_API_KEY`).",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "kind": {
+              "const": "tavily",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "WebFetchSettings": {
+      "description": "The `server_tools.web_fetch` section. Its presence enables the\n`bitrouter:web_fetch` server tool (advertised only when a request declares\nit). An empty `backends` list leaves the tool effectively off.",
+      "properties": {
+        "backends": {
+          "description": "Extraction backends in preference/failover order; the first that resolves\na key is the default.",
+          "items": {
+            "$ref": "#/$defs/WebFetchBackendConfig"
+          },
+          "type": "array"
+        },
+        "max_content_tokens": {
+          "default": null,
+          "description": "Default cap on returned content per fetch, in tokens (caller may lower\nit). Defaults to [`DEFAULT_MAX_CONTENT_TOKENS`].",
+          "format": "uint32",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
     },
     "WebSearchBackendConfig": {
       "description": "One configured search backend. The `kind` tag selects the engine; the BYOK\nkey resolves from `api_key` (supports `${VAR}` substitution) or, when\nomitted, the engine's conventional environment variable.",

--- a/skills/bitrouter/references/providers.md
+++ b/skills/bitrouter/references/providers.md
@@ -272,6 +272,22 @@ server_tools:
 
 HTTP backends (`parallel` / `exa` / `firecrawl` / `tavily`) take an optional `api_key` (supports `${VAR}`) and `api_base`; a backend with no resolvable key is skipped. The `native` backend runs a nested completion (so it needs a routable model) — it forwards a provider's own search tool, making one provider's native web search usable from models that lack it.
 
+### Built-in web fetch (BYOK)
+
+The `web_fetch` server tool gives any model routed through BitRouter the ability to fetch and read a specific URL's full content, served by a BYOK extraction backend. Advertised only when the caller declares `{"type":"bitrouter:web_fetch"}` (optionally with `backend` / `max_content_tokens` overrides). The model calls `web_fetch` with a `url`; BitRouter fetches it and returns `{status, backend, url, title?, content, published?}`.
+
+```yaml
+server_tools:
+  web_fetch:
+    max_content_tokens: 25000   # default per-fetch content cap (caller may lower)
+    backends:                   # preference / failover order
+      - kind: exa               # POST /contents, key from api_key or EXA_API_KEY
+      - kind: firecrawl         # POST /v2/scrape, key from api_key or FIRECRAWL_API_KEY
+      - kind: tavily            # POST /extract, key from api_key or TAVILY_API_KEY
+```
+
+BYOK extraction happens on the provider's infrastructure (BitRouter does not dereference the URL itself), so the backends own the fetch safety surface.
+
 ## ACP agents
 
 ```yaml


### PR DESCRIPTION
## Summary

Adds a built-in `bitrouter:web_fetch` server tool — a BYOK URL-content fetcher that mirrors the existing `web_search` tool. A model declares `{"type":"bitrouter:web_fetch"}`, calls `web_fetch` with a `url`, and BitRouter fetches the page through a configured extraction backend and returns normalized content.

- **Backends (BYOK, ordered preference + failover):** Exa `/contents`, Firecrawl `/v2/scrape`, Tavily `/extract`. Request shapes/auth verified against current provider docs. (Parallel deferred — its extract endpoint was not verified; trivially addable via the same `HttpFetchEngine` pattern.)
- **No direct-HTTP engine** → extraction runs on provider infra, so BitRouter never dereferences the model-supplied URL and needs no SSRF guard this PR.
- **Result schema:** `{status, backend, url, title?, content, published?}` — defensive `serde_json::Value` parsing; empty extraction → failover.
- **Content cap:** `max_content_tokens` (deployment → declaration → call, each may only lower), enforced as `tokens × 4` chars via the existing `CHARS_PER_TOKEN` convention; pushed to Exa's server-side `maxCharacters` as an optimization.
- **Wiring:** `server_tools.web_fetch` config, declaration parsing (bitrouter-namespace-gated, anti-hijack), `WebFetchToolset`, app assembly (shared `resolve_byok_key`), `server_tools_enabled` updated so a web_fetch-only deployment advertises the tool, regenerated config JSON schema, and skill docs.

Deliberately **out of scope** (later PRs from the design spec): `engine: auto` / native-of-routed-model, `allowed_domains`/`excluded_domains`, per-request call budget (cut as overdesign — the loop already bounds tools uniformly), telemetry.

## Test Plan

- [x] `cargo nextest run --all-features` — 1217 unit/integration tests pass
- [x] `cargo clippy --all-features --all-targets` — clean (no `#[allow]`)
- [x] `cargo fmt -- --check` — clean
- [x] `cargo xtask generate-schema --check` — schema drift guard green
- [x] **Real-environment:** `live_fetch_smoke` (Exa/Firecrawl/Tavily) fetched a live page, content correctly capped; `live_search_smoke` validated all backends; daemon booted with the config and served `GET /v1/models` → 200 with backends resolved
- [ ] Reviewer: confirm engine request/response shapes against current provider APIs

🤖 Generated with [Claude Code](https://claude.com/claude-code)