### PR TITLE
fix: harden agentic registry sync workflow

### DIFF
--- a/.github/workflows/registry-sync.yml
+++ b/.github/workflows/registry-sync.yml
@@ -32,6 +32,13 @@ jobs:
         run: |
           cargo run -p dist-helper -- registry sync --write
 
+      - name: Install agentic sync tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y curl ripgrep
+          curl --version
+          rg --version
+
       - uses: actions/setup-node@v4
 
       - name: Sync agentic registry feeds
@@ -51,6 +58,7 @@ jobs:
           npm install -g @openai/codex
           export CODEX_HOME="${RUNNER_TEMP}/codex-home"
           mkdir -p "$CODEX_HOME"
+          mkdir -p target/agentic-sync
           codex --search -a never exec \
             --ignore-user-config \
             --ignore-rules \

--- a/.github/workflows/registry-sync.yml
+++ b/.github/workflows/registry-sync.yml
@@ -113,7 +113,13 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add registry dist/registry
           git commit -m "chore: sync registry catalog"
-          git push --force-with-lease origin "HEAD:${BRANCH}"
+          remote_ref="$(git ls-remote --heads origin "${BRANCH}")"
+          remote_sha="$(printf '%s\n' "${remote_ref}" | awk '{print $1}')"
+          if [ -n "${remote_sha}" ]; then
+            git push --force-with-lease="refs/heads/${BRANCH}:${remote_sha}" origin "HEAD:${BRANCH}"
+          else
+            git push origin "HEAD:${BRANCH}"
+          fi
 
           pr_number="$(gh pr list --head "${BRANCH}" --json number --jq '.[0].number // empty')"
           if [ -n "${pr_number}" ]; then

--- a/helpers/dist-helper/src/registry.rs
+++ b/helpers/dist-helper/src/registry.rs
@@ -465,6 +465,14 @@ pub fn agentic_prompt(root: &Path) -> Result<String> {
     writeln!(out, "Source reading rules:")?;
     writeln!(
         out,
+        "- The workflow installs `curl` and `rg`; use them before other fetch/parsing tools."
+    )?;
+    writeln!(
+        out,
+        "- For each source URL, first run `mkdir -p target/agentic-sync`, fetch the full primary document with `curl -sS -L <url> -o target/agentic-sync/<provider>-<n>.html`, then inspect that saved file with `rg`."
+    )?;
+    writeln!(
+        out,
         "- Raw HTML or rendered app HTML is still readable source material, not a reason to skip a provider."
     )?;
     writeln!(
@@ -474,6 +482,10 @@ pub fn agentic_prompt(root: &Path) -> Result<String> {
     writeln!(
         out,
         "- If a page is long, noisy, or rendered by a frontend framework, use generic extraction strategies: convert to text/Markdown with an available reader tool, parse visible text, search embedded JSON, or inspect repeated model/pricing records in the full page."
+    )?;
+    writeln!(
+        out,
+        "- Do not fetch `_next/`, static assets, JavaScript chunks, CSS, fonts, or images unless the saved primary document and a text/Markdown fallback both lack catalog data."
     )?;
     writeln!(
         out,
@@ -2422,6 +2434,10 @@ auto_sync:
         assert!(prompt.contains("writes: models, pricing"));
         assert!(prompt.contains("Raw HTML or rendered app HTML is still readable source material"));
         assert!(prompt.contains("Do not use truncated output"));
+        assert!(prompt.contains("mkdir -p target/agentic-sync"));
+        assert!(prompt.contains("curl -sS -L"));
+        assert!(prompt.contains("rg"));
+        assert!(prompt.contains("Do not fetch `_next/`, static assets, JavaScript chunks"));
         assert!(prompt.contains("generic extraction strategies"));
         assert!(prompt.contains("Do not use YAML serializers"));
         assert!(


### PR DESCRIPTION
## What changed

- Install and verify `curl` and `rg` before the agentic registry sync step.
- Pre-create `target/agentic-sync` for source snapshots.
- Update the agentic sync prompt to require fetching each source URL's full primary document with `curl`, inspecting the saved file with `rg`, and avoiding framework/static chunks unless primary HTML plus a text fallback do not contain catalog data.
- Harden the automated registry PR push: read the current remote `automation/registry-sync` SHA with `git ls-remote` and pass it explicitly to `--force-with-lease`, falling back to a normal branch creation push when the branch does not exist.
- Add prompt assertions so the source-reading contract stays fixed.

## Why

The headless sync agent was spending effort on Next.js scripts even when the model catalog was already present in the primary HTML response. A later workflow run showed the agent extracted the catalog correctly, but the final `git push --force-with-lease` failed with `stale info` because the checkout only fetched `main` and did not have the automation branch's current remote-tracking ref.

This makes both parts deterministic: the agent reads source documents in the intended order, and the workflow pushes the generated registry PR branch using an explicit remote lease.

## Validation

- `cargo fmt -- --check`
- `cargo test -p dist-helper registry::tests::agentic_sync_requires_urls_and_renders_task_prompt`
- `cargo run -p dist-helper -- registry agentic-prompt`
- `cargo test -p dist-helper registry::tests::`
- `cargo clippy -p dist-helper --all-targets -- -D warnings`
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/registry-sync.yml")'`
- `git push --dry-run --force-with-lease=refs/heads/automation/registry-sync:<current-sha> origin HEAD:automation/registry-sync`
