### PR TITLE
feat(registry): add GPT-5.6 family and Grok 4.5

### DIFF
--- a/dist/registry/models.json
+++ b/dist/registry/models.json
@@ -4098,6 +4098,207 @@
       "release_date": "2026-04-23"
     },
     {
+      "family": "gpt",
+      "id": "openai/gpt-5.6-luna",
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "knowledge_cutoff": "2026-05-31",
+      "max_input_tokens": 400000,
+      "max_output_tokens": 128000,
+      "name": "OpenAI: GPT-5.6 Luna",
+      "open_weights": false,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools"
+          ],
+          "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 272000,
+                "input_tokens": {
+                  "cache_read": 0.2,
+                  "cache_write": 2.5,
+                  "no_cache": 2.0
+                },
+                "output_tokens": {
+                  "text": 9.0
+                }
+              }
+            ],
+            "input_tokens": {
+              "cache_read": 0.1,
+              "cache_write": 1.25,
+              "no_cache": 1.0
+            },
+            "output_tokens": {
+              "text": 6.0
+            }
+          },
+          "provider": "openai",
+          "provider_model_id": "gpt-5.6-luna",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "responses",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "provider": "openai-codex",
+          "provider_model_id": "gpt-5.6-luna"
+        }
+      ],
+      "release_date": "2026-06-25"
+    },
+    {
+      "family": "gpt",
+      "id": "openai/gpt-5.6-sol",
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "knowledge_cutoff": "2026-05-31",
+      "max_input_tokens": 1000000,
+      "max_output_tokens": 128000,
+      "name": "OpenAI: GPT-5.6 Sol",
+      "open_weights": false,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools"
+          ],
+          "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 272000,
+                "input_tokens": {
+                  "cache_read": 1.0,
+                  "cache_write": 12.5,
+                  "no_cache": 10.0
+                },
+                "output_tokens": {
+                  "text": 45.0
+                }
+              }
+            ],
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 30.0
+            }
+          },
+          "provider": "openai",
+          "provider_model_id": "gpt-5.6-sol",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "responses",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "provider": "openai-codex",
+          "provider_model_id": "gpt-5.6-sol"
+        }
+      ],
+      "release_date": "2026-06-25"
+    },
+    {
+      "family": "gpt",
+      "id": "openai/gpt-5.6-terra",
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "knowledge_cutoff": "2026-05-31",
+      "max_input_tokens": 1000000,
+      "max_output_tokens": 128000,
+      "name": "OpenAI: GPT-5.6 Terra",
+      "open_weights": false,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools"
+          ],
+          "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 272000,
+                "input_tokens": {
+                  "cache_read": 0.5,
+                  "cache_write": 6.25,
+                  "no_cache": 5.0
+                },
+                "output_tokens": {
+                  "text": 22.5
+                }
+              }
+            ],
+            "input_tokens": {
+              "cache_read": 0.25,
+              "cache_write": 3.125,
+              "no_cache": 2.5
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider": "openai",
+          "provider_model_id": "gpt-5.6-terra",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "responses",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "provider": "openai-codex",
+          "provider_model_id": "gpt-5.6-terra"
+        }
+      ],
+      "release_date": "2026-06-25"
+    },
+    {
       "description": "Qwen3.5 open-source native vision-language MoE (122B total, 10B active).",
       "family": "qwen3.5",
       "id": "qwen/qwen3.5-122b-a10b",
@@ -5436,6 +5637,7 @@
           ],
           "pricing": {
             "input_tokens": {
+              "cache_read": 0.2,
               "no_cache": 1.25
             },
             "output_tokens": {
@@ -5564,6 +5766,59 @@
     },
     {
       "family": "grok",
+      "id": "x-ai/grok-4.5",
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "max_input_tokens": 500000,
+      "name": "xAI: Grok 4.5",
+      "open_weights": false,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": [
+            "responses",
+            "openai"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "provider": "supergrok",
+          "provider_model_id": "grok-4.5"
+        },
+        {
+          "api_protocol": [
+            "responses",
+            "openai"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 6.0
+            }
+          },
+          "provider": "xai",
+          "provider_model_id": "grok-4.5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        }
+      ],
+      "release_date": "2026-07-08"
+    },
+    {
+      "family": "grok",
       "id": "x-ai/grok-build-0.1",
       "input_modalities": [
         "text"
@@ -5642,6 +5897,7 @@
           ],
           "pricing": {
             "input_tokens": {
+              "cache_read": 0.2,
               "no_cache": 1.0
             },
             "output_tokens": {

--- a/dist/registry/providers.json
+++ b/dist/registry/providers.json
@@ -3540,6 +3540,123 @@
             "structured_outputs",
             "tools"
           ],
+          "id": "openai/gpt-5.6-sol",
+          "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 272000,
+                "input_tokens": {
+                  "cache_read": 1.0,
+                  "cache_write": 12.5,
+                  "no_cache": 10.0
+                },
+                "output_tokens": {
+                  "text": 45.0
+                }
+              }
+            ],
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 30.0
+            }
+          },
+          "provider_model_id": "gpt-5.6-sol",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools"
+          ],
+          "id": "openai/gpt-5.6-terra",
+          "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 272000,
+                "input_tokens": {
+                  "cache_read": 0.5,
+                  "cache_write": 6.25,
+                  "no_cache": 5.0
+                },
+                "output_tokens": {
+                  "text": 22.5
+                }
+              }
+            ],
+            "input_tokens": {
+              "cache_read": 0.25,
+              "cache_write": 3.125,
+              "no_cache": 2.5
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider_model_id": "gpt-5.6-terra",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools"
+          ],
+          "id": "openai/gpt-5.6-luna",
+          "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 272000,
+                "input_tokens": {
+                  "cache_read": 0.2,
+                  "cache_write": 2.5,
+                  "no_cache": 2.0
+                },
+                "output_tokens": {
+                  "text": 9.0
+                }
+              }
+            ],
+            "input_tokens": {
+              "cache_read": 0.1,
+              "cache_write": 1.25,
+              "no_cache": 1.0
+            },
+            "output_tokens": {
+              "text": 6.0
+            }
+          },
+          "provider_model_id": "gpt-5.6-luna",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools"
+          ],
           "id": "openai/gpt-5.5",
           "pricing": {
             "input_tokens": {
@@ -3645,6 +3762,33 @@
         "terms_of_service_url": "https://openai.com/terms"
       },
       "models": [
+        {
+          "api_protocol": "responses",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "openai/gpt-5.6-sol",
+          "provider_model_id": "gpt-5.6-sol"
+        },
+        {
+          "api_protocol": "responses",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "openai/gpt-5.6-terra",
+          "provider_model_id": "gpt-5.6-terra"
+        },
+        {
+          "api_protocol": "responses",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "openai/gpt-5.6-luna",
+          "provider_model_id": "gpt-5.6-luna"
+        },
         {
           "api_protocol": "responses",
           "capabilities": [
@@ -6556,6 +6700,18 @@
             "reasoning",
             "tools"
           ],
+          "id": "x-ai/grok-4.5",
+          "provider_model_id": "grok-4.5"
+        },
+        {
+          "api_protocol": [
+            "responses",
+            "openai"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
           "id": "x-ai/grok-4.20-multi-agent",
           "provider_model_id": "grok-4.20-multi-agent"
         },
@@ -7445,6 +7601,30 @@
             "reasoning",
             "tools"
           ],
+          "id": "x-ai/grok-4.5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 6.0
+            }
+          },
+          "provider_model_id": "grok-4.5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "responses",
+            "openai"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
           "id": "x-ai/grok-4.3",
           "pricing": {
             "input_tokens": {
@@ -7494,6 +7674,7 @@
           "id": "x-ai/grok-build-0.1",
           "pricing": {
             "input_tokens": {
+              "cache_read": 0.2,
               "no_cache": 1.0
             },
             "output_tokens": {
@@ -7517,6 +7698,7 @@
           "id": "x-ai/grok-4.20-multi-agent",
           "pricing": {
             "input_tokens": {
+              "cache_read": 0.2,
               "no_cache": 1.25
             },
             "output_tokens": {

--- a/docs/get-started/supported-models.md
+++ b/docs/get-started/supported-models.md
@@ -18,48 +18,52 @@ Prices are USD per **million tokens**, taken from the current [registry](https:/
 | `anthropic/claude-opus-4.8` | Anthropic: Claude Opus 4.8 | 1M | text, image | — | $5 | $25 |
 | `anthropic/claude-sonnet-4.6` | Anthropic: Claude Sonnet 4.6 | 1M | text, image | — | $3 | $15 |
 | `anthropic/claude-sonnet-5` | Anthropic: Claude Sonnet 5 | 1M | text, image | — | $2 | $10 |
-| `deepseek/deepseek-v3.2` | DeepSeek: DeepSeek V3.2 | 128K | text | ✅ | $0.2288 | $0.3432 |
+| `deepseek/deepseek-v3.2` | DeepSeek: DeepSeek V3.2 | 128K | text | ✅ | $0.21 | $0.315 |
 | `deepseek/deepseek-v4-flash` | DeepSeek: DeepSeek V4 Flash | 256K | text | ✅ | $0.09 | $0.18 |
 | `deepseek/deepseek-v4-pro` | DeepSeek: DeepSeek V4 Pro | 256K | text | ✅ | $0.435 | $0.87 |
 | `google/gemini-3.1-flash-lite-preview` | Google: Gemini 3.1 Flash Lite Preview | 1M | text, image | — | $0.25 | $1.5 |
 | `google/gemini-3.1-pro-preview` | Google: Gemini 3.1 Pro Preview | 2M | text, image | — | $2 | $12 |
 | `google/gemini-3.5-flash` | Google: Gemini 3.5 Flash | 1M | text, image, audio | — | $1.5 | $9 |
 | `google/gemma-4-31b` | Google: Gemma 4 31B | 128K | text, image | ✅ | $0.13 | $0.4 |
-| `inclusionai/ling-2.6-1t` | Ling 2.6 1T | 256K | text | ✅ | $0.3 | $2.5 |
-| `inclusionai/ling-2.6-flash` | Ling 2.6 Flash | 256K | text | ✅ | $0.1 | $0.3 |
-| `inclusionai/ring-2.6-1t` | Ring 2.6 1T | 256K | text | ✅ | $0.3 | $2.5 |
+| `inclusionai/ling-2.6-1t` | Ling 2.6 1T | 256K | text | ✅ | $0.075 | $0.625 |
+| `inclusionai/ling-2.6-flash` | Ling 2.6 Flash | 256K | text | ✅ | $0.01 | $0.03 |
+| `inclusionai/ring-2.6-1t` | Ring 2.6 1T | 256K | text | ✅ | $0.075 | $0.625 |
 | `meituan/longcat-2.0` | LongCat 2.0 | 1M | text | ✅ | — | — |
-| `minimax/minimax-m2.5` | MiniMax: M2.5 | 192K | text | ✅ | $0.15 | $1.2 |
-| `minimax/minimax-m2.7` | MiniMax: M2.7 | 192K | text | ✅ | $0.25 | $1 |
+| `minimax/minimax-m2.5` | MiniMax: M2.5 | 192K | text | ✅ | $0.15 | $0.9 |
+| `minimax/minimax-m2.7` | MiniMax: M2.7 | 192K | text | ✅ | $0.225 | $0.9 |
 | `minimax/minimax-m3` | MiniMax: M3 | 1M | text, image | ✅ | $0.3 | $1.2 |
 | `moonshotai/kimi-k2.5` | Kimi: K2.5 | 256K | text, image | ✅ | $0.375 | $2.025 |
 | `moonshotai/kimi-k2.6` | Kimi: K2.6 | 256K | text | ✅ | $0.66 | $3.41 |
 | `moonshotai/kimi-k2.7-code` | Kimi: K2.7 Code | 256K | text, image | ✅ | $0.612 | $3.069 |
-| `nex-agi/nex-n2-pro` | Nex AGI: Nex-N2-Pro | 256K | text, image | ✅ | — | — |
-| `nvidia/nemotron-3-super-120b-a12b` | Nemotron 3 Super 120B-A12B | 256K | text | ✅ | — | — |
-| `nvidia/nemotron-3-ultra-550b-a55b` | Nemotron 3 Ultra 550B-A55B | 1M | text | ✅ | — | — |
+| `nex-agi/nex-n2-pro` | Nex AGI: Nex-N2-Pro | 256K | text, image | ✅ | $0.25 | $1 |
+| `nvidia/nemotron-3-super-120b-a12b` | Nemotron 3 Super 120B-A12B | 256K | text | ✅ | $0.08 | $0.45 |
+| `nvidia/nemotron-3-ultra-550b-a55b` | Nemotron 3 Ultra 550B-A55B | 1M | text | ✅ | $0.5 | $2.2 |
 | `openai/gpt-5.4` | OpenAI: GPT-5.4 | 128K | text, image | — | $2.5 | $15 |
 | `openai/gpt-5.4-mini` | OpenAI: GPT-5.4 Mini | 128K | text, image | — | $0.75 | $4.5 |
 | `openai/gpt-5.5` | OpenAI: GPT-5.5 | 128K | text, image | — | $5 | $30 |
+| `openai/gpt-5.6-luna` | OpenAI: GPT-5.6 Luna | 400K | text, image | — | $1 | $6 |
+| `openai/gpt-5.6-sol` | OpenAI: GPT-5.6 Sol | 1M | text, image | — | $5 | $30 |
+| `openai/gpt-5.6-terra` | OpenAI: GPT-5.6 Terra | 1M | text, image | — | $2.5 | $15 |
 | `qwen/qwen3.5-122b-a10b` | Qwen: Qwen3.5 122B-A10B | 256K | text, image | ✅ | $0.26 | $2.08 |
-| `qwen/qwen3.5-27b` | Qwen: Qwen3.5 27B | 256K | text, image | ✅ | $0.25 | $2 |
-| `qwen/qwen3.6-27b` | Qwen: Qwen3.6 27B | 256K | text, image | ✅ | $0.3 | $3.2 |
-| `qwen/qwen3.6-35b-a3b` | Qwen: Qwen3.6 35B-A3B | 256K | text, image | ✅ | $0.2 | $1.6 |
+| `qwen/qwen3.5-27b` | Qwen: Qwen3.5 27B | 256K | text, image | ✅ | $0.195 | $1.56 |
+| `qwen/qwen3.6-27b` | Qwen: Qwen3.6 27B | 256K | text, image | ✅ | $0.285 | $2.4 |
+| `qwen/qwen3.6-35b-a3b` | Qwen: Qwen3.6 35B-A3B | 256K | text, image | ✅ | $0.14 | $1 |
 | `qwen/qwen3.6-flash` | Qwen: Qwen3.6 Flash | 1M | text, image | — | $0.165 | $0.99 |
 | `qwen/qwen3.7-max` | Qwen: Qwen3.7 Max | 1M | text | — | $1.25 | $3.75 |
 | `qwen/qwen3.7-plus` | Qwen: Qwen3.7 Plus | 1M | text, image | — | $0.276 | $1.101 |
-| `stepfun/step-3.5-flash` | StepFun: Step 3.5 Flash | 256K | text | ✅ | $0.09 | $0.3 |
-| `stepfun/step-3.7-flash` | StepFun: Step 3.7 Flash | 256K | text, image | ✅ | $0.2 | $1.15 |
-| `tencent/hy3` | Hunyuan 3 | 256K | text | ✅ | $0.066 | $0.26 |
+| `stepfun/step-3.5-flash` | StepFun: Step 3.5 Flash | 256K | text | ✅ | $0.072 | $0.216 |
+| `stepfun/step-3.7-flash` | StepFun: Step 3.7 Flash | 256K | text, image | ✅ | $0.15 | $0.8625 |
+| `tencent/hy3` | Hunyuan 3 | 256K | text | ✅ | $0 | $0 |
 | `x-ai/grok-4.20` | xAI: Grok 4.20 | 128K | text, image | — | $1.25 | $2.5 |
 | `x-ai/grok-4.20-multi-agent` | xAI: Grok 4.20 Multi-Agent | 1M | text, image | — | $1.25 | $2.5 |
 | `x-ai/grok-4.3` | xAI: Grok 4.3 | 1M | text, image | — | $1.25 | $2.5 |
+| `x-ai/grok-4.5` | xAI: Grok 4.5 | 500K | text, image | — | $2 | $6 |
 | `x-ai/grok-build-0.1` | xAI: Grok Build 0.1 | 256K | text | — | $1 | $2 |
 | `xiaomi/mimo-v2.5` | Xiaomi: MiMo V2.5 | 256K | text | ✅ | $0.14 | $0.28 |
 | `xiaomi/mimo-v2.5-pro` | Xiaomi: MiMo V2.5 Pro | 256K | text | ✅ | $0.435 | $0.87 |
-| `z-ai/glm-4.7` | Zhipu: GLM-4.7 | 200K | text | ✅ | $0.6 | $2.2 |
+| `z-ai/glm-4.7` | Zhipu: GLM-4.7 | 200K | text | ✅ | $0.4 | $1.75 |
 | `z-ai/glm-5` | Zhipu: GLM-5 | 198K | text | ✅ | $0.6 | $1.92 |
-| `z-ai/glm-5.1` | Zhipu: GLM-5.1 | 128K | text | ✅ | $0.95 | $3.15 |
+| `z-ai/glm-5.1` | Zhipu: GLM-5.1 | 128K | text | ✅ | $0.83 | $3.33 |
 | `z-ai/glm-5.2` | Zhipu: GLM-5.2 | 1M | text | ✅ | $0.979 | $3.08 |
 
 ## Using BitRouter Cloud

--- a/docs/get-started/supported-models.zh.md
+++ b/docs/get-started/supported-models.zh.md
@@ -18,48 +18,52 @@ BitRouter 能路由到的每个模型都列在下面。你可以经自己的供�
 | `anthropic/claude-opus-4.8` | Anthropic: Claude Opus 4.8 | 1M | text, image | — | $5 | $25 |
 | `anthropic/claude-sonnet-4.6` | Anthropic: Claude Sonnet 4.6 | 1M | text, image | — | $3 | $15 |
 | `anthropic/claude-sonnet-5` | Anthropic: Claude Sonnet 5 | 1M | text, image | — | $2 | $10 |
-| `deepseek/deepseek-v3.2` | DeepSeek: DeepSeek V3.2 | 128K | text | ✅ | $0.2288 | $0.3432 |
+| `deepseek/deepseek-v3.2` | DeepSeek: DeepSeek V3.2 | 128K | text | ✅ | $0.21 | $0.315 |
 | `deepseek/deepseek-v4-flash` | DeepSeek: DeepSeek V4 Flash | 256K | text | ✅ | $0.09 | $0.18 |
 | `deepseek/deepseek-v4-pro` | DeepSeek: DeepSeek V4 Pro | 256K | text | ✅ | $0.435 | $0.87 |
 | `google/gemini-3.1-flash-lite-preview` | Google: Gemini 3.1 Flash Lite Preview | 1M | text, image | — | $0.25 | $1.5 |
 | `google/gemini-3.1-pro-preview` | Google: Gemini 3.1 Pro Preview | 2M | text, image | — | $2 | $12 |
 | `google/gemini-3.5-flash` | Google: Gemini 3.5 Flash | 1M | text, image, audio | — | $1.5 | $9 |
 | `google/gemma-4-31b` | Google: Gemma 4 31B | 128K | text, image | ✅ | $0.13 | $0.4 |
-| `inclusionai/ling-2.6-1t` | Ling 2.6 1T | 256K | text | ✅ | $0.3 | $2.5 |
-| `inclusionai/ling-2.6-flash` | Ling 2.6 Flash | 256K | text | ✅ | $0.1 | $0.3 |
-| `inclusionai/ring-2.6-1t` | Ring 2.6 1T | 256K | text | ✅ | $0.3 | $2.5 |
+| `inclusionai/ling-2.6-1t` | Ling 2.6 1T | 256K | text | ✅ | $0.075 | $0.625 |
+| `inclusionai/ling-2.6-flash` | Ling 2.6 Flash | 256K | text | ✅ | $0.01 | $0.03 |
+| `inclusionai/ring-2.6-1t` | Ring 2.6 1T | 256K | text | ✅ | $0.075 | $0.625 |
 | `meituan/longcat-2.0` | LongCat 2.0 | 1M | text | ✅ | — | — |
-| `minimax/minimax-m2.5` | MiniMax: M2.5 | 192K | text | ✅ | $0.15 | $1.2 |
-| `minimax/minimax-m2.7` | MiniMax: M2.7 | 192K | text | ✅ | $0.25 | $1 |
+| `minimax/minimax-m2.5` | MiniMax: M2.5 | 192K | text | ✅ | $0.15 | $0.9 |
+| `minimax/minimax-m2.7` | MiniMax: M2.7 | 192K | text | ✅ | $0.225 | $0.9 |
 | `minimax/minimax-m3` | MiniMax: M3 | 1M | text, image | ✅ | $0.3 | $1.2 |
 | `moonshotai/kimi-k2.5` | Kimi: K2.5 | 256K | text, image | ✅ | $0.375 | $2.025 |
 | `moonshotai/kimi-k2.6` | Kimi: K2.6 | 256K | text | ✅ | $0.66 | $3.41 |
 | `moonshotai/kimi-k2.7-code` | Kimi: K2.7 Code | 256K | text, image | ✅ | $0.612 | $3.069 |
-| `nex-agi/nex-n2-pro` | Nex AGI: Nex-N2-Pro | 256K | text, image | ✅ | — | — |
-| `nvidia/nemotron-3-super-120b-a12b` | Nemotron 3 Super 120B-A12B | 256K | text | ✅ | — | — |
-| `nvidia/nemotron-3-ultra-550b-a55b` | Nemotron 3 Ultra 550B-A55B | 1M | text | ✅ | — | — |
+| `nex-agi/nex-n2-pro` | Nex AGI: Nex-N2-Pro | 256K | text, image | ✅ | $0.25 | $1 |
+| `nvidia/nemotron-3-super-120b-a12b` | Nemotron 3 Super 120B-A12B | 256K | text | ✅ | $0.08 | $0.45 |
+| `nvidia/nemotron-3-ultra-550b-a55b` | Nemotron 3 Ultra 550B-A55B | 1M | text | ✅ | $0.5 | $2.2 |
 | `openai/gpt-5.4` | OpenAI: GPT-5.4 | 128K | text, image | — | $2.5 | $15 |
 | `openai/gpt-5.4-mini` | OpenAI: GPT-5.4 Mini | 128K | text, image | — | $0.75 | $4.5 |
 | `openai/gpt-5.5` | OpenAI: GPT-5.5 | 128K | text, image | — | $5 | $30 |
+| `openai/gpt-5.6-luna` | OpenAI: GPT-5.6 Luna | 400K | text, image | — | $1 | $6 |
+| `openai/gpt-5.6-sol` | OpenAI: GPT-5.6 Sol | 1M | text, image | — | $5 | $30 |
+| `openai/gpt-5.6-terra` | OpenAI: GPT-5.6 Terra | 1M | text, image | — | $2.5 | $15 |
 | `qwen/qwen3.5-122b-a10b` | Qwen: Qwen3.5 122B-A10B | 256K | text, image | ✅ | $0.26 | $2.08 |
-| `qwen/qwen3.5-27b` | Qwen: Qwen3.5 27B | 256K | text, image | ✅ | $0.25 | $2 |
-| `qwen/qwen3.6-27b` | Qwen: Qwen3.6 27B | 256K | text, image | ✅ | $0.3 | $3.2 |
-| `qwen/qwen3.6-35b-a3b` | Qwen: Qwen3.6 35B-A3B | 256K | text, image | ✅ | $0.2 | $1.6 |
+| `qwen/qwen3.5-27b` | Qwen: Qwen3.5 27B | 256K | text, image | ✅ | $0.195 | $1.56 |
+| `qwen/qwen3.6-27b` | Qwen: Qwen3.6 27B | 256K | text, image | ✅ | $0.285 | $2.4 |
+| `qwen/qwen3.6-35b-a3b` | Qwen: Qwen3.6 35B-A3B | 256K | text, image | ✅ | $0.14 | $1 |
 | `qwen/qwen3.6-flash` | Qwen: Qwen3.6 Flash | 1M | text, image | — | $0.165 | $0.99 |
 | `qwen/qwen3.7-max` | Qwen: Qwen3.7 Max | 1M | text | — | $1.25 | $3.75 |
 | `qwen/qwen3.7-plus` | Qwen: Qwen3.7 Plus | 1M | text, image | — | $0.276 | $1.101 |
-| `stepfun/step-3.5-flash` | StepFun: Step 3.5 Flash | 256K | text | ✅ | $0.09 | $0.3 |
-| `stepfun/step-3.7-flash` | StepFun: Step 3.7 Flash | 256K | text, image | ✅ | $0.2 | $1.15 |
-| `tencent/hy3` | Hunyuan 3 | 256K | text | ✅ | $0.066 | $0.26 |
+| `stepfun/step-3.5-flash` | StepFun: Step 3.5 Flash | 256K | text | ✅ | $0.072 | $0.216 |
+| `stepfun/step-3.7-flash` | StepFun: Step 3.7 Flash | 256K | text, image | ✅ | $0.15 | $0.8625 |
+| `tencent/hy3` | Hunyuan 3 | 256K | text | ✅ | $0 | $0 |
 | `x-ai/grok-4.20` | xAI: Grok 4.20 | 128K | text, image | — | $1.25 | $2.5 |
 | `x-ai/grok-4.20-multi-agent` | xAI: Grok 4.20 Multi-Agent | 1M | text, image | — | $1.25 | $2.5 |
 | `x-ai/grok-4.3` | xAI: Grok 4.3 | 1M | text, image | — | $1.25 | $2.5 |
+| `x-ai/grok-4.5` | xAI: Grok 4.5 | 500K | text, image | — | $2 | $6 |
 | `x-ai/grok-build-0.1` | xAI: Grok Build 0.1 | 256K | text | — | $1 | $2 |
 | `xiaomi/mimo-v2.5` | Xiaomi: MiMo V2.5 | 256K | text | ✅ | $0.14 | $0.28 |
 | `xiaomi/mimo-v2.5-pro` | Xiaomi: MiMo V2.5 Pro | 256K | text | ✅ | $0.435 | $0.87 |
-| `z-ai/glm-4.7` | Zhipu: GLM-4.7 | 200K | text | ✅ | $0.6 | $2.2 |
+| `z-ai/glm-4.7` | Zhipu: GLM-4.7 | 200K | text | ✅ | $0.4 | $1.75 |
 | `z-ai/glm-5` | Zhipu: GLM-5 | 198K | text | ✅ | $0.6 | $1.92 |
-| `z-ai/glm-5.1` | Zhipu: GLM-5.1 | 128K | text | ✅ | $0.95 | $3.15 |
+| `z-ai/glm-5.1` | Zhipu: GLM-5.1 | 128K | text | ✅ | $0.83 | $3.33 |
 | `z-ai/glm-5.2` | Zhipu: GLM-5.2 | 1M | text | ✅ | $0.979 | $3.08 |
 
 ## 使用 BitRouter Cloud

--- a/docs/get-started/supported-providers.md
+++ b/docs/get-started/supported-providers.md
@@ -9,19 +9,19 @@ Every model in the [catalog](/docs/get-started/supported-models) is served by on
 
 | Provider | Name | HQ | Protocols | Billing | Models |
 | --- | --- | --- | --- | --- | --- |
-| `alibaba` | Alibaba Cloud | CN | anthropic, openai, responses | Per-token | 4 |
-| `alibaba_cn` | Alibaba Cloud | CN | anthropic, openai, responses | Per-token | 4 |
-| `alibaba_coding_plan` | Alibaba Cloud | CN | openai | Subscription | 7 |
+| `alibaba` | Alibaba Cloud | CN | anthropic, openai, responses | Per-token | 8 |
+| `alibaba_cn` | Alibaba Cloud | CN | anthropic, openai, responses | Per-token | 13 |
+| `alibaba_coding_plan` | Alibaba Cloud | CN | openai | Subscription | 8 |
 | `ambient` | Ambient | US | openai | Per-token | 2 |
 | `anthropic` | Anthropic | US | anthropic | Per-token | 8 |
-| `atlascloud` | Atlas Cloud | US | openai | Per-token | 14 |
-| `bitrouter` | BitRouter | US | — | Per-token | 0 |
+| `atlascloud` | Atlas Cloud | US | openai | Per-token | 13 |
+| `bitrouter` | BitRouter | US | openai | Per-token | 49 |
 | `byteplus` | BytePlus | CN | openai | Per-token | 1 |
-| `cerebras` | Cerebras | US | openai | Per-token | 1 |
+| `cerebras` | Cerebras | US | openai | Per-token | 3 |
 | `chutes` | Chutes | US | openai | Per-token | 7 |
 | `claude-code` | Anthropic | US | anthropic | Subscription | 7 |
 | `deepseek` | DeepSeek | CN | anthropic, openai | Per-token | 2 |
-| `github-copilot` | GitHub | US | openai | Subscription | 13 |
+| `github-copilot` | GitHub | US | openai | Subscription | 14 |
 | `gmicloud` | GMI Cloud | US | openai | Per-token | 13 |
 | `google` | Google | US | google, openai | Per-token | 4 |
 | `google-ai` | Google | US | google, openai | Subscription | 3 |
@@ -30,14 +30,15 @@ Every model in the [catalog](/docs/get-started/supported-models) is served by on
 | `moonshotai` | Moonshot AI | CN | anthropic, openai | Per-token | 3 |
 | `moonshotai_coding_plan` | Moonshot AI | CN | openai | Subscription | 1 |
 | `novita` | Novita AI | US | openai | Per-token | 18 |
-| `openai` | OpenAI | US | openai, responses | Per-token | 3 |
-| `openai-codex` | OpenAI | US | responses | Subscription | 3 |
+| `openai` | OpenAI | US | openai, responses | Per-token | 6 |
+| `openai-codex` | OpenAI | US | responses | Subscription | 6 |
 | `opencode-go` | OpenCode | US | openai | Subscription | 18 |
-| `opencode-zen` | OpenCode | US | openai | Per-token | 24 |
-| `openrouter` | OpenRouter | US | anthropic, openai, responses | Per-token | 39 |
+| `opencode-zen` | OpenCode | US | openai | Per-token | 26 |
+| `openrouter` | OpenRouter | US | anthropic, openai, responses | Per-token | 52 |
 | `phala` | Phala | US | openai | Per-token | 5 |
-| `qianfan` | Baidu AI Cloud | CN | openai | Per-token | 3 |
-| `qianfan_cn` | Baidu AI Cloud | CN | openai | Per-token | 6 |
+| `qianfan` | Baidu AI Cloud | CN | openai | Per-token | 8 |
+| `qianfan_cn` | Baidu AI Cloud | CN | openai | Per-token | 9 |
+| `redpill` | RedPill | SG | openai | Per-token | 5 |
 | `siliconflow` | SiliconFlow | CN | openai | Per-token | 17 |
 | `siliconflow_cn` | SiliconFlow | CN | openai | Per-token | 13 |
 | `stepfun` | StepFun | CN | anthropic, openai | Per-token | 2 |
@@ -45,18 +46,18 @@ Every model in the [catalog](/docs/get-started/supported-models) is served by on
 | `stepfun_step_plan` | StepFun | CN | anthropic, openai | Subscription | 2 |
 | `stepfun_step_plan_cn` | StepFun | CN | anthropic, openai | Subscription | 2 |
 | `streamlake` | StreamLake | CN | openai | Per-token | 3 |
-| `supergrok` | xAI | US | openai, responses | Subscription | 4 |
+| `supergrok` | xAI | US | openai, responses | Subscription | 5 |
 | `tencent` | Tencent Cloud | CN | anthropic, openai, responses | Per-token | 11 |
-| `tencent_cn` | Tencent Cloud | CN | anthropic, openai, responses | Per-token | 11 |
-| `tinfoil` | Tinfoil | US | openai | Per-token | 3 |
+| `tencent_cn` | Tencent Cloud | CN | anthropic, openai, responses | Per-token | 12 |
+| `tinfoil` | Tinfoil | US | openai | Per-token | 5 |
 | `volcengine` | Volcengine | CN | openai | Per-token | 2 |
-| `xai` | xAI | US | openai, responses | Per-token | 4 |
+| `xai` | xAI | US | openai, responses | Per-token | 5 |
 | `xiaomi` | Xiaomi | CN | anthropic, openai, responses | Per-token | 5 |
 | `xiaomi_token_plan` | Xiaomi | CN | anthropic, openai, responses | Subscription | 2 |
 | `xiaomi_token_plan_cn` | Xiaomi | CN | anthropic, openai, responses | Subscription | 2 |
 | `xiaomi_token_plan_eu` | Xiaomi | CN | anthropic, openai, responses | Subscription | 2 |
-| `zai` | Z.ai | CN | anthropic, openai | Per-token | 3 |
-| `zai_coding_plan` | Z.ai | CN | anthropic, openai | Subscription | 3 |
+| `zai` | Z.ai | CN | anthropic, openai | Per-token | 4 |
+| `zai_coding_plan` | Z.ai | CN | anthropic, openai | Subscription | 4 |
 
 ## Register your own
 

--- a/docs/get-started/supported-providers.zh.md
+++ b/docs/get-started/supported-providers.zh.md
@@ -9,19 +9,19 @@ description: BitRouter 网络上已注册的每个供应商——由任何人都
 
 | 供应商 | 名称 | 总部 | 协议 | 计费 | 模型数 |
 | --- | --- | --- | --- | --- | --- |
-| `alibaba` | Alibaba Cloud | CN | anthropic, openai, responses | Per-token | 4 |
-| `alibaba_cn` | Alibaba Cloud | CN | anthropic, openai, responses | Per-token | 4 |
-| `alibaba_coding_plan` | Alibaba Cloud | CN | openai | Subscription | 7 |
+| `alibaba` | Alibaba Cloud | CN | anthropic, openai, responses | Per-token | 8 |
+| `alibaba_cn` | Alibaba Cloud | CN | anthropic, openai, responses | Per-token | 13 |
+| `alibaba_coding_plan` | Alibaba Cloud | CN | openai | Subscription | 8 |
 | `ambient` | Ambient | US | openai | Per-token | 2 |
 | `anthropic` | Anthropic | US | anthropic | Per-token | 8 |
-| `atlascloud` | Atlas Cloud | US | openai | Per-token | 14 |
-| `bitrouter` | BitRouter | US | — | Per-token | 0 |
+| `atlascloud` | Atlas Cloud | US | openai | Per-token | 13 |
+| `bitrouter` | BitRouter | US | openai | Per-token | 49 |
 | `byteplus` | BytePlus | CN | openai | Per-token | 1 |
-| `cerebras` | Cerebras | US | openai | Per-token | 1 |
+| `cerebras` | Cerebras | US | openai | Per-token | 3 |
 | `chutes` | Chutes | US | openai | Per-token | 7 |
 | `claude-code` | Anthropic | US | anthropic | Subscription | 7 |
 | `deepseek` | DeepSeek | CN | anthropic, openai | Per-token | 2 |
-| `github-copilot` | GitHub | US | openai | Subscription | 13 |
+| `github-copilot` | GitHub | US | openai | Subscription | 14 |
 | `gmicloud` | GMI Cloud | US | openai | Per-token | 13 |
 | `google` | Google | US | google, openai | Per-token | 4 |
 | `google-ai` | Google | US | google, openai | Subscription | 3 |
@@ -30,14 +30,15 @@ description: BitRouter 网络上已注册的每个供应商——由任何人都
 | `moonshotai` | Moonshot AI | CN | anthropic, openai | Per-token | 3 |
 | `moonshotai_coding_plan` | Moonshot AI | CN | openai | Subscription | 1 |
 | `novita` | Novita AI | US | openai | Per-token | 18 |
-| `openai` | OpenAI | US | openai, responses | Per-token | 3 |
-| `openai-codex` | OpenAI | US | responses | Subscription | 3 |
+| `openai` | OpenAI | US | openai, responses | Per-token | 6 |
+| `openai-codex` | OpenAI | US | responses | Subscription | 6 |
 | `opencode-go` | OpenCode | US | openai | Subscription | 18 |
-| `opencode-zen` | OpenCode | US | openai | Per-token | 24 |
-| `openrouter` | OpenRouter | US | anthropic, openai, responses | Per-token | 39 |
+| `opencode-zen` | OpenCode | US | openai | Per-token | 26 |
+| `openrouter` | OpenRouter | US | anthropic, openai, responses | Per-token | 52 |
 | `phala` | Phala | US | openai | Per-token | 5 |
-| `qianfan` | Baidu AI Cloud | CN | openai | Per-token | 3 |
-| `qianfan_cn` | Baidu AI Cloud | CN | openai | Per-token | 6 |
+| `qianfan` | Baidu AI Cloud | CN | openai | Per-token | 8 |
+| `qianfan_cn` | Baidu AI Cloud | CN | openai | Per-token | 9 |
+| `redpill` | RedPill | SG | openai | Per-token | 5 |
 | `siliconflow` | SiliconFlow | CN | openai | Per-token | 17 |
 | `siliconflow_cn` | SiliconFlow | CN | openai | Per-token | 13 |
 | `stepfun` | StepFun | CN | anthropic, openai | Per-token | 2 |
@@ -45,18 +46,18 @@ description: BitRouter 网络上已注册的每个供应商——由任何人都
 | `stepfun_step_plan` | StepFun | CN | anthropic, openai | Subscription | 2 |
 | `stepfun_step_plan_cn` | StepFun | CN | anthropic, openai | Subscription | 2 |
 | `streamlake` | StreamLake | CN | openai | Per-token | 3 |
-| `supergrok` | xAI | US | openai, responses | Subscription | 4 |
+| `supergrok` | xAI | US | openai, responses | Subscription | 5 |
 | `tencent` | Tencent Cloud | CN | anthropic, openai, responses | Per-token | 11 |
-| `tencent_cn` | Tencent Cloud | CN | anthropic, openai, responses | Per-token | 11 |
-| `tinfoil` | Tinfoil | US | openai | Per-token | 3 |
+| `tencent_cn` | Tencent Cloud | CN | anthropic, openai, responses | Per-token | 12 |
+| `tinfoil` | Tinfoil | US | openai | Per-token | 5 |
 | `volcengine` | Volcengine | CN | openai | Per-token | 2 |
-| `xai` | xAI | US | openai, responses | Per-token | 4 |
+| `xai` | xAI | US | openai, responses | Per-token | 5 |
 | `xiaomi` | Xiaomi | CN | anthropic, openai, responses | Per-token | 5 |
 | `xiaomi_token_plan` | Xiaomi | CN | anthropic, openai, responses | Subscription | 2 |
 | `xiaomi_token_plan_cn` | Xiaomi | CN | anthropic, openai, responses | Subscription | 2 |
 | `xiaomi_token_plan_eu` | Xiaomi | CN | anthropic, openai, responses | Subscription | 2 |
-| `zai` | Z.ai | CN | anthropic, openai | Per-token | 3 |
-| `zai_coding_plan` | Z.ai | CN | anthropic, openai | Subscription | 3 |
+| `zai` | Z.ai | CN | anthropic, openai | Per-token | 4 |
+| `zai_coding_plan` | Z.ai | CN | anthropic, openai | Subscription | 4 |
 
 ## 注册你自己的供应商
 

--- a/registry/models/openai.yaml
+++ b/registry/models/openai.yaml
@@ -1,3 +1,48 @@
+# GPT-5.6 family (Sol/Terra/Luna) — preview from 2026-06-25, general release
+# ~2026-07-09. Pricing is confirmed from OpenAI's launch catalog (see
+# providers/openai.yaml). OpenAI has not published an official spec sheet, so the
+# max_*_tokens and knowledge_cutoff below are the figures reported post-launch
+# (~1M context on Sol/Terra, ~400K on Luna; 128K output; ~May 2026 cutoff) and
+# should be reconciled once models.dev/OpenAI confirm.
+- id: openai/gpt-5.6-sol
+  name: 'OpenAI: GPT-5.6 Sol'
+  input_modalities:
+  - text
+  - image
+  output_modalities:
+  - text
+  max_input_tokens: 1000000
+  max_output_tokens: 128000
+  release_date: 2026-06-25
+  knowledge_cutoff: 2026-05-31
+  open_weights: false
+  family: gpt
+- id: openai/gpt-5.6-terra
+  name: 'OpenAI: GPT-5.6 Terra'
+  input_modalities:
+  - text
+  - image
+  output_modalities:
+  - text
+  max_input_tokens: 1000000
+  max_output_tokens: 128000
+  release_date: 2026-06-25
+  knowledge_cutoff: 2026-05-31
+  open_weights: false
+  family: gpt
+- id: openai/gpt-5.6-luna
+  name: 'OpenAI: GPT-5.6 Luna'
+  input_modalities:
+  - text
+  - image
+  output_modalities:
+  - text
+  max_input_tokens: 400000
+  max_output_tokens: 128000
+  release_date: 2026-06-25
+  knowledge_cutoff: 2026-05-31
+  open_weights: false
+  family: gpt
 - id: openai/gpt-5.4-mini
   name: 'OpenAI: GPT-5.4 Mini'
   input_modalities:

--- a/registry/models/x-ai.yaml
+++ b/registry/models/x-ai.yaml
@@ -20,6 +20,17 @@
   release_date: 2026-03-12
   open_weights: false
   family: grok
+- id: x-ai/grok-4.5
+  name: 'xAI: Grok 4.5'
+  input_modalities:
+  - text
+  - image
+  output_modalities:
+  - text
+  max_input_tokens: 500000
+  release_date: 2026-07-08
+  open_weights: false
+  family: grok
 - id: x-ai/grok-4.3
   name: 'xAI: Grok 4.3'
   input_modalities:

--- a/registry/providers/openai-codex.yaml
+++ b/registry/providers/openai-codex.yaml
@@ -47,6 +47,17 @@ auth:
     # Loopback redirect on a pinned port, registered against the OAuth client.
     redirect_uri: http://localhost:1455/auth/callback
 models:
+  # GPT-5.6 family — available through the OpenAI API and Codex during the
+  # 2026-06-25 limited preview. Flat-rate subscription, so no per-token pricing.
+  - id: openai/gpt-5.6-sol
+    provider_model_id: gpt-5.6-sol
+    capabilities: [reasoning, tools]
+  - id: openai/gpt-5.6-terra
+    provider_model_id: gpt-5.6-terra
+    capabilities: [reasoning, tools]
+  - id: openai/gpt-5.6-luna
+    provider_model_id: gpt-5.6-luna
+    capabilities: [reasoning, tools]
   - id: openai/gpt-5.5
     provider_model_id: gpt-5.5
     capabilities: [reasoning, tools]

--- a/registry/providers/openai.yaml
+++ b/registry/providers/openai.yaml
@@ -14,6 +14,73 @@ rate_limits:
   - "*":
       requests_per_minute: 60
 models:
+  # GPT-5.6 family. Pricing per 1M tokens from OpenAI's launch catalog. Like
+  # GPT-5.5, input above 272k tokens bills at the long-context tier (roughly 2x
+  # input, higher output) — encoded via context_tiers. cache_read is the 90%-off
+  # input rate; cache_write is the one-time cost to populate the prompt cache.
+  - id: openai/gpt-5.6-sol
+    provider_model_id: gpt-5.6-sol
+    pricing:
+      input_tokens:
+        no_cache: 5
+        cache_read: 0.5
+        cache_write: 6.25
+      output_tokens:
+        text: 30
+      context_tiers:
+        - above_input_tokens: 272000
+          input_tokens:
+            no_cache: 10
+            cache_read: 1
+            cache_write: 12.5
+          output_tokens:
+            text: 45
+    capabilities:
+      - reasoning
+      - structured_outputs
+      - tools
+  - id: openai/gpt-5.6-terra
+    provider_model_id: gpt-5.6-terra
+    pricing:
+      input_tokens:
+        no_cache: 2.5
+        cache_read: 0.25
+        cache_write: 3.125
+      output_tokens:
+        text: 15
+      context_tiers:
+        - above_input_tokens: 272000
+          input_tokens:
+            no_cache: 5
+            cache_read: 0.5
+            cache_write: 6.25
+          output_tokens:
+            text: 22.5
+    capabilities:
+      - reasoning
+      - structured_outputs
+      - tools
+  - id: openai/gpt-5.6-luna
+    provider_model_id: gpt-5.6-luna
+    pricing:
+      input_tokens:
+        no_cache: 1
+        cache_read: 0.1
+        cache_write: 1.25
+      output_tokens:
+        text: 6
+      context_tiers:
+        - above_input_tokens: 272000
+          input_tokens:
+            no_cache: 2
+            cache_read: 0.2
+            cache_write: 2.5
+          output_tokens:
+            text: 9
+    capabilities:
+      - reasoning
+      - structured_outputs
+      - tools
   - id: openai/gpt-5.5
     provider_model_id: gpt-5.5
     pricing:

--- a/registry/providers/supergrok.yaml
+++ b/registry/providers/supergrok.yaml
@@ -23,6 +23,11 @@ api_protocol:
   - "*": [responses, openai]
 rate_limits: []
 models:
+  - id: x-ai/grok-4.5
+    provider_model_id: grok-4.5
+    capabilities:
+      - reasoning
+      - tools
   - id: x-ai/grok-4.20-multi-agent
     provider_model_id: grok-4.20-multi-agent
     capabilities:

--- a/registry/providers/xai.yaml
+++ b/registry/providers/xai.yaml
@@ -15,6 +15,19 @@ rate_limits:
 # Catalog source: https://models.dev/api.json (provider key `xai`); >200k tier on Grok 4 family doubles the base price listed here.
 # Pricing is per 1M tokens.
 models:
+  - id: x-ai/grok-4.5
+    provider_model_id: grok-4.5
+    # Pricing from the xAI API catalog ($2.00 in / $6.00 out per 1M, $0.50
+    # cached input). 500k-token context window.
+    pricing:
+      input_tokens:
+        no_cache: 2
+        cache_read: 0.5
+      output_tokens:
+        text: 6
+    capabilities:
+      - reasoning
+      - tools
   - id: x-ai/grok-4.3
     provider_model_id: grok-4.3
     pricing:
@@ -41,21 +54,22 @@ models:
       - tools
   - id: x-ai/grok-build-0.1
     provider_model_id: grok-build-0.1
-    # Pricing from the xAI console catalog ($1.00 in / $2.00 out per 1M).
-    # No cached-input rate published there, so cache_read is omitted.
+    # Pricing from the xAI catalog ($1.00 in / $0.20 cached / $2.00 out per 1M).
     pricing:
       input_tokens:
         no_cache: 1
+        cache_read: 0.2
       output_tokens:
         text: 2
     capabilities:
       - tools
   - id: x-ai/grok-4.20-multi-agent
     provider_model_id: grok-4.20-multi-agent-0309
-    # Pricing from the xAI console catalog ($1.25 in / $2.50 out per 1M).
+    # Pricing from the xAI catalog ($1.25 in / $0.20 cached / $2.50 out per 1M).
     pricing:
       input_tokens:
         no_cache: 1.25
+        cache_read: 0.2
       output_tokens:
         text: 2.5
     capabilities:


### PR DESCRIPTION
## Summary

Adds newly launched models to the registry, researched and verified against vendor catalogs.

**GPT-5.6 family (Sol / Terra / Luna)** — preview 2026-06-25, general release ~2026-07-09
- Added to `registry/models/openai.yaml` and both OpenAI providers (`openai.yaml` metered, `openai-codex.yaml` subscription).
- Pricing from OpenAI's launch catalog, per 1M tokens:

  | Model | Input | Cached | Cache write | Output | Long-context (>272k in) |
  |---|---|---|---|---|---|
  | Sol | $5 | $0.50 | $6.25 | $30 | $10 / $1 / $12.50 / $45 |
  | Terra | $2.50 | $0.25 | $3.125 | $15 | $5 / $0.50 / $6.25 / $22.50 |
  | Luna | $1 | $0.10 | $1.25 | $6 | $2 / $0.20 / $2.50 / $9 |
- Long-context tier encoded via `context_tiers` at the 272k-token boundary (inherited from GPT-5.5).

**Grok 4.5** — dev 2026-07-08, public 2026-07-09
- Added to `registry/models/x-ai.yaml` and both xAI providers (`xai.yaml` metered, `supergrok.yaml` subscription).
- 500k context; $2 in / $0.50 cached / $6 out per 1M — verified against xAI's published catalog.
- Also backfilled the newly published `$0.20/1M` cached-input rate on `grok-build-0.1` and `grok-4.20-multi-agent-0309`, which the catalog now lists.

Rebuilt `dist/registry/{models,providers}.json` and regenerated the `supported-models` / `supported-providers` docs tables (EN + zh) via the standard scripts.

## Caveat

GPT-5.6 **pricing** is confirmed from OpenAI's launch catalog. **Context windows** (~1M Sol/Terra, ~400K Luna; 128K output) and the **~May 2026 knowledge cutoff** are reported post-launch figures — OpenAI has not shipped an official spec sheet — and are flagged in-file for reconciliation once models.dev/OpenAI confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)