### PR TITLE
fix: harden agentic registry sync

### DIFF
--- a/.github/workflows/registry-sync.yml
+++ b/.github/workflows/registry-sync.yml
@@ -70,6 +70,7 @@ jobs:
             cat target/registry-agentic-result.md
             exit 1
           fi
+          cargo run -p dist-helper -- registry agentic-diff-check
 
       - name: Build and check registry dist
         run: |

--- a/helpers/dist-helper/src/main.rs
+++ b/helpers/dist-helper/src/main.rs
@@ -52,6 +52,12 @@ enum RegistryCommand {
     },
     /// Render the prompt used by the headless agentic registry sync step.
     AgenticPrompt,
+    /// Check that an agentic sync made a narrow, reviewable registry diff.
+    AgenticDiffCheck {
+        /// Maximum deleted lines allowed in one provider YAML file.
+        #[arg(long, default_value_t = 80)]
+        max_provider_deletions: usize,
+    },
 }
 
 #[tokio::main]
@@ -78,6 +84,9 @@ async fn run(cli: Cli) -> Result<()> {
                 print!("{}", registry::agentic_prompt(&root)?);
                 Ok(())
             }
+            RegistryCommand::AgenticDiffCheck {
+                max_provider_deletions,
+            } => registry::agentic_diff_check(&root, max_provider_deletions),
         },
         Command::Check => {
             schema::generate(&root, true)?;

--- a/helpers/dist-helper/src/registry.rs
+++ b/helpers/dist-helper/src/registry.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::Write as _;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::Command as ProcessCommand;
 
 use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
@@ -444,6 +445,14 @@ pub fn agentic_prompt(root: &Path) -> Result<String> {
         out,
         "- Do not infer provider catalog changes from `dist/` artifacts or helper source code.\n"
     )?;
+    writeln!(
+        out,
+        "- Do not use YAML serializers, formatters, or full-file rewrites. Preserve comments, ordering, quoting, and indentation; edit the smallest necessary YAML ranges."
+    )?;
+    writeln!(
+        out,
+        "- The current source model count is context only, not a limit. Add every public production model from the linked source that maps to an existing canonical model ID.\n"
+    )?;
     writeln!(out, "Providers to sync:\n")?;
     if providers.is_empty() {
         writeln!(
@@ -493,7 +502,15 @@ pub fn agentic_prompt(root: &Path) -> Result<String> {
     )?;
     writeln!(
         out,
-        "- For usage-token providers, add pricing when the linked source documents it."
+        "- Only modify data classes listed in the provider `writes` line."
+    )?;
+    writeln!(
+        out,
+        "- If `writes` does not include `pricing`, preserve all existing `pricing` fields exactly."
+    )?;
+    writeln!(
+        out,
+        "- If `writes` includes `pricing`, add or update pricing only when the linked source documents it."
     )?;
     writeln!(
         out,
@@ -546,7 +563,7 @@ fn render_agentic_provider(root: &Path, provider: &LoadedProvider, out: &mut Str
     }
     writeln!(
         out,
-        "  - status: {:?}; billing: {:?}; access: {:?}; model_count: {}",
+        "  - status: {:?}; billing: {:?}; access: {:?}; existing_model_count: {} (current source count, not a limit)",
         data.status,
         data.billing,
         data.access,
@@ -561,11 +578,11 @@ fn render_agentic_provider(root: &Path, provider: &LoadedProvider, out: &mut Str
             .as_ref()
             .into_iter()
             .flatten()
-            .map(|write| format!("{write:?}"))
+            .map(|write| write.source_key())
             .collect();
         writeln!(out, "  - writes: {}", writes.join(", "))?;
     } else {
-        writeln!(out, "  - writes: models, pricing")?;
+        writeln!(out, "  - writes: models")?;
     }
     writeln!(out, "  - urls:")?;
     for url in sync.urls.as_deref().unwrap_or_default() {
@@ -585,6 +602,60 @@ fn slash_path(path: &Path) -> String {
         .map(|component| component.as_os_str().to_string_lossy())
         .collect::<Vec<_>>()
         .join("/")
+}
+
+pub fn agentic_diff_check(root: &Path, max_provider_deletions: usize) -> Result<()> {
+    let output = ProcessCommand::new("git")
+        .arg("-C")
+        .arg(root)
+        .args([
+            "diff",
+            "--numstat",
+            "--",
+            "registry/providers",
+            "registry/models",
+        ])
+        .output()
+        .context("running git diff --numstat for agentic registry sync")?;
+    if !output.status.success() {
+        bail!(
+            "git diff --numstat failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let issues = agentic_diff_issues_from_numstat(&stdout, max_provider_deletions);
+    if !issues.is_empty() {
+        bail!("{}", issues.join("\n"));
+    }
+    println!("agentic registry diff check passed");
+    Ok(())
+}
+
+fn agentic_diff_issues_from_numstat(numstat: &str, max_provider_deletions: usize) -> Vec<String> {
+    let mut issues = Vec::new();
+    for line in numstat.lines() {
+        let mut parts = line.splitn(3, '\t');
+        let _additions = parts.next();
+        let Some(deletions) = parts.next() else {
+            continue;
+        };
+        let Some(path) = parts.next() else {
+            continue;
+        };
+        if !path.starts_with("registry/providers/") {
+            continue;
+        }
+        let Ok(deletions) = deletions.parse::<usize>() else {
+            continue;
+        };
+        if deletions > max_provider_deletions {
+            issues.push(format!(
+                "{path}: agentic sync rewrote too much provider YAML ({deletions} deleted lines; max {max_provider_deletions}). Preserve formatting and make narrower edits."
+            ));
+        }
+    }
+    issues
 }
 
 struct Artifacts {
@@ -1742,6 +1813,15 @@ enum AutoSyncWrite {
     Pricing,
 }
 
+impl AutoSyncWrite {
+    fn source_key(self) -> &'static str {
+        match self {
+            Self::Models => "models",
+            Self::Pricing => "pricing",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 struct RateLimits {
@@ -2141,8 +2221,26 @@ auto_sync:
         assert!(prompt.contains("cargo run -p dist-helper -- registry validate"));
         assert!(prompt.contains("If the listed URLs are unreachable"));
         assert!(prompt.contains("Do not remove or edit provider `auto_sync`"));
+        assert!(prompt.contains("current source count, not a limit"));
+        assert!(prompt.contains("existing_model_count: 1"));
+        assert!(prompt.contains("Do not use YAML serializers"));
         assert!(prompt.contains("include the exact `registry valid:` output line"));
         assert!(!prompt.contains("canonical_models_json"));
+        assert!(!prompt.contains("; model_count: 1"));
+    }
+
+    #[test]
+    fn agentic_diff_check_rejects_large_provider_rewrites() {
+        let issues = agentic_diff_issues_from_numstat(
+            "12\t179\tregistry/providers/worldrouter.yaml\n\
+             70\t0\tregistry/providers/another.yaml\n\
+             12\t179\tregistry/models/anthropic/example.yaml\n",
+            80,
+        );
+
+        assert_eq!(issues.len(), 1);
+        assert!(issues[0].contains("registry/providers/worldrouter.yaml"));
+        assert!(issues[0].contains("179 deleted lines"));
     }
 
     #[test]

--- a/helpers/dist-helper/src/registry.rs
+++ b/helpers/dist-helper/src/registry.rs
@@ -514,6 +514,10 @@ pub fn agentic_prompt(root: &Path) -> Result<String> {
     )?;
     writeln!(
         out,
+        "- When `writes` includes `pricing`, re-check pricing for every provider model against the linked source. Update confirmed changes; leave pricing unchanged only when it cannot be confirmed."
+    )?;
+    writeln!(
+        out,
         "- If `writes` does not include `pricing`, preserve `pricing` in all pre-existing model entries exactly; do not recalculate, normalize, or remove it."
     )?;
     writeln!(
@@ -586,7 +590,7 @@ fn render_agentic_provider(root: &Path, provider: &LoadedProvider, out: &mut Str
             .collect();
         writeln!(out, "  - writes: {}", writes.join(", "))?;
     } else {
-        writeln!(out, "  - writes: models")?;
+        writeln!(out, "  - writes: models, pricing")?;
     }
     writeln!(out, "  - urls:")?;
     for url in sync.urls.as_deref().unwrap_or_default() {
@@ -2227,10 +2231,13 @@ auto_sync:
         assert!(prompt.contains("Do not remove or edit provider `auto_sync`"));
         assert!(prompt.contains("current source count, not a limit"));
         assert!(prompt.contains("existing_model_count: 1"));
+        assert!(prompt.contains("writes: models, pricing"));
         assert!(prompt.contains("Do not use YAML serializers"));
         assert!(
             prompt.contains("A newly added provider model entry may include its own `pricing`")
         );
+        assert!(prompt.contains("re-check pricing for every provider model"));
+        assert!(prompt.contains("leave pricing unchanged only when it cannot be confirmed"));
         assert!(prompt.contains("preserve `pricing` in all pre-existing model entries exactly"));
         assert!(prompt.contains("include the exact `registry valid:` output line"));
         assert!(!prompt.contains("canonical_models_json"));

--- a/helpers/dist-helper/src/registry.rs
+++ b/helpers/dist-helper/src/registry.rs
@@ -506,11 +506,15 @@ pub fn agentic_prompt(root: &Path) -> Result<String> {
     )?;
     writeln!(
         out,
-        "- If `writes` does not include `pricing`, preserve all existing `pricing` fields exactly."
+        "- Treat `writes: models` as permission to add or remove provider model entries. A newly added provider model entry may include its own `pricing` when the linked source documents it."
     )?;
     writeln!(
         out,
-        "- If `writes` includes `pricing`, add or update pricing only when the linked source documents it."
+        "- Treat `writes: pricing` as permission to update `pricing` on pre-existing provider model entries."
+    )?;
+    writeln!(
+        out,
+        "- If `writes` does not include `pricing`, preserve `pricing` in all pre-existing model entries exactly; do not recalculate, normalize, or remove it."
     )?;
     writeln!(
         out,
@@ -2224,6 +2228,10 @@ auto_sync:
         assert!(prompt.contains("current source count, not a limit"));
         assert!(prompt.contains("existing_model_count: 1"));
         assert!(prompt.contains("Do not use YAML serializers"));
+        assert!(
+            prompt.contains("A newly added provider model entry may include its own `pricing`")
+        );
+        assert!(prompt.contains("preserve `pricing` in all pre-existing model entries exactly"));
         assert!(prompt.contains("include the exact `registry valid:` output line"));
         assert!(!prompt.contains("canonical_models_json"));
         assert!(!prompt.contains("; model_count: 1"));

--- a/registry/providers/worldrouter.yaml
+++ b/registry/providers/worldrouter.yaml
@@ -191,8 +191,6 @@ auth_scheme: x-api-key
 community: true
 auto_sync:
   feed: agentic
-  writes:
-    - models
   urls:
     - https://router.worldclaw.ai/models
     - https://router.worldclaw.ai/docs/api

--- a/registry/providers/worldrouter.yaml
+++ b/registry/providers/worldrouter.yaml
@@ -191,6 +191,8 @@ auth_scheme: x-api-key
 community: true
 auto_sync:
   feed: agentic
+  writes:
+    - models
   urls:
     - https://router.worldclaw.ai/models
     - https://router.worldclaw.ai/docs/api


### PR DESCRIPTION
## Summary
- clarify the agentic sync prompt so existing model counts are context, not limits
- forbid YAML serializers/full-file rewrites
- define `writes: models` as allowing complete new model entries, including documented pricing for newly added models
- default agentic providers to `writes: models, pricing` so pricing is re-checked for every provider model
- require confirmed source facts before changing pricing; leave it unchanged only when it cannot be confirmed
- add a workflow diff guard that blocks large provider YAML rewrites before opening sync PRs
- let WorldRouter use the default `models, pricing` sync scope

## Context
The closed automated PR #644 rewrote `registry/providers/worldrouter.yaml` with serializer formatting and did not add missing catalog entries such as `claude-opus-4.8`. The workflow accepted that because validation only checked schema legality, not whether the agent made a narrow source edit.

## Verification
- `cargo test -p dist-helper registry::tests::`
- `cargo run -p dist-helper -- registry agentic-prompt`
- `cargo run -p dist-helper -- registry validate`
- `cargo run -p dist-helper -- registry build`
- `cargo run -p dist-helper -- check`
- `cargo run -p dist-helper -- registry agentic-diff-check`
- `git diff --check`