### PR TITLE
fix: harden agentic registry sync

### DIFF
--- a/.github/workflows/registry-sync.yml
+++ b/.github/workflows/registry-sync.yml
@@ -55,6 +55,7 @@ jobs:
             --ignore-user-config \
             --ignore-rules \
             --ephemeral \
+            --output-last-message target/registry-agentic-result.md \
             -C "$GITHUB_WORKSPACE" \
             -m "$AGENTIC_SYNC_MODEL" \
             -c 'model_provider="bitrouter"' \
@@ -62,8 +63,13 @@ jobs:
             -c 'model_providers.bitrouter.base_url="https://api.bitrouter.ai/v1"' \
             -c 'model_providers.bitrouter.wire_api="responses"' \
             -c 'model_providers.bitrouter.env_key="BITROUTER_API_KEY"' \
-            -s workspace-write \
+            -s danger-full-access \
             - < target/registry-agentic-sync.md
+          if ! grep -q 'registry valid:' target/registry-agentic-result.md; then
+            echo "::error::agentic registry sync did not report successful validation"
+            cat target/registry-agentic-result.md
+            exit 1
+          fi
 
       - name: Build and check registry dist
         run: |

--- a/helpers/dist-helper/src/registry.rs
+++ b/helpers/dist-helper/src/registry.rs
@@ -500,7 +500,10 @@ pub fn agentic_prompt(root: &Path) -> Result<String> {
         "- For subscription providers, do not invent token pricing.\n"
     )?;
     writeln!(out, "Validation:")?;
-    writeln!(out, "After editing registry source YAML, run exactly:")?;
+    writeln!(
+        out,
+        "Always run this command before your final response, even if no source files changed:"
+    )?;
     writeln!(out, "`cargo run -p dist-helper -- registry validate`\n")?;
     writeln!(
         out,
@@ -519,6 +522,10 @@ pub fn agentic_prompt(root: &Path) -> Result<String> {
         "- models skipped because canonical mapping or facts were uncertain"
     )?;
     writeln!(out, "- validation result")?;
+    writeln!(
+        out,
+        "- include the exact `registry valid:` output line from validation"
+    )?;
     Ok(out)
 }
 
@@ -2134,6 +2141,7 @@ auto_sync:
         assert!(prompt.contains("cargo run -p dist-helper -- registry validate"));
         assert!(prompt.contains("If the listed URLs are unreachable"));
         assert!(prompt.contains("Do not remove or edit provider `auto_sync`"));
+        assert!(prompt.contains("include the exact `registry valid:` output line"));
         assert!(!prompt.contains("canonical_models_json"));
     }
 


### PR DESCRIPTION
## What changed

- Run the headless Codex agentic registry sync with `danger-full-access` sandbox on GitHub Actions so it does not hit bubblewrap loopback failures on hosted Ubuntu runners.
- Capture the agent final response with `--output-last-message` and fail the workflow unless it reports the exact `registry valid:` validation line.
- Update the agent prompt/test to require validation even when no source files changed.

## Why

The latest `Registry Sync` workflow on main completed successfully, but the agentic step did not actually run tools. Codex reported `bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted`, then exited without validating or editing the registry, and the workflow silently continued.

## Validation

- `cargo test -p dist-helper registry::tests::agentic_sync_requires_urls_and_renders_task_prompt`
- `cargo test -p dist-helper registry::tests::`
- `cargo fmt -- --check`
- `cargo run -p dist-helper -- check`
- `cargo clippy -p dist-helper --all-targets -- -D warnings`
- `git diff --check`
