### PR TITLE
docs(get-started): enumerate full model & provider tables

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,13 +46,20 @@ internal links).
    here — those are owned by `bitrouter-docs` (see `docs/CONTRIBUTING.md`).
 5. **ALWAYS** keep `docs/get-started/supported-models.md` and
    `supported-providers.md` (and their `.zh.md` siblings) consistent with the
-   `registry/` catalog. The `<ModelsTable />` / `<ProvidersTable />` tables are
-   fetched from the registry at runtime, but the surrounding **prose** hardcodes
-   registry-derived facts — the discounted-vs-closed-source vendor families
-   (`gpt-*`, `claude-*`, `gemini-*`, `grok-*`), example model ids, and the
-   default discount percentage. When you add, remove, or re-scope a vendor or
-   provider in `registry/models/` or `registry/providers/`, update that prose in
-   the same change so the docs never describe a catalog that no longer matches.
+   `registry/` catalog whenever you add, remove, or re-scope a vendor or provider
+   in `registry/models/` or `registry/providers/`. Two things must stay in sync:
+   - **The catalog/directory tables.** These are generated, not hand-edited. Rebuild
+     the registry (`cargo run -p dist-helper -- registry build`) and then
+     regenerate the tables (`python3 scripts/gen-supported-tables.py`), which
+     rewrites the block under the `Model catalog` / `Provider directory` anchor
+     heading in all four pages from `dist/registry/{models,providers}.json`. The
+     English and Chinese tables share identical data rows — only the header row
+     differs — so run the script rather than editing rows by hand.
+   - **The surrounding prose.** It hardcodes registry-derived facts the script does
+     not touch: the discounted-vs-closed-source vendor families (`gpt-*`,
+     `claude-*`, `gemini-*`, `grok-*`), example model ids, and the default discount
+     percentage. Update these in the same change so the docs never describe a
+     catalog that no longer matches.
 
 ## Contributing
 

--- a/docs/get-started/supported-models.md
+++ b/docs/get-started/supported-models.md
@@ -1,15 +1,66 @@
 ---
 title: Supported Models
-description: The full catalog of models any BitRouter account can call — live pricing, reachable over your own keys or one hosted BitRouter Cloud account, with automatic discounts on open models.
+description: The full catalog of models any BitRouter account can call — with pricing, reachable over your own keys or one hosted BitRouter Cloud account, with automatic discounts on open models.
 ---
 
-Every model BitRouter can route to is listed below, with live pricing. Reach any of them over your own provider keys ([BYOK](/docs/features/byok), paid to the providers at their list price) or one [BitRouter Cloud](/docs/get-started/configuration) account — one sign-in, no upstream keys, billed per request with failed requests not charged. Running your own model? See [local & private models](/docs/integrations/models) (free).
+Every model BitRouter can route to is listed below. Reach any of them over your own provider keys ([BYOK](/docs/features/byok), paid to the providers at their list price) or one [BitRouter Cloud](/docs/get-started/configuration) account — one sign-in, no upstream keys, billed per request with failed requests not charged. Running your own model? See [local & private models](/docs/integrations/models) (free).
 
-Prices are USD per **million tokens**, refreshed continuously from the live catalog. Open models are served **25% below official** by default — see [Discounted open models](#discounted-open-models) below.
+Prices are USD per **million tokens**, taken from the current [registry](https://github.com/bitrouter/bitrouter/tree/main/registry) snapshot (each model's lowest-priced provider; `—` means no per-token provider lists it yet). Open models are served **25% below official** by default — see [Discounted open models](#discounted-open-models) below. Every model is served by one or more registered providers — see [Supported Providers](/docs/get-started/supported-providers) for the full list and how to register your own.
 
-<ModelsTable />
+## Model catalog
 
-Every model above is served by one or more registered providers — see [Supported Providers](/docs/get-started/supported-providers) for the full list and how to register your own.
+| Model | Name | Context | Modalities | Open weights | Input $/M | Output $/M |
+| --- | --- | --- | --- | --- | --- | --- |
+| `anthropic/claude-fable-5` | Anthropic: Claude Fable 5 | 1M | text, image | — | $10 | $50 |
+| `anthropic/claude-haiku-4.5` | Anthropic: Claude Haiku 4.5 | 200K | text, image | — | $1 | $5 |
+| `anthropic/claude-opus-4.6` | Anthropic: Claude Opus 4.6 | 200K | text, image | — | $5 | $25 |
+| `anthropic/claude-opus-4.7` | Anthropic: Claude Opus 4.7 | 200K | text, image | — | $4.5 | $22.5 |
+| `anthropic/claude-opus-4.8` | Anthropic: Claude Opus 4.8 | 1M | text, image | — | $5 | $25 |
+| `anthropic/claude-sonnet-4.6` | Anthropic: Claude Sonnet 4.6 | 1M | text, image | — | $3 | $15 |
+| `anthropic/claude-sonnet-5` | Anthropic: Claude Sonnet 5 | 1M | text, image | — | $2 | $10 |
+| `deepseek/deepseek-v3.2` | DeepSeek: DeepSeek V3.2 | 128K | text | ✅ | $0.2288 | $0.3432 |
+| `deepseek/deepseek-v4-flash` | DeepSeek: DeepSeek V4 Flash | 256K | text | ✅ | $0.09 | $0.18 |
+| `deepseek/deepseek-v4-pro` | DeepSeek: DeepSeek V4 Pro | 256K | text | ✅ | $0.435 | $0.87 |
+| `google/gemini-3.1-flash-lite-preview` | Google: Gemini 3.1 Flash Lite Preview | 1M | text, image | — | $0.25 | $1.5 |
+| `google/gemini-3.1-pro-preview` | Google: Gemini 3.1 Pro Preview | 2M | text, image | — | $2 | $12 |
+| `google/gemini-3.5-flash` | Google: Gemini 3.5 Flash | 1M | text, image, audio | — | $1.5 | $9 |
+| `google/gemma-4-31b` | Google: Gemma 4 31B | 128K | text, image | ✅ | $0.13 | $0.4 |
+| `inclusionai/ling-2.6-1t` | Ling 2.6 1T | 256K | text | ✅ | $0.3 | $2.5 |
+| `inclusionai/ling-2.6-flash` | Ling 2.6 Flash | 256K | text | ✅ | $0.1 | $0.3 |
+| `inclusionai/ring-2.6-1t` | Ring 2.6 1T | 256K | text | ✅ | $0.3 | $2.5 |
+| `meituan/longcat-2.0` | LongCat 2.0 | 1M | text | ✅ | — | — |
+| `minimax/minimax-m2.5` | MiniMax: M2.5 | 192K | text | ✅ | $0.15 | $1.15 |
+| `minimax/minimax-m2.7` | MiniMax: M2.7 | 192K | text | ✅ | $0.25 | $1 |
+| `minimax/minimax-m3` | MiniMax: M3 | 1M | text, image | ✅ | $0.3 | $1.2 |
+| `moonshotai/kimi-k2.5` | Kimi: K2.5 | 256K | text, image | ✅ | $0.375 | $2.025 |
+| `moonshotai/kimi-k2.6` | Kimi: K2.6 | 256K | text | ✅ | $0.66 | $3.41 |
+| `moonshotai/kimi-k2.7-code` | Kimi: K2.7 Code | 256K | text, image | ✅ | $0.612 | $3.069 |
+| `nex-agi/nex-n2-pro` | Nex AGI: Nex-N2-Pro | 256K | text, image | ✅ | — | — |
+| `nvidia/nemotron-3-super-120b-a12b` | Nemotron 3 Super 120B-A12B | 256K | text | ✅ | — | — |
+| `nvidia/nemotron-3-ultra-550b-a55b` | Nemotron 3 Ultra 550B-A55B | 1M | text | ✅ | — | — |
+| `openai/gpt-5.4` | OpenAI: GPT-5.4 | 128K | text, image | — | $2.5 | $15 |
+| `openai/gpt-5.4-mini` | OpenAI: GPT-5.4 Mini | 128K | text, image | — | $0.75 | $4.5 |
+| `openai/gpt-5.5` | OpenAI: GPT-5.5 | 128K | text, image | — | $5 | $30 |
+| `qwen/qwen3.5-122b-a10b` | Qwen: Qwen3.5 122B-A10B | 256K | text, image | ✅ | $0.26 | $2.08 |
+| `qwen/qwen3.5-27b` | Qwen: Qwen3.5 27B | 256K | text, image | ✅ | $0.25 | $2 |
+| `qwen/qwen3.6-27b` | Qwen: Qwen3.6 27B | 256K | text, image | ✅ | $0.3 | $3.2 |
+| `qwen/qwen3.6-35b-a3b` | Qwen: Qwen3.6 35B-A3B | 256K | text, image | ✅ | $0.2 | $1.6 |
+| `qwen/qwen3.6-flash` | Qwen: Qwen3.6 Flash | 1M | text, image | — | $0.165 | $0.99 |
+| `qwen/qwen3.7-max` | Qwen: Qwen3.7 Max | 1M | text | — | $1.25 | $3.75 |
+| `qwen/qwen3.7-plus` | Qwen: Qwen3.7 Plus | 1M | text, image | — | $0.276 | $1.101 |
+| `stepfun/step-3.5-flash` | StepFun: Step 3.5 Flash | 256K | text | ✅ | $0.09 | $0.3 |
+| `stepfun/step-3.7-flash` | StepFun: Step 3.7 Flash | 256K | text, image | ✅ | $0.2 | $1.15 |
+| `tencent/hy3` | Hunyuan 3 | 256K | text | ✅ | $0.066 | $0.26 |
+| `x-ai/grok-4.20` | xAI: Grok 4.20 | 128K | text, image | — | $1.25 | $2.5 |
+| `x-ai/grok-4.20-multi-agent` | xAI: Grok 4.20 Multi-Agent | 1M | text, image | — | $1.25 | $2.5 |
+| `x-ai/grok-4.3` | xAI: Grok 4.3 | 1M | text, image | — | $1.25 | $2.5 |
+| `x-ai/grok-build-0.1` | xAI: Grok Build 0.1 | 256K | text | — | $1 | $2 |
+| `xiaomi/mimo-v2.5` | Xiaomi: MiMo V2.5 | 256K | text | ✅ | $0.14 | $0.28 |
+| `xiaomi/mimo-v2.5-pro` | Xiaomi: MiMo V2.5 Pro | 256K | text | ✅ | $0.435 | $0.87 |
+| `z-ai/glm-4.7` | Zhipu: GLM-4.7 | 200K | text | ✅ | $0.6 | $2.2 |
+| `z-ai/glm-5` | Zhipu: GLM-5 | 198K | text | ✅ | $0.6 | $1.92 |
+| `z-ai/glm-5.1` | Zhipu: GLM-5.1 | 128K | text | ✅ | $0.95 | $3.15 |
+| `z-ai/glm-5.2` | Zhipu: GLM-5.2 | 1M | text | ✅ | $0.979 | $3.08 |
 
 ## Using BitRouter Cloud
 

--- a/docs/get-started/supported-models.zh.md
+++ b/docs/get-started/supported-models.zh.md
@@ -1,15 +1,66 @@
 ---
 title: Supported Models
-description: 任何 BitRouter 账户都能调用的完整模型目录——实时定价，可经你自己的密钥或一个托管的 BitRouter Cloud 账户触达，并对开放模型自动打折。
+description: 任何 BitRouter 账户都能调用的完整模型目录——附定价，可经你自己的密钥或一个托管的 BitRouter Cloud 账户触达，并对开放模型自动打折。
 ---
 
-BitRouter 能路由到的每个模型都列在下面，并附实时定价。你可以经自己的供应商密钥（[BYOK](/docs/features/byok)，按各供应商官方价直接向其付费）触达它们中的任意一个，也可以经一个 [BitRouter Cloud](/docs/get-started/configuration) 账户——一次登录，无需上游密钥，按请求计费且失败请求不计费。要运行自己的模型？参见[本地与私有模型](/docs/integrations/models)（免费）。
+BitRouter 能路由到的每个模型都列在下面。你可以经自己的供应商密钥（[BYOK](/docs/features/byok)，按各供应商官方价直接向其付费）触达它们中的任意一个，也可以经一个 [BitRouter Cloud](/docs/get-started/configuration) 账户——一次登录，无需上游密钥，按请求计费且失败请求不计费。要运行自己的模型？参见[本地与私有模型](/docs/integrations/models)（免费）。
 
-价格以美元 / **百万 token** 计，并持续从实时目录刷新。开放模型默认以**官方价低 25%** 提供——参见下文[折扣开放模型](#discounted-open-models)。
+价格以美元 / **百万 token** 计，取自当前[注册表](https://github.com/bitrouter/bitrouter/tree/main/registry)快照（每个模型价格最低的供应商；`—` 表示暂无按量计费的供应商提供）。开放模型默认以**官方价低 25%** 提供——参见下文[折扣开放模型](#discounted-open-models)。每个模型都由一个或多个已注册供应商提供服务——完整列表以及如何注册自己的供应商，见[支持的供应商](/docs/get-started/supported-providers)。
 
-<ModelsTable />
+## 模型目录
 
-上述每个模型都由一个或多个已注册供应商提供服务——完整列表以及如何注册自己的供应商，见[支持的供应商](/docs/get-started/supported-providers)。
+| 模型 | 名称 | 上下文 | 模态 | 开源权重 | 输入 $/M | 输出 $/M |
+| --- | --- | --- | --- | --- | --- | --- |
+| `anthropic/claude-fable-5` | Anthropic: Claude Fable 5 | 1M | text, image | — | $10 | $50 |
+| `anthropic/claude-haiku-4.5` | Anthropic: Claude Haiku 4.5 | 200K | text, image | — | $1 | $5 |
+| `anthropic/claude-opus-4.6` | Anthropic: Claude Opus 4.6 | 200K | text, image | — | $5 | $25 |
+| `anthropic/claude-opus-4.7` | Anthropic: Claude Opus 4.7 | 200K | text, image | — | $4.5 | $22.5 |
+| `anthropic/claude-opus-4.8` | Anthropic: Claude Opus 4.8 | 1M | text, image | — | $5 | $25 |
+| `anthropic/claude-sonnet-4.6` | Anthropic: Claude Sonnet 4.6 | 1M | text, image | — | $3 | $15 |
+| `anthropic/claude-sonnet-5` | Anthropic: Claude Sonnet 5 | 1M | text, image | — | $2 | $10 |
+| `deepseek/deepseek-v3.2` | DeepSeek: DeepSeek V3.2 | 128K | text | ✅ | $0.2288 | $0.3432 |
+| `deepseek/deepseek-v4-flash` | DeepSeek: DeepSeek V4 Flash | 256K | text | ✅ | $0.09 | $0.18 |
+| `deepseek/deepseek-v4-pro` | DeepSeek: DeepSeek V4 Pro | 256K | text | ✅ | $0.435 | $0.87 |
+| `google/gemini-3.1-flash-lite-preview` | Google: Gemini 3.1 Flash Lite Preview | 1M | text, image | — | $0.25 | $1.5 |
+| `google/gemini-3.1-pro-preview` | Google: Gemini 3.1 Pro Preview | 2M | text, image | — | $2 | $12 |
+| `google/gemini-3.5-flash` | Google: Gemini 3.5 Flash | 1M | text, image, audio | — | $1.5 | $9 |
+| `google/gemma-4-31b` | Google: Gemma 4 31B | 128K | text, image | ✅ | $0.13 | $0.4 |
+| `inclusionai/ling-2.6-1t` | Ling 2.6 1T | 256K | text | ✅ | $0.3 | $2.5 |
+| `inclusionai/ling-2.6-flash` | Ling 2.6 Flash | 256K | text | ✅ | $0.1 | $0.3 |
+| `inclusionai/ring-2.6-1t` | Ring 2.6 1T | 256K | text | ✅ | $0.3 | $2.5 |
+| `meituan/longcat-2.0` | LongCat 2.0 | 1M | text | ✅ | — | — |
+| `minimax/minimax-m2.5` | MiniMax: M2.5 | 192K | text | ✅ | $0.15 | $1.15 |
+| `minimax/minimax-m2.7` | MiniMax: M2.7 | 192K | text | ✅ | $0.25 | $1 |
+| `minimax/minimax-m3` | MiniMax: M3 | 1M | text, image | ✅ | $0.3 | $1.2 |
+| `moonshotai/kimi-k2.5` | Kimi: K2.5 | 256K | text, image | ✅ | $0.375 | $2.025 |
+| `moonshotai/kimi-k2.6` | Kimi: K2.6 | 256K | text | ✅ | $0.66 | $3.41 |
+| `moonshotai/kimi-k2.7-code` | Kimi: K2.7 Code | 256K | text, image | ✅ | $0.612 | $3.069 |
+| `nex-agi/nex-n2-pro` | Nex AGI: Nex-N2-Pro | 256K | text, image | ✅ | — | — |
+| `nvidia/nemotron-3-super-120b-a12b` | Nemotron 3 Super 120B-A12B | 256K | text | ✅ | — | — |
+| `nvidia/nemotron-3-ultra-550b-a55b` | Nemotron 3 Ultra 550B-A55B | 1M | text | ✅ | — | — |
+| `openai/gpt-5.4` | OpenAI: GPT-5.4 | 128K | text, image | — | $2.5 | $15 |
+| `openai/gpt-5.4-mini` | OpenAI: GPT-5.4 Mini | 128K | text, image | — | $0.75 | $4.5 |
+| `openai/gpt-5.5` | OpenAI: GPT-5.5 | 128K | text, image | — | $5 | $30 |
+| `qwen/qwen3.5-122b-a10b` | Qwen: Qwen3.5 122B-A10B | 256K | text, image | ✅ | $0.26 | $2.08 |
+| `qwen/qwen3.5-27b` | Qwen: Qwen3.5 27B | 256K | text, image | ✅ | $0.25 | $2 |
+| `qwen/qwen3.6-27b` | Qwen: Qwen3.6 27B | 256K | text, image | ✅ | $0.3 | $3.2 |
+| `qwen/qwen3.6-35b-a3b` | Qwen: Qwen3.6 35B-A3B | 256K | text, image | ✅ | $0.2 | $1.6 |
+| `qwen/qwen3.6-flash` | Qwen: Qwen3.6 Flash | 1M | text, image | — | $0.165 | $0.99 |
+| `qwen/qwen3.7-max` | Qwen: Qwen3.7 Max | 1M | text | — | $1.25 | $3.75 |
+| `qwen/qwen3.7-plus` | Qwen: Qwen3.7 Plus | 1M | text, image | — | $0.276 | $1.101 |
+| `stepfun/step-3.5-flash` | StepFun: Step 3.5 Flash | 256K | text | ✅ | $0.09 | $0.3 |
+| `stepfun/step-3.7-flash` | StepFun: Step 3.7 Flash | 256K | text, image | ✅ | $0.2 | $1.15 |
+| `tencent/hy3` | Hunyuan 3 | 256K | text | ✅ | $0.066 | $0.26 |
+| `x-ai/grok-4.20` | xAI: Grok 4.20 | 128K | text, image | — | $1.25 | $2.5 |
+| `x-ai/grok-4.20-multi-agent` | xAI: Grok 4.20 Multi-Agent | 1M | text, image | — | $1.25 | $2.5 |
+| `x-ai/grok-4.3` | xAI: Grok 4.3 | 1M | text, image | — | $1.25 | $2.5 |
+| `x-ai/grok-build-0.1` | xAI: Grok Build 0.1 | 256K | text | — | $1 | $2 |
+| `xiaomi/mimo-v2.5` | Xiaomi: MiMo V2.5 | 256K | text | ✅ | $0.14 | $0.28 |
+| `xiaomi/mimo-v2.5-pro` | Xiaomi: MiMo V2.5 Pro | 256K | text | ✅ | $0.435 | $0.87 |
+| `z-ai/glm-4.7` | Zhipu: GLM-4.7 | 200K | text | ✅ | $0.6 | $2.2 |
+| `z-ai/glm-5` | Zhipu: GLM-5 | 198K | text | ✅ | $0.6 | $1.92 |
+| `z-ai/glm-5.1` | Zhipu: GLM-5.1 | 128K | text | ✅ | $0.95 | $3.15 |
+| `z-ai/glm-5.2` | Zhipu: GLM-5.2 | 1M | text | ✅ | $0.979 | $3.08 |
 
 ## 使用 BitRouter Cloud
 

--- a/docs/get-started/supported-providers.md
+++ b/docs/get-started/supported-providers.md
@@ -3,9 +3,62 @@ title: Supported Providers
 description: Every provider registered on the BitRouter network — served from the public, open-source registry that anyone can join.
 ---
 
-Every model in the [catalog](/docs/get-started/supported-models) is served by one or more **registered providers**. Membership lives in the public, open-source [registry](https://github.com/bitrouter/bitrouter/tree/main/registry) — anyone can [register a provider](/docs/guides/register-as-a-provider). The list refreshes from the registry continuously, so a newly-merged provider shows up within minutes.
+Every model in the [catalog](/docs/get-started/supported-models) is served by one or more **registered providers**. Membership lives in the public, open-source [registry](https://github.com/bitrouter/bitrouter/tree/main/registry) — anyone can [register a provider](/docs/guides/register-as-a-provider). The directory below is generated from the current registry snapshot.
 
-<ProvidersTable />
+## Provider directory
+
+| Provider | Name | HQ | Protocols | Billing | Models |
+| --- | --- | --- | --- | --- | --- |
+| `akashml` | AkashML | US | openai | Per-token | 3 |
+| `alibaba` | Alibaba Cloud | CN | anthropic, openai, responses | Per-token | 4 |
+| `alibaba_cn` | Alibaba Cloud | CN | anthropic, openai, responses | Per-token | 4 |
+| `alibaba_coding_plan` | Alibaba Cloud | CN | openai | Subscription | 7 |
+| `ambient` | Ambient | US | openai | Per-token | 2 |
+| `anthropic` | Anthropic | US | anthropic | Per-token | 8 |
+| `atlascloud` | Atlas Cloud | US | openai | Per-token | 14 |
+| `bitrouter` | BitRouter | US | — | Per-token | 0 |
+| `byteplus` | BytePlus | CN | openai | Per-token | 1 |
+| `cerebras` | Cerebras | US | openai | Per-token | 1 |
+| `chutes` | Chutes | US | openai | Per-token | 7 |
+| `claude-code` | Anthropic | US | anthropic | Subscription | 7 |
+| `deepseek` | DeepSeek | CN | anthropic, openai | Per-token | 2 |
+| `github-copilot` | GitHub | US | openai | Subscription | 13 |
+| `gmicloud` | GMI Cloud | US | openai | Per-token | 13 |
+| `google` | Google | US | google, openai | Per-token | 4 |
+| `google-ai` | Google | US | google, openai | Subscription | 3 |
+| `ionet` | io.net | US | openai | Per-token | 9 |
+| `minimax` | MiniMax | CN | anthropic, openai | Per-token | 3 |
+| `minimax_cn` | MiniMax | CN | anthropic, openai | Per-token | 3 |
+| `moonshotai` | Moonshot AI | CN | anthropic, openai | Per-token | 3 |
+| `moonshotai_coding_plan` | Moonshot AI | CN | openai | Subscription | 1 |
+| `novita` | Novita AI | US | openai | Per-token | 18 |
+| `openai` | OpenAI | US | openai, responses | Per-token | 3 |
+| `openai-codex` | OpenAI | US | responses | Subscription | 3 |
+| `opencode-go` | OpenCode | US | openai | Subscription | 18 |
+| `opencode-zen` | OpenCode | US | openai | Per-token | 24 |
+| `openrouter` | OpenRouter | US | anthropic, openai, responses | Per-token | 39 |
+| `phala` | Phala | US | openai | Per-token | 5 |
+| `qianfan` | Baidu AI Cloud | CN | openai | Per-token | 3 |
+| `qianfan_cn` | Baidu AI Cloud | CN | openai | Per-token | 6 |
+| `siliconflow` | SiliconFlow | CN | openai | Per-token | 17 |
+| `siliconflow_cn` | SiliconFlow | CN | openai | Per-token | 13 |
+| `stepfun` | StepFun | CN | anthropic, openai | Per-token | 2 |
+| `stepfun_cn` | StepFun | CN | anthropic, openai | Per-token | 2 |
+| `stepfun_step_plan` | StepFun | CN | anthropic, openai | Subscription | 2 |
+| `stepfun_step_plan_cn` | StepFun | CN | anthropic, openai | Subscription | 2 |
+| `streamlake` | StreamLake | CN | openai | Per-token | 3 |
+| `supergrok` | xAI | US | openai, responses | Subscription | 4 |
+| `tencent` | Tencent Cloud | CN | anthropic, openai, responses | Per-token | 11 |
+| `tencent_cn` | Tencent Cloud | CN | anthropic, openai, responses | Per-token | 11 |
+| `tinfoil` | Tinfoil | US | openai | Per-token | 3 |
+| `volcengine` | Volcengine | CN | openai | Per-token | 2 |
+| `xai` | xAI | US | openai, responses | Per-token | 4 |
+| `xiaomi` | Xiaomi | CN | anthropic, openai, responses | Per-token | 5 |
+| `xiaomi_token_plan` | Xiaomi | CN | anthropic, openai, responses | Subscription | 2 |
+| `xiaomi_token_plan_cn` | Xiaomi | CN | anthropic, openai, responses | Subscription | 2 |
+| `xiaomi_token_plan_eu` | Xiaomi | CN | anthropic, openai, responses | Subscription | 2 |
+| `zai` | Z.ai | CN | anthropic, openai | Per-token | 3 |
+| `zai_coding_plan` | Z.ai | CN | anthropic, openai | Subscription | 3 |
 
 ## Register your own
 

--- a/docs/get-started/supported-providers.zh.md
+++ b/docs/get-started/supported-providers.zh.md
@@ -3,9 +3,62 @@ title: Supported Providers
 description: BitRouter 网络上已注册的每个供应商——由任何人都可加入的公开、开源注册表提供服务。
 ---
 
-[目录](/docs/get-started/supported-models)中的每个模型都由一个或多个**已注册供应商**提供服务。成员资格维护在公开、开源的 [registry](https://github.com/bitrouter/bitrouter/tree/main/registry) 中——任何人都可以[注册供应商](/docs/guides/register-as-a-provider)。该列表持续从注册表刷新，因此新合并的供应商会在几分钟内出现。
+[目录](/docs/get-started/supported-models)中的每个模型都由一个或多个**已注册供应商**提供服务。成员资格维护在公开、开源的 [registry](https://github.com/bitrouter/bitrouter/tree/main/registry) 中——任何人都可以[注册供应商](/docs/guides/register-as-a-provider)。下面的目录由当前注册表快照生成。
 
-<ProvidersTable />
+## 供应商目录
+
+| 供应商 | 名称 | 总部 | 协议 | 计费 | 模型数 |
+| --- | --- | --- | --- | --- | --- |
+| `akashml` | AkashML | US | openai | Per-token | 3 |
+| `alibaba` | Alibaba Cloud | CN | anthropic, openai, responses | Per-token | 4 |
+| `alibaba_cn` | Alibaba Cloud | CN | anthropic, openai, responses | Per-token | 4 |
+| `alibaba_coding_plan` | Alibaba Cloud | CN | openai | Subscription | 7 |
+| `ambient` | Ambient | US | openai | Per-token | 2 |
+| `anthropic` | Anthropic | US | anthropic | Per-token | 8 |
+| `atlascloud` | Atlas Cloud | US | openai | Per-token | 14 |
+| `bitrouter` | BitRouter | US | — | Per-token | 0 |
+| `byteplus` | BytePlus | CN | openai | Per-token | 1 |
+| `cerebras` | Cerebras | US | openai | Per-token | 1 |
+| `chutes` | Chutes | US | openai | Per-token | 7 |
+| `claude-code` | Anthropic | US | anthropic | Subscription | 7 |
+| `deepseek` | DeepSeek | CN | anthropic, openai | Per-token | 2 |
+| `github-copilot` | GitHub | US | openai | Subscription | 13 |
+| `gmicloud` | GMI Cloud | US | openai | Per-token | 13 |
+| `google` | Google | US | google, openai | Per-token | 4 |
+| `google-ai` | Google | US | google, openai | Subscription | 3 |
+| `ionet` | io.net | US | openai | Per-token | 9 |
+| `minimax` | MiniMax | CN | anthropic, openai | Per-token | 3 |
+| `minimax_cn` | MiniMax | CN | anthropic, openai | Per-token | 3 |
+| `moonshotai` | Moonshot AI | CN | anthropic, openai | Per-token | 3 |
+| `moonshotai_coding_plan` | Moonshot AI | CN | openai | Subscription | 1 |
+| `novita` | Novita AI | US | openai | Per-token | 18 |
+| `openai` | OpenAI | US | openai, responses | Per-token | 3 |
+| `openai-codex` | OpenAI | US | responses | Subscription | 3 |
+| `opencode-go` | OpenCode | US | openai | Subscription | 18 |
+| `opencode-zen` | OpenCode | US | openai | Per-token | 24 |
+| `openrouter` | OpenRouter | US | anthropic, openai, responses | Per-token | 39 |
+| `phala` | Phala | US | openai | Per-token | 5 |
+| `qianfan` | Baidu AI Cloud | CN | openai | Per-token | 3 |
+| `qianfan_cn` | Baidu AI Cloud | CN | openai | Per-token | 6 |
+| `siliconflow` | SiliconFlow | CN | openai | Per-token | 17 |
+| `siliconflow_cn` | SiliconFlow | CN | openai | Per-token | 13 |
+| `stepfun` | StepFun | CN | anthropic, openai | Per-token | 2 |
+| `stepfun_cn` | StepFun | CN | anthropic, openai | Per-token | 2 |
+| `stepfun_step_plan` | StepFun | CN | anthropic, openai | Subscription | 2 |
+| `stepfun_step_plan_cn` | StepFun | CN | anthropic, openai | Subscription | 2 |
+| `streamlake` | StreamLake | CN | openai | Per-token | 3 |
+| `supergrok` | xAI | US | openai, responses | Subscription | 4 |
+| `tencent` | Tencent Cloud | CN | anthropic, openai, responses | Per-token | 11 |
+| `tencent_cn` | Tencent Cloud | CN | anthropic, openai, responses | Per-token | 11 |
+| `tinfoil` | Tinfoil | US | openai | Per-token | 3 |
+| `volcengine` | Volcengine | CN | openai | Per-token | 2 |
+| `xai` | xAI | US | openai, responses | Per-token | 4 |
+| `xiaomi` | Xiaomi | CN | anthropic, openai, responses | Per-token | 5 |
+| `xiaomi_token_plan` | Xiaomi | CN | anthropic, openai, responses | Subscription | 2 |
+| `xiaomi_token_plan_cn` | Xiaomi | CN | anthropic, openai, responses | Subscription | 2 |
+| `xiaomi_token_plan_eu` | Xiaomi | CN | anthropic, openai, responses | Subscription | 2 |
+| `zai` | Z.ai | CN | anthropic, openai | Per-token | 3 |
+| `zai_coding_plan` | Z.ai | CN | anthropic, openai | Subscription | 3 |
 
 ## 注册你自己的供应商
 

--- a/scripts/gen-supported-tables.py
+++ b/scripts/gen-supported-tables.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Regenerate the models/providers tables in docs/get-started/supported-*.
+
+Source of truth is the generated registry catalog dist/registry/{models,providers}.json
+(rebuild it with `cargo run -p dist-helper -- registry build` after editing
+registry/). This script rewrites the table under a fixed anchor heading in each
+doc, so the surrounding prose is preserved. English and Chinese pages share the
+same data rows (only the header row differs), keeping the translations in lockstep.
+
+Usage: python3 scripts/gen-supported-tables.py
+"""
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MODELS = json.loads((ROOT / "dist/registry/models.json").read_text())["data"]
+PROVIDERS = json.loads((ROOT / "dist/registry/providers.json").read_text())["data"]
+
+
+def cell(s):
+    return str(s).replace("|", r"\|")
+
+
+# Common context windows use mixed decimal/binary conventions; map the known
+# sizes to their conventional label, and fall back to decimal K/M otherwise.
+CTX_SIZES = {
+    128000: "128K", 131072: "128K", 196608: "192K", 200000: "200K",
+    202752: "198K", 256000: "256K", 262144: "256K", 524288: "512K",
+    1000000: "1M", 1048576: "1M", 2000000: "2M", 2097152: "2M", 4194304: "4M",
+}
+
+
+def ctx(n):
+    if not n:
+        return "—"
+    if n in CTX_SIZES:
+        return CTX_SIZES[n]
+    if n >= 1_000_000:
+        return f"{n / 1_000_000:g}M"
+    return f"{round(n / 1000)}K"
+
+
+def usd(v):
+    return "—" if v is None else f"${v:g}"
+
+
+def best_price(model):
+    """Cheapest listed input price across serving providers, with that provider's output price."""
+    best = None
+    for pr in model.get("providers", []):
+        pg = pr.get("pricing")
+        if not pg:
+            continue
+        i = (pg.get("input_tokens") or {}).get("no_cache")
+        if i is None:
+            continue
+        o = (pg.get("output_tokens") or {}).get("text")
+        if best is None or i < best[0]:
+            best = (i, o)
+    return best or (None, None)
+
+
+def model_rows():
+    rows = []
+    for m in sorted(MODELS, key=lambda x: x["id"]):
+        i, o = best_price(m)
+        rows.append(
+            "| {id} | {name} | {ctx} | {mod} | {open} | {i} | {o} |".format(
+                id=f"`{m['id']}`",
+                name=cell(m.get("name", m["id"])),
+                ctx=ctx(m.get("max_input_tokens")),
+                mod=cell(", ".join(m.get("input_modalities", [])) or "—"),
+                open="✅" if m.get("open_weights") else "—",
+                i=usd(i),
+                o=usd(o),
+            )
+        )
+    return rows
+
+
+BILLING = {"usage_token": "Per-token", "subscription": "Subscription"}
+
+
+def provider_rows():
+    rows = []
+    for p in sorted(PROVIDERS, key=lambda x: x["id"]):
+        meta = p.get("metadata") or {}
+        protos = set()
+        for m in p.get("models", []):
+            ap = m.get("api_protocol")
+            if isinstance(ap, list):
+                protos.update(ap)
+            elif ap:
+                protos.add(ap)
+        protocols = sorted(protos)
+        rows.append(
+            "| {id} | {name} | {hq} | {proto} | {billing} | {n} |".format(
+                id=f"`{p['id']}`",
+                name=cell(meta.get("name", p["id"])),
+                hq=cell(meta.get("headquarters", "—")),
+                proto=cell(", ".join(protocols) or "—"),
+                billing=BILLING.get(p.get("billing"), cell(p.get("billing", "—"))),
+                n=len(p.get("models", [])),
+            )
+        )
+    return rows
+
+
+def table(header, rows):
+    cols = header.count("|") - 1
+    return "\n".join([header, "| " + " | ".join(["---"] * cols) + " |", *rows])
+
+
+# (file, anchor heading, header row, rows)
+MODELS_HDR_EN = "| Model | Name | Context | Modalities | Open weights | Input $/M | Output $/M |"
+MODELS_HDR_ZH = "| 模型 | 名称 | 上下文 | 模态 | 开源权重 | 输入 $/M | 输出 $/M |"
+PROV_HDR_EN = "| Provider | Name | HQ | Protocols | Billing | Models |"
+PROV_HDR_ZH = "| 供应商 | 名称 | 总部 | 协议 | 计费 | 模型数 |"
+
+TARGETS = [
+    ("docs/get-started/supported-models.md", "## Model catalog", MODELS_HDR_EN, model_rows),
+    ("docs/get-started/supported-models.zh.md", "## 模型目录", MODELS_HDR_ZH, model_rows),
+    ("docs/get-started/supported-providers.md", "## Provider directory", PROV_HDR_EN, provider_rows),
+    ("docs/get-started/supported-providers.zh.md", "## 供应商目录", PROV_HDR_ZH, provider_rows),
+]
+
+
+def rewrite(path, anchor, header, rows):
+    p = ROOT / path
+    lines = p.read_text().splitlines()
+    try:
+        start = next(i for i, ln in enumerate(lines) if ln.strip() == anchor)
+    except StopIteration:
+        raise SystemExit(f"anchor {anchor!r} not found in {path}")
+    end = next((i for i in range(start + 1, len(lines)) if lines[i].startswith("## ")), len(lines))
+    block = ["", table(header, rows), ""]
+    new = lines[: start + 1] + block + lines[end:]
+    p.write_text("\n".join(new) + "\n")
+
+
+def main():
+    mr, pr = model_rows(), provider_rows()
+    for path, anchor, header, builder in TARGETS:
+        rewrite(path, anchor, header, builder())
+    print(f"gen-supported-tables: wrote {len(mr)} models, {len(pr)} providers into 4 docs")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

The `supported-models` and `supported-providers` pages relied on the `<ModelsTable />` / `<ProvidersTable />` components, which currently aren't rendering — so the pages showed no actual list. This replaces them with **static tables generated from the registry**, including per-model pricing.

## What's in the tables

- **Model catalog** (50 models) — id, name, context window, modalities, open-weights, and the input/output price (USD per M) of each model's cheapest listed provider. `—` where no per-token provider lists it yet.
- **Provider directory** (50 providers) — id, name, HQ, protocols, billing (per-token / subscription), and model count.

## Kept reproducible, not hand-transcribed

`scripts/gen-supported-tables.py` reads `dist/registry/{models,providers}.json` and rewrites the block under the `Model catalog` / `Provider directory` anchor heading in all four pages. Properties:

- **EN/ZH lockstep** — English and Chinese share byte-identical data rows; only the header row differs (translated). Verified by diff.
- **Idempotent** — re-running produces no change.
- **Prose preserved** — only the table block under the anchor heading is rewritten.

## CLAUDE.md

Rule 5 now documents the regenerate-on-registry-change workflow: rebuild the registry (`cargo run -p dist-helper -- registry build`), then `python3 scripts/gen-supported-tables.py`, and keep the surrounding prose (closed-source vendor families, example ids, discount %) in sync too.

## Notes

- Intros reworded from "live pricing / continuously refreshed" to a registry **snapshot**, since the tables are now static.
- The `bitrouter` self-hosted provider shows 0 models / `—` protocols — accurate to the registry (it serves discounted open models dynamically, explained in the Discounted-open-models section).
- Docs-only; no Rust touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)