### PR TITLE
Sync and activate provider registry catalogs

### DIFF
--- a/dist/registry/models.json
+++ b/dist/registry/models.json
@@ -35,6 +35,21 @@
           }
         },
         {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 1.0,
+              "cache_write": 12.5,
+              "no_cache": 10.0
+            },
+            "output_tokens": {
+              "text": 50.0
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "anthropic/claude-fable-5"
+        },
+        {
           "api_protocol": "anthropic",
           "provider": "claude-code",
           "provider_model_id": "claude-fable-5"
@@ -114,6 +129,21 @@
           "rate_limits": {
             "requests_per_minute": 60
           }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.1,
+              "cache_write": 1.25,
+              "no_cache": 1.0
+            },
+            "output_tokens": {
+              "text": 5.0
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "anthropic/claude-haiku-4.5"
         },
         {
           "api_protocol": "anthropic",
@@ -205,6 +235,21 @@
           "rate_limits": {
             "requests_per_minute": 60
           }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "anthropic/claude-opus-4.6"
         },
         {
           "api_protocol": "anthropic",
@@ -312,6 +357,20 @@
           }
         },
         {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.45,
+              "no_cache": 4.5
+            },
+            "output_tokens": {
+              "text": 22.5
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "anthropic/claude-opus-4.7"
+        },
+        {
           "api_protocol": "anthropic",
           "capabilities": [
             "reasoning",
@@ -414,6 +473,21 @@
           "rate_limits": {
             "requests_per_minute": 60
           }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "anthropic/claude-opus-4.8"
         },
         {
           "api_protocol": "anthropic",
@@ -521,6 +595,21 @@
           "rate_limits": {
             "requests_per_minute": 60
           }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.3,
+              "cache_write": 3.75,
+              "no_cache": 3.0
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "anthropic/claude-sonnet-4.6"
         },
         {
           "api_protocol": "anthropic",
@@ -631,6 +720,21 @@
           }
         },
         {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "cache_write": 2.5,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 10.0
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "anthropic/claude-sonnet-5"
+        },
+        {
           "api_protocol": "anthropic",
           "capabilities": [
             "reasoning",
@@ -640,6 +744,45 @@
           ],
           "provider": "claude-code",
           "provider_model_id": "claude-sonnet-5"
+        },
+        {
+          "api_protocol": "openai",
+          "provider": "github-copilot",
+          "provider_model_id": "claude-sonnet-5"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "cache_write": 2.5,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 10.0
+            }
+          },
+          "provider": "opencode-zen",
+          "provider_model_id": "claude-sonnet-5"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "cache_write": 2.5,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 10.0
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "anthropic/claude-sonnet-5"
         }
       ],
       "release_date": "2026-06-30"
@@ -672,6 +815,20 @@
           },
           "provider": "atlascloud",
           "provider_model_id": "deepseek-ai/deepseek-v3.2"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.105,
+              "no_cache": 0.21
+            },
+            "output_tokens": {
+              "text": 0.315
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "deepseek/deepseek-v3.2"
         },
         {
           "api_protocol": "openai",
@@ -845,6 +1002,27 @@
       ],
       "providers": [
         {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.0028,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider": "alibaba_cn",
+          "provider_model_id": "deepseek-v4-flash",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
           "api_protocol": "openai",
           "pricing": {
             "input_tokens": {
@@ -856,6 +1034,20 @@
           },
           "provider": "atlascloud",
           "provider_model_id": "deepseek-ai/deepseek-v4-flash"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.02,
+              "no_cache": 0.09
+            },
+            "output_tokens": {
+              "text": 0.18
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "deepseek/deepseek-v4-flash"
         },
         {
           "api_protocol": [
@@ -1058,6 +1250,27 @@
       ],
       "providers": [
         {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.003625,
+              "no_cache": 0.435
+            },
+            "output_tokens": {
+              "text": 0.87
+            }
+          },
+          "provider": "alibaba_cn",
+          "provider_model_id": "deepseek-v4-pro",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
           "api_protocol": "openai",
           "pricing": {
             "input_tokens": {
@@ -1069,6 +1282,20 @@
           },
           "provider": "atlascloud",
           "provider_model_id": "deepseek-ai/deepseek-v4-pro"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.003625,
+              "no_cache": 0.435
+            },
+            "output_tokens": {
+              "text": 0.87
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "deepseek/deepseek-v4-pro"
         },
         {
           "api_protocol": [
@@ -1307,6 +1534,20 @@
       ],
       "providers": [
         {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.025,
+              "no_cache": 0.25
+            },
+            "output_tokens": {
+              "text": 1.5
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "google/gemini-3.1-flash-lite-preview"
+        },
+        {
           "api_protocol": [
             "google",
             "openai"
@@ -1375,6 +1616,20 @@
         "text"
       ],
       "providers": [
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 12.0
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "google/gemini-3.1-pro-preview"
+        },
         {
           "api_protocol": "openai",
           "provider": "github-copilot",
@@ -1455,6 +1710,20 @@
         "text"
       ],
       "providers": [
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.15,
+              "no_cache": 1.5
+            },
+            "output_tokens": {
+              "text": 9.0
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "google/gemini-3.5-flash"
+        },
         {
           "api_protocol": "openai",
           "provider": "github-copilot",
@@ -1558,8 +1827,53 @@
               "text": 0.4
             }
           },
+          "provider": "bitrouter",
+          "provider_model_id": "google/gemma-4-31b"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.99
+            },
+            "output_tokens": {
+              "text": 1.49
+            }
+          },
+          "provider": "cerebras",
+          "provider_model_id": "gemma-4-31b",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.13
+            },
+            "output_tokens": {
+              "text": 0.4
+            }
+          },
           "provider": "siliconflow",
           "provider_model_id": "google/gemma-4-31B-it"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.4
+            },
+            "output_tokens": {
+              "text": 1.0
+            }
+          },
+          "provider": "tinfoil",
+          "provider_model_id": "gemma4-31b",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
         }
       ],
       "release_date": "2026-04-02"
@@ -1589,7 +1903,39 @@
               "text": 2.5
             }
           },
+          "provider": "bitrouter",
+          "provider_model_id": "inclusionai/ling-2.6-1t"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.06,
+              "no_cache": 0.3
+            },
+            "output_tokens": {
+              "text": 2.5
+            }
+          },
           "provider": "novita",
+          "provider_model_id": "inclusionai/ling-2.6-1t"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.015,
+              "no_cache": 0.075
+            },
+            "output_tokens": {
+              "text": 0.625
+            }
+          },
+          "provider": "openrouter",
           "provider_model_id": "inclusionai/ling-2.6-1t"
         }
       ],
@@ -1620,7 +1966,39 @@
               "text": 0.3
             }
           },
+          "provider": "bitrouter",
+          "provider_model_id": "inclusionai/ling-2.6-flash"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.02,
+              "no_cache": 0.1
+            },
+            "output_tokens": {
+              "text": 0.3
+            }
+          },
           "provider": "novita",
+          "provider_model_id": "inclusionai/ling-2.6-flash"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.002,
+              "no_cache": 0.01
+            },
+            "output_tokens": {
+              "text": 0.03
+            }
+          },
+          "provider": "openrouter",
           "provider_model_id": "inclusionai/ling-2.6-flash"
         }
       ],
@@ -1651,7 +2029,39 @@
               "text": 2.5
             }
           },
+          "provider": "bitrouter",
+          "provider_model_id": "inclusionai/ring-2.6-1t"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.06,
+              "no_cache": 0.3
+            },
+            "output_tokens": {
+              "text": 2.5
+            }
+          },
           "provider": "novita",
+          "provider_model_id": "inclusionai/ring-2.6-1t"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.015,
+              "no_cache": 0.075
+            },
+            "output_tokens": {
+              "text": 0.625
+            }
+          },
+          "provider": "openrouter",
           "provider_model_id": "inclusionai/ring-2.6-1t"
         }
       ],
@@ -1688,6 +2098,26 @@
       ],
       "providers": [
         {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.3
+            },
+            "output_tokens": {
+              "text": 1.2
+            }
+          },
+          "provider": "alibaba_cn",
+          "provider_model_id": "MiniMax-M2.5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
           "api_protocol": "openai",
           "provider": "alibaba_coding_plan",
           "provider_model_id": "MiniMax-M2.5",
@@ -1707,6 +2137,20 @@
           },
           "provider": "atlascloud",
           "provider_model_id": "minimaxai/minimax-m2.5"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.05,
+              "no_cache": 0.15
+            },
+            "output_tokens": {
+              "text": 0.9
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "minimax/minimax-m2.5"
         },
         {
           "api_protocol": "openai",
@@ -1923,6 +2367,43 @@
       "providers": [
         {
           "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.06,
+              "cache_write": 0.375,
+              "no_cache": 0.3
+            },
+            "output_tokens": {
+              "text": 1.2
+            }
+          },
+          "provider": "alibaba_cn",
+          "provider_model_id": "MiniMax/MiniMax-M2.7",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.045,
+              "cache_write": 0.28125,
+              "no_cache": 0.225
+            },
+            "output_tokens": {
+              "text": 0.9
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "minimax/minimax-m2.7"
+        },
+        {
+          "api_protocol": [
             "anthropic",
             "openai"
           ],
@@ -2102,6 +2583,20 @@
           "provider_model_id": "minimaxai/minimax-m3"
         },
         {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.06,
+              "no_cache": 0.3
+            },
+            "output_tokens": {
+              "text": 1.2
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "minimax/minimax-m3"
+        },
+        {
           "api_protocol": [
             "anthropic",
             "openai"
@@ -2272,6 +2767,26 @@
       ],
       "providers": [
         {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.574
+            },
+            "output_tokens": {
+              "text": 2.411
+            }
+          },
+          "provider": "alibaba_cn",
+          "provider_model_id": "kimi-k2.5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
           "api_protocol": "openai",
           "provider": "alibaba_coding_plan",
           "provider_model_id": "kimi-k2.5",
@@ -2290,6 +2805,19 @@
             }
           },
           "provider": "atlascloud",
+          "provider_model_id": "moonshotai/kimi-k2.5"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.375
+            },
+            "output_tokens": {
+              "text": 2.025
+            }
+          },
+          "provider": "bitrouter",
           "provider_model_id": "moonshotai/kimi-k2.5"
         },
         {
@@ -2482,6 +3010,26 @@
       ],
       "providers": [
         {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.929
+            },
+            "output_tokens": {
+              "text": 3.858
+            }
+          },
+          "provider": "alibaba_cn",
+          "provider_model_id": "kimi-k2.6",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
           "api_protocol": "openai",
           "pricing": {
             "input_tokens": {
@@ -2510,6 +3058,20 @@
             }
           },
           "provider": "atlascloud",
+          "provider_model_id": "moonshotai/kimi-k2.6"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.12,
+              "no_cache": 0.7125
+            },
+            "output_tokens": {
+              "text": 3.0
+            }
+          },
+          "provider": "bitrouter",
           "provider_model_id": "moonshotai/kimi-k2.6"
         },
         {
@@ -2818,6 +3380,20 @@
         },
         {
           "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.1296,
+              "no_cache": 0.612
+            },
+            "output_tokens": {
+              "text": 3.069
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "moonshotai/kimi-k2.7-code"
+        },
+        {
+          "api_protocol": "openai",
           "provider": "github-copilot",
           "provider_model_id": "kimi-k2.7-code"
         },
@@ -2910,7 +3486,26 @@
       "output_modalities": [
         "text"
       ],
-      "providers": [],
+      "providers": [
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.025,
+              "no_cache": 0.25
+            },
+            "output_tokens": {
+              "text": 1.0
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "nex-agi/nex-n2-pro"
+        }
+      ],
       "release_date": "2026-06-08"
     },
     {
@@ -2927,7 +3522,25 @@
       "output_modalities": [
         "text"
       ],
-      "providers": [],
+      "providers": [
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.08
+            },
+            "output_tokens": {
+              "text": 0.45
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "nvidia/nemotron-3-super-120b-a12b"
+        }
+      ],
       "release_date": "2026-03-11"
     },
     {
@@ -2943,7 +3556,26 @@
       "output_modalities": [
         "text"
       ],
-      "providers": [],
+      "providers": [
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.1,
+              "no_cache": 0.5
+            },
+            "output_tokens": {
+              "text": 2.2
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "nvidia/nemotron-3-ultra-550b-a55b"
+        }
+      ],
       "release_date": "2026-06-04"
     },
     {
@@ -2962,6 +3594,20 @@
         "text"
       ],
       "providers": [
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.25,
+              "no_cache": 2.5
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "openai/gpt-5.4"
+        },
         {
           "api_protocol": "openai",
           "provider": "github-copilot",
@@ -3054,6 +3700,20 @@
       "providers": [
         {
           "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.075,
+              "no_cache": 0.75
+            },
+            "output_tokens": {
+              "text": 4.5
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "openai/gpt-5.4-mini"
+        },
+        {
+          "api_protocol": "openai",
           "provider": "github-copilot",
           "provider_model_id": "gpt-5.4-mini"
         },
@@ -3142,6 +3802,20 @@
         "text"
       ],
       "providers": [
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 30.0
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "openai/gpt-5.5"
+        },
         {
           "api_protocol": "openai",
           "provider": "github-copilot",
@@ -3247,6 +3921,39 @@
       ],
       "providers": [
         {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.4
+            },
+            "output_tokens": {
+              "text": 3.2
+            }
+          },
+          "provider": "alibaba",
+          "provider_model_id": "qwen3.5-122b-a10b",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.26
+            },
+            "output_tokens": {
+              "text": 2.08
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "qwen/qwen3.5-122b-a10b"
+        },
+        {
           "api_protocol": "openai",
           "pricing": {
             "input_tokens": {
@@ -3257,6 +3964,23 @@
             }
           },
           "provider": "novita",
+          "provider_model_id": "qwen/qwen3.5-122b-a10b"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.26
+            },
+            "output_tokens": {
+              "text": 2.08
+            }
+          },
+          "provider": "openrouter",
           "provider_model_id": "qwen/qwen3.5-122b-a10b"
         },
         {
@@ -3305,6 +4029,39 @@
       ],
       "providers": [
         {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.3
+            },
+            "output_tokens": {
+              "text": 2.4
+            }
+          },
+          "provider": "alibaba",
+          "provider_model_id": "qwen3.5-27b",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.25
+            },
+            "output_tokens": {
+              "text": 2.0
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "qwen/qwen3.5-27b"
+        },
+        {
           "api_protocol": "openai",
           "pricing": {
             "input_tokens": {
@@ -3315,6 +4072,23 @@
             }
           },
           "provider": "novita",
+          "provider_model_id": "qwen/qwen3.5-27b"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.195
+            },
+            "output_tokens": {
+              "text": 1.56
+            }
+          },
+          "provider": "openrouter",
           "provider_model_id": "qwen/qwen3.5-27b"
         },
         {
@@ -3363,6 +4137,57 @@
       ],
       "providers": [
         {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.6
+            },
+            "output_tokens": {
+              "text": 3.6
+            }
+          },
+          "provider": "alibaba",
+          "provider_model_id": "qwen3.6-27b",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.3
+            },
+            "output_tokens": {
+              "text": 3.2
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "qwen/qwen3.6-27b"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.15,
+              "no_cache": 0.285
+            },
+            "output_tokens": {
+              "text": 2.4
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "qwen/qwen3.6-27b"
+        },
+        {
           "api_protocol": "openai",
           "pricing": {
             "input_tokens": {
@@ -3394,6 +4219,56 @@
         "text"
       ],
       "providers": [
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.248
+            },
+            "output_tokens": {
+              "text": 1.485
+            }
+          },
+          "provider": "alibaba",
+          "provider_model_id": "qwen3.6-35b-a3b",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.2
+            },
+            "output_tokens": {
+              "text": 1.6
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "qwen/qwen3.6-35b-a3b"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 1.0
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "qwen/qwen3.6-35b-a3b"
+        },
         {
           "api_protocol": "openai",
           "pricing": {
@@ -3510,6 +4385,19 @@
           }
         },
         {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.165
+            },
+            "output_tokens": {
+              "text": 0.99
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "qwen/qwen3.6-flash"
+        },
+        {
           "api_protocol": [
             "openai",
             "responses",
@@ -3603,6 +4491,21 @@
             }
           },
           "provider": "atlascloud",
+          "provider_model_id": "qwen/qwen3.7-max"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.25,
+              "cache_write": 1.5625,
+              "no_cache": 1.25
+            },
+            "output_tokens": {
+              "text": 3.75
+            }
+          },
+          "provider": "bitrouter",
           "provider_model_id": "qwen/qwen3.7-max"
         },
         {
@@ -3761,6 +4664,19 @@
         },
         {
           "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.276
+            },
+            "output_tokens": {
+              "text": 1.101
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "qwen/qwen3.7-plus"
+        },
+        {
+          "api_protocol": "openai",
           "provider": "opencode-go",
           "provider_model_id": "qwen3.7-plus"
         },
@@ -3800,6 +4716,20 @@
         "text"
       ],
       "providers": [
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.01425,
+              "no_cache": 0.072
+            },
+            "output_tokens": {
+              "text": 0.216
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "stepfun/step-3.5-flash"
+        },
         {
           "api_protocol": [
             "openai",
@@ -3940,6 +4870,20 @@
       ],
       "providers": [
         {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.03,
+              "no_cache": 0.15
+            },
+            "output_tokens": {
+              "text": 0.8625
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "stepfun/step-3.7-flash"
+        },
+        {
           "api_protocol": [
             "openai",
             "responses",
@@ -4058,8 +5002,61 @@
               "text": 0.26
             }
           },
+          "provider": "bitrouter",
+          "provider_model_id": "tencent/hy3"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "no_cache": 0.2
+            },
+            "output_tokens": {
+              "text": 0.8
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "tencent/hy3"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.029,
+              "no_cache": 0.066
+            },
+            "output_tokens": {
+              "text": 0.26
+            }
+          },
           "provider": "siliconflow",
           "provider_model_id": "tencent/Hy3-preview"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.0,
+              "cache_write": 0.0,
+              "no_cache": 0.0
+            },
+            "output_tokens": {
+              "text": 0.0
+            }
+          },
+          "provider": "tencent_cn",
+          "provider_model_id": "hy3",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
         }
       ],
       "release_date": "2026-07-06"
@@ -4079,6 +5076,20 @@
         "text"
       ],
       "providers": [
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "no_cache": 1.25
+            },
+            "output_tokens": {
+              "text": 2.5
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "x-ai/grok-4.20"
+        },
         {
           "api_protocol": [
             "openai",
@@ -4149,6 +5160,20 @@
         "text"
       ],
       "providers": [
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "no_cache": 1.25
+            },
+            "output_tokens": {
+              "text": 2.5
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "x-ai/grok-4.20-multi-agent"
+        },
         {
           "api_protocol": [
             "openai",
@@ -4233,6 +5258,20 @@
           "provider_model_id": "xai/grok-4.3"
         },
         {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "no_cache": 1.25
+            },
+            "output_tokens": {
+              "text": 2.5
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "x-ai/grok-4.3"
+        },
+        {
           "api_protocol": [
             "openai",
             "responses",
@@ -4302,6 +5341,20 @@
         "text"
       ],
       "providers": [
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "no_cache": 1.0
+            },
+            "output_tokens": {
+              "text": 2.0
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "x-ai/grok-build-0.1"
+        },
         {
           "api_protocol": "openai",
           "pricing": {
@@ -4385,6 +5438,20 @@
         "text"
       ],
       "providers": [
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.0028,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "xiaomi/mimo-v2.5"
+        },
         {
           "api_protocol": "openai",
           "provider": "opencode-go",
@@ -4502,6 +5569,20 @@
       "providers": [
         {
           "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.0036,
+              "no_cache": 0.435
+            },
+            "output_tokens": {
+              "text": 0.87
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "xiaomi/mimo-v2.5-pro"
+        },
+        {
+          "api_protocol": "openai",
           "provider": "opencode-go",
           "provider_model_id": "mimo-v2.5-pro"
         },
@@ -4615,6 +5696,46 @@
       "providers": [
         {
           "api_protocol": "openai",
+          "provider": "alibaba_coding_plan",
+          "provider_model_id": "glm-4.7",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.11,
+              "no_cache": 0.6
+            },
+            "output_tokens": {
+              "text": 2.2
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "z-ai/glm-4.7"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.0,
+              "cache_write": 0.0,
+              "no_cache": 2.25
+            },
+            "output_tokens": {
+              "text": 2.75
+            }
+          },
+          "provider": "cerebras",
+          "provider_model_id": "zai-glm-4.7",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
           "pricing": {
             "input_tokens": {
               "cache_read": 0.11,
@@ -4626,6 +5747,70 @@
           },
           "provider": "novita",
           "provider_model_id": "zai-org/glm-4.7"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.1,
+              "no_cache": 0.6
+            },
+            "output_tokens": {
+              "text": 2.2
+            }
+          },
+          "provider": "opencode-zen",
+          "provider_model_id": "glm-4.7"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.08,
+              "no_cache": 0.4
+            },
+            "output_tokens": {
+              "text": 1.75
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "z-ai/glm-4.7"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.11,
+              "cache_write": 0.0,
+              "no_cache": 0.6
+            },
+            "output_tokens": {
+              "text": 2.2
+            }
+          },
+          "provider": "zai",
+          "provider_model_id": "glm-4.7",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "provider": "zai_coding_plan",
+          "provider_model_id": "glm-4.7",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
         }
       ],
       "release_date": "2025-12-23"
@@ -4645,12 +5830,46 @@
       ],
       "providers": [
         {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.86
+            },
+            "output_tokens": {
+              "text": 3.15
+            }
+          },
+          "provider": "alibaba_cn",
+          "provider_model_id": "glm-5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
           "api_protocol": "openai",
           "provider": "alibaba_coding_plan",
           "provider_model_id": "glm-5",
           "rate_limits": {
             "requests_per_minute": 60
           }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.12,
+              "no_cache": 0.6
+            },
+            "output_tokens": {
+              "text": 1.92
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "z-ai/glm-5"
         },
         {
           "api_protocol": "openai",
@@ -4872,6 +6091,27 @@
       ],
       "providers": [
         {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.17,
+              "no_cache": 0.87
+            },
+            "output_tokens": {
+              "text": 3.48
+            }
+          },
+          "provider": "alibaba_cn",
+          "provider_model_id": "glm-5.1",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
           "api_protocol": "openai",
           "pricing": {
             "input_tokens": {
@@ -4883,6 +6123,20 @@
           },
           "provider": "atlascloud",
           "provider_model_id": "zai-org/glm-5.1"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.182,
+              "no_cache": 0.98
+            },
+            "output_tokens": {
+              "text": 3.08
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "z-ai/glm-5.1"
         },
         {
           "api_protocol": "openai",
@@ -5139,6 +6393,28 @@
       ],
       "providers": [
         {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.275,
+              "cache_write": 0.0,
+              "no_cache": 1.1
+            },
+            "output_tokens": {
+              "text": 3.851
+            }
+          },
+          "provider": "alibaba_cn",
+          "provider_model_id": "glm-5.2",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
           "api_protocol": "openai",
           "pricing": {
             "input_tokens": {
@@ -5150,6 +6426,20 @@
           },
           "provider": "atlascloud",
           "provider_model_id": "zai-org/glm-5.2"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.182,
+              "no_cache": 0.979
+            },
+            "output_tokens": {
+              "text": 3.08
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "z-ai/glm-5.2"
         },
         {
           "api_protocol": "openai",
@@ -5303,6 +6593,22 @@
           },
           "provider": "tencent_cn",
           "provider_model_id": "glm-5.2",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 1.5
+            },
+            "output_tokens": {
+              "text": 5.25
+            }
+          },
+          "provider": "tinfoil",
+          "provider_model_id": "glm-5-2",
           "rate_limits": {
             "requests_per_minute": 60
           }

--- a/dist/registry/providers.json
+++ b/dist/registry/providers.json
@@ -133,6 +133,86 @@
           "rate_limits": {
             "requests_per_minute": 60
           }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "qwen/qwen3.5-122b-a10b",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.4
+            },
+            "output_tokens": {
+              "text": 3.2
+            }
+          },
+          "provider_model_id": "qwen3.5-122b-a10b",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "qwen/qwen3.5-27b",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.3
+            },
+            "output_tokens": {
+              "text": 2.4
+            }
+          },
+          "provider_model_id": "qwen3.5-27b",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "qwen/qwen3.6-27b",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.6
+            },
+            "output_tokens": {
+              "text": 3.6
+            }
+          },
+          "provider_model_id": "qwen3.6-27b",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "qwen/qwen3.6-35b-a3b",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.248
+            },
+            "output_tokens": {
+              "text": 1.485
+            }
+          },
+          "provider_model_id": "qwen3.6-35b-a3b",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
         }
       ],
       "name": "alibaba",
@@ -279,6 +359,193 @@
           "rate_limits": {
             "requests_per_minute": 60
           }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "minimax/minimax-m2.5",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.3
+            },
+            "output_tokens": {
+              "text": 1.2
+            }
+          },
+          "provider_model_id": "MiniMax-M2.5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "minimax/minimax-m2.7",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.06,
+              "cache_write": 0.375,
+              "no_cache": 0.3
+            },
+            "output_tokens": {
+              "text": 1.2
+            }
+          },
+          "provider_model_id": "MiniMax/MiniMax-M2.7",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "deepseek/deepseek-v4-flash",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.0028,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider_model_id": "deepseek-v4-flash",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "deepseek/deepseek-v4-pro",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.003625,
+              "no_cache": 0.435
+            },
+            "output_tokens": {
+              "text": 0.87
+            }
+          },
+          "provider_model_id": "deepseek-v4-pro",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "z-ai/glm-5",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.86
+            },
+            "output_tokens": {
+              "text": 3.15
+            }
+          },
+          "provider_model_id": "glm-5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "z-ai/glm-5.1",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.17,
+              "no_cache": 0.87
+            },
+            "output_tokens": {
+              "text": 3.48
+            }
+          },
+          "provider_model_id": "glm-5.1",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "z-ai/glm-5.2",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.275,
+              "cache_write": 0.0,
+              "no_cache": 1.1
+            },
+            "output_tokens": {
+              "text": 3.851
+            }
+          },
+          "provider_model_id": "glm-5.2",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "moonshotai/kimi-k2.5",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.574
+            },
+            "output_tokens": {
+              "text": 2.411
+            }
+          },
+          "provider_model_id": "kimi-k2.5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "moonshotai/kimi-k2.6",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.929
+            },
+            "output_tokens": {
+              "text": 3.858
+            }
+          },
+          "provider_model_id": "kimi-k2.6",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
         }
       ],
       "name": "alibaba_cn",
@@ -365,6 +632,14 @@
           "api_protocol": "openai",
           "id": "z-ai/glm-5",
           "provider_model_id": "glm-5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "id": "z-ai/glm-4.7",
+          "provider_model_id": "glm-4.7",
           "rate_limits": {
             "requests_per_minute": 60
           }
@@ -876,11 +1151,6 @@
     {
       "access": "api_key",
       "api_base": "https://api.bitrouter.ai/v1",
-      "api_protocol": [
-        {
-          "*": "openai"
-        }
-      ],
       "auth": {
         "env": "BITROUTER_API_KEY",
         "kind": "bearer"
@@ -900,9 +1170,653 @@
         "slug": "bitrouter",
         "terms_of_service_url": "https://bitrouter.ai/legal/terms"
       },
-      "models": [],
+      "models": [
+        {
+          "api_protocol": "openai",
+          "id": "anthropic/claude-fable-5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 1.0,
+              "cache_write": 12.5,
+              "no_cache": 10.0
+            },
+            "output_tokens": {
+              "text": 50.0
+            }
+          },
+          "provider_model_id": "anthropic/claude-fable-5"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "anthropic/claude-haiku-4.5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.1,
+              "cache_write": 1.25,
+              "no_cache": 1.0
+            },
+            "output_tokens": {
+              "text": 5.0
+            }
+          },
+          "provider_model_id": "anthropic/claude-haiku-4.5"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "anthropic/claude-opus-4.6",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider_model_id": "anthropic/claude-opus-4.6"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "anthropic/claude-opus-4.7",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.45,
+              "no_cache": 4.5
+            },
+            "output_tokens": {
+              "text": 22.5
+            }
+          },
+          "provider_model_id": "anthropic/claude-opus-4.7"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "anthropic/claude-opus-4.8",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider_model_id": "anthropic/claude-opus-4.8"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "anthropic/claude-sonnet-4.6",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.3,
+              "cache_write": 3.75,
+              "no_cache": 3.0
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider_model_id": "anthropic/claude-sonnet-4.6"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "anthropic/claude-sonnet-5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "cache_write": 2.5,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 10.0
+            }
+          },
+          "provider_model_id": "anthropic/claude-sonnet-5"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "deepseek/deepseek-v3.2",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.105,
+              "no_cache": 0.21
+            },
+            "output_tokens": {
+              "text": 0.315
+            }
+          },
+          "provider_model_id": "deepseek/deepseek-v3.2"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "deepseek/deepseek-v4-flash",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.02,
+              "no_cache": 0.09
+            },
+            "output_tokens": {
+              "text": 0.18
+            }
+          },
+          "provider_model_id": "deepseek/deepseek-v4-flash"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "deepseek/deepseek-v4-pro",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.003625,
+              "no_cache": 0.435
+            },
+            "output_tokens": {
+              "text": 0.87
+            }
+          },
+          "provider_model_id": "deepseek/deepseek-v4-pro"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "google/gemini-3.1-flash-lite-preview",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.025,
+              "no_cache": 0.25
+            },
+            "output_tokens": {
+              "text": 1.5
+            }
+          },
+          "provider_model_id": "google/gemini-3.1-flash-lite-preview"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "google/gemini-3.1-pro-preview",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 12.0
+            }
+          },
+          "provider_model_id": "google/gemini-3.1-pro-preview"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "google/gemini-3.5-flash",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.15,
+              "no_cache": 1.5
+            },
+            "output_tokens": {
+              "text": 9.0
+            }
+          },
+          "provider_model_id": "google/gemini-3.5-flash"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "google/gemma-4-31b",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.13
+            },
+            "output_tokens": {
+              "text": 0.4
+            }
+          },
+          "provider_model_id": "google/gemma-4-31b"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "inclusionai/ling-2.6-1t",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.06,
+              "no_cache": 0.3
+            },
+            "output_tokens": {
+              "text": 2.5
+            }
+          },
+          "provider_model_id": "inclusionai/ling-2.6-1t"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "inclusionai/ling-2.6-flash",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.02,
+              "no_cache": 0.1
+            },
+            "output_tokens": {
+              "text": 0.3
+            }
+          },
+          "provider_model_id": "inclusionai/ling-2.6-flash"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "inclusionai/ring-2.6-1t",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.06,
+              "no_cache": 0.3
+            },
+            "output_tokens": {
+              "text": 2.5
+            }
+          },
+          "provider_model_id": "inclusionai/ring-2.6-1t"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "minimax/minimax-m2.5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.05,
+              "no_cache": 0.15
+            },
+            "output_tokens": {
+              "text": 0.9
+            }
+          },
+          "provider_model_id": "minimax/minimax-m2.5"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "minimax/minimax-m2.7",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.045,
+              "cache_write": 0.28125,
+              "no_cache": 0.225
+            },
+            "output_tokens": {
+              "text": 0.9
+            }
+          },
+          "provider_model_id": "minimax/minimax-m2.7"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "minimax/minimax-m3",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.06,
+              "no_cache": 0.3
+            },
+            "output_tokens": {
+              "text": 1.2
+            }
+          },
+          "provider_model_id": "minimax/minimax-m3"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "moonshotai/kimi-k2.5",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.375
+            },
+            "output_tokens": {
+              "text": 2.025
+            }
+          },
+          "provider_model_id": "moonshotai/kimi-k2.5"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "moonshotai/kimi-k2.6",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.12,
+              "no_cache": 0.7125
+            },
+            "output_tokens": {
+              "text": 3.0
+            }
+          },
+          "provider_model_id": "moonshotai/kimi-k2.6"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "moonshotai/kimi-k2.7-code",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.1296,
+              "no_cache": 0.612
+            },
+            "output_tokens": {
+              "text": 3.069
+            }
+          },
+          "provider_model_id": "moonshotai/kimi-k2.7-code"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "openai/gpt-5.4",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.25,
+              "no_cache": 2.5
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider_model_id": "openai/gpt-5.4"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "openai/gpt-5.4-mini",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.075,
+              "no_cache": 0.75
+            },
+            "output_tokens": {
+              "text": 4.5
+            }
+          },
+          "provider_model_id": "openai/gpt-5.4-mini"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "openai/gpt-5.5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 30.0
+            }
+          },
+          "provider_model_id": "openai/gpt-5.5"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "qwen/qwen3.5-122b-a10b",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.26
+            },
+            "output_tokens": {
+              "text": 2.08
+            }
+          },
+          "provider_model_id": "qwen/qwen3.5-122b-a10b"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "qwen/qwen3.5-27b",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.25
+            },
+            "output_tokens": {
+              "text": 2.0
+            }
+          },
+          "provider_model_id": "qwen/qwen3.5-27b"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "qwen/qwen3.6-27b",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.3
+            },
+            "output_tokens": {
+              "text": 3.2
+            }
+          },
+          "provider_model_id": "qwen/qwen3.6-27b"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "qwen/qwen3.6-35b-a3b",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.2
+            },
+            "output_tokens": {
+              "text": 1.6
+            }
+          },
+          "provider_model_id": "qwen/qwen3.6-35b-a3b"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "qwen/qwen3.6-flash",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.165
+            },
+            "output_tokens": {
+              "text": 0.99
+            }
+          },
+          "provider_model_id": "qwen/qwen3.6-flash"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "qwen/qwen3.7-max",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.25,
+              "cache_write": 1.5625,
+              "no_cache": 1.25
+            },
+            "output_tokens": {
+              "text": 3.75
+            }
+          },
+          "provider_model_id": "qwen/qwen3.7-max"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "qwen/qwen3.7-plus",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.276
+            },
+            "output_tokens": {
+              "text": 1.101
+            }
+          },
+          "provider_model_id": "qwen/qwen3.7-plus"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "stepfun/step-3.5-flash",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.01425,
+              "no_cache": 0.072
+            },
+            "output_tokens": {
+              "text": 0.216
+            }
+          },
+          "provider_model_id": "stepfun/step-3.5-flash"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "stepfun/step-3.7-flash",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.03,
+              "no_cache": 0.15
+            },
+            "output_tokens": {
+              "text": 0.8625
+            }
+          },
+          "provider_model_id": "stepfun/step-3.7-flash"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "tencent/hy3",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.029,
+              "no_cache": 0.066
+            },
+            "output_tokens": {
+              "text": 0.26
+            }
+          },
+          "provider_model_id": "tencent/hy3"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "x-ai/grok-4.20",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "no_cache": 1.25
+            },
+            "output_tokens": {
+              "text": 2.5
+            }
+          },
+          "provider_model_id": "x-ai/grok-4.20"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "x-ai/grok-4.20-multi-agent",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "no_cache": 1.25
+            },
+            "output_tokens": {
+              "text": 2.5
+            }
+          },
+          "provider_model_id": "x-ai/grok-4.20-multi-agent"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "x-ai/grok-4.3",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "no_cache": 1.25
+            },
+            "output_tokens": {
+              "text": 2.5
+            }
+          },
+          "provider_model_id": "x-ai/grok-4.3"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "x-ai/grok-build-0.1",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "no_cache": 1.0
+            },
+            "output_tokens": {
+              "text": 2.0
+            }
+          },
+          "provider_model_id": "x-ai/grok-build-0.1"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "xiaomi/mimo-v2.5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.0028,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider_model_id": "xiaomi/mimo-v2.5"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "xiaomi/mimo-v2.5-pro",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.0036,
+              "no_cache": 0.435
+            },
+            "output_tokens": {
+              "text": 0.87
+            }
+          },
+          "provider_model_id": "xiaomi/mimo-v2.5-pro"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "z-ai/glm-4.7",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.11,
+              "no_cache": 0.6
+            },
+            "output_tokens": {
+              "text": 2.2
+            }
+          },
+          "provider_model_id": "z-ai/glm-4.7"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "z-ai/glm-5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.12,
+              "no_cache": 0.6
+            },
+            "output_tokens": {
+              "text": 1.92
+            }
+          },
+          "provider_model_id": "z-ai/glm-5"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "z-ai/glm-5.1",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.182,
+              "no_cache": 0.98
+            },
+            "output_tokens": {
+              "text": 3.08
+            }
+          },
+          "provider_model_id": "z-ai/glm-5.1"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "z-ai/glm-5.2",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.182,
+              "no_cache": 0.979
+            },
+            "output_tokens": {
+              "text": 3.08
+            }
+          },
+          "provider_model_id": "z-ai/glm-5.2"
+        }
+      ],
       "name": "bitrouter",
-      "rate_limits": [],
       "required_config": [
         "api_key"
       ],
@@ -985,6 +1899,40 @@
             }
           },
           "provider_model_id": "gpt-oss-120b",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "id": "google/gemma-4-31b",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.99
+            },
+            "output_tokens": {
+              "text": 1.49
+            }
+          },
+          "provider_model_id": "gemma-4-31b",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "id": "z-ai/glm-4.7",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.0,
+              "cache_write": 0.0,
+              "no_cache": 2.25
+            },
+            "output_tokens": {
+              "text": 2.75
+            }
+          },
+          "provider_model_id": "zai-glm-4.7",
           "rate_limits": {
             "requests_per_minute": 60
           }
@@ -1441,6 +2389,11 @@
           "api_protocol": "openai",
           "id": "moonshotai/kimi-k2.7-code",
           "provider_model_id": "kimi-k2.7-code"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "anthropic/claude-sonnet-5",
+          "provider_model_id": "claude-sonnet-5"
         }
       ],
       "name": "github-copilot",
@@ -3137,6 +4090,35 @@
             }
           },
           "provider_model_id": "grok-build-0.1"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "anthropic/claude-sonnet-5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "cache_write": 2.5,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 10.0
+            }
+          },
+          "provider_model_id": "claude-sonnet-5"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "z-ai/glm-4.7",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.1,
+              "no_cache": 0.6
+            },
+            "output_tokens": {
+              "text": 2.2
+            }
+          },
+          "provider_model_id": "glm-4.7"
         }
       ],
       "name": "opencode-zen",
@@ -3881,6 +4863,237 @@
             }
           },
           "provider_model_id": "x-ai/grok-build-0.1"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "anthropic/claude-sonnet-5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "cache_write": 2.5,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 10.0
+            }
+          },
+          "provider_model_id": "anthropic/claude-sonnet-5"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "inclusionai/ling-2.6-1t",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.015,
+              "no_cache": 0.075
+            },
+            "output_tokens": {
+              "text": 0.625
+            }
+          },
+          "provider_model_id": "inclusionai/ling-2.6-1t"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "inclusionai/ling-2.6-flash",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.002,
+              "no_cache": 0.01
+            },
+            "output_tokens": {
+              "text": 0.03
+            }
+          },
+          "provider_model_id": "inclusionai/ling-2.6-flash"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "inclusionai/ring-2.6-1t",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.015,
+              "no_cache": 0.075
+            },
+            "output_tokens": {
+              "text": 0.625
+            }
+          },
+          "provider_model_id": "inclusionai/ring-2.6-1t"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "nex-agi/nex-n2-pro",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.025,
+              "no_cache": 0.25
+            },
+            "output_tokens": {
+              "text": 1.0
+            }
+          },
+          "provider_model_id": "nex-agi/nex-n2-pro"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "nvidia/nemotron-3-super-120b-a12b",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.08
+            },
+            "output_tokens": {
+              "text": 0.45
+            }
+          },
+          "provider_model_id": "nvidia/nemotron-3-super-120b-a12b"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "nvidia/nemotron-3-ultra-550b-a55b",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.1,
+              "no_cache": 0.5
+            },
+            "output_tokens": {
+              "text": 2.2
+            }
+          },
+          "provider_model_id": "nvidia/nemotron-3-ultra-550b-a55b"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "qwen/qwen3.5-122b-a10b",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.26
+            },
+            "output_tokens": {
+              "text": 2.08
+            }
+          },
+          "provider_model_id": "qwen/qwen3.5-122b-a10b"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "qwen/qwen3.5-27b",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.195
+            },
+            "output_tokens": {
+              "text": 1.56
+            }
+          },
+          "provider_model_id": "qwen/qwen3.5-27b"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "qwen/qwen3.6-27b",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.15,
+              "no_cache": 0.285
+            },
+            "output_tokens": {
+              "text": 2.4
+            }
+          },
+          "provider_model_id": "qwen/qwen3.6-27b"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "qwen/qwen3.6-35b-a3b",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 1.0
+            }
+          },
+          "provider_model_id": "qwen/qwen3.6-35b-a3b"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "tencent/hy3",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "no_cache": 0.2
+            },
+            "output_tokens": {
+              "text": 0.8
+            }
+          },
+          "provider_model_id": "tencent/hy3"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "z-ai/glm-4.7",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.08,
+              "no_cache": 0.4
+            },
+            "output_tokens": {
+              "text": 1.75
+            }
+          },
+          "provider_model_id": "z-ai/glm-4.7"
         }
       ],
       "name": "openrouter",
@@ -5680,6 +6893,27 @@
           "rate_limits": {
             "requests_per_minute": 60
           }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "id": "tencent/hy3",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.0,
+              "cache_write": 0.0,
+              "no_cache": 0.0
+            },
+            "output_tokens": {
+              "text": 0.0
+            }
+          },
+          "provider_model_id": "hy3",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
         }
       ],
       "name": "tencent_cn",
@@ -5766,6 +7000,38 @@
             }
           },
           "provider_model_id": "kimi-k2-6",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "id": "google/gemma-4-31b",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.4
+            },
+            "output_tokens": {
+              "text": 1.0
+            }
+          },
+          "provider_model_id": "gemma4-31b",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "id": "z-ai/glm-5.2",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 1.5
+            },
+            "output_tokens": {
+              "text": 5.25
+            }
+          },
+          "provider_model_id": "glm-5-2",
           "rate_limits": {
             "requests_per_minute": 60
           }
@@ -6389,6 +7655,27 @@
           "rate_limits": {
             "requests_per_minute": 60
           }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "id": "z-ai/glm-4.7",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.11,
+              "cache_write": 0.0,
+              "no_cache": 0.6
+            },
+            "output_tokens": {
+              "text": 2.2
+            }
+          },
+          "provider_model_id": "glm-4.7",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
         }
       ],
       "name": "zai",
@@ -6456,6 +7743,17 @@
           ],
           "id": "z-ai/glm-5",
           "provider_model_id": "glm-5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "id": "z-ai/glm-4.7",
+          "provider_model_id": "glm-4.7",
           "rate_limits": {
             "requests_per_minute": 60
           }

--- a/helpers/dist-helper/src/registry.rs
+++ b/helpers/dist-helper/src/registry.rs
@@ -212,14 +212,7 @@ async fn sync_v1_models_loaded(root: &Path, loaded: &LoadedRegistry, write: bool
             ));
             continue;
         };
-        let Some(headers) = v1_auth_headers(&provider.data) else {
-            skipped.push(format!(
-                "{}: credential unavailable for v1_models",
-                provider.data.name
-            ));
-            continue;
-        };
-        let body = fetch_v1_models(&url, headers)
+        let body = fetch_v1_models(&url, v1_auth_headers(&provider.data))
             .await
             .with_context(|| format!("syncing {} from {url}", provider.data.name))?;
         let plan = v1_models_plan_for_provider(&provider.data, &body, &resolve)
@@ -306,11 +299,18 @@ fn v1_models_plan_for_provider(
         if have.contains(canonical_id.as_str()) || !staged.insert(canonical_id.clone()) {
             continue;
         }
+        let pricing = match provider.billing {
+            Billing::Subscription => None,
+            Billing::UsageToken => match model.pricing {
+                Some(pricing) => Some(pricing),
+                None => continue,
+            },
+        };
         adds.push(ProviderModel {
             id: canonical_id,
             provider_model_id: model.id,
             api_protocol: None,
-            pricing: None,
+            pricing,
             rate_limits: None,
             capabilities: Vec::new(),
             deprecation_date: None,
@@ -330,31 +330,8 @@ fn v1_models_url(provider: &ProviderFile) -> Option<String> {
     }
 }
 
-fn v1_auth_headers(provider: &ProviderFile) -> Option<Vec<(String, String)>> {
-    let Some(auth) = &provider.auth else {
-        return Some(Vec::new());
-    };
-    match auth.kind {
-        AuthKind::Bearer => {
-            let env = auth.env.as_ref()?;
-            let token = nonempty_env(env)?;
-            Some(vec![(
-                "Authorization".to_string(),
-                format!("Bearer {token}"),
-            )])
-        }
-        AuthKind::Header => {
-            let env = auth.env.as_ref()?;
-            let header = auth.header.as_ref()?;
-            let value = nonempty_env(env)?;
-            Some(vec![(header.clone(), value)])
-        }
-        AuthKind::Oauth | AuthKind::Native => None,
-    }
-}
-
-fn nonempty_env(name: &str) -> Option<String> {
-    std::env::var(name).ok().filter(|value| !value.is_empty())
+fn v1_auth_headers(_provider: &ProviderFile) -> Vec<(String, String)> {
+    Vec::new()
 }
 
 async fn fetch_v1_models(url: &str, headers: Vec<(String, String)>) -> Result<String> {
@@ -385,6 +362,8 @@ struct V1ModelsResponse {
 #[derive(Debug, Deserialize)]
 struct V1Model {
     id: String,
+    #[serde(default)]
+    pricing: Option<ModelPricing>,
 }
 
 pub fn agentic_prompt(root: &Path) -> Result<String> {
@@ -2367,6 +2346,7 @@ models:
   - id: openai/gpt-5.5
     provider_model_id: gpt-5.5
 status: active
+billing: subscription
 api_base: https://api.acme.test/v1
 auto_sync:
   feed: v1_models
@@ -2392,6 +2372,103 @@ auto_sync:
         assert_eq!(plan.adds[0].id, "anthropic/claude-sonnet-4.6");
         assert_eq!(plan.adds[0].provider_model_id, "claude-sonnet-4-6");
         assert!(plan.adds[0].pricing.is_none());
+    }
+
+    #[test]
+    fn v1_models_catalog_copies_pricing_when_present() {
+        let provider: ProviderFile = serde_saphyr::from_str(
+            r#"
+name: acme
+api_protocol:
+  - "*": openai
+models: []
+status: active
+api_base: https://api.acme.test/v1
+auto_sync:
+  feed: v1_models
+"#,
+        )
+        .unwrap();
+        let resolve = canonical_resolver(["openai/gpt-5.5"]);
+        let body = r#"
+{
+  "data": [
+    {
+      "id": "openai/gpt-5.5",
+      "pricing": {
+        "input_tokens": {
+          "no_cache": 1.5,
+          "cache_read": 0.15
+        },
+        "output_tokens": {
+          "text": 6.0
+        }
+      }
+    }
+  ]
+}
+"#;
+
+        let plan = v1_models_plan_for_provider(&provider, body, &resolve).unwrap();
+
+        assert_eq!(plan.adds.len(), 1);
+        let pricing = plan.adds[0].pricing.as_ref().expect("pricing copied");
+        let input = pricing.input_tokens.as_ref().expect("input pricing");
+        let output = pricing.output_tokens.as_ref().expect("output pricing");
+        assert_eq!(input.no_cache, Some(1.5));
+        assert_eq!(input.cache_read, Some(0.15));
+        assert_eq!(output.text, Some(6.0));
+    }
+
+    #[test]
+    fn v1_models_catalog_skips_usage_token_models_without_pricing() {
+        let provider: ProviderFile = serde_saphyr::from_str(
+            r#"
+name: acme
+api_protocol:
+  - "*": openai
+models: []
+status: active
+api_base: https://api.acme.test/v1
+auto_sync:
+  feed: v1_models
+"#,
+        )
+        .unwrap();
+        let resolve = canonical_resolver(["openai/gpt-5.5"]);
+        let body = r#"
+{
+  "data": [
+    { "id": "openai/gpt-5.5" }
+  ]
+}
+"#;
+
+        let plan = v1_models_plan_for_provider(&provider, body, &resolve).unwrap();
+
+        assert!(plan.adds.is_empty());
+    }
+
+    #[test]
+    fn v1_models_sync_uses_public_endpoint_even_with_runtime_auth() {
+        let provider: ProviderFile = serde_saphyr::from_str(
+            r#"
+name: acme
+api_protocol:
+  - "*": openai
+models: []
+status: active
+api_base: https://api.acme.test/v1
+auth:
+  kind: bearer
+  env: ACME_API_KEY
+auto_sync:
+  feed: v1_models
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(v1_auth_headers(&provider), Vec::<(String, String)>::new());
     }
 
     #[test]

--- a/registry/providers/alibaba.yaml
+++ b/registry/providers/alibaba.yaml
@@ -66,6 +66,34 @@ models:
             no_cache: 1
           output_tokens:
             text: 4
+  - id: qwen/qwen3.5-122b-a10b
+    provider_model_id: qwen3.5-122b-a10b
+    pricing:
+      input_tokens:
+        no_cache: 0.4
+      output_tokens:
+        text: 3.2
+  - id: qwen/qwen3.5-27b
+    provider_model_id: qwen3.5-27b
+    pricing:
+      input_tokens:
+        no_cache: 0.3
+      output_tokens:
+        text: 2.4
+  - id: qwen/qwen3.6-27b
+    provider_model_id: qwen3.6-27b
+    pricing:
+      input_tokens:
+        no_cache: 0.6
+      output_tokens:
+        text: 3.6
+  - id: qwen/qwen3.6-35b-a3b
+    provider_model_id: qwen3.6-35b-a3b
+    pricing:
+      input_tokens:
+        no_cache: 0.248
+      output_tokens:
+        text: 1.485
 status: active
 weight: 1
 submitted_at: 2026-05-25

--- a/registry/providers/alibaba_cn.yaml
+++ b/registry/providers/alibaba_cn.yaml
@@ -64,6 +64,76 @@ models:
             no_cache: 0.66
           output_tokens:
             text: 3.961
+  - id: minimax/minimax-m2.5
+    provider_model_id: MiniMax-M2.5
+    pricing:
+      input_tokens:
+        no_cache: 0.3
+      output_tokens:
+        text: 1.2
+  - id: minimax/minimax-m2.7
+    provider_model_id: MiniMax/MiniMax-M2.7
+    pricing:
+      input_tokens:
+        no_cache: 0.3
+        cache_read: 0.06
+        cache_write: 0.375
+      output_tokens:
+        text: 1.2
+  - id: deepseek/deepseek-v4-flash
+    provider_model_id: deepseek-v4-flash
+    pricing:
+      input_tokens:
+        no_cache: 0.14
+        cache_read: 0.0028
+      output_tokens:
+        text: 0.28
+  - id: deepseek/deepseek-v4-pro
+    provider_model_id: deepseek-v4-pro
+    pricing:
+      input_tokens:
+        no_cache: 0.435
+        cache_read: 0.003625
+      output_tokens:
+        text: 0.87
+  - id: z-ai/glm-5
+    provider_model_id: glm-5
+    pricing:
+      input_tokens:
+        no_cache: 0.86
+      output_tokens:
+        text: 3.15
+  - id: z-ai/glm-5.1
+    provider_model_id: glm-5.1
+    pricing:
+      input_tokens:
+        no_cache: 0.87
+        cache_read: 0.17
+      output_tokens:
+        text: 3.48
+  - id: z-ai/glm-5.2
+    provider_model_id: glm-5.2
+    pricing:
+      input_tokens:
+        no_cache: 1.1
+        cache_read: 0.275
+        cache_write: 0
+      output_tokens:
+        text: 3.851
+  - id: moonshotai/kimi-k2.5
+    provider_model_id: kimi-k2.5
+    pricing:
+      input_tokens:
+        no_cache: 0.574
+      output_tokens:
+        text: 2.411
+  - id: moonshotai/kimi-k2.6
+    provider_model_id: kimi-k2.6
+    pricing:
+      input_tokens:
+        no_cache: 0.929
+      output_tokens:
+        text: 3.858
 status: active
 weight: 1
 submitted_at: 2026-07-06

--- a/registry/providers/alibaba_coding_plan.yaml
+++ b/registry/providers/alibaba_coding_plan.yaml
@@ -31,6 +31,8 @@ models:
     provider_model_id: MiniMax-M2.5
   - id: z-ai/glm-5
     provider_model_id: glm-5
+  - id: z-ai/glm-4.7
+    provider_model_id: glm-4.7
 status: active
 weight: 1
 submitted_at: 2026-06-05

--- a/registry/providers/bitrouter.yaml
+++ b/registry/providers/bitrouter.yaml
@@ -14,7 +14,375 @@ doc_url: https://docs.bitrouter.ai
 api_protocol:
   - "*": openai
 rate_limits: []
-models: []
+models:
+  - id: anthropic/claude-fable-5
+    provider_model_id: anthropic/claude-fable-5
+    pricing:
+      input_tokens:
+        no_cache: 10
+        cache_read: 1
+        cache_write: 12.5
+      output_tokens:
+        text: 50
+  - id: anthropic/claude-haiku-4.5
+    provider_model_id: anthropic/claude-haiku-4.5
+    pricing:
+      input_tokens:
+        no_cache: 1
+        cache_read: 0.1
+        cache_write: 1.25
+      output_tokens:
+        text: 5
+  - id: anthropic/claude-opus-4.6
+    provider_model_id: anthropic/claude-opus-4.6
+    pricing:
+      input_tokens:
+        no_cache: 5
+        cache_read: 0.5
+        cache_write: 6.25
+      output_tokens:
+        text: 25
+  - id: anthropic/claude-opus-4.7
+    provider_model_id: anthropic/claude-opus-4.7
+    pricing:
+      input_tokens:
+        no_cache: 4.5
+        cache_read: 0.45
+      output_tokens:
+        text: 22.5
+  - id: anthropic/claude-opus-4.8
+    provider_model_id: anthropic/claude-opus-4.8
+    pricing:
+      input_tokens:
+        no_cache: 5
+        cache_read: 0.5
+        cache_write: 6.25
+      output_tokens:
+        text: 25
+  - id: anthropic/claude-sonnet-4.6
+    provider_model_id: anthropic/claude-sonnet-4.6
+    pricing:
+      input_tokens:
+        no_cache: 3
+        cache_read: 0.3
+        cache_write: 3.75
+      output_tokens:
+        text: 15
+  - id: anthropic/claude-sonnet-5
+    provider_model_id: anthropic/claude-sonnet-5
+    pricing:
+      input_tokens:
+        no_cache: 2
+        cache_read: 0.2
+        cache_write: 2.5
+      output_tokens:
+        text: 10
+  - id: deepseek/deepseek-v3.2
+    provider_model_id: deepseek/deepseek-v3.2
+    pricing:
+      input_tokens:
+        no_cache: 0.21
+        cache_read: 0.105
+      output_tokens:
+        text: 0.315
+  - id: deepseek/deepseek-v4-flash
+    provider_model_id: deepseek/deepseek-v4-flash
+    pricing:
+      input_tokens:
+        no_cache: 0.09
+        cache_read: 0.02
+      output_tokens:
+        text: 0.18
+  - id: deepseek/deepseek-v4-pro
+    provider_model_id: deepseek/deepseek-v4-pro
+    pricing:
+      input_tokens:
+        no_cache: 0.435
+        cache_read: 0.003625
+      output_tokens:
+        text: 0.87
+  - id: google/gemini-3.1-flash-lite-preview
+    provider_model_id: google/gemini-3.1-flash-lite-preview
+    pricing:
+      input_tokens:
+        no_cache: 0.25
+        cache_read: 0.025
+      output_tokens:
+        text: 1.5
+  - id: google/gemini-3.1-pro-preview
+    provider_model_id: google/gemini-3.1-pro-preview
+    pricing:
+      input_tokens:
+        no_cache: 2
+        cache_read: 0.2
+      output_tokens:
+        text: 12
+  - id: google/gemini-3.5-flash
+    provider_model_id: google/gemini-3.5-flash
+    pricing:
+      input_tokens:
+        no_cache: 1.5
+        cache_read: 0.15
+      output_tokens:
+        text: 9
+  - id: google/gemma-4-31b
+    provider_model_id: google/gemma-4-31b
+    pricing:
+      input_tokens:
+        no_cache: 0.13
+      output_tokens:
+        text: 0.4
+  - id: inclusionai/ling-2.6-1t
+    provider_model_id: inclusionai/ling-2.6-1t
+    pricing:
+      input_tokens:
+        no_cache: 0.3
+        cache_read: 0.06
+      output_tokens:
+        text: 2.5
+  - id: inclusionai/ling-2.6-flash
+    provider_model_id: inclusionai/ling-2.6-flash
+    pricing:
+      input_tokens:
+        no_cache: 0.1
+        cache_read: 0.02
+      output_tokens:
+        text: 0.3
+  - id: inclusionai/ring-2.6-1t
+    provider_model_id: inclusionai/ring-2.6-1t
+    pricing:
+      input_tokens:
+        no_cache: 0.3
+        cache_read: 0.06
+      output_tokens:
+        text: 2.5
+  - id: minimax/minimax-m2.5
+    provider_model_id: minimax/minimax-m2.5
+    pricing:
+      input_tokens:
+        no_cache: 0.15
+        cache_read: 0.05
+      output_tokens:
+        text: 0.9
+  - id: minimax/minimax-m2.7
+    provider_model_id: minimax/minimax-m2.7
+    pricing:
+      input_tokens:
+        no_cache: 0.225
+        cache_read: 0.045
+        cache_write: 0.28125
+      output_tokens:
+        text: 0.9
+  - id: minimax/minimax-m3
+    provider_model_id: minimax/minimax-m3
+    pricing:
+      input_tokens:
+        no_cache: 0.3
+        cache_read: 0.06
+      output_tokens:
+        text: 1.2
+  - id: moonshotai/kimi-k2.5
+    provider_model_id: moonshotai/kimi-k2.5
+    pricing:
+      input_tokens:
+        no_cache: 0.375
+      output_tokens:
+        text: 2.025
+  - id: moonshotai/kimi-k2.6
+    provider_model_id: moonshotai/kimi-k2.6
+    pricing:
+      input_tokens:
+        no_cache: 0.7125
+        cache_read: 0.12
+      output_tokens:
+        text: 3
+  - id: moonshotai/kimi-k2.7-code
+    provider_model_id: moonshotai/kimi-k2.7-code
+    pricing:
+      input_tokens:
+        no_cache: 0.612
+        cache_read: 0.1296
+      output_tokens:
+        text: 3.069
+  - id: openai/gpt-5.4
+    provider_model_id: openai/gpt-5.4
+    pricing:
+      input_tokens:
+        no_cache: 2.5
+        cache_read: 0.25
+      output_tokens:
+        text: 15
+  - id: openai/gpt-5.4-mini
+    provider_model_id: openai/gpt-5.4-mini
+    pricing:
+      input_tokens:
+        no_cache: 0.75
+        cache_read: 0.075
+      output_tokens:
+        text: 4.5
+  - id: openai/gpt-5.5
+    provider_model_id: openai/gpt-5.5
+    pricing:
+      input_tokens:
+        no_cache: 5
+        cache_read: 0.5
+      output_tokens:
+        text: 30
+  - id: qwen/qwen3.5-122b-a10b
+    provider_model_id: qwen/qwen3.5-122b-a10b
+    pricing:
+      input_tokens:
+        no_cache: 0.26
+      output_tokens:
+        text: 2.08
+  - id: qwen/qwen3.5-27b
+    provider_model_id: qwen/qwen3.5-27b
+    pricing:
+      input_tokens:
+        no_cache: 0.25
+      output_tokens:
+        text: 2
+  - id: qwen/qwen3.6-27b
+    provider_model_id: qwen/qwen3.6-27b
+    pricing:
+      input_tokens:
+        no_cache: 0.3
+      output_tokens:
+        text: 3.2
+  - id: qwen/qwen3.6-35b-a3b
+    provider_model_id: qwen/qwen3.6-35b-a3b
+    pricing:
+      input_tokens:
+        no_cache: 0.2
+      output_tokens:
+        text: 1.6
+  - id: qwen/qwen3.6-flash
+    provider_model_id: qwen/qwen3.6-flash
+    pricing:
+      input_tokens:
+        no_cache: 0.165
+      output_tokens:
+        text: 0.99
+  - id: qwen/qwen3.7-max
+    provider_model_id: qwen/qwen3.7-max
+    pricing:
+      input_tokens:
+        no_cache: 1.25
+        cache_read: 0.25
+        cache_write: 1.5625
+      output_tokens:
+        text: 3.75
+  - id: qwen/qwen3.7-plus
+    provider_model_id: qwen/qwen3.7-plus
+    pricing:
+      input_tokens:
+        no_cache: 0.276
+      output_tokens:
+        text: 1.101
+  - id: stepfun/step-3.5-flash
+    provider_model_id: stepfun/step-3.5-flash
+    pricing:
+      input_tokens:
+        no_cache: 0.072
+        cache_read: 0.01425
+      output_tokens:
+        text: 0.216
+  - id: stepfun/step-3.7-flash
+    provider_model_id: stepfun/step-3.7-flash
+    pricing:
+      input_tokens:
+        no_cache: 0.15
+        cache_read: 0.03
+      output_tokens:
+        text: 0.8625
+  - id: tencent/hy3
+    provider_model_id: tencent/hy3
+    pricing:
+      input_tokens:
+        no_cache: 0.066
+        cache_read: 0.029
+      output_tokens:
+        text: 0.26
+  - id: x-ai/grok-4.20
+    provider_model_id: x-ai/grok-4.20
+    pricing:
+      input_tokens:
+        no_cache: 1.25
+        cache_read: 0.2
+      output_tokens:
+        text: 2.5
+  - id: x-ai/grok-4.20-multi-agent
+    provider_model_id: x-ai/grok-4.20-multi-agent
+    pricing:
+      input_tokens:
+        no_cache: 1.25
+        cache_read: 0.2
+      output_tokens:
+        text: 2.5
+  - id: x-ai/grok-4.3
+    provider_model_id: x-ai/grok-4.3
+    pricing:
+      input_tokens:
+        no_cache: 1.25
+        cache_read: 0.2
+      output_tokens:
+        text: 2.5
+  - id: x-ai/grok-build-0.1
+    provider_model_id: x-ai/grok-build-0.1
+    pricing:
+      input_tokens:
+        no_cache: 1
+        cache_read: 0.2
+      output_tokens:
+        text: 2
+  - id: xiaomi/mimo-v2.5
+    provider_model_id: xiaomi/mimo-v2.5
+    pricing:
+      input_tokens:
+        no_cache: 0.14
+        cache_read: 0.0028
+      output_tokens:
+        text: 0.28
+  - id: xiaomi/mimo-v2.5-pro
+    provider_model_id: xiaomi/mimo-v2.5-pro
+    pricing:
+      input_tokens:
+        no_cache: 0.435
+        cache_read: 0.0036
+      output_tokens:
+        text: 0.87
+  - id: z-ai/glm-4.7
+    provider_model_id: z-ai/glm-4.7
+    pricing:
+      input_tokens:
+        no_cache: 0.6
+        cache_read: 0.11
+      output_tokens:
+        text: 2.2
+  - id: z-ai/glm-5
+    provider_model_id: z-ai/glm-5
+    pricing:
+      input_tokens:
+        no_cache: 0.6
+        cache_read: 0.12
+      output_tokens:
+        text: 1.92
+  - id: z-ai/glm-5.1
+    provider_model_id: z-ai/glm-5.1
+    pricing:
+      input_tokens:
+        no_cache: 0.98
+        cache_read: 0.182
+      output_tokens:
+        text: 3.08
+  - id: z-ai/glm-5.2
+    provider_model_id: z-ai/glm-5.2
+    pricing:
+      input_tokens:
+        no_cache: 0.979
+        cache_read: 0.182
+      output_tokens:
+        text: 3.08
 status: active
 weight: 1
 community: false

--- a/registry/providers/cerebras.yaml
+++ b/registry/providers/cerebras.yaml
@@ -24,6 +24,22 @@ models:
       - reasoning
       - structured_outputs
       - tools
+  - id: google/gemma-4-31b
+    provider_model_id: gemma-4-31b
+    pricing:
+      input_tokens:
+        no_cache: 0.99
+      output_tokens:
+        text: 1.49
+  - id: z-ai/glm-4.7
+    provider_model_id: zai-glm-4.7
+    pricing:
+      input_tokens:
+        no_cache: 2.25
+        cache_read: 0
+        cache_write: 0
+      output_tokens:
+        text: 2.75
 status: active
 weight: 1
 submitted_at: 2026-06-16

--- a/registry/providers/claude-code.yaml
+++ b/registry/providers/claude-code.yaml
@@ -63,3 +63,6 @@ auth_scheme: x-api-key
 auth:
   kind: oauth
   handler: anthropic
+auto_sync:
+  feed: models_dev
+  key: anthropic

--- a/registry/providers/github-copilot.yaml
+++ b/registry/providers/github-copilot.yaml
@@ -49,6 +49,8 @@ models:
     provider_model_id: gpt-5.5
   - id: moonshotai/kimi-k2.7-code
     provider_model_id: kimi-k2.7-code
+  - id: anthropic/claude-sonnet-5
+    provider_model_id: claude-sonnet-5
 status: active
 weight: 1
 community: false

--- a/registry/providers/google-ai.yaml
+++ b/registry/providers/google-ai.yaml
@@ -43,3 +43,6 @@ status: active
 auth:
   kind: oauth
   handler: google-ai
+auto_sync:
+  feed: models_dev
+  key: google

--- a/registry/providers/minimax_cn.yaml
+++ b/registry/providers/minimax_cn.yaml
@@ -55,3 +55,4 @@ api_base: https://api.minimaxi.com/anthropic/v1
 auth_scheme: x-api-key
 auto_sync:
   feed: models_dev
+  key: minimax-cn

--- a/registry/providers/openai-codex.yaml
+++ b/registry/providers/openai-codex.yaml
@@ -12,8 +12,10 @@
 # - https://github.com/sst/opencode/blob/dev/packages/opencode/src/plugin/codex.ts
 #
 # Codex speaks the Responses API exclusively. The explicit model entries are listed
-# below (no per-token `pricing` — it's a flat-rate subscription); the
-# backend's FULL catalog is still pulled at runtime via `auto_sync: v1_models`.
+# below (no per-token `pricing` — it's a flat-rate subscription). Keep this on
+# models.dev's `openai` catalog; do not wire `auto_sync: v1_models` here: the
+# backend `/models` endpoint requires the user's OAuth credential and is not a
+# public catalog endpoint.
 # `access: local_pkce` — credentials come from the local OAuth+PKCE flow against
 # the user's ChatGPT subscription, so there is no portable key to BYOK.
 name: openai-codex
@@ -56,4 +58,5 @@ models:
     capabilities: [reasoning, tools]
 status: active
 auto_sync:
-  feed: v1_models
+  feed: models_dev
+  key: openai

--- a/registry/providers/opencode-zen.yaml
+++ b/registry/providers/opencode-zen.yaml
@@ -216,6 +216,23 @@ models:
         cache_read: 0.2
       output_tokens:
         text: 2
+  - id: anthropic/claude-sonnet-5
+    provider_model_id: claude-sonnet-5
+    pricing:
+      input_tokens:
+        no_cache: 2
+        cache_read: 0.2
+        cache_write: 2.5
+      output_tokens:
+        text: 10
+  - id: z-ai/glm-4.7
+    provider_model_id: glm-4.7
+    pricing:
+      input_tokens:
+        no_cache: 0.6
+        cache_read: 0.1
+      output_tokens:
+        text: 2.2
 status: active
 weight: 1
 community: false

--- a/registry/providers/openrouter.yaml
+++ b/registry/providers/openrouter.yaml
@@ -338,6 +338,107 @@ models:
         cache_read: 0.2
       output_tokens:
         text: 2
+  - id: anthropic/claude-sonnet-5
+    provider_model_id: anthropic/claude-sonnet-5
+    pricing:
+      input_tokens:
+        no_cache: 2
+        cache_read: 0.2
+        cache_write: 2.5
+      output_tokens:
+        text: 10
+  - id: inclusionai/ling-2.6-1t
+    provider_model_id: inclusionai/ling-2.6-1t
+    pricing:
+      input_tokens:
+        no_cache: 0.075
+        cache_read: 0.015
+      output_tokens:
+        text: 0.625
+  - id: inclusionai/ling-2.6-flash
+    provider_model_id: inclusionai/ling-2.6-flash
+    pricing:
+      input_tokens:
+        no_cache: 0.01
+        cache_read: 0.002
+      output_tokens:
+        text: 0.03
+  - id: inclusionai/ring-2.6-1t
+    provider_model_id: inclusionai/ring-2.6-1t
+    pricing:
+      input_tokens:
+        no_cache: 0.075
+        cache_read: 0.015
+      output_tokens:
+        text: 0.625
+  - id: nex-agi/nex-n2-pro
+    provider_model_id: nex-agi/nex-n2-pro
+    pricing:
+      input_tokens:
+        no_cache: 0.25
+        cache_read: 0.025
+      output_tokens:
+        text: 1
+  - id: nvidia/nemotron-3-super-120b-a12b
+    provider_model_id: nvidia/nemotron-3-super-120b-a12b
+    pricing:
+      input_tokens:
+        no_cache: 0.08
+      output_tokens:
+        text: 0.45
+  - id: nvidia/nemotron-3-ultra-550b-a55b
+    provider_model_id: nvidia/nemotron-3-ultra-550b-a55b
+    pricing:
+      input_tokens:
+        no_cache: 0.5
+        cache_read: 0.1
+      output_tokens:
+        text: 2.2
+  - id: qwen/qwen3.5-122b-a10b
+    provider_model_id: qwen/qwen3.5-122b-a10b
+    pricing:
+      input_tokens:
+        no_cache: 0.26
+      output_tokens:
+        text: 2.08
+  - id: qwen/qwen3.5-27b
+    provider_model_id: qwen/qwen3.5-27b
+    pricing:
+      input_tokens:
+        no_cache: 0.195
+      output_tokens:
+        text: 1.56
+  - id: qwen/qwen3.6-27b
+    provider_model_id: qwen/qwen3.6-27b
+    pricing:
+      input_tokens:
+        no_cache: 0.285
+        cache_read: 0.15
+      output_tokens:
+        text: 2.4
+  - id: qwen/qwen3.6-35b-a3b
+    provider_model_id: qwen/qwen3.6-35b-a3b
+    pricing:
+      input_tokens:
+        no_cache: 0.14
+      output_tokens:
+        text: 1
+  - id: tencent/hy3
+    provider_model_id: tencent/hy3
+    pricing:
+      input_tokens:
+        no_cache: 0.2
+        cache_read: 0.5
+      output_tokens:
+        text: 0.8
+  - id: z-ai/glm-4.7
+    provider_model_id: z-ai/glm-4.7
+    pricing:
+      input_tokens:
+        no_cache: 0.4
+        cache_read: 0.08
+      output_tokens:
+        text: 1.75
 status: active
 weight: 1
 community: false

--- a/registry/providers/stepfun_cn.yaml
+++ b/registry/providers/stepfun_cn.yaml
@@ -44,4 +44,4 @@ weight: 1
 submitted_at: 2026-06-01
 auto_sync:
   feed: models_dev
-  key: stepfun-cn
+  key: stepfun

--- a/registry/providers/stepfun_step_plan.yaml
+++ b/registry/providers/stepfun_step_plan.yaml
@@ -29,3 +29,6 @@ status: active
 weight: 1
 submitted_at: 2026-07-06
 auth_scheme: x-api-key
+auto_sync:
+  feed: models_dev
+  key: stepfun-ai

--- a/registry/providers/stepfun_step_plan_cn.yaml
+++ b/registry/providers/stepfun_step_plan_cn.yaml
@@ -29,3 +29,6 @@ status: active
 weight: 1
 submitted_at: 2026-07-06
 auth_scheme: x-api-key
+auto_sync:
+  feed: models_dev
+  key: stepfun

--- a/registry/providers/supergrok.yaml
+++ b/registry/providers/supergrok.yaml
@@ -46,3 +46,6 @@ status: active
 auth:
   kind: oauth
   handler: supergrok
+auto_sync:
+  feed: models_dev
+  key: xai

--- a/registry/providers/tencent_cn.yaml
+++ b/registry/providers/tencent_cn.yaml
@@ -11,8 +11,8 @@ metadata:
 # Tencent Cloud "TokenHub" China (Guangzhou station) — an OpenAI-
 # compatible model marketplace re-serving DeepSeek / GLM / Kimi / MiniMax.
 # Bearer-token auth (OpenAI transport). Prices below are the Guangzhou-station
-# USD-per-1M-token rates. Manual provider (no auto_sync): TokenHub's catalog is
-# recorded here from the vendor's published model + price list.
+# USD-per-1M-token rates. Refreshed by models.dev's `tencent-tokenhub` catalog;
+# manually keep provider extras that are absent from that feed.
 # Official: https://cloud.tencent.com/ (TI / MaaS TokenHub)
 api_protocol:
   - minimax/minimax-m3: [openai, responses, anthropic]
@@ -157,6 +157,18 @@ models:
     capabilities:
       - reasoning
       - tools
+  - id: tencent/hy3
+    provider_model_id: hy3
+    pricing:
+      input_tokens:
+        no_cache: 0
+        cache_read: 0
+        cache_write: 0
+      output_tokens:
+        text: 0
 status: active
 weight: 1
 submitted_at: 2026-05-23
+auto_sync:
+  feed: models_dev
+  key: tencent-tokenhub

--- a/registry/providers/tinfoil.yaml
+++ b/registry/providers/tinfoil.yaml
@@ -46,8 +46,24 @@ models:
       - reasoning
       - structured_outputs
       - tools
+  - id: google/gemma-4-31b
+    provider_model_id: gemma4-31b
+    pricing:
+      input_tokens:
+        no_cache: 0.4
+      output_tokens:
+        text: 1
+  - id: z-ai/glm-5.2
+    provider_model_id: glm-5-2
+    pricing:
+      input_tokens:
+        no_cache: 1.5
+      output_tokens:
+        text: 5.25
 status: active
 weight: 1
 submitted_at: 2026-05-12
 auth_scheme: x-api-key
 community: true
+auto_sync:
+  feed: models_dev

--- a/registry/providers/xiaomi_token_plan.yaml
+++ b/registry/providers/xiaomi_token_plan.yaml
@@ -32,3 +32,6 @@ status: active
 weight: 1
 submitted_at: 2026-07-06
 auth_scheme: x-api-key
+auto_sync:
+  feed: models_dev
+  key: xiaomi-token-plan-sgp

--- a/registry/providers/xiaomi_token_plan_cn.yaml
+++ b/registry/providers/xiaomi_token_plan_cn.yaml
@@ -32,3 +32,6 @@ status: active
 weight: 1
 submitted_at: 2026-07-06
 auth_scheme: x-api-key
+auto_sync:
+  feed: models_dev
+  key: xiaomi-token-plan-cn

--- a/registry/providers/xiaomi_token_plan_eu.yaml
+++ b/registry/providers/xiaomi_token_plan_eu.yaml
@@ -32,3 +32,6 @@ status: active
 weight: 1
 submitted_at: 2026-07-06
 auth_scheme: x-api-key
+auto_sync:
+  feed: models_dev
+  key: xiaomi-token-plan-ams

--- a/registry/providers/zai.yaml
+++ b/registry/providers/zai.yaml
@@ -44,6 +44,15 @@ models:
     capabilities:
       - reasoning
       - tools
+  - id: z-ai/glm-4.7
+    provider_model_id: glm-4.7
+    pricing:
+      input_tokens:
+        no_cache: 0.6
+        cache_read: 0.11
+        cache_write: 0
+      output_tokens:
+        text: 2.2
 status: active
 weight: 1
 submitted_at: 2026-05-25

--- a/registry/providers/zai_coding_plan.yaml
+++ b/registry/providers/zai_coding_plan.yaml
@@ -27,6 +27,8 @@ models:
     capabilities:
       - reasoning
       - tools
+  - id: z-ai/glm-4.7
+    provider_model_id: glm-4.7
 status: active
 weight: 1
 submitted_at: 2026-06-05
@@ -34,3 +36,4 @@ api_base: https://api.z.ai/api/coding/paas/v4
 auth_scheme: x-api-key
 auto_sync:
   feed: models_dev
+  key: zai-coding-plan


### PR DESCRIPTION
## Summary

- Sync provider registry model catalogs and regenerate dist registry artifacts.
- Fix `v1_models` sync so it only reads public `/models` catalogs, copies pricing for usage-token providers, and skips usage-token models without pricing.
- Move `openai-codex` off credentialed `v1_models` and onto models.dev's `openai` catalog; add missing models.dev feed mappings for subscription and token-plan providers.
- Verify and activate Atlas Cloud, StreamLake, Baidu Qianfan international/China, Phala, and RedPill provider entries; GMI Cloud, SiliconFlow, and Alibaba SG remain active via models.dev-backed catalogs.
- Add `redpill` as the RedPill/Phala Network OpenAI-compatible endpoint at `https://api.redpill.ai/v1`.

## Root Cause

Several providers had live models.dev entries but no `models_dev` feed mapping, while `openai-codex` had previously been treated like a public `/v1/models` provider even though its backend catalog requires user OAuth. The `v1_models` helper also reused runtime auth semantics and did not preserve pricing from public catalogs.

The activation audit also found stale staging data:

- Atlas Cloud had a stale `z-ai/glm-5.1` price and a model no longer present in the live public `/v1/models` response.
- StreamLake pricing/base URL had drifted from the current Vanchin docs.
- Baidu Qianfan international had outdated ERNIE-only entries even though its public `/v1/models` now exposes a current catalog.
- Baidu Qianfan China needed to align with the official auth-gated `/v2/models` documentation.

## Evidence

- `https://models.dev/api.json`: GMI Cloud, SiliconFlow, and Alibaba SG catalog/pricing feeds.
- `https://api.atlascloud.ai/v1/models`: public Atlas Cloud model IDs and pricing.
- `https://www.streamlake.ai/document/DOC/mgrnm4xm362hvp5wyce`: StreamLake pricing.
- `https://www.streamlake.ai/document/DOC/mg6k6nlp8j6qxicx4c9`: StreamLake OpenAI-compatible base URLs.
- `https://api.baiduqianfan.ai/v1/models`: public Baidu Qianfan international model IDs and pricing.
- `https://cloud.baidu.com/doc/qianfan-api/s/Dmba8k71y`: Baidu Qianfan China auth-gated `/v2/models` docs and sample pricing response.
- `https://inference.phala.com/v1/models`: public Phala model IDs and pricing.
- `https://api.redpill.ai/v1/models`: public RedPill model IDs and pricing.

## Validation

- `cargo run -p dist-helper -- registry sync --write`
- `cargo run -p dist-helper -- registry build`
- `cargo test -p dist-helper`
- `cargo run -p dist-helper -- check`
- `cargo fmt --check`
- `git diff --check`

Live catalog audit after the sync changes: `models_dev=39`, `v1_models=1` (`bitrouter`), `agentic=0`, `models_dev_missing=0`.

Activation audit after provider updates: target providers are active; Atlas/Qianfan/Phala/RedPill provider model IDs all matched their live catalogs with `missing=0`.