### PR TITLE
feat: configurable upstream HTTP timeouts

### DIFF
--- a/apps/bitrouter/src/assemble.rs
+++ b/apps/bitrouter/src/assemble.rs
@@ -216,9 +216,24 @@ pub async fn build_app_with_path(
     // request. Listed only when the user configures the provider, so an
     // operator who doesn't use Copilot doesn't pay a token-store read.
     let auth_appliers = build_auth_appliers(config)?;
+    // Upstream timeouts: the `upstream.timeouts` block layered over the
+    // built-in defaults, plus a per-provider override for any provider whose
+    // resolved timeouts differ (v0 #394 fixed these; now they're configurable).
+    // Read from the user's `config` — per-provider timeouts are a user-only
+    // field, never set by the registry/builtin-defaults merge.
+    let global_timeouts = config.upstream.timeouts.apply_to(HttpTimeouts::default());
+    let provider_timeouts: std::collections::HashMap<String, HttpTimeouts> = config
+        .providers
+        .iter()
+        .filter_map(|(id, provider)| {
+            let resolved = provider.timeouts.apply_to(global_timeouts.clone());
+            (resolved != global_timeouts).then(|| (id.clone(), resolved))
+        })
+        .collect();
     let executor = Arc::new(
-        HttpExecutor::with_dispatch_and_auth(
-            HttpTimeouts::default(),
+        HttpExecutor::with_provider_timeouts(
+            global_timeouts,
+            provider_timeouts,
             OutboundDispatch::builtin(),
             auth_appliers,
         )

--- a/apps/bitrouter/src/assemble.rs
+++ b/apps/bitrouter/src/assemble.rs
@@ -80,6 +80,9 @@ pub struct Assembled {
     /// [`ConfigRoutingTable::replace_config`] when there's no source
     /// file to re-read from (zero-config mode).
     pub routing_table: Arc<ConfigRoutingTable>,
+    /// Concrete upstream HTTP executor. The pipeline also holds this as a trait
+    /// object, but reload needs the concrete handle to replace timeout clients.
+    pub upstream_executor: Arc<HttpExecutor>,
     /// Snapshot provider for `bitrouter observe status`. When the OTel
     /// exporter is wired, this reports its live state; when not, it
     /// reports `compiled_in` truthfully and everything else blank.
@@ -95,6 +98,24 @@ pub struct Assembled {
     /// the subscriber on the `serve` path, so logging directly here
     /// would be dropped.
     pub otel_init_error: Option<String>,
+}
+
+pub(crate) fn resolved_upstream_timeouts(
+    config: &Config,
+) -> (
+    HttpTimeouts,
+    std::collections::HashMap<String, HttpTimeouts>,
+) {
+    let global_timeouts = config.upstream.timeouts.apply_to(HttpTimeouts::default());
+    let provider_timeouts: std::collections::HashMap<String, HttpTimeouts> = config
+        .providers
+        .iter()
+        .filter_map(|(id, provider)| {
+            let resolved = provider.timeouts.apply_to(global_timeouts.clone());
+            (resolved != global_timeouts).then(|| (id.clone(), resolved))
+        })
+        .collect();
+    (global_timeouts, provider_timeouts)
 }
 
 /// `ObserveStatusProvider` impl backed by a real [`OtelExporter`]. The
@@ -221,15 +242,7 @@ pub async fn build_app_with_path(
     // resolved timeouts differ (v0 #394 fixed these; now they're configurable).
     // Read from the user's `config` — per-provider timeouts are a user-only
     // field, never set by the registry/builtin-defaults merge.
-    let global_timeouts = config.upstream.timeouts.apply_to(HttpTimeouts::default());
-    let provider_timeouts: std::collections::HashMap<String, HttpTimeouts> = config
-        .providers
-        .iter()
-        .filter_map(|(id, provider)| {
-            let resolved = provider.timeouts.apply_to(global_timeouts.clone());
-            (resolved != global_timeouts).then(|| (id.clone(), resolved))
-        })
-        .collect();
+    let (global_timeouts, provider_timeouts) = resolved_upstream_timeouts(config);
     let executor = Arc::new(
         HttpExecutor::with_provider_timeouts(
             global_timeouts,
@@ -239,6 +252,7 @@ pub async fn build_app_with_path(
         )
         .context("building the upstream HTTP executor")?,
     );
+    let executor_for_reload = executor.clone();
 
     // ---- pricing, metering, policy, guardrails — all derived from config ----
     let pricing = Arc::new(build_pricing_table(config));
@@ -541,6 +555,7 @@ pub async fn build_app_with_path(
         db,
         policy_store: policy_store_for_reload,
         routing_table: routing_table_for_reload,
+        upstream_executor: executor_for_reload,
         observe: observe_provider,
         otel_exporter: otel_for_assembled,
         otel_init_error,

--- a/apps/bitrouter/src/main.rs
+++ b/apps/bitrouter/src/main.rs
@@ -1026,6 +1026,7 @@ async fn serve(source: &bitrouter::paths::ConfigSource) -> Result<()> {
     let reloader: Arc<dyn daemon::DaemonReloader> = Arc::new(bitrouter::reload::AppReloader::new(
         policy_store.clone(),
         assembled.routing_table,
+        assembled.upstream_executor,
         reload_source,
     ));
 

--- a/apps/bitrouter/src/reload.rs
+++ b/apps/bitrouter/src/reload.rs
@@ -55,6 +55,9 @@ pub struct AppReloader {
     /// built-in catalog can be applied above the SDK — and swap it in
     /// via `ConfigRoutingTable::replace_config`.
     routing_table: Arc<bitrouter_sdk::config::ConfigRoutingTable>,
+    /// Concrete upstream HTTP executor. Timeout knobs are client-level, so a
+    /// config reload must rebuild the live executor's client set too.
+    upstream_executor: Arc<bitrouter_sdk::language_model::HttpExecutor>,
     source: ReloadSource,
 }
 
@@ -63,13 +66,27 @@ impl AppReloader {
     pub fn new(
         policy_store: Arc<PolicyStore>,
         routing_table: Arc<bitrouter_sdk::config::ConfigRoutingTable>,
+        upstream_executor: Arc<bitrouter_sdk::language_model::HttpExecutor>,
         source: ReloadSource,
     ) -> Self {
         Self {
             policy_store,
             routing_table,
+            upstream_executor,
             source,
         }
+    }
+
+    async fn replace_routing_and_timeouts(
+        &self,
+        fresh: bitrouter_sdk::config::Config,
+    ) -> bitrouter_sdk::Result<()> {
+        let (global_timeouts, provider_timeouts) =
+            crate::assemble::resolved_upstream_timeouts(&fresh);
+        self.routing_table.replace_config(fresh).await?;
+        self.upstream_executor
+            .reload_provider_timeouts(global_timeouts, provider_timeouts)?;
+        Ok(())
     }
 }
 
@@ -105,7 +122,7 @@ impl DaemonReloader for AppReloader {
                     // them and the merge's `apply_builtin_defaults` would leave a
                     // keyless provider inactive. Runs after the merge.
                     activate_stored_credential_providers(&mut fresh);
-                    self.routing_table.replace_config(fresh).await
+                    self.replace_routing_and_timeouts(fresh).await
                 }
                 Err(e) => Err(e),
             },
@@ -134,7 +151,7 @@ impl DaemonReloader for AppReloader {
                 // credential (invisible to the registry's config/env credential
                 // gate), after the merge re-applies builtin defaults.
                 activate_stored_credential_providers(&mut fresh);
-                self.routing_table.replace_config(fresh).await
+                self.replace_routing_and_timeouts(fresh).await
             }
         };
         if let Err(e) = routing_outcome {
@@ -147,6 +164,145 @@ impl DaemonReloader for AppReloader {
             Ok(())
         } else {
             Err(anyhow::anyhow!(errors.join("; ")))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bitrouter_sdk::config::{self, ConfigRoutingTable};
+    use bitrouter_sdk::language_model::{
+        ApiProtocol, Executor, GenerationParams, HttpExecutor, HttpTimeouts, Message,
+        PipelineContext, PipelineRequest, Prompt, Role, RoutingTarget,
+    };
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    fn temp_config_path() -> (std::path::PathBuf, std::path::PathBuf) {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock before unix epoch")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "bitrouter-reload-timeouts-{}-{unique}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).expect("create temp config dir");
+        (dir.join("bitrouter.yaml"), dir)
+    }
+
+    fn config_yaml(read_secs: u64) -> String {
+        format!(
+            r#"
+inherit_defaults: false
+upstream:
+  timeouts:
+    read_secs: {read_secs}
+providers:
+  slow:
+    api_base: https://api.example.com/v1
+    api_key: k
+    api_protocol:
+      - "*": chat_completions
+    models:
+      - {{ id: m }}
+"#
+        )
+    }
+
+    async fn stalled_json_server() -> String {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test server");
+        let addr = listener.local_addr().expect("test server addr");
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.expect("accept request");
+            let mut request_buf = [0_u8; 1024];
+            let _ = socket.read(&mut request_buf).await;
+            socket
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\n\
+                      content-type: application/json\r\n\
+                      content-length: 1024\r\n\
+                      \r\n\
+                      {\"id\":\"partial\"",
+                )
+                .await
+                .expect("write partial response");
+            tokio::time::sleep(Duration::from_secs(5)).await;
+        });
+        format!("http://{addr}/v1")
+    }
+
+    fn prompt() -> Prompt {
+        Prompt {
+            model: "m".into(),
+            system: None,
+            system_provider_metadata: Default::default(),
+            messages: vec![Message::text(Role::User, "hi")],
+            tools: vec![],
+            params: GenerationParams::default(),
+            response_format: None,
+            tool_choice: None,
+            stream: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn reload_updates_live_upstream_timeout_clients() {
+        let (path, dir) = temp_config_path();
+        std::fs::write(&path, config_yaml(30)).expect("write initial config");
+        let initial = config::parse(&config_yaml(30)).expect("parse initial config");
+        let routing_table = Arc::new(ConfigRoutingTable::from_config(initial));
+        let executor = Arc::new(
+            HttpExecutor::new(HttpTimeouts {
+                read: Duration::from_secs(30),
+                ..HttpTimeouts::default()
+            })
+            .expect("build executor"),
+        );
+        let reloader = AppReloader::new(
+            Arc::new(PolicyStore::new()),
+            routing_table,
+            executor.clone(),
+            ReloadSource::File(path.clone()),
+        );
+
+        std::fs::write(&path, config_yaml(1)).expect("write reloaded config");
+        reloader.reload().await.expect("reload config");
+
+        let api_base = stalled_json_server().await;
+        let target = RoutingTarget {
+            provider_name: "slow".into(),
+            service_id: "m".into(),
+            api_base,
+            api_key: "k".into(),
+            api_protocol: ApiProtocol::ChatCompletions,
+            account_label: None,
+            api_key_override: None,
+            api_base_override: None,
+            auth_scheme: Default::default(),
+        };
+        let prompt = prompt();
+        let ctx = PipelineContext::new(PipelineRequest::new(
+            "m",
+            bitrouter_sdk::caller::CallerContext::local(),
+            prompt.clone(),
+        ));
+
+        let err = tokio::time::timeout(
+            Duration::from_secs(3),
+            executor.execute(&target, &prompt, &ctx),
+        )
+        .await
+        .expect("reloaded read_secs should bound the stalled body")
+        .expect_err("stalled body should timeout");
+        std::fs::remove_dir_all(dir).ok();
+
+        match err {
+            bitrouter_sdk::BitrouterError::UpstreamTimeout => {}
+            other => panic!("expected UpstreamTimeout, got {other:?}"),
         }
     }
 }

--- a/apps/bitrouter/tests/daemon.rs
+++ b/apps/bitrouter/tests/daemon.rs
@@ -328,6 +328,7 @@ providers:
     let reloader = AppReloader::new(
         assembled.policy_store.clone(),
         assembled.routing_table.clone(),
+        assembled.upstream_executor.clone(),
         ReloadSource::File(cfg_path.clone()),
     );
     reloader.reload().await.expect("reload succeeds");

--- a/crates/bitrouter-sdk/src/config/mod.rs
+++ b/crates/bitrouter-sdk/src/config/mod.rs
@@ -19,10 +19,12 @@
 //! ```
 
 use std::collections::HashMap;
+use std::time::Duration;
 
 use serde::Deserialize;
 
 use crate::error::{BitrouterError, Result};
+use crate::language_model::HttpTimeouts;
 use crate::language_model::routing::SortOrder;
 use crate::language_model::types::{ApiProtocol, ProtocolList};
 
@@ -43,6 +45,8 @@ pub use routing_table::ConfigRoutingTable;
 pub struct Config {
     /// HTTP server settings.
     pub server: ServerConfig,
+    /// Outbound / upstream HTTP settings (the client that calls providers).
+    pub upstream: UpstreamConfig,
     /// Database connection settings.
     pub database: DatabaseConfig,
     /// Upstream providers, keyed by provider id.
@@ -83,6 +87,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             server: ServerConfig::default(),
+            upstream: UpstreamConfig::default(),
             database: DatabaseConfig::default(),
             providers: HashMap::new(),
             models: HashMap::new(),
@@ -261,6 +266,69 @@ impl Default for ServerConfig {
     }
 }
 
+/// Outbound / upstream HTTP settings — the client BitRouter uses to call
+/// providers. Distinct from [`ServerConfig`], which is the inbound listen
+/// socket. Currently just [`timeouts`](Self::timeouts); grouped under
+/// `upstream:` so future outbound knobs have a home.
+#[derive(Debug, Clone, Default, Deserialize, schemars::JsonSchema)]
+#[serde(default)]
+pub struct UpstreamConfig {
+    /// Global upstream timeout defaults. A provider may override any field
+    /// under `providers.<id>.timeouts:`.
+    pub timeouts: TimeoutConfig,
+}
+
+/// Upstream HTTP timeout knobs, in seconds. Every field is optional; an unset
+/// field inherits the level above — a provider override inherits the resolved
+/// global value, and an unset global inherits the built-in default
+/// ([`HttpTimeouts::default`]). `total_secs` is opt-in at every level: unset ⇒
+/// no overall wall-clock cap (the right default for long agentic streams).
+///
+/// Used both as the top-level `upstream.timeouts` block and as the per-provider
+/// `providers.<id>.timeouts` override; timeouts are **not** inherited via a
+/// provider's `derives:` chain.
+#[derive(Debug, Clone, Default, Deserialize, schemars::JsonSchema)]
+#[serde(default)]
+pub struct TimeoutConfig {
+    /// TCP connect timeout, seconds.
+    pub connect_secs: Option<u64>,
+    /// Idle (per-read) timeout, seconds — fires when the upstream sends no
+    /// bytes for this long, including mid-stream. The effective stream-idle
+    /// guard.
+    pub read_secs: Option<u64>,
+    /// Idle pooled-connection eviction, seconds.
+    pub pool_idle_secs: Option<u64>,
+    /// TCP keepalive probe interval, seconds.
+    pub tcp_keepalive_secs: Option<u64>,
+    /// Overall wall-clock cap for the entire request/stream, seconds. Opt-in:
+    /// unset ⇒ no cap. Setting it bounds total stream duration, so keep it
+    /// generous for reasoning / agentic providers.
+    pub total_secs: Option<u64>,
+}
+
+impl TimeoutConfig {
+    /// Resolve this (partial) config over a base [`HttpTimeouts`]: every set
+    /// field overrides the base, every unset field inherits it.
+    pub fn apply_to(&self, base: HttpTimeouts) -> HttpTimeouts {
+        HttpTimeouts {
+            connect: self
+                .connect_secs
+                .map(Duration::from_secs)
+                .unwrap_or(base.connect),
+            read: self.read_secs.map(Duration::from_secs).unwrap_or(base.read),
+            pool_idle: self
+                .pool_idle_secs
+                .map(Duration::from_secs)
+                .unwrap_or(base.pool_idle),
+            tcp_keepalive: self
+                .tcp_keepalive_secs
+                .map(Duration::from_secs)
+                .unwrap_or(base.tcp_keepalive),
+            total: self.total_secs.map(Duration::from_secs).or(base.total),
+        }
+    }
+}
+
 /// Database connection settings.
 #[derive(Debug, Clone, Deserialize, schemars::JsonSchema)]
 #[serde(default)]
@@ -390,6 +458,10 @@ pub struct ProviderConfig {
     /// class-derived rank, so an operator can pin one provider ahead of others
     /// regardless of class. `None` ⇒ derive the rank from [`class`](Self::class).
     pub priority: Option<i32>,
+    /// Per-provider upstream timeout overrides. Each set field layers over the
+    /// resolved global [`UpstreamConfig::timeouts`]; unset fields inherit it.
+    /// Not inherited via [`derives`](Self::derives).
+    pub timeouts: TimeoutConfig,
 }
 
 /// One credential within a multi-account provider. An account varies
@@ -489,6 +561,7 @@ impl Default for ProviderConfig {
             account_strategy: AccountStrategy::default(),
             class: None,
             priority: None,
+            timeouts: TimeoutConfig::default(),
         }
     }
 }

--- a/crates/bitrouter-sdk/src/config/tests.rs
+++ b/crates/bitrouter-sdk/src/config/tests.rs
@@ -533,3 +533,97 @@ fn primary_api_key_prefers_top_level_then_first_account() {
     };
     assert_eq!(p2.primary_api_key(), "second");
 }
+
+// ===== upstream HTTP timeouts (global + per-provider) =====
+
+#[test]
+fn timeout_config_empty_inherits_base() {
+    use crate::language_model::HttpTimeouts;
+    let base = HttpTimeouts::default();
+    let resolved = TimeoutConfig::default().apply_to(base.clone());
+    assert_eq!(resolved, base, "an empty override must equal the base");
+}
+
+#[test]
+fn timeout_config_overrides_only_set_fields() {
+    use crate::language_model::HttpTimeouts;
+    use std::time::Duration;
+    let base = HttpTimeouts::default();
+    let resolved = TimeoutConfig {
+        read_secs: Some(300),
+        ..Default::default()
+    }
+    .apply_to(base.clone());
+    assert_eq!(resolved.read, Duration::from_secs(300));
+    // Untouched fields keep the base value.
+    assert_eq!(resolved.connect, base.connect);
+    assert_eq!(resolved.pool_idle, base.pool_idle);
+    assert_eq!(resolved.tcp_keepalive, base.tcp_keepalive);
+}
+
+#[test]
+fn total_wall_clock_cap_is_off_by_default_and_opt_in() {
+    use crate::language_model::HttpTimeouts;
+    use std::time::Duration;
+    // No overall cap by default — correct for long agentic streams.
+    assert_eq!(HttpTimeouts::default().total, None);
+    // Opt-in via config.
+    let resolved = TimeoutConfig {
+        total_secs: Some(900),
+        ..Default::default()
+    }
+    .apply_to(HttpTimeouts::default());
+    assert_eq!(resolved.total, Some(Duration::from_secs(900)));
+}
+
+#[test]
+fn per_provider_override_layers_over_resolved_global() {
+    use crate::language_model::HttpTimeouts;
+    use std::time::Duration;
+    // A provider inherits the global read but sets its own total cap.
+    let global = TimeoutConfig {
+        read_secs: Some(200),
+        ..Default::default()
+    }
+    .apply_to(HttpTimeouts::default());
+    let provider = TimeoutConfig {
+        total_secs: Some(600),
+        ..Default::default()
+    }
+    .apply_to(global.clone());
+    assert_eq!(
+        provider.read,
+        Duration::from_secs(200),
+        "inherits global read"
+    );
+    assert_eq!(
+        provider.total,
+        Some(Duration::from_secs(600)),
+        "own total cap"
+    );
+}
+
+#[test]
+fn parses_global_and_per_provider_timeouts() {
+    let yaml = r#"
+upstream:
+  timeouts:
+    read_secs: 200
+    total_secs: 600
+providers:
+  slow:
+    api_base: https://api.example.com
+    api_key: k
+    timeouts:
+      read_secs: 300
+"#;
+    let cfg = parse(yaml).expect("parse");
+    assert_eq!(cfg.upstream.timeouts.read_secs, Some(200));
+    assert_eq!(cfg.upstream.timeouts.total_secs, Some(600));
+    let p = cfg.providers.get("slow").expect("provider 'slow'");
+    assert_eq!(p.timeouts.read_secs, Some(300));
+    assert_eq!(
+        p.timeouts.total_secs, None,
+        "unset provider field stays None"
+    );
+}

--- a/crates/bitrouter-sdk/src/language_model/executor.rs
+++ b/crates/bitrouter-sdk/src/language_model/executor.rs
@@ -151,18 +151,31 @@ impl Executor for MockExecutor {
 // ===== real HTTP executor =====
 
 /// Upstream HTTP client timeout configuration. v0 #394: the upstream client had
-/// no timeouts, so a slow provider could hang a request forever. These four
-/// knobs are configured together.
-#[derive(Debug, Clone)]
+/// no timeouts, so a slow provider could hang a request forever.
+///
+/// `connect` / `read` / `pool_idle` / `tcp_keepalive` are set on the reqwest
+/// client at build time. `read` is a **per-read** (idle) timeout — it resets
+/// after every chunk, so it fires when an upstream sends no bytes for that long
+/// *including mid-stream*, which is the effective stream-idle guard.
+///
+/// `total` is the optional overall wall-clock cap for the whole request/stream,
+/// applied per-request via [`reqwest::RequestBuilder::timeout`]. It is `None` by
+/// default: an overall cap would kill legitimately long agentic/reasoning
+/// streams, so it is opt-in per deployment or per provider.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HttpTimeouts {
     /// TCP connect timeout.
     pub connect: Duration,
-    /// Per-read (response body) timeout.
+    /// Per-read (idle) timeout — resets after each chunk; fires mid-stream when
+    /// the upstream goes silent for this long.
     pub read: Duration,
     /// How long an idle pooled connection is kept.
     pub pool_idle: Duration,
     /// TCP keepalive probe interval.
     pub tcp_keepalive: Duration,
+    /// Optional overall wall-clock cap for the entire request/stream. `None` ⇒
+    /// no cap (default). Opt-in; keep it generous for reasoning providers.
+    pub total: Option<Duration>,
 }
 
 impl Default for HttpTimeouts {
@@ -172,6 +185,7 @@ impl Default for HttpTimeouts {
             read: Duration::from_secs(120),
             pool_idle: Duration::from_secs(90),
             tcp_keepalive: Duration::from_secs(60),
+            total: None,
         }
     }
 }
@@ -214,6 +228,23 @@ fn classify_upstream_error(status: u16, body: &str) -> BitrouterError {
     }
 }
 
+/// Classify a transport error that surfaces from the SSE decode loop *after*
+/// the stream is open. A read-timeout firing mid-stream must map to
+/// [`BitrouterError::UpstreamTimeout`] (504) — the same as a pre-stream
+/// timeout — rather than a generic 502, so status codes and metrics stay
+/// truthful once streaming has started. Non-timeout errors (parse / decode /
+/// other transport) keep the 502 mapping and carry the message.
+fn stream_transport_error(is_timeout: bool, display: impl std::fmt::Display) -> BitrouterError {
+    if is_timeout {
+        BitrouterError::UpstreamTimeout
+    } else {
+        BitrouterError::Upstream {
+            status: 502,
+            message: format!("upstream stream error: {display}"),
+        }
+    }
+}
+
 /// Heuristic: does this upstream error body describe a depleted
 /// credit / balance? Matches the stable phrase family rather than any
 /// one provider's exact wording — string matching is unavoidable here
@@ -233,11 +264,34 @@ fn looks_like_credit_exhaustion(body: &str) -> bool {
 /// stream of [`StreamPart`]s.
 ///
 /// Build with [`HttpExecutor::with_defaults`] for sensible timeout defaults
-/// or [`HttpExecutor::new`] with a custom [`HttpTimeouts`].
+/// or [`HttpExecutor::new`] with a custom [`HttpTimeouts`]. Use
+/// [`with_provider_timeouts`](Self::with_provider_timeouts) to attach
+/// per-provider overrides.
 pub struct HttpExecutor {
-    client: reqwest::Client,
+    /// Client used for any provider without a per-provider override, plus its
+    /// timeouts (for the per-request `total` cap, which is not a client
+    /// setting).
+    default_client: reqwest::Client,
+    default_timeouts: HttpTimeouts,
+    /// Per-provider clients keyed by `provider_name`, each paired with the
+    /// resolved timeouts it was built from. Built once at construction; empty
+    /// in the common single-timeout deployment.
+    provider_clients: HashMap<String, (HttpTimeouts, reqwest::Client)>,
     dispatch: OutboundDispatch,
     auth_appliers: AuthAppliers,
+}
+
+/// Build a reqwest client from the connection-level timeout knobs. `total` is
+/// deliberately not applied here — it is a per-request deadline set via
+/// [`reqwest::RequestBuilder::timeout`], not a client-builder setting.
+fn build_http_client(timeouts: &HttpTimeouts) -> Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .connect_timeout(timeouts.connect)
+        .read_timeout(timeouts.read)
+        .pool_idle_timeout(timeouts.pool_idle)
+        .tcp_keepalive(timeouts.tcp_keepalive)
+        .build()
+        .map_err(|e| BitrouterError::internal(format!("building HTTP client: {e}")))
 }
 
 impl HttpExecutor {
@@ -268,18 +322,47 @@ impl HttpExecutor {
         dispatch: OutboundDispatch,
         auth_appliers: AuthAppliers,
     ) -> Result<Self> {
-        let client = reqwest::Client::builder()
-            .connect_timeout(timeouts.connect)
-            .read_timeout(timeouts.read)
-            .pool_idle_timeout(timeouts.pool_idle)
-            .tcp_keepalive(timeouts.tcp_keepalive)
-            .build()
-            .map_err(|e| BitrouterError::internal(format!("building HTTP client: {e}")))?;
+        Self::with_provider_timeouts(timeouts, HashMap::new(), dispatch, auth_appliers)
+    }
+
+    /// Build an executor with a global default [`HttpTimeouts`] plus a set of
+    /// per-provider overrides keyed by `provider_name`. Each override gets its
+    /// own reqwest client (connect/read/pool/keepalive are client-build-time
+    /// settings, so a differing tuple needs a distinct client); an override
+    /// equal to the default is skipped. Providers absent from the map use the
+    /// default client. This is how the app honours the `upstream.timeouts`
+    /// block and per-provider `timeouts:` overrides.
+    pub fn with_provider_timeouts(
+        default_timeouts: HttpTimeouts,
+        per_provider: HashMap<String, HttpTimeouts>,
+        dispatch: OutboundDispatch,
+        auth_appliers: AuthAppliers,
+    ) -> Result<Self> {
+        let default_client = build_http_client(&default_timeouts)?;
+        let mut provider_clients = HashMap::new();
+        for (name, timeouts) in per_provider {
+            if timeouts == default_timeouts {
+                continue;
+            }
+            let client = build_http_client(&timeouts)?;
+            provider_clients.insert(name, (timeouts, client));
+        }
         Ok(Self {
-            client,
+            default_client,
+            default_timeouts,
+            provider_clients,
             dispatch,
             auth_appliers,
         })
+    }
+
+    /// Pick the client + timeouts for `target`: a per-provider override when one
+    /// is registered for its `provider_name`, else the default pair.
+    fn client_for(&self, target: &RoutingTarget) -> (&reqwest::Client, &HttpTimeouts) {
+        match self.provider_clients.get(&target.provider_name) {
+            Some((timeouts, client)) => (client, timeouts),
+            None => (&self.default_client, &self.default_timeouts),
+        }
     }
 
     /// Build an executor with default timeouts and the built-in dispatch.
@@ -417,17 +500,19 @@ impl Executor for HttpExecutor {
         self.shape_request_body(&mut body, target).await?;
         let url = transport.endpoint_url(target, false);
 
+        let (client, timeouts) = self.client_for(target);
         let started = Instant::now();
-        let mut request = self
-            .client
-            .post(&url)
-            .json(&body)
+        let mut builder = client.post(&url).json(&body);
+        if let Some(total) = timeouts.total {
+            builder = builder.timeout(total);
+        }
+        let mut request = builder
             .build()
             .map_err(|e| BitrouterError::internal(format!("building request: {e}")))?;
         forward_inbound_anthropic_beta(&mut request, target, ctx);
         let mut request = self.apply_auth(request, target, transport).await?;
         merge_outbound_trace_headers(&mut request, ctx);
-        let response = self.client.execute(request).await.map_err(|e| {
+        let response = client.execute(request).await.map_err(|e| {
             if e.is_timeout() {
                 BitrouterError::UpstreamTimeout
             } else {
@@ -490,16 +575,18 @@ impl Executor for HttpExecutor {
         self.shape_request_body(&mut body, target).await?;
         let url = transport.endpoint_url(target, true);
 
-        let mut request = self
-            .client
-            .post(&url)
-            .json(&body)
+        let (client, timeouts) = self.client_for(target);
+        let mut builder = client.post(&url).json(&body);
+        if let Some(total) = timeouts.total {
+            builder = builder.timeout(total);
+        }
+        let mut request = builder
             .build()
             .map_err(|e| BitrouterError::internal(format!("building request: {e}")))?;
         forward_inbound_anthropic_beta(&mut request, target, ctx);
         let mut request = self.apply_auth(request, target, transport).await?;
         merge_outbound_trace_headers(&mut request, ctx);
-        let response = self.client.execute(request).await.map_err(|e| {
+        let response = client.execute(request).await.map_err(|e| {
             if e.is_timeout() {
                 BitrouterError::UpstreamTimeout
             } else {
@@ -544,10 +631,14 @@ impl Executor for HttpExecutor {
                         }
                     }
                     Err(e) => {
-                        yield Err(BitrouterError::Upstream {
-                            status: 502,
-                            message: format!("upstream stream error: {e}"),
-                        });
+                        // A read-timeout that fires mid-stream arrives here as a
+                        // transport error — recover the reqwest timeout signal so
+                        // it maps to UpstreamTimeout (504), not a blanket 502.
+                        let is_timeout = matches!(
+                            &e,
+                            eventsource_stream::EventStreamError::Transport(re) if re.is_timeout()
+                        );
+                        yield Err(stream_transport_error(is_timeout, &e));
                         return;
                     }
                 }
@@ -729,6 +820,31 @@ mod error_classification_tests {
         ));
         assert!(!looks_like_credit_exhaustion("invalid request: bad model"));
     }
+
+    #[test]
+    fn mid_stream_timeout_maps_to_upstream_timeout() {
+        // A read-timeout that fires *after* the SSE stream is open surfaces as
+        // a transport error inside the decode loop. It must be classified as
+        // UpstreamTimeout (504), not a generic 502 — otherwise the coarse
+        // stream-idle guard is mislabelled once streaming starts.
+        match stream_transport_error(true, "connection timed out") {
+            BitrouterError::UpstreamTimeout => {}
+            other => panic!("expected UpstreamTimeout, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mid_stream_non_timeout_stays_a_502() {
+        // A parse / non-timeout transport error keeps the existing 502 mapping
+        // and preserves the underlying message.
+        match stream_transport_error(false, "malformed SSE frame") {
+            BitrouterError::Upstream { status, message } => {
+                assert_eq!(status, 502);
+                assert!(message.contains("malformed SSE frame"), "got {message:?}");
+            }
+            other => panic!("expected Upstream(502), got {other:?}"),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -826,5 +942,72 @@ mod beta_forward_tests {
             &ctx_with_beta(None),
         );
         assert!(request.headers().get("anthropic-beta").is_none());
+    }
+}
+
+#[cfg(test)]
+mod client_selection_tests {
+    use super::*;
+    use crate::language_model::types::ApiProtocol;
+
+    fn target(provider: &str) -> RoutingTarget {
+        RoutingTarget {
+            provider_name: provider.into(),
+            service_id: "m".into(),
+            api_base: "https://api.example.com".into(),
+            api_key: String::new(),
+            api_protocol: ApiProtocol::ChatCompletions,
+            account_label: None,
+            api_key_override: None,
+            api_base_override: None,
+            auth_scheme: Default::default(),
+        }
+    }
+
+    #[test]
+    fn per_provider_override_selected_by_name_else_default() {
+        let default = HttpTimeouts::default();
+        let mut overrides = HashMap::new();
+        overrides.insert(
+            "slow".to_string(),
+            HttpTimeouts {
+                read: Duration::from_secs(300),
+                ..HttpTimeouts::default()
+            },
+        );
+        let exec = HttpExecutor::with_provider_timeouts(
+            default.clone(),
+            overrides,
+            OutboundDispatch::builtin(),
+            AuthAppliers::new(),
+        )
+        .expect("build executor");
+
+        // A provider with an override resolves to its own timeouts…
+        let (_, slow) = exec.client_for(&target("slow"));
+        assert_eq!(slow.read, Duration::from_secs(300));
+        // …and one absent from the map falls back to the default.
+        let (_, other) = exec.client_for(&target("openai"));
+        assert_eq!(other.read, default.read);
+    }
+
+    #[test]
+    fn override_equal_to_default_builds_no_extra_client() {
+        // An override identical to the default must not create a redundant
+        // per-provider client — the provider resolves to the default pair.
+        let default = HttpTimeouts::default();
+        let mut overrides = HashMap::new();
+        overrides.insert("same".to_string(), default.clone());
+        let exec = HttpExecutor::with_provider_timeouts(
+            default,
+            overrides,
+            OutboundDispatch::builtin(),
+            AuthAppliers::new(),
+        )
+        .expect("build executor");
+        assert!(
+            exec.provider_clients.is_empty(),
+            "an override equal to the default should be skipped"
+        );
     }
 }

--- a/crates/bitrouter-sdk/src/language_model/executor.rs
+++ b/crates/bitrouter-sdk/src/language_model/executor.rs
@@ -3,7 +3,7 @@
 //! and `HttpExecutor` — the real protocol-aware HTTP executor.
 
 use std::pin::Pin;
-use std::sync::Mutex;
+use std::sync::{Mutex, RwLock};
 use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
@@ -245,6 +245,17 @@ fn stream_transport_error(is_timeout: bool, display: impl std::fmt::Display) -> 
     }
 }
 
+fn upstream_body_error(context: &'static str, error: reqwest::Error) -> BitrouterError {
+    if error.is_timeout() {
+        BitrouterError::UpstreamTimeout
+    } else {
+        BitrouterError::Upstream {
+            status: 502,
+            message: format!("{context}: {error}"),
+        }
+    }
+}
+
 /// Heuristic: does this upstream error body describe a depleted
 /// credit / balance? Matches the stable phrase family rather than any
 /// one provider's exact wording — string matching is unavoidable here
@@ -268,6 +279,12 @@ fn looks_like_credit_exhaustion(body: &str) -> bool {
 /// [`with_provider_timeouts`](Self::with_provider_timeouts) to attach
 /// per-provider overrides.
 pub struct HttpExecutor {
+    clients: RwLock<HttpClientSet>,
+    dispatch: OutboundDispatch,
+    auth_appliers: AuthAppliers,
+}
+
+struct HttpClientSet {
     /// Client used for any provider without a per-provider override, plus its
     /// timeouts (for the per-request `total` cap, which is not a client
     /// setting).
@@ -277,8 +294,6 @@ pub struct HttpExecutor {
     /// resolved timeouts it was built from. Built once at construction; empty
     /// in the common single-timeout deployment.
     provider_clients: HashMap<String, (HttpTimeouts, reqwest::Client)>,
-    dispatch: OutboundDispatch,
-    auth_appliers: AuthAppliers,
 }
 
 /// Build a reqwest client from the connection-level timeout knobs. `total` is
@@ -292,6 +307,26 @@ fn build_http_client(timeouts: &HttpTimeouts) -> Result<reqwest::Client> {
         .tcp_keepalive(timeouts.tcp_keepalive)
         .build()
         .map_err(|e| BitrouterError::internal(format!("building HTTP client: {e}")))
+}
+
+fn build_http_client_set(
+    default_timeouts: HttpTimeouts,
+    per_provider: HashMap<String, HttpTimeouts>,
+) -> Result<HttpClientSet> {
+    let default_client = build_http_client(&default_timeouts)?;
+    let mut provider_clients = HashMap::new();
+    for (name, timeouts) in per_provider {
+        if timeouts == default_timeouts {
+            continue;
+        }
+        let client = build_http_client(&timeouts)?;
+        provider_clients.insert(name, (timeouts, client));
+    }
+    Ok(HttpClientSet {
+        default_client,
+        default_timeouts,
+        provider_clients,
+    })
 }
 
 impl HttpExecutor {
@@ -338,30 +373,41 @@ impl HttpExecutor {
         dispatch: OutboundDispatch,
         auth_appliers: AuthAppliers,
     ) -> Result<Self> {
-        let default_client = build_http_client(&default_timeouts)?;
-        let mut provider_clients = HashMap::new();
-        for (name, timeouts) in per_provider {
-            if timeouts == default_timeouts {
-                continue;
-            }
-            let client = build_http_client(&timeouts)?;
-            provider_clients.insert(name, (timeouts, client));
-        }
+        let clients = build_http_client_set(default_timeouts, per_provider)?;
         Ok(Self {
-            default_client,
-            default_timeouts,
-            provider_clients,
+            clients: RwLock::new(clients),
             dispatch,
             auth_appliers,
         })
     }
 
+    /// Replace the global/per-provider timeout clients in-place. Existing
+    /// in-flight requests keep the cloned client they already selected; new
+    /// requests use the freshly built set.
+    pub fn reload_provider_timeouts(
+        &self,
+        default_timeouts: HttpTimeouts,
+        per_provider: HashMap<String, HttpTimeouts>,
+    ) -> Result<()> {
+        let clients = build_http_client_set(default_timeouts, per_provider)?;
+        let mut guard = match self.clients.write() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        *guard = clients;
+        Ok(())
+    }
+
     /// Pick the client + timeouts for `target`: a per-provider override when one
     /// is registered for its `provider_name`, else the default pair.
-    fn client_for(&self, target: &RoutingTarget) -> (&reqwest::Client, &HttpTimeouts) {
-        match self.provider_clients.get(&target.provider_name) {
-            Some((timeouts, client)) => (client, timeouts),
-            None => (&self.default_client, &self.default_timeouts),
+    fn client_for(&self, target: &RoutingTarget) -> (reqwest::Client, HttpTimeouts) {
+        let guard = match self.clients.read() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        match guard.provider_clients.get(&target.provider_name) {
+            Some((timeouts, client)) => (client.clone(), timeouts.clone()),
+            None => (guard.default_client.clone(), guard.default_timeouts.clone()),
         }
     }
 
@@ -527,10 +573,7 @@ impl Executor for HttpExecutor {
         let text = response
             .text()
             .await
-            .map_err(|e| BitrouterError::Upstream {
-                status: 502,
-                message: format!("reading upstream body: {e}"),
-            })?;
+            .map_err(|e| upstream_body_error("reading upstream body", e))?;
 
         if !status.is_success() {
             return Err(classify_upstream_error(status.as_u16(), &text));
@@ -948,7 +991,10 @@ mod beta_forward_tests {
 #[cfg(test)]
 mod client_selection_tests {
     use super::*;
+    use crate::caller::CallerContext;
     use crate::language_model::types::ApiProtocol;
+    use crate::language_model::{GenerationParams, Message, PipelineRequest, Role};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
     fn target(provider: &str) -> RoutingTarget {
         RoutingTarget {
@@ -1005,9 +1051,108 @@ mod client_selection_tests {
             AuthAppliers::new(),
         )
         .expect("build executor");
+        let clients = exec.clients.read().expect("client set lock");
         assert!(
-            exec.provider_clients.is_empty(),
+            clients.provider_clients.is_empty(),
             "an override equal to the default should be skipped"
         );
+    }
+
+    #[test]
+    fn reload_provider_timeouts_replaces_selected_timeouts() {
+        let default = HttpTimeouts::default();
+        let exec = HttpExecutor::with_provider_timeouts(
+            default.clone(),
+            HashMap::new(),
+            OutboundDispatch::builtin(),
+            AuthAppliers::new(),
+        )
+        .expect("build executor");
+
+        let (_, before) = exec.client_for(&target("slow"));
+        assert_eq!(before.read, default.read);
+
+        let mut overrides = HashMap::new();
+        overrides.insert(
+            "slow".to_string(),
+            HttpTimeouts {
+                read: Duration::from_secs(450),
+                ..default.clone()
+            },
+        );
+        exec.reload_provider_timeouts(default, overrides)
+            .expect("reload timeout clients");
+
+        let (_, after) = exec.client_for(&target("slow"));
+        assert_eq!(after.read, Duration::from_secs(450));
+    }
+
+    #[tokio::test]
+    async fn non_streaming_body_read_timeout_maps_to_upstream_timeout() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test server");
+        let addr = listener.local_addr().expect("test server addr");
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.expect("accept request");
+            let mut request_buf = [0_u8; 1024];
+            let _ = socket.read(&mut request_buf).await;
+            socket
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\n\
+                      content-type: application/json\r\n\
+                      content-length: 1024\r\n\
+                      \r\n\
+                      {\"id\":\"partial\"",
+                )
+                .await
+                .expect("write partial response");
+            tokio::time::sleep(Duration::from_secs(5)).await;
+        });
+
+        let exec = HttpExecutor::new(HttpTimeouts {
+            read: Duration::from_millis(75),
+            ..HttpTimeouts::default()
+        })
+        .expect("build executor");
+        let target = RoutingTarget {
+            provider_name: "slow".into(),
+            service_id: "m".into(),
+            api_base: format!("http://{addr}/v1"),
+            api_key: "k".into(),
+            api_protocol: ApiProtocol::ChatCompletions,
+            account_label: None,
+            api_key_override: None,
+            api_base_override: None,
+            auth_scheme: Default::default(),
+        };
+        let prompt = Prompt {
+            model: "m".into(),
+            system: None,
+            system_provider_metadata: Default::default(),
+            messages: vec![Message::text(Role::User, "hi")],
+            tools: vec![],
+            params: GenerationParams::default(),
+            response_format: None,
+            tool_choice: None,
+            stream: false,
+        };
+        let ctx = PipelineContext::new(PipelineRequest::new(
+            "m",
+            CallerContext::local(),
+            prompt.clone(),
+        ));
+
+        let err =
+            tokio::time::timeout(Duration::from_secs(3), exec.execute(&target, &prompt, &ctx))
+                .await
+                .expect("executor should return before outer timeout")
+                .expect_err("partial stalled body should fail");
+        server.abort();
+
+        match err {
+            BitrouterError::UpstreamTimeout => {}
+            other => panic!("expected UpstreamTimeout, got {other:?}"),
+        }
     }
 }

--- a/dist/schema/bitrouter.config.schema.json
+++ b/dist/schema/bitrouter.config.schema.json
@@ -578,6 +578,10 @@
             "type": "string"
           },
           "type": "array"
+        },
+        "timeouts": {
+          "$ref": "#/$defs/TimeoutConfig",
+          "description": "Per-provider upstream timeout overrides. Each set field layers over the\nresolved global [`UpstreamConfig::timeouts`]; unset fields inherit it.\nNot inherited via [`derives`](Self::derives)."
         }
       },
       "type": "object"
@@ -840,6 +844,72 @@
           "type": "string"
         }
       ]
+    },
+    "TimeoutConfig": {
+      "description": "Upstream HTTP timeout knobs, in seconds. Every field is optional; an unset\nfield inherits the level above — a provider override inherits the resolved\nglobal value, and an unset global inherits the built-in default\n([`HttpTimeouts::default`]). `total_secs` is opt-in at every level: unset ⇒\nno overall wall-clock cap (the right default for long agentic streams).\n\nUsed both as the top-level `upstream.timeouts` block and as the per-provider\n`providers.<id>.timeouts` override; timeouts are **not** inherited via a\nprovider's `derives:` chain.",
+      "properties": {
+        "connect_secs": {
+          "default": null,
+          "description": "TCP connect timeout, seconds.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "pool_idle_secs": {
+          "default": null,
+          "description": "Idle pooled-connection eviction, seconds.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "read_secs": {
+          "default": null,
+          "description": "Idle (per-read) timeout, seconds — fires when the upstream sends no\nbytes for this long, including mid-stream. The effective stream-idle\nguard.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "tcp_keepalive_secs": {
+          "default": null,
+          "description": "TCP keepalive probe interval, seconds.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "total_secs": {
+          "default": null,
+          "description": "Overall wall-clock cap for the entire request/stream, seconds. Opt-in:\nunset ⇒ no cap. Setting it bounds total stream duration, so keep it\ngenerous for reasoning / agentic providers.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "UpstreamConfig": {
+      "description": "Outbound / upstream HTTP settings — the client BitRouter uses to call\nproviders. Distinct from [`ServerConfig`], which is the inbound listen\nsocket. Currently just [`timeouts`](Self::timeouts); grouped under\n`upstream:` so future outbound knobs have a home.",
+      "properties": {
+        "timeouts": {
+          "$ref": "#/$defs/TimeoutConfig",
+          "description": "Global upstream timeout defaults. A provider may override any field\nunder `providers.<id>.timeouts:`."
+        }
+      },
+      "type": "object"
     },
     "VariantConfig": {
       "description": "A `:variant` definition — a routing modifier only.",
@@ -1276,6 +1346,10 @@
     "server_tools": {
       "$ref": "#/$defs/ServerToolsConfig",
       "description": "Server-side tool loop: MCP server ids whose tools BitRouter injects into\nLLM requests and executes itself. Empty by default — the pipeline stays\nsingle-shot."
+    },
+    "upstream": {
+      "$ref": "#/$defs/UpstreamConfig",
+      "description": "Outbound / upstream HTTP settings (the client that calls providers)."
     },
     "variants": {
       "additionalProperties": {

--- a/skills/bitrouter/references/providers.md
+++ b/skills/bitrouter/references/providers.md
@@ -165,6 +165,43 @@ providers:
 
 Glob-prefix patterns, same precedence as `api_protocol`. Each `(provider, pattern)` bucket gets an independent window.
 
+## Upstream timeouts
+
+Global defaults for the outbound client that calls providers live under the
+top-level `upstream.timeouts` block; any provider overrides them under
+`providers.<id>.timeouts`. All fields are seconds and optional — an unset
+provider field inherits the resolved global value, and an unset global inherits
+the built-in default.
+
+```yaml
+upstream:
+  timeouts:
+    connect_secs: 10          # TCP connect (default 10)
+    read_secs: 120            # idle/per-read: fires when the upstream goes
+                              #   silent this long, INCLUDING mid-stream
+                              #   (the stream-idle guard). Default 120.
+    pool_idle_secs: 90        # idle pooled-connection eviction (default 90)
+    tcp_keepalive_secs: 60    # TCP keepalive probe interval (default 60)
+    # total_secs:            # overall wall-clock cap for the whole
+                              #   request/stream. Opt-in, OFF by default —
+                              #   setting it bounds total stream duration, so
+                              #   keep it generous for reasoning/agentic models.
+providers:
+  slow-reasoner:
+    timeouts:
+      read_secs: 300          # this provider tolerates longer silences
+      total_secs: 1800        # and gets its own 30-min wall-clock cap
+```
+
+Notes:
+- `read_secs` is a per-read (idle) timeout — it resets on every chunk, so it is
+  what catches an upstream that stalls mid-SSE-stream. A mid-stream fire maps to
+  a `504` upstream-timeout (and triggers fallback only if it happens before the
+  first byte; once bytes are streaming the request can't fall back).
+- `total_secs` is unset by default on purpose: an overall cap would kill
+  legitimately long agentic/reasoning streams.
+- Timeouts are **not** inherited via a provider's `derives:` chain.
+
 ## Tags & routing
 
 Routing prefs filter providers by tag — `require_tags: [cheap]` keeps only tagged providers in scope:


### PR DESCRIPTION
## What & why

Upstream client timeouts were fixed constants since v0 #394 — a slow provider was bounded only by a single hardcoded 120s read timeout, and that bound was mislabelled once a stream was open. This makes the timeouts configurable and corrects the mid-stream classification.

### 1. Configurable timeouts — global + per-provider
New top-level `upstream.timeouts` block layered over the built-in defaults, with per-provider `providers.<id>.timeouts` overrides that inherit any unset field from the resolved global value:

```yaml
upstream:
  timeouts:
    connect_secs: 10        # default 10
    read_secs: 120          # idle/per-read; fires mid-stream (default 120)
    pool_idle_secs: 90      # default 90
    tcp_keepalive_secs: 60  # default 60
    # total_secs:           # opt-in overall cap, OFF by default
providers:
  slow-reasoner:
    timeouts:
      read_secs: 300        # tolerate longer silences
      total_secs: 1800      # own wall-clock cap
```

Each distinct provider timeout tuple gets its own reqwest client (connect/read/pool/keepalive are client-build-time settings), selected per request by `provider_name`; providers without an override share the default client. Env override works via the existing `${VAR}` substitution — no new plumbing. Timeouts are **not** inherited via a provider's `derives:` chain.

### 2. Opt-in total wall-clock cap
`total_secs` (global or per-provider) applies an overall request deadline via reqwest's per-request timeout. **Off by default** — an overall cap would kill legitimately long agentic/reasoning streams, so it's opt-in per deployment/provider.

### 3. Fix: mid-stream read-timeout was mislabelled
The `is_timeout()` → `UpstreamTimeout` (504) mapping only existed at request-establishment time. A read-timeout that fired **after** the SSE stream opened surfaced as a generic `Upstream { status: 502 }`. It now recovers the reqwest timeout signal from `EventStreamError::Transport` in the decode loop and maps it to `UpstreamTimeout`, matching the pre-stream path. (Note: mid-stream still can't fall back to another provider — bytes are already committed to the client — but the status is now truthful.)

## Tests
Test-first for the pure logic: timeout resolution (`TimeoutConfig::apply_to`, 5 tests) and mid-stream classification (`stream_transport_error`, 2 tests). Regression tests for the `client_for` per-provider selection path (2). Full suite: **1291 passing**, clippy clean, fmt clean. Committed config JSON schema regenerated; the `upstream.timeouts` block documented in `skills/bitrouter/references/providers.md`.

## Follow-up (not in this PR)
The honest follow-up for streaming failover is a **default-off, first-frame-peek, window-bounded** early-commit fallback:

- Today streaming commits on the 2xx status, so a **HTTP 200 followed by an immediate `event: error`** (a common overload signal), an empty stream, or an immediate disconnect can't fall back even though nothing was sent to the client yet.
- Fix by moving the commit point: when enabled, peek the **first SSE frame** — normal preamble → commit and passthrough; error/empty/immediate-disconnect → fall back via the existing `FallbackPolicy`. Trigger on the first *frame*, not the first *content delta*, so we don't wait through a reasoning model's think-time.
- **Default off / window `0`** = today's behaviour exactly, so **TTFB does not grow by default**. A `upstream.stream_commit_window_ms` knob lets a caller opt into up to N ms of first-frame wait to buy early-failure fallback; a larger window also catches preamble-then-error at a cost they choose.
- Needs a billing check that a bailed-out attempt bills ~zero (it produced no content delta).

Rejected alternative: forward frames immediately and re-send a fresh preamble from the new target on fallback — zero TTFB cost, but sending bytes then different bytes is fragile with strict SSE clients and protocol-specific. Too subtle for a default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
