### PR TITLE
feat(providers): add SuperGrok BYO subscription

### DIFF
--- a/apps/bitrouter/src/assemble.rs
+++ b/apps/bitrouter/src/assemble.rs
@@ -855,6 +855,14 @@ fn build_auth_appliers(config: &Config) -> Result<AuthAppliers> {
             .context("building the openai-codex AuthApplier")?;
         appliers.register("openai-codex", Arc::new(applier));
     }
+    // The SuperGrok subscription applier (OAuth imported from the Grok CLI
+    // session). Registered under `supergrok`, distinct from the metered `xai`
+    // API-key provider.
+    if config.providers.contains_key("supergrok") {
+        let applier = bitrouter_providers::supergrok::SuperGrokAuthApplier::new(&store_path)
+            .context("building the supergrok AuthApplier")?;
+        appliers.register("supergrok", Arc::new(applier));
+    }
     Ok(appliers)
 }
 

--- a/apps/bitrouter/src/commands.rs
+++ b/apps/bitrouter/src/commands.rs
@@ -340,6 +340,7 @@ impl AuthMethod {
 fn import_cli_for(provider_id: &str) -> Option<&'static str> {
     match provider_id {
         bitrouter_providers::codex::PROVIDER_ID => Some("Codex"),
+        bitrouter_providers::supergrok::PROVIDER_ID => Some("Grok"),
         _ => None,
     }
 }
@@ -793,6 +794,7 @@ fn run_cli_import(
 ) -> Result<bitrouter_providers::oauth::credential_store::Credential> {
     let imported = match provider_id {
         bitrouter_providers::codex::PROVIDER_ID => bitrouter_providers::import::codex::import(),
+        bitrouter_providers::supergrok::PROVIDER_ID => bitrouter_providers::import::grok::import(),
         other => anyhow::bail!("no vendor-CLI import is available for provider '{other}'"),
     }
     .with_context(|| format!("importing a CLI credential for {provider_id}"))?;

--- a/crates/bitrouter-providers/src/import/grok.rs
+++ b/crates/bitrouter-providers/src/import/grok.rs
@@ -1,0 +1,224 @@
+//! Import the Grok CLI's SuperGrok (xAI subscription) OAuth credential.
+//!
+//! The official Grok CLI (`grok`, from `x.ai/cli`) persists its OAuth session
+//! as JSON in `$GROK_HOME/auth.json` (default `~/.grok/auth.json`). The file is
+//! an object keyed by `"<issuer>::<client_id>"`; each value carries the access
+//! token under `key` (a JWT), a `refresh_token`, an `expires_at`, and an
+//! `auth_mode` (`"oidc"` for the subscription login vs an api-key session). We
+//! adopt the OIDC entry — the one that carries both a `key` and a
+//! `refresh_token` — and map it onto [`OAuthToken`]. Refresh then works exactly
+//! as it does for a browser-obtained credential (public OIDC client against
+//! `https://auth.x.ai/oauth2/token`).
+//!
+//! The access token is a JWT; its `exp` claim gives the expiry (matching the
+//! sibling `expires_at` field), falling back to a one-hour TTL that the refresh
+//! path renews before it lapses.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use serde::Deserialize;
+
+use crate::import::{ImportError, ImportSource, Imported, home_dir};
+use crate::oauth::credential_store::OAuthToken;
+
+/// Credential filename inside `$GROK_HOME`.
+const AUTH_FILENAME: &str = "auth.json";
+/// Fallback access-token lifetime when the JWT carries no `exp` claim — one
+/// hour. The refresh path renews the token before it lapses.
+const FALLBACK_TTL_SECS: u64 = 3600;
+
+/// One `"<issuer>::<client_id>"` entry in the Grok CLI's `auth.json`. Only the
+/// fields we consume are declared; everything else (email, team_id, …) is
+/// ignored.
+#[derive(Deserialize)]
+struct AuthEntry {
+    /// The access token — a JWT the xAI API accepts as a Bearer.
+    #[serde(default)]
+    key: Option<String>,
+    /// The long-lived refresh token. Present on the OIDC (subscription) entry;
+    /// absent on an api-key session. Entry selection keys on the presence of
+    /// `key` + `refresh_token`, which excludes api-key sessions (they carry
+    /// neither), so it needs no `auth_mode` check to stay robust.
+    #[serde(default)]
+    refresh_token: Option<String>,
+}
+
+/// Import the Grok credential from `$GROK_HOME/auth.json` (default
+/// `~/.grok/auth.json`). Returns `Ok(None)` when the file is absent or carries
+/// no subscription (OIDC) session.
+pub fn import() -> Result<Option<Imported>, ImportError> {
+    let home = grok_home().ok_or(ImportError::NoHome)?;
+    from_file(&home.join(AUTH_FILENAME))
+}
+
+/// Import from a specific `auth.json`. `Ok(None)` when the file is absent or
+/// carries no entry with both an access token and a refresh token.
+pub fn from_file(path: &Path) -> Result<Option<Imported>, ImportError> {
+    let bytes = match std::fs::read(path) {
+        Ok(b) => b,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(source) => {
+            return Err(ImportError::Io {
+                path: path.to_path_buf(),
+                source,
+            });
+        }
+    };
+    let blob = String::from_utf8_lossy(&bytes);
+    match parse_blob(blob.as_ref(), &path.display().to_string())? {
+        Some(token) => Ok(Some(Imported {
+            token,
+            source: ImportSource::File(path.to_path_buf()),
+        })),
+        None => Ok(None),
+    }
+}
+
+/// Resolve `$GROK_HOME` (default `~/.grok`).
+fn grok_home() -> Option<PathBuf> {
+    if let Some(dir) = std::env::var_os("GROK_HOME").filter(|v| !v.is_empty()) {
+        return Some(PathBuf::from(dir));
+    }
+    home_dir().map(|h| h.join(".grok"))
+}
+
+/// Parse the `{ "<issuer>::<client_id>": { … } }` map. Selects the first entry
+/// carrying both a non-empty `key` and `refresh_token` (the subscription OIDC
+/// session; an api-key session has neither a JWT `key` nor a refresh token).
+/// `Ok(None)` when the map has no such entry. Expiry comes from the access
+/// token's JWT `exp` claim, else a one-hour fallback.
+fn parse_blob(blob: &str, origin: &str) -> Result<Option<OAuthToken>, ImportError> {
+    let entries: BTreeMap<String, AuthEntry> =
+        serde_json::from_str(blob).map_err(|source| ImportError::Json {
+            origin: origin.to_string(),
+            source,
+        })?;
+    let Some((access_token, refresh_token)) = entries.into_values().find_map(|e| {
+        let key = e.key.filter(|s| !s.is_empty())?;
+        let refresh = e.refresh_token.filter(|s| !s.is_empty())?;
+        Some((key, refresh))
+    }) else {
+        return Ok(None);
+    };
+    let expires_at =
+        decode_jwt_exp(&access_token).unwrap_or_else(|| now_secs() + FALLBACK_TTL_SECS);
+    Ok(Some(OAuthToken {
+        access_token,
+        expires_at,
+        refresh_token: Some(refresh_token),
+    }))
+}
+
+/// Decode the `exp` (Unix seconds) claim from a JWT access token's payload.
+/// `None` when the string isn't a three-segment JWT, the payload isn't
+/// base64url JSON, or it carries no numeric `exp`. Signature is not
+/// verified — the token arrived from the OAuth server over TLS.
+fn decode_jwt_exp(token: &str) -> Option<u64> {
+    #[derive(Deserialize)]
+    struct Exp {
+        exp: Option<u64>,
+    }
+    let payload = token
+        .split('.')
+        .nth(1)
+        .filter(|_| token.split('.').count() == 3)?;
+    let bytes = URL_SAFE_NO_PAD.decode(payload).ok()?;
+    let parsed: Exp = serde_json::from_slice(&bytes).ok()?;
+    parsed.exp
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_jwt_exp(exp: u64) -> String {
+        let header = URL_SAFE_NO_PAD.encode("{}");
+        let payload =
+            URL_SAFE_NO_PAD.encode(format!(r#"{{"exp":{exp},"iss":"https://auth.x.ai"}}"#));
+        let sig = URL_SAFE_NO_PAD.encode("sig");
+        format!("{header}.{payload}.{sig}")
+    }
+
+    fn tmp_file(contents: &str) -> PathBuf {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir =
+            std::env::temp_dir().join(format!("bitrouter-import-grok-{}-{id}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("auth.json");
+        std::fs::write(&path, contents).unwrap();
+        path
+    }
+
+    fn auth_json(entry_key: &str, access: &str, refresh: &str, auth_mode: &str) -> String {
+        format!(
+            r#"{{"{entry_key}":{{"key":"{access}","refresh_token":"{refresh}","auth_mode":"{auth_mode}","expires_at":"2026-07-09T23:12:46Z"}}}}"#
+        )
+    }
+
+    #[test]
+    fn parses_oidc_entry_and_reads_jwt_exp() {
+        let jwt = make_jwt_exp(1_783_638_765);
+        let json = auth_json("https://auth.x.ai::b1a00492", &jwt, "rt-abc", "oidc");
+        let path = tmp_file(&json);
+        let imported = from_file(&path).unwrap().unwrap();
+        assert_eq!(imported.token.access_token, jwt);
+        assert_eq!(imported.token.refresh_token.as_deref(), Some("rt-abc"));
+        assert_eq!(imported.token.expires_at, 1_783_638_765);
+    }
+
+    #[test]
+    fn non_jwt_access_token_falls_back_to_ttl() {
+        let json = auth_json("https://auth.x.ai::b1a00492", "not-a-jwt", "rt", "oidc");
+        let path = tmp_file(&json);
+        let imported = from_file(&path).unwrap().unwrap();
+        assert!(imported.token.expires_at >= now_secs());
+    }
+
+    #[test]
+    fn api_key_only_entry_is_none() {
+        // An api-key session carries neither a JWT `key` nor a refresh token,
+        // so there is no subscription credential to adopt.
+        let path = tmp_file(r#"{"api":{"api_key":"xai-...","auth_mode":"key"}}"#);
+        assert!(from_file(&path).unwrap().is_none());
+    }
+
+    #[test]
+    fn entry_missing_refresh_token_is_skipped() {
+        let jwt = make_jwt_exp(1_783_638_765);
+        let json = format!(r#"{{"e":{{"key":"{jwt}"}}}}"#);
+        let path = tmp_file(&json);
+        assert!(from_file(&path).unwrap().is_none());
+    }
+
+    #[test]
+    fn absent_file_is_none() {
+        let missing = std::env::temp_dir().join("bitrouter-import-grok-absent/nope/auth.json");
+        assert!(from_file(&missing).unwrap().is_none());
+    }
+
+    #[test]
+    fn selects_oidc_entry_when_api_key_entry_also_present() {
+        let jwt = make_jwt_exp(1_783_638_765);
+        // Two entries: an api-key one (no refresh_token) and the OIDC one.
+        let json = format!(
+            r#"{{"api":{{"api_key":"xai-x"}},"https://auth.x.ai::c":{{"key":"{jwt}","refresh_token":"rt"}}}}"#
+        );
+        let path = tmp_file(&json);
+        let imported = from_file(&path).unwrap().unwrap();
+        assert_eq!(imported.token.access_token, jwt);
+        assert_eq!(imported.token.refresh_token.as_deref(), Some("rt"));
+    }
+}

--- a/crates/bitrouter-providers/src/import/mod.rs
+++ b/crates/bitrouter-providers/src/import/mod.rs
@@ -16,9 +16,12 @@
 //!   `~/.claude/.credentials.json`. See [`claude_code`].
 //! - Codex — macOS Keychain `Codex Auth`, else `$CODEX_HOME/auth.json`
 //!   (default `~/.codex/auth.json`). See [`codex`].
+//! - Grok — `$GROK_HOME/auth.json` (default `~/.grok/auth.json`), the OIDC
+//!   (SuperGrok subscription) entry. See [`grok`].
 
 pub mod claude_code;
 pub mod codex;
+pub mod grok;
 mod keychain;
 
 use std::path::PathBuf;

--- a/crates/bitrouter-providers/src/lib.rs
+++ b/crates/bitrouter-providers/src/lib.rs
@@ -89,6 +89,8 @@ mod entry;
 pub mod import;
 pub mod oauth;
 pub mod registry;
+#[cfg(feature = "pkce")]
+pub mod supergrok;
 
 pub use apply::{
     activate_stored_credential_providers, apply_builtin_defaults, zero_config,

--- a/crates/bitrouter-providers/src/supergrok/mod.rs
+++ b/crates/bitrouter-providers/src/supergrok/mod.rs
@@ -1,0 +1,400 @@
+//! SuperGrok — the xAI **subscription** `AuthApplier` (grok.com / X Premium+).
+//!
+//! Registered under the provider id `"supergrok"`. This applier resolves an
+//! OAuth credential minted by the official Grok CLI's SuperGrok login and
+//! shapes the request as a subscription call: `Authorization: Bearer <jwt>`
+//! against `https://api.x.ai/v1`. Distinct from the `xai` provider, which is
+//! the metered API-key path (`XAI_API_KEY`) — the subscription credential is a
+//! different grant that xAI host-locks to `*.x.ai`.
+//!
+//! | Stored credential | Outbound headers |
+//! |---|---|
+//! | `Credential::Oauth` (SuperGrok) | `Authorization: Bearer <access_token>`. |
+//! | _no credential in store_        | `401` — there is no API-key fallback here (use the `xai` provider for that). |
+//!
+//! The credential is obtained by importing the Grok CLI's own session
+//! (`~/.grok/auth.json`, the OIDC entry) via
+//! [`crate::import::grok`] — mirroring the Codex import. The access token is a
+//! JWT the xAI API accepts as a Bearer; the applier refreshes it via the public
+//! OIDC client against `https://auth.x.ai/oauth2/token` when it is within
+//! [`crate::oauth::refresh::REFRESH_WINDOW`] of expiry, writes the new token
+//! back to the store, and caches it in memory.
+//!
+//! ## Auth client
+//!
+//! SuperGrok's OIDC client is public (PKCE, no client secret), so refresh needs
+//! only the client id — the standard [`crate::oauth::refresh::refresh`] path.
+//! The client id + token endpoint are the ones the official Grok CLI ships
+//! with (confirmed in `~/.grok/auth.json`, keyed `<issuer>::<client_id>`). A
+//! native browser login could be added later via [`crate::oauth::registry`];
+//! today the only path is importing the Grok CLI session.
+
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use reqwest::header::HeaderValue;
+
+use bitrouter_sdk::language_model::AuthApplier;
+use bitrouter_sdk::language_model::types::RoutingTarget;
+use bitrouter_sdk::{BitrouterError, Result};
+
+use crate::oauth::auth_code::AuthCodeError;
+use crate::oauth::credential_store::{Credential, CredentialStore, DEFAULT_LABEL, OAuthToken};
+use crate::oauth::refresh::{needs_refresh, refresh};
+
+/// Provider id this applier is registered under.
+pub const PROVIDER_ID: &str = "supergrok";
+
+/// SuperGrok's public OIDC client id — the one the official Grok CLI ships with
+/// (confirmed as the `<issuer>::<client_id>` key in `~/.grok/auth.json`).
+const CLIENT_ID: &str = "b1a00492-073a-47ea-816f-4c329264a828";
+
+/// OIDC token endpoint for the refresh-token grant (from `auth.x.ai`'s
+/// `/.well-known/openid-configuration`).
+const TOKEN_ENDPOINT: &str = "https://auth.x.ai/oauth2/token";
+
+/// `AuthApplier` for `provider_name == "supergrok"`.
+pub struct SuperGrokAuthApplier {
+    store_path: std::path::PathBuf,
+    refresh_client: reqwest::Client,
+    client_id: String,
+    token_endpoint: String,
+    cache: Arc<Mutex<std::collections::HashMap<String, OAuthToken>>>,
+    /// Per-label single-flight gate around disk-read → refresh → persist. See
+    /// [`crate::claude_code::ClaudeCodeAuthApplier`] for the rationale
+    /// (concurrent refreshes can have the older refresh_token invalidated per
+    /// RFC 6749 §6).
+    refresh_gates: Arc<Mutex<std::collections::HashMap<String, Arc<tokio::sync::Mutex<()>>>>>,
+}
+
+impl SuperGrokAuthApplier {
+    /// Build an applier reading the credential store at `store_path` and using
+    /// SuperGrok's public OIDC client + token endpoint.
+    pub fn new(store_path: impl Into<std::path::PathBuf>) -> Result<Self> {
+        let refresh_client = reqwest::Client::builder()
+            .user_agent(concat!("bitrouter-providers/", env!("CARGO_PKG_VERSION")))
+            .timeout(Duration::from_secs(30))
+            .build()
+            .map_err(|e| {
+                BitrouterError::internal(format!(
+                    "building SuperGrok OAuth refresh HTTP client: {e}"
+                ))
+            })?;
+        Ok(Self {
+            store_path: store_path.into(),
+            refresh_client,
+            client_id: CLIENT_ID.to_string(),
+            token_endpoint: TOKEN_ENDPOINT.to_string(),
+            cache: Arc::new(Mutex::new(std::collections::HashMap::new())),
+            refresh_gates: Arc::new(Mutex::new(std::collections::HashMap::new())),
+        })
+    }
+
+    /// Tests override the refresh client + endpoint.
+    #[cfg(test)]
+    pub(crate) fn with_client_and_endpoint(
+        store_path: impl Into<std::path::PathBuf>,
+        refresh_client: reqwest::Client,
+        client_id: impl Into<String>,
+        token_endpoint: impl Into<String>,
+    ) -> Self {
+        Self {
+            store_path: store_path.into(),
+            refresh_client,
+            client_id: client_id.into(),
+            token_endpoint: token_endpoint.into(),
+            cache: Arc::new(Mutex::new(std::collections::HashMap::new())),
+            refresh_gates: Arc::new(Mutex::new(std::collections::HashMap::new())),
+        }
+    }
+
+    /// Per-label single-flight gate — same shape as the Codex applier.
+    fn refresh_gate(&self, label: &str) -> Arc<tokio::sync::Mutex<()>> {
+        let mut guard = self
+            .refresh_gates
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        guard
+            .entry(label.to_string())
+            .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+            .clone()
+    }
+
+    fn cached_fresh(&self, label: &str) -> Option<OAuthToken> {
+        let guard = self.cache.lock().ok()?;
+        let token = guard.get(label)?;
+        (!needs_refresh(token)).then(|| token.clone())
+    }
+
+    fn store_in_cache(&self, label: &str, token: &OAuthToken) {
+        if let Ok(mut guard) = self.cache.lock() {
+            guard.insert(label.to_string(), token.clone());
+        }
+    }
+
+    async fn resolve_token(&self, label: &str) -> Result<OAuthToken> {
+        // 1. Lock-free cache hit.
+        if let Some(cached) = self.cached_fresh(label) {
+            return Ok(cached);
+        }
+        // 2. Acquire the per-label gate before any disk or network work.
+        let gate = self.refresh_gate(label);
+        let _guard = gate.lock().await;
+        // 3. Double-checked locking — another task may have refreshed while we
+        //    were waiting on the gate.
+        if let Some(cached) = self.cached_fresh(label) {
+            return Ok(cached);
+        }
+        let store = CredentialStore::load(&self.store_path).map_err(|e| {
+            BitrouterError::internal(format!(
+                "reading credential store at {}: {e}",
+                self.store_path.display()
+            ))
+        })?;
+        let stored = store
+            .get_any(PROVIDER_ID, label)
+            .ok_or_else(|| BitrouterError::Upstream {
+                status: 401,
+                message: format!(
+                    "no supergrok credential for label '{label}' — \
+                     run `bitrouter providers login supergrok` (imports your Grok CLI session)"
+                ),
+            })?;
+        let token = stored
+            .as_oauth()
+            .cloned()
+            .ok_or_else(|| BitrouterError::Upstream {
+                status: 401,
+                message: format!(
+                    "supergrok credential for '{label}' is an API key — this provider only \
+                     accepts subscription OAuth tokens (use the `xai` provider for an API key)"
+                ),
+            })?;
+        if needs_refresh(&token) {
+            let refreshed = refresh(
+                &self.refresh_client,
+                &self.token_endpoint,
+                &self.client_id,
+                &token,
+            )
+            .await
+            .map_err(refresh_to_bitrouter_error)?;
+            self.persist_refreshed(label, refreshed.clone())?;
+            self.store_in_cache(label, &refreshed);
+            return Ok(refreshed);
+        }
+        self.store_in_cache(label, &token);
+        Ok(token)
+    }
+
+    fn persist_refreshed(&self, label: &str, token: OAuthToken) -> Result<()> {
+        let mut store = CredentialStore::load(&self.store_path).map_err(|e| {
+            BitrouterError::internal(format!(
+                "reloading credential store before refresh write-back: {e}"
+            ))
+        })?;
+        store
+            .set(PROVIDER_ID, label, Credential::from_oauth_token(token))
+            .map_err(|e| {
+                BitrouterError::internal(format!("persisting refreshed supergrok OAuth token: {e}"))
+            })?;
+        Ok(())
+    }
+
+    fn label_for<'a>(&self, target: &'a RoutingTarget) -> &'a str {
+        target.account_label.as_deref().unwrap_or(DEFAULT_LABEL)
+    }
+}
+
+fn refresh_to_bitrouter_error(e: AuthCodeError) -> BitrouterError {
+    match e {
+        AuthCodeError::OAuthError { error, description } => BitrouterError::Upstream {
+            status: 401,
+            message: format!(
+                "supergrok OAuth refresh failed ({error}{}). Re-run `bitrouter providers login supergrok`.",
+                description.map(|d| format!(": {d}")).unwrap_or_default()
+            ),
+        },
+        other => BitrouterError::Upstream {
+            status: 502,
+            message: format!("supergrok OAuth refresh transport error: {other}"),
+        },
+    }
+}
+
+#[async_trait]
+impl AuthApplier for SuperGrokAuthApplier {
+    async fn apply(
+        &self,
+        mut request: reqwest::Request,
+        target: &RoutingTarget,
+    ) -> Result<reqwest::Request> {
+        let label = self.label_for(target);
+        let token = self.resolve_token(label).await?;
+        let bearer = format!("Bearer {}", token.access_token);
+        let auth = HeaderValue::from_str(&bearer).map_err(|e| {
+            BitrouterError::internal(format!("invalid SuperGrok bearer for Authorization: {e}"))
+        })?;
+        request
+            .headers_mut()
+            .insert(reqwest::header::AUTHORIZATION, auth);
+        Ok(request)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use bitrouter_sdk::language_model::types::ApiProtocol;
+    use wiremock::MockServer;
+
+    use super::*;
+
+    fn tmp_store_path() -> PathBuf {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "bitrouter-supergrok-test-{}-{id}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir.join("creds.json")
+    }
+
+    fn supergrok_target(label: Option<&str>) -> RoutingTarget {
+        RoutingTarget {
+            provider_name: PROVIDER_ID.to_string(),
+            service_id: "grok-build-0.1".to_string(),
+            api_base: "https://api.x.ai/v1".to_string(),
+            api_key: String::new(),
+            api_protocol: ApiProtocol::Responses,
+            account_label: label.map(String::from),
+            api_key_override: None,
+            api_base_override: None,
+            auth_scheme: Default::default(),
+        }
+    }
+
+    #[tokio::test]
+    async fn applies_bearer_from_stored_oauth() {
+        let path = tmp_store_path();
+        {
+            let mut store = CredentialStore::load(&path).unwrap();
+            store
+                .set(
+                    PROVIDER_ID,
+                    DEFAULT_LABEL,
+                    Credential::from_oauth_token(OAuthToken {
+                        access_token: "grok-jwt-fresh".into(),
+                        expires_at: 0, // non-expiring → no refresh attempt
+                        refresh_token: Some("r".into()),
+                    }),
+                )
+                .unwrap();
+        }
+        let applier = SuperGrokAuthApplier::new(&path).unwrap();
+        let req = reqwest::Client::new()
+            .post("https://api.x.ai/v1/responses")
+            .build()
+            .unwrap();
+        let authed = applier.apply(req, &supergrok_target(None)).await.unwrap();
+        assert_eq!(
+            authed
+                .headers()
+                .get(reqwest::header::AUTHORIZATION)
+                .and_then(|v| v.to_str().ok()),
+            Some("Bearer grok-jwt-fresh")
+        );
+    }
+
+    #[tokio::test]
+    async fn fails_when_no_credential_stored() {
+        let path = tmp_store_path();
+        let applier = SuperGrokAuthApplier::new(&path).unwrap();
+        let req = reqwest::Client::new()
+            .post("https://api.x.ai/v1/responses")
+            .build()
+            .unwrap();
+        let err = applier
+            .apply(req, &supergrok_target(None))
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("bitrouter providers login supergrok"),
+            "expected helpful hint, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_api_key_credential() {
+        let path = tmp_store_path();
+        {
+            let mut store = CredentialStore::load(&path).unwrap();
+            store
+                .set(PROVIDER_ID, DEFAULT_LABEL, Credential::api_key("xai-..."))
+                .unwrap();
+        }
+        let applier = SuperGrokAuthApplier::new(&path).unwrap();
+        let req = reqwest::Client::new()
+            .post("https://api.x.ai/v1/responses")
+            .build()
+            .unwrap();
+        let err = applier
+            .apply(req, &supergrok_target(None))
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("subscription OAuth"),
+            "expected API-key rejection, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn fresh_token_skips_refresh() {
+        let path = tmp_store_path();
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        {
+            let mut store = CredentialStore::load(&path).unwrap();
+            store
+                .set(
+                    PROVIDER_ID,
+                    DEFAULT_LABEL,
+                    Credential::from_oauth_token(OAuthToken {
+                        access_token: "still-fresh".into(),
+                        expires_at: now + 3600,
+                        refresh_token: Some("ignored".into()),
+                    }),
+                )
+                .unwrap();
+        }
+        // Point refresh at a wiremock with no mounts → any hit 404s and fails.
+        let server = MockServer::start().await;
+        let applier = SuperGrokAuthApplier::with_client_and_endpoint(
+            &path,
+            reqwest::Client::new(),
+            "client-1",
+            format!("{}/oauth/token", server.uri()),
+        );
+        let req = reqwest::Client::new()
+            .post("https://api.x.ai/v1/responses")
+            .build()
+            .unwrap();
+        let authed = applier.apply(req, &supergrok_target(None)).await.unwrap();
+        assert_eq!(
+            authed
+                .headers()
+                .get(reqwest::header::AUTHORIZATION)
+                .and_then(|v| v.to_str().ok()),
+            Some("Bearer still-fresh")
+        );
+    }
+}

--- a/dist/registry/providers.json
+++ b/dist/registry/providers.json
@@ -6673,7 +6673,14 @@
       "api_base": "https://api.x.ai/v1",
       "auth": {
         "handler": "supergrok",
-        "kind": "oauth"
+        "kind": "oauth",
+        "params": {
+          "authorize_endpoint": "https://auth.x.ai/oauth2/authorize",
+          "client_id": "b1a00492-073a-47ea-816f-4c329264a828",
+          "issuer": "https://auth.x.ai",
+          "scope": "openid profile email offline_access grok-cli:access api:access",
+          "token_endpoint": "https://auth.x.ai/oauth2/token"
+        }
       },
       "auth_scheme": "x-api-key",
       "billing": "subscription",

--- a/registry/providers/supergrok.yaml
+++ b/registry/providers/supergrok.yaml
@@ -1,11 +1,13 @@
 # SuperGrok — xAI's consumer subscription (grok.com / X Premium+), routed with
 # the user's subscription credentials rather than a metered API key. Modeled on
 # the `claude-code` / `openai-codex` subscription pattern: flat-rate (no
-# per-token pricing), activated by a local OAuth login.
+# per-token pricing), activated by importing the official Grok CLI's session.
 #
-# NOTE: the `supergrok` OAuth handler is not yet implemented in bitrouter — this
-# registry entry stages the provider; the handler (client id + endpoints) still
-# needs wiring before it is routable.
+# The `supergrok` handler is implemented in bitrouter_providers::supergrok: it
+# adopts the Grok CLI's OIDC session (`~/.grok/auth.json`) via
+# `bitrouter providers login supergrok`, sets `Authorization: Bearer <jwt>`
+# against `api.x.ai/v1`, and refreshes via the public OIDC client below. The
+# subscription grant is distinct from the metered `xai` API-key provider.
 name: supergrok
 display_name: SuperGrok (subscription)
 metadata:
@@ -51,6 +53,16 @@ status: active
 auth:
   kind: oauth
   handler: supergrok
+  # Public OIDC client the official Grok CLI ships with (confirmed as the
+  # `<issuer>::<client_id>` key in `~/.grok/auth.json`). PKCE, no client secret,
+  # so refresh needs only the client id. The `supergrok` handler pins these; the
+  # params are recorded here for documentation and a future native login.
+  params:
+    client_id: b1a00492-073a-47ea-816f-4c329264a828
+    issuer: https://auth.x.ai
+    authorize_endpoint: https://auth.x.ai/oauth2/authorize
+    token_endpoint: https://auth.x.ai/oauth2/token
+    scope: openid profile email offline_access grok-cli:access api:access
 auto_sync:
   feed: models_dev
   key: xai

--- a/skills/bitrouter/SKILL.md
+++ b/skills/bitrouter/SKILL.md
@@ -120,6 +120,7 @@ Separately, a JSON Schema for the config is committed at `dist/schema/bitrouter.
 bitrouter providers login claude-code       # Claude Pro/Max via Claude Code session
 bitrouter providers login openai-codex      # ChatGPT/Codex subscription
 bitrouter providers login github-copilot    # browser device flow, token stored on disk
+bitrouter providers login supergrok         # SuperGrok via the Grok CLI session (~/.grok)
 ```
 
 ## 4. Connect your SDK
@@ -187,7 +188,7 @@ Read these on demand — don't load them all upfront.
 ## 7. Gotchas
 
 - **Always ask Local-or-Cloud first.** The default of "just install locally" is wrong for users who want managed billing — they should never install the daemon at all.
-- **Cloud sign-in is `bitrouter cloud login`.** Per-provider OAuth is `bitrouter providers login <provider>` (today: `claude-code`, `github-copilot`, and `openai-codex`), not a top-level `login` command.
+- **Cloud sign-in is `bitrouter cloud login`.** Per-provider OAuth is `bitrouter providers login <provider>` (today: `claude-code`, `github-copilot`, `openai-codex`, and `supergrok`), not a top-level `login` command.
 - **Cloud management is `bitrouter cloud …`.** After `bitrouter cloud login`, run `bitrouter cloud --help` for the subcommand index: `keys`, `usage`, `requests`, `billing`, `policy`, `budget`, `preset`, `byok`. Every leaf accepts `--json`.
 - **Local port: `127.0.0.1:4356`.** Old docs (and the upstream README) sometimes say 8787 — those are stale.
 - **Cloud endpoints:** `https://api.bitrouter.ai/v1` for the OpenAI shape; `https://api.bitrouter.ai` (no `/v1`) for the Anthropic SDK — same asymmetry as Local.

--- a/skills/bitrouter/references/providers.md
+++ b/skills/bitrouter/references/providers.md
@@ -20,13 +20,14 @@ section). The one in-binary exception is the hosted `bitrouter` cloud gateway.
 | `claude-code` | — (local OAuth) | Claude Code session | `bitrouter providers login claude-code`; Claude Pro/Max subscription provider, distinct from `anthropic` API-key billing |
 | `github-copilot` | — (local OAuth) | Device flow | `bitrouter providers login github-copilot`; per-model protocol map (Claude → Anthropic, gpt-5.x-codex → Responses, rest → Chat) |
 | `openai-codex` | — (local PKCE) | ChatGPT subscription | `bitrouter providers login openai-codex` |
+| `supergrok` | — (local OAuth) | SuperGrok subscription | `bitrouter providers login supergrok`; imports the Grok CLI session (`~/.grok/auth.json`), distinct from `xai` API-key billing |
 | `opencode-zen` | `OPENCODE_ZEN_API_KEY` | Bearer | Per-family protocol routing |
 | `opencode-go` | `OPENCODE_ZEN_API_KEY` (shared) | Bearer | Low-cost subscription tier — same credential as Zen |
 
 Zero-config mode auto-enables every API-key provider whose env var is present;
 an API-key provider without its credential gets `active: false` and falls out of
 the routing table. Local-OAuth/PKCE providers (`claude-code`, `github-copilot`,
-`openai-codex`) are enabled by `bitrouter providers login`, not an env var. **First run with no network
+`openai-codex`, `supergrok`) are enabled by `bitrouter providers login`, not an env var. **First run with no network
 and no cache**: the registry is empty, so only fully-specified local providers
 and the in-binary `bitrouter` cloud gateway are available — the known-provider
 shorthand needs one prior successful fetch. Startup still succeeds.


### PR DESCRIPTION
## What

Wires the `supergrok` handler that `registry/providers/supergrok.yaml` had staged (comment previously said *"not yet implemented"*). BitRouter can now adopt the official **Grok CLI's SuperGrok (xAI subscription)** session and route it as a first-party subscription provider — the same shape as `openai-codex` / `claude-code`, distinct from the metered `xai` API-key provider.

```
bitrouter providers login supergrok        # imports ~/.grok/auth.json (OIDC entry)
… then route:  supergrok:x-ai/grok-build-0.1
```

## How

- **`import/grok.rs`** — reads `~/.grok/auth.json` (object keyed `<issuer>::<client_id>`), selects the OIDC entry (has a JWT `key` + `refresh_token`, which excludes api-key sessions), decodes the JWT `exp` for expiry → `OAuthToken`. Mirrors `import/codex.rs`.
- **`supergrok/mod.rs`** — `SuperGrokAuthApplier`: in-memory cache + per-label single-flight refresh via the **public OIDC client** (`auth.x.ai/oauth2/token`; client id ships with the Grok CLI, no secret), then `Authorization: Bearer <jwt>` against `api.x.ai/v1`. Rejects api-key credentials; returns a 401 with a login hint when none is stored.
- **`commands.rs`** — `import_cli_for` + `run_cli_import` route `supergrok` → the Grok import (import-first; no browser flow wired yet).
- **`assemble.rs`** — registers the applier when `supergrok` is configured.
- **`registry/providers/supergrok.yaml`** (+ rebuilt `dist`) — documents the implemented handler and its public OIDC client params.
- **`skills/bitrouter`** — lists `supergrok` among the loginable providers, per the repo's skill-lockstep rule.

## Design notes

- **Import-only for now.** Client id + token endpoint are constants in the applier; no `oauth/registry.rs` PKCE entry, so only `ImportFromCli` is offered — keeps the PR fully tested and doesn't ship an unverified browser flow. A native `login` is an easy follow-up.
- **Subscription providers stay explicit-route-only** (`routing_table.rs`): a bare canonical id never auto-cascades onto a personal plan, so callers use `supergrok:<model>` — identical to `claude-code:` / `openai-codex:`.

## Test plan

- `cargo test -p bitrouter-providers --features pkce` — **166 pass** (10 new: import parsing/selection/expiry, applier bearer/refresh/rejection).
- `cargo clippy` (providers + app) clean; `cargo fmt --check` clean; providers builds with **and** without `pkce` (modules stay gated).
- **Live end-to-end against a real SuperGrok subscription**: `grok-build-0.1` and `grok-4.5` return completions (non-streaming + streaming) through bitrouter via `supergrok:<model>`. Confirmed the imported JWT is accepted as a plain Bearer on `api.x.ai/v1` with no extra headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)