### PR TITLE
feat(cli): route `update` through the JSON output layer

### DIFF
--- a/apps/bitrouter/src/cloud/cli.rs
+++ b/apps/bitrouter/src/cloud/cli.rs
@@ -748,16 +748,11 @@ async fn run_namespace(action: NamespaceAction) -> std::result::Result<(), SdkEr
         NamespaceAction::Current(flag) => {
             // Offline — the namespace is baked into the local credential.
             let nsid = client.namespace_id();
-            if effective_json(flag.json) {
-                let body = serde_json::json!({ "namespace_id": nsid });
-                println!("{}", serde_json::to_string_pretty(&body)?);
-            } else {
-                match nsid {
-                    Some(id) => println!("{id}"),
-                    None => println!("(no namespace — run `bitrouter cloud login`)"),
-                }
-            }
-            Ok(())
+            let body = serde_json::json!({ "namespace_id": nsid });
+            emit(flag.json, &body, |_| match nsid {
+                Some(id) => id.to_owned(),
+                None => "(no namespace — run `bitrouter cloud login`)".to_owned(),
+            })
         }
     }
 }

--- a/apps/bitrouter/src/main.rs
+++ b/apps/bitrouter/src/main.rs
@@ -712,11 +712,14 @@ async fn run(cli: Cli, output: &bitrouter::output::Output) -> Result<()> {
             };
             let outcome = bitrouter::update::run(opts, &socket).await?;
             if outcome.restart_needed {
+                // Bring the daemon onto the new binary before emitting, so a
+                // restart failure surfaces as the error envelope. The restart's
+                // own report is folded into `outcome.report.daemon`.
                 let log_path = resolve_log_path(source.home(), None);
-                restart(&source, &socket, &log_path).await.map(|_| ())
-            } else {
-                Ok(())
+                restart(&source, &socket, &log_path).await?;
             }
+            output.emit(&outcome.report)?;
+            Ok(())
         }
     }
 }

--- a/apps/bitrouter/src/output/reports/mod.rs
+++ b/apps/bitrouter/src/output/reports/mod.rs
@@ -12,4 +12,5 @@ pub mod observe;
 pub mod routing;
 pub mod skills;
 pub mod tools;
+pub mod update;
 pub mod verify;

--- a/apps/bitrouter/src/output/reports/update.rs
+++ b/apps/bitrouter/src/output/reports/update.rs
@@ -1,0 +1,321 @@
+//! Report for the `bitrouter update` self-updater.
+//!
+//! Every terminal outcome of `update` — a package-manager delegation, a
+//! `--check` probe, a declined confirmation, a no-op, or a completed swap —
+//! is one [`UpdateReport`]. Interactive prompts and progress are diagnostics
+//! and go to stderr; this is the single result value on stdout.
+
+use serde::Serialize;
+
+use crate::output::CliReport;
+use crate::output::human::Human;
+
+/// Result of `bitrouter update`. `status` is the discriminant; the remaining
+/// fields are populated only for the outcomes they belong to.
+#[derive(Debug, Serialize)]
+pub struct UpdateReport {
+    /// `delegated` | `checked` | `aborted` | `unchanged` | `updated`.
+    pub status: &'static str,
+    /// The version of the currently-running binary.
+    pub current_version: String,
+    /// `checked`: whether a newer release exists.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub update_available: Option<bool>,
+    /// The version this outcome refers to: the available release (`checked`)
+    /// or the freshly-installed one (`updated`). Absent when unknown / N/A.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target_version: Option<String>,
+    /// `delegated`: how the binary was installed (`homebrew` | `cargo` |
+    /// `unknown`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub install_method: Option<&'static str>,
+    /// `delegated`: the exact command to run to upgrade out-of-band.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub upgrade_command: Option<String>,
+    /// `updated`: the running daemon's fate — `restarted` (we restarted it) or
+    /// `restart_needed` (still on the old binary). Absent when no daemon runs.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub daemon: Option<&'static str>,
+}
+
+impl UpdateReport {
+    /// No cargo-dist receipt: tell the user the package-manager command instead
+    /// of clobbering a managed install.
+    pub fn delegated(
+        current_version: String,
+        install_method: &'static str,
+        upgrade_command: String,
+    ) -> Self {
+        Self {
+            status: "delegated",
+            current_version,
+            update_available: None,
+            target_version: None,
+            install_method: Some(install_method),
+            upgrade_command: Some(upgrade_command),
+            daemon: None,
+        }
+    }
+
+    /// `--check`: report whether a newer release exists, and which (when known).
+    pub fn checked(
+        current_version: String,
+        available: bool,
+        target_version: Option<String>,
+    ) -> Self {
+        Self {
+            status: "checked",
+            current_version,
+            update_available: Some(available),
+            target_version,
+            install_method: None,
+            upgrade_command: None,
+            daemon: None,
+        }
+    }
+
+    /// The user declined the confirmation prompt.
+    pub fn aborted(current_version: String) -> Self {
+        Self {
+            status: "aborted",
+            current_version,
+            update_available: None,
+            target_version: None,
+            install_method: None,
+            upgrade_command: None,
+            daemon: None,
+        }
+    }
+
+    /// The updater ran but the binary was already current.
+    pub fn unchanged(current_version: String) -> Self {
+        Self {
+            status: "unchanged",
+            current_version,
+            update_available: None,
+            target_version: None,
+            install_method: None,
+            upgrade_command: None,
+            daemon: None,
+        }
+    }
+
+    /// The binary was swapped to `new_version`. `daemon` records whether a
+    /// running daemon was restarted onto it or still needs a manual restart.
+    pub fn updated(
+        current_version: String,
+        new_version: String,
+        daemon: Option<&'static str>,
+    ) -> Self {
+        Self {
+            status: "updated",
+            current_version,
+            update_available: None,
+            target_version: Some(new_version),
+            install_method: None,
+            upgrade_command: None,
+            daemon,
+        }
+    }
+}
+
+impl CliReport for UpdateReport {
+    fn render(&self, h: &mut Human<'_>) -> std::io::Result<()> {
+        match self.status {
+            "delegated" => {
+                let how = match self.install_method {
+                    Some("homebrew") => "Homebrew",
+                    Some("cargo") => "Cargo",
+                    _ => "your package manager",
+                };
+                h.line(&format!(
+                    "bitrouter looks installed via {how}. Update with:"
+                ))?;
+                if let Some(cmd) = &self.upgrade_command {
+                    h.line(&format!("    {cmd}"))?;
+                }
+                Ok(())
+            }
+            "checked" => {
+                if self.update_available == Some(true) {
+                    match &self.target_version {
+                        Some(v) => h.line(&format!(
+                            "update available: {} -> {v}",
+                            self.current_version
+                        )),
+                        None => h.line("update available (target version unknown)"),
+                    }
+                } else {
+                    h.line(&format!("up to date ({})", self.current_version))
+                }
+            }
+            "aborted" => h.line("aborted"),
+            "unchanged" => h.line(&format!("already up to date ({})", self.current_version)),
+            "updated" => {
+                let new = self.target_version.as_deref().unwrap_or("(unknown)");
+                h.line(&format!("✓ updated {} -> {new}", self.current_version))?;
+                match self.daemon {
+                    Some("restarted") => {
+                        h.note(&format!("Restarted the running daemon on {new}."))
+                    }
+                    Some("restart_needed") => h.note(&format!(
+                        "A daemon is running the old binary. Run `bitrouter restart` to serve {new}."
+                    )),
+                    _ => Ok(()),
+                }
+            }
+            other => h.line(other),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::output::{Format, Output};
+
+    fn json(r: &dyn CliReport) -> serde_json::Value {
+        serde_json::from_slice(&Output::new(Format::Json).render_to_vec(r)).unwrap()
+    }
+
+    fn human(r: &dyn CliReport) -> String {
+        String::from_utf8(Output::new(Format::Human).render_to_vec(r)).unwrap()
+    }
+
+    #[test]
+    fn delegated_carries_method_and_command() {
+        let r = UpdateReport::delegated(
+            "1.0.0-alpha.19".into(),
+            "homebrew",
+            "brew upgrade bitrouter".into(),
+        );
+        assert_eq!(
+            json(&r),
+            serde_json::json!({
+                "status": "delegated",
+                "current_version": "1.0.0-alpha.19",
+                "install_method": "homebrew",
+                "upgrade_command": "brew upgrade bitrouter"
+            })
+        );
+        let h = human(&r);
+        assert!(h.contains("looks installed via Homebrew"), "{h:?}");
+        assert!(h.contains("    brew upgrade bitrouter"), "{h:?}");
+    }
+
+    #[test]
+    fn checked_available_names_target_version() {
+        let r = UpdateReport::checked("1.0.0-alpha.19".into(), true, Some("1.0.0-alpha.20".into()));
+        assert_eq!(
+            json(&r),
+            serde_json::json!({
+                "status": "checked",
+                "current_version": "1.0.0-alpha.19",
+                "update_available": true,
+                "target_version": "1.0.0-alpha.20"
+            })
+        );
+        assert_eq!(
+            human(&r),
+            "update available: 1.0.0-alpha.19 -> 1.0.0-alpha.20\n"
+        );
+    }
+
+    #[test]
+    fn checked_up_to_date_omits_target() {
+        let r = UpdateReport::checked("1.0.0-alpha.19".into(), false, None);
+        assert_eq!(
+            json(&r),
+            serde_json::json!({
+                "status": "checked",
+                "current_version": "1.0.0-alpha.19",
+                "update_available": false
+            })
+        );
+        assert_eq!(human(&r), "up to date (1.0.0-alpha.19)\n");
+    }
+
+    #[test]
+    fn checked_available_but_target_unknown() {
+        // `is_update_needed()` is true but `query_new_version()` came back empty.
+        let r = UpdateReport::checked("1.0.0-alpha.19".into(), true, None);
+        assert_eq!(
+            json(&r),
+            serde_json::json!({
+                "status": "checked",
+                "current_version": "1.0.0-alpha.19",
+                "update_available": true
+            })
+        );
+        assert_eq!(human(&r), "update available (target version unknown)\n");
+    }
+
+    #[test]
+    fn updated_without_running_daemon_omits_daemon_key() {
+        let r = UpdateReport::updated("1.0.0-alpha.19".into(), "1.0.0-alpha.20".into(), None);
+        assert_eq!(
+            json(&r),
+            serde_json::json!({
+                "status": "updated",
+                "current_version": "1.0.0-alpha.19",
+                "target_version": "1.0.0-alpha.20"
+            })
+        );
+        // No running daemon -> just the result line, no follow-up note.
+        assert_eq!(human(&r), "✓ updated 1.0.0-alpha.19 -> 1.0.0-alpha.20\n");
+    }
+
+    #[test]
+    fn updated_with_restart_hint_renders_note() {
+        let r = UpdateReport::updated(
+            "1.0.0-alpha.19".into(),
+            "1.0.0-alpha.20".into(),
+            Some("restart_needed"),
+        );
+        assert_eq!(
+            json(&r),
+            serde_json::json!({
+                "status": "updated",
+                "current_version": "1.0.0-alpha.19",
+                "target_version": "1.0.0-alpha.20",
+                "daemon": "restart_needed"
+            })
+        );
+        let h = human(&r);
+        assert!(
+            h.contains("✓ updated 1.0.0-alpha.19 -> 1.0.0-alpha.20"),
+            "{h:?}"
+        );
+        assert!(h.contains("Run `bitrouter restart`"), "{h:?}");
+    }
+
+    #[test]
+    fn updated_restarted_omits_hint() {
+        let r = UpdateReport::updated(
+            "1.0.0-alpha.19".into(),
+            "1.0.0-alpha.20".into(),
+            Some("restarted"),
+        );
+        let h = human(&r);
+        assert!(
+            h.contains("Restarted the running daemon on 1.0.0-alpha.20"),
+            "{h:?}"
+        );
+    }
+
+    #[test]
+    fn unchanged_and_aborted_are_one_liners() {
+        assert_eq!(
+            human(&UpdateReport::unchanged("1.0.0-alpha.19".into())),
+            "already up to date (1.0.0-alpha.19)\n"
+        );
+        assert_eq!(
+            human(&UpdateReport::aborted("1.0.0-alpha.19".into())),
+            "aborted\n"
+        );
+        assert_eq!(
+            json(&UpdateReport::aborted("1.0.0-alpha.19".into())),
+            serde_json::json!({"status": "aborted", "current_version": "1.0.0-alpha.19"})
+        );
+    }
+}

--- a/apps/bitrouter/src/update.rs
+++ b/apps/bitrouter/src/update.rs
@@ -3,6 +3,7 @@
 //! nudge-cache TTL) lives in small pure functions so it can be unit-tested
 //! without touching the network or replacing the running binary.
 
+use crate::output::reports::update::UpdateReport;
 use crate::{daemon, style};
 use anyhow::Result;
 use axoupdater::{AxoUpdater, UpdateRequest};
@@ -30,6 +31,15 @@ fn detect_install_method(exe: &Path, cargo_home: Option<&Path>) -> InstallMethod
         return InstallMethod::Cargo;
     }
     InstallMethod::Unknown
+}
+
+/// Stable lowercase label for the JSON `install_method` field.
+fn method_label(method: InstallMethod) -> &'static str {
+    match method {
+        InstallMethod::Homebrew => "homebrew",
+        InstallMethod::Cargo => "cargo",
+        InstallMethod::Unknown => "unknown",
+    }
 }
 
 /// The exact command a user should run to upgrade a package-manager-managed
@@ -79,11 +89,30 @@ pub struct UpdateOptions {
     pub yes: bool,
 }
 
-/// What the dispatch layer must still do after `run` returns.
+/// The result of `run`: the report to emit through the [`Output`] driver, plus
+/// whether the dispatch layer must still restart a running daemon onto the new
+/// binary before emitting.
+///
+/// [`Output`]: crate::output::Output
 #[derive(Debug)]
 pub struct RunOutcome {
-    /// A running daemon needs restarting to pick up the new binary.
+    /// The single result value for `bitrouter update`, rendered to stdout.
+    pub report: UpdateReport,
+    /// A running daemon needs restarting to pick up the new binary. When true,
+    /// `report.daemon` is already set to `restarted` on the optimistic
+    /// assumption the restart succeeds (a failure surfaces as the error
+    /// envelope instead, replacing the whole result).
     pub restart_needed: bool,
+}
+
+impl RunOutcome {
+    /// A terminal outcome that needs no daemon restart.
+    fn done(report: UpdateReport) -> Self {
+        Self {
+            report,
+            restart_needed: false,
+        }
+    }
 }
 
 /// Current binary version, baked in at compile time.
@@ -120,27 +149,17 @@ fn build_updater() -> Option<AxoUpdater> {
 }
 
 pub async fn run(opts: UpdateOptions, socket: &Path) -> Result<RunOutcome> {
-    let p = style::Palette::for_stdout();
-    let current = current_version();
+    let current = current_version().to_string();
 
     // 1. No receipt -> package-manager install; delegate, never clobber.
     let Some(mut updater) = build_updater() else {
         let exe = std::env::current_exe().unwrap_or_default();
         let method = detect_install_method(&exe, cargo_home().as_deref());
-        println!(
-            "{dim}bitrouter looks installed via {how}. Update with:{reset}\n    {cmd}",
-            dim = p.dim,
-            reset = p.reset,
-            how = match method {
-                InstallMethod::Homebrew => "Homebrew",
-                InstallMethod::Cargo => "Cargo",
-                InstallMethod::Unknown => "your package manager",
-            },
-            cmd = delegation_command(method),
-        );
-        return Ok(RunOutcome {
-            restart_needed: false,
-        });
+        return Ok(RunOutcome::done(UpdateReport::delegated(
+            current,
+            method_label(method),
+            delegation_command(method),
+        )));
     };
 
     // 2. Channel / pin.
@@ -156,63 +175,52 @@ pub async fn run(opts: UpdateOptions, socket: &Path) -> Result<RunOutcome> {
 
     // 3. Dry run.
     if opts.check {
-        if updater.is_update_needed().await? {
-            match updater.query_new_version().await? {
-                Some(v) => println!("update available: {current} -> {v}"),
-                None => println!("update available (target version unknown)"),
-            }
+        let available = updater.is_update_needed().await?;
+        let target = if available {
+            updater.query_new_version().await?.map(|v| v.to_string())
         } else {
-            println!("up to date ({current})");
-        }
-        return Ok(RunOutcome {
-            restart_needed: false,
-        });
+            None
+        };
+        return Ok(RunOutcome::done(UpdateReport::checked(
+            current, available, target,
+        )));
     }
 
-    // 4. Confirm + swap.
-    if !opts.yes && !confirm(&p, current, &target_label)? {
-        println!("aborted");
-        return Ok(RunOutcome {
-            restart_needed: false,
-        });
+    // 4. Confirm + swap. The prompt is interactive UI, not the command result,
+    // so it goes to stderr — stdout carries only the final report.
+    if !opts.yes && !confirm(&current, &target_label)? {
+        return Ok(RunOutcome::done(UpdateReport::aborted(current)));
     }
     let Some(result) = updater.run().await? else {
-        println!("already up to date ({current})");
-        return Ok(RunOutcome {
-            restart_needed: false,
-        });
+        return Ok(RunOutcome::done(UpdateReport::unchanged(current)));
     };
-    println!(
-        "{green}✓{reset} updated {current} -> {new}",
-        green = p.green,
-        reset = p.reset,
-        new = result.new_version,
-    );
+    let new_version = result.new_version.to_string();
 
-    // 5. Daemon awareness.
+    // 5. Daemon awareness. The dispatch layer performs the restart (when asked)
+    // before emitting; we label the report optimistically here.
     let daemon_running = daemon::endpoint_in_use(socket);
-    if daemon_running && !opts.restart {
-        println!(
-            "{dim}A daemon is running the old binary. Run `bitrouter restart` to serve {new}.{reset}",
-            dim = p.dim,
-            reset = p.reset,
-            new = result.new_version,
-        );
-    }
+    let (daemon, restart_needed) = match (daemon_running, opts.restart) {
+        (true, true) => (Some("restarted"), true),
+        (true, false) => (Some("restart_needed"), false),
+        (false, _) => (None, false),
+    };
     Ok(RunOutcome {
-        restart_needed: daemon_running && opts.restart,
+        report: UpdateReport::updated(current, new_version, daemon),
+        restart_needed,
     })
 }
 
 /// Interactive y/N confirmation. Defaults to no on empty input or non-tty EOF.
-fn confirm(p: &style::Palette, current: &str, target: &str) -> Result<bool> {
+/// The prompt is written to stderr so stdout stays a clean JSON result.
+fn confirm(current: &str, target: &str) -> Result<bool> {
     use std::io::Write;
-    print!(
+    let p = style::Palette::for_stderr();
+    eprint!(
         "Update bitrouter from {bold}{current}{reset} to {target}? [y/N] ",
         bold = p.bold,
         reset = p.reset,
     );
-    std::io::stdout().flush()?;
+    std::io::stderr().flush()?;
     let mut line = String::new();
     if std::io::stdin().read_line(&mut line)? == 0 {
         return Ok(false);


### PR DESCRIPTION
## What

`bitrouter update` was the one one-shot CLI command still printing ANSI-colored prose to stdout, so it broke the *"every command prints a single clean JSON value to stdout"* contract introduced by the CLI output-layer refactor (#610). This converts it.

```
bitrouter update --check                 # {"status":"checked","current_version":"…","update_available":false}
bitrouter -H update --check              # up to date (1.0.0-alpha.19)
bitrouter update --check 2>/dev/null | jq   # clean JSON, like every other command
```

## How

- **`UpdateReport`** (`output/reports/update.rs`) — a `CliReport` covering every terminal outcome (`delegated` / `checked` / `aborted` / `unchanged` / `updated`), with both the JSON view and a human rendering built from the shared `Human` toolkit.
- **`update::run`** now returns the report instead of printing. The `Command::Update` dispatcher emits it through the single `Output` driver, and restarts a running daemon (when `--restart` is given) **before** emitting — so a restart failure surfaces as the uniform error envelope rather than a double-emit. The `daemon` field records the daemon's fate (`restarted` / `restart_needed`).
- The interactive **confirm prompt moved to stderr**, keeping stdout pure JSON.
- **`cloud namespace current`** now routes through the cloud subtree's `emit` writer instead of an inline `println!` — removing the last stdout bypass in that subtree (byte-identical output in both JSON and human modes).

## Testing

- `cargo clippy --all-targets` clean; `cargo fmt --check` clean.
- `cargo test -p bitrouter`: **216 lib + 2 main + 11 daemon + 22 e2e + 5 full_stack + 1 observe** — all green. The new report has 8 unit tests asserting exact JSON shape + human strings across every outcome (including the `update_available: true` / unknown-target race and the no-daemon case that omits the `daemon` key).
- Smoke-tested the built binary end-to-end: `update --check` and `update` both emit one clean JSON value on stdout, `-H` renders the human view, the confirm prompt is on stderr, and exit codes are correct.

## Notes / non-goals

- The top-level `bitrouter update` command is still absent from `CLI.md` (a pre-existing gap from when the self-updater was added). It's left for a follow-up; this PR keeps the global "every command emits JSON" statement in `CLI.md` accurate by making `update` actually comply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)