### PR TITLE
fix(registry): correct Tencent TokenHub intl base URL

### DIFF
--- a/dist/registry/providers.json
+++ b/dist/registry/providers.json
@@ -6563,7 +6563,7 @@
     },
     {
       "access": "api_key",
-      "api_base": "https://tokenhub-intl.tencentmaas.com/v1",
+      "api_base": "https://tokenhub-intl.tencentcloudmaas.com/v1",
       "auth_scheme": "x-api-key",
       "billing": "usage_token",
       "byok": true,

--- a/helpers/dist-helper/src/registry.rs
+++ b/helpers/dist-helper/src/registry.rs
@@ -2590,6 +2590,33 @@ auto_sync:
     }
 
     #[test]
+    fn tencent_tokenhub_base_urls_match_official_hosts() {
+        let root = crate::workspace_root();
+        let loaded = load_registry(&root).expect("loads checked-in registry");
+        let api_base = |name: &str| {
+            loaded
+                .providers
+                .iter()
+                .find(|provider| provider.data.name == name)
+                .unwrap_or_else(|| panic!("missing provider {name}"))
+                .data
+                .api_base
+                .as_deref()
+                .unwrap_or_else(|| panic!("provider {name} must set api_base"))
+                .to_string()
+        };
+
+        assert_eq!(
+            api_base("tencent"),
+            "https://tokenhub-intl.tencentcloudmaas.com/v1"
+        );
+        assert_eq!(
+            api_base("tencent_cn"),
+            "https://tokenhub.tencentmaas.com/v1"
+        );
+    }
+
+    #[test]
     fn agentic_sync_without_urls_is_invalid() {
         let root = test_root("agentic-missing-urls");
         write(

--- a/registry/providers/tencent.yaml
+++ b/registry/providers/tencent.yaml
@@ -17,7 +17,7 @@ metadata:
 api_protocol:
   - minimax/minimax-m3: [openai, responses, anthropic]
   - "*": [openai, anthropic]
-api_base: https://tokenhub-intl.tencentmaas.com/v1
+api_base: https://tokenhub-intl.tencentcloudmaas.com/v1
 rate_limits:
   - "*":
       requests_per_minute: 60


### PR DESCRIPTION
## Summary

- Correct the Tencent TokenHub international provider base URL from `tokenhub-intl.tencentmaas.com` to `tokenhub-intl.tencentcloudmaas.com`.
- Regenerate `dist/registry/providers.json` so the published registry snapshot matches the source YAML.
- Add a dist-helper regression test that locks the official TokenHub hosts for `tencent` and `tencent_cn`.

## Root Cause

The Tencent international TokenHub endpoint in the OSS registry used the wrong host. The wrong host returns Tencent `401002` responses (`API Key does not exist or signature verification failed`), which bitrouter-cloud redacts into a client-facing provider 502. A real curl against `https://tokenhub-intl.tencentcloudmaas.com/v1/chat/completions` succeeds with the rotated TokenHub key.

`tencent_cn` remains unchanged at `https://tokenhub.tencentmaas.com/v1`, matching the China TokenHub endpoint.

## Validation

- `cargo test -p dist-helper`
- `cargo run -p dist-helper -- registry validate`
- `cargo run -p dist-helper -- registry build --check`
- `cargo run -p dist-helper -- check`