### PR TITLE
fix: use kimi for agentic registry sync

### DIFF
--- a/.github/workflows/registry-sync.yml
+++ b/.github/workflows/registry-sync.yml
@@ -15,7 +15,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  AGENTIC_SYNC_MODEL: z-ai/glm-5.2
+  AGENTIC_SYNC_MODEL: moonshotai/kimi-k2.7-code
 
 jobs:
   sync:

--- a/helpers/dist-helper/src/registry.rs
+++ b/helpers/dist-helper/src/registry.rs
@@ -2476,7 +2476,7 @@ auto_sync:
         let workflow = include_str!("../../../.github/workflows/registry-sync.yml");
 
         assert!(workflow.contains(r#"cron: "0 22 * * *""#));
-        assert!(workflow.contains("AGENTIC_SYNC_MODEL: z-ai/glm-5.2"));
+        assert!(workflow.contains("AGENTIC_SYNC_MODEL: moonshotai/kimi-k2.7-code"));
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- Switch the registry agentic sync workflow default model back to `moonshotai/kimi-k2.7-code`.
- Update the dist-helper workflow default assertion to match.

## Why

`z-ai/glm-5.2` currently fails through the production BitRouter Cloud route with upstream provider authentication errors, which causes Codex streaming runs to end with `request failed; please retry`.

## Validation

- `cargo fmt -p dist-helper`
- `cargo test -p dist-helper registry_sync_workflow_uses_agentic_defaults`