### PR TITLE
fix(messages): drop unsigned reasoning on Anthropic wire

### DIFF
--- a/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
@@ -147,8 +147,10 @@ fn parse_reasoning_metadata(block: &serde_json::Value, block_type: &str) -> Prov
 /// Render a canonical reasoning part back into its Anthropic block, inverting
 /// [`parse_reasoning_metadata`]. A `redactedThinking` flag re-emits a
 /// `redacted_thinking` block whose `data` is the preserved encrypted payload
-/// (falling back to `text` when absent); otherwise a `thinking` block, carrying
-/// its `signature` when one round-tripped.
+/// (falling back to `text` when absent); a signed Anthropic reasoning block
+/// re-emits as `thinking`. Unsigned reasoning is intentionally dropped on this
+/// wire because Claude Code replays `thinking` blocks into follow-up requests,
+/// and Anthropic rejects blocks without a valid Anthropic signature.
 ///
 /// A `cache_control` breakpoint is intentionally **not** re-applied here:
 /// Anthropic rejects `cache_control` on `thinking` / `redacted_thinking` blocks
@@ -158,7 +160,7 @@ fn parse_reasoning_metadata(block: &serde_json::Value, block_type: &str) -> Prov
 /// dropped on render rather than producing a request the API would reject.
 /// <https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking>
 /// <https://github.com/vercel/ai/blob/8e650ab809ac47de5d16f26bf544a9a73b0d39a3/packages/anthropic/src/convert-to-anthropic-messages-prompt.ts>
-fn render_reasoning_block(text: &str, meta: &ProviderMetadata) -> serde_json::Value {
+fn render_reasoning_block(text: &str, meta: &ProviderMetadata) -> Option<serde_json::Value> {
     let ns = provider_namespace(meta, PROVIDER_ID_ANTHROPIC);
     let is_redacted = ns
         .and_then(|o| o.get(ANTHROPIC_REDACTED))
@@ -171,13 +173,13 @@ fn render_reasoning_block(text: &str, meta: &ProviderMetadata) -> serde_json::Va
             .and_then(|o| o.get(ANTHROPIC_REDACTED_DATA))
             .cloned()
             .unwrap_or_else(|| serde_json::Value::String(text.to_string()));
-        serde_json::json!({ "type": "redacted_thinking", "data": data })
-    } else {
+        Some(serde_json::json!({ "type": "redacted_thinking", "data": data }))
+    } else if let Some(sig) = ns.and_then(|o| o.get(ANTHROPIC_SIGNATURE)) {
         let mut obj = serde_json::json!({ "type": "thinking", "thinking": text });
-        if let Some(sig) = ns.and_then(|o| o.get(ANTHROPIC_SIGNATURE)) {
-            obj["signature"] = sig.clone();
-        }
-        obj
+        obj["signature"] = sig.clone();
+        Some(obj)
+    } else {
+        None
     }
 }
 
@@ -1081,6 +1083,7 @@ impl InboundAdapter for MessagesAdapter {
             block_kind: None,
             block_index: 0,
             pending_sources: Vec::new(),
+            pending_reasoning: None,
         })
     }
 }
@@ -1733,7 +1736,7 @@ fn render_content_block(c: &Content) -> Option<serde_json::Value> {
         Content::Reasoning {
             text,
             provider_metadata,
-        } => Some(render_reasoning_block(text, provider_metadata)),
+        } => render_reasoning_block(text, provider_metadata),
         Content::ToolCall {
             id,
             name,
@@ -2344,16 +2347,14 @@ impl StreamDecoder for MessagesStreamDecoder {
 /// per-block `content_block_start` / `_delta` / `_stop`, `message_delta`,
 /// `message_stop`.
 ///
-/// Block transitions: Anthropic's `content_block_*` events are typed
-/// (`text` / `thinking` / `tool_use`). Strict clients (e.g. Claude Code)
-/// reject a `text_delta` inside a still-open `thinking` block. The encoder
-/// therefore tracks the **kind** of the currently open block and closes it
-/// before opening a new block of a different kind (text → thinking, etc.).
-/// Same-kind consecutive deltas reuse the open block.
+/// Block transitions: Anthropic's `content_block_*` events are typed. The
+/// encoder tracks the **kind** of the currently open emitted block and closes it
+/// before opening a new block of a different kind. Same-kind consecutive deltas
+/// reuse the open block. Reasoning is buffered separately until an Anthropic
+/// signature proves it is safe to emit as a sealed `thinking` block.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum EncoderBlockKind {
     Text,
-    Thinking,
     ToolUse,
 }
 
@@ -2417,6 +2418,12 @@ struct MessagesStreamEncoder {
     /// rather than emitted per-source so the streamed wire matches the
     /// non-streaming render (one block) and stays a valid pair.
     pending_sources: Vec<serde_json::Value>,
+    /// Reasoning text is buffered until its terminal signature arrives. Claude
+    /// Code replays `thinking` blocks into follow-up requests, and Anthropic
+    /// rejects any block that is not signed by Anthropic. Non-Anthropic
+    /// reasoning has no valid signature, so it must not be exposed as a
+    /// `thinking` block on this wire.
+    pending_reasoning: Option<String>,
 }
 
 impl MessagesStreamEncoder {
@@ -2514,6 +2521,60 @@ impl MessagesStreamEncoder {
         self.block_index += 1;
     }
 
+    fn begin_reasoning_buffer(&mut self, frames: &mut Vec<SseFrame>) {
+        self.close_block(frames);
+        self.pending_reasoning = Some(String::new());
+    }
+
+    fn push_reasoning_delta(&mut self, frames: &mut Vec<SseFrame>, text: &str) {
+        if self.pending_reasoning.is_none() {
+            self.begin_reasoning_buffer(frames);
+        }
+        if let Some(buffer) = &mut self.pending_reasoning {
+            buffer.push_str(text);
+        }
+    }
+
+    fn flush_reasoning_buffer(&mut self, frames: &mut Vec<SseFrame>, signature: Option<&str>) {
+        let Some(text) = self.pending_reasoning.take() else {
+            return;
+        };
+        let Some(signature) = signature else {
+            return;
+        };
+        frames.push(Self::ev(
+            "content_block_start",
+            serde_json::json!({
+                "type": "content_block_start",
+                "index": self.block_index,
+                "content_block": { "type": "thinking", "thinking": "" },
+            }),
+        ));
+        if !text.is_empty() {
+            frames.push(Self::ev(
+                "content_block_delta",
+                serde_json::json!({
+                    "type": "content_block_delta",
+                    "index": self.block_index,
+                    "delta": { "type": "thinking_delta", "thinking": text },
+                }),
+            ));
+        }
+        frames.push(Self::ev(
+            "content_block_delta",
+            serde_json::json!({
+                "type": "content_block_delta",
+                "index": self.block_index,
+                "delta": { "type": "signature_delta", "signature": signature },
+            }),
+        ));
+        frames.push(Self::ev(
+            "content_block_stop",
+            serde_json::json!({ "type": "content_block_stop", "index": self.block_index }),
+        ));
+        self.block_index += 1;
+    }
+
     /// If a block of a different kind is currently open, close it; then ensure
     /// a block of `wanted` is open. Returns whether a *new* block was opened
     /// this call so the caller can append the right `content_block_start`.
@@ -2530,14 +2591,12 @@ impl MessagesStreamEncoder {
         }
     }
 
-    /// Force-open a *fresh* text / thinking block, emitting its
+    /// Force-open a *fresh* text block, emitting its
     /// `content_block_start`. Unlike [`Self::ensure_block_open`] this always
     /// closes any currently-open block first, so an explicit canonical
-    /// [`StreamPart::TextStart`] / [`StreamPart::ReasoningStart`] starts a new
-    /// content block at the next index even when one of the same kind was
-    /// already open — this is the merged-block fix on this wire. A `text` block
-    /// opens with an empty `text`, a `thinking` block with empty `thinking`,
-    /// matching `content_block_start` on each kind.
+    /// [`StreamPart::TextStart`] starts a new content block at the next index
+    /// even when one of the same kind was already open — this is the
+    /// merged-block fix on this wire.
     /// <https://docs.anthropic.com/en/api/messages-streaming>
     fn open_fresh_block(&mut self, frames: &mut Vec<SseFrame>, kind: EncoderBlockKind) {
         self.close_block(frames);
@@ -2545,7 +2604,6 @@ impl MessagesStreamEncoder {
         self.block_open = true;
         let content_block = match kind {
             EncoderBlockKind::Text => serde_json::json!({ "type": "text", "text": "" }),
-            EncoderBlockKind::Thinking => serde_json::json!({ "type": "thinking", "thinking": "" }),
             // Tool blocks frame themselves via the `name`-bearing `ToolCallDelta`
             // arm, never through a start marker; keep the payload self-consistent
             // if a future caller routes one here.
@@ -2576,6 +2634,7 @@ impl MessagesStreamEncoder {
     ) {
         // Collapse all buffered citations into one pair just before the
         // terminal frames, matching the non-streaming render's tail placement.
+        self.pending_reasoning = None;
         self.flush_pending_sources(frames);
         self.close_block(frames);
         let u = usage.unwrap_or_default();
@@ -2639,43 +2698,31 @@ impl StreamEncoder for MessagesStreamEncoder {
                 // a generated file is surfaced only on the non-streaming path.
             }
             StreamPart::TextStart { .. } => {
+                self.pending_reasoning = None;
                 // Explicit block boundary from a block-framed upstream — open a
                 // *fresh* text content block so two distinct upstream text blocks
                 // re-encode as two `content_block_start`s, not one merged block.
                 self.open_fresh_block(&mut frames, EncoderBlockKind::Text);
             }
             StreamPart::ReasoningStart { .. } => {
-                self.open_fresh_block(&mut frames, EncoderBlockKind::Thinking);
+                self.begin_reasoning_buffer(&mut frames);
             }
             StreamPart::TextEnd { .. } => {
+                self.pending_reasoning = None;
                 // Close the block the matching start opened; `close_block` is a
                 // no-op if nothing is open, so a stray end is harmless.
                 self.close_block(&mut frames);
             }
             StreamPart::ReasoningEnd { signature, .. } => {
-                // Re-emit the thinking block's continuity signature as a
-                // `signature_delta` (Anthropic's wire shape) just before its
-                // `content_block_stop`, so a streamed thinking block re-encodes
-                // signed and a follow-up turn replays it without an
-                // "Invalid `signature`" rejection. Only when a thinking block is
-                // actually open — a stray/empty reasoning-end stays a no-op.
+                // Only signed Anthropic thinking may be emitted on the Messages
+                // wire. Unsigned reasoning from non-Anthropic upstreams would be
+                // replayed by Claude Code as an invalid `thinking` block on the
+                // next turn.
                 // <https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking>
-                if let Some(sig) = signature
-                    && self.block_open
-                    && self.block_kind == Some(EncoderBlockKind::Thinking)
-                {
-                    frames.push(Self::ev(
-                        "content_block_delta",
-                        serde_json::json!({
-                            "type": "content_block_delta",
-                            "index": self.block_index,
-                            "delta": { "type": "signature_delta", "signature": sig },
-                        }),
-                    ));
-                }
-                self.close_block(&mut frames);
+                self.flush_reasoning_buffer(&mut frames, signature.as_deref());
             }
             StreamPart::TextDelta { text } => {
+                self.pending_reasoning = None;
                 if self.ensure_block_open(&mut frames, EncoderBlockKind::Text) {
                     frames.push(Self::ev(
                         "content_block_start",
@@ -2696,30 +2743,14 @@ impl StreamEncoder for MessagesStreamEncoder {
                 ));
             }
             StreamPart::ReasoningDelta { text } => {
-                if self.ensure_block_open(&mut frames, EncoderBlockKind::Thinking) {
-                    frames.push(Self::ev(
-                        "content_block_start",
-                        serde_json::json!({
-                            "type": "content_block_start",
-                            "index": self.block_index,
-                            "content_block": { "type": "thinking", "thinking": "" },
-                        }),
-                    ));
-                }
-                frames.push(Self::ev(
-                    "content_block_delta",
-                    serde_json::json!({
-                        "type": "content_block_delta",
-                        "index": self.block_index,
-                        "delta": { "type": "thinking_delta", "thinking": text },
-                    }),
-                ));
+                self.push_reasoning_delta(&mut frames, text);
             }
             StreamPart::ToolCallDelta {
                 id,
                 name,
                 arguments,
             } => {
+                self.pending_reasoning = None;
                 if let Some(name) = name.as_deref().filter(|n| !n.is_empty()) {
                     // A new tool call always opens its own block, even if a
                     // tool_use block was already open (consecutive tool calls
@@ -2825,6 +2856,7 @@ impl StreamEncoder for MessagesStreamEncoder {
                 self.block_index += 1;
             }
             StreamPart::Source { source } => {
+                self.pending_reasoning = None;
                 // Buffer a streamed citation as a `web_search_result` entry; all
                 // entries flush together as one collapsed `server_tool_use` ↔
                 // `web_search_tool_result` pair at terminal

--- a/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
@@ -81,11 +81,18 @@ fn sample_prompt() -> Prompt {
 /// A canonical result with reasoning + text + a tool call, in that order — the
 /// order must survive every conversion (v0 #416, #454-1).
 fn sample_result() -> GenerateResult {
+    let mut reasoning_metadata = ProviderMetadata::new();
+    set_provider_metadata(
+        &mut reasoning_metadata,
+        "anthropic",
+        "signature",
+        "SIG-sample-reasoning".into(),
+    );
     GenerateResult {
         content: vec![
             Content::Reasoning {
                 text: "thinking...".to_string(),
-                provider_metadata: Default::default(),
+                provider_metadata: reasoning_metadata,
             },
             Content::Text {
                 text: "the answer is 4".to_string(),
@@ -181,10 +188,11 @@ fn conversion_matrix_4x4_non_streaming() {
     }
 }
 
-/// The streaming 4×4 matrix: for every (inbound, outbound) pair, encode a
-/// canonical part stream in the outbound protocol, decode it back, and assert
-/// the text/reasoning/tool-call parts survive — then re-encode in the inbound
-/// protocol.
+/// The streaming matrix: for every outbound protocol, encode a canonical part
+/// stream, decode it back, and assert visible text/tool-call parts survive.
+/// Unsigned reasoning survives on protocols that can carry provider-agnostic
+/// reasoning; Messages intentionally drops it because Claude Code replays
+/// Anthropic `thinking` blocks into follow-up requests.
 #[test]
 fn conversion_matrix_4x4_streaming() {
     let canonical_parts = vec![
@@ -250,12 +258,20 @@ fn conversion_matrix_4x4_streaming() {
             text, "the answer",
             "{outbound_proto:?}: streaming text survived encode→decode"
         );
-        assert!(
-            decoded
-                .iter()
-                .any(|p| matches!(p, StreamPart::ReasoningDelta { .. })),
-            "{outbound_proto:?}: reasoning delta survived"
-        );
+        let reasoning_survived = decoded
+            .iter()
+            .any(|p| matches!(p, StreamPart::ReasoningDelta { .. }));
+        if outbound_proto == ApiProtocol::Messages {
+            assert!(
+                !reasoning_survived,
+                "{outbound_proto:?}: unsigned reasoning must not become Anthropic thinking"
+            );
+        } else {
+            assert!(
+                reasoning_survived,
+                "{outbound_proto:?}: reasoning delta survived"
+            );
+        }
         assert!(
             decoded
                 .iter()
@@ -1635,8 +1651,13 @@ fn messages_stream_encoder_closes_block_on_kind_transition() {
     let adapter = adapter_for(ApiProtocol::Messages);
     let mut encoder = adapter.stream_encoder("msg_x", "claude-3-7-sonnet");
     let parts = [
+        StreamPart::ReasoningStart { id: "r1".into() },
         StreamPart::ReasoningDelta {
             text: "think ".into(),
+        },
+        StreamPart::ReasoningEnd {
+            id: "r1".into(),
+            signature: Some("SIG-transition".into()),
         },
         StreamPart::TextDelta {
             text: "answer ".into(),
@@ -1668,6 +1689,47 @@ fn messages_stream_encoder_closes_block_on_kind_transition() {
     assert!(
         thinking_open < first_stop && first_stop < text_open,
         "block_stop must fall *between* thinking_start and text_start; got:\n{joined}"
+    );
+}
+
+#[test]
+fn messages_stream_encoder_drops_unsigned_reasoning() {
+    // Non-Anthropic reasoning has no Anthropic continuity signature. If it is
+    // exposed to Claude Code as a `thinking` block, the next Claude request
+    // replays that block and Anthropic rejects it as an invalid signature.
+    let events = encode_stream_events(
+        ApiProtocol::Messages,
+        &[
+            StreamPart::ReasoningStart { id: "r1".into() },
+            StreamPart::ReasoningDelta {
+                text: "provider-private reasoning".into(),
+            },
+            StreamPart::ReasoningEnd {
+                id: "r1".into(),
+                signature: None,
+            },
+            StreamPart::TextDelta {
+                text: "visible answer".into(),
+            },
+            StreamPart::Finish {
+                reason: FinishReason::Stop,
+            },
+        ],
+    );
+    let joined = events
+        .iter()
+        .map(|(name, data)| format!("{name} {data}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        !joined.contains("\"type\":\"thinking\"")
+            && !joined.contains("\"type\": \"thinking\"")
+            && !joined.contains("signature_delta"),
+        "unsigned reasoning must not become Anthropic thinking: {joined}"
+    );
+    assert!(
+        joined.contains("visible answer"),
+        "dropping unsigned reasoning must not drop visible text: {joined}"
     );
 }
 
@@ -1851,7 +1913,7 @@ fn text_reasoning_text_reencodes_with_three_distinct_blocks() {
         },
         StreamPart::ReasoningEnd {
             id: "b".into(),
-            signature: None,
+            signature: Some("SIG-blocks".into()),
         },
         StreamPart::TextStart { id: "c".into() },
         StreamPart::TextDelta {
@@ -2624,6 +2686,39 @@ fn messages_response_roundtrip() {
     assert_eq!(json["content"][2]["type"], "tool_use");
     let parsed = adapter.parse_response(json).unwrap();
     assert_eq!(parsed.content.len(), 3);
+}
+
+#[test]
+fn messages_response_drops_unsigned_reasoning() {
+    let adapter = adapter_for(ApiProtocol::Messages);
+    let prompt = sample_prompt();
+    let result = GenerateResult {
+        content: vec![
+            Content::Reasoning {
+                text: "provider-private reasoning".to_string(),
+                provider_metadata: Default::default(),
+            },
+            Content::Text {
+                text: "visible answer".to_string(),
+                provider_metadata: Default::default(),
+            },
+        ],
+        usage: None,
+        finish_reason: Some(FinishReason::Stop),
+        response_id: None,
+        stop_details: None,
+        provider_metadata: Default::default(),
+    };
+    let json = adapter
+        .render_response(&result, &prompt, "msg_unsigned")
+        .unwrap();
+    let blocks = json["content"].as_array().unwrap();
+    assert!(
+        blocks.iter().all(|b| b["type"] != "thinking"),
+        "unsigned reasoning must not render as Anthropic thinking: {json}"
+    );
+    assert_eq!(blocks[0]["type"], "text");
+    assert_eq!(blocks[0]["text"], "visible answer");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Drop provider-agnostic/unsigned reasoning when rendering Anthropic Messages responses or streams, while preserving signed Anthropic `thinking` and `redacted_thinking` round trips.

## Root Cause

Claude Code replays Anthropic `thinking` blocks into follow-up requests. In mixed-provider routing, non-Anthropic upstreams can emit reasoning without an Anthropic continuity signature. BitRouter was encoding that reasoning as an Anthropic `thinking` block, so the next request back to Claude was rejected with `Invalid signature in thinking block`.

## Changes

- Render `Content::Reasoning` as Anthropic `thinking` only when it carries Anthropic signature metadata, or as `redacted_thinking` when it carries redacted metadata.
- Buffer Messages streaming reasoning until `ReasoningEnd`; flush it only if a signature is present.
- Add regression coverage for unsigned reasoning suppression and keep signed thinking round-trip tests passing.

## Validation

- `cargo test -p bitrouter-sdk --features config_file language_model::protocol::tests` (251 passed)
- Live Harbor/Terminal-Bench single-case policy smoke: `regex-log` reward 1.0, with DeepSeek weak-model routes observed and no `Invalid signature` errors after the fix.