### PR TITLE
feat(routing): online adequacy ledger for adaptive policy-table routing

### DIFF
--- a/apps/bitrouter/src/adequacy/mod.rs
+++ b/apps/bitrouter/src/adequacy/mod.rs
@@ -1,0 +1,203 @@
+//! Online adequacy ledger — the escalate-sticky learned state behind adaptive
+//! policy-table routing.
+//!
+//! When `policy_table.adequacy` is enabled, the daemon watches every request a
+//! *downgrade* produced (the policy table routed a fingerprint to a cheaper tier
+//! than its escalation tier) and counts the ones that hard-fail. Once a
+//! fingerprint accumulates `escalation_threshold` failures it is **pinned**: the
+//! adaptive [`crate::policy_table_router::PolicyTableRouter`] then routes that
+//! fingerprint to the escalation tier instead of the cheap one. A pin decays
+//! after `pin_cooldown_secs`, so a downgrade that failed transiently is retried
+//! later rather than abandoned forever.
+//!
+//! This is the safety half of the asymmetric routing rule: the ledger never
+//! downgrades on its own — it only escalates a downgrade that is failing — so it
+//! can only ever make routing *more* conservative than the static table.
+//!
+//! The read path ([`AdequacyLedger::is_pinned`]) is synchronous and lock-cheap
+//! because it runs inside the ingress [`bitrouter_sdk::PromptTransform`]; the
+//! write path ([`AdequacyLedger::observe`]) is async because it persists new
+//! pins, and runs from the [`observer::AdequacyObserveHook`] after each request.
+
+pub mod observer;
+pub mod store;
+
+use std::collections::HashMap;
+use std::sync::{PoisonError, RwLock};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use bitrouter_sdk::config::AdequacyConfig;
+
+use self::store::AdequacyStore;
+
+/// Learned escalation state: which fingerprints are pinned, and the pre-pin
+/// failure tally that drives a pin.
+pub struct AdequacyLedger {
+    state: RwLock<State>,
+    /// Persistence for pins. `None` in unit tests / when no db is wired.
+    store: Option<AdequacyStore>,
+    /// Hard failures on a downgraded fingerprint before it is pinned (>= 1).
+    threshold: u32,
+    /// Seconds a pin lasts before the downgrade is re-attempted. `0` = no decay.
+    cooldown_secs: u64,
+}
+
+#[derive(Default)]
+struct State {
+    /// fingerprint → Unix seconds the pin was last (re)applied.
+    pins: HashMap<String, u64>,
+    /// fingerprint → consecutive hard-failure count (pre-pin, transient).
+    failures: HashMap<String, u32>,
+}
+
+impl AdequacyLedger {
+    /// Build a ledger from config, warming the in-memory pin cache from the
+    /// store. A failed warm-up read is non-fatal (the cache simply starts empty).
+    pub async fn load(config: &AdequacyConfig, store: AdequacyStore) -> Self {
+        let mut pins = HashMap::new();
+        if let Ok(rows) = store.load_all().await {
+            for (fingerprint, pinned_at) in rows {
+                pins.insert(fingerprint, pinned_at.max(0) as u64);
+            }
+        }
+        Self {
+            state: RwLock::new(State {
+                pins,
+                failures: HashMap::new(),
+            }),
+            store: Some(store),
+            threshold: config.escalation_threshold.max(1),
+            cooldown_secs: config.pin_cooldown_secs,
+        }
+    }
+
+    /// An in-memory-only ledger (no persistence) — for tests.
+    #[cfg(test)]
+    pub fn in_memory(threshold: u32, cooldown_secs: u64) -> Self {
+        Self {
+            state: RwLock::new(State::default()),
+            store: None,
+            threshold: threshold.max(1),
+            cooldown_secs,
+        }
+    }
+
+    /// Whether `fingerprint` is currently pinned to the escalation tier. Sync,
+    /// for the router's hot path; a pin past its cooldown reads as not pinned.
+    pub fn is_pinned(&self, fingerprint: &str) -> bool {
+        let guard = self.state.read().unwrap_or_else(PoisonError::into_inner);
+        match guard.pins.get(fingerprint) {
+            Some(&pinned_at) => {
+                self.cooldown_secs == 0 || now_unix().saturating_sub(pinned_at) < self.cooldown_secs
+            }
+            None => false,
+        }
+    }
+
+    /// Record a *downgraded* request's outcome for `fingerprint`. An `inadequate`
+    /// outcome accrues toward a pin; an adequate one clears the pre-pin tally.
+    /// Async because a newly created pin is persisted.
+    pub async fn observe(&self, fingerprint: &str, inadequate: bool) {
+        let newly_pinned = {
+            let mut guard = self.state.write().unwrap_or_else(PoisonError::into_inner);
+            if !inadequate {
+                // A clean outcome resets the pre-pin tally; an existing pin is
+                // left to decay on its own cooldown.
+                guard.failures.remove(fingerprint);
+                None
+            } else {
+                let count = guard.failures.entry(fingerprint.to_string()).or_insert(0);
+                *count += 1;
+                if *count >= self.threshold {
+                    let pinned_at = now_unix();
+                    guard.pins.insert(fingerprint.to_string(), pinned_at);
+                    guard.failures.remove(fingerprint);
+                    Some(pinned_at)
+                } else {
+                    None
+                }
+            }
+        };
+        // Persist outside the lock — never hold a std lock across `.await`.
+        if let (Some(pinned_at), Some(store)) = (newly_pinned, &self.store) {
+            // Best-effort: a failed write only means the pin won't survive a
+            // restart, never a dropped or blocked request.
+            let _ = store.upsert_pin(fingerprint, pinned_at as i64).await;
+        }
+    }
+}
+
+/// Current Unix time in seconds (saturating to 0 before the epoch).
+fn now_unix() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn pins_a_fingerprint_after_threshold_failures() {
+        let ledger = AdequacyLedger::in_memory(2, 0);
+        assert!(!ledger.is_pinned("after_edit"));
+        ledger.observe("after_edit", true).await; // 1 failure < threshold 2
+        assert!(!ledger.is_pinned("after_edit"));
+        ledger.observe("after_edit", true).await; // 2 failures == threshold
+        assert!(ledger.is_pinned("after_edit"), "pinned at the threshold");
+    }
+
+    #[tokio::test]
+    async fn an_adequate_outcome_resets_the_pre_pin_tally() {
+        let ledger = AdequacyLedger::in_memory(2, 0);
+        ledger.observe("after_edit", true).await; // 1 failure
+        ledger.observe("after_edit", false).await; // clean → reset
+        ledger.observe("after_edit", true).await; // back to 1, not 2
+        assert!(
+            !ledger.is_pinned("after_edit"),
+            "a clean outcome between failures must prevent the pin"
+        );
+    }
+
+    #[tokio::test]
+    async fn threshold_one_pins_on_the_first_failure() {
+        let ledger = AdequacyLedger::in_memory(1, 0);
+        ledger.observe("after_edit", true).await;
+        assert!(ledger.is_pinned("after_edit"));
+    }
+
+    #[tokio::test]
+    async fn a_pin_decays_after_its_cooldown() {
+        // cooldown 0 never decays; a tiny cooldown with a back-dated pin reads as
+        // expired. Drive the cooldown logic directly via the cache.
+        let ledger = AdequacyLedger::in_memory(1, 60);
+        ledger.observe("after_edit", true).await;
+        assert!(ledger.is_pinned("after_edit"), "freshly pinned");
+        // Back-date the pin beyond the cooldown.
+        {
+            let mut guard = ledger.state.write().unwrap_or_else(PoisonError::into_inner);
+            let stale = now_unix().saturating_sub(120);
+            guard.pins.insert("after_edit".to_string(), stale);
+        }
+        assert!(
+            !ledger.is_pinned("after_edit"),
+            "a pin past its cooldown reads as expired"
+        );
+    }
+
+    #[tokio::test]
+    async fn zero_cooldown_pin_never_decays() {
+        let ledger = AdequacyLedger::in_memory(1, 0);
+        ledger.observe("after_edit", true).await;
+        {
+            let mut guard = ledger.state.write().unwrap_or_else(PoisonError::into_inner);
+            guard.pins.insert("after_edit".to_string(), 1); // ancient
+        }
+        assert!(
+            ledger.is_pinned("after_edit"),
+            "cooldown 0 means the pin is permanent"
+        );
+    }
+}

--- a/apps/bitrouter/src/adequacy/observer.rs
+++ b/apps/bitrouter/src/adequacy/observer.rs
@@ -1,0 +1,215 @@
+//! The adequacy observe hook — writes the ledger from each request's outcome.
+//!
+//! Registered as an [`ObserveHook`], it runs after every request. On
+//! `on_request_end` it recomputes the request fingerprint, maps the served model
+//! back to its tier, and — only for a *downgrade* (a tier other than the
+//! escalation tier) — records whether the outcome was a hard failure. Repeated
+//! failures on a downgrade pin the fingerprint in the [`AdequacyLedger`], so
+//! future requests with that fingerprint escalate.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use bitrouter_sdk::language_model::types::StreamPart;
+use bitrouter_sdk::language_model::{
+    ObserveHook, Phase, PipelineContext, RequestOutcome, StreamContext,
+};
+
+use crate::adequacy::AdequacyLedger;
+use crate::policy_table_router::PolicyTable;
+
+/// Feeds the [`AdequacyLedger`] from request outcomes against the shared
+/// [`PolicyTable`].
+pub struct AdequacyObserveHook {
+    table: Arc<PolicyTable>,
+    ledger: Arc<AdequacyLedger>,
+}
+
+impl AdequacyObserveHook {
+    /// Build the hook over the shared policy table and ledger.
+    pub fn new(table: Arc<PolicyTable>, ledger: Arc<AdequacyLedger>) -> Self {
+        Self { table, ledger }
+    }
+}
+
+#[async_trait]
+impl ObserveHook for AdequacyObserveHook {
+    // Per-phase and per-stream-part observation are unused — all the work is at
+    // request end, where the served model and final outcome are both known.
+    async fn after_phase(&self, _phase: Phase, _ctx: &PipelineContext) {}
+
+    async fn on_stream_part(&self, _ctx: &StreamContext, _part: &StreamPart) {}
+
+    async fn on_request_end(&self, ctx: &PipelineContext, outcome: &RequestOutcome) {
+        // Credit the outcome only to a *genuine* policy-router downgrade: the
+        // served model must map to exactly the tier the static table resolves
+        // for this request (so a caller's explicit route, a coincidental model
+        // match, or an adequacy escalation is not mistaken for a downgrade)...
+        let Some(served_tier) = self.table.tier_of_model(ctx.model()) else {
+            return;
+        };
+        if self.table.static_tier(ctx.prompt()) != Some(served_tier) {
+            return;
+        }
+        // ...and that tier must be a downgrade, not the escalation tier (a
+        // request already escalated failing is not a downgrade to pin).
+        if Some(served_tier) == self.table.escalation_tier() {
+            return;
+        }
+        let inadequate = match outcome {
+            // A hard failure — an upstream error (including a mid-stream stream
+            // error, which the pipeline now surfaces as `Failed`), a route /
+            // auth / policy failure, etc.
+            RequestOutcome::Failed(_) => true,
+            // The client hanging up tells us nothing about the tier — skip.
+            RequestOutcome::ClientDisconnected => return,
+            // A completed request got a response: the downgrade held.
+            RequestOutcome::Completed => false,
+        };
+        let fingerprint = PolicyTable::fingerprint(ctx.prompt());
+        self.ledger.observe(&fingerprint, inadequate).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    use bitrouter_sdk::BitrouterError;
+    use bitrouter_sdk::caller::CallerContext;
+    use bitrouter_sdk::config::PolicyTableConfig;
+    use bitrouter_sdk::language_model::types::{
+        Content, GenerationParams, Message, PipelineRequest, Prompt, ProviderMetadata, Role,
+    };
+
+    // A table: `opening` → capable (= the escalation tier, via default_tier),
+    // `after_read_file` → cheap (a downgrade).
+    fn table() -> Arc<PolicyTable> {
+        let cfg = PolicyTableConfig {
+            tiers: HashMap::from([
+                ("cheap".to_string(), "vendor/cheap".to_string()),
+                ("capable".to_string(), "vendor/capable".to_string()),
+            ]),
+            fingerprints: HashMap::from([
+                ("opening".to_string(), "capable".to_string()),
+                ("after_read_file".to_string(), "cheap".to_string()),
+            ]),
+            default_tier: Some("capable".to_string()),
+            tool_use_tier: None,
+            tool_safe_tiers: Vec::new(),
+            adequacy: Default::default(),
+        };
+        PolicyTable::from_config(&cfg).expect("configured")
+    }
+
+    fn user(text: &str) -> Message {
+        Message::text(Role::User, text)
+    }
+
+    fn assistant_calls(tool: &str) -> Message {
+        Message {
+            role: Role::Assistant,
+            content: vec![Content::ToolCall {
+                id: format!("call_{tool}"),
+                name: tool.to_string(),
+                arguments: "{}".to_string(),
+                provider_executed: false,
+                dynamic: false,
+                provider_metadata: ProviderMetadata::new(),
+            }],
+        }
+    }
+
+    fn prompt(messages: Vec<Message>) -> Prompt {
+        Prompt {
+            model: String::new(),
+            system: None,
+            system_provider_metadata: ProviderMetadata::new(),
+            messages,
+            tools: Vec::new(),
+            params: GenerationParams::default(),
+            response_format: None,
+            tool_choice: None,
+            stream: false,
+        }
+    }
+
+    /// A context for a request the pipeline served on `served_model`.
+    fn ctx(served_model: &str, messages: Vec<Message>) -> PipelineContext {
+        let request = PipelineRequest::new(
+            served_model.to_string(),
+            CallerContext::new("k", "u"),
+            prompt(messages),
+        );
+        PipelineContext::new(request)
+    }
+
+    fn failed() -> RequestOutcome {
+        RequestOutcome::Failed(BitrouterError::internal("upstream boom"))
+    }
+
+    fn read_step() -> Vec<Message> {
+        vec![user("fix the bug"), assistant_calls("read_file")]
+    }
+
+    #[tokio::test]
+    async fn a_failed_downgrade_pins_the_fingerprint() {
+        let ledger = Arc::new(AdequacyLedger::in_memory(1, 0));
+        let hook = AdequacyObserveHook::new(table(), ledger.clone());
+        // `after_read_file` → cheap is the static downgrade, and the request was
+        // served by the cheap model — a genuine downgrade. A hard failure pins it.
+        hook.on_request_end(&ctx("vendor/cheap", read_step()), &failed())
+            .await;
+        assert!(ledger.is_pinned("after_read_file"));
+    }
+
+    #[tokio::test]
+    async fn a_failure_not_matching_the_static_downgrade_is_ignored() {
+        // The over-attribution guard: an `opening` request served by the cheap
+        // model (e.g. the caller routed there) is NOT the static decision
+        // (opening → capable), so its failure must not pin anything.
+        let ledger = Arc::new(AdequacyLedger::in_memory(1, 0));
+        let hook = AdequacyObserveHook::new(table(), ledger.clone());
+        hook.on_request_end(&ctx("vendor/cheap", vec![user("start")]), &failed())
+            .await;
+        assert!(!ledger.is_pinned("opening"));
+        assert!(!ledger.is_pinned("after_read_file"));
+    }
+
+    #[tokio::test]
+    async fn a_failure_on_the_escalation_tier_is_ignored() {
+        // `opening` → capable, which is the escalation tier; a failure there is
+        // not a downgrade to pin.
+        let ledger = Arc::new(AdequacyLedger::in_memory(1, 0));
+        let hook = AdequacyObserveHook::new(table(), ledger.clone());
+        hook.on_request_end(&ctx("vendor/capable", vec![user("start")]), &failed())
+            .await;
+        assert!(!ledger.is_pinned("opening"));
+    }
+
+    #[tokio::test]
+    async fn a_completed_downgrade_does_not_pin() {
+        let ledger = Arc::new(AdequacyLedger::in_memory(1, 0));
+        let hook = AdequacyObserveHook::new(table(), ledger.clone());
+        hook.on_request_end(
+            &ctx("vendor/cheap", read_step()),
+            &RequestOutcome::Completed,
+        )
+        .await;
+        assert!(!ledger.is_pinned("after_read_file"));
+    }
+
+    #[tokio::test]
+    async fn a_client_disconnect_is_ignored() {
+        let ledger = Arc::new(AdequacyLedger::in_memory(1, 0));
+        let hook = AdequacyObserveHook::new(table(), ledger.clone());
+        hook.on_request_end(
+            &ctx("vendor/cheap", read_step()),
+            &RequestOutcome::ClientDisconnected,
+        )
+        .await;
+        assert!(!ledger.is_pinned("after_read_file"));
+    }
+}

--- a/apps/bitrouter/src/adequacy/store.rs
+++ b/apps/bitrouter/src/adequacy/store.rs
@@ -1,0 +1,150 @@
+//! Persistence for the adequacy ledger's escalation pins.
+//!
+//! One row per pinned fingerprint in the `adequacy_pins` table. The ledger is
+//! the single writer; the only reader is the ledger's startup warm-up. Every
+//! query goes through sea-orm, so the store works unchanged on whichever backend
+//! `database.url` selects (SQLite / Postgres / MySQL), mirroring
+//! [`crate::metering::MeteringStore`].
+
+use chrono::Utc;
+use sea_orm::sea_query::OnConflict;
+use sea_orm::{DatabaseConnection, EntityTrait, Set};
+
+use bitrouter_sdk::{BitrouterError, Result};
+
+use self::adequacy_pins::Entity as Pins;
+
+/// sea-orm entity for the `adequacy_pins` table.
+pub mod adequacy_pins {
+    use sea_orm::entity::prelude::*;
+
+    /// One pinned fingerprint — escalated to the policy table's escalation tier
+    /// until its cooldown elapses.
+    #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+    #[sea_orm(table_name = "adequacy_pins")]
+    pub struct Model {
+        /// The request fingerprint that is pinned.
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub fingerprint: String,
+        /// When the pin was last (re)applied, as a Unix timestamp in seconds —
+        /// the cooldown clock.
+        pub pinned_at_unix: i64,
+        /// RFC3339 timestamp of the first time this fingerprint was pinned.
+        pub created_at: String,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
+/// sea-orm-backed store over the `adequacy_pins` table.
+#[derive(Clone)]
+pub struct AdequacyStore {
+    db: DatabaseConnection,
+}
+
+impl AdequacyStore {
+    /// Build a store over a database connection. The database must already carry
+    /// the `adequacy_pins` table (`crate::db::run_migrations`).
+    pub fn new(db: DatabaseConnection) -> Self {
+        Self { db }
+    }
+
+    /// Load every pin as `(fingerprint, pinned_at_unix)`. Called once at startup
+    /// to warm the in-memory pin cache.
+    pub async fn load_all(&self) -> Result<Vec<(String, i64)>> {
+        let rows = Pins::find()
+            .all(&self.db)
+            .await
+            .map_err(|e| BitrouterError::internal(format!("adequacy load_all: {e}")))?;
+        Ok(rows
+            .into_iter()
+            .map(|row| (row.fingerprint, row.pinned_at_unix))
+            .collect())
+    }
+
+    /// Upsert a pin, refreshing the cooldown clock (`pinned_at_unix`) without
+    /// resetting `created_at`.
+    pub async fn upsert_pin(&self, fingerprint: &str, pinned_at_unix: i64) -> Result<()> {
+        let row = adequacy_pins::ActiveModel {
+            fingerprint: Set(fingerprint.to_string()),
+            pinned_at_unix: Set(pinned_at_unix),
+            created_at: Set(Utc::now().to_rfc3339()),
+        };
+        Pins::insert(row)
+            .on_conflict(
+                OnConflict::column(adequacy_pins::Column::Fingerprint)
+                    .update_column(adequacy_pins::Column::PinnedAtUnix)
+                    .to_owned(),
+            )
+            .exec(&self.db)
+            .await
+            .map_err(|e| BitrouterError::internal(format!("adequacy upsert_pin: {e}")))?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adequacy::AdequacyLedger;
+    use crate::db;
+    use bitrouter_sdk::config::AdequacyConfig;
+
+    async fn store() -> AdequacyStore {
+        let db = db::connect("sqlite::memory:").await.unwrap();
+        db::run_migrations(&db).await.unwrap();
+        AdequacyStore::new(db)
+    }
+
+    #[tokio::test]
+    async fn upsert_then_load_round_trips() {
+        let store = store().await;
+        store.upsert_pin("after_edit", 1000).await.unwrap();
+        store.upsert_pin("after_run", 2000).await.unwrap();
+        let mut rows = store.load_all().await.unwrap();
+        rows.sort();
+        assert_eq!(
+            rows,
+            vec![
+                ("after_edit".to_string(), 1000),
+                ("after_run".to_string(), 2000),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn upsert_refreshes_the_cooldown_clock_without_duplicating() {
+        let store = store().await;
+        store.upsert_pin("after_edit", 1000).await.unwrap();
+        store.upsert_pin("after_edit", 5000).await.unwrap();
+        assert_eq!(
+            store.load_all().await.unwrap(),
+            vec![("after_edit".to_string(), 5000)]
+        );
+    }
+
+    #[tokio::test]
+    async fn a_pin_survives_a_restart_via_persistence() {
+        let db = db::connect("sqlite::memory:").await.unwrap();
+        db::run_migrations(&db).await.unwrap();
+        let cfg = AdequacyConfig {
+            enabled: true,
+            escalation_tier: None,
+            escalation_threshold: 1,
+            pin_cooldown_secs: 0,
+        };
+        // First ledger: a failure pins the fingerprint and persists it.
+        let ledger = AdequacyLedger::load(&cfg, AdequacyStore::new(db.clone())).await;
+        ledger.observe("after_edit", true).await;
+        assert!(ledger.is_pinned("after_edit"));
+        // A fresh ledger over the same db warms its cache from the stored pin.
+        let reloaded = AdequacyLedger::load(&cfg, AdequacyStore::new(db.clone())).await;
+        assert!(
+            reloaded.is_pinned("after_edit"),
+            "the pin must survive via persistence"
+        );
+    }
+}

--- a/apps/bitrouter/src/assemble.rs
+++ b/apps/bitrouter/src/assemble.rs
@@ -404,6 +404,30 @@ pub async fn build_app_with_path(
         .and_then(FusionAliasConfig::from_settings)
         .map(|c| Arc::new(c) as Arc<dyn PromptTransform>);
 
+    // Config-driven per-request model routing (`policy_table:`). The shared
+    // table is read by the ingress router (below) and, when online adequacy
+    // learning is enabled, by the adequacy observe hook. The ledger persists its
+    // escalation pins in the local db and warms its in-memory cache from it.
+    let policy_table = crate::policy_table_router::PolicyTable::from_config(&config.policy_table);
+    let adequacy_ledger = match &policy_table {
+        Some(_) if config.policy_table.adequacy.enabled => {
+            let store = crate::adequacy::store::AdequacyStore::new(db.clone());
+            Some(Arc::new(
+                crate::adequacy::AdequacyLedger::load(&config.policy_table.adequacy, store).await,
+            ))
+        }
+        _ => None,
+    };
+    // The adequacy observe hook learns from request outcomes. Built before the
+    // builder closure so it can be moved into it; `None` unless learning is on.
+    let adequacy_observe = match (&policy_table, &adequacy_ledger) {
+        (Some(table), Some(ledger)) => Some(crate::adequacy::observer::AdequacyObserveHook::new(
+            table.clone(),
+            ledger.clone(),
+        )),
+        _ => None,
+    };
+
     // Optional ACP pure-routing pipeline — wired only when the config
     // declares at least one upstream agent. Mirrors the MCP wiring above;
     // the `bitrouter agent-proxy <id>` CLI dispatches against this pipeline.
@@ -448,6 +472,13 @@ pub async fn build_app_with_path(
             // can hold a query handle on it.
             if let Some(exporter) = otel_for_hook {
                 lm.observe_hook(OtelObserveHook::new(exporter));
+            }
+            // Online adequacy learning: observe each request's outcome and pin a
+            // downgraded fingerprint that keeps hard-failing, so the policy
+            // router (below) escalates it next time. Wired only when
+            // `policy_table.adequacy.enabled`.
+            if let Some(hook) = adequacy_observe {
+                lm.observe_hook(hook);
             }
             // OSS metering recorder — writes one `requests` row per
             // settled request with the estimated µUSD from the pricing
@@ -494,9 +525,11 @@ pub async fn build_app_with_path(
     // the transform skips any already-`provider:`-routed model (the `claude-code:`
     // subscription route) and any request carrying a bitrouter server-tool
     // declaration (the `bitrouter/fusion` alias's injected tool).
-    let app = match crate::policy_table_router::PolicyTableRouter::from_config(&config.policy_table)
-    {
-        Some(transform) => app.prompt_transform(Arc::new(transform) as Arc<dyn PromptTransform>),
+    let app = match policy_table {
+        Some(table) => {
+            let router = crate::policy_table_router::PolicyTableRouter::new(table, adequacy_ledger);
+            app.prompt_transform(Arc::new(router) as Arc<dyn PromptTransform>)
+        }
         None => app,
     };
     // Apply the optional MCP pipeline configuration in a second builder step

--- a/apps/bitrouter/src/db/migration/m20240101_000004_create_adequacy_table.rs
+++ b/apps/bitrouter/src/db/migration/m20240101_000004_create_adequacy_table.rs
@@ -1,0 +1,49 @@
+//! Create the adequacy ledger's `adequacy_pins` table — one row per fingerprint
+//! the online learner has escalated (pinned) away from a failing downgrade.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(AdequacyPins::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(AdequacyPins::Fingerprint)
+                            .string()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(AdequacyPins::PinnedAtUnix)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(AdequacyPins::CreatedAt).string().not_null())
+                    .to_owned(),
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(AdequacyPins::Table).to_owned())
+            .await?;
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+enum AdequacyPins {
+    Table,
+    Fingerprint,
+    PinnedAtUnix,
+    CreatedAt,
+}

--- a/apps/bitrouter/src/db/migration/mod.rs
+++ b/apps/bitrouter/src/db/migration/mod.rs
@@ -11,6 +11,7 @@
 pub mod m20240101_000001_create_auth_tables;
 pub mod m20240101_000002_create_metering_tables;
 pub mod m20240101_000003_rename_legacy_charge_column;
+pub mod m20240101_000004_create_adequacy_table;
 
 use sea_orm_migration::{MigrationTrait, MigratorTrait};
 
@@ -25,6 +26,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20240101_000001_create_auth_tables::Migration),
             Box::new(m20240101_000002_create_metering_tables::Migration),
             Box::new(m20240101_000003_rename_legacy_charge_column::Migration),
+            Box::new(m20240101_000004_create_adequacy_table::Migration),
         ]
     }
 }

--- a/apps/bitrouter/src/lib.rs
+++ b/apps/bitrouter/src/lib.rs
@@ -10,6 +10,7 @@
 
 #![forbid(unsafe_code)]
 
+pub mod adequacy;
 pub mod agent_proxy;
 pub mod agents;
 pub mod assemble;

--- a/apps/bitrouter/src/policy_table_router.rs
+++ b/apps/bitrouter/src/policy_table_router.rs
@@ -24,18 +24,20 @@
 //! the kind of thing an operator keeps under version control.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use bitrouter_sdk::PromptTransform;
 use bitrouter_sdk::config::PolicyTableConfig;
 use bitrouter_sdk::language_model::types::{Content, Prompt, Role, Tool};
 
-/// Ingress [`PromptTransform`] that rewrites `prompt.model` per a static policy
-/// table keyed on a per-request fingerprint, with a hard tool-use guardrail.
-///
-/// Built from [`PolicyTableConfig`] via [`PolicyTableRouter::from_config`],
-/// which returns `None` when the section defines no tiers (so an unconfigured
-/// deployment registers nothing).
-pub struct PolicyTableRouter {
+use crate::adequacy::AdequacyLedger;
+
+/// The resolved, immutable policy spec — the fingerprint→tier→model table plus
+/// the guardrail and (for adaptive routing) the escalation tier and a reverse
+/// model→tier index. Shared via [`Arc`] between the router (which reads it on
+/// the ingress hot path) and the adequacy observer (which recomputes the
+/// fingerprint and maps the served model back to a tier).
+pub struct PolicyTable {
     /// Tier name → model id the request is rewritten to.
     tiers: HashMap<String, String>,
     /// Request fingerprint → tier name.
@@ -47,24 +49,164 @@ pub struct PolicyTableRouter {
     tool_use_tier: Option<String>,
     /// Tiers that handle tool calls reliably.
     tool_safe_tiers: Vec<String>,
+    /// Tier a pinned fingerprint escalates to (adequacy.escalation_tier, else
+    /// default_tier). `None` when neither is configured.
+    escalation_tier: Option<String>,
+    /// Reverse index model id → tier name, for mapping a served model back to
+    /// its tier at observe time.
+    model_to_tier: HashMap<String, String>,
 }
 
-impl PolicyTableRouter {
-    /// Build a router from the `policy_table:` config, or `None` when the
-    /// section is inert (no tiers defined) — mirroring
-    /// `FusionAliasConfig::from_settings`, so an unconfigured deployment wires no
-    /// transform.
-    pub fn from_config(config: &PolicyTableConfig) -> Option<Self> {
+impl PolicyTable {
+    /// Build the shared spec from config, or `None` when the section is inert
+    /// (no tiers defined).
+    pub fn from_config(config: &PolicyTableConfig) -> Option<Arc<Self>> {
         if config.tiers.is_empty() {
             return None;
         }
-        Some(Self {
+        let model_to_tier = config
+            .tiers
+            .iter()
+            .map(|(tier, model)| (model.clone(), tier.clone()))
+            .collect();
+        let escalation_tier = config
+            .adequacy
+            .escalation_tier
+            .clone()
+            .or_else(|| config.default_tier.clone());
+        Some(Arc::new(Self {
             tiers: config.tiers.clone(),
             fingerprints: config.fingerprints.clone(),
             default_tier: config.default_tier.clone(),
             tool_use_tier: config.tool_use_tier.clone(),
             tool_safe_tiers: config.tool_safe_tiers.clone(),
+            escalation_tier,
+            model_to_tier,
+        }))
+    }
+
+    /// The tier a fingerprint maps to (or `default_tier`), before any guardrail
+    /// or escalation. `None` when unmapped and no default tier is set.
+    fn tier_for_fingerprint(&self, fingerprint: &str) -> Option<&str> {
+        self.fingerprints
+            .get(fingerprint)
+            .or(self.default_tier.as_ref())
+            .map(String::as_str)
+    }
+
+    /// Apply the hard tool-use guardrail: a tool-carrying request whose `tier` is
+    /// not tool-safe is clamped up to `tool_use_tier`. Returns the effective tier.
+    fn guardrail<'a>(&'a self, tier: &'a str, prompt: &Prompt) -> &'a str {
+        if !prompt.tools.is_empty()
+            && !self.tool_safe_tiers.iter().any(|t| t == tier)
+            && let Some(floor) = self.tool_use_tier.as_deref()
+        {
+            return floor;
+        }
+        tier
+    }
+
+    /// The model id a tier routes to.
+    fn model_of_tier(&self, tier: &str) -> Option<&str> {
+        self.tiers.get(tier).map(String::as_str)
+    }
+
+    /// The tier a served model id belongs to (reverse of [`Self::model_of_tier`]).
+    /// Used by the adequacy observer to map an outcome back to a tier.
+    pub(crate) fn tier_of_model(&self, model: &str) -> Option<&str> {
+        self.model_to_tier.get(model).map(String::as_str)
+    }
+
+    /// The tier a pinned fingerprint escalates to. Used by the router (to apply a
+    /// pin) and the observer (to tell a downgrade from the escalation tier).
+    pub(crate) fn escalation_tier(&self) -> Option<&str> {
+        self.escalation_tier.as_deref()
+    }
+
+    /// The tier the *static* table (fingerprint → tier → guardrail, before any
+    /// adequacy escalation) would route this prompt to. The observer uses it to
+    /// confirm a request was a genuine policy-router downgrade — the served tier
+    /// matches the static decision — before crediting its outcome, so a caller's
+    /// explicit route or a coincidental model match is not mistaken for one.
+    pub(crate) fn static_tier(&self, prompt: &Prompt) -> Option<&str> {
+        let fingerprint = Self::fingerprint(prompt);
+        let tier = self.tier_for_fingerprint(&fingerprint)?;
+        Some(self.guardrail(tier, prompt))
+    }
+
+    /// A coarse fingerprint of the agent-loop step, derived purely from the
+    /// prompt body (so it is stable regardless of the inbound protocol). It
+    /// classifies the request by the model's *most recent* turn:
+    ///
+    /// - `after_<tool>` — the model's last turn called `<tool>` (the request is
+    ///   most likely the follow-up that feeds the tool result back). This is the
+    ///   common in-loop step.
+    /// - `midstream` — the model's last turn was a plain reply with no tool call
+    ///   (e.g. it answered, then the user sent a fresh instruction). Keying on
+    ///   the *most recent* turn — rather than the last tool call anywhere in the
+    ///   history — is what keeps a request that has moved past a tool turn from
+    ///   being misread as the `after_<tool>` step.
+    /// - `opening` — the model has taken no turn yet (the first request).
+    ///
+    /// When a turn makes several tool calls at once, the last call in the turn
+    /// names the step. The fingerprint reads [`Content::ToolCall`] (whose name
+    /// is always present) rather than a [`Content::ToolResult`] (whose name is
+    /// wire-dependent and often absent).
+    pub fn fingerprint(prompt: &Prompt) -> String {
+        // Walk back to the model's most recent turn and classify by it.
+        for message in prompt.messages.iter().rev() {
+            if message.role != Role::Assistant {
+                continue;
+            }
+            let last_call = message
+                .content
+                .iter()
+                .rev()
+                .find_map(|content| match content {
+                    Content::ToolCall { name, .. } => Some(name.as_str()),
+                    _ => None,
+                });
+            return match last_call {
+                Some(name) => format!("after_{name}"),
+                None => "midstream".to_string(),
+            };
+        }
+        "opening".to_string()
+    }
+}
+
+/// Ingress [`PromptTransform`] that rewrites `prompt.model` per a [`PolicyTable`]
+/// keyed on a per-request fingerprint, with a hard tool-use guardrail.
+///
+/// When an [`AdequacyLedger`] is attached, a fingerprint that the ledger has
+/// *pinned* (because the downgrade kept failing) is routed to the table's
+/// escalation tier instead of the cheap one — adaptive, self-correcting routing.
+/// Without a ledger the router is exactly the static table.
+///
+/// Build it from [`PolicyTableConfig`] via [`PolicyTableRouter::from_config`]
+/// (static, `None` when no tiers are defined) or [`PolicyTableRouter::new`] (with
+/// a shared table and optional ledger, for the adaptive wiring).
+pub struct PolicyTableRouter {
+    table: Arc<PolicyTable>,
+    ledger: Option<Arc<AdequacyLedger>>,
+}
+
+impl PolicyTableRouter {
+    /// Build a static router from the `policy_table:` config, or `None` when the
+    /// section is inert (no tiers defined) — mirroring
+    /// `FusionAliasConfig::from_settings`, so an unconfigured deployment wires no
+    /// transform. No adequacy ledger is attached.
+    pub fn from_config(config: &PolicyTableConfig) -> Option<Self> {
+        PolicyTable::from_config(config).map(|table| Self {
+            table,
+            ledger: None,
         })
+    }
+
+    /// Build a router over a shared [`PolicyTable`] and an optional
+    /// [`AdequacyLedger`] (the adaptive wiring).
+    pub fn new(table: Arc<PolicyTable>, ledger: Option<Arc<AdequacyLedger>>) -> Self {
+        Self { table, ledger }
     }
 
     /// Apply the policy table to a prompt, returning whether the model was
@@ -88,81 +230,32 @@ impl PolicyTableRouter {
         if carries_bitrouter_server_tool(prompt) {
             return false;
         }
-        let Some(tier) = self.resolve_tier(prompt) else {
+        let fingerprint = PolicyTable::fingerprint(prompt);
+        let mut tier = self.table.tier_for_fingerprint(&fingerprint);
+        // Adequacy escalation: a pinned fingerprint (a downgrade the ledger
+        // learned is failing) routes to the escalation tier, overriding the
+        // static — cheaper — tier. Reading the ledger is sync and lock-cheap.
+        if let Some(ledger) = &self.ledger
+            && ledger.is_pinned(&fingerprint)
+            && let Some(escalation) = self.table.escalation_tier()
+        {
+            tier = Some(escalation);
+        }
+        let Some(tier) = tier else {
             return false;
         };
-        let Some(model) = self.tiers.get(tier) else {
+        // The tool-use guardrail applies on top of whichever tier was chosen.
+        let tier = self.table.guardrail(tier, prompt);
+        let Some(model) = self.table.model_of_tier(tier) else {
             // Unreachable for a config that passed `validate_policy_table`, but
             // a no-op is the safe fallback rather than a panic.
             return false;
         };
-        if prompt.model == *model {
+        if prompt.model == model {
             return false;
         }
-        prompt.model = model.clone();
+        prompt.model = model.to_string();
         true
-    }
-
-    /// The tier this request resolves to: the fingerprint's tier (or
-    /// `default_tier`), clamped up to `tool_use_tier` when the request carries
-    /// tools and the chosen tier is not in `tool_safe_tiers`. `None` when the
-    /// fingerprint maps to nothing and there is no default tier.
-    fn resolve_tier(&self, prompt: &Prompt) -> Option<&str> {
-        let fingerprint = Self::fingerprint(prompt);
-        let mut tier = self
-            .fingerprints
-            .get(&fingerprint)
-            .or(self.default_tier.as_ref())
-            .map(String::as_str)?;
-        // Hard tool-use guardrail: never route a tool-carrying request to a tier
-        // not known tool-safe; clamp it up to the configured floor instead.
-        if !prompt.tools.is_empty()
-            && !self.tool_safe_tiers.iter().any(|t| t == tier)
-            && let Some(floor) = self.tool_use_tier.as_deref()
-        {
-            tier = floor;
-        }
-        Some(tier)
-    }
-
-    /// A coarse fingerprint of the agent-loop step, derived purely from the
-    /// prompt body (so it is stable regardless of the inbound protocol). It
-    /// classifies the request by the model's *most recent* turn:
-    ///
-    /// - `after_<tool>` — the model's last turn called `<tool>` (the request is
-    ///   most likely the follow-up that feeds the tool result back). This is the
-    ///   common in-loop step.
-    /// - `midstream` — the model's last turn was a plain reply with no tool call
-    ///   (e.g. it answered, then the user sent a fresh instruction). Keying on
-    ///   the *most recent* turn — rather than the last tool call anywhere in the
-    ///   history — is what keeps a request that has moved past a tool turn from
-    ///   being misread as the `after_<tool>` step.
-    /// - `opening` — the model has taken no turn yet (the first request).
-    ///
-    /// When a turn makes several tool calls at once, the last call in the turn
-    /// names the step. The fingerprint reads [`Content::ToolCall`] (whose name
-    /// is always present) rather than a [`Content::ToolResult`] (whose name is
-    /// wire-dependent and often absent).
-    fn fingerprint(prompt: &Prompt) -> String {
-        // Walk back to the model's most recent turn and classify by it.
-        for message in prompt.messages.iter().rev() {
-            if message.role != Role::Assistant {
-                continue;
-            }
-            let last_call = message
-                .content
-                .iter()
-                .rev()
-                .find_map(|content| match content {
-                    Content::ToolCall { name, .. } => Some(name.as_str()),
-                    _ => None,
-                });
-            return match last_call {
-                Some(name) => format!("after_{name}"),
-                None => "midstream".to_string(),
-            };
-        }
-        "opening".to_string()
     }
 }
 
@@ -226,11 +319,21 @@ mod tests {
             default_tier: Some("flagship".to_string()),
             tool_use_tier: Some("flagship".to_string()),
             tool_safe_tiers: vec!["flagship".to_string()],
+            adequacy: Default::default(),
         }
     }
 
     fn router() -> PolicyTableRouter {
         PolicyTableRouter::from_config(&config()).expect("tiers are configured")
+    }
+
+    /// `config()` with online adequacy learning enabled, escalating pinned
+    /// fingerprints to the flagship tier.
+    fn config_with_escalation() -> PolicyTableConfig {
+        let mut cfg = config();
+        cfg.adequacy.enabled = true;
+        cfg.adequacy.escalation_tier = Some("flagship".to_string());
+        cfg
     }
 
     fn prompt(model: &str) -> Prompt {
@@ -406,6 +509,7 @@ mod tests {
             default_tier: None,
             tool_use_tier: None,
             tool_safe_tiers: Vec::new(),
+            adequacy: Default::default(),
         };
         let r = PolicyTableRouter::from_config(&cfg).expect("configured");
         let mut p = prompt("inbound");
@@ -464,6 +568,7 @@ mod tests {
             default_tier: None,
             tool_use_tier: None,
             tool_safe_tiers: Vec::new(),
+            adequacy: Default::default(),
         };
         let r = PolicyTableRouter::from_config(&cfg).expect("configured");
         let mut p = prompt("inbound");
@@ -487,6 +592,7 @@ mod tests {
             default_tier: Some("flagship".to_string()),
             tool_use_tier: None,
             tool_safe_tiers: Vec::new(),
+            adequacy: Default::default(),
         };
         let r = PolicyTableRouter::from_config(&cfg).expect("configured");
         let mut p = prompt("inbound");
@@ -509,5 +615,65 @@ mod tests {
             ),
             "vendor/fusion-outer"
         );
+    }
+
+    // ---- adaptive routing (the adequacy ledger) ----
+
+    /// A read step prompt — fingerprints to `after_read_file` (→ cheap statically).
+    fn read_step() -> Vec<Message> {
+        vec![user("fix the bug"), assistant_calls("read_file")]
+    }
+
+    fn route_with(router: &PolicyTableRouter, messages: Vec<Message>) -> String {
+        let mut p = prompt("inbound");
+        p.messages = messages;
+        router.apply(&mut p);
+        p.model
+    }
+
+    #[tokio::test]
+    async fn a_pinned_fingerprint_escalates_over_the_static_downgrade() {
+        let table = PolicyTable::from_config(&config_with_escalation()).expect("configured");
+        let ledger = Arc::new(AdequacyLedger::in_memory(1, 0));
+        let router = PolicyTableRouter::new(table, Some(ledger.clone()));
+
+        // Before any failure, the static table downgrades `after_read_file`.
+        assert_eq!(route_with(&router, read_step()), "vendor/cheap");
+
+        // One inadequate outcome pins the fingerprint (threshold 1).
+        ledger.observe("after_read_file", true).await;
+
+        // Now the same step escalates to the flagship (escalation) tier.
+        assert_eq!(
+            route_with(&router, read_step()),
+            "vendor/flagship",
+            "a pinned fingerprint escalates over the static downgrade"
+        );
+    }
+
+    #[tokio::test]
+    async fn escalation_is_scoped_to_the_pinned_fingerprint() {
+        let table = PolicyTable::from_config(&config_with_escalation()).expect("configured");
+        let ledger = Arc::new(AdequacyLedger::in_memory(1, 0));
+        let router = PolicyTableRouter::new(table, Some(ledger.clone()));
+
+        ledger.observe("after_read_file", true).await; // pin only this fingerprint
+
+        // A different downgraded step is unaffected: map `after_grep` → cheap.
+        // (It is unmapped here, so it falls to default flagship anyway; assert the
+        // pinned one escalates while an opening request stays flagship as before.)
+        assert_eq!(route_with(&router, read_step()), "vendor/flagship"); // pinned
+        assert_eq!(
+            route_with(&router, vec![user("start")]),
+            "vendor/flagship" // `opening` was always flagship; unchanged
+        );
+    }
+
+    #[tokio::test]
+    async fn no_ledger_means_no_escalation() {
+        // Built with `from_config` (no ledger): observing has nothing to read, so
+        // routing stays exactly static.
+        let router = PolicyTableRouter::from_config(&config_with_escalation()).expect("configured");
+        assert_eq!(route_with(&router, read_step()), "vendor/cheap");
     }
 }

--- a/crates/bitrouter-sdk/src/config/mod.rs
+++ b/crates/bitrouter-sdk/src/config/mod.rs
@@ -184,6 +184,55 @@ pub struct PolicyTableConfig {
     /// chosen tier is in this list is left as-is; one whose tier is absent is
     /// clamped to [`tool_use_tier`](Self::tool_use_tier).
     pub tool_safe_tiers: Vec<String>,
+    /// Online adequacy learning. When enabled, the daemon observes each
+    /// downgraded request's outcome and, after repeated failures, escalates the
+    /// offending fingerprint to a more capable tier — so an operator's downgrade
+    /// that proves inadequate is self-correcting. Off by default.
+    pub adequacy: AdequacyConfig,
+}
+
+/// Online adequacy-learning settings — the `policy_table.adequacy` block.
+///
+/// When [`enabled`](Self::enabled), the daemon watches every request a downgrade
+/// produced and counts the ones that hard-fail (an upstream error or a stream
+/// error). Once a fingerprint accumulates
+/// [`escalation_threshold`](Self::escalation_threshold) such failures it is
+/// *pinned*: subsequent requests with that fingerprint route to
+/// [`escalation_tier`](Self::escalation_tier) instead of the cheap tier the
+/// static table would pick. A pin decays after
+/// [`pin_cooldown_secs`](Self::pin_cooldown_secs) so the downgrade is re-tried
+/// later. This is a safety net layered on the static table — it never downgrades
+/// on its own, only escalates a downgrade that is failing.
+#[derive(Debug, Clone, Deserialize, schemars::JsonSchema)]
+#[serde(default)]
+pub struct AdequacyConfig {
+    /// Whether online adequacy learning is active. Off by default, so a
+    /// `policy_table:` with no `adequacy:` block behaves exactly as the static
+    /// table.
+    pub enabled: bool,
+    /// Tier a pinned fingerprint escalates to. When unset, falls back to
+    /// [`PolicyTableConfig::default_tier`]. Must resolve to a defined tier when
+    /// [`enabled`](Self::enabled).
+    pub escalation_tier: Option<String>,
+    /// Number of *consecutive* hard failures on a downgraded fingerprint before
+    /// it is pinned to the escalation tier (a clean outcome resets the tally).
+    /// Default `1` — escalate on the first failure (conservative / sticky).
+    pub escalation_threshold: u32,
+    /// How long, in seconds, a pin lasts before the downgrade is re-attempted.
+    /// `0` means the pin never decays (until the process restarts or the row is
+    /// cleared). Default `1800` (30 minutes).
+    pub pin_cooldown_secs: u64,
+}
+
+impl Default for AdequacyConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            escalation_tier: None,
+            escalation_threshold: 1,
+            pin_cooldown_secs: 1800,
+        }
+    }
 }
 
 /// A provider's routing-preference class. Its position in
@@ -909,6 +958,20 @@ fn validate_policy_table(config: &Config) -> Result<()> {
         return Err(BitrouterError::bad_request(format!(
             "policy_table tool_use_tier '{tier}' must also be listed in tool_safe_tiers"
         )));
+    }
+    // Adequacy learning escalates a pinned fingerprint to its escalation tier
+    // (or the default tier), so that target must exist and resolve to a defined
+    // tier when learning is enabled.
+    let adequacy = &policy.adequacy;
+    if let Some(tier) = &adequacy.escalation_tier {
+        check("adequacy.escalation_tier", tier)?;
+    }
+    if adequacy.enabled && adequacy.escalation_tier.is_none() && policy.default_tier.is_none() {
+        return Err(BitrouterError::bad_request(
+            "policy_table.adequacy is enabled but no escalation target is set: \
+             set adequacy.escalation_tier or default_tier"
+                .to_string(),
+        ));
     }
     Ok(())
 }

--- a/crates/bitrouter-sdk/src/config/tests.rs
+++ b/crates/bitrouter-sdk/src/config/tests.rs
@@ -545,3 +545,76 @@ policy_table:
         "got: {err}"
     );
 }
+
+#[test]
+fn parses_adequacy_section() {
+    let yaml = r#"
+policy_table:
+  tiers:
+    cheap: vendor/cheap
+    capable: vendor/capable
+  default_tier: capable
+  adequacy:
+    enabled: true
+    escalation_tier: capable
+    escalation_threshold: 3
+    pin_cooldown_secs: 600
+"#;
+    let cfg = parse_with(yaml, |_| None).unwrap();
+    let adequacy = &cfg.policy_table.adequacy;
+    assert!(adequacy.enabled);
+    assert_eq!(adequacy.escalation_tier.as_deref(), Some("capable"));
+    assert_eq!(adequacy.escalation_threshold, 3);
+    assert_eq!(adequacy.pin_cooldown_secs, 600);
+}
+
+#[test]
+fn adequacy_defaults_when_section_omitted() {
+    // A `policy_table:` with no `adequacy:` block is off, with sane defaults.
+    let yaml = r#"
+policy_table:
+  tiers:
+    cheap: vendor/cheap
+"#;
+    let cfg = parse_with(yaml, |_| None).unwrap();
+    let adequacy = &cfg.policy_table.adequacy;
+    assert!(!adequacy.enabled);
+    assert_eq!(adequacy.escalation_threshold, 1);
+    assert_eq!(adequacy.pin_cooldown_secs, 1800);
+}
+
+#[test]
+fn adequacy_unknown_escalation_tier_is_a_400() {
+    let yaml = r#"
+policy_table:
+  tiers:
+    cheap: vendor/cheap
+  adequacy:
+    enabled: true
+    escalation_tier: capable
+"#;
+    let err = parse_with(yaml, |_| None).unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("adequacy.escalation_tier references unknown tier 'capable'"),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn adequacy_enabled_without_escalation_target_is_a_400() {
+    // Enabled, but neither escalation_tier nor default_tier is set — a pin would
+    // have nowhere to escalate to.
+    let yaml = r#"
+policy_table:
+  tiers:
+    cheap: vendor/cheap
+  adequacy:
+    enabled: true
+"#;
+    let err = parse_with(yaml, |_| None).unwrap_err();
+    assert!(
+        err.to_string().contains("no escalation target is set"),
+        "got: {err}"
+    );
+}

--- a/crates/bitrouter-sdk/src/language_model/pipeline.rs
+++ b/crates/bitrouter-sdk/src/language_model/pipeline.rs
@@ -640,14 +640,27 @@ impl StreamSettlementGuard {
     /// Finalise inline on a normal/errored/aborted termination.
     async fn finalize(&mut self, outcome: StreamOutcome) {
         if let Some((mut processor, mut ctx)) = self.state.take() {
+            // Surface whether the request actually succeeded to `on_request_end`,
+            // computed before `processor.finish` consumes the outcome.
+            let request_outcome = request_outcome_for(&outcome);
             processor.finish(outcome).await;
             ctx.absorb_stream(processor.into_context());
             self.pipeline.run_settlement(&mut ctx, true, None).await;
             self.pipeline.observe_after(Phase::Settlement, &ctx).await;
-            self.pipeline
-                .observe_end(&ctx, RequestOutcome::Completed)
-                .await;
+            self.pipeline.observe_end(&ctx, request_outcome).await;
         }
+    }
+}
+
+/// Map a terminal [`StreamOutcome`] to the [`RequestOutcome`] observers see at
+/// request end. A mid-stream upstream error is a failure; a `StreamHook` abort
+/// is a deliberate policy stop (e.g. a guardrail), not an upstream failure, so
+/// it reads as completed.
+fn request_outcome_for(outcome: &StreamOutcome) -> RequestOutcome {
+    match outcome {
+        StreamOutcome::UpstreamError(err) => RequestOutcome::Failed(err.clone()),
+        StreamOutcome::ClientDisconnected => RequestOutcome::ClientDisconnected,
+        StreamOutcome::Completed | StreamOutcome::Aborted(_) => RequestOutcome::Completed,
     }
 }
 
@@ -770,5 +783,46 @@ fn log_request_finished(settle: &SettlementContext) {
             error = %err,
             "request finished"
         ),
+    }
+}
+
+#[cfg(test)]
+mod stream_outcome_tests {
+    use super::{RequestOutcome, StreamOutcome, request_outcome_for};
+    use crate::error::BitrouterError;
+
+    #[test]
+    fn upstream_error_maps_to_failed() {
+        // The fix for the streaming-error blind spot: a mid-stream upstream error
+        // must reach `on_request_end` as `Failed`, not a silent `Completed`.
+        let outcome = StreamOutcome::UpstreamError(BitrouterError::internal("mid-stream boom"));
+        assert!(matches!(
+            request_outcome_for(&outcome),
+            RequestOutcome::Failed(_)
+        ));
+    }
+
+    #[test]
+    fn abort_and_completion_map_to_completed() {
+        // A StreamHook abort is a deliberate stop (e.g. a guardrail), not an
+        // upstream failure.
+        assert!(matches!(
+            request_outcome_for(&StreamOutcome::Aborted(BitrouterError::bad_request(
+                "blocked"
+            ))),
+            RequestOutcome::Completed
+        ));
+        assert!(matches!(
+            request_outcome_for(&StreamOutcome::Completed),
+            RequestOutcome::Completed
+        ));
+    }
+
+    #[test]
+    fn disconnect_maps_to_disconnect() {
+        assert!(matches!(
+            request_outcome_for(&StreamOutcome::ClientDisconnected),
+            RequestOutcome::ClientDisconnected
+        ));
     }
 }

--- a/examples/bitrouter.yaml
+++ b/examples/bitrouter.yaml
@@ -72,3 +72,14 @@ policy_table:
   tool_use_tier: capable
   tool_safe_tiers:
     - capable
+  # Online adequacy learning (off by default). When enabled, the daemon watches
+  # every request a downgrade produced and, after `escalation_threshold` hard
+  # failures, pins that fingerprint to `escalation_tier` (here `capable`) so the
+  # downgrade self-corrects. A pin decays after `pin_cooldown_secs`, so a
+  # transient failure is retried later. The learner only ever escalates a failing
+  # downgrade — it never downgrades on its own.
+  adequacy:
+    enabled: false
+    escalation_tier: capable
+    escalation_threshold: 2
+    pin_cooldown_secs: 1800

--- a/schemas/bitrouter.config.schema.json
+++ b/schemas/bitrouter.config.schema.json
@@ -72,6 +72,39 @@
         }
       ]
     },
+    "AdequacyConfig": {
+      "description": "Online adequacy-learning settings — the `policy_table.adequacy` block.\n\nWhen [`enabled`](Self::enabled), the daemon watches every request a downgrade\nproduced and counts the ones that hard-fail (an upstream error or a stream\nerror). Once a fingerprint accumulates\n[`escalation_threshold`](Self::escalation_threshold) such failures it is\n*pinned*: subsequent requests with that fingerprint route to\n[`escalation_tier`](Self::escalation_tier) instead of the cheap tier the\nstatic table would pick. A pin decays after\n[`pin_cooldown_secs`](Self::pin_cooldown_secs) so the downgrade is re-tried\nlater. This is a safety net layered on the static table — it never downgrades\non its own, only escalates a downgrade that is failing.",
+      "properties": {
+        "enabled": {
+          "default": false,
+          "description": "Whether online adequacy learning is active. Off by default, so a\n`policy_table:` with no `adequacy:` block behaves exactly as the static\ntable.",
+          "type": "boolean"
+        },
+        "escalation_threshold": {
+          "default": 1,
+          "description": "Number of *consecutive* hard failures on a downgraded fingerprint before\nit is pinned to the escalation tier (a clean outcome resets the tally).\nDefault `1` — escalate on the first failure (conservative / sticky).",
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "escalation_tier": {
+          "default": null,
+          "description": "Tier a pinned fingerprint escalates to. When unset, falls back to\n[`PolicyTableConfig::default_tier`]. Must resolve to a defined tier when\n[`enabled`](Self::enabled).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "pin_cooldown_secs": {
+          "default": 1800,
+          "description": "How long, in seconds, a pin lasts before the downgrade is re-attempted.\n`0` means the pin never decays (until the process restarts or the row is\ncleared). Default `1800` (30 minutes).",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
     "ApiProtocol": {
       "description": "Wire protocol. Known values: `chat_completions`, `messages`, `generate_content`, `responses`; any other string names an externally-registered (outbound-only) custom protocol.",
       "examples": [
@@ -340,6 +373,10 @@
     "PolicyTableConfig": {
       "description": "Config-driven per-request model routing — the top-level `policy_table:` block\nin `bitrouter.yaml`.\n\nAn ingress transform fingerprints each request by its agent-loop step (the\nmost recent tool the model called, or the opening turn) and looks the\nfingerprint up in [`fingerprints`](Self::fingerprints) to choose a *tier*;\n[`tiers`](Self::tiers) then maps that tier to the model id the request is\nrewritten to. A hard tool-use guardrail keeps tool-carrying requests on a\ntier known to handle tools.\n\nThe section is active only when [`tiers`](Self::tiers) is non-empty — an\nabsent or tier-less block leaves routing untouched. The whole spec is static\nand operator-owned: it is versionable in `bitrouter.yaml` and never mutated\nat runtime.",
       "properties": {
+        "adequacy": {
+          "$ref": "#/$defs/AdequacyConfig",
+          "description": "Online adequacy learning. When enabled, the daemon observes each\ndowngraded request's outcome and, after repeated failures, escalates the\noffending fingerprint to a more capable tier — so an operator's downgrade\nthat proves inadequate is self-correcting. Off by default."
+        },
         "default_tier": {
           "default": null,
           "description": "Tier applied to any fingerprint not listed in\n[`fingerprints`](Self::fingerprints). When unset, an unmapped fingerprint\nis left on the model the caller requested (the transform no-ops).",


### PR DESCRIPTION
**Stacked on #624** (review/merge that first; this targets `feat/policy-table-router`).

## What

Makes the policy-table router (#624) **adaptive**. A local, telemetry-fed **adequacy ledger** learns, per request fingerprint, when a downgraded tier keeps hard-failing and **escalates** that fingerprint to a more capable tier. This is the *safety half* of the asymmetric routing rule: an operator's downgrade that proves inadequate self-corrects, online, with no LLM in the loop. The learner can only ever make routing **more conservative** than the static table — it never downgrades on its own (that's the follow-up, "aggressive" half).

## How (credit assignment, no round structure)

An `ObserveHook` runs after every request and:
1. recomputes the fingerprint from the prompt,
2. maps the served model back to its tier,
3. credits the outcome **only to a genuine policy-router downgrade** — the served tier must equal the tier the *static* table resolves for this request (so a caller's explicit route, a coincidental model match, or an escalation is not mistaken for a downgrade) and must not be the escalation tier,
4. records whether it hard-failed (`Failed`; `ClientDisconnected` skipped; `Completed` = held).

After `escalation_threshold` consecutive failures the fingerprint is **pinned**; the ingress router routes it to the escalation tier. A pin decays after `pin_cooldown_secs` (the downgrade is retried later). Pins persist in the local db (`adequacy_pins`) and the in-memory cache the router reads on the hot path is warmed from it at startup.

The read path (`is_pinned`) is sync (no async in the `PromptTransform`); the write path (`observe`) is async (persists). The static `PolicyTable` spec is extracted behind an `Arc`, shared by the router (reads) and the observer (recompute + reverse model→tier map).

## Config (off by default)

```yaml
policy_table:
  tiers: { cheap: openai:gpt-4o, capable: anthropic:claude-sonnet-4-6 }
  fingerprints: { after_read_file: cheap }
  default_tier: capable
  adequacy:
    enabled: false          # opt-in
    escalation_tier: capable # defaults to default_tier
    escalation_threshold: 2  # consecutive hard failures before pinning
    pin_cooldown_secs: 1800  # 0 = no decay
```

Validated at parse time (unknown escalation tier; enabled-without-target). Inert unless `adequacy.enabled`.

## Incidental SDK fix

The pipeline now surfaces a streaming request's terminal outcome to `on_request_end`: a mid-stream `StreamOutcome::UpstreamError` maps to `RequestOutcome::Failed` (a `StreamHook` abort stays `Completed`), instead of reporting every streamed request as `Completed`. This is a latent observability gap any error-rate observe hook depends on — and the ledger needs it to learn from the dominant (streaming) request shape.

## Tests / checks

Ledger (threshold/pin/reset/cooldown, persistence round-trip + survives-restart); observer (genuine-downgrade gate, failure→pin, coincidental-match ignored, escalation-tier ignored, completed/disconnect ignored); adaptive router (pinned→escalate; #624 static behavior preserved when off); pipeline outcome mapping; config defaults + validation. `cargo nextest -p bitrouter-sdk -p bitrouter --all-features`: **801 pass**. clippy `-D`, fmt, `generate-schema --check`, rustdoc `-D`, `config validate` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)