### PR TITLE
fix(codex): Harden Codex spawn checks

### DIFF
--- a/apps/bitrouter/src/commands.rs
+++ b/apps/bitrouter/src/commands.rs
@@ -574,9 +574,7 @@ fn choose_auth_method(
             entry.id
         );
     }
-    if selectable.len() == 1 {
-        Ok(selectable[0])
-    } else if options.no_browser {
+    if selectable.len() == 1 || options.no_browser {
         Ok(selectable[0])
     } else {
         prompt_method_choice(&entry.display_name, &selectable)

--- a/apps/bitrouter/src/commands.rs
+++ b/apps/bitrouter/src/commands.rs
@@ -451,7 +451,24 @@ pub struct LoginOutcome {
     pub path: String,
 }
 
+/// Non-interactive provider-login controls.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ProviderLoginOptions {
+    /// Require importing an already-authenticated vendor CLI session.
+    pub import_existing: bool,
+    /// Refuse browser-based PKCE flows.
+    pub no_browser: bool,
+}
+
 pub async fn login_provider(provider_id: &str, label: &str) -> Result<LoginOutcome> {
+    login_provider_with_options(provider_id, label, ProviderLoginOptions::default()).await
+}
+
+pub async fn login_provider_with_options(
+    provider_id: &str,
+    label: &str,
+    options: ProviderLoginOptions,
+) -> Result<LoginOutcome> {
     use bitrouter_providers::builtin;
 
     // The `bitrouter` cloud gateway is compiled in; every other provider's
@@ -492,11 +509,7 @@ pub async fn login_provider(provider_id: &str, label: &str) -> Result<LoginOutco
             std::mem::discriminant(&entry.auth)
         );
     }
-    let chosen = if methods.len() == 1 {
-        methods[0]
-    } else {
-        prompt_method_choice(&entry.display_name, &methods)?
-    };
+    let chosen = choose_auth_method(&entry, &methods, options)?;
     eprintln!();
     eprintln!(
         "  Logging in to {} via {}",
@@ -529,6 +542,45 @@ pub async fn login_provider(provider_id: &str, label: &str) -> Result<LoginOutco
         method: kind.to_string(),
         path: store.path().display().to_string(),
     })
+}
+
+fn choose_auth_method(
+    entry: &bitrouter_providers::ProviderEntry,
+    methods: &[AuthMethod],
+    options: ProviderLoginOptions,
+) -> Result<AuthMethod> {
+    if options.import_existing {
+        if methods.contains(&AuthMethod::ImportFromCli) {
+            return Ok(AuthMethod::ImportFromCli);
+        }
+        anyhow::bail!(
+            "provider '{}' cannot import an existing vendor CLI session",
+            entry.id
+        );
+    }
+
+    let selectable: Vec<AuthMethod> = if options.no_browser {
+        methods
+            .iter()
+            .copied()
+            .filter(|m| *m != AuthMethod::PkceSubscription)
+            .collect()
+    } else {
+        methods.to_vec()
+    };
+    if selectable.is_empty() {
+        anyhow::bail!(
+            "provider '{}' has no non-browser login path; rerun without --no-browser",
+            entry.id
+        );
+    }
+    if selectable.len() == 1 {
+        Ok(selectable[0])
+    } else if options.no_browser {
+        Ok(selectable[0])
+    } else {
+        prompt_method_choice(&entry.display_name, &selectable)
+    }
 }
 
 /// Adopt the user's existing Claude Code session as the live credential source
@@ -1247,6 +1299,50 @@ mod tests {
         assert!(methods.contains(&AuthMethod::ImportFromCli));
         assert!(methods.contains(&AuthMethod::PkceSubscription));
         assert!(!methods.contains(&AuthMethod::ClaudeCodeSession));
+    }
+
+    #[test]
+    fn import_existing_selects_vendor_cli_import_without_prompting() {
+        let entry = entry_for(serde_json::json!({
+            "name": "openai-codex",
+            "api_base": "https://chatgpt.com/backend-api/codex",
+            "status": "active",
+            "auth": { "kind": "oauth", "handler": "openai-codex" },
+            "models": []
+        }));
+        let methods = available_methods(&entry);
+        let chosen = choose_auth_method(
+            &entry,
+            &methods,
+            ProviderLoginOptions {
+                import_existing: true,
+                no_browser: true,
+            },
+        )
+        .unwrap();
+        assert_eq!(chosen, AuthMethod::ImportFromCli);
+    }
+
+    #[test]
+    fn import_existing_rejects_providers_without_vendor_cli_import() {
+        let entry = entry_for(serde_json::json!({
+            "name": "anthropic",
+            "api_base": "https://api.anthropic.com/v1",
+            "status": "active",
+            "auth": { "kind": "header", "header": "x-api-key", "env": "ANTHROPIC_API_KEY" },
+            "models": []
+        }));
+        let methods = available_methods(&entry);
+        let err = choose_auth_method(
+            &entry,
+            &methods,
+            ProviderLoginOptions {
+                import_existing: true,
+                no_browser: true,
+            },
+        )
+        .unwrap_err();
+        assert!(format!("{err:#}").contains("cannot import"));
     }
 
     fn sample_config() -> Config {

--- a/apps/bitrouter/src/main.rs
+++ b/apps/bitrouter/src/main.rs
@@ -21,7 +21,6 @@ use clap::{Parser, Subcommand, ValueEnum};
 
 use bitrouter::commands;
 use bitrouter::daemon::{self, DaemonCommand, DaemonResponse, RouteHop};
-use bitrouter::output::Output;
 use bitrouter::output::reports::admin::{
     KeySignReport, PolicyCreateReport, ProviderLoginReport, ProviderLogoutReport,
 };
@@ -39,6 +38,7 @@ use bitrouter::output::reports::tools::{
     ToolsStatusReport,
 };
 use bitrouter::output::reports::verify::{Check, VerifyReport};
+use bitrouter::output::{CliReport, Output};
 use bitrouter_sdk::config;
 
 /// BitRouter — an LLM API router.
@@ -257,6 +257,10 @@ enum Command {
         /// regardless.)
         #[arg(long)]
         no_start: bool,
+        /// Check the agent binary, BitRouter base URL, and route compatibility
+        /// without launching the agent.
+        #[arg(long)]
+        check: bool,
         /// Arguments forwarded verbatim to the agent binary. Everything after
         /// `--` lands here.
         #[arg(last = true, allow_hyphen_values = true)]
@@ -541,6 +545,13 @@ enum ProviderAction {
         /// Ignored for the `bitrouter` provider (it uses the cloud credential).
         #[arg(short, long, default_value = "default")]
         label: String,
+        /// Import an existing vendor CLI session without prompting for a
+        /// browser sign-in. Currently supported by openai-codex.
+        #[arg(long)]
+        import_existing: bool,
+        /// Do not run a browser-based provider OAuth flow.
+        #[arg(long)]
+        no_browser: bool,
     },
     /// Log out of an upstream provider — clears every stored credential for
     /// it. For the built-in `bitrouter` provider this is `cloud logout`.
@@ -674,22 +685,30 @@ async fn run(cli: Cli, output: &bitrouter::output::Output) -> Result<()> {
             base_url,
             no_install,
             no_start,
+            check,
             agent_args,
         } => {
             let source = bitrouter::paths::resolve_config(config.as_deref())?;
             let cfg = bitrouter::paths::load_config(&source).await?;
-            bitrouter::spawn::run(
-                &source,
-                &cfg,
-                bitrouter::spawn::SpawnOptions {
-                    agent,
-                    agent_args,
-                    base_url,
-                    no_install,
-                    no_start,
-                },
-            )
-            .await
+            let opts = bitrouter::spawn::SpawnOptions {
+                agent,
+                agent_args,
+                base_url,
+                no_install,
+                no_start,
+                check,
+            };
+            if opts.check {
+                let report = bitrouter::spawn::check(&cfg, &opts).await?;
+                output.emit(&report)?;
+                if report.exit_code() == 0 {
+                    Ok(())
+                } else {
+                    std::process::exit(report.exit_code());
+                }
+            } else {
+                bitrouter::spawn::run(&source, &cfg, opts).await
+            }
         }
         Command::Cloud { action } => bitrouter::cloud::cli::run(action, output.format()).await,
         Command::Skills { action } => bitrouter::skills::cli::run(action, output).await,
@@ -1696,11 +1715,22 @@ async fn providers(action: ProviderAction, output: &Output) -> Result<()> {
             output.emit(&ProvidersReport { providers })?;
             Ok(())
         }
-        ProviderAction::Login { provider, label } => {
+        ProviderAction::Login {
+            provider,
+            label,
+            import_existing,
+            no_browser,
+        } => {
             // The built-in `bitrouter` provider authenticates with the cloud
             // OAuth credential, so logging into it IS the cloud sign-in
             // (`cloud login`); other providers use the per-provider store.
             if provider == "bitrouter" {
+                if import_existing || no_browser {
+                    anyhow::bail!(
+                        "`bitrouter providers login bitrouter` uses BitRouter Cloud OAuth; \
+                         --import-existing/--no-browser apply to upstream provider logins"
+                    );
+                }
                 bitrouter::cloud::cli::run(
                     bitrouter::cloud::cli::CloudAction::Login {
                         authorization_server: None,
@@ -1711,7 +1741,15 @@ async fn providers(action: ProviderAction, output: &Output) -> Result<()> {
                 )
                 .await
             } else {
-                let outcome = bitrouter::commands::login_provider(&provider, &label).await?;
+                let outcome = bitrouter::commands::login_provider_with_options(
+                    &provider,
+                    &label,
+                    bitrouter::commands::ProviderLoginOptions {
+                        import_existing,
+                        no_browser,
+                    },
+                )
+                .await?;
                 output.emit(&ProviderLoginReport {
                     provider: outcome.provider,
                     label: outcome.label,
@@ -2005,6 +2043,39 @@ mod tests {
                 assert!(!stable && !restart && !yes);
             }
             _ => panic!("expected Update"),
+        }
+    }
+
+    #[test]
+    fn provider_login_import_existing_flags_parse() {
+        use clap::Parser;
+        let cli = Cli::try_parse_from([
+            "bitrouter",
+            "providers",
+            "login",
+            "openai-codex",
+            "--import-existing",
+            "--no-browser",
+            "--label",
+            "work",
+        ])
+        .expect("parse");
+        match cli.command {
+            Command::Providers {
+                action:
+                    ProviderAction::Login {
+                        provider,
+                        label,
+                        import_existing,
+                        no_browser,
+                    },
+            } => {
+                assert_eq!(provider, "openai-codex");
+                assert_eq!(label, "work");
+                assert!(import_existing);
+                assert!(no_browser);
+            }
+            _ => panic!("expected provider login"),
         }
     }
 }

--- a/apps/bitrouter/src/spawn.rs
+++ b/apps/bitrouter/src/spawn.rs
@@ -37,10 +37,14 @@
 use std::ffi::OsString;
 use std::io::IsTerminal;
 use std::path::PathBuf;
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use clap::ValueEnum;
+use serde::Serialize;
 
+use crate::output::CliReport;
+use crate::output::human::Human;
 use crate::style::Palette;
 
 /// The coding-agent harnesses `bitrouter spawn` can launch.
@@ -143,6 +147,73 @@ pub struct SpawnOptions {
     /// warn. (Set by `--no-start`.) Has no effect for a non-local / `--base-url`
     /// target, which is never auto-started regardless.
     pub no_start: bool,
+    /// Check the spawn environment and route without launching the agent.
+    pub check: bool,
+}
+
+/// One preflight check outcome.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SpawnCheckStatus {
+    Pass,
+    Warn,
+    Fail,
+}
+
+/// A single preflight row.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SpawnCheckRow {
+    pub name: String,
+    pub status: SpawnCheckStatus,
+    pub message: String,
+}
+
+/// Result of `bitrouter spawn --check`.
+#[derive(Debug, Clone, Serialize)]
+pub struct SpawnCheckReport {
+    pub agent: String,
+    pub base_url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    pub checks: Vec<SpawnCheckRow>,
+}
+
+impl SpawnCheckReport {
+    fn has_failures(&self) -> bool {
+        self.checks
+            .iter()
+            .any(|c| matches!(c.status, SpawnCheckStatus::Fail))
+    }
+}
+
+impl CliReport for SpawnCheckReport {
+    fn render(&self, h: &mut Human<'_>) -> std::io::Result<()> {
+        h.line(&format!(
+            "spawn check for {} via {}",
+            self.agent, self.base_url
+        ))?;
+        if let Some(model) = &self.model {
+            h.line(&format!("  model: {model}"))?;
+        }
+        h.blank()?;
+        for check in &self.checks {
+            h.line(&format!(
+                "  {} {}: {}",
+                match check.status {
+                    SpawnCheckStatus::Pass => "✓",
+                    SpawnCheckStatus::Warn => "!",
+                    SpawnCheckStatus::Fail => "✗",
+                },
+                check.name,
+                check.message
+            ))?;
+        }
+        Ok(())
+    }
+
+    fn exit_code(&self) -> i32 {
+        if self.has_failures() { 1 } else { 0 }
+    }
 }
 
 /// Run `bitrouter spawn`. Resolves the base URL from `cfg`, locates the agent
@@ -162,6 +233,18 @@ pub async fn run(
         Some(explicit) => explicit.clone(),
         None => derive_base_url(&cfg.server.listen),
     };
+
+    if opts.agent == SpawnAgent::Codex {
+        let conflicts = codex_forwarded_config_args(&opts.agent_args);
+        if !conflicts.is_empty() {
+            anyhow::bail!(
+                "codex forwarded config flags ({}) can override BitRouter's one-shot provider \
+                 injection. Remove those -c/--config flags and run `bitrouter spawn --agent \
+                 codex --check` to inspect the route before launching.",
+                conflicts.join(", ")
+            );
+        }
+    }
 
     // Locate the binary; prompt-to-install when it's missing.
     let binary = ensure_agent_installed(opts.agent, opts.no_install).await?;
@@ -223,6 +306,180 @@ pub async fn run(
     // Propagate the agent's exit code. A launcher should be transparent: the
     // shell sees the agent's status, not bitrouter's.
     std::process::exit(status.code().unwrap_or(1));
+}
+
+/// Check a spawn invocation without launching the child process.
+pub async fn check(
+    cfg: &bitrouter_sdk::config::Config,
+    opts: &SpawnOptions,
+) -> Result<SpawnCheckReport> {
+    let spec = opts.agent.spec();
+    let base_url = opts
+        .base_url
+        .clone()
+        .unwrap_or_else(|| derive_base_url(&cfg.server.listen));
+    let model = (opts.agent == SpawnAgent::Codex)
+        .then(|| codex_requested_model(&opts.agent_args))
+        .flatten();
+    let mut checks = Vec::new();
+
+    checks.push(match resolve_binary(spec.binary) {
+        Some(path) => SpawnCheckRow {
+            name: "agent binary".to_string(),
+            status: SpawnCheckStatus::Pass,
+            message: format!("found {}", path.display()),
+        },
+        None => SpawnCheckRow {
+            name: "agent binary".to_string(),
+            status: SpawnCheckStatus::Fail,
+            message: format!("{} is not on PATH", spec.binary),
+        },
+    });
+
+    checks.push(check_base_url(&base_url).await);
+
+    if opts.agent == SpawnAgent::Codex {
+        let conflicts = codex_forwarded_config_args(&opts.agent_args);
+        checks.push(if conflicts.is_empty() {
+            SpawnCheckRow {
+                name: "codex config overrides".to_string(),
+                status: SpawnCheckStatus::Pass,
+                message: "no forwarded -c/--config flags detected".to_string(),
+            }
+        } else {
+            SpawnCheckRow {
+                name: "codex config overrides".to_string(),
+                status: SpawnCheckStatus::Fail,
+                message: format!(
+                    "forwarded {} can override BitRouter's provider injection",
+                    conflicts.join(", ")
+                ),
+            }
+        });
+
+        checks.push(match &model {
+            Some(model) => {
+                codex_route_check(model, crate::commands::resolve_route(cfg, model).await)
+            }
+            None => SpawnCheckRow {
+                name: "codex model route".to_string(),
+                status: SpawnCheckStatus::Warn,
+                message: "no --model/-m forwarded; Codex will choose its default model".to_string(),
+            },
+        });
+    }
+
+    Ok(SpawnCheckReport {
+        agent: spec.id.to_string(),
+        base_url,
+        model,
+        checks,
+    })
+}
+
+async fn check_base_url(base_url: &str) -> SpawnCheckRow {
+    let health = format!("{}/health", bitrouter_root_url(base_url));
+    let client = match reqwest::Client::builder()
+        .timeout(Duration::from_secs(2))
+        .build()
+    {
+        Ok(client) => client,
+        Err(e) => {
+            return SpawnCheckRow {
+                name: "bitrouter base url".to_string(),
+                status: SpawnCheckStatus::Warn,
+                message: format!("could not build HTTP client: {e}"),
+            };
+        }
+    };
+    match client.get(&health).send().await {
+        Ok(resp) if resp.status().is_success() => SpawnCheckRow {
+            name: "bitrouter base url".to_string(),
+            status: SpawnCheckStatus::Pass,
+            message: format!("{health} responded {}", resp.status()),
+        },
+        Ok(resp) => SpawnCheckRow {
+            name: "bitrouter base url".to_string(),
+            status: SpawnCheckStatus::Fail,
+            message: format!("{health} responded {}", resp.status()),
+        },
+        Err(e) => SpawnCheckRow {
+            name: "bitrouter base url".to_string(),
+            status: SpawnCheckStatus::Fail,
+            message: format!("could not reach {health}: {e}"),
+        },
+    }
+}
+
+fn bitrouter_root_url(base_url: &str) -> String {
+    let trimmed = base_url.trim_end_matches('/');
+    trimmed.strip_suffix("/v1").unwrap_or(trimmed).to_string()
+}
+
+fn codex_requested_model(args: &[String]) -> Option<String> {
+    let mut iter = args.iter();
+    while let Some(arg) = iter.next() {
+        if arg == "--model" || arg == "-m" {
+            return iter.next().filter(|v| !v.is_empty()).cloned();
+        }
+        if let Some(value) = arg.strip_prefix("--model=")
+            && !value.is_empty()
+        {
+            return Some(value.to_string());
+        }
+    }
+    None
+}
+
+fn codex_forwarded_config_args(args: &[String]) -> Vec<&'static str> {
+    args.iter()
+        .filter_map(|arg| match arg.as_str() {
+            "-c" => Some("-c"),
+            "--config" => Some("--config"),
+            s if s.starts_with("--config=") => Some("--config"),
+            _ => None,
+        })
+        .collect()
+}
+
+fn codex_route_check(model: &str, route: Result<Vec<crate::daemon::RouteHop>>) -> SpawnCheckRow {
+    match route {
+        Ok(chain) if chain.is_empty() => SpawnCheckRow {
+            name: "codex model route".to_string(),
+            status: SpawnCheckStatus::Fail,
+            message: format!("{model} resolved to an empty route chain"),
+        },
+        Ok(chain) => {
+            let providers = chain
+                .iter()
+                .map(|hop| format!("{}:{} ({})", hop.provider, hop.service_id, hop.api_protocol))
+                .collect::<Vec<_>>()
+                .join(" -> ");
+            if chain
+                .iter()
+                .any(|hop| hop.api_protocol.eq_ignore_ascii_case("responses"))
+            {
+                SpawnCheckRow {
+                    name: "codex model route".to_string(),
+                    status: SpawnCheckStatus::Pass,
+                    message: format!("{model} can route through Responses: {providers}"),
+                }
+            } else {
+                SpawnCheckRow {
+                    name: "codex model route".to_string(),
+                    status: SpawnCheckStatus::Fail,
+                    message: format!(
+                        "{model} has no responses-compatible endpoint for Codex: {providers}"
+                    ),
+                }
+            }
+        }
+        Err(e) => SpawnCheckRow {
+            name: "codex model route".to_string(),
+            status: SpawnCheckStatus::Fail,
+            message: format!("could not resolve {model}: {e:#}"),
+        },
+    }
 }
 
 /// Build the environment overrides layered on top of the inherited parent
@@ -977,6 +1234,82 @@ mod tests {
                 .iter()
                 .all(|arg| !arg.contains("experimental_bearer_token"))
         );
+    }
+
+    #[test]
+    fn codex_requested_model_reads_forwarded_model_args() {
+        assert_eq!(
+            codex_requested_model(&[
+                "exec".to_string(),
+                "--model".to_string(),
+                "gpt-5.5".to_string()
+            ])
+            .as_deref(),
+            Some("gpt-5.5")
+        );
+        assert_eq!(
+            codex_requested_model(&[
+                "exec".to_string(),
+                "-m".to_string(),
+                "local-model".to_string()
+            ])
+            .as_deref(),
+            Some("local-model")
+        );
+        assert_eq!(codex_requested_model(&["exec".to_string()]), None);
+    }
+
+    #[test]
+    fn codex_forwarded_config_args_are_flagged_before_launch() {
+        let conflicts = codex_forwarded_config_args(&[
+            "exec".to_string(),
+            "-c".to_string(),
+            "foo=1".to_string(),
+        ]);
+        assert_eq!(conflicts, vec!["-c"]);
+
+        let conflicts = codex_forwarded_config_args(&[
+            "exec".to_string(),
+            "--config".to_string(),
+            "model_provider=\"openai\"".to_string(),
+        ]);
+        assert_eq!(conflicts, vec!["--config"]);
+    }
+
+    #[test]
+    fn bitrouter_root_url_strips_v1_for_preflight_health_probe() {
+        assert_eq!(
+            bitrouter_root_url("http://127.0.0.1:4356/v1"),
+            "http://127.0.0.1:4356"
+        );
+        assert_eq!(
+            bitrouter_root_url("http://127.0.0.1:4356"),
+            "http://127.0.0.1:4356"
+        );
+    }
+
+    #[test]
+    fn codex_route_check_accepts_any_responses_provider() {
+        let route = vec![crate::daemon::RouteHop {
+            provider: "openai".to_string(),
+            service_id: "gpt-5.5".to_string(),
+            api_protocol: "responses".to_string(),
+        }];
+        let check = codex_route_check("gpt-5.5", Ok(route));
+        assert_eq!(check.status, SpawnCheckStatus::Pass);
+        assert!(check.message.contains("openai"));
+    }
+
+    #[test]
+    fn codex_route_check_rejects_non_responses_provider() {
+        let route = vec![crate::daemon::RouteHop {
+            provider: "anthropic".to_string(),
+            service_id: "claude-sonnet".to_string(),
+            api_protocol: "messages".to_string(),
+        }];
+        let check = codex_route_check("claude-sonnet", Ok(route));
+        assert_eq!(check.status, SpawnCheckStatus::Fail);
+        assert!(check.message.contains("responses"));
     }
 
     #[test]

--- a/crates/bitrouter-sdk/src/server.rs
+++ b/crates/bitrouter-sdk/src/server.rs
@@ -550,13 +550,27 @@ fn mcp_error_response(id: serde_json::Value, code: i64, message: &str) -> Respon
         .into_response()
 }
 
-async fn list_models(State(state): State<AppState>) -> impl IntoResponse {
+async fn list_models(State(state): State<AppState>, headers: HeaderMap) -> impl IntoResponse {
     let models = state.language_model.routing_table().list_models();
     let data: Vec<_> = models
         .into_iter()
         .map(|m| serde_json::json!({ "id": m.id, "object": "model", "providers": m.providers }))
         .collect();
-    Json(serde_json::json!({ "object": "list", "data": data }))
+    let mut body = serde_json::json!({ "object": "list", "data": data });
+    if is_codex_user_agent(&headers)
+        && let Some(obj) = body.as_object_mut()
+        && let Some(data) = obj.get("data").cloned()
+    {
+        obj.insert("models".to_string(), data);
+    }
+    Json(body)
+}
+
+fn is_codex_user_agent(headers: &HeaderMap) -> bool {
+    headers
+        .get(header::USER_AGENT)
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|ua| ua.to_ascii_lowercase().contains("codex"))
 }
 
 // ===== inbound protocol handlers =====
@@ -816,6 +830,80 @@ impl IntoResponse for BitrouterError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::language_model::PipelineBuilder;
+    use crate::language_model::executor::MockExecutor;
+    use crate::language_model::routing::StaticRoutingTable;
+    use crate::language_model::types::{ApiProtocol, AuthScheme, RoutingTarget};
+    use axum::body::to_bytes;
+    use axum::http::{Request, header};
+    use tower::ServiceExt;
+
+    fn test_state_with_models() -> AppState {
+        let table = StaticRoutingTable::new();
+        table.insert(
+            "gpt-5.5",
+            vec![RoutingTarget {
+                provider_name: "openai-codex".to_string(),
+                service_id: "gpt-5.5".to_string(),
+                api_base: "https://example.invalid".to_string(),
+                api_key: "test-key".to_string(),
+                api_protocol: ApiProtocol::Responses,
+                account_label: None,
+                api_key_override: None,
+                api_base_override: None,
+                auth_scheme: AuthScheme::XApiKey,
+            }],
+        );
+        let mut builder = PipelineBuilder::new();
+        builder
+            .routing_table(Arc::new(table))
+            .executor(Arc::new(MockExecutor::always_text("ok")));
+        let pipeline = builder.build().unwrap();
+        AppState {
+            language_model: Arc::new(pipeline),
+            mcp: None,
+            skip_auth: true,
+            metrics_renderer: None,
+            prompt_transforms: vec![],
+        }
+    }
+
+    async fn models_json(user_agent: Option<&str>) -> serde_json::Value {
+        let mut builder = Request::builder().uri("/v1/models");
+        if let Some(ua) = user_agent {
+            builder = builder.header(header::USER_AGENT, ua);
+        }
+        let response = build_router(test_state_with_models())
+            .oneshot(builder.body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    #[tokio::test]
+    async fn v1_models_keeps_openai_shape_for_generic_clients() {
+        let body = models_json(None).await;
+        assert_eq!(body["object"], serde_json::json!("list"));
+        assert!(body.get("data").is_some());
+        assert!(
+            body.get("models").is_none(),
+            "generic OpenAI-compatible clients should keep the existing response shape: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn v1_models_adds_codex_models_field_for_codex_user_agent() {
+        let body = models_json(Some("codex-cli/0.142.5")).await;
+        assert_eq!(body["object"], serde_json::json!("list"));
+        assert_eq!(body["data"][0]["id"], serde_json::json!("gpt-5.5"));
+        assert_eq!(
+            body["models"][0]["id"],
+            serde_json::json!("gpt-5.5"),
+            "Codex CLI expects a top-level models field while the OpenAI data field remains present"
+        );
+    }
 
     #[test]
     fn payment_required_emits_www_authenticate() {

--- a/docs/integrations/codex-subscription.md
+++ b/docs/integrations/codex-subscription.md
@@ -18,12 +18,24 @@ bitrouter providers login openai-codex
 
 By default, the menu offers **"Import an existing session from the vendor CLI"** first. BitRouter reads the credential the Codex CLI already stored in `$CODEX_HOME/auth.json` (default `~/.codex/auth.json`) first, then the macOS Keychain, and adopts it with no fresh browser sign-in. If no local Codex session exists, choose the browser subscription flow; it opens OpenAI's authorize page (PKCE, on a pinned loopback port), then stores the credential under `$XDG_DATA_HOME/bitrouter/oauth-tokens.json`. The token auto-refreshes — log in once. To remove it:
 
+For scripts and E2E checks, skip the menu and require the existing local Codex session:
+
+```bash
+bitrouter providers login openai-codex --import-existing --no-browser
+```
+
+This command fails instead of opening a browser when no local Codex credential is available.
+
 ```bash
 bitrouter providers logout openai-codex
 ```
 
 <Callout type="info">
 **Already signed in to Codex?** Press enter on the default import option. The file credential wins over Keychain so BitRouter follows the same local Codex home you are already using.
+</Callout>
+
+<Callout type="info">
+Provider credentials are separate from BitRouter Cloud credentials. `bitrouter cloud login` signs the CLI into your BitRouter account; `bitrouter providers login openai-codex` stores a ChatGPT/Codex subscription credential for the upstream `openai-codex` provider.
 </Callout>
 
 ### Multiple accounts

--- a/docs/integrations/codex.md
+++ b/docs/integrations/codex.md
@@ -27,7 +27,19 @@ Everything after `--` is forwarded to Codex:
 bitrouter spawn --agent codex -- --model openai/gpt-5-codex
 ```
 
+Before launching a long run, ask BitRouter to check the route it will use:
+
+```bash
+bitrouter spawn --agent codex --check -- --model openai/gpt-5-codex
+```
+
+The check verifies that `codex` is installed, the BitRouter base URL is reachable, and the forwarded model has at least one Responses-compatible endpoint. It does **not** require the provider to be `openai-codex`; any model source that routes over the Responses protocol can be used by the Codex harness.
+
 `spawn` does not edit `~/.codex/config.toml`. It starts from your existing Codex model selection, then points Codex at a transient `bitrouter` provider with `base_url = "<BitRouter>/v1"` and `wire_api = "responses"`. If `BITROUTER_API_KEY` is exported, Codex uses it through `env_key`; otherwise BitRouter injects a local placeholder that works with the `skip_auth: true` default written by `bitrouter init`.
+
+<Callout type="warn">
+Avoid forwarding Codex `-c` / `--config` flags through `bitrouter spawn --agent codex`. Current Codex releases can let those forwarded config flags override the transient provider injection, which means the run may silently stop using BitRouter. `spawn` rejects that shape and asks you to move the option into Codex config or inspect the route with `--check`.
+</Callout>
 
 ## Permanent config
 


### PR DESCRIPTION
## Summary

- Add `bitrouter spawn --agent codex --check` to preflight the agent binary, BitRouter health endpoint, forwarded Codex config flags, and the requested model route.
- Treat Codex route compatibility as Responses-protocol compatibility, not as a hard requirement that the resolved provider is `openai-codex`.
- Gate the Codex CLI `/v1/models` compatibility shape on `User-Agent` containing `codex`, while preserving the normal OpenAI-compatible `data` list for generic clients.
- Add provider-login controls for scripts/E2E: `bitrouter providers login openai-codex --import-existing --no-browser`, plus docs for Codex spawn and subscription onboarding.

## Validation

- `cargo test -p bitrouter-sdk --all-features`
- `cargo test -p bitrouter --lib --bin bitrouter --all-features`
- `cargo fmt -- --check`
- `git diff --check`
- `cargo build -p bitrouter`
- `target/debug/bitrouter spawn --help | rg -- '--check|--agent|--base-url'`
- `target/debug/bitrouter providers login --help | rg -- '--import-existing|--no-browser|--label'`
- Local `spawn --check` smoke using a temporary non-`openai-codex` provider named `local-responses` with `api_protocol: responses`.

## Note

A broader `cargo test -p bitrouter --all-features` run still trips the existing `observe_hierarchy` OTLP collector path mismatch (`/` vs `/v1/traces`). This PR leaves that unrelated observe behavior untouched.