### PR TITLE
feat: add qwen3.7-plus/max and 3.6-flash, trim 3.5-397b

### DIFF
--- a/dist/registry/models.json
+++ b/dist/registry/models.json
@@ -3018,25 +3018,6 @@
       "release_date": "2026-02-23"
     },
     {
-      "description": "Qwen3.5 open-source native vision-language flagship MoE (397B total, 17B active).",
-      "family": "qwen3.5",
-      "id": "qwen/qwen3.5-397b-a17b",
-      "input_modalities": [
-        "text",
-        "image"
-      ],
-      "knowledge_cutoff": "2025-04",
-      "max_input_tokens": 262144,
-      "max_output_tokens": 65536,
-      "name": "Qwen: Qwen3.5 397B-A17B",
-      "open_weights": true,
-      "output_modalities": [
-        "text"
-      ],
-      "providers": [],
-      "release_date": "2026-02-16"
-    },
-    {
       "description": "Qwen3.6 open-source native vision-language model (27B).",
       "family": "qwen3.6",
       "id": "qwen/qwen3.6-27b",

--- a/dist/registry/models.json
+++ b/dist/registry/models.json
@@ -3073,6 +3073,634 @@
       "release_date": "2026-04-17"
     },
     {
+      "family": "qwen3.6",
+      "id": "qwen/qwen3.6-flash",
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "knowledge_cutoff": "2025-04",
+      "max_input_tokens": 1000000,
+      "max_output_tokens": 65536,
+      "name": "Qwen: Qwen3.6 Flash",
+      "open_weights": false,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 256000,
+                "input_tokens": {
+                  "no_cache": 0.66
+                },
+                "output_tokens": {
+                  "text": 3.961
+                }
+              }
+            ],
+            "input_tokens": {
+              "no_cache": 0.165
+            },
+            "output_tokens": {
+              "text": 0.99
+            }
+          },
+          "provider": "alibaba_cn",
+          "provider_model_id": "qwen3.6-flash",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "provider": "alibaba_coding_plan_sg",
+          "provider_model_id": "qwen3.6-flash",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 256000,
+                "input_tokens": {
+                  "no_cache": 0.66
+                },
+                "output_tokens": {
+                  "text": 3.961
+                }
+              }
+            ],
+            "input_tokens": {
+              "no_cache": 0.165
+            },
+            "output_tokens": {
+              "text": 0.99
+            }
+          },
+          "provider": "alibaba_eu",
+          "provider_model_id": "qwen3.6-flash",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 256000,
+                "input_tokens": {
+                  "no_cache": 0.66
+                },
+                "output_tokens": {
+                  "text": 3.961
+                }
+              }
+            ],
+            "input_tokens": {
+              "no_cache": 0.165
+            },
+            "output_tokens": {
+              "text": 0.99
+            }
+          },
+          "provider": "alibaba_hk",
+          "provider_model_id": "qwen3.6-flash",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 256000,
+                "input_tokens": {
+                  "no_cache": 0.66
+                },
+                "output_tokens": {
+                  "text": 3.961
+                }
+              }
+            ],
+            "input_tokens": {
+              "no_cache": 0.165
+            },
+            "output_tokens": {
+              "text": 0.99
+            }
+          },
+          "provider": "alibaba_jp",
+          "provider_model_id": "qwen3.6-flash",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 256000,
+                "input_tokens": {
+                  "no_cache": 1.0
+                },
+                "output_tokens": {
+                  "text": 4.0
+                }
+              }
+            ],
+            "input_tokens": {
+              "no_cache": 0.25
+            },
+            "output_tokens": {
+              "text": 1.5
+            }
+          },
+          "provider": "alibaba_sg",
+          "provider_model_id": "qwen3.6-flash",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 256000,
+                "input_tokens": {
+                  "no_cache": 0.66
+                },
+                "output_tokens": {
+                  "text": 3.961
+                }
+              }
+            ],
+            "input_tokens": {
+              "no_cache": 0.165
+            },
+            "output_tokens": {
+              "text": 0.99
+            }
+          },
+          "provider": "alibaba_us",
+          "provider_model_id": "qwen3.6-flash",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_write": 0.234375,
+              "no_cache": 0.1875
+            },
+            "output_tokens": {
+              "text": 1.125
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "qwen/qwen3.6-flash"
+        }
+      ],
+      "release_date": "2026-04-27"
+    },
+    {
+      "family": "qwen3.7",
+      "id": "qwen/qwen3.7-max",
+      "input_modalities": [
+        "text"
+      ],
+      "max_input_tokens": 1000000,
+      "max_output_tokens": 65536,
+      "name": "Qwen: Qwen3.7 Max",
+      "open_weights": false,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 1.65
+            },
+            "output_tokens": {
+              "text": 4.951
+            }
+          },
+          "provider": "alibaba_cn",
+          "provider_model_id": "qwen3.7-max",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "provider": "alibaba_coding_plan_sg",
+          "provider_model_id": "qwen3.7-max",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 1.65
+            },
+            "output_tokens": {
+              "text": 4.951
+            }
+          },
+          "provider": "alibaba_eu",
+          "provider_model_id": "qwen3.7-max",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 1.65
+            },
+            "output_tokens": {
+              "text": 4.951
+            }
+          },
+          "provider": "alibaba_hk",
+          "provider_model_id": "qwen3.7-max",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 1.65
+            },
+            "output_tokens": {
+              "text": 4.951
+            }
+          },
+          "provider": "alibaba_jp",
+          "provider_model_id": "qwen3.7-max",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 2.5
+            },
+            "output_tokens": {
+              "text": 7.5
+            }
+          },
+          "provider": "alibaba_sg",
+          "provider_model_id": "qwen3.7-max",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 2.5
+            },
+            "output_tokens": {
+              "text": 7.5
+            }
+          },
+          "provider": "alibaba_us",
+          "provider_model_id": "qwen3.7-max-us",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "provider": "opencode-go",
+          "provider_model_id": "qwen3.7-max"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.25,
+              "cache_write": 1.5625,
+              "no_cache": 1.25
+            },
+            "output_tokens": {
+              "text": 3.75
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "qwen/qwen3.7-max"
+        }
+      ],
+      "release_date": "2026-06-10"
+    },
+    {
+      "family": "qwen3.7",
+      "id": "qwen/qwen3.7-plus",
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "knowledge_cutoff": "2025-04",
+      "max_input_tokens": 1000000,
+      "max_output_tokens": 65536,
+      "name": "Qwen: Qwen3.7 Plus",
+      "open_weights": false,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 256000,
+                "input_tokens": {
+                  "no_cache": 0.826
+                },
+                "output_tokens": {
+                  "text": 3.301
+                }
+              }
+            ],
+            "input_tokens": {
+              "no_cache": 0.276
+            },
+            "output_tokens": {
+              "text": 1.101
+            }
+          },
+          "provider": "alibaba_cn",
+          "provider_model_id": "qwen3.7-plus",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "provider": "alibaba_coding_plan_sg",
+          "provider_model_id": "qwen3.7-plus",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 256000,
+                "input_tokens": {
+                  "no_cache": 0.826
+                },
+                "output_tokens": {
+                  "text": 3.301
+                }
+              }
+            ],
+            "input_tokens": {
+              "no_cache": 0.276
+            },
+            "output_tokens": {
+              "text": 1.101
+            }
+          },
+          "provider": "alibaba_eu",
+          "provider_model_id": "qwen3.7-plus",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 256000,
+                "input_tokens": {
+                  "no_cache": 0.826
+                },
+                "output_tokens": {
+                  "text": 3.301
+                }
+              }
+            ],
+            "input_tokens": {
+              "no_cache": 0.276
+            },
+            "output_tokens": {
+              "text": 1.101
+            }
+          },
+          "provider": "alibaba_hk",
+          "provider_model_id": "qwen3.7-plus",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 256000,
+                "input_tokens": {
+                  "no_cache": 1.2
+                },
+                "output_tokens": {
+                  "text": 4.8
+                }
+              }
+            ],
+            "input_tokens": {
+              "no_cache": 0.4
+            },
+            "output_tokens": {
+              "text": 1.6
+            }
+          },
+          "provider": "alibaba_jp",
+          "provider_model_id": "qwen3.7-plus",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 256000,
+                "input_tokens": {
+                  "no_cache": 1.2
+                },
+                "output_tokens": {
+                  "text": 4.8
+                }
+              }
+            ],
+            "input_tokens": {
+              "no_cache": 0.4
+            },
+            "output_tokens": {
+              "text": 1.6
+            }
+          },
+          "provider": "alibaba_sg",
+          "provider_model_id": "qwen3.7-plus",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 256000,
+                "input_tokens": {
+                  "no_cache": 1.2
+                },
+                "output_tokens": {
+                  "text": 4.8
+                }
+              }
+            ],
+            "input_tokens": {
+              "no_cache": 0.4
+            },
+            "output_tokens": {
+              "text": 1.6
+            }
+          },
+          "provider": "alibaba_us",
+          "provider_model_id": "qwen3.7-plus-us",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "provider": "opencode-go",
+          "provider_model_id": "qwen3.7-plus"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.064,
+              "cache_write": 0.4,
+              "no_cache": 0.32
+            },
+            "output_tokens": {
+              "text": 1.28
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "qwen/qwen3.7-plus"
+        }
+      ],
+      "release_date": "2026-06-01"
+    },
+    {
       "id": "stepfun/step-3.5-flash",
       "input_modalities": [
         "text"

--- a/registry/models/qwen.yaml
+++ b/registry/models/qwen.yaml
@@ -64,3 +64,40 @@
   knowledge_cutoff: 2025-04
   open_weights: true
   family: qwen3.5
+- id: qwen/qwen3.7-plus
+  name: 'Qwen: Qwen3.7 Plus'
+  input_modalities:
+  - text
+  - image
+  output_modalities:
+  - text
+  max_input_tokens: 1000000
+  max_output_tokens: 65536
+  release_date: 2026-06-01
+  knowledge_cutoff: 2025-04
+  open_weights: false
+  family: qwen3.7
+- id: qwen/qwen3.7-max
+  name: 'Qwen: Qwen3.7 Max'
+  input_modalities:
+  - text
+  output_modalities:
+  - text
+  max_input_tokens: 1000000
+  max_output_tokens: 65536
+  release_date: 2026-06-10
+  open_weights: false
+  family: qwen3.7
+- id: qwen/qwen3.6-flash
+  name: 'Qwen: Qwen3.6 Flash'
+  input_modalities:
+  - text
+  - image
+  output_modalities:
+  - text
+  max_input_tokens: 1000000
+  max_output_tokens: 65536
+  release_date: 2026-04-27
+  knowledge_cutoff: 2025-04
+  open_weights: false
+  family: qwen3.6

--- a/registry/models/qwen.yaml
+++ b/registry/models/qwen.yaml
@@ -50,20 +50,6 @@
   release_date: 2026-02-23
   open_weights: true
   family: qwen3.5
-- id: qwen/qwen3.5-397b-a17b
-  name: 'Qwen: Qwen3.5 397B-A17B'
-  description: Qwen3.5 open-source native vision-language flagship MoE (397B total, 17B active).
-  input_modalities:
-  - text
-  - image
-  output_modalities:
-  - text
-  max_input_tokens: 262144
-  max_output_tokens: 65536
-  release_date: 2026-02-16
-  knowledge_cutoff: 2025-04
-  open_weights: true
-  family: qwen3.5
 - id: qwen/qwen3.7-plus
   name: 'Qwen: Qwen3.7 Plus'
   input_modalities:


### PR DESCRIPTION
## Summary

Adds three Qwen commercial-tier models and trims one prior-gen open flagship. Catalog: 48 → **50** canonical models.

**Added (closed, commercial):**
- `qwen/qwen3.7-plus` — text+image, 1M ctx, rel 2026-06-01
- `qwen/qwen3.7-max` — text-only, 1M ctx, rel 2026-06-10
- `qwen/qwen3.6-flash` — text+image, 1M ctx, rel 2026-04-27

**Trimmed:**
- `qwen/qwen3.5-397b-a17b` — the prior-gen 397B open flagship, superseded by `qwen3.6-27b` on SWE tasks and the heaviest to self-host (192GB). The `qwen3.5-122b-a10b` covers the large open-MoE agentic niche more efficiently (leads Terminal-Bench 2 / BFCL among the 3.5 open family).

Net Qwen lineup (8): open `27b`, `35b-a3b`, `122b-a10b`, `3.6-27b`; closed `3.7-plus`, `3.7-max`, `3.6-flash`.

## Verification
- [x] `cargo run -p dist-helper -- registry build && check` — `registry valid: 50 canonical models, 45 providers`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
