### PR TITLE
docs(readme): size-match the status badge (shields.io)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # BitRouter
 
 [![Build status](https://github.com/bitrouter/bitrouter/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/bitrouter/bitrouter/actions)
-[![Status](https://bitrouter.openstatus.dev/badge/v2)](https://bitrouter.openstatus.dev)
+[![Status](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.openstatus.dev%2Fpublic%2Fstatus%2Fbitrouter&query=%24.status&label=status)](https://bitrouter.openstatus.dev)
 [![Crates.io](https://img.shields.io/crates/v/bitrouter)](https://crates.io/crates/bitrouter)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Twitter](https://img.shields.io/badge/Twitter-black?logo=x&logoColor=white)](https://x.com/BitRouterAI)


### PR DESCRIPTION
Follow-up to #634. The OpenStatus `/badge/v2` SVG is ~34px tall and can't be shrunk (`sm` is already its default/smallest — `md`/`lg`/`xl` only go bigger), so it stood **taller than the other badges**.

This renders the live status as a **shields.io dynamic badge** fed by OpenStatus's public status endpoint (`https://api.openstatus.dev/public/status/bitrouter` → `{"status":"..."}`):

```markdown
[![Status](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.openstatus.dev%2Fpublic%2Fstatus%2Fbitrouter&query=%24.status&label=status)](https://bitrouter.openstatus.dev)
```

- **Height 20px** — matches the crates.io / License / etc. shields badges exactly (verified).
- Still **live** (`status: operational` / `incident` / …) and still links to the status page.
- Neutral shields-blue color (status is conveyed by the text, not a possibly-misleading color).

**Tradeoff:** this depends on the OpenStatus *public status* endpoint + the shields.io proxy (two hops, mild caching) rather than the first-party OpenStatus SVG. If you'd rather have the first-party badge and accept the taller size, the native `/badge/v2` is the alternative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)