### PR TITLE
fix: clarify agentic pricing units

### DIFF
--- a/.github/workflows/registry-sync.yml
+++ b/.github/workflows/registry-sync.yml
@@ -22,9 +22,17 @@ jobs:
     name: sync source registry feeds
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub token
+        uses: actions/create-github-app-token@v2
+        id: generate-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v6
         with:
           ref: main
+          token: ${{ steps.generate-token.outputs.token }}
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
 
@@ -87,7 +95,7 @@ jobs:
 
       - name: Open registry sync PR
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
           BRANCH: automation/registry-sync
         run: |
           if git diff --quiet -- registry dist/registry; then
@@ -109,8 +117,8 @@ jobs:
           - `cargo run -p dist-helper -- check`
           EOF
 
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "bitrouter-automation[bot]"
+          git config user.email "267229870+bitrouter-automation[bot]@users.noreply.github.com"
           git add registry dist/registry
           git commit -m "chore: sync registry catalog"
           remote_ref="$(git ls-remote --heads origin "${BRANCH}")"

--- a/helpers/dist-helper/src/registry.rs
+++ b/helpers/dist-helper/src/registry.rs
@@ -2501,6 +2501,15 @@ auto_sync:
 
         assert!(workflow.contains(r#"cron: "0 22 * * *""#));
         assert!(workflow.contains("AGENTIC_SYNC_MODEL: moonshotai/kimi-k2.7-code"));
+        assert!(workflow.contains("uses: actions/create-github-app-token@v2"));
+        assert!(workflow.contains("app-id: ${{ secrets.APP_ID }}"));
+        assert!(workflow.contains("private-key: ${{ secrets.APP_PRIVATE_KEY }}"));
+        assert!(workflow.contains("token: ${{ steps.generate-token.outputs.token }}"));
+        assert!(workflow.contains("GH_TOKEN: ${{ steps.generate-token.outputs.token }}"));
+        assert!(workflow.contains(r#"git config user.name "bitrouter-automation[bot]""#));
+        assert!(workflow.contains(
+            r#"git config user.email "267229870+bitrouter-automation[bot]@users.noreply.github.com""#
+        ));
     }
 
     #[test]

--- a/helpers/dist-helper/src/registry.rs
+++ b/helpers/dist-helper/src/registry.rs
@@ -562,6 +562,23 @@ pub fn agentic_prompt(root: &Path) -> Result<String> {
         out,
         "- For subscription providers, do not invent token pricing.\n"
     )?;
+    writeln!(out, "Pricing unit rules:")?;
+    writeln!(
+        out,
+        "- Registry pricing values are USD per 1 million tokens unless the schema field explicitly says otherwise."
+    )?;
+    writeln!(
+        out,
+        "- Credits, points, coins, or other provider-internal units are not USD. Find and cite the provider's conversion to USD before using them."
+    )?;
+    writeln!(
+        out,
+        "- If the source only exposes provider-internal units and no USD conversion can be confirmed, do not copy provider-internal unit numbers into pricing. Preserve existing pricing for existing entries; skip new usage-token models whose pricing cannot be converted and report them as uncertain."
+    )?;
+    writeln!(
+        out,
+        "- Before broad pricing rewrites, compare at least one existing model's current registry price against the source number. Large uniform multipliers usually mean a unit conversion is missing; re-check the source instead of applying the raw numbers.\n"
+    )?;
     writeln!(out, "Validation:")?;
     writeln!(
         out,
@@ -587,6 +604,10 @@ pub fn agentic_prompt(root: &Path) -> Result<String> {
     writeln!(
         out,
         "- models skipped because canonical mapping or facts were uncertain"
+    )?;
+    writeln!(
+        out,
+        "- pricing units and conversions used, especially for credits/points/coins"
     )?;
     writeln!(out, "- validation result")?;
     writeln!(
@@ -2442,6 +2463,9 @@ auto_sync:
         assert!(prompt.contains("re-check pricing for every provider model"));
         assert!(prompt.contains("leave pricing unchanged only when it cannot be confirmed"));
         assert!(prompt.contains("preserve `pricing` in all pre-existing model entries exactly"));
+        assert!(prompt.contains("Registry pricing values are USD per 1 million tokens"));
+        assert!(prompt.contains("Credits, points, coins, or other provider-internal units"));
+        assert!(prompt.contains("do not copy provider-internal unit numbers into pricing"));
         assert!(prompt.contains("include the exact `registry valid:` output line"));
         assert!(!prompt.contains("canonical_models_json"));
         assert!(!prompt.contains("; model_count: 1"));


### PR DESCRIPTION
## What changed

- Add pricing unit guidance to the agentic registry sync prompt.
- Tell the agent that registry pricing is USD per 1M tokens, not provider-internal credits/points/coins.
- Ask the agent to preserve or skip pricing when conversion to USD cannot be confirmed, and to summarize conversions used.
- Extend the existing prompt-rendering test to cover these instructions.
- Update the registry sync workflow to use the configured `bitrouter-automation` GitHub App token and commit identity when opening/updating automation PRs.

## Why

PR #657 showed WorldRouter prices copied from `Credits` fields directly into registry USD pricing. The workflow should keep relying on maintainer review, not hard reject large price diffs, so this improves the agent prompt instead of adding a rigid CI threshold.

Registry sync PRs were also being opened with `GITHUB_TOKEN` / `github-actions[bot]`, which does not trigger normal PR CI in the way our configured automation bot does. This follows the release-plz / old provider-registry pattern by using the GitHub App token.

## Validation

- `cargo test -p dist-helper agentic_sync_requires_urls_and_renders_task_prompt` initially failed before the prompt change
- `cargo test -p dist-helper registry_sync_workflow_uses_agentic_defaults` initially failed before the workflow token change
- `cargo fmt -p dist-helper --check`
- `cargo test -p dist-helper`
- `cargo run -p dist-helper -- registry agentic-prompt`
