### PR TITLE
fix(registry): add claude-sonnet-5 to anthropic provider

### DIFF
--- a/dist/registry/models.json
+++ b/dist/registry/models.json
@@ -666,6 +666,30 @@
             "tools",
             "image_input"
           ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "cache_write": 2.5,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 10.0
+            }
+          },
+          "provider": "anthropic",
+          "provider_model_id": "claude-sonnet-5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "anthropic",
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools",
+            "image_input"
+          ],
           "provider": "claude-code",
           "provider_model_id": "claude-sonnet-5"
         }

--- a/dist/registry/providers.json
+++ b/dist/registry/providers.json
@@ -1203,6 +1203,30 @@
             "tools",
             "image_input"
           ],
+          "id": "anthropic/claude-sonnet-5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "cache_write": 2.5,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 10.0
+            }
+          },
+          "provider_model_id": "claude-sonnet-5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "anthropic",
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools",
+            "image_input"
+          ],
           "id": "anthropic/claude-sonnet-4.6",
           "pricing": {
             "input_tokens": {

--- a/registry/providers/anthropic.yaml
+++ b/registry/providers/anthropic.yaml
@@ -53,6 +53,21 @@ models:
       - reasoning
       - structured_outputs
       - tools
+  - id: anthropic/claude-sonnet-5
+    provider_model_id: claude-sonnet-5
+    # Introductory pricing through 2026-08-31; rises to $3/$15 after.
+    pricing:
+      input_tokens:
+        no_cache: 2
+        cache_read: 0.2
+        cache_write: 2.5
+      output_tokens:
+        text: 10
+    capabilities:
+      - reasoning
+      - structured_outputs
+      - tools
+      - image_input
   - id: anthropic/claude-sonnet-4.6
     provider_model_id: claude-sonnet-4-6
     pricing:


### PR DESCRIPTION
## Summary
- Anthropic released Claude Sonnet 5 on 2026-06-30 and now serves it on their standard hosted API, but `registry/providers/anthropic.yaml` only listed `anthropic/claude-sonnet-5` under the `claude-code` (subscription/OAuth) provider, not the `anthropic` (hosted API-key) provider.
- This meant `/v1/models` reported `total_online: 0` for `claude-sonnet-5` even though it's generally available — no hosted provider entry existed for it.
- Adds the model to `registry/providers/anthropic.yaml` with introductory pricing ($2/M input, $10/M output through 2026-08-31, rising to $3/$15 after), matching the existing pricing pattern (cache_read = 0.1x, cache_write = 1.25x of no_cache).
- Regenerated `dist/registry/{models,providers}.json` via `cargo run -p dist-helper -- registry build`.

## Test plan
- [x] `cargo run -p dist-helper -- registry validate` — passes (50 canonical models, 45 providers; no new advisories)
- [x] `cargo run -p dist-helper -- registry build` — regenerated dist/registry JSON, diff reviewed
- [x] `cargo fmt -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)