### PR TITLE
feat: add supergrok + google-ai subscription providers

### DIFF
--- a/dist/registry/models.json
+++ b/dist/registry/models.json
@@ -116,6 +116,11 @@
           }
         },
         {
+          "api_protocol": "anthropic",
+          "provider": "claude-code",
+          "provider_model_id": "claude-haiku-4-5"
+        },
+        {
           "api_protocol": "openai",
           "provider": "github-copilot",
           "provider_model_id": "claude-haiku-4.5"
@@ -1441,6 +1446,18 @@
         },
         {
           "api_protocol": [
+            "google",
+            "openai"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "provider": "google-ai-subscription",
+          "provider_model_id": "gemini-3.1-pro-preview"
+        },
+        {
+          "api_protocol": [
             "openai",
             "responses",
             "anthropic"
@@ -1529,6 +1546,18 @@
           "rate_limits": {
             "requests_per_minute": 60
           }
+        },
+        {
+          "api_protocol": [
+            "google",
+            "openai"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "provider": "google-ai-subscription",
+          "provider_model_id": "gemini-3.5-flash"
         },
         {
           "api_protocol": "openai",
@@ -4074,6 +4103,17 @@
           "provider_model_id": "x-ai/grok-4.20"
         },
         {
+          "api_protocol": [
+            "responses",
+            "openai"
+          ],
+          "capabilities": [
+            "tools"
+          ],
+          "provider": "supergrok",
+          "provider_model_id": "grok-4.20-0309-non-reasoning"
+        },
+        {
           "api_protocol": "openai",
           "capabilities": [
             "reasoning",
@@ -4163,6 +4203,18 @@
             "reasoning",
             "tools"
           ],
+          "provider": "supergrok",
+          "provider_model_id": "grok-4.20-multi-agent-0309"
+        },
+        {
+          "api_protocol": [
+            "responses",
+            "openai"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
           "pricing": {
             "input_tokens": {
               "no_cache": 1.25
@@ -4211,6 +4263,18 @@
           },
           "provider": "openrouter",
           "provider_model_id": "x-ai/grok-4.3"
+        },
+        {
+          "api_protocol": [
+            "responses",
+            "openai"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "provider": "supergrok",
+          "provider_model_id": "grok-4.3"
         },
         {
           "api_protocol": [
@@ -4283,6 +4347,17 @@
           },
           "provider": "openrouter",
           "provider_model_id": "x-ai/grok-build-0.1"
+        },
+        {
+          "api_protocol": [
+            "responses",
+            "openai"
+          ],
+          "capabilities": [
+            "tools"
+          ],
+          "provider": "supergrok",
+          "provider_model_id": "grok-build-0.1"
         },
         {
           "api_protocol": [

--- a/dist/registry/providers.json
+++ b/dist/registry/providers.json
@@ -1620,6 +1620,11 @@
           "api_protocol": "anthropic",
           "id": "anthropic/claude-fable-5",
           "provider_model_id": "claude-fable-5"
+        },
+        {
+          "api_protocol": "anthropic",
+          "id": "anthropic/claude-haiku-4.5",
+          "provider_model_id": "claude-haiku-4-5"
         }
       ],
       "name": "claude-code",
@@ -1939,6 +1944,74 @@
       ],
       "status": "active",
       "submitted_at": "2026-05-25",
+      "weight": 1.0
+    },
+    {
+      "access": "local_oauth",
+      "api_base": "https://generativelanguage.googleapis.com/v1beta",
+      "auth": {
+        "handler": "google",
+        "kind": "oauth"
+      },
+      "auth_scheme": "x-api-key",
+      "billing": "subscription",
+      "byok": false,
+      "community": false,
+      "display_name": "Google AI (subscription)",
+      "doc_url": "https://antigravity.google/docs/models",
+      "id": "google-ai-subscription",
+      "kind": "first_party",
+      "metadata": {
+        "headquarters": "US",
+        "name": "Google",
+        "privacy_policy_url": "https://policies.google.com/privacy",
+        "slug": "google",
+        "status_page_url": "https://status.cloud.google.com",
+        "terms_of_service_url": "https://ai.google.dev/gemini-api/terms"
+      },
+      "models": [
+        {
+          "api_protocol": [
+            "google",
+            "openai"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "google/gemini-3.5-flash",
+          "provider_model_id": "gemini-3.5-flash"
+        },
+        {
+          "api_protocol": [
+            "google",
+            "openai"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "google/gemini-3.1-pro-preview",
+          "provider_model_id": "gemini-3.1-pro-preview"
+        },
+        {
+          "api_protocol": [
+            "google",
+            "openai"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "openai/gpt-oss-120b",
+          "provider_model_id": "gpt-oss-120b"
+        }
+      ],
+      "name": "google-ai-subscription",
+      "required_config": [
+        "local_oauth"
+      ],
+      "status": "active",
       "weight": 1.0
     },
     {
@@ -2661,6 +2734,15 @@
           ],
           "id": "openai/gpt-5.4-mini",
           "provider_model_id": "gpt-5.4-mini"
+        },
+        {
+          "api_protocol": "responses",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "openai/gpt-5.3-codex-spark",
+          "provider_model_id": "gpt-5.3-codex-spark"
         }
       ],
       "name": "openai-codex",
@@ -4237,6 +4319,83 @@
       ],
       "status": "active",
       "submitted_at": "2026-07-06",
+      "weight": 1.0
+    },
+    {
+      "access": "local_pkce",
+      "api_base": "https://api.x.ai/v1",
+      "auth": {
+        "handler": "grok",
+        "kind": "oauth"
+      },
+      "auth_scheme": "x-api-key",
+      "billing": "subscription",
+      "byok": false,
+      "community": false,
+      "display_name": "SuperGrok (subscription)",
+      "id": "supergrok",
+      "kind": "first_party",
+      "metadata": {
+        "headquarters": "US",
+        "name": "xAI",
+        "privacy_policy_url": "https://x.ai/legal/privacy-policy",
+        "slug": "xai",
+        "status_page_url": "https://status.x.ai",
+        "terms_of_service_url": "https://x.ai/legal/terms-of-service"
+      },
+      "models": [
+        {
+          "api_protocol": [
+            "responses",
+            "openai"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "x-ai/grok-4.3",
+          "provider_model_id": "grok-4.3"
+        },
+        {
+          "api_protocol": [
+            "responses",
+            "openai"
+          ],
+          "capabilities": [
+            "tools"
+          ],
+          "id": "x-ai/grok-4.20",
+          "provider_model_id": "grok-4.20-0309-non-reasoning"
+        },
+        {
+          "api_protocol": [
+            "responses",
+            "openai"
+          ],
+          "capabilities": [
+            "tools"
+          ],
+          "id": "x-ai/grok-build-0.1",
+          "provider_model_id": "grok-build-0.1"
+        },
+        {
+          "api_protocol": [
+            "responses",
+            "openai"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "x-ai/grok-4.20-multi-agent",
+          "provider_model_id": "grok-4.20-multi-agent-0309"
+        }
+      ],
+      "name": "supergrok",
+      "required_config": [
+        "local_pkce"
+      ],
+      "status": "active",
       "weight": 1.0
     },
     {

--- a/registry/providers/claude-code.yaml
+++ b/registry/providers/claude-code.yaml
@@ -49,6 +49,9 @@ models:
   - id: anthropic/claude-fable-5
     provider_model_id: claude-fable-5
     capabilities: []
+  - id: anthropic/claude-haiku-4.5
+    provider_model_id: claude-haiku-4-5
+    capabilities: []
 status: active
 weight: 1
 community: false

--- a/registry/providers/google-ai-subscription.yaml
+++ b/registry/providers/google-ai-subscription.yaml
@@ -1,0 +1,57 @@
+# Google AI subscription — Antigravity route, OAuth-only.
+#
+# NOT the same as `google`: that entry is the BYOK `GEMINI_API_KEY` Generative
+# Language API. This entry is the flat-rate Google AI subscription (AI Pro / AI
+# Ultra) reached through Antigravity's Google OAuth login, so it carries NO
+# per-token `pricing` (billing: subscription).
+#
+# Model set = what Google itself serves under the subscription per
+# https://antigravity.google/docs/models : the Gemini family plus the gpt-oss
+# open-weights model on Google's compute budget. Claude models are available in
+# Antigravity only by adding your own Anthropic API key (BYOK), so they belong
+# to `anthropic`/`claude-code`, not to this subscription, and are excluded here.
+#
+# NOTE: `handler: google` is not yet implemented in apps/bitrouter, and the
+# Antigravity subscription endpoint is not publicly documented — `api_base`
+# below is the Gemini Generative Language base as a provisional placeholder.
+# Both the endpoint and the OAuth handler must be finalized before `providers
+# login google-ai-subscription` will work; this is a registry-source stub.
+name: google-ai-subscription
+display_name: Google AI (subscription)
+metadata:
+  headquarters: US
+  name: Google
+  privacy_policy_url: https://policies.google.com/privacy
+  slug: google
+  status_page_url: https://status.cloud.google.com
+  terms_of_service_url: https://ai.google.dev/gemini-api/terms
+kind: first_party
+billing: subscription
+access: local_oauth
+api_base: https://generativelanguage.googleapis.com/v1beta
+doc_url: https://antigravity.google/docs/models
+api_protocol:
+  - "*": [google, openai]
+models:
+  - id: google/gemini-3.5-flash
+    provider_model_id: gemini-3.5-flash
+    capabilities:
+      - reasoning
+      - tools
+  - id: google/gemini-3.1-pro-preview
+    provider_model_id: gemini-3.1-pro-preview
+    capabilities:
+      - reasoning
+      - tools
+  # Open-weights model Google serves on the subscription compute budget. Not in
+  # the curated registry/models catalog on this base — rides as a subscription extra.
+  - id: openai/gpt-oss-120b
+    provider_model_id: gpt-oss-120b
+    capabilities:
+      - reasoning
+      - tools
+status: active
+weight: 1
+auth:
+  kind: oauth
+  handler: google

--- a/registry/providers/openai-codex.yaml
+++ b/registry/providers/openai-codex.yaml
@@ -54,6 +54,12 @@ models:
   - id: openai/gpt-5.4-mini
     provider_model_id: gpt-5.4-mini
     capabilities: [reasoning, tools]
+  # ChatGPT Pro only (research preview). Plus/Business seats cannot reach it;
+  # for those users the runtime v1_models probe simply won't return it. Not in
+  # the curated registry/models catalog — rides as a subscription extra.
+  - id: openai/gpt-5.3-codex-spark
+    provider_model_id: gpt-5.3-codex-spark
+    capabilities: [reasoning, tools]
 status: active
 auto_sync:
   feed: v1_models

--- a/registry/providers/supergrok.yaml
+++ b/registry/providers/supergrok.yaml
@@ -1,0 +1,52 @@
+# xAI SuperGrok — subscription route (SuperGrok / X Premium+), OAuth-only.
+#
+# NOT the same as `xai`: that entry is the BYOK, per-token API-key route. This
+# entry is the flat-rate SuperGrok subscription reached through the Grok Build
+# CLI's OAuth login, so it carries NO per-token `pricing` (billing:
+# subscription). The model catalog mirrors `xai` (same xAI backend); the plan
+# is what changes, not the models.
+#
+# NOTE: `handler: grok` is not yet implemented in apps/bitrouter — this is a
+# registry-source stub so the provider is catalog-visible. `providers login
+# supergrok` will not work until the OAuth handler lands.
+name: supergrok
+display_name: SuperGrok (subscription)
+metadata:
+  headquarters: US
+  name: xAI
+  privacy_policy_url: https://x.ai/legal/privacy-policy
+  slug: xai
+  status_page_url: https://status.x.ai
+  terms_of_service_url: https://x.ai/legal/terms-of-service
+kind: first_party
+billing: subscription
+access: local_pkce
+api_base: https://api.x.ai/v1
+api_protocol:
+  - "*": [responses, openai]
+# Catalog mirrors `xai` (registry/providers/xai.yaml); no pricing under a
+# flat-rate subscription.
+models:
+  - id: x-ai/grok-4.3
+    provider_model_id: grok-4.3
+    capabilities:
+      - reasoning
+      - tools
+  - id: x-ai/grok-4.20
+    provider_model_id: grok-4.20-0309-non-reasoning
+    capabilities:
+      - tools
+  - id: x-ai/grok-build-0.1
+    provider_model_id: grok-build-0.1
+    capabilities:
+      - tools
+  - id: x-ai/grok-4.20-multi-agent
+    provider_model_id: grok-4.20-multi-agent-0309
+    capabilities:
+      - reasoning
+      - tools
+status: active
+weight: 1
+auth:
+  kind: oauth
+  handler: grok

--- a/skills/bitrouter/references/providers.md
+++ b/skills/bitrouter/references/providers.md
@@ -19,7 +19,9 @@ section). The one in-binary exception is the hosted `bitrouter` cloud gateway.
 | `openrouter` | `OPENROUTER_API_KEY` | Bearer | Forwards every OpenRouter model |
 | `claude-code` | — (local OAuth) | Claude Code session | `bitrouter providers login claude-code`; Claude Pro/Max subscription provider, distinct from `anthropic` API-key billing |
 | `github-copilot` | — (local OAuth) | Device flow | `bitrouter providers login github-copilot`; per-model protocol map (Claude → Anthropic, gpt-5.x-codex → Responses, rest → Chat) |
-| `openai-codex` | — (local PKCE) | ChatGPT subscription | `bitrouter providers login openai-codex` |
+| `openai-codex` | — (local PKCE) | ChatGPT subscription | `bitrouter providers login openai-codex`; includes Pro-only `gpt-5.3-codex-spark` |
+| `supergrok` | — (local PKCE) | SuperGrok subscription | xAI SuperGrok / X Premium+, distinct from `xai` API-key billing — **OAuth handler not yet implemented** |
+| `google-ai-subscription` | — (local OAuth) | Google AI subscription | Antigravity route (Gemini + `gpt-oss-120b`), distinct from `google` API-key billing — **OAuth handler + endpoint not yet finalized** |
 | `opencode-zen` | `OPENCODE_ZEN_API_KEY` | Bearer | Per-family protocol routing |
 | `opencode-go` | `OPENCODE_ZEN_API_KEY` (shared) | Bearer | Low-cost subscription tier — same credential as Zen |
 


### PR DESCRIPTION
## Summary

Stacked on top of #645 (base branch `claude/clever-fermi-969fc7`). Adds two first-party **subscription** providers and refreshes the two existing ones. All four are `billing: subscription` → no per-token `pricing`.

### New providers
- **`supergrok`** — xAI SuperGrok / X Premium+ route. Catalog mirrors `xai` (same xAI backend; the plan changes, not the models), `access: local_pkce`, `handler: grok`.
- **`google-ai-subscription`** — Antigravity route. Google-served set per [antigravity.google/docs/models](https://antigravity.google/docs/models): `gemini-3.5-flash`, `gemini-3.1-pro-preview`, `gpt-oss-120b`. Claude-in-Antigravity is BYOK (bring your own Anthropic key) so it's excluded. `access: local_oauth`, `handler: google`.

### Updated from official pages
- **`openai-codex`** — add Pro-only `gpt-5.3-codex-spark` ([codex/pricing](https://developers.openai.com/codex/pricing)). Keeps the `v1_models` runtime probe.
- **`claude-code`** — add `claude-haiku-4.5` so its catalog mirrors `anthropic.yaml`.

## Design notes
- **OAuth handlers are stubs.** `handler: grok` and `handler: google` are **not yet implemented** in `apps/bitrouter`, so `providers login supergrok` / `login google-ai-subscription` won't work until the handlers land. These entries are registry-source only — catalog-visible, login-inert (staged intentionally).
- **`google-ai-subscription` `api_base` is provisional.** Antigravity's subscription endpoint isn't publicly documented; the Gemini Generative Language base is a placeholder until the handler + endpoint are finalized. Flagged in the file header.
- **No canonical `registry/models` entries added.** Leaning on #645's decoupling, `gpt-5.3-codex-spark` and `gpt-oss-120b` ride as non-curated subscription extras — they appear in the non-failing `registry validate` advisory, and `check` stays green.

## Validation
- `cargo run -p dist-helper -- registry build` — 45 providers, 55 canonical models
- `cargo run -p dist-helper -- registry validate` — valid; advisory lists the two new extras
- `cargo run -p dist-helper -- check` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
