### PR TITLE
docs(readme): add OpenStatus service status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # BitRouter
 
 [![Build status](https://github.com/bitrouter/bitrouter/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/bitrouter/bitrouter/actions)
+[![Status](https://bitrouter.openstatus.dev/badge/v2)](https://bitrouter.openstatus.dev)
 [![Crates.io](https://img.shields.io/crates/v/bitrouter)](https://crates.io/crates/bitrouter)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Twitter](https://img.shields.io/badge/Twitter-black?logo=x&logoColor=white)](https://x.com/BitRouterAI)


### PR DESCRIPTION
Adds a live **service status badge** to the README, next to the CI build badge, linking to the public OpenStatus status page.

```markdown
[![Status](https://bitrouter.openstatus.dev/badge/v2)](https://bitrouter.openstatus.dev)
```

- Uses the OpenStatus `/badge/v2` SVG for the `bitrouter` status page ([bitrouter.openstatus.dev](https://bitrouter.openstatus.dev)); verified it returns `image/svg+xml`.
- Reflects live per-model uptime monitoring. Note the badge shows the **aggregate** page status, so it may read "Degraded" while any monitored model's upstream is down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)