### PR TITLE
fix: improve agentic source reading

### DIFF
--- a/helpers/dist-helper/src/registry.rs
+++ b/helpers/dist-helper/src/registry.rs
@@ -462,6 +462,23 @@ pub fn agentic_prompt(root: &Path) -> Result<String> {
         out,
         "- The current source model count is context only, not a limit. Add every public production model from the linked source that maps to an existing canonical model ID.\n"
     )?;
+    writeln!(out, "Source reading rules:")?;
+    writeln!(
+        out,
+        "- Raw HTML or rendered app HTML is still readable source material, not a reason to skip a provider."
+    )?;
+    writeln!(
+        out,
+        "- Do not use truncated output, first lines, or `head` output to conclude that a catalog is missing. Fetch the full response or save it to a temporary file before deciding."
+    )?;
+    writeln!(
+        out,
+        "- If a page is long, noisy, or rendered by a frontend framework, use generic extraction strategies: convert to text/Markdown with an available reader tool, parse visible text, search embedded JSON, or inspect repeated model/pricing records in the full page."
+    )?;
+    writeln!(
+        out,
+        "- Only report a source as unreadable after full-page retrieval and at least one fallback extraction method both fail.\n"
+    )?;
     writeln!(out, "Providers to sync:\n")?;
     if providers.is_empty() {
         writeln!(
@@ -2403,6 +2420,9 @@ auto_sync:
         assert!(prompt.contains("current source count, not a limit"));
         assert!(prompt.contains("existing_model_count: 1"));
         assert!(prompt.contains("writes: models, pricing"));
+        assert!(prompt.contains("Raw HTML or rendered app HTML is still readable source material"));
+        assert!(prompt.contains("Do not use truncated output"));
+        assert!(prompt.contains("generic extraction strategies"));
         assert!(prompt.contains("Do not use YAML serializers"));
         assert!(
             prompt.contains("A newly added provider model entry may include its own `pricing`")

--- a/registry/providers/worldrouter.yaml
+++ b/registry/providers/worldrouter.yaml
@@ -193,6 +193,3 @@ auto_sync:
   feed: agentic
   urls:
     - https://router.worldclaw.ai/models
-    - https://router.worldclaw.ai/docs/api
-    - https://router.worldclaw.ai/faq
-    - https://worldclaw.ai/


### PR DESCRIPTION
## Summary
- add generic source-reading rules to the agentic registry sync prompt
- tell the agent not to treat raw HTML or frontend-rendered HTML as unreadable by default
- require full-page retrieval plus a fallback extraction method before reporting a source as unreadable
- remove non-catalog WorldRouter URLs from its agentic sync config

## Context
The latest registry sync run skipped WorldRouter after looking at truncated Next.js HTML, even though the `/models` page is readable and contains model/pricing data. This keeps the fix provider-agnostic: the prompt asks for complete reads and generic extraction strategies, without hard-coding a provider-specific selector.

## Verification
- `cargo test -p dist-helper registry::tests::agentic_sync_requires_urls_and_renders_task_prompt`
- `cargo test -p dist-helper registry::tests::`
- `cargo run -p dist-helper -- registry agentic-prompt`
- `cargo run -p dist-helper -- registry validate`
- `cargo run -p dist-helper -- registry build`
- `cargo run -p dist-helper -- check`
- `cargo fmt -- --check`
- `cargo clippy -p dist-helper --all-targets -- -D warnings`
- `git diff --check`