### PR TITLE
feat: verify and activate provider registry entries

### DIFF
--- a/dist/registry/models.json
+++ b/dist/registry/models.json
@@ -807,6 +807,7 @@
           "api_protocol": "openai",
           "pricing": {
             "input_tokens": {
+              "cache_read": 0.13,
               "no_cache": 0.26
             },
             "output_tokens": {
@@ -885,6 +886,20 @@
         {
           "api_protocol": "openai",
           "pricing": {
+            "input_tokens": {
+              "cache_read": 0.0252,
+              "no_cache": 0.252
+            },
+            "output_tokens": {
+              "text": 0.378
+            }
+          },
+          "provider": "qianfan",
+          "provider_model_id": "deepseek-v3.2"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
             "context_tiers": [
               {
                 "above_input_tokens": 32000,
@@ -897,7 +912,6 @@
               }
             ],
             "input_tokens": {
-              "cache_read": 0.056,
               "no_cache": 0.28
             },
             "output_tokens": {
@@ -1026,6 +1040,7 @@
           "api_protocol": "openai",
           "pricing": {
             "input_tokens": {
+              "cache_read": 0.028,
               "no_cache": 0.14
             },
             "output_tokens": {
@@ -1159,6 +1174,50 @@
           "api_protocol": "openai",
           "pricing": {
             "input_tokens": {
+              "cache_read": 0.0197,
+              "no_cache": 0.0983
+            },
+            "output_tokens": {
+              "text": 0.1966
+            }
+          },
+          "provider": "qianfan",
+          "provider_model_id": "deepseek-v4-flash"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider": "qianfan_cn",
+          "provider_model_id": "deepseek-v4-flash"
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.2
+            },
+            "output_tokens": {
+              "text": 0.4
+            }
+          },
+          "provider": "redpill",
+          "provider_model_id": "deepseek/deepseek-v4-flash"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
               "cache_read": 0.028,
               "no_cache": 0.14
             },
@@ -1274,6 +1333,7 @@
           "api_protocol": "openai",
           "pricing": {
             "input_tokens": {
+              "cache_read": 0.13,
               "no_cache": 1.68
             },
             "output_tokens": {
@@ -1407,7 +1467,20 @@
           "api_protocol": "openai",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.139,
+              "cache_read": 0.063,
+              "no_cache": 0.7605
+            },
+            "output_tokens": {
+              "text": 1.521
+            }
+          },
+          "provider": "qianfan",
+          "provider_model_id": "deepseek-v4-pro"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
               "no_cache": 1.67
             },
             "output_tokens": {
@@ -1416,6 +1489,23 @@
           },
           "provider": "qianfan_cn",
           "provider_model_id": "deepseek-v4-pro"
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 1.5
+            },
+            "output_tokens": {
+              "text": 5.25
+            }
+          },
+          "provider": "redpill",
+          "provider_model_id": "deepseek/deepseek-v4-pro"
         },
         {
           "api_protocol": "openai",
@@ -2129,6 +2219,7 @@
           "api_protocol": "openai",
           "pricing": {
             "input_tokens": {
+              "cache_read": 0.06,
               "no_cache": 0.295
             },
             "output_tokens": {
@@ -2273,6 +2364,19 @@
           },
           "provider": "openrouter",
           "provider_model_id": "minimax/minimax-m2.5"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.29
+            },
+            "output_tokens": {
+              "text": 1.17
+            }
+          },
+          "provider": "qianfan_cn",
+          "provider_model_id": "minimax-m2.5"
         },
         {
           "api_protocol": "openai",
@@ -2572,7 +2676,20 @@
         {
           "api_protocol": "openai",
           "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 512000,
+                "input_tokens": {
+                  "cache_read": 0.12,
+                  "no_cache": 0.6
+                },
+                "output_tokens": {
+                  "text": 2.4
+                }
+              }
+            ],
             "input_tokens": {
+              "cache_read": 0.06,
               "no_cache": 0.3
             },
             "output_tokens": {
@@ -2798,6 +2915,7 @@
           "api_protocol": "openai",
           "pricing": {
             "input_tokens": {
+              "cache_read": 0.2,
               "no_cache": 0.49
             },
             "output_tokens": {
@@ -2915,6 +3033,19 @@
           },
           "provider": "openrouter",
           "provider_model_id": "moonshotai/kimi-k2.5"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.56
+            },
+            "output_tokens": {
+              "text": 2.92
+            }
+          },
+          "provider": "qianfan_cn",
+          "provider_model_id": "kimi-k2.5"
         },
         {
           "api_protocol": "openai",
@@ -3051,6 +3182,7 @@
           "api_protocol": "openai",
           "pricing": {
             "input_tokens": {
+              "cache_read": 0.16,
               "no_cache": 0.95
             },
             "output_tokens": {
@@ -3205,6 +3337,7 @@
           ],
           "pricing": {
             "input_tokens": {
+              "cache_read": 0.37,
               "no_cache": 1.09
             },
             "output_tokens": {
@@ -3218,15 +3351,33 @@
           "api_protocol": "openai",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.153,
-              "no_cache": 0.9
+              "cache_read": 0.144,
+              "no_cache": 0.684
             },
             "output_tokens": {
-              "text": 3.75
+              "text": 3.42
             }
           },
-          "provider": "qianfan_cn",
+          "provider": "qianfan",
           "provider_model_id": "kimi-k2.6"
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.37,
+              "no_cache": 1.09
+            },
+            "output_tokens": {
+              "text": 4.6
+            }
+          },
+          "provider": "redpill",
+          "provider_model_id": "moonshotai/kimi-k2.6"
         },
         {
           "api_protocol": "openai",
@@ -3369,6 +3520,7 @@
           "api_protocol": "openai",
           "pricing": {
             "input_tokens": {
+              "cache_read": 0.16,
               "no_cache": 0.95
             },
             "output_tokens": {
@@ -4484,6 +4636,7 @@
           "api_protocol": "openai",
           "pricing": {
             "input_tokens": {
+              "cache_read": 0.5,
               "no_cache": 2.5
             },
             "output_tokens": {
@@ -4652,7 +4805,20 @@
         {
           "api_protocol": "openai",
           "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 262144,
+                "input_tokens": {
+                  "cache_read": 0.24,
+                  "no_cache": 1.2
+                },
+                "output_tokens": {
+                  "text": 4.8
+                }
+              }
+            ],
             "input_tokens": {
+              "cache_read": 0.08,
               "no_cache": 0.4
             },
             "output_tokens": {
@@ -5027,6 +5193,20 @@
           "api_protocol": "openai",
           "pricing": {
             "input_tokens": {
+              "cache_read": 0.0261,
+              "no_cache": 0.066
+            },
+            "output_tokens": {
+              "text": 0.26
+            }
+          },
+          "provider": "qianfan",
+          "provider_model_id": "hy3-preview"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
               "cache_read": 0.029,
               "no_cache": 0.066
             },
@@ -5247,7 +5427,20 @@
         {
           "api_protocol": "openai",
           "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 200000,
+                "input_tokens": {
+                  "cache_read": 0.4,
+                  "no_cache": 2.5
+                },
+                "output_tokens": {
+                  "text": 5.0
+                }
+              }
+            ],
             "input_tokens": {
+              "cache_read": 0.2,
               "no_cache": 1.25
             },
             "output_tokens": {
@@ -5961,6 +6154,20 @@
           "api_protocol": "openai",
           "pricing": {
             "input_tokens": {
+              "cache_read": 0.14,
+              "no_cache": 0.7
+            },
+            "output_tokens": {
+              "text": 2.24
+            }
+          },
+          "provider": "qianfan",
+          "provider_model_id": "glm-5"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
               "no_cache": 0.95
             },
             "output_tokens": {
@@ -6115,10 +6322,11 @@
           "api_protocol": "openai",
           "pricing": {
             "input_tokens": {
-              "no_cache": 0.95
+              "cache_read": 0.234,
+              "no_cache": 1.26
             },
             "output_tokens": {
-              "text": 3.15
+              "text": 3.96
             }
           },
           "provider": "atlascloud",
@@ -6232,6 +6440,7 @@
           ],
           "pricing": {
             "input_tokens": {
+              "cache_read": 0.6,
               "no_cache": 1.21
             },
             "output_tokens": {
@@ -6239,6 +6448,62 @@
             }
           },
           "provider": "phala",
+          "provider_model_id": "z-ai/glm-5.1"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.182,
+              "no_cache": 0.98
+            },
+            "output_tokens": {
+              "text": 3.08
+            }
+          },
+          "provider": "qianfan",
+          "provider_model_id": "glm-5.1"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 32000,
+                "input_tokens": {
+                  "no_cache": 1.11
+                },
+                "output_tokens": {
+                  "text": 3.89
+                }
+              }
+            ],
+            "input_tokens": {
+              "no_cache": 0.83
+            },
+            "output_tokens": {
+              "text": 3.33
+            }
+          },
+          "provider": "qianfan_cn",
+          "provider_model_id": "glm-5.1"
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.6,
+              "no_cache": 1.21
+            },
+            "output_tokens": {
+              "text": 4.2
+            }
+          },
+          "provider": "redpill",
           "provider_model_id": "z-ai/glm-5.1"
         },
         {
@@ -6418,10 +6683,11 @@
           "api_protocol": "openai",
           "pricing": {
             "input_tokens": {
-              "no_cache": 1.26
+              "cache_read": 0.26,
+              "no_cache": 1.4
             },
             "output_tokens": {
-              "text": 3.96
+              "text": 4.4
             }
           },
           "provider": "atlascloud",
@@ -6514,6 +6780,7 @@
           ],
           "pricing": {
             "input_tokens": {
+              "cache_read": 0.7,
               "no_cache": 1.4
             },
             "output_tokens": {
@@ -6521,6 +6788,38 @@
             }
           },
           "provider": "phala",
+          "provider_model_id": "z-ai/glm-5.2"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.208,
+              "no_cache": 1.12
+            },
+            "output_tokens": {
+              "text": 3.96
+            }
+          },
+          "provider": "qianfan",
+          "provider_model_id": "glm-5.2"
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.7,
+              "no_cache": 1.4
+            },
+            "output_tokens": {
+              "text": 4.4
+            }
+          },
+          "provider": "redpill",
           "provider_model_id": "z-ai/glm-5.2"
         },
         {

--- a/dist/registry/providers.json
+++ b/dist/registry/providers.json
@@ -939,7 +939,7 @@
     {
       "access": "api_key",
       "api_base": "https://api.atlascloud.ai/v1",
-      "auth_scheme": "x-api-key",
+      "auth_scheme": "bearer",
       "billing": "usage_token",
       "byok": true,
       "community": false,
@@ -962,6 +962,7 @@
           "id": "qwen/qwen3.7-max",
           "pricing": {
             "input_tokens": {
+              "cache_read": 0.5,
               "no_cache": 2.5
             },
             "output_tokens": {
@@ -974,7 +975,20 @@
           "api_protocol": "openai",
           "id": "qwen/qwen3.7-plus",
           "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 262144,
+                "input_tokens": {
+                  "cache_read": 0.24,
+                  "no_cache": 1.2
+                },
+                "output_tokens": {
+                  "text": 4.8
+                }
+              }
+            ],
             "input_tokens": {
+              "cache_read": 0.08,
               "no_cache": 0.4
             },
             "output_tokens": {
@@ -988,6 +1002,7 @@
           "id": "deepseek/deepseek-v4-pro",
           "pricing": {
             "input_tokens": {
+              "cache_read": 0.13,
               "no_cache": 1.68
             },
             "output_tokens": {
@@ -1001,6 +1016,7 @@
           "id": "deepseek/deepseek-v4-flash",
           "pricing": {
             "input_tokens": {
+              "cache_read": 0.028,
               "no_cache": 0.14
             },
             "output_tokens": {
@@ -1014,6 +1030,7 @@
           "id": "deepseek/deepseek-v3.2",
           "pricing": {
             "input_tokens": {
+              "cache_read": 0.13,
               "no_cache": 0.26
             },
             "output_tokens": {
@@ -1027,6 +1044,7 @@
           "id": "moonshotai/kimi-k2.5",
           "pricing": {
             "input_tokens": {
+              "cache_read": 0.2,
               "no_cache": 0.49
             },
             "output_tokens": {
@@ -1040,6 +1058,7 @@
           "id": "moonshotai/kimi-k2.6",
           "pricing": {
             "input_tokens": {
+              "cache_read": 0.16,
               "no_cache": 0.95
             },
             "output_tokens": {
@@ -1053,6 +1072,7 @@
           "id": "moonshotai/kimi-k2.7-code",
           "pricing": {
             "input_tokens": {
+              "cache_read": 0.16,
               "no_cache": 0.95
             },
             "output_tokens": {
@@ -1066,6 +1086,7 @@
           "id": "minimax/minimax-m2.5",
           "pricing": {
             "input_tokens": {
+              "cache_read": 0.06,
               "no_cache": 0.295
             },
             "output_tokens": {
@@ -1078,7 +1099,20 @@
           "api_protocol": "openai",
           "id": "minimax/minimax-m3",
           "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 512000,
+                "input_tokens": {
+                  "cache_read": 0.12,
+                  "no_cache": 0.6
+                },
+                "output_tokens": {
+                  "text": 2.4
+                }
+              }
+            ],
             "input_tokens": {
+              "cache_read": 0.06,
               "no_cache": 0.3
             },
             "output_tokens": {
@@ -1092,10 +1126,11 @@
           "id": "z-ai/glm-5.1",
           "pricing": {
             "input_tokens": {
-              "no_cache": 0.95
+              "cache_read": 0.234,
+              "no_cache": 1.26
             },
             "output_tokens": {
-              "text": 3.15
+              "text": 3.96
             }
           },
           "provider_model_id": "zai-org/glm-5.1"
@@ -1105,10 +1140,11 @@
           "id": "z-ai/glm-5.2",
           "pricing": {
             "input_tokens": {
-              "no_cache": 1.26
+              "cache_read": 0.26,
+              "no_cache": 1.4
             },
             "output_tokens": {
-              "text": 3.96
+              "text": 4.4
             }
           },
           "provider_model_id": "zai-org/glm-5.2"
@@ -1117,7 +1153,20 @@
           "api_protocol": "openai",
           "id": "x-ai/grok-4.3",
           "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 200000,
+                "input_tokens": {
+                  "cache_read": 0.4,
+                  "no_cache": 2.5
+                },
+                "output_tokens": {
+                  "text": 5.0
+                }
+              }
+            ],
             "input_tokens": {
+              "cache_read": 0.2,
               "no_cache": 1.25
             },
             "output_tokens": {
@@ -1125,26 +1174,13 @@
             }
           },
           "provider_model_id": "xai/grok-4.3"
-        },
-        {
-          "api_protocol": "openai",
-          "id": "openai/gpt-oss-120b",
-          "pricing": {
-            "input_tokens": {
-              "no_cache": 0.03
-            },
-            "output_tokens": {
-              "text": 0.1
-            }
-          },
-          "provider_model_id": "openai/gpt-oss-120b"
         }
       ],
       "name": "atlascloud",
       "required_config": [
         "api_key"
       ],
-      "status": "staging",
+      "status": "active",
       "submitted_at": "2026-07-07",
       "weight": 1.0
     },
@@ -5168,6 +5204,7 @@
           "id": "moonshotai/kimi-k2.6",
           "pricing": {
             "input_tokens": {
+              "cache_read": 0.37,
               "no_cache": 1.09
             },
             "output_tokens": {
@@ -5185,6 +5222,7 @@
           "id": "z-ai/glm-5.1",
           "pricing": {
             "input_tokens": {
+              "cache_read": 0.6,
               "no_cache": 1.21
             },
             "output_tokens": {
@@ -5202,6 +5240,7 @@
           "id": "z-ai/glm-5.2",
           "pricing": {
             "input_tokens": {
+              "cache_read": 0.7,
               "no_cache": 1.4
             },
             "output_tokens": {
@@ -5239,49 +5278,122 @@
       "models": [
         {
           "api_protocol": "openai",
-          "id": "baidu/ernie-4.5",
+          "id": "deepseek/deepseek-v3.2",
           "pricing": {
             "input_tokens": {
-              "no_cache": 0.55
+              "cache_read": 0.0252,
+              "no_cache": 0.252
             },
             "output_tokens": {
-              "text": 2.2
+              "text": 0.378
             }
           },
-          "provider_model_id": "ernie-4.5"
+          "provider_model_id": "deepseek-v3.2"
         },
         {
           "api_protocol": "openai",
-          "id": "baidu/ernie-x1",
+          "id": "deepseek/deepseek-v4-pro",
           "pricing": {
             "input_tokens": {
-              "no_cache": 0.28
+              "cache_read": 0.063,
+              "no_cache": 0.7605
             },
             "output_tokens": {
-              "text": 1.1
+              "text": 1.521
             }
           },
-          "provider_model_id": "ernie-x1"
+          "provider_model_id": "deepseek-v4-pro"
         },
         {
           "api_protocol": "openai",
-          "id": "baidu/ernie-5.1",
+          "id": "deepseek/deepseek-v4-flash",
           "pricing": {
             "input_tokens": {
-              "no_cache": 0.59
+              "cache_read": 0.0197,
+              "no_cache": 0.0983
             },
             "output_tokens": {
-              "text": 2.65
+              "text": 0.1966
             }
           },
-          "provider_model_id": "ernie-5.1"
+          "provider_model_id": "deepseek-v4-flash"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "moonshotai/kimi-k2.6",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.144,
+              "no_cache": 0.684
+            },
+            "output_tokens": {
+              "text": 3.42
+            }
+          },
+          "provider_model_id": "kimi-k2.6"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "z-ai/glm-5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.14,
+              "no_cache": 0.7
+            },
+            "output_tokens": {
+              "text": 2.24
+            }
+          },
+          "provider_model_id": "glm-5"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "z-ai/glm-5.1",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.182,
+              "no_cache": 0.98
+            },
+            "output_tokens": {
+              "text": 3.08
+            }
+          },
+          "provider_model_id": "glm-5.1"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "z-ai/glm-5.2",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.208,
+              "no_cache": 1.12
+            },
+            "output_tokens": {
+              "text": 3.96
+            }
+          },
+          "provider_model_id": "glm-5.2"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "tencent/hy3",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.0261,
+              "no_cache": 0.066
+            },
+            "output_tokens": {
+              "text": 0.26
+            }
+          },
+          "provider_model_id": "hy3-preview"
         }
       ],
       "name": "qianfan",
       "required_config": [
         "api_key"
       ],
-      "status": "staging",
+      "status": "active",
       "submitted_at": "2026-07-07",
       "weight": 1.0
     },
@@ -5312,7 +5424,6 @@
           "id": "deepseek/deepseek-v4-pro",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.139,
               "no_cache": 1.67
             },
             "output_tokens": {
@@ -5320,6 +5431,19 @@
             }
           },
           "provider_model_id": "deepseek-v4-pro"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "deepseek/deepseek-v4-flash",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider_model_id": "deepseek-v4-flash"
         },
         {
           "api_protocol": "openai",
@@ -5337,7 +5461,6 @@
               }
             ],
             "input_tokens": {
-              "cache_read": 0.056,
               "no_cache": 0.28
             },
             "output_tokens": {
@@ -5348,17 +5471,53 @@
         },
         {
           "api_protocol": "openai",
-          "id": "moonshotai/kimi-k2.6",
+          "id": "moonshotai/kimi-k2.5",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.153,
-              "no_cache": 0.9
+              "no_cache": 0.56
             },
             "output_tokens": {
-              "text": 3.75
+              "text": 2.92
             }
           },
-          "provider_model_id": "kimi-k2.6"
+          "provider_model_id": "kimi-k2.5"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "minimax/minimax-m2.5",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.29
+            },
+            "output_tokens": {
+              "text": 1.17
+            }
+          },
+          "provider_model_id": "minimax-m2.5"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "z-ai/glm-5.1",
+          "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 32000,
+                "input_tokens": {
+                  "no_cache": 1.11
+                },
+                "output_tokens": {
+                  "text": 3.89
+                }
+              }
+            ],
+            "input_tokens": {
+              "no_cache": 0.83
+            },
+            "output_tokens": {
+              "text": 3.33
+            }
+          },
+          "provider_model_id": "glm-5.1"
         },
         {
           "api_protocol": "openai",
@@ -5389,7 +5548,6 @@
           "id": "baidu/ernie-4.5-turbo-128k",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.028,
               "no_cache": 0.11
             },
             "output_tokens": {
@@ -5416,8 +5574,124 @@
       "required_config": [
         "api_key"
       ],
-      "status": "staging",
+      "status": "active",
       "submitted_at": "2026-07-07",
+      "weight": 1.0
+    },
+    {
+      "access": "api_key",
+      "api_base": "https://api.redpill.ai/v1",
+      "auth_scheme": "bearer",
+      "billing": "usage_token",
+      "byok": true,
+      "community": false,
+      "display_name": "RedPill (Phala Network)",
+      "doc_url": "https://docs.redpill.ai/get-started/introduction",
+      "id": "redpill",
+      "kind": "gateway",
+      "metadata": {
+        "headquarters": "SG",
+        "name": "RedPill",
+        "privacy_policy_url": "https://redpill.ai/privacy",
+        "slug": "redpill",
+        "terms_of_service_url": "https://redpill.ai/terms"
+      },
+      "models": [
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "deepseek/deepseek-v4-pro",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 1.5
+            },
+            "output_tokens": {
+              "text": 5.25
+            }
+          },
+          "provider_model_id": "deepseek/deepseek-v4-pro"
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "deepseek/deepseek-v4-flash",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.2
+            },
+            "output_tokens": {
+              "text": 0.4
+            }
+          },
+          "provider_model_id": "deepseek/deepseek-v4-flash"
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "moonshotai/kimi-k2.6",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.37,
+              "no_cache": 1.09
+            },
+            "output_tokens": {
+              "text": 4.6
+            }
+          },
+          "provider_model_id": "moonshotai/kimi-k2.6"
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "z-ai/glm-5.1",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.6,
+              "no_cache": 1.21
+            },
+            "output_tokens": {
+              "text": 4.2
+            }
+          },
+          "provider_model_id": "z-ai/glm-5.1"
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "z-ai/glm-5.2",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.7,
+              "no_cache": 1.4
+            },
+            "output_tokens": {
+              "text": 4.4
+            }
+          },
+          "provider_model_id": "z-ai/glm-5.2"
+        }
+      ],
+      "name": "redpill",
+      "required_config": [
+        "api_key"
+      ],
+      "status": "active",
+      "submitted_at": "2026-07-08",
       "weight": 1.0
     },
     {
@@ -6138,7 +6412,7 @@
     },
     {
       "access": "api_key",
-      "api_base": "https://wanqing.streamlakeapi.com/api/gateway/v1/endpoints",
+      "api_base": "https://vanchin.streamlake.ai/api/gateway/v1/endpoints",
       "auth_scheme": "bearer",
       "billing": "usage_token",
       "byok": true,
@@ -6152,6 +6426,7 @@
         ],
         "headquarters": "CN",
         "name": "StreamLake",
+        "privacy_policy_url": "https://www.streamlake.ai/document/DOC/mgkci47q13qr66h9i54",
         "slug": "streamlake",
         "terms_of_service_url": "https://www.streamlake.ai/document/DOC/mgkchnd89grpt1961fw"
       },
@@ -6161,11 +6436,12 @@
           "id": "kwaipilot/kat-coder-pro-v2",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.058,
-              "no_cache": 0.29
+              "cache_read": 0.06,
+              "cache_write": 0.0,
+              "no_cache": 0.3
             },
             "output_tokens": {
-              "text": 1.17
+              "text": 1.2
             }
           },
           "provider_model_id": "kat-coder-pro-v2"
@@ -6175,11 +6451,11 @@
           "id": "kwaipilot/kat-coder-pro-v2.5",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.139,
-              "no_cache": 0.69
+              "cache_read": 0.15,
+              "no_cache": 0.74
             },
             "output_tokens": {
-              "text": 2.78
+              "text": 2.96
             }
           },
           "provider_model_id": "kat-coder-pro-v2.5"
@@ -6189,11 +6465,11 @@
           "id": "kwaipilot/kat-coder-air-v2.5",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.028,
-              "no_cache": 0.14
+              "cache_read": 0.03,
+              "no_cache": 0.15
             },
             "output_tokens": {
-              "text": 0.56
+              "text": 0.6
             }
           },
           "provider_model_id": "kat-coder-air-v2.5"
@@ -6203,7 +6479,7 @@
       "required_config": [
         "api_key"
       ],
-      "status": "staging",
+      "status": "active",
       "submitted_at": "2026-07-07",
       "weight": 1.0
     },

--- a/registry/providers/atlascloud.yaml
+++ b/registry/providers/atlascloud.yaml
@@ -1,14 +1,8 @@
-# SCAFFOLD — UNVERIFIED. status: staging (does not route until a human verifies
-# and flips to active). Researched 2026-07 from https://www.atlascloud.ai/ docs +
-# collection/provider/model pages. OpenAI-compatible aggregator; native USD
-# pricing per 1M tokens.
-# VERIFY BEFORE ACTIVATING:
-#   - Ground truth for served model ids is `GET https://api.atlascloud.ai/v1/models`
-#     (authenticated). Reconcile every provider_model_id below against it.
-#   - Atlas vendor prefixes differ from ours: deepseek-ai/, minimaxai/, zai-org/, xai/.
-#   - Confirm env var name (docs sample uses ATLASCLOUD_API_KEY) and per-model prices
-#     on the live model pages; no cached-input rate is published.
-#   - No published RPM; no dedicated ToS/status page (privacy page is confirmed).
+# Verified 2026-07-08 against the public
+# `GET https://api.atlascloud.ai/v1/models` catalog and Atlas Cloud docs.
+# Atlas exposes an OpenAI-compatible LLM endpoint; catalog pricing is per token,
+# converted below to USD per 1M tokens. `openai/gpt-oss-120b` was removed because
+# it is no longer present in the live `/models` response.
 name: atlascloud
 display_name: Atlas Cloud
 metadata:
@@ -22,6 +16,7 @@ metadata:
 api_base: https://api.atlascloud.ai/v1
 api_protocol:
   - "*": openai
+auth_scheme: bearer
 kind: gateway
 models:
   - id: qwen/qwen3.7-max
@@ -29,6 +24,7 @@ models:
     pricing:
       input_tokens:
         no_cache: 2.5
+        cache_read: 0.5
       output_tokens:
         text: 7.5
   - id: qwen/qwen3.7-plus
@@ -36,13 +32,22 @@ models:
     pricing:
       input_tokens:
         no_cache: 0.4
+        cache_read: 0.08
       output_tokens:
         text: 1.6
+      context_tiers:
+        - above_input_tokens: 262144
+          input_tokens:
+            no_cache: 1.2
+            cache_read: 0.24
+          output_tokens:
+            text: 4.8
   - id: deepseek/deepseek-v4-pro
     provider_model_id: deepseek-ai/deepseek-v4-pro
     pricing:
       input_tokens:
         no_cache: 1.68
+        cache_read: 0.13
       output_tokens:
         text: 3.38
   - id: deepseek/deepseek-v4-flash
@@ -50,6 +55,7 @@ models:
     pricing:
       input_tokens:
         no_cache: 0.14
+        cache_read: 0.028
       output_tokens:
         text: 0.28
   - id: deepseek/deepseek-v3.2
@@ -57,6 +63,7 @@ models:
     pricing:
       input_tokens:
         no_cache: 0.26
+        cache_read: 0.13
       output_tokens:
         text: 0.38
   - id: moonshotai/kimi-k2.5
@@ -64,6 +71,7 @@ models:
     pricing:
       input_tokens:
         no_cache: 0.49
+        cache_read: 0.2
       output_tokens:
         text: 2.5
   - id: moonshotai/kimi-k2.6
@@ -71,6 +79,7 @@ models:
     pricing:
       input_tokens:
         no_cache: 0.95
+        cache_read: 0.16
       output_tokens:
         text: 4
   - id: moonshotai/kimi-k2.7-code
@@ -78,6 +87,7 @@ models:
     pricing:
       input_tokens:
         no_cache: 0.95
+        cache_read: 0.16
       output_tokens:
         text: 4
   - id: minimax/minimax-m2.5
@@ -85,6 +95,7 @@ models:
     pricing:
       input_tokens:
         no_cache: 0.295
+        cache_read: 0.06
       output_tokens:
         text: 1.2
   - id: minimax/minimax-m3
@@ -92,36 +103,47 @@ models:
     pricing:
       input_tokens:
         no_cache: 0.3
+        cache_read: 0.06
       output_tokens:
         text: 1.2
+      context_tiers:
+        - above_input_tokens: 512000
+          input_tokens:
+            no_cache: 0.6
+            cache_read: 0.12
+          output_tokens:
+            text: 2.4
   - id: z-ai/glm-5.1
     provider_model_id: zai-org/glm-5.1
     pricing:
       input_tokens:
-        no_cache: 0.95
+        no_cache: 1.26
+        cache_read: 0.234
       output_tokens:
-        text: 3.15
+        text: 3.96
   - id: z-ai/glm-5.2
     provider_model_id: zai-org/glm-5.2
     pricing:
       input_tokens:
-        no_cache: 1.26
+        no_cache: 1.4
+        cache_read: 0.26
       output_tokens:
-        text: 3.96
+        text: 4.4
   - id: x-ai/grok-4.3
     provider_model_id: xai/grok-4.3
     pricing:
       input_tokens:
         no_cache: 1.25
+        cache_read: 0.2
       output_tokens:
         text: 2.5
-  - id: openai/gpt-oss-120b
-    provider_model_id: openai/gpt-oss-120b
-    pricing:
-      input_tokens:
-        no_cache: 0.03
-      output_tokens:
-        text: 0.1
-status: staging
+      context_tiers:
+        - above_input_tokens: 200000
+          input_tokens:
+            no_cache: 2.5
+            cache_read: 0.4
+          output_tokens:
+            text: 5
+status: active
 weight: 1
 submitted_at: 2026-07-07

--- a/registry/providers/qianfan.yaml
+++ b/registry/providers/qianfan.yaml
@@ -1,17 +1,7 @@
-# SCAFFOLD — UNVERIFIED. status: staging (does not route until a human verifies
-# and flips to active). Researched 2026-07 from Baidu AI Cloud Qianfan intl docs
-# (intl.cloud.baidu.com). Baidu Qianfan — INTERNATIONAL endpoint, billed in USD,
-# on a separate intl console (console.bce.baidu.com/qianfan/intl). Same Bearer
-# API-key auth (bce-v3/ALTAK-...) as the China endpoint. The CHINA sibling is a
-# separate provider `qianfan_cn` (qianfan.baidubce.com/v2, RMB).
-# PRICING: USD per 1M tokens, from Baidu's ERNIE 4.5 / X1 launch pricing + ERNIE
-# 5.1 — these are announcement figures, NOT a live-console read.
-# VERIFY BEFORE ACTIVATING:
-#   - Exact intl model-id strings (intl curl samples use `ernie-4.0-turbo-8k`
-#     style suffixes; the base ids/prices below need confirming per SKU).
-#   - The intl catalog is a subset of China's and also serves DeepSeek / Kimi /
-#     MiniMax / GLM in USD — add those once their intl prices are confirmed.
-#   - Provider name `qianfan` → env QIANFAN_API_KEY.
+# Verified 2026-07-08 against Baidu Qianfan international docs and the public
+# `GET https://api.baiduqianfan.ai/v1/models` catalog. The endpoint is
+# OpenAI-compatible and uses Bearer API keys (`bce-v3/ALTAK-...`). Prices below
+# are the live catalog's per-token prices converted to USD per 1M tokens.
 name: qianfan
 display_name: Baidu Qianfan (International)
 metadata:
@@ -26,27 +16,70 @@ api_protocol:
 auth_scheme: bearer
 kind: cloud
 models:
-  - id: baidu/ernie-4.5
-    provider_model_id: ernie-4.5
+  - id: deepseek/deepseek-v3.2
+    provider_model_id: deepseek-v3.2
     pricing:
       input_tokens:
-        no_cache: 0.55
+        no_cache: 0.252
+        cache_read: 0.0252
       output_tokens:
-        text: 2.2
-  - id: baidu/ernie-x1
-    provider_model_id: ernie-x1
+        text: 0.378
+  - id: deepseek/deepseek-v4-pro
+    provider_model_id: deepseek-v4-pro
     pricing:
       input_tokens:
-        no_cache: 0.28
+        no_cache: 0.7605
+        cache_read: 0.063
       output_tokens:
-        text: 1.1
-  - id: baidu/ernie-5.1
-    provider_model_id: ernie-5.1
+        text: 1.521
+  - id: deepseek/deepseek-v4-flash
+    provider_model_id: deepseek-v4-flash
     pricing:
       input_tokens:
-        no_cache: 0.59
+        no_cache: 0.0983
+        cache_read: 0.0197
       output_tokens:
-        text: 2.65
-status: staging
+        text: 0.1966
+  - id: moonshotai/kimi-k2.6
+    provider_model_id: kimi-k2.6
+    pricing:
+      input_tokens:
+        no_cache: 0.684
+        cache_read: 0.144
+      output_tokens:
+        text: 3.42
+  - id: z-ai/glm-5
+    provider_model_id: glm-5
+    pricing:
+      input_tokens:
+        no_cache: 0.7
+        cache_read: 0.14
+      output_tokens:
+        text: 2.24
+  - id: z-ai/glm-5.1
+    provider_model_id: glm-5.1
+    pricing:
+      input_tokens:
+        no_cache: 0.98
+        cache_read: 0.182
+      output_tokens:
+        text: 3.08
+  - id: z-ai/glm-5.2
+    provider_model_id: glm-5.2
+    pricing:
+      input_tokens:
+        no_cache: 1.12
+        cache_read: 0.208
+      output_tokens:
+        text: 3.96
+  - id: tencent/hy3
+    provider_model_id: hy3-preview
+    pricing:
+      input_tokens:
+        no_cache: 0.066
+        cache_read: 0.0261
+      output_tokens:
+        text: 0.26
+status: active
 weight: 1
 submitted_at: 2026-07-07

--- a/registry/providers/qianfan_cn.yaml
+++ b/registry/providers/qianfan_cn.yaml
@@ -1,16 +1,7 @@
-# SCAFFOLD — UNVERIFIED. status: staging (does not route until a human verifies
-# and flips to active). Researched 2026-07 from Baidu AI Cloud Qianfan docs.
-# Baidu Qianfan (百度千帆) — CHINA endpoint. OpenAI-compatible /v2 endpoint on the
-# cloud.baidu.com console (mainland account), Bearer API-key auth (key format
-# bce-v3/ALTAK-...; NOT the legacy AK/SK flow). The INTERNATIONAL sibling is a
-# separate provider `qianfan` (api.baiduqianfan.ai, USD).
-# PRICING: official China rates are RMB per 1M tokens; converted to USD below at
-# ~7.2 CNY/USD — VERIFY every id + price on the live console (catalog churns).
-# context_tiers reflect Qianfan's ≤32k vs 32–128k input brackets.
-# VERIFY BEFORE ACTIVATING:
-#   - Provider name `qianfan_cn` → env QIANFAN_CN_API_KEY.
-#   - Exact ERNIE model-id strings/suffixes; per-model RPM/TPM (tier-dependent).
-#   - No confirmed Anthropic-compatible endpoint.
+# Verified 2026-07-08 from Baidu Qianfan China `/v2/models` documentation. The
+# live catalog endpoint requires a Bearer API key, so this remains a manual
+# provider rather than `auto_sync: v1_models`. Official prices are RMB per 1K
+# tokens; values below are converted to USD per 1M tokens at ~7.2 CNY/USD.
 name: qianfan_cn
 display_name: Baidu Qianfan (China)
 metadata:
@@ -33,15 +24,20 @@ models:
     pricing:
       input_tokens:
         no_cache: 1.67
-        cache_read: 0.139
       output_tokens:
         text: 3.33
+  - id: deepseek/deepseek-v4-flash
+    provider_model_id: deepseek-v4-flash
+    pricing:
+      input_tokens:
+        no_cache: 0.14
+      output_tokens:
+        text: 0.28
   - id: deepseek/deepseek-v3.2
     provider_model_id: deepseek-v3.2
     pricing:
       input_tokens:
         no_cache: 0.28
-        cache_read: 0.056
       output_tokens:
         text: 0.42
       context_tiers:
@@ -50,14 +46,33 @@ models:
             no_cache: 0.56
           output_tokens:
             text: 0.83
-  - id: moonshotai/kimi-k2.6
-    provider_model_id: kimi-k2.6
+  - id: moonshotai/kimi-k2.5
+    provider_model_id: kimi-k2.5
     pricing:
       input_tokens:
-        no_cache: 0.9
-        cache_read: 0.153
+        no_cache: 0.56
       output_tokens:
-        text: 3.75
+        text: 2.92
+  - id: minimax/minimax-m2.5
+    provider_model_id: minimax-m2.5
+    pricing:
+      input_tokens:
+        no_cache: 0.29
+      output_tokens:
+        text: 1.17
+  - id: z-ai/glm-5.1
+    provider_model_id: glm-5.1
+    pricing:
+      input_tokens:
+        no_cache: 0.83
+      output_tokens:
+        text: 3.33
+      context_tiers:
+        - above_input_tokens: 32000
+          input_tokens:
+            no_cache: 1.11
+          output_tokens:
+            text: 3.89
   - id: baidu/ernie-5.0
     provider_model_id: ernie-5.0
     pricing:
@@ -76,7 +91,6 @@ models:
     pricing:
       input_tokens:
         no_cache: 0.11
-        cache_read: 0.028
       output_tokens:
         text: 0.44
   - id: baidu/ernie-x1-turbo-32k
@@ -86,6 +100,6 @@ models:
         no_cache: 0.14
       output_tokens:
         text: 0.56
-status: staging
+status: active
 weight: 1
 submitted_at: 2026-07-07

--- a/registry/providers/redpill.yaml
+++ b/registry/providers/redpill.yaml
@@ -1,21 +1,21 @@
-name: phala
-display_name: Phala
+name: redpill
+display_name: RedPill (Phala Network)
 metadata:
-  headquarters: US
-  name: Phala
-  privacy_policy_url: https://phala.com/privacy
-  slug: phala
-  status_page_url: https://status.phala.network
-  terms_of_service_url: https://phala.network/terms
-api_base: https://inference.phala.com/v1
+  headquarters: SG
+  name: RedPill
+  privacy_policy_url: https://redpill.ai/privacy
+  slug: redpill
+  terms_of_service_url: https://redpill.ai/terms
+api_base: https://api.redpill.ai/v1
 api_protocol:
   - "*": openai
 auth_scheme: bearer
 kind: gateway
-# Phala Cloud confidential (GPU-TEE) inference gateway. Verified 2026-07-08
-# against the public `GET https://inference.phala.com/v1/models` catalog.
-# Distinct from the `redpill` provider, which uses `https://api.redpill.ai/v1`.
-# Prices below are the live catalog's per-token prices converted to USD per 1M.
+doc_url: https://docs.redpill.ai/get-started/introduction
+# RedPill is Phala Network's confidential AI gateway. Verified 2026-07-08
+# against public `GET https://api.redpill.ai/v1/models`; the response currently
+# matches Phala's inference catalog for these models. Prices below are converted
+# from per-token catalog values to USD per 1M tokens.
 models:
   - id: deepseek/deepseek-v4-pro
     provider_model_id: deepseek/deepseek-v4-pro
@@ -72,4 +72,4 @@ models:
       - tools
 status: active
 weight: 1
-submitted_at: 2026-07-07
+submitted_at: 2026-07-08

--- a/registry/providers/streamlake.yaml
+++ b/registry/providers/streamlake.yaml
@@ -1,17 +1,7 @@
-# SCAFFOLD — UNVERIFIED. status: staging (does not route until a human verifies
-# and flips to active). Researched 2026-07 from https://www.streamlake.com/ docs.
-# StreamLake (快手万擎 / Vanchin) is Kuaishou's enterprise MaaS. OpenAI-compatible.
-# PRICING: official rates are RMB per 1M tokens; converted to USD below at
-# ~7.2 CNY/USD — VERIFY on the live pricing page (changes frequently; last seen
-# 2026-07-07). OpenRouter's USD for kat-coder-pro-v2 ($0.30 in / $1.20 out)
-# corroborates the converted figures.
-# VERIFY BEFORE ACTIVATING:
-#   - Exact model-id casing the API accepts (docs use lowercase kat-coder-*).
-#   - RPM/TPM (not published), status page, and privacy-policy URL (not found).
-#   - Hosted DeepSeek/Kimi/Qwen/GLM are BYO-deployed inference endpoints (ep-...),
-#     NOT a fixed catalog — omitted here. Add only if confirmed in the console.
-#   - Anthropic (claude-code-proxy) surface exists but is per-model
-#     (.../v1/endpoints/<model>/claude-code-proxy) — not a provider-wide endpoint.
+# Verified 2026-07-08 from StreamLake/Vanchin docs. The pay-as-you-go OpenAI
+# base URL is `https://vanchin.streamlake.ai/api/gateway/v1/endpoints`; the
+# coding-plan URL is a separate subscription surface and is not represented here.
+# Pricing is official USD per 1M tokens from the StreamLake pricing page.
 name: streamlake
 display_name: StreamLake (Kuaishou Vanchin)
 metadata:
@@ -19,9 +9,10 @@ metadata:
   datacenters:
     - CN
   name: StreamLake
+  privacy_policy_url: https://www.streamlake.ai/document/DOC/mgkci47q13qr66h9i54
   slug: streamlake
   terms_of_service_url: https://www.streamlake.ai/document/DOC/mgkchnd89grpt1961fw
-api_base: https://wanqing.streamlakeapi.com/api/gateway/v1/endpoints
+api_base: https://vanchin.streamlake.ai/api/gateway/v1/endpoints
 api_protocol:
   - "*": openai
 auth_scheme: bearer
@@ -31,26 +22,27 @@ models:
     provider_model_id: kat-coder-pro-v2
     pricing:
       input_tokens:
-        no_cache: 0.29
-        cache_read: 0.058
+        no_cache: 0.3
+        cache_read: 0.06
+        cache_write: 0
       output_tokens:
-        text: 1.17
+        text: 1.2
   - id: kwaipilot/kat-coder-pro-v2.5
     provider_model_id: kat-coder-pro-v2.5
     pricing:
       input_tokens:
-        no_cache: 0.69
-        cache_read: 0.139
+        no_cache: 0.74
+        cache_read: 0.15
       output_tokens:
-        text: 2.78
+        text: 2.96
   - id: kwaipilot/kat-coder-air-v2.5
     provider_model_id: kat-coder-air-v2.5
     pricing:
       input_tokens:
-        no_cache: 0.14
-        cache_read: 0.028
+        no_cache: 0.15
+        cache_read: 0.03
       output_tokens:
-        text: 0.56
-status: staging
+        text: 0.6
+status: active
 weight: 1
 submitted_at: 2026-07-07


### PR DESCRIPTION
## Summary

- Activate verified Atlas Cloud, StreamLake, Baidu Qianfan international/China, Phala, and RedPill provider entries.
- Add `redpill` as the RedPill/Phala Network OpenAI-compatible endpoint at `https://api.redpill.ai/v1`.
- Keep GMI Cloud, SiliconFlow, and Alibaba SG active via their existing models.dev-backed catalogs.
- Refresh provider IDs, base URLs, cache pricing, and token pricing from live catalogs or official docs.
- Regenerate dist registry artifacts; provider count is now 49.

## Evidence

- `https://models.dev/api.json`: GMI Cloud, SiliconFlow, and Alibaba SG catalog/pricing feeds.
- `https://api.atlascloud.ai/v1/models`: public Atlas Cloud model IDs and pricing.
- `https://www.streamlake.ai/document/DOC/mgrnm4xm362hvp5wyce`: StreamLake pricing.
- `https://www.streamlake.ai/document/DOC/mg6k6nlp8j6qxicx4c9`: StreamLake OpenAI-compatible base URLs.
- `https://api.baiduqianfan.ai/v1/models`: public Baidu Qianfan international model IDs and pricing.
- `https://cloud.baidu.com/doc/qianfan-api/s/Dmba8k71y`: Baidu Qianfan China auth-gated `/v2/models` docs and sample pricing response.
- `https://inference.phala.com/v1/models`: public Phala model IDs and pricing.
- `https://api.redpill.ai/v1/models`: public RedPill model IDs and pricing.

## Notable Corrections

- Removed Atlas Cloud `openai/gpt-oss-120b` because it is no longer present in the live public `/v1/models` response.
- Updated Atlas Cloud `z-ai/glm-5.1`, `z-ai/glm-5.2`, cache-read prices, and context tiers from the live catalog.
- Updated StreamLake to the current Vanchin pay-as-you-go base URL and official USD pricing.
- Replaced Baidu Qianfan international's stale ERNIE-only list with the current public catalog subset.
- Corrected Baidu Qianfan China Kimi from `kimi-k2.6` to documented `kimi-k2.5`, and added verified DeepSeek Flash/MiniMax/GLM entries.
- Added RedPill separately from Phala direct so RedPill API keys can target `api.redpill.ai`.

## Validation

- `cargo test -p dist-helper`
- `cargo run -p dist-helper -- check`
- `cargo fmt --check`
- `git diff --check`
- Live catalog cross-check: Atlas/Qianfan/Phala/RedPill provider model IDs matched with `missing=0`.
- Target provider status audit: GMI Cloud, Atlas Cloud, StreamLake, SiliconFlow, Baidu Qianfan international/China, Phala, RedPill, and Alibaba SG are active.