### PR TITLE
fix: preserve stream error settlement

### DIFF
--- a/crates/bitrouter-sdk/src/language_model/pipeline.rs
+++ b/crates/bitrouter-sdk/src/language_model/pipeline.rs
@@ -356,43 +356,45 @@ impl Pipeline {
         mut guard: StreamSettlementGuard,
     ) -> impl Stream<Item = Result<StreamPart>> + Send {
         async_stream::stream! {
-            // Set on every break path below; the loop only exits via `break`.
-            let outcome: StreamOutcome;
             'pump: loop {
-                let processor = guard.processor();
                 match upstream.next().await {
                     Some(Ok(part)) => {
                         let is_finish = part.is_terminal();
-                        match processor.process_part(part).await {
+                        let processed = guard.processor().process_part(part).await;
+                        match processed {
                             Ok(parts) => {
+                                if is_finish {
+                                    guard.finalize(StreamOutcome::Completed).await;
+                                }
                                 for p in parts {
                                     yield Ok(p);
                                 }
                             }
                             Err(abort_err) => {
-                                outcome = StreamOutcome::Aborted(abort_err.clone());
+                                guard
+                                    .finalize(StreamOutcome::Aborted(abort_err.clone()))
+                                    .await;
                                 yield Err(abort_err);
                                 break 'pump;
                             }
                         }
                         if is_finish {
-                            outcome = StreamOutcome::Completed;
                             break 'pump;
                         }
                     }
                     Some(Err(e)) => {
-                        outcome = StreamOutcome::UpstreamError(e.clone());
+                        guard
+                            .finalize(StreamOutcome::UpstreamError(e.clone()))
+                            .await;
                         yield Err(e);
                         break 'pump;
                     }
                     None => {
-                        outcome = StreamOutcome::Completed;
+                        guard.finalize(StreamOutcome::Completed).await;
                         break 'pump;
                     }
                 }
             }
-            // Normal/errored/aborted termination — finalise inline.
-            guard.finalize(outcome).await;
         }
     }
 
@@ -640,13 +642,24 @@ impl StreamSettlementGuard {
     /// Finalise inline on a normal/errored/aborted termination.
     async fn finalize(&mut self, outcome: StreamOutcome) {
         if let Some((mut processor, mut ctx)) = self.state.take() {
+            let (settlement_error, request_outcome) = stream_terminal_metadata(&outcome);
             processor.finish(outcome).await;
             ctx.absorb_stream(processor.into_context());
-            self.pipeline.run_settlement(&mut ctx, true, None).await;
-            self.pipeline.observe_after(Phase::Settlement, &ctx).await;
             self.pipeline
-                .observe_end(&ctx, RequestOutcome::Completed)
+                .run_settlement(&mut ctx, true, settlement_error)
                 .await;
+            self.pipeline.observe_after(Phase::Settlement, &ctx).await;
+            self.pipeline.observe_end(&ctx, request_outcome).await;
+        }
+    }
+}
+
+fn stream_terminal_metadata(outcome: &StreamOutcome) -> (Option<BitrouterError>, RequestOutcome) {
+    match outcome {
+        StreamOutcome::Completed => (None, RequestOutcome::Completed),
+        StreamOutcome::ClientDisconnected => (None, RequestOutcome::ClientDisconnected),
+        StreamOutcome::Aborted(err) | StreamOutcome::UpstreamError(err) => {
+            (Some(err.clone()), RequestOutcome::Failed(err.clone()))
         }
     }
 }

--- a/crates/bitrouter-sdk/src/language_model/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/tests.rs
@@ -122,6 +122,53 @@ impl SettlementRecorder for UsageCapturingRecorder {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SettlementSnapshot {
+    prompt_tokens: u64,
+    completion_tokens: u64,
+    has_error: bool,
+}
+
+struct SettlementSnapshotRecorder(Arc<std::sync::Mutex<Vec<SettlementSnapshot>>>);
+#[async_trait]
+impl SettlementRecorder for SettlementSnapshotRecorder {
+    async fn record(&self, ctx: &mut SettlementContext) -> Result<()> {
+        self.0.lock().unwrap().push(SettlementSnapshot {
+            prompt_tokens: ctx.prompt_tokens,
+            completion_tokens: ctx.completion_tokens,
+            has_error: ctx.error.is_some(),
+        });
+        Ok(())
+    }
+}
+
+struct StreamErrorExecutor {
+    error: BitrouterError,
+}
+
+#[async_trait]
+impl Executor for StreamErrorExecutor {
+    async fn execute(
+        &self,
+        _target: &RoutingTarget,
+        _prompt: &Prompt,
+        _ctx: &PipelineContext,
+    ) -> Result<ExecutionResult> {
+        Err(self.error.clone())
+    }
+
+    async fn execute_stream(
+        &self,
+        _target: &RoutingTarget,
+        _prompt: &Prompt,
+        _ctx: &PipelineContext,
+    ) -> Result<StreamPartStream> {
+        Ok(Box::pin(futures::stream::iter(vec![Err(self
+            .error
+            .clone())])))
+    }
+}
+
 /// A `StreamHook` that records `on_stream_end` outcomes and can rewrite / abort.
 struct ScriptedStreamHook {
     interest: StreamInterest,
@@ -637,6 +684,57 @@ async fn disconnect_before_usage_bills_estimated_output() {
     assert!(
         completion >= 1,
         "completion-token estimate must be non-zero ({completion}); ~31 chars / 4 ≈ 8 tokens"
+    );
+}
+
+#[tokio::test]
+async fn upstream_stream_error_is_not_reclassified_as_client_disconnect_when_dropped() {
+    let ended = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let captured: Arc<std::sync::Mutex<Vec<SettlementSnapshot>>> =
+        Arc::new(std::sync::Mutex::new(Vec::new()));
+    let upstream_error = BitrouterError::Upstream {
+        status: 401,
+        message: "upstream auth failed".into(),
+    };
+    let pipeline = pipeline_with(
+        routing_table(&["openai"]),
+        Arc::new(StreamErrorExecutor {
+            error: upstream_error,
+        }),
+        |b| {
+            b.stream_hook(ScriptedStreamHook {
+                interest: StreamInterest::all(),
+                mode: StreamMode::Pass,
+                ended_with: ended.clone(),
+            })
+            .settlement_recorder(SettlementSnapshotRecorder(captured.clone()));
+        },
+    );
+
+    let mut stream = pipeline
+        .clone()
+        .execute_stream(stream_request())
+        .await
+        .expect("stream starts");
+    let first = stream.next().await.expect("upstream error item");
+    assert!(first.is_err(), "the upstream error surfaced to the client");
+
+    drop(stream);
+    let _ = pipeline.drain_pending_settlements().await;
+
+    assert_eq!(
+        *ended.lock().unwrap(),
+        vec!["upstream_error"],
+        "dropping after receiving the error must not overwrite the terminal outcome"
+    );
+    assert_eq!(
+        captured.lock().unwrap().as_slice(),
+        &[SettlementSnapshot {
+            prompt_tokens: 0,
+            completion_tokens: 0,
+            has_error: true,
+        }],
+        "failed streams without usage must settle as failed and unbillable"
     );
 }
 


### PR DESCRIPTION
## What changed

- Finalize streaming requests with the known terminal outcome before yielding terminal errors or final frames downstream.
- Carry `UpstreamError` / `Aborted` into streaming settlement and request-end observation instead of recording every finalized stream as success.
- Add a regression test for the case where a client drops the stream immediately after receiving an upstream stream error.

## Why

Production logs showed upstream `response.failed` events followed by `client disconnected mid-stream before upstream usage frame; billing estimated usage` for the same request IDs. The stream guard could be dropped after yielding the error but before inline finalization resumed, causing the drop path to overwrite the real upstream error with `ClientDisconnected` and estimate usage.

## Validation

- `cargo fmt -- --check`
- `cargo nextest run --all-features`
- `cargo clippy --all-features`