### PR TITLE
feat(routing): aggressive downgrade discovery + convergence eval

### DIFF
--- a/apps/bitrouter/src/adequacy/eval.rs
+++ b/apps/bitrouter/src/adequacy/eval.rs
@@ -1,0 +1,183 @@
+//! Convergence eval — the offline form of the adequacy benchmark (E3).
+//!
+//! It drives the *whole* loop — ingress [`PolicyTableRouter`] + the
+//! [`AdequacyObserveHook`] + the [`AdequacyLedger`] — over a synthetic workload
+//! with known ground truth, and asserts the ledger converges to the
+//! cost-optimal-yet-safe policy: it *discovers and locks* the downgrades that are
+//! genuinely safe, and *escalates and keeps off* the ones that are not, with no
+//! round structure and no randomness. This is the test-shaped counterpart of an
+//! offline benchmark; it needs no live upstream because the outcome of each
+//! simulated request is decided by the workload's ground truth.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use bitrouter_sdk::BitrouterError;
+use bitrouter_sdk::caller::CallerContext;
+use bitrouter_sdk::config::{AdequacyConfig, PolicyTableConfig};
+use bitrouter_sdk::language_model::types::{
+    Content, GenerationParams, Message, PipelineRequest, Prompt, ProviderMetadata, Role,
+};
+use bitrouter_sdk::language_model::{ObserveHook, PipelineContext, RequestOutcome};
+
+use crate::adequacy::AdequacyLedger;
+use crate::adequacy::observer::AdequacyObserveHook;
+use crate::policy_table_router::{PolicyTable, PolicyTableRouter};
+
+const CHEAP: &str = "vendor/cheap";
+const CAPABLE: &str = "vendor/capable";
+
+/// A workload with both halves to exercise: an operator-configured downgrade
+/// (`after_routine` → cheap) that is unsafe and must escalate; and two
+/// exploration candidates (left at the capable tier) — one safe to downgrade,
+/// one not.
+fn workload_table() -> Arc<PolicyTable> {
+    let cfg = PolicyTableConfig {
+        tiers: HashMap::from([
+            ("cheap".to_string(), CHEAP.to_string()),
+            ("capable".to_string(), CAPABLE.to_string()),
+        ]),
+        fingerprints: HashMap::from([("after_routine".to_string(), "cheap".to_string())]),
+        default_tier: Some("capable".to_string()),
+        tool_use_tier: None,
+        tool_safe_tiers: Vec::new(),
+        adequacy: AdequacyConfig {
+            enabled: true,
+            explore_enabled: true,
+            explore_tier: Some("cheap".to_string()),
+            ..Default::default()
+        },
+    };
+    PolicyTable::from_config(&cfg).expect("configured")
+}
+
+/// Ground truth: whether the cheap tier is actually adequate for a fingerprint.
+fn cheap_is_adequate(fingerprint: &str) -> bool {
+    match fingerprint {
+        // A safe downgrade — exploration should discover and lock it.
+        "after_safe" => true,
+        // Unsafe steps — cheap always fails; the ledger must escalate.
+        "after_risky" | "after_routine" => false,
+        _ => true,
+    }
+}
+
+/// A prompt whose fingerprint is `after_<tool>`.
+fn prompt_after(tool: &str) -> Prompt {
+    Prompt {
+        model: "inbound".to_string(),
+        system: None,
+        system_provider_metadata: ProviderMetadata::new(),
+        messages: vec![
+            Message::text(Role::User, "go"),
+            Message {
+                role: Role::Assistant,
+                content: vec![Content::ToolCall {
+                    id: format!("call_{tool}"),
+                    name: tool.to_string(),
+                    arguments: "{}".to_string(),
+                    provider_executed: false,
+                    dynamic: false,
+                    provider_metadata: ProviderMetadata::new(),
+                }],
+            },
+        ],
+        tools: Vec::new(),
+        params: GenerationParams::default(),
+        response_format: None,
+        tool_choice: None,
+        stream: false,
+    }
+}
+
+fn context(served_model: &str, prompt: Prompt) -> PipelineContext {
+    PipelineContext::new(PipelineRequest::new(
+        served_model.to_string(),
+        CallerContext::new("k", "u"),
+        prompt,
+    ))
+}
+
+#[tokio::test]
+async fn the_loop_converges_to_a_safe_cheaper_policy() {
+    let table = workload_table();
+    // interval 1 = trial each eligible request; lock after 2 adequate trials;
+    // pins never decay so convergence is stable within the run.
+    let ledger = Arc::new(AdequacyLedger::in_memory_explore(1, 0, 1, 2));
+    let router = PolicyTableRouter::new(table.clone(), Some(ledger.clone()));
+    let observer = AdequacyObserveHook::new(table.clone(), ledger.clone());
+
+    // Pricing for the savings claim: cheap is 10x cheaper than capable.
+    let price = |model: &str| if model == CHEAP { 1u64 } else { 10u64 };
+
+    let mut spend = 0u64;
+    let mut flagship_only_spend = 0u64;
+
+    for _round in 0..30 {
+        for tool in ["safe", "risky", "routine"] {
+            let fingerprint = format!("after_{tool}");
+            // Route.
+            let mut prompt = prompt_after(tool);
+            router.apply(&mut prompt);
+            let served = prompt.model.clone();
+            spend += price(&served);
+            flagship_only_spend += price(CAPABLE);
+
+            // Simulate the outcome from ground truth: a cheap route to an
+            // inadequate step hard-fails; everything else completes.
+            let served_cheap = served == CHEAP;
+            let inadequate = served_cheap && !cheap_is_adequate(&fingerprint);
+            let outcome = if inadequate {
+                RequestOutcome::Failed(BitrouterError::internal("cheap inadequate"))
+            } else {
+                RequestOutcome::Completed
+            };
+
+            // Observe.
+            observer
+                .on_request_end(&context(&served, prompt_after(tool)), &outcome)
+                .await;
+        }
+    }
+
+    // Discovery: the genuinely-safe downgrade is locked to the cheap tier.
+    assert!(
+        ledger.is_locked("after_safe"),
+        "exploration must discover and lock the safe downgrade"
+    );
+    // Safety: the unsafe exploration candidate is never locked, and is escalated.
+    assert!(
+        !ledger.is_locked("after_risky"),
+        "the unsafe downgrade must not be locked"
+    );
+    assert!(
+        ledger.is_pinned("after_risky"),
+        "the unsafe exploration candidate must be escalated"
+    );
+    // Safety: the unsafe *operator* downgrade self-corrects (escalated).
+    assert!(
+        ledger.is_pinned("after_routine"),
+        "the unsafe operator downgrade must self-correct"
+    );
+
+    // Final routing reflects the converged policy.
+    let route = |tool: &str| {
+        let mut p = prompt_after(tool);
+        router.apply(&mut p);
+        p.model
+    };
+    assert_eq!(route("safe"), CHEAP, "safe step settled on the cheap tier");
+    assert_eq!(route("risky"), CAPABLE, "risky step escalated to capable");
+    assert_eq!(
+        route("routine"),
+        CAPABLE,
+        "routine (operator) downgrade escalated to capable"
+    );
+
+    // The loop spent strictly less than routing everything at the capable tier —
+    // the discovered safe downgrade is a real, net saving.
+    assert!(
+        spend < flagship_only_spend,
+        "the converged policy must cost less than capable-only: {spend} vs {flagship_only_spend}"
+    );
+}

--- a/apps/bitrouter/src/adequacy/mod.rs
+++ b/apps/bitrouter/src/adequacy/mod.rs
@@ -1,24 +1,30 @@
-//! Online adequacy ledger — the escalate-sticky learned state behind adaptive
-//! policy-table routing.
+//! Online adequacy ledger — the learned state behind adaptive policy-table
+//! routing. It has two halves of the asymmetric routing rule:
 //!
-//! When `policy_table.adequacy` is enabled, the daemon watches every request a
-//! *downgrade* produced (the policy table routed a fingerprint to a cheaper tier
-//! than its escalation tier) and counts the ones that hard-fail. Once a
-//! fingerprint accumulates `escalation_threshold` failures it is **pinned**: the
-//! adaptive [`crate::policy_table_router::PolicyTableRouter`] then routes that
-//! fingerprint to the escalation tier instead of the cheap one. A pin decays
-//! after `pin_cooldown_secs`, so a downgrade that failed transiently is retried
-//! later rather than abandoned forever.
+//! - **Safety (escalate-sticky).** When a *downgrade* keeps hard-failing, the
+//!   fingerprint is **pinned** and the router escalates it to a more capable
+//!   tier. A pin decays after a cooldown so a transient failure is retried.
+//! - **Aggressive (downgrade discovery).** When exploration is enabled, a
+//!   fingerprint the static table routes to the escalation tier (one the
+//!   operator did *not* downgrade) is periodically **trialed** on the cheap
+//!   explore tier; after enough adequate trials it is **locked** to the cheap
+//!   tier — a downgrade discovered automatically. A trial that fails escalates
+//!   and stops, exactly like the safety path.
 //!
-//! This is the safety half of the asymmetric routing rule: the ledger never
-//! downgrades on its own — it only escalates a downgrade that is failing — so it
-//! can only ever make routing *more* conservative than the static table.
+//! Together: never net-lose (a failing downgrade self-corrects) while still
+//! pursuing cheaper routes (safe downgrades are found, not only hand-configured).
+//! No LLM, no randomness — the trial cadence is a deterministic counter.
 //!
-//! The read path ([`AdequacyLedger::is_pinned`]) is synchronous and lock-cheap
-//! because it runs inside the ingress [`bitrouter_sdk::PromptTransform`]; the
-//! write path ([`AdequacyLedger::observe`]) is async because it persists new
-//! pins, and runs from the [`observer::AdequacyObserveHook`] after each request.
+//! The read paths ([`AdequacyLedger::is_pinned`] / [`is_locked`](AdequacyLedger::is_locked)
+//! / [`should_trial`](AdequacyLedger::should_trial)) are synchronous and
+//! lock-cheap because they run inside the ingress [`bitrouter_sdk::PromptTransform`];
+//! the write path ([`AdequacyLedger::observe`]) is async because a new pin is
+//! persisted, and runs from the [`observer::AdequacyObserveHook`] after each
+//! request. Pins persist across restarts (the safety state); locks are in-memory
+//! and re-discovered (an optimization, cheap to re-learn).
 
+#[cfg(test)]
+mod eval;
 pub mod observer;
 pub mod store;
 
@@ -30,55 +36,104 @@ use bitrouter_sdk::config::AdequacyConfig;
 
 use self::store::AdequacyStore;
 
-/// Learned escalation state: which fingerprints are pinned, and the pre-pin
-/// failure tally that drives a pin.
+/// What the observer determined about one request, for the ledger to fold in.
+pub enum Outcome {
+    /// A static (operator-configured) downgrade — the served tier is the cheap
+    /// tier the static table assigned this fingerprint. Consecutive failures pin.
+    StaticDowngrade {
+        /// Whether the request hard-failed.
+        inadequate: bool,
+    },
+    /// An exploration candidate — the static table routes this fingerprint to the
+    /// escalation tier (the operator did not downgrade it). `trialed` is whether
+    /// this request was routed to the cheap explore tier (a trial or a locked
+    /// route), vs left on the escalation tier (which only advances the cadence).
+    Exploration {
+        /// Whether this request went to the explore tier.
+        trialed: bool,
+        /// Whether the request hard-failed (only meaningful when `trialed`).
+        inadequate: bool,
+    },
+}
+
+/// Learned escalation + exploration state, keyed by request fingerprint.
 pub struct AdequacyLedger {
     state: RwLock<State>,
     /// Persistence for pins. `None` in unit tests / when no db is wired.
     store: Option<AdequacyStore>,
-    /// Hard failures on a downgraded fingerprint before it is pinned (>= 1).
+    /// Consecutive hard failures on a downgrade before it is pinned (>= 1).
     threshold: u32,
     /// Seconds a pin lasts before the downgrade is re-attempted. `0` = no decay.
     cooldown_secs: u64,
+    /// Trial cadence: ~one in `explore_interval` candidate requests is a trial.
+    explore_interval: u32,
+    /// Consecutive adequate trials before a fingerprint locks to the cheap tier.
+    explore_threshold: u32,
 }
 
 #[derive(Default)]
 struct State {
-    /// fingerprint → Unix seconds the pin was last (re)applied.
-    pins: HashMap<String, u64>,
-    /// fingerprint → consecutive hard-failure count (pre-pin, transient).
-    failures: HashMap<String, u32>,
+    entries: HashMap<String, Entry>,
+}
+
+/// Per-fingerprint learned state.
+#[derive(Default)]
+struct Entry {
+    /// Consecutive hard-failure tally toward a pin (pre-pin, transient).
+    failures: u32,
+    /// Unix seconds the escalation pin was applied; `None` = not pinned.
+    pinned_at: Option<u64>,
+    /// Exploration candidate requests observed (drives the trial cadence).
+    observed: u32,
+    /// Consecutive adequate trials toward a lock.
+    adequate_trials: u32,
+    /// Locked to the explore tier — a discovered, learned downgrade.
+    locked: bool,
 }
 
 impl AdequacyLedger {
     /// Build a ledger from config, warming the in-memory pin cache from the
-    /// store. A failed warm-up read is non-fatal (the cache simply starts empty).
+    /// store. A failed warm-up read is non-fatal (the cache starts empty).
     pub async fn load(config: &AdequacyConfig, store: AdequacyStore) -> Self {
-        let mut pins = HashMap::new();
+        let mut entries: HashMap<String, Entry> = HashMap::new();
         if let Ok(rows) = store.load_all().await {
             for (fingerprint, pinned_at) in rows {
-                pins.insert(fingerprint, pinned_at.max(0) as u64);
+                entries.entry(fingerprint).or_default().pinned_at = Some(pinned_at.max(0) as u64);
             }
         }
         Self {
-            state: RwLock::new(State {
-                pins,
-                failures: HashMap::new(),
-            }),
+            state: RwLock::new(State { entries }),
             store: Some(store),
             threshold: config.escalation_threshold.max(1),
             cooldown_secs: config.pin_cooldown_secs,
+            explore_interval: config.explore_interval.max(1),
+            explore_threshold: config.explore_threshold.max(1),
         }
     }
 
-    /// An in-memory-only ledger (no persistence) — for tests.
+    /// An in-memory-only ledger (no persistence) with the given pin threshold /
+    /// cooldown and trial-every-request, lock-on-first-adequate-trial — for tests
+    /// that only exercise the safety path.
     #[cfg(test)]
     pub fn in_memory(threshold: u32, cooldown_secs: u64) -> Self {
+        Self::in_memory_explore(threshold, cooldown_secs, 1, 1)
+    }
+
+    /// An in-memory-only ledger with full exploration parameters — for tests.
+    #[cfg(test)]
+    pub fn in_memory_explore(
+        threshold: u32,
+        cooldown_secs: u64,
+        explore_interval: u32,
+        explore_threshold: u32,
+    ) -> Self {
         Self {
             state: RwLock::new(State::default()),
             store: None,
             threshold: threshold.max(1),
             cooldown_secs,
+            explore_interval: explore_interval.max(1),
+            explore_threshold: explore_threshold.max(1),
         }
     }
 
@@ -86,35 +141,75 @@ impl AdequacyLedger {
     /// for the router's hot path; a pin past its cooldown reads as not pinned.
     pub fn is_pinned(&self, fingerprint: &str) -> bool {
         let guard = self.state.read().unwrap_or_else(PoisonError::into_inner);
-        match guard.pins.get(fingerprint) {
-            Some(&pinned_at) => {
+        guard
+            .entries
+            .get(fingerprint)
+            .and_then(|e| e.pinned_at)
+            .is_some_and(|pinned_at| {
                 self.cooldown_secs == 0 || now_unix().saturating_sub(pinned_at) < self.cooldown_secs
-            }
-            None => false,
+            })
+    }
+
+    /// Whether `fingerprint` is locked to the explore tier (a learned downgrade).
+    pub fn is_locked(&self, fingerprint: &str) -> bool {
+        let guard = self.state.read().unwrap_or_else(PoisonError::into_inner);
+        guard.entries.get(fingerprint).is_some_and(|e| e.locked)
+    }
+
+    /// Whether the next request for an exploration candidate `fingerprint` should
+    /// be a trial on the explore tier (deterministic cadence). The router only
+    /// consults this when the fingerprint is neither pinned nor locked.
+    pub fn should_trial(&self, fingerprint: &str) -> bool {
+        let guard = self.state.read().unwrap_or_else(PoisonError::into_inner);
+        match guard.entries.get(fingerprint) {
+            Some(e) if !e.locked => e.observed > 0 && e.observed % self.explore_interval == 0,
+            // Unseen candidate: observed == 0, not yet a trial (the first request
+            // routes to the safe escalation tier and advances the cadence).
+            _ => false,
         }
     }
 
-    /// Record a *downgraded* request's outcome for `fingerprint`. An `inadequate`
-    /// outcome accrues toward a pin; an adequate one clears the pre-pin tally.
-    /// Async because a newly created pin is persisted.
-    pub async fn observe(&self, fingerprint: &str, inadequate: bool) {
+    /// Fold a request's [`Outcome`] into the ledger. Async because a newly
+    /// created pin is persisted.
+    pub async fn observe(&self, fingerprint: &str, outcome: Outcome) {
         let newly_pinned = {
             let mut guard = self.state.write().unwrap_or_else(PoisonError::into_inner);
-            if !inadequate {
-                // A clean outcome resets the pre-pin tally; an existing pin is
-                // left to decay on its own cooldown.
-                guard.failures.remove(fingerprint);
-                None
-            } else {
-                let count = guard.failures.entry(fingerprint.to_string()).or_insert(0);
-                *count += 1;
-                if *count >= self.threshold {
-                    let pinned_at = now_unix();
-                    guard.pins.insert(fingerprint.to_string(), pinned_at);
-                    guard.failures.remove(fingerprint);
-                    Some(pinned_at)
-                } else {
-                    None
+            let entry = guard.entries.entry(fingerprint.to_string()).or_default();
+            match outcome {
+                Outcome::StaticDowngrade { inadequate } => {
+                    if inadequate {
+                        entry.failures += 1;
+                        (entry.failures >= self.threshold).then(|| pin(entry))
+                    } else {
+                        // A clean outcome resets the pre-pin tally; an existing
+                        // pin decays on its own cooldown.
+                        entry.failures = 0;
+                        None
+                    }
+                }
+                Outcome::Exploration {
+                    trialed,
+                    inadequate,
+                } => {
+                    // Every candidate request (trialed or not) advances the cadence.
+                    entry.observed = entry.observed.saturating_add(1);
+                    if !trialed {
+                        None
+                    } else if inadequate {
+                        // A failed trial / locked route: un-learn the downgrade
+                        // and escalate (sticky), like the safety path.
+                        entry.adequate_trials = 0;
+                        entry.locked = false;
+                        Some(pin(entry))
+                    } else if !entry.locked {
+                        entry.adequate_trials += 1;
+                        if entry.adequate_trials >= self.explore_threshold {
+                            entry.locked = true;
+                        }
+                        None
+                    } else {
+                        None
+                    }
                 }
             }
         };
@@ -125,6 +220,15 @@ impl AdequacyLedger {
             let _ = store.upsert_pin(fingerprint, pinned_at as i64).await;
         }
     }
+}
+
+/// Apply an escalation pin to `entry`, clearing the pre-pin tally, and return the
+/// pin time (Unix seconds) so the caller can persist it.
+fn pin(entry: &mut Entry) -> u64 {
+    let pinned_at = now_unix();
+    entry.pinned_at = Some(pinned_at);
+    entry.failures = 0;
+    pinned_at
 }
 
 /// Current Unix time in seconds (saturating to 0 before the epoch).
@@ -139,65 +243,113 @@ fn now_unix() -> u64 {
 mod tests {
     use super::*;
 
+    fn fail() -> Outcome {
+        Outcome::StaticDowngrade { inadequate: true }
+    }
+    fn ok() -> Outcome {
+        Outcome::StaticDowngrade { inadequate: false }
+    }
+    fn trial(inadequate: bool) -> Outcome {
+        Outcome::Exploration {
+            trialed: true,
+            inadequate,
+        }
+    }
+    fn non_trial() -> Outcome {
+        Outcome::Exploration {
+            trialed: false,
+            inadequate: false,
+        }
+    }
+
+    // ---- safety half (pins) ----
+
     #[tokio::test]
     async fn pins_a_fingerprint_after_threshold_failures() {
         let ledger = AdequacyLedger::in_memory(2, 0);
+        ledger.observe("after_edit", fail()).await;
         assert!(!ledger.is_pinned("after_edit"));
-        ledger.observe("after_edit", true).await; // 1 failure < threshold 2
-        assert!(!ledger.is_pinned("after_edit"));
-        ledger.observe("after_edit", true).await; // 2 failures == threshold
-        assert!(ledger.is_pinned("after_edit"), "pinned at the threshold");
+        ledger.observe("after_edit", fail()).await;
+        assert!(ledger.is_pinned("after_edit"));
     }
 
     #[tokio::test]
     async fn an_adequate_outcome_resets_the_pre_pin_tally() {
         let ledger = AdequacyLedger::in_memory(2, 0);
-        ledger.observe("after_edit", true).await; // 1 failure
-        ledger.observe("after_edit", false).await; // clean → reset
-        ledger.observe("after_edit", true).await; // back to 1, not 2
-        assert!(
-            !ledger.is_pinned("after_edit"),
-            "a clean outcome between failures must prevent the pin"
-        );
-    }
-
-    #[tokio::test]
-    async fn threshold_one_pins_on_the_first_failure() {
-        let ledger = AdequacyLedger::in_memory(1, 0);
-        ledger.observe("after_edit", true).await;
-        assert!(ledger.is_pinned("after_edit"));
+        ledger.observe("after_edit", fail()).await;
+        ledger.observe("after_edit", ok()).await;
+        ledger.observe("after_edit", fail()).await;
+        assert!(!ledger.is_pinned("after_edit"));
     }
 
     #[tokio::test]
     async fn a_pin_decays_after_its_cooldown() {
-        // cooldown 0 never decays; a tiny cooldown with a back-dated pin reads as
-        // expired. Drive the cooldown logic directly via the cache.
         let ledger = AdequacyLedger::in_memory(1, 60);
-        ledger.observe("after_edit", true).await;
-        assert!(ledger.is_pinned("after_edit"), "freshly pinned");
-        // Back-date the pin beyond the cooldown.
+        ledger.observe("after_edit", fail()).await;
+        assert!(ledger.is_pinned("after_edit"));
         {
             let mut guard = ledger.state.write().unwrap_or_else(PoisonError::into_inner);
             let stale = now_unix().saturating_sub(120);
-            guard.pins.insert("after_edit".to_string(), stale);
+            guard.entries.get_mut("after_edit").unwrap().pinned_at = Some(stale);
         }
-        assert!(
-            !ledger.is_pinned("after_edit"),
-            "a pin past its cooldown reads as expired"
-        );
+        assert!(!ledger.is_pinned("after_edit"));
     }
 
     #[tokio::test]
     async fn zero_cooldown_pin_never_decays() {
         let ledger = AdequacyLedger::in_memory(1, 0);
-        ledger.observe("after_edit", true).await;
+        ledger.observe("after_edit", fail()).await;
         {
             let mut guard = ledger.state.write().unwrap_or_else(PoisonError::into_inner);
-            guard.pins.insert("after_edit".to_string(), 1); // ancient
+            guard.entries.get_mut("after_edit").unwrap().pinned_at = Some(1);
         }
+        assert!(ledger.is_pinned("after_edit"));
+    }
+
+    // ---- aggressive half (exploration) ----
+
+    #[tokio::test]
+    async fn trial_cadence_fires_every_interval() {
+        // interval 3: the first two candidate observations don't trial; the third
+        // does (observed cycles 1,2,3 → trial at 3).
+        let ledger = AdequacyLedger::in_memory_explore(1, 0, 3, 2);
+        assert!(!ledger.should_trial("opening")); // unseen
+        ledger.observe("opening", non_trial()).await; // observed=1
+        assert!(!ledger.should_trial("opening"));
+        ledger.observe("opening", non_trial()).await; // observed=2
+        assert!(!ledger.should_trial("opening"));
+        ledger.observe("opening", non_trial()).await; // observed=3
+        assert!(ledger.should_trial("opening"), "trial due at the interval");
+    }
+
+    #[tokio::test]
+    async fn locks_after_enough_adequate_trials() {
+        let ledger = AdequacyLedger::in_memory_explore(1, 0, 1, 2);
+        ledger.observe("opening", trial(false)).await; // 1 adequate trial
+        assert!(!ledger.is_locked("opening"));
+        ledger.observe("opening", trial(false)).await; // 2 → lock
+        assert!(ledger.is_locked("opening"), "locked after the threshold");
+    }
+
+    #[tokio::test]
+    async fn a_failed_trial_escalates_and_does_not_lock() {
+        let ledger = AdequacyLedger::in_memory_explore(1, 0, 1, 2);
+        ledger.observe("opening", trial(false)).await; // 1 adequate
+        ledger.observe("opening", trial(true)).await; // failure → pin, reset
+        assert!(!ledger.is_locked("opening"));
+        assert!(ledger.is_pinned("opening"), "a failed trial escalates");
+    }
+
+    #[tokio::test]
+    async fn a_failed_locked_route_unlocks_and_escalates() {
+        let ledger = AdequacyLedger::in_memory_explore(1, 0, 1, 1);
+        ledger.observe("opening", trial(false)).await; // locks (threshold 1)
+        assert!(ledger.is_locked("opening"));
+        ledger.observe("opening", trial(true)).await; // locked route fails
         assert!(
-            ledger.is_pinned("after_edit"),
-            "cooldown 0 means the pin is permanent"
+            !ledger.is_locked("opening"),
+            "a failed locked route un-locks"
         );
+        assert!(ledger.is_pinned("opening"));
     }
 }

--- a/apps/bitrouter/src/adequacy/observer.rs
+++ b/apps/bitrouter/src/adequacy/observer.rs
@@ -16,7 +16,7 @@ use bitrouter_sdk::language_model::{
     ObserveHook, Phase, PipelineContext, RequestOutcome, StreamContext,
 };
 
-use crate::adequacy::AdequacyLedger;
+use crate::adequacy::{AdequacyLedger, Outcome};
 use crate::policy_table_router::PolicyTable;
 
 /// Feeds the [`AdequacyLedger`] from request outcomes against the shared
@@ -42,33 +42,62 @@ impl ObserveHook for AdequacyObserveHook {
     async fn on_stream_part(&self, _ctx: &StreamContext, _part: &StreamPart) {}
 
     async fn on_request_end(&self, ctx: &PipelineContext, outcome: &RequestOutcome) {
-        // Credit the outcome only to a *genuine* policy-router downgrade: the
-        // served model must map to exactly the tier the static table resolves
-        // for this request (so a caller's explicit route, a coincidental model
-        // match, or an adequacy escalation is not mistaken for a downgrade)...
-        let Some(served_tier) = self.table.tier_of_model(ctx.model()) else {
-            return;
-        };
-        if self.table.static_tier(ctx.prompt()) != Some(served_tier) {
-            return;
-        }
-        // ...and that tier must be a downgrade, not the escalation tier (a
-        // request already escalated failing is not a downgrade to pin).
-        if Some(served_tier) == self.table.escalation_tier() {
-            return;
-        }
         let inadequate = match outcome {
             // A hard failure — an upstream error (including a mid-stream stream
-            // error, which the pipeline now surfaces as `Failed`), a route /
-            // auth / policy failure, etc.
+            // error, which the pipeline surfaces as `Failed`), a route / auth /
+            // policy failure, etc.
             RequestOutcome::Failed(_) => true,
             // The client hanging up tells us nothing about the tier — skip.
             RequestOutcome::ClientDisconnected => return,
-            // A completed request got a response: the downgrade held.
+            // A completed request got a response: the route held.
             RequestOutcome::Completed => false,
         };
-        let fingerprint = PolicyTable::fingerprint(ctx.prompt());
-        self.ledger.observe(&fingerprint, inadequate).await;
+        // Which of the table's tiers actually served the request. Not one of
+        // ours ⇒ nothing to learn.
+        let Some(served_tier) = self.table.tier_of_model(ctx.model()) else {
+            return;
+        };
+        let static_tier = self.table.static_tier(ctx.prompt());
+        let escalation_tier = self.table.escalation_tier();
+
+        // A genuine *static* (operator-configured) downgrade: the served tier is
+        // exactly the static decision, and it is a downgrade (not the escalation
+        // tier). This guards against a caller's explicit route / coincidental
+        // model match being mistaken for one.
+        if static_tier == Some(served_tier) && Some(served_tier) != escalation_tier {
+            let fingerprint = PolicyTable::fingerprint(ctx.prompt());
+            self.ledger
+                .observe(&fingerprint, Outcome::StaticDowngrade { inadequate })
+                .await;
+            return;
+        }
+
+        // An *exploration* candidate: the static decision is the escalation tier
+        // (the operator did not downgrade it). The request either trialed the
+        // explore tier or stayed on the escalation tier (advancing the cadence).
+        if self.table.exploration_enabled()
+            && escalation_tier.is_some()
+            && static_tier == escalation_tier
+        {
+            let trialed = self.table.explore_tier() == Some(served_tier);
+            // Count only a trial (served the explore tier) or a cadence-advance
+            // (served the escalation tier). A candidate served on some third tier
+            // — e.g. a tool request whose explore-tier trial the guardrail clamped
+            // up to the tool-use tier — is intentionally not counted: a real trial
+            // there would be clamped too, so exploration is correctly inert for it.
+            if trialed || Some(served_tier) == escalation_tier {
+                let fingerprint = PolicyTable::fingerprint(ctx.prompt());
+                self.ledger
+                    .observe(
+                        &fingerprint,
+                        Outcome::Exploration {
+                            trialed,
+                            inadequate,
+                        },
+                    )
+                    .await;
+            }
+        }
     }
 }
 
@@ -100,6 +129,28 @@ mod tests {
             tool_use_tier: None,
             tool_safe_tiers: Vec::new(),
             adequacy: Default::default(),
+        };
+        PolicyTable::from_config(&cfg).expect("configured")
+    }
+
+    // The same table with exploration on: `opening` (static = capable = the
+    // escalation tier) is a candidate trialed toward `cheap`.
+    fn explore_table() -> Arc<PolicyTable> {
+        let cfg = PolicyTableConfig {
+            tiers: HashMap::from([
+                ("cheap".to_string(), "vendor/cheap".to_string()),
+                ("capable".to_string(), "vendor/capable".to_string()),
+            ]),
+            fingerprints: HashMap::from([("opening".to_string(), "capable".to_string())]),
+            default_tier: Some("capable".to_string()),
+            tool_use_tier: None,
+            tool_safe_tiers: Vec::new(),
+            adequacy: bitrouter_sdk::config::AdequacyConfig {
+                enabled: true,
+                explore_enabled: true,
+                explore_tier: Some("cheap".to_string()),
+                ..Default::default()
+            },
         };
         PolicyTable::from_config(&cfg).expect("configured")
     }
@@ -211,5 +262,48 @@ mod tests {
         )
         .await;
         assert!(!ledger.is_pinned("after_read_file"));
+    }
+
+    // ---- exploration classification ----
+
+    #[tokio::test]
+    async fn a_failed_trial_pins_the_candidate() {
+        // `opening` is an exploration candidate (static = capable = escalation).
+        // A request served by the cheap (explore) tier is a trial; failing it pins.
+        let ledger = Arc::new(AdequacyLedger::in_memory_explore(1, 0, 1, 1));
+        let hook = AdequacyObserveHook::new(explore_table(), ledger.clone());
+        hook.on_request_end(&ctx("vendor/cheap", vec![user("start")]), &failed())
+            .await;
+        assert!(ledger.is_pinned("opening"));
+    }
+
+    #[tokio::test]
+    async fn an_adequate_trial_advances_toward_a_lock() {
+        // explore_threshold 1 → one adequate trial locks the downgrade.
+        let ledger = Arc::new(AdequacyLedger::in_memory_explore(1, 0, 1, 1));
+        let hook = AdequacyObserveHook::new(explore_table(), ledger.clone());
+        hook.on_request_end(
+            &ctx("vendor/cheap", vec![user("start")]),
+            &RequestOutcome::Completed,
+        )
+        .await;
+        assert!(ledger.is_locked("opening"), "an adequate trial locks it");
+    }
+
+    #[tokio::test]
+    async fn a_candidate_on_the_escalation_tier_advances_the_cadence() {
+        // A candidate served by the escalation tier is not a trial — it only
+        // advances the trial cadence (interval 2 → due after two such requests).
+        let ledger = Arc::new(AdequacyLedger::in_memory_explore(1, 0, 2, 2));
+        let hook = AdequacyObserveHook::new(explore_table(), ledger.clone());
+        assert!(!ledger.should_trial("opening"));
+        for _ in 0..2 {
+            hook.on_request_end(
+                &ctx("vendor/capable", vec![user("start")]),
+                &RequestOutcome::Completed,
+            )
+            .await;
+        }
+        assert!(ledger.should_trial("opening"), "the cadence advanced");
     }
 }

--- a/apps/bitrouter/src/adequacy/store.rs
+++ b/apps/bitrouter/src/adequacy/store.rs
@@ -89,7 +89,7 @@ impl AdequacyStore {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::adequacy::AdequacyLedger;
+    use crate::adequacy::{AdequacyLedger, Outcome};
     use crate::db;
     use bitrouter_sdk::config::AdequacyConfig;
 
@@ -135,10 +135,13 @@ mod tests {
             escalation_tier: None,
             escalation_threshold: 1,
             pin_cooldown_secs: 0,
+            ..Default::default()
         };
         // First ledger: a failure pins the fingerprint and persists it.
         let ledger = AdequacyLedger::load(&cfg, AdequacyStore::new(db.clone())).await;
-        ledger.observe("after_edit", true).await;
+        ledger
+            .observe("after_edit", Outcome::StaticDowngrade { inadequate: true })
+            .await;
         assert!(ledger.is_pinned("after_edit"));
         // A fresh ledger over the same db warms its cache from the stored pin.
         let reloaded = AdequacyLedger::load(&cfg, AdequacyStore::new(db.clone())).await;

--- a/apps/bitrouter/src/policy_table_router.rs
+++ b/apps/bitrouter/src/policy_table_router.rs
@@ -52,6 +52,11 @@ pub struct PolicyTable {
     /// Tier a pinned fingerprint escalates to (adequacy.escalation_tier, else
     /// default_tier). `None` when neither is configured.
     escalation_tier: Option<String>,
+    /// Cheap tier exploration trials toward (adequacy.explore_tier). `None` when
+    /// exploration is off.
+    explore_tier: Option<String>,
+    /// Whether aggressive downgrade discovery is enabled.
+    exploration_enabled: bool,
     /// Reverse index model id → tier name, for mapping a served model back to
     /// its tier at observe time.
     model_to_tier: HashMap<String, String>,
@@ -74,6 +79,11 @@ impl PolicyTable {
             .escalation_tier
             .clone()
             .or_else(|| config.default_tier.clone());
+        // Exploration is live only when enabled, a target tier is set, and there
+        // is an escalation tier to be a candidate against.
+        let exploration_enabled = config.adequacy.explore_enabled
+            && config.adequacy.explore_tier.is_some()
+            && escalation_tier.is_some();
         Some(Arc::new(Self {
             tiers: config.tiers.clone(),
             fingerprints: config.fingerprints.clone(),
@@ -81,6 +91,8 @@ impl PolicyTable {
             tool_use_tier: config.tool_use_tier.clone(),
             tool_safe_tiers: config.tool_safe_tiers.clone(),
             escalation_tier,
+            explore_tier: config.adequacy.explore_tier.clone(),
+            exploration_enabled,
             model_to_tier,
         }))
     }
@@ -124,14 +136,30 @@ impl PolicyTable {
     }
 
     /// The tier the *static* table (fingerprint → tier → guardrail, before any
-    /// adequacy escalation) would route this prompt to. The observer uses it to
+    /// adequacy adaptation) would route this prompt to. The observer uses it to
     /// confirm a request was a genuine policy-router downgrade — the served tier
     /// matches the static decision — before crediting its outcome, so a caller's
     /// explicit route or a coincidental model match is not mistaken for one.
     pub(crate) fn static_tier(&self, prompt: &Prompt) -> Option<&str> {
         let fingerprint = Self::fingerprint(prompt);
-        let tier = self.tier_for_fingerprint(&fingerprint)?;
+        self.static_tier_for(&fingerprint, prompt)
+    }
+
+    /// [`Self::static_tier`] for an already-computed fingerprint.
+    fn static_tier_for(&self, fingerprint: &str, prompt: &Prompt) -> Option<&str> {
+        let tier = self.tier_for_fingerprint(fingerprint)?;
         Some(self.guardrail(tier, prompt))
+    }
+
+    /// The cheap tier exploration trials toward (raw; gate on
+    /// [`Self::exploration_enabled`]).
+    pub(crate) fn explore_tier(&self) -> Option<&str> {
+        self.explore_tier.as_deref()
+    }
+
+    /// Whether aggressive downgrade discovery is live.
+    pub(crate) fn exploration_enabled(&self) -> bool {
+        self.exploration_enabled
     }
 
     /// A coarse fingerprint of the agent-loop step, derived purely from the
@@ -231,21 +259,17 @@ impl PolicyTableRouter {
             return false;
         }
         let fingerprint = PolicyTable::fingerprint(prompt);
-        let mut tier = self.table.tier_for_fingerprint(&fingerprint);
-        // Adequacy escalation: a pinned fingerprint (a downgrade the ledger
-        // learned is failing) routes to the escalation tier, overriding the
-        // static — cheaper — tier. Reading the ledger is sync and lock-cheap.
-        if let Some(ledger) = &self.ledger
-            && ledger.is_pinned(&fingerprint)
-            && let Some(escalation) = self.table.escalation_tier()
-        {
-            tier = Some(escalation);
-        }
-        let Some(tier) = tier else {
+        // The static decision (fingerprint → tier → guardrail). No tier ⇒ no-op.
+        let Some(static_tier) = self.table.static_tier_for(&fingerprint, prompt) else {
             return false;
         };
-        // The tool-use guardrail applies on top of whichever tier was chosen.
-        let tier = self.table.guardrail(tier, prompt);
+        // Layer the ledger's adaptation on top (escalation pin / exploration);
+        // without a ledger this is exactly the static tier. Reading the ledger is
+        // sync and lock-cheap.
+        let tier = match &self.ledger {
+            Some(ledger) => self.adapt(ledger, &fingerprint, static_tier, prompt),
+            None => static_tier,
+        };
         let Some(model) = self.table.model_of_tier(tier) else {
             // Unreachable for a config that passed `validate_policy_table`, but
             // a no-op is the safe fallback rather than a panic.
@@ -256,6 +280,38 @@ impl PolicyTableRouter {
         }
         prompt.model = model.to_string();
         true
+    }
+
+    /// Adapt the `static_tier` using the ledger's learned state. Safety wins
+    /// first: a *pinned* fingerprint escalates. Otherwise, an exploration
+    /// *candidate* (one the static table routes to the escalation tier) is routed
+    /// to the explore tier when it is locked (a learned downgrade) or due for a
+    /// trial. Every override is re-guardrailed; an inapplicable case returns the
+    /// static tier unchanged.
+    fn adapt<'a>(
+        &'a self,
+        ledger: &AdequacyLedger,
+        fingerprint: &str,
+        static_tier: &'a str,
+        prompt: &Prompt,
+    ) -> &'a str {
+        // Safety half: a pinned downgrade escalates.
+        if ledger.is_pinned(fingerprint)
+            && let Some(escalation) = self.table.escalation_tier()
+        {
+            return self.table.guardrail(escalation, prompt);
+        }
+        // Aggressive half: trial / lock a downgrade for a candidate fingerprint
+        // (the static decision is the escalation tier — the operator left it
+        // capable, so it is eligible for cheaper trials).
+        if self.table.exploration_enabled()
+            && Some(static_tier) == self.table.escalation_tier()
+            && let Some(explore) = self.table.explore_tier()
+            && (ledger.is_locked(fingerprint) || ledger.should_trial(fingerprint))
+        {
+            return self.table.guardrail(explore, prompt);
+        }
+        static_tier
     }
 }
 
@@ -301,6 +357,7 @@ fn is_bitrouter_namespaced(name: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::adequacy::Outcome;
     use bitrouter_sdk::language_model::types::{GenerationParams, Message, ProviderMetadata, Tool};
 
     /// A policy table with a cheap and a flagship tier: `opening` and tool-heavy
@@ -641,7 +698,12 @@ mod tests {
         assert_eq!(route_with(&router, read_step()), "vendor/cheap");
 
         // One inadequate outcome pins the fingerprint (threshold 1).
-        ledger.observe("after_read_file", true).await;
+        ledger
+            .observe(
+                "after_read_file",
+                Outcome::StaticDowngrade { inadequate: true },
+            )
+            .await;
 
         // Now the same step escalates to the flagship (escalation) tier.
         assert_eq!(
@@ -657,7 +719,12 @@ mod tests {
         let ledger = Arc::new(AdequacyLedger::in_memory(1, 0));
         let router = PolicyTableRouter::new(table, Some(ledger.clone()));
 
-        ledger.observe("after_read_file", true).await; // pin only this fingerprint
+        ledger
+            .observe(
+                "after_read_file",
+                Outcome::StaticDowngrade { inadequate: true },
+            )
+            .await; // pin only this fingerprint
 
         // A different downgraded step is unaffected: map `after_grep` → cheap.
         // (It is unmapped here, so it falls to default flagship anyway; assert the
@@ -675,5 +742,100 @@ mod tests {
         // routing stays exactly static.
         let router = PolicyTableRouter::from_config(&config_with_escalation()).expect("configured");
         assert_eq!(route_with(&router, read_step()), "vendor/cheap");
+    }
+
+    // ---- aggressive exploration (downgrade discovery) ----
+
+    /// `config()` with exploration on: `opening` → flagship (the escalation tier)
+    /// is an exploration candidate, trialed toward the cheap tier.
+    fn config_with_exploration() -> PolicyTableConfig {
+        let mut cfg = config_with_escalation();
+        cfg.adequacy.explore_enabled = true;
+        cfg.adequacy.explore_tier = Some("cheap".to_string());
+        cfg.adequacy.explore_interval = 2;
+        cfg.adequacy.explore_threshold = 2;
+        cfg
+    }
+
+    fn exploring_router(ledger: Arc<AdequacyLedger>) -> PolicyTableRouter {
+        let table = PolicyTable::from_config(&config_with_exploration()).expect("configured");
+        PolicyTableRouter::new(table, Some(ledger))
+    }
+
+    fn trial_ok() -> Outcome {
+        Outcome::Exploration {
+            trialed: true,
+            inadequate: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn an_unseen_candidate_stays_on_the_escalation_tier() {
+        // No learned state yet → `opening` routes to its static (escalation) tier.
+        let router = exploring_router(Arc::new(AdequacyLedger::in_memory_explore(1, 0, 2, 2)));
+        assert_eq!(route_with(&router, vec![user("start")]), "vendor/flagship");
+    }
+
+    #[tokio::test]
+    async fn a_due_trial_routes_a_candidate_to_the_explore_tier() {
+        let ledger = Arc::new(AdequacyLedger::in_memory_explore(1, 0, 2, 2));
+        // Two non-trial observations advance the cadence so a trial is due.
+        let non_trial = || Outcome::Exploration {
+            trialed: false,
+            inadequate: false,
+        };
+        ledger.observe("opening", non_trial()).await;
+        ledger.observe("opening", non_trial()).await;
+        let router = exploring_router(ledger);
+        assert_eq!(
+            route_with(&router, vec![user("start")]),
+            "vendor/cheap",
+            "a candidate due for a trial routes to the explore tier"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_locked_candidate_routes_to_the_explore_tier() {
+        let ledger = Arc::new(AdequacyLedger::in_memory_explore(1, 0, 2, 2));
+        ledger.observe("opening", trial_ok()).await; // 1 adequate trial
+        ledger.observe("opening", trial_ok()).await; // 2 → locked
+        let router = exploring_router(ledger);
+        assert_eq!(route_with(&router, vec![user("start")]), "vendor/cheap");
+    }
+
+    #[tokio::test]
+    async fn a_pinned_candidate_escalates_over_exploration() {
+        let ledger = Arc::new(AdequacyLedger::in_memory_explore(1, 0, 2, 2));
+        // A failed trial pins the candidate (safety wins).
+        ledger
+            .observe(
+                "opening",
+                Outcome::Exploration {
+                    trialed: true,
+                    inadequate: true,
+                },
+            )
+            .await;
+        let router = exploring_router(ledger);
+        assert_eq!(
+            route_with(&router, vec![user("start")]),
+            "vendor/flagship",
+            "a pin overrides exploration"
+        );
+    }
+
+    #[tokio::test]
+    async fn exploration_respects_the_tool_use_guardrail() {
+        // A locked candidate that carries tools is clamped back up by the
+        // guardrail: a tool request is never downgraded below the tool-safe tier,
+        // even when exploration has locked the cheap tier.
+        let ledger = Arc::new(AdequacyLedger::in_memory_explore(1, 0, 2, 1));
+        ledger.observe("opening", trial_ok()).await; // locks (threshold 1)
+        let router = exploring_router(ledger);
+        let mut p = prompt("inbound");
+        p.messages = vec![user("start")];
+        p.tools = vec![a_tool()];
+        router.apply(&mut p);
+        assert_eq!(p.model, "vendor/flagship", "guardrail clamps the trial");
     }
 }

--- a/crates/bitrouter-sdk/src/config/mod.rs
+++ b/crates/bitrouter-sdk/src/config/mod.rs
@@ -222,6 +222,26 @@ pub struct AdequacyConfig {
     /// `0` means the pin never decays (until the process restarts or the row is
     /// cleared). Default `1800` (30 minutes).
     pub pin_cooldown_secs: u64,
+    /// Aggressive downgrade *discovery*: when [`explore_enabled`](Self::explore_enabled)
+    /// is on, the daemon periodically trials [`explore_tier`](Self::explore_tier)
+    /// on fingerprints the static table routes to the escalation tier (i.e. ones
+    /// the operator did *not* downgrade), and locks a fingerprint to the cheap
+    /// tier once it survives [`explore_threshold`](Self::explore_threshold)
+    /// trials — so safe downgrades are found automatically rather than only
+    /// hand-configured. A trial that fails escalates and stops (the same pin as
+    /// the safety path). Off by default; requires `enabled`. This is the
+    /// *aggressive* half — it routes traffic the operator left at the capable
+    /// tier to a cheaper one on a fraction of requests.
+    pub explore_enabled: bool,
+    /// The cheap tier exploration trials toward. Must resolve to a defined tier
+    /// when [`explore_enabled`](Self::explore_enabled). Required to explore.
+    pub explore_tier: Option<String>,
+    /// Trial cadence: roughly one in `explore_interval` eligible requests is a
+    /// trial (the rest stay on the escalation tier). Default `5`.
+    pub explore_interval: u32,
+    /// Consecutive adequate trials before a fingerprint is locked to the cheap
+    /// tier (the learned downgrade). Default `3`.
+    pub explore_threshold: u32,
 }
 
 impl Default for AdequacyConfig {
@@ -231,6 +251,10 @@ impl Default for AdequacyConfig {
             escalation_tier: None,
             escalation_threshold: 1,
             pin_cooldown_secs: 1800,
+            explore_enabled: false,
+            explore_tier: None,
+            explore_interval: 5,
+            explore_threshold: 3,
         }
     }
 }
@@ -971,6 +995,24 @@ fn validate_policy_table(config: &Config) -> Result<()> {
             "policy_table.adequacy is enabled but no escalation target is set: \
              set adequacy.escalation_tier or default_tier"
                 .to_string(),
+        ));
+    }
+    // Exploration trials toward `explore_tier`, which must exist and be a defined
+    // tier when exploration is enabled.
+    if let Some(tier) = &adequacy.explore_tier {
+        check("adequacy.explore_tier", tier)?;
+    }
+    if adequacy.explore_enabled && adequacy.explore_tier.is_none() {
+        return Err(BitrouterError::bad_request(
+            "policy_table.adequacy.explore_enabled is set but adequacy.explore_tier is not"
+                .to_string(),
+        ));
+    }
+    // Exploration rides on the adequacy ledger, which is only wired when learning
+    // is enabled — so `explore_enabled` without `enabled` would be silently inert.
+    if adequacy.explore_enabled && !adequacy.enabled {
+        return Err(BitrouterError::bad_request(
+            "policy_table.adequacy.explore_enabled requires adequacy.enabled".to_string(),
         ));
     }
     Ok(())

--- a/crates/bitrouter-sdk/src/config/tests.rs
+++ b/crates/bitrouter-sdk/src/config/tests.rs
@@ -618,3 +618,99 @@ policy_table:
         "got: {err}"
     );
 }
+
+#[test]
+fn parses_exploration_section() {
+    let yaml = r#"
+policy_table:
+  tiers:
+    cheap: vendor/cheap
+    capable: vendor/capable
+  default_tier: capable
+  adequacy:
+    enabled: true
+    explore_enabled: true
+    explore_tier: cheap
+    explore_interval: 8
+    explore_threshold: 4
+"#;
+    let cfg = parse_with(yaml, |_| None).unwrap();
+    let adequacy = &cfg.policy_table.adequacy;
+    assert!(adequacy.explore_enabled);
+    assert_eq!(adequacy.explore_tier.as_deref(), Some("cheap"));
+    assert_eq!(adequacy.explore_interval, 8);
+    assert_eq!(adequacy.explore_threshold, 4);
+}
+
+#[test]
+fn exploration_defaults_when_omitted() {
+    let yaml = r#"
+policy_table:
+  tiers:
+    cheap: vendor/cheap
+"#;
+    let cfg = parse_with(yaml, |_| None).unwrap();
+    let adequacy = &cfg.policy_table.adequacy;
+    assert!(!adequacy.explore_enabled);
+    assert_eq!(adequacy.explore_interval, 5);
+    assert_eq!(adequacy.explore_threshold, 3);
+}
+
+#[test]
+fn exploration_unknown_explore_tier_is_a_400() {
+    let yaml = r#"
+policy_table:
+  tiers:
+    cheap: vendor/cheap
+  default_tier: cheap
+  adequacy:
+    enabled: true
+    explore_tier: nope
+"#;
+    let err = parse_with(yaml, |_| None).unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("adequacy.explore_tier references unknown tier 'nope'"),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn exploration_enabled_without_target_is_a_400() {
+    let yaml = r#"
+policy_table:
+  tiers:
+    cheap: vendor/cheap
+  default_tier: cheap
+  adequacy:
+    enabled: true
+    explore_enabled: true
+"#;
+    let err = parse_with(yaml, |_| None).unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("explore_enabled is set but adequacy.explore_tier is not"),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn exploration_requires_adequacy_enabled() {
+    // `explore_enabled` without `enabled` would be silently inert (the ledger is
+    // only wired when learning is on) — reject it loudly.
+    let yaml = r#"
+policy_table:
+  tiers:
+    cheap: vendor/cheap
+  default_tier: cheap
+  adequacy:
+    explore_enabled: true
+    explore_tier: cheap
+"#;
+    let err = parse_with(yaml, |_| None).unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("explore_enabled requires adequacy.enabled"),
+        "got: {err}"
+    );
+}

--- a/examples/bitrouter.yaml
+++ b/examples/bitrouter.yaml
@@ -83,3 +83,14 @@ policy_table:
     escalation_tier: capable
     escalation_threshold: 2
     pin_cooldown_secs: 1800
+    # Aggressive downgrade *discovery* (off by default). When enabled, the daemon
+    # periodically trials `explore_tier` on fingerprints the table routes to the
+    # escalation tier (ones you did NOT downgrade) and locks a fingerprint to the
+    # cheap tier once it survives `explore_threshold` trials — finding safe
+    # downgrades automatically. A trial that fails escalates and stops, like the
+    # safety path. This routes some of your capable-tier traffic to the cheap tier
+    # speculatively, so it is the aggressive knob.
+    explore_enabled: false
+    explore_tier: cheap
+    explore_interval: 5
+    explore_threshold: 3

--- a/schemas/bitrouter.config.schema.json
+++ b/schemas/bitrouter.config.schema.json
@@ -95,6 +95,33 @@
             "null"
           ]
         },
+        "explore_enabled": {
+          "default": false,
+          "description": "Aggressive downgrade *discovery*: when [`explore_enabled`](Self::explore_enabled)\nis on, the daemon periodically trials [`explore_tier`](Self::explore_tier)\non fingerprints the static table routes to the escalation tier (i.e. ones\nthe operator did *not* downgrade), and locks a fingerprint to the cheap\ntier once it survives [`explore_threshold`](Self::explore_threshold)\ntrials — so safe downgrades are found automatically rather than only\nhand-configured. A trial that fails escalates and stops (the same pin as\nthe safety path). Off by default; requires `enabled`. This is the\n*aggressive* half — it routes traffic the operator left at the capable\ntier to a cheaper one on a fraction of requests.",
+          "type": "boolean"
+        },
+        "explore_interval": {
+          "default": 5,
+          "description": "Trial cadence: roughly one in `explore_interval` eligible requests is a\ntrial (the rest stay on the escalation tier). Default `5`.",
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "explore_threshold": {
+          "default": 3,
+          "description": "Consecutive adequate trials before a fingerprint is locked to the cheap\ntier (the learned downgrade). Default `3`.",
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "explore_tier": {
+          "default": null,
+          "description": "The cheap tier exploration trials toward. Must resolve to a defined tier\nwhen [`explore_enabled`](Self::explore_enabled). Required to explore.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "pin_cooldown_secs": {
           "default": 1800,
           "description": "How long, in seconds, a pin lasts before the downgrade is re-attempted.\n`0` means the pin never decays (until the process restarts or the row is\ncleared). Default `1800` (30 minutes).",


### PR DESCRIPTION
**Stacked on #625** (which is stacked on #624). Review/merge those first; this targets `feat/adequacy-ledger`.

## What

The *aggressive* half of the asymmetric routing rule, on top of the adequacy ledger's safety half (#625). When exploration is enabled, the daemon periodically **trials** the cheap `explore_tier` on fingerprints the static table routes to the escalation tier — ones the operator did **not** downgrade — and **locks** a fingerprint to the cheap tier once it survives `explore_threshold` adequate trials. Safe downgrades are discovered automatically rather than only hand-configured. A trial that fails escalates and stops (the same sticky pin as the safety path), so the guarantee holds: **never net-lose, while still pursuing cheaper routes.**

Deterministic (the trial cadence is a counter — no randomness), opt-in (`policy_table.adequacy.explore_enabled`), and the tool-use guardrail still clamps any trial that would downgrade a tool request below the floor.

## How

- **Router decision order** (`adapt`): explicit/server-tool guards → static decision → `pin?`→escalate → `locked?`→cheap → `trial due?`→cheap → guardrail. P2/#624 behavior is preserved exactly when exploration is off or no ledger is wired.
- **Ledger**: a unified per-fingerprint `Entry` (failure tally + pin + trial cadence counter + adequate-trial tally + lock). `should_trial` fires ~1/`explore_interval` deterministically. A failed trial un-locks and pins.
- **Observer**: classifies each request into a typed `Outcome` — `StaticDowngrade` (served == static decision, a downgrade) vs `Exploration` (static decision is the escalation tier; `trialed` = served the explore tier vs cadence-advance on the escalation tier). The two branches partition on `static == escalation`, so a trial can't be miscounted as a static downgrade or vice versa.
- **Persistence**: pins persist (safety); locks are in-memory and cheaply re-discovered.

## Convergence eval

`apps/bitrouter/src/adequacy/eval.rs` drives the **real** router + observer + ledger over a synthetic workload with known ground truth and asserts the loop converges: it locks the genuinely-safe downgrade (`after_safe`→cheap), escalates the unsafe exploration candidate (`after_risky`→capable) and the unsafe operator downgrade (`after_routine`→capable), and spends strictly less than a capable-only baseline (~31% cheaper). No live upstream, no randomness — the offline form of the benchmark (E3).

## Deferred (documented)

The verification-gated, **in-request** "resumable cheap attempt" (route cheap → judge the response → re-run on the capable tier if inadequate, so a wrong cheap route costs ~1x not ~2-3x) is intentionally **not** here: it is an invasive change to the execution path that deserves its own design. Trial-based discovery captures most of the cost-discovery value at far lower risk.

## Config (off by default)

```yaml
policy_table:
  adequacy:
    enabled: true          # required for exploration
    explore_enabled: false # opt-in aggressive half
    explore_tier: cheap
    explore_interval: 5    # ~1 in N eligible requests is a trial
    explore_threshold: 3   # adequate trials before locking
```

Validated at parse time: unknown `explore_tier`; `explore_enabled` without `explore_tier`; `explore_enabled` without `enabled`.

## Tests / checks

Ledger (cadence, lock threshold, failed-trial-pins, failed-locked-route-unlocks); router (trial / locked / pin-overrides-exploration / unseen-stays-escalation / guardrail-clamps-a-trial); observer (trial-fail-pins, adequate-trial-locks, cadence-advance); the convergence eval; config defaults + 3 validation cases. `cargo nextest -p bitrouter-sdk -p bitrouter --all-features`: **818 pass**. clippy `-D`, fmt, `generate-schema --check`, rustdoc `-D`, `config validate` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)