### PR TITLE
feat(providers): add Antigravity BYO subscription

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,17 @@
 version = 4
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
 name = "agent-client-protocol"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,6 +206,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-channel"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,6 +227,31 @@ dependencies = [
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-fs"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
+dependencies = [
+ "async-lock",
+ "blocking",
+ "futures-lite",
 ]
 
 [[package]]
@@ -251,6 +299,17 @@ dependencies = [
  "event-listener",
  "futures-lite",
  "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1115,6 +1174,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bitrouter-sdk",
+ "keyring",
  "rand 0.9.4",
  "reqwest 0.12.28",
  "serde",
@@ -1215,6 +1275,15 @@ name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
 ]
@@ -1333,6 +1402,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1406,6 +1484,16 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -1526,6 +1614,16 @@ checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
  "time",
  "version_check",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1815,6 +1913,35 @@ name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "dbus"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab69f03cc8c4340c9c8e315114e1658e6775a9b16a04357973aa21cec22b32e"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dbus-secret-service"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
+dependencies = [
+ "aes",
+ "block-padding",
+ "cbc",
+ "dbus",
+ "fastrand",
+ "hkdf",
+ "num",
+ "once_cell",
+ "sha2",
+ "zeroize",
+]
 
 [[package]]
 name = "dcap-qvl"
@@ -2123,12 +2250,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
 name = "enum-as-inner"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
 dependencies = [
  "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn",
@@ -3036,6 +3190,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
 name = "inventory"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3223,6 +3387,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "byteorder",
+ "dbus-secret-service",
+ "log",
+ "secret-service",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
+ "windows-sys 0.60.2",
+ "zbus",
+ "zeroize",
+]
+
+[[package]]
 name = "konst"
 version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3257,6 +3438,15 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
 
 [[package]]
 name = "libm"
@@ -3358,6 +3548,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "miette"
 version = "7.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3427,6 +3626,19 @@ checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
 dependencies = [
  "num-traits",
  "pxfm",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -3705,6 +3917,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -4632,7 +4854,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
 ]
 
 [[package]]
@@ -4660,7 +4882,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni",
  "log",
@@ -4669,7 +4891,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki",
- "security-framework",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -4948,13 +5170,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "secret-service"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4d35ad99a181be0a60ffcbe85d680d98f87bdc4d7644ade319b87076b9dbfd4"
+dependencies = [
+ "aes",
+ "cbc",
+ "futures-util",
+ "generic-array",
+ "hkdf",
+ "num",
+ "once_cell",
+ "rand 0.8.6",
+ "serde",
+ "sha2",
+ "zbus",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -5081,6 +5335,17 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -6086,6 +6351,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6665,6 +6941,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -6696,11 +6981,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -6734,6 +7036,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6744,6 +7052,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6758,10 +7072,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6776,6 +7102,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6786,6 +7118,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -6800,6 +7138,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6810,6 +7154,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -6973,6 +7323,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xdg-home"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7005,6 +7365,68 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zbus"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-fs",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "hex",
+ "nix 0.29.0",
+ "ordered-stream",
+ "rand 0.8.6",
+ "serde",
+ "serde_repr",
+ "sha1",
+ "static_assertions",
+ "tracing",
+ "uds_windows",
+ "windows-sys 0.52.0",
+ "xdg-home",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "zvariant",
 ]
 
 [[package]]
@@ -7106,3 +7528,40 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zvariant"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "zvariant_derive",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,21 @@ repository = "https://github.com/bitrouter/bitrouter"
 rust-version = "1.88"
 
 [workspace.dependencies]
+# Cross-platform OS keyring reader (macOS Keychain / Linux Secret Service /
+# Windows Credential Manager). Used to import the Antigravity `agy` CLI session,
+# which stores its Google OAuth token in the OS keyring. The Linux backend is
+# `async-secret-service` (pure-Rust zbus — avoids the C `libdbus-1-dev` system
+# dependency `sync-secret-service` would pull) driven by `async-io`'s block-on
+# (independent of tokio, so the sync `Entry` API is safe to call from bitrouter's
+# async CLI); `crypto-rust` keeps the session crypto dependency-light.
+keyring = { version = "3", default-features = false, features = [
+    "apple-native",
+    "windows-native",
+    "async-secret-service",
+    "async-io",
+    "crypto-rust",
+] }
+
 # internal crates
 bitrouter-sdk = { path = "crates/bitrouter-sdk", version = "1.0.0-alpha.22", default-features = false }
 bitrouter-attestation = { path = "crates/bitrouter-attestation", version = "1.0.0-alpha.22" }

--- a/apps/bitrouter/src/assemble.rs
+++ b/apps/bitrouter/src/assemble.rs
@@ -242,11 +242,21 @@ pub async fn build_app_with_path(
     // Read from the user's `config` — per-provider timeouts are a user-only
     // field, never set by the registry/builtin-defaults merge.
     let (global_timeouts, provider_timeouts) = resolved_upstream_timeouts(config);
+    // The `google-ai` subscription provider (Antigravity / `agy`) speaks a custom
+    // protocol (Gemini generateContent retargeted at cloudcode-pa's `v1internal:*`
+    // method endpoints), registered on the dispatch only when it is configured.
+    let mut dispatch = OutboundDispatch::builtin();
+    if config
+        .providers
+        .contains_key(bitrouter_providers::antigravity::PROVIDER_ID)
+    {
+        bitrouter_providers::antigravity::protocol::register(&mut dispatch);
+    }
     let executor = Arc::new(
         HttpExecutor::with_provider_timeouts(
             global_timeouts,
             provider_timeouts,
-            OutboundDispatch::builtin(),
+            dispatch,
             auth_appliers,
         )
         .context("building the upstream HTTP executor")?,
@@ -862,6 +872,20 @@ fn build_auth_appliers(config: &Config) -> Result<AuthAppliers> {
         let applier = bitrouter_providers::supergrok::SuperGrokAuthApplier::new(&store_path)
             .context("building the supergrok AuthApplier")?;
         appliers.register("supergrok", Arc::new(applier));
+    }
+    // The `google-ai` subscription applier (Google OAuth imported from the `agy`
+    // CLI session). The custom protocol adapter is registered separately on the
+    // dispatch above.
+    if config
+        .providers
+        .contains_key(bitrouter_providers::antigravity::PROVIDER_ID)
+    {
+        let applier = bitrouter_providers::antigravity::AntigravityAuthApplier::new(&store_path)
+            .context("building the google-ai AuthApplier")?;
+        appliers.register(
+            bitrouter_providers::antigravity::PROVIDER_ID,
+            Arc::new(applier),
+        );
     }
     Ok(appliers)
 }

--- a/apps/bitrouter/src/commands.rs
+++ b/apps/bitrouter/src/commands.rs
@@ -341,6 +341,7 @@ fn import_cli_for(provider_id: &str) -> Option<&'static str> {
     match provider_id {
         bitrouter_providers::codex::PROVIDER_ID => Some("Codex"),
         bitrouter_providers::supergrok::PROVIDER_ID => Some("Grok"),
+        bitrouter_providers::antigravity::PROVIDER_ID => Some("Antigravity (agy)"),
         _ => None,
     }
 }
@@ -795,6 +796,9 @@ fn run_cli_import(
     let imported = match provider_id {
         bitrouter_providers::codex::PROVIDER_ID => bitrouter_providers::import::codex::import(),
         bitrouter_providers::supergrok::PROVIDER_ID => bitrouter_providers::import::grok::import(),
+        bitrouter_providers::antigravity::PROVIDER_ID => {
+            bitrouter_providers::import::antigravity::import()
+        }
         other => anyhow::bail!("no vendor-CLI import is available for provider '{other}'"),
     }
     .with_context(|| format!("importing a CLI credential for {provider_id}"))?;

--- a/crates/bitrouter-providers/Cargo.toml
+++ b/crates/bitrouter-providers/Cargo.toml
@@ -15,7 +15,7 @@ rust-version.workspace = true
 # `bitrouter-providers` (`bitrouter-cloud`, downstream crates) don't pull
 # `sha2` / `base64` / `rand` they don't use. `apps/bitrouter` enables it.
 default = []
-pkce = ["dep:sha2", "dep:base64", "dep:rand", "dep:url", "tokio/net", "tokio/io-util", "tokio/sync"]
+pkce = ["dep:sha2", "dep:base64", "dep:rand", "dep:url", "dep:keyring", "tokio/net", "tokio/io-util", "tokio/sync"]
 
 [dependencies]
 # `config_file` for `bitrouter_sdk::config::{Config, ProviderConfig, PatternMap}`
@@ -38,6 +38,9 @@ sha2 = { workspace = true, optional = true }
 base64 = { workspace = true, optional = true }
 rand = { workspace = true, optional = true }
 url = { workspace = true, optional = true }
+# Cross-platform OS keyring — reads the Antigravity `agy` session. Gated with
+# the rest of the interactive-login deps behind `pkce`.
+keyring = { workspace = true, optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "net", "io-util", "sync"] }

--- a/crates/bitrouter-providers/src/antigravity/agy_client.rs
+++ b/crates/bitrouter-providers/src/antigravity/agy_client.rs
@@ -1,0 +1,206 @@
+//! The Antigravity OAuth client — pinned public id, secret read from the local
+//! `agy` binary at runtime.
+//!
+//! `agy` is a Google **confidential** (installed-app) OAuth client: refreshing
+//! its `1//…` refresh token requires the client id **and** a `GOCSPX-…` secret.
+//! Google embeds that secret in every copy of the binary (installed-app secrets
+//! are not treated as confidential by design — see Google's OAuth docs), but we
+//! deliberately do **not** vendor it into bitrouter. Instead we read it out of
+//! the `agy` executable already on the user's machine — the same binary that
+//! minted the token we're refreshing. So refresh works only when `agy` is
+//! installed, which is exactly the precondition for having an `agy` session at
+//! all.
+//!
+//! The client id is a **public** identifier (safe to embed); only the secret is
+//! extracted. `agy` ships more than one OAuth client, so [`extract_secrets`]
+//! returns every `GOCSPX-…` candidate and the caller tries each until the
+//! refresh succeeds.
+
+use std::path::PathBuf;
+
+/// Antigravity's public OAuth client id (confirmed in the `agy` binary and the
+/// stored `~/.gemini` session). Public identifier — safe to embed.
+pub const CLIENT_ID: &str =
+    "1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com";
+
+/// Google's OAuth token endpoint — the confidential refresh grant target.
+pub const TOKEN_ENDPOINT: &str = "https://oauth2.googleapis.com/token";
+
+/// Marker every Google OAuth client secret starts with.
+const SECRET_PREFIX: &[u8] = b"GOCSPX-";
+/// Body length after `GOCSPX-`. Google OAuth client secrets are a fixed
+/// `GOCSPX-` + 28 base64url-ish chars; taking exactly this many cleanly splits
+/// secrets that sit alnum-adjacent to each other or to trailing data (both seen
+/// in the `agy` binary), which a greedy scan cannot disambiguate.
+const SECRET_BODY_LEN: usize = 28;
+
+/// Errors resolving the `agy` OAuth client.
+#[derive(Debug, thiserror::Error)]
+pub enum AgyClientError {
+    /// The `agy` binary couldn't be located.
+    #[error(
+        "cannot find the `agy` binary to refresh the Antigravity token — install it \
+         (https://antigravity.google/docs/cli/install) or set AGY_BIN"
+    )]
+    NotFound,
+    /// Reading the binary failed.
+    #[error("reading the `agy` binary at {path}: {source}")]
+    Io {
+        /// Path that failed to read.
+        path: PathBuf,
+        /// Underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+    /// No `GOCSPX-…` secret was found in the binary (unexpected — a format
+    /// change on Google's side).
+    #[error(
+        "no OAuth client secret found in the `agy` binary at {0} — its format may have changed"
+    )]
+    NoSecret(PathBuf),
+}
+
+/// Locate the installed `agy` binary. Resolution order: `$AGY_BIN`, then `PATH`
+/// (`which`-style), then the platform default install location.
+pub fn locate_agy() -> Option<PathBuf> {
+    if let Some(p) = std::env::var_os("AGY_BIN").filter(|v| !v.is_empty()) {
+        let p = PathBuf::from(p);
+        if p.is_file() {
+            return Some(p);
+        }
+    }
+    if let Some(p) = which_on_path("agy") {
+        return Some(p);
+    }
+    default_install_path().filter(|p| p.is_file())
+}
+
+/// Read the `agy` binary and return every distinct `GOCSPX-…` secret candidate,
+/// in first-seen order. The caller tries each against the refresh endpoint.
+pub fn extract_secrets() -> Result<Vec<String>, AgyClientError> {
+    let path = locate_agy().ok_or(AgyClientError::NotFound)?;
+    let bytes = std::fs::read(&path).map_err(|source| AgyClientError::Io {
+        path: path.clone(),
+        source,
+    })?;
+    let secrets = scan_secrets(&bytes);
+    if secrets.is_empty() {
+        return Err(AgyClientError::NoSecret(path));
+    }
+    Ok(secrets)
+}
+
+/// Scan a byte buffer for `GOCSPX-…` secrets. Pure — unit-tested on synthetic
+/// buffers. Each candidate is `GOCSPX-` plus exactly [`SECRET_BODY_LEN`]
+/// base64url-ish bytes (`[A-Za-z0-9_-]`); an occurrence with fewer valid body
+/// bytes is skipped. Duplicates are dropped, first-seen order preserved.
+fn scan_secrets(bytes: &[u8]) -> Vec<String> {
+    let prefix = SECRET_PREFIX.len();
+    let total = prefix + SECRET_BODY_LEN;
+    let mut out: Vec<String> = Vec::new();
+    let mut i = 0;
+    while i + prefix <= bytes.len() {
+        if &bytes[i..i + prefix] != SECRET_PREFIX {
+            i += 1;
+            continue;
+        }
+        if i + total <= bytes.len()
+            && bytes[i + prefix..i + total]
+                .iter()
+                .all(|&b| is_secret_byte(b))
+            && let Ok(s) = std::str::from_utf8(&bytes[i..i + total])
+        {
+            let s = s.to_string();
+            if !out.contains(&s) {
+                out.push(s);
+            }
+        }
+        // Advance past this prefix; overlapping `GOCSPX-` starts can't occur
+        // inside a valid body, so skipping one byte is sufficient and safe.
+        i += 1;
+    }
+    out
+}
+
+fn is_secret_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'-' || b == b'_'
+}
+
+/// Minimal `which`: scan `PATH` for an executable named `name`.
+fn which_on_path(name: &str) -> Option<PathBuf> {
+    let path = std::env::var_os("PATH")?;
+    for dir in std::env::split_paths(&path) {
+        let candidate = dir.join(name);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        #[cfg(windows)]
+        {
+            let exe = dir.join(format!("{name}.exe"));
+            if exe.is_file() {
+                return Some(exe);
+            }
+        }
+    }
+    None
+}
+
+/// Platform default install path for `agy`.
+fn default_install_path() -> Option<PathBuf> {
+    #[cfg(windows)]
+    {
+        std::env::var_os("LOCALAPPDATA")
+            .map(|d| PathBuf::from(d).join("agy").join("bin").join("agy.exe"))
+    }
+    #[cfg(not(windows))]
+    {
+        std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".local").join("bin").join("agy"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Synthetic secrets built at runtime — a `GOCSPX-` + 28-char shape matching
+    // the real format, WITHOUT a literal Google secret in source (bitrouter
+    // ships no Google secret, not even in tests; push-protection enforces it).
+    // The prefix is assembled from a byte slice so the source never contains the
+    // `GOCSPX-<body>` token a secret scanner keys on.
+    fn fake_secret(body_char: char) -> String {
+        let prefix = std::str::from_utf8(SECRET_PREFIX).unwrap();
+        let body: String = std::iter::repeat_n(body_char, SECRET_BODY_LEN).collect();
+        format!("{prefix}{body}")
+    }
+
+    #[test]
+    fn extracts_two_concatenated_secrets_and_stops_at_trailing_junk() {
+        // Mirrors the real `strings` output: two secrets back-to-back, then a
+        // non-secret word glued on with no separator.
+        let s1 = fake_secret('a');
+        let s2 = fake_secret('b');
+        let blob = format!("noise\0{s1}{s2}https://x");
+        let secrets = scan_secrets(blob.as_bytes());
+        assert_eq!(secrets, vec![s1, s2.clone()]);
+        // The trailing "https://x" must not be glued onto the second secret.
+        assert!(!secrets[1].contains("https"));
+    }
+
+    #[test]
+    fn dedups_repeated_secrets() {
+        let s1 = fake_secret('a');
+        let blob = format!("{s1} xx {s1}");
+        assert_eq!(scan_secrets(blob.as_bytes()), vec![s1]);
+    }
+
+    #[test]
+    fn no_secret_yields_empty() {
+        assert!(scan_secrets(b"nothing to see here").is_empty());
+    }
+
+    #[test]
+    fn prefix_with_short_body_is_ignored() {
+        // "GOCSPX-" with fewer than 28 valid body chars → not a secret.
+        assert!(scan_secrets(b"GOCSPX-tooShort rest").is_empty());
+    }
+}

--- a/crates/bitrouter-providers/src/antigravity/mod.rs
+++ b/crates/bitrouter-providers/src/antigravity/mod.rs
@@ -1,0 +1,480 @@
+//! Antigravity (Google) — the `agy` **subscription** integration that powers the
+//! `google-ai` provider ([`PROVIDER_ID`]; there is no separate `antigravity`
+//! provider — see `registry/providers/google-ai.yaml`).
+//!
+//! Routes the user's Google Antigravity session (imported from the `agy` CLI,
+//! see [`crate::import::antigravity`]) to Google's Code Assist backend
+//! (`cloudcode-pa.googleapis.com/v1internal:*`). Three parts:
+//!
+//! - [`agy_client`] — the OAuth client: a pinned public id plus the confidential
+//!   `GOCSPX-…` secret read from the local `agy` binary at refresh time (never
+//!   vendored here).
+//! - [`protocol`] — an [`AuthApplier`]-adjacent
+//!   `Adapter`/`Transport` pair registered under the `Custom("antigravity")`
+//!   protocol. It reuses the Gemini `generateContent` translation but targets
+//!   the `v1internal:{verb}` method endpoint and unwraps the `{"response": …}`
+//!   envelope cloudcode-pa wraps replies in.
+//! - the [`AntigravityAuthApplier`] — sets the Bearer + first-party spoof
+//!   headers, resolves the project id via a cached `loadCodeAssist` bootstrap,
+//!   and wraps the request body in the `{model, project, request}` envelope.
+
+pub mod agy_client;
+pub mod protocol;
+
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use reqwest::header::{HeaderName, HeaderValue};
+
+use bitrouter_sdk::language_model::AuthApplier;
+use bitrouter_sdk::language_model::types::RoutingTarget;
+use bitrouter_sdk::{BitrouterError, Result};
+
+use crate::oauth::auth_code::AuthCodeError;
+use crate::oauth::credential_store::{Credential, CredentialStore, DEFAULT_LABEL, OAuthToken};
+use crate::oauth::refresh::{needs_refresh, refresh_with_client_secret};
+
+/// Provider id this applier is registered under. The `google-ai` subscription
+/// provider is powered by this Antigravity (`agy` / cloudcode-pa) integration —
+/// there is no separate `antigravity` provider.
+pub const PROVIDER_ID: &str = "google-ai";
+
+/// `User-Agent` version we present as. cloudcode-pa is lenient about the exact
+/// version, but the `antigravity/*` shape is what admits the request to the
+/// Antigravity model set. Matches the current `agy` release line.
+const AGY_VERSION: &str = "1.1.0";
+
+/// `loadCodeAssist` request body — the minimal shape that returns the project.
+const LOAD_CODE_ASSIST_BODY: &str = r#"{"metadata":{"pluginType":"GEMINI"}}"#;
+
+/// `AuthApplier` for `provider_name == "antigravity"`.
+///
+/// Per request: resolve the Google OAuth Bearer (refreshing via the confidential
+/// `agy` client when stale), resolve the Code Assist project id (cached
+/// `loadCodeAssist` bootstrap), wrap the body in the `{model, project, request}`
+/// envelope, and set the first-party spoof headers. The `v1internal:{verb}` URL
+/// and the `{"response": …}` unwrap are handled by [`protocol`].
+pub struct AntigravityAuthApplier {
+    store_path: std::path::PathBuf,
+    http: reqwest::Client,
+    /// `label -> freshest OAuthToken`.
+    token_cache: Arc<Mutex<std::collections::HashMap<String, OAuthToken>>>,
+    /// `label -> Code Assist project id` (from `loadCodeAssist`).
+    project_cache: Arc<Mutex<std::collections::HashMap<String, String>>>,
+    /// The `GOCSPX-…` secret that last refreshed successfully, cached to avoid
+    /// re-scanning the `agy` binary and re-trying every candidate.
+    working_secret: Arc<Mutex<Option<String>>>,
+    /// Per-label single-flight gate around the disk-read → refresh → persist
+    /// sequence (RFC 6749 §6 refresh-token rotation).
+    refresh_gates: Arc<Mutex<std::collections::HashMap<String, Arc<tokio::sync::Mutex<()>>>>>,
+}
+
+impl AntigravityAuthApplier {
+    /// Build an applier reading + writing the credential store at `store_path`.
+    pub fn new(store_path: impl Into<std::path::PathBuf>) -> Result<Self> {
+        let http = reqwest::Client::builder()
+            .user_agent(concat!("bitrouter-providers/", env!("CARGO_PKG_VERSION")))
+            .timeout(Duration::from_secs(30))
+            .build()
+            .map_err(|e| {
+                BitrouterError::internal(format!("building Antigravity HTTP client: {e}"))
+            })?;
+        Ok(Self {
+            store_path: store_path.into(),
+            http,
+            token_cache: Arc::new(Mutex::new(std::collections::HashMap::new())),
+            project_cache: Arc::new(Mutex::new(std::collections::HashMap::new())),
+            working_secret: Arc::new(Mutex::new(None)),
+            refresh_gates: Arc::new(Mutex::new(std::collections::HashMap::new())),
+        })
+    }
+
+    fn label_for<'a>(&self, target: &'a RoutingTarget) -> &'a str {
+        target.account_label.as_deref().unwrap_or(DEFAULT_LABEL)
+    }
+
+    fn refresh_gate(&self, label: &str) -> Arc<tokio::sync::Mutex<()>> {
+        let mut guard = self.refresh_gates.lock().unwrap_or_else(|p| p.into_inner());
+        guard
+            .entry(label.to_string())
+            .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+            .clone()
+    }
+
+    fn cached_fresh(&self, label: &str) -> Option<OAuthToken> {
+        let guard = self.token_cache.lock().ok()?;
+        let token = guard.get(label)?;
+        (!needs_refresh(token)).then(|| token.clone())
+    }
+
+    fn store_in_cache(&self, label: &str, token: &OAuthToken) {
+        if let Ok(mut guard) = self.token_cache.lock() {
+            guard.insert(label.to_string(), token.clone());
+        }
+    }
+
+    /// Resolve a fresh Bearer for `label`, refreshing through the confidential
+    /// `agy` client when the stored token is near expiry.
+    async fn resolve_token(&self, label: &str) -> Result<OAuthToken> {
+        if let Some(cached) = self.cached_fresh(label) {
+            return Ok(cached);
+        }
+        let gate = self.refresh_gate(label);
+        let _guard = gate.lock().await;
+        if let Some(cached) = self.cached_fresh(label) {
+            return Ok(cached);
+        }
+        let store = CredentialStore::load(&self.store_path).map_err(|e| {
+            BitrouterError::internal(format!(
+                "reading credential store at {}: {e}",
+                self.store_path.display()
+            ))
+        })?;
+        let stored = store
+            .get_any(PROVIDER_ID, label)
+            .and_then(|c| c.as_oauth().cloned())
+            .ok_or_else(|| BitrouterError::Upstream {
+                status: 401,
+                message: format!(
+                    "no google-ai credential for label '{label}' — \
+                     run `bitrouter providers login google-ai` (imports your `agy` session)"
+                ),
+            })?;
+        if needs_refresh(&stored) {
+            let refreshed = self.refresh_via_agy(&stored).await?;
+            self.persist_refreshed(label, refreshed.clone())?;
+            self.store_in_cache(label, &refreshed);
+            return Ok(refreshed);
+        }
+        self.store_in_cache(label, &stored);
+        Ok(stored)
+    }
+
+    /// Refresh the Google OAuth token using the confidential `agy` client. The
+    /// client secret is read from the local `agy` binary; `agy` embeds more than
+    /// one, so each candidate is tried until the grant succeeds (then cached).
+    async fn refresh_via_agy(&self, token: &OAuthToken) -> Result<OAuthToken> {
+        let secrets = self.secret_candidates()?;
+        let mut last: Option<AuthCodeError> = None;
+        for secret in secrets {
+            match refresh_with_client_secret(
+                &self.http,
+                agy_client::TOKEN_ENDPOINT,
+                agy_client::CLIENT_ID,
+                &secret,
+                token,
+            )
+            .await
+            {
+                Ok(refreshed) => {
+                    if let Ok(mut guard) = self.working_secret.lock() {
+                        *guard = Some(secret);
+                    }
+                    return Ok(refreshed);
+                }
+                Err(e) => last = Some(e),
+            }
+        }
+        Err(match last {
+            Some(e) => refresh_to_bitrouter_error(e),
+            None => BitrouterError::Upstream {
+                status: 401,
+                message: "no `agy` OAuth client secret available to refresh the Antigravity token"
+                    .into(),
+            },
+        })
+    }
+
+    /// The secret candidates to try: the last-working one first (cheap), else
+    /// every `GOCSPX-…` extracted from the `agy` binary.
+    fn secret_candidates(&self) -> Result<Vec<String>> {
+        if let Ok(guard) = self.working_secret.lock()
+            && let Some(s) = guard.as_ref()
+        {
+            return Ok(vec![s.clone()]);
+        }
+        agy_client::extract_secrets().map_err(|e| BitrouterError::Upstream {
+            status: 401,
+            message: format!("cannot refresh the Antigravity token: {e}"),
+        })
+    }
+
+    fn persist_refreshed(&self, label: &str, token: OAuthToken) -> Result<()> {
+        let mut store = CredentialStore::load(&self.store_path).map_err(|e| {
+            BitrouterError::internal(format!("reloading credential store before write-back: {e}"))
+        })?;
+        store
+            .set(PROVIDER_ID, label, Credential::from_oauth_token(token))
+            .map_err(|e| {
+                BitrouterError::internal(format!("persisting refreshed antigravity token: {e}"))
+            })?;
+        Ok(())
+    }
+
+    /// Resolve the Code Assist project id for `label`, calling `loadCodeAssist`
+    /// once and caching the result. `api_base` is the cloudcode-pa base from the
+    /// routing target.
+    async fn resolve_project(&self, label: &str, api_base: &str, bearer: &str) -> Result<String> {
+        if let Ok(guard) = self.project_cache.lock()
+            && let Some(p) = guard.get(label)
+        {
+            return Ok(p.clone());
+        }
+        let url = format!(
+            "{}/v1internal:loadCodeAssist",
+            api_base.trim_end_matches('/')
+        );
+        let resp = self
+            .http
+            .post(&url)
+            .header(reqwest::header::AUTHORIZATION, format!("Bearer {bearer}"))
+            .header(reqwest::header::USER_AGENT, user_agent())
+            .header("Client-Metadata", client_metadata())
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .body(LOAD_CODE_ASSIST_BODY)
+            .send()
+            .await
+            .map_err(|e| BitrouterError::Upstream {
+                status: 502,
+                message: format!("Antigravity loadCodeAssist request failed: {e}"),
+            })?;
+        let status = resp.status();
+        let body: serde_json::Value = resp.json().await.map_err(|e| BitrouterError::Upstream {
+            status: 502,
+            message: format!("Antigravity loadCodeAssist returned non-JSON: {e}"),
+        })?;
+        if !status.is_success() {
+            return Err(BitrouterError::Upstream {
+                status: status.as_u16(),
+                message: format!("Antigravity loadCodeAssist failed: {body}"),
+            });
+        }
+        let project = body
+            .get("cloudaicompanionProject")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| BitrouterError::Upstream {
+                status: 502,
+                message: "Antigravity loadCodeAssist returned no cloudaicompanionProject — \
+                          the account may need onboarding in the `agy` CLI first"
+                    .into(),
+            })?
+            .to_string();
+        if let Ok(mut guard) = self.project_cache.lock() {
+            guard.insert(label.to_string(), project.clone());
+        }
+        Ok(project)
+    }
+}
+
+fn refresh_to_bitrouter_error(e: AuthCodeError) -> BitrouterError {
+    match e {
+        AuthCodeError::OAuthError { error, description } => BitrouterError::Upstream {
+            status: 401,
+            message: format!(
+                "google-ai OAuth refresh failed ({error}{}). Re-run `agy` to re-authenticate, \
+                 then `bitrouter providers login google-ai`.",
+                description.map(|d| format!(": {d}")).unwrap_or_default()
+            ),
+        },
+        other => BitrouterError::Upstream {
+            status: 502,
+            message: format!("antigravity OAuth refresh transport error: {other}"),
+        },
+    }
+}
+
+/// The `User-Agent` presented to cloudcode-pa: `antigravity/<ver> <goos>/<goarch>`.
+fn user_agent() -> String {
+    format!("antigravity/{AGY_VERSION} {}/{}", go_os(), go_arch())
+}
+
+/// The `Client-Metadata` header identifying the (spoofed) first-party client.
+fn client_metadata() -> String {
+    format!(
+        r#"{{"ideType":"IDE_UNSPECIFIED","platform":"{}","pluginType":"GEMINI"}}"#,
+        go_platform()
+    )
+}
+
+/// Go's `runtime.GOOS` for this target (the `agy` UA uses Go naming).
+fn go_os() -> &'static str {
+    match std::env::consts::OS {
+        "macos" => "darwin",
+        other => other, // "linux", "windows"
+    }
+}
+
+/// Go's `runtime.GOARCH` for this target.
+fn go_arch() -> &'static str {
+    match std::env::consts::ARCH {
+        "aarch64" => "arm64",
+        "x86_64" => "amd64",
+        other => other,
+    }
+}
+
+/// cloudcode-pa `Client-Metadata.platform` value.
+fn go_platform() -> &'static str {
+    match std::env::consts::OS {
+        "macos" => "DARWIN",
+        "windows" => "WINDOWS",
+        _ => "LINUX",
+    }
+}
+
+#[async_trait]
+impl AuthApplier for AntigravityAuthApplier {
+    async fn apply(
+        &self,
+        mut request: reqwest::Request,
+        target: &RoutingTarget,
+    ) -> Result<reqwest::Request> {
+        let label = self.label_for(target);
+        let token = self.resolve_token(label).await?;
+        let headers = request.headers_mut();
+        let bearer = format!("Bearer {}", token.access_token);
+        headers.insert(
+            reqwest::header::AUTHORIZATION,
+            HeaderValue::from_str(&bearer).map_err(|e| {
+                BitrouterError::internal(format!("invalid antigravity bearer: {e}"))
+            })?,
+        );
+        // The Gemini transport default would set `x-goog-api-key`; cloudcode-pa
+        // authenticates by Bearer, so drop it.
+        headers.remove("x-goog-api-key");
+        headers.insert(
+            reqwest::header::USER_AGENT,
+            HeaderValue::from_str(&user_agent())
+                .map_err(|e| BitrouterError::internal(format!("invalid user-agent: {e}")))?,
+        );
+        headers.insert(
+            HeaderName::from_static("client-metadata"),
+            HeaderValue::from_str(&client_metadata())
+                .map_err(|e| BitrouterError::internal(format!("invalid client-metadata: {e}")))?,
+        );
+        Ok(request)
+    }
+
+    async fn prepare_body(
+        &self,
+        body: &mut serde_json::Value,
+        target: &RoutingTarget,
+    ) -> Result<()> {
+        // Wrap the rendered Gemini body in cloudcode-pa's envelope:
+        // `{ model, project, request: <gemini body> }`. Needs the Bearer (to
+        // call loadCodeAssist for the project) — resolved + cached here.
+        let label = self.label_for(target);
+        let token = self.resolve_token(label).await?;
+        let project = self
+            .resolve_project(label, target.effective_api_base(), &token.access_token)
+            .await?;
+        let inner = std::mem::replace(body, serde_json::Value::Null);
+        *body = serde_json::json!({
+            "model": target.service_id,
+            "project": project,
+            "request": inner,
+        });
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use bitrouter_sdk::language_model::types::ApiProtocol;
+
+    use super::*;
+
+    fn tmp_store_path() -> PathBuf {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "bitrouter-antigravity-test-{}-{id}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir.join("creds.json")
+    }
+
+    fn target() -> RoutingTarget {
+        RoutingTarget {
+            provider_name: PROVIDER_ID.into(),
+            service_id: "gemini-2.5-flash".into(),
+            api_base: "https://cloudcode-pa.googleapis.com".into(),
+            api_key: String::new(),
+            api_protocol: ApiProtocol::Custom(protocol::PROTOCOL.into()),
+            account_label: None,
+            api_key_override: None,
+            api_base_override: None,
+            auth_scheme: Default::default(),
+        }
+    }
+
+    #[tokio::test]
+    async fn apply_fails_without_credential() {
+        let applier = AntigravityAuthApplier::new(tmp_store_path()).unwrap();
+        let req = reqwest::Client::new()
+            .post("https://cloudcode-pa.googleapis.com/v1internal:generateContent")
+            .build()
+            .unwrap();
+        let err = applier.apply(req, &target()).await.unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("bitrouter providers login google-ai"),
+            "expected login hint, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_sets_bearer_and_spoof_headers() {
+        let path = tmp_store_path();
+        {
+            let mut store = CredentialStore::load(&path).unwrap();
+            store
+                .set(
+                    PROVIDER_ID,
+                    DEFAULT_LABEL,
+                    Credential::from_oauth_token(OAuthToken {
+                        access_token: "ya29.test".into(),
+                        expires_at: 0, // non-expiring → no refresh
+                        refresh_token: Some("1//r".into()),
+                    }),
+                )
+                .unwrap();
+        }
+        let applier = AntigravityAuthApplier::new(&path).unwrap();
+        let req = reqwest::Client::new()
+            .post("https://cloudcode-pa.googleapis.com/v1internal:generateContent")
+            .build()
+            .unwrap();
+        let authed = applier.apply(req, &target()).await.unwrap();
+        let h = authed.headers();
+        assert_eq!(
+            h.get(reqwest::header::AUTHORIZATION)
+                .and_then(|v| v.to_str().ok()),
+            Some("Bearer ya29.test")
+        );
+        assert!(
+            h.get(reqwest::header::USER_AGENT)
+                .and_then(|v| v.to_str().ok())
+                .is_some_and(|ua| ua.starts_with("antigravity/"))
+        );
+        assert!(h.get("client-metadata").is_some());
+        assert!(h.get("x-goog-api-key").is_none());
+    }
+
+    #[test]
+    fn user_agent_and_platform_are_well_formed() {
+        let ua = user_agent();
+        assert!(ua.starts_with("antigravity/"));
+        assert!(ua.contains('/'));
+        let cm = client_metadata();
+        assert!(cm.contains("\"pluginType\":\"GEMINI\""));
+    }
+}

--- a/crates/bitrouter-providers/src/antigravity/protocol.rs
+++ b/crates/bitrouter-providers/src/antigravity/protocol.rs
@@ -1,0 +1,271 @@
+//! The `Custom("antigravity")` protocol — Gemini `generateContent` retargeted at
+//! Google's Code Assist backend (`cloudcode-pa.googleapis.com/v1internal:*`).
+//!
+//! cloudcode-pa speaks the same Gemini content shape as the public Generative
+//! Language API, with two wire differences:
+//!
+//! 1. **Method endpoint**: `POST {base}/v1internal:{verb}` (the model+project
+//!    ride in the request body envelope), not `.../models/{model}:{verb}`.
+//! 2. **Response envelope**: replies (and every streamed chunk) are wrapped in
+//!    `{"response": {…gemini…}, "traceId": …, "metadata": …}`.
+//!
+//! So this [`OutboundAdapter`]/[`Transport`] pair **composes** the built-in
+//! [`GenerateContentAdapter`]: render + parse delegate to it, we only override
+//! the endpoint URL and unwrap the `response` envelope before the Gemini parser
+//! sees it. The request-body envelope (`{model, project, request}`) and auth are
+//! added by [`super::AntigravityAuthApplier`], which registers under the same
+//! provider id.
+//!
+//! Registered on the [`OutboundDispatch`](bitrouter_sdk::language_model::OutboundDispatch) at app startup (see
+//! `apps/bitrouter`), keyed by the `Custom("antigravity")` protocol the registry
+//! selects via `api_protocol: antigravity`.
+
+use async_trait::async_trait;
+use serde_json::Value;
+
+use bitrouter_sdk::language_model::protocol::generate_content::{
+    GenerateContentAdapter, GenerateContentTransport,
+};
+use bitrouter_sdk::language_model::{
+    ApiProtocol, GenerateResult, OutboundAdapter, Prompt, RoutingTarget, SseEvent, StreamDecoder,
+    StreamPart, Transport,
+};
+use bitrouter_sdk::{Result, language_model::protocol};
+
+/// The `Custom(_)` protocol name. The registry selects this via
+/// `api_protocol: antigravity`; the app registers the adapter/transport under it.
+pub const PROTOCOL: &str = "antigravity";
+
+/// The JSON key cloudcode-pa wraps every response (and stream chunk) in.
+const RESPONSE_ENVELOPE_KEY: &str = "response";
+
+fn antigravity_protocol() -> ApiProtocol {
+    ApiProtocol::Custom(PROTOCOL.to_string())
+}
+
+/// Unwrap the cloudcode-pa `{"response": …}` envelope, returning the inner
+/// Gemini value. Passes a value through unchanged when the key is absent (so a
+/// bare response, or a future shape, still parses).
+fn unwrap_response(mut body: Value) -> Value {
+    if let Some(obj) = body.as_object_mut()
+        && let Some(inner) = obj.remove(RESPONSE_ENVELOPE_KEY)
+    {
+        return inner;
+    }
+    body
+}
+
+/// Outbound adapter: delegates Gemini render/parse to [`GenerateContentAdapter`],
+/// overriding only the response-envelope unwrap.
+pub struct AntigravityAdapter {
+    inner: GenerateContentAdapter,
+}
+
+impl AntigravityAdapter {
+    /// Construct the adapter.
+    pub fn new() -> Self {
+        Self {
+            inner: GenerateContentAdapter,
+        }
+    }
+}
+
+impl Default for AntigravityAdapter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl OutboundAdapter for AntigravityAdapter {
+    fn protocol(&self) -> ApiProtocol {
+        antigravity_protocol()
+    }
+
+    fn render_request(&self, prompt: &Prompt) -> Result<Value> {
+        // The bare Gemini body; the applier wraps it in the
+        // `{model, project, request}` envelope in `prepare_body`.
+        self.inner.render_request(prompt)
+    }
+
+    fn parse_response(&self, body: Value) -> Result<GenerateResult> {
+        self.inner.parse_response(unwrap_response(body))
+    }
+
+    fn stream_decoder(&self) -> Box<dyn StreamDecoder> {
+        Box::new(AntigravityStreamDecoder {
+            inner: self.inner.stream_decoder(),
+        })
+    }
+
+    fn supports_response_format(&self) -> bool {
+        self.inner.supports_response_format()
+    }
+}
+
+/// Transport: `POST {base}/v1internal:{verb}` (method endpoint), Bearer auth
+/// handled by the applier.
+pub struct AntigravityTransport;
+
+#[async_trait]
+impl Transport for AntigravityTransport {
+    fn protocol(&self) -> ApiProtocol {
+        antigravity_protocol()
+    }
+
+    fn endpoint_url(&self, target: &RoutingTarget, stream: bool) -> String {
+        let base = target.effective_api_base().trim_end_matches('/');
+        let verb = if stream {
+            "v1internal:streamGenerateContent?alt=sse"
+        } else {
+            "v1internal:generateContent"
+        };
+        format!("{base}/{verb}")
+    }
+
+    async fn authorise(
+        &self,
+        request: reqwest::Request,
+        target: &RoutingTarget,
+    ) -> Result<reqwest::Request> {
+        // Auth is owned by `AntigravityAuthApplier`; the executor calls the
+        // applier's `apply` instead of this when an applier is registered for
+        // the provider. This path only runs if the applier is somehow absent —
+        // fall back to the Gemini transport's default rather than sending
+        // unauthenticated.
+        GenerateContentTransport.authorise(request, target).await
+    }
+}
+
+/// Stream decoder wrapping the Gemini decoder: unwraps `{"response": …}` from
+/// each SSE chunk before the Gemini state machine parses it.
+struct AntigravityStreamDecoder {
+    inner: Box<dyn StreamDecoder>,
+}
+
+impl StreamDecoder for AntigravityStreamDecoder {
+    fn decode(&mut self, event: &SseEvent) -> Result<Vec<StreamPart>> {
+        let data = event.data.trim();
+        // Only rewrite well-formed JSON chunks carrying the envelope; anything
+        // else (blank keepalives, `[DONE]`, already-bare chunks) passes through
+        // to the inner decoder untouched.
+        let rewritten = match serde_json::from_str::<Value>(data) {
+            Ok(v) if v.get(RESPONSE_ENVELOPE_KEY).is_some() => Some(SseEvent {
+                event: event.event.clone(),
+                data: unwrap_response(v).to_string(),
+            }),
+            _ => None,
+        };
+        match rewritten {
+            Some(ref ev) => self.inner.decode(ev),
+            None => self.inner.decode(event),
+        }
+    }
+
+    fn finish(&mut self) -> Result<Vec<StreamPart>> {
+        self.inner.finish()
+    }
+}
+
+/// Register the Antigravity adapter + transport on an [`OutboundDispatch`](bitrouter_sdk::language_model::OutboundDispatch) under
+/// the `Custom("antigravity")` protocol. Called at app startup.
+pub fn register(dispatch: &mut protocol::OutboundDispatch) {
+    dispatch.register(
+        std::sync::Arc::new(AntigravityAdapter::new()),
+        std::sync::Arc::new(AntigravityTransport),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bitrouter_sdk::language_model::types::ApiProtocol;
+
+    fn target() -> RoutingTarget {
+        RoutingTarget {
+            provider_name: "antigravity".into(),
+            service_id: "gemini-2.5-flash".into(),
+            api_base: "https://cloudcode-pa.googleapis.com".into(),
+            api_key: String::new(),
+            api_protocol: ApiProtocol::Custom(PROTOCOL.into()),
+            account_label: None,
+            api_key_override: None,
+            api_base_override: None,
+            auth_scheme: Default::default(),
+        }
+    }
+
+    #[test]
+    fn endpoint_is_v1internal_method_style() {
+        let t = AntigravityTransport;
+        assert_eq!(
+            t.endpoint_url(&target(), false),
+            "https://cloudcode-pa.googleapis.com/v1internal:generateContent"
+        );
+        assert_eq!(
+            t.endpoint_url(&target(), true),
+            "https://cloudcode-pa.googleapis.com/v1internal:streamGenerateContent?alt=sse"
+        );
+    }
+
+    #[test]
+    fn unwrap_strips_response_envelope() {
+        let wrapped = serde_json::json!({
+            "response": {"candidates": [{"content": {"parts": [{"text": "hi"}]}}]},
+            "traceId": "t", "metadata": {}
+        });
+        let inner = unwrap_response(wrapped);
+        assert!(inner.get("candidates").is_some());
+        assert!(inner.get("traceId").is_none());
+    }
+
+    #[test]
+    fn unwrap_passes_bare_response_through() {
+        let bare = serde_json::json!({"candidates": []});
+        assert_eq!(unwrap_response(bare.clone()), bare);
+    }
+
+    #[test]
+    fn parse_response_unwraps_then_delegates_to_gemini() {
+        let adapter = AntigravityAdapter::new();
+        let wrapped = serde_json::json!({
+            "response": {
+                "candidates": [{
+                    "content": {"parts": [{"text": "agy-envelope-ok"}], "role": "model"},
+                    "finishReason": "STOP"
+                }],
+                "usageMetadata": {"promptTokenCount": 1, "candidatesTokenCount": 2}
+            },
+            "traceId": "abc"
+        });
+        let result = adapter.parse_response(wrapped).expect("parse");
+        let text = result
+            .content
+            .iter()
+            .find_map(|c| match c {
+                bitrouter_sdk::language_model::Content::Text { text, .. } => Some(text.clone()),
+                _ => None,
+            })
+            .expect("text content");
+        assert_eq!(text, "agy-envelope-ok");
+    }
+
+    #[test]
+    fn stream_decoder_unwraps_chunk_before_gemini_parse() {
+        let adapter = AntigravityAdapter::new();
+        let mut dec = adapter.stream_decoder();
+        let chunk = serde_json::json!({
+            "response": {"candidates": [{"content": {"parts": [{"text": "hello"}]}}]},
+            "traceId": "t"
+        });
+        let parts = dec
+            .decode(&SseEvent {
+                event: None,
+                data: chunk.to_string(),
+            })
+            .expect("decode");
+        let got_text = parts
+            .iter()
+            .any(|p| matches!(p, StreamPart::TextDelta { text } if text == "hello"));
+        assert!(got_text, "expected a TextDelta 'hello', got {parts:?}");
+    }
+}

--- a/crates/bitrouter-providers/src/import/antigravity.rs
+++ b/crates/bitrouter-providers/src/import/antigravity.rs
@@ -1,0 +1,234 @@
+//! Import the Antigravity CLI (`agy`) Google OAuth session.
+//!
+//! The official `agy` CLI stores its Google OAuth credential in the OS keyring
+//! (macOS Keychain / Linux Secret Service / Windows Credential Manager) under
+//! `(service = "gemini", account = "antigravity")`, using Go's `go-keyring`
+//! library. The stored value is `go-keyring-base64:` + base64 of the JSON:
+//!
+//! ```json
+//! {"token":{"access_token":"ya29.…","token_type":"Bearer",
+//!           "refresh_token":"1//…","expiry":"2026-07-09T16:05:35.08-04:00"},
+//!  "auth_method":"consumer"}
+//! ```
+//!
+//! We adopt the **`consumer`** session (Google personal-login) — the
+//! `access_token` is a Google `ya29.…` Bearer accepted by `cloudcode-pa`, the
+//! `refresh_token` is a Google `1//…` token, and `expiry` is RFC 3339. The
+//! access token is opaque (not a JWT), so expiry comes from the `expiry` field.
+//! The "use a Google Cloud project" path (`auth_method != "consumer"`) is a
+//! different shape and is not imported here.
+//!
+//! Refresh needs `agy`'s confidential OAuth client (client id + `GOCSPX-…`
+//! secret) — see [`crate::antigravity::agy_client`]; the secret is read from
+//! the installed `agy` binary at refresh time rather than shipped here.
+
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD;
+use serde::Deserialize;
+
+use crate::import::{ImportError, ImportSource, Imported};
+use crate::oauth::credential_store::OAuthToken;
+
+/// Keyring generic-password service `agy` stores its token under.
+const KEYCHAIN_SERVICE: &str = "gemini";
+/// Keyring account name within that service.
+const KEYCHAIN_ACCOUNT: &str = "antigravity";
+/// Prefix `go-keyring` prepends to base64-encoded secrets.
+const GO_KEYRING_B64_PREFIX: &str = "go-keyring-base64:";
+/// The only `auth_method` we import — the Google personal-login session.
+const CONSUMER_AUTH_METHOD: &str = "consumer";
+
+/// The `go-keyring`-stored JSON envelope.
+#[derive(Deserialize)]
+struct AgyCredential {
+    token: Option<AgyToken>,
+    #[serde(default)]
+    auth_method: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct AgyToken {
+    access_token: Option<String>,
+    #[serde(default)]
+    refresh_token: Option<String>,
+    /// RFC 3339 timestamp, e.g. `2026-07-09T16:05:35.088074-04:00`.
+    #[serde(default)]
+    expiry: Option<String>,
+}
+
+/// Import the Antigravity credential from the OS keyring. Returns `Ok(None)`
+/// when no `agy` session is present (or it isn't a `consumer` session).
+pub fn import() -> Result<Option<Imported>, ImportError> {
+    let Some(raw) = read_keyring()? else {
+        return Ok(None);
+    };
+    match parse_secret(&raw)? {
+        Some(token) => Ok(Some(Imported {
+            token,
+            source: ImportSource::Keychain(KEYCHAIN_SERVICE),
+        })),
+        None => Ok(None),
+    }
+}
+
+/// Read the raw `go-keyring` secret string from the OS keyring. `None` when the
+/// entry is absent; errors on a keyring backend failure.
+fn read_keyring() -> Result<Option<String>, ImportError> {
+    let entry = keyring::Entry::new(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT)
+        .map_err(|e| ImportError::Keyring(e.to_string()))?;
+    match entry.get_password() {
+        Ok(secret) => Ok(Some(secret)),
+        Err(keyring::Error::NoEntry) => Ok(None),
+        Err(e) => Err(ImportError::Keyring(e.to_string())),
+    }
+}
+
+/// Parse the raw keyring secret (`go-keyring-base64:` + base64 JSON, or plain
+/// JSON) into an [`OAuthToken`]. `Ok(None)` when it isn't a `consumer` session
+/// or carries no access token. Pure — unit-tested without a keyring.
+fn parse_secret(raw: &str) -> Result<Option<OAuthToken>, ImportError> {
+    let json = decode_go_keyring(raw)?;
+    let cred: AgyCredential =
+        serde_json::from_slice(&json).map_err(|source| ImportError::Json {
+            origin: "agy keyring".to_string(),
+            source,
+        })?;
+    // Only adopt the Google personal-login session; the GCP-project path is a
+    // different credential shape.
+    if cred.auth_method.as_deref() != Some(CONSUMER_AUTH_METHOD) {
+        return Ok(None);
+    }
+    let Some(token) = cred.token else {
+        return Ok(None);
+    };
+    let access_token = match token.access_token.filter(|s| !s.is_empty()) {
+        Some(t) => t,
+        None => return Ok(None),
+    };
+    let expires_at = token
+        .expiry
+        .as_deref()
+        .and_then(rfc3339_to_epoch)
+        .unwrap_or(0);
+    Ok(Some(OAuthToken {
+        access_token,
+        expires_at,
+        refresh_token: token.refresh_token.filter(|s| !s.is_empty()),
+    }))
+}
+
+/// Strip the `go-keyring-base64:` prefix and base64-decode; a value without the
+/// prefix is treated as raw JSON bytes (some backends store it un-encoded).
+fn decode_go_keyring(raw: &str) -> Result<Vec<u8>, ImportError> {
+    match raw.strip_prefix(GO_KEYRING_B64_PREFIX) {
+        Some(b64) => STANDARD
+            .decode(b64.trim())
+            .map_err(|e| ImportError::Keyring(format!("agy keyring base64 decode: {e}"))),
+        None => Ok(raw.as_bytes().to_vec()),
+    }
+}
+
+/// Parse an RFC 3339 timestamp to Unix seconds. Handles a trailing `Z` or a
+/// `±HH:MM` offset and an optional fractional-second part (ignored). `None` on
+/// any malformed field. Dep-free (no `chrono`/`time`): the `agy` access token
+/// is opaque, so this is the only expiry source.
+fn rfc3339_to_epoch(s: &str) -> Option<u64> {
+    // Split date and time on 'T'.
+    let (date, rest) = s.split_once('T')?;
+    let mut d = date.split('-');
+    let year: i64 = d.next()?.parse().ok()?;
+    let month: i64 = d.next()?.parse().ok()?;
+    let day: i64 = d.next()?.parse().ok()?;
+
+    // Separate the time-of-day from the timezone designator: a trailing `Z`
+    // (UTC), else a `±HH:MM` offset.
+    let (time, tz): (&str, i64) = if let Some(t) = rest.strip_suffix('Z') {
+        (t, 0)
+    } else {
+        let idx = rest.rfind(['+', '-'])?;
+        let sign = if &rest[idx..=idx] == "-" { -1 } else { 1 };
+        let (t, off) = rest.split_at(idx);
+        let off = &off[1..]; // drop the sign
+        let (oh, om) = off.split_once(':')?;
+        let offset_secs = sign * (oh.parse::<i64>().ok()? * 3600 + om.parse::<i64>().ok()? * 60);
+        (t, offset_secs)
+    };
+
+    // Time-of-day; drop any fractional seconds.
+    let time = time.split('.').next()?;
+    let mut tp = time.split(':');
+    let hour: i64 = tp.next()?.parse().ok()?;
+    let minute: i64 = tp.next()?.parse().ok()?;
+    let second: i64 = tp.next()?.parse().ok()?;
+
+    // Days since the Unix epoch (Howard Hinnant's days_from_civil).
+    let y = if month <= 2 { year - 1 } else { year };
+    let era = if y >= 0 { y } else { y - 399 } / 400;
+    let yoe = y - era * 400;
+    let doy = (153 * (if month > 2 { month - 3 } else { month + 9 }) + 2) / 5 + day - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    let days = era * 146097 + doe - 719468;
+
+    let epoch = days * 86400 + hour * 3600 + minute * 60 + second - tz;
+    (epoch >= 0).then_some(epoch as u64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn envelope(auth_method: &str, expiry: &str) -> String {
+        let json = format!(
+            r#"{{"token":{{"access_token":"ya29.AAA","token_type":"Bearer","refresh_token":"1//RT","expiry":"{expiry}"}},"auth_method":"{auth_method}"}}"#
+        );
+        format!("{GO_KEYRING_B64_PREFIX}{}", STANDARD.encode(json))
+    }
+
+    #[test]
+    fn parses_consumer_session_with_offset_expiry() {
+        let raw = envelope("consumer", "2026-07-09T16:05:35.088074-04:00");
+        let tok = parse_secret(&raw).unwrap().unwrap();
+        assert_eq!(tok.access_token, "ya29.AAA");
+        assert_eq!(tok.refresh_token.as_deref(), Some("1//RT"));
+        // 2026-07-09T16:05:35-04:00 == 2026-07-09T20:05:35Z == 1783627535.
+        assert_eq!(tok.expires_at, 1_783_627_535);
+    }
+
+    #[test]
+    fn parses_z_suffix_expiry() {
+        assert_eq!(
+            rfc3339_to_epoch("2026-07-09T20:05:35Z"),
+            Some(1_783_627_535)
+        );
+        assert_eq!(rfc3339_to_epoch("1970-01-01T00:00:00Z"), Some(0));
+    }
+
+    #[test]
+    fn rejects_non_consumer_session() {
+        let raw = envelope("gcp", "2026-07-09T20:05:35Z");
+        assert!(parse_secret(&raw).unwrap().is_none());
+    }
+
+    #[test]
+    fn plain_json_without_prefix_is_accepted() {
+        let raw = r#"{"token":{"access_token":"ya29.X","refresh_token":"1//Y","expiry":"2026-07-09T20:05:35Z"},"auth_method":"consumer"}"#;
+        let tok = parse_secret(raw).unwrap().unwrap();
+        assert_eq!(tok.access_token, "ya29.X");
+    }
+
+    #[test]
+    fn missing_access_token_is_none() {
+        let raw = format!(
+            "{GO_KEYRING_B64_PREFIX}{}",
+            STANDARD.encode(r#"{"token":{"refresh_token":"1//Z"},"auth_method":"consumer"}"#)
+        );
+        assert!(parse_secret(&raw).unwrap().is_none());
+    }
+
+    #[test]
+    fn malformed_expiry_falls_back_to_zero() {
+        let raw = envelope("consumer", "not-a-date");
+        let tok = parse_secret(&raw).unwrap().unwrap();
+        assert_eq!(tok.expires_at, 0);
+    }
+}

--- a/crates/bitrouter-providers/src/import/mod.rs
+++ b/crates/bitrouter-providers/src/import/mod.rs
@@ -19,6 +19,7 @@
 //! - Grok — `$GROK_HOME/auth.json` (default `~/.grok/auth.json`), the OIDC
 //!   (SuperGrok subscription) entry. See [`grok`].
 
+pub mod antigravity;
 pub mod claude_code;
 pub mod codex;
 pub mod grok;
@@ -32,7 +33,8 @@ use crate::oauth::credential_store::OAuthToken;
 /// tell the user which source was adopted.
 #[derive(Debug, Clone)]
 pub enum ImportSource {
-    /// The macOS login Keychain; the field is the generic-password service.
+    /// The OS keyring (macOS Keychain / Linux Secret Service / Windows
+    /// Credential Manager); the field is the generic-password service.
     Keychain(&'static str),
     /// A JSON file on disk at the given path.
     File(PathBuf),
@@ -41,7 +43,7 @@ pub enum ImportSource {
 impl std::fmt::Display for ImportSource {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ImportSource::Keychain(service) => write!(f, "macOS Keychain ({service})"),
+            ImportSource::Keychain(service) => write!(f, "OS keyring ({service})"),
             ImportSource::File(path) => write!(f, "{}", path.display()),
         }
     }
@@ -86,6 +88,9 @@ pub enum ImportError {
         /// The vendor CLI name, for the message.
         cli: &'static str,
     },
+    /// The OS keyring backend failed (locked keychain, no Secret Service, …).
+    #[error("reading the OS keyring: {0}")]
+    Keyring(String),
 }
 
 /// Resolve the user's home directory from `HOME` (Unix) or `USERPROFILE`

--- a/crates/bitrouter-providers/src/lib.rs
+++ b/crates/bitrouter-providers/src/lib.rs
@@ -77,6 +77,8 @@
 
 #[cfg(feature = "pkce")]
 pub mod anthropic;
+#[cfg(feature = "pkce")]
+pub mod antigravity;
 mod apply;
 pub mod builtin;
 #[cfg(feature = "pkce")]

--- a/crates/bitrouter-providers/src/oauth/refresh.rs
+++ b/crates/bitrouter-providers/src/oauth/refresh.rs
@@ -29,6 +29,38 @@ pub async fn refresh(
     client_id: &str,
     current: &OAuthToken,
 ) -> Result<OAuthToken, AuthCodeError> {
+    refresh_inner(client, token_endpoint, client_id, None, current).await
+}
+
+/// Like [`refresh`], but for a **confidential** OAuth client — includes
+/// `client_secret` in the grant. Google installed-app clients (e.g. the
+/// Antigravity `agy` CLI) require the secret even though it ships inside the
+/// binary; [`crate::antigravity`] extracts it from the local `agy` at runtime
+/// rather than embedding Google's secret here.
+pub async fn refresh_with_client_secret(
+    client: &reqwest::Client,
+    token_endpoint: &str,
+    client_id: &str,
+    client_secret: &str,
+    current: &OAuthToken,
+) -> Result<OAuthToken, AuthCodeError> {
+    refresh_inner(
+        client,
+        token_endpoint,
+        client_id,
+        Some(client_secret),
+        current,
+    )
+    .await
+}
+
+async fn refresh_inner(
+    client: &reqwest::Client,
+    token_endpoint: &str,
+    client_id: &str,
+    client_secret: Option<&str>,
+    current: &OAuthToken,
+) -> Result<OAuthToken, AuthCodeError> {
     if !token_endpoint.starts_with("https://") {
         return Err(AuthCodeError::InsecureEndpoint(token_endpoint.to_string()));
     }
@@ -41,11 +73,14 @@ pub async fn refresh(
                           `bitrouter providers login <provider>`"
                     .into(),
             })?;
-    let form = [
+    let mut form = vec![
         ("grant_type", "refresh_token"),
         ("client_id", client_id),
         ("refresh_token", refresh_token),
     ];
+    if let Some(secret) = client_secret {
+        form.push(("client_secret", secret));
+    }
     let response = client
         .post(token_endpoint)
         .header(reqwest::header::ACCEPT, "application/json")

--- a/crates/bitrouter-providers/src/registry/types.rs
+++ b/crates/bitrouter-providers/src/registry/types.rs
@@ -53,6 +53,10 @@ pub enum RegistryProtocol {
     Google,
     /// OpenAI Responses.
     Responses,
+    /// Google Antigravity Code Assist — Gemini `generateContent` retargeted at
+    /// `cloudcode-pa.googleapis.com/v1internal:*` (custom protocol, registered
+    /// by `bitrouter_providers::antigravity`).
+    Antigravity,
 }
 
 impl RegistryProtocol {
@@ -63,6 +67,9 @@ impl RegistryProtocol {
             RegistryProtocol::Anthropic => ApiProtocol::Messages,
             RegistryProtocol::Google => ApiProtocol::GenerateContent,
             RegistryProtocol::Responses => ApiProtocol::Responses,
+            // Matches the protocol the antigravity adapter registers under
+            // (`bitrouter_providers::antigravity::protocol::PROTOCOL`).
+            RegistryProtocol::Antigravity => ApiProtocol::Custom("antigravity".to_string()),
         }
     }
 }

--- a/dist/registry/models.json
+++ b/dist/registry/models.json
@@ -1659,17 +1659,6 @@
         },
         {
           "api_protocol": [
-            "google",
-            "openai"
-          ],
-          "capabilities": [
-            "tools"
-          ],
-          "provider": "google-ai",
-          "provider_model_id": "gemini-3.1-flash-lite-preview"
-        },
-        {
-          "api_protocol": [
             "openai",
             "responses",
             "anthropic"
@@ -1748,18 +1737,6 @@
           "rate_limits": {
             "requests_per_minute": 60
           }
-        },
-        {
-          "api_protocol": [
-            "google",
-            "openai"
-          ],
-          "capabilities": [
-            "reasoning",
-            "tools"
-          ],
-          "provider": "google-ai",
-          "provider_model_id": "gemini-3.1-pro-preview"
         },
         {
           "api_protocol": [
@@ -1842,18 +1819,6 @@
           "rate_limits": {
             "requests_per_minute": 60
           }
-        },
-        {
-          "api_protocol": [
-            "google",
-            "openai"
-          ],
-          "capabilities": [
-            "reasoning",
-            "tools"
-          ],
-          "provider": "google-ai",
-          "provider_model_id": "gemini-3.5-flash"
         },
         {
           "api_protocol": "openai",

--- a/dist/registry/providers.json
+++ b/dist/registry/providers.json
@@ -2820,7 +2820,7 @@
     },
     {
       "access": "local_oauth",
-      "api_base": "https://generativelanguage.googleapis.com/v1beta",
+      "api_base": "https://cloudcode-pa.googleapis.com",
       "auth": {
         "handler": "google-ai",
         "kind": "oauth"
@@ -2830,6 +2830,7 @@
       "byok": false,
       "community": false,
       "display_name": "Google AI (subscription)",
+      "doc_url": "https://antigravity.google/docs/cli/install",
       "id": "google-ai",
       "kind": "first_party",
       "metadata": {
@@ -2842,45 +2843,36 @@
       },
       "models": [
         {
-          "api_protocol": [
-            "google",
-            "openai"
-          ],
+          "api_protocol": "antigravity",
           "capabilities": [
-            "reasoning",
-            "tools"
+            "tools",
+            "image_input"
           ],
-          "id": "google/gemini-3.1-pro-preview",
-          "provider_model_id": "gemini-3.1-pro-preview"
+          "id": "google/gemini-2.5-flash",
+          "provider_model_id": "gemini-2.5-flash"
         },
         {
-          "api_protocol": [
-            "google",
-            "openai"
-          ],
+          "api_protocol": "antigravity",
           "capabilities": [
             "reasoning",
-            "tools"
+            "tools",
+            "image_input"
           ],
-          "id": "google/gemini-3.5-flash",
-          "provider_model_id": "gemini-3.5-flash"
+          "id": "google/gemini-3-flash",
+          "provider_model_id": "gemini-3-flash"
         },
         {
-          "api_protocol": [
-            "google",
-            "openai"
-          ],
+          "api_protocol": "antigravity",
           "capabilities": [
-            "tools"
+            "reasoning",
+            "tools",
+            "image_input"
           ],
-          "id": "google/gemini-3.1-flash-lite-preview",
-          "provider_model_id": "gemini-3.1-flash-lite-preview"
+          "id": "google/gemini-3-pro",
+          "provider_model_id": "gemini-3-pro-high"
         }
       ],
       "name": "google-ai",
-      "protocol_endpoints": {
-        "chat_completions": "https://generativelanguage.googleapis.com/v1beta/openai"
-      },
       "required_config": [
         "local_oauth"
       ],

--- a/docs/get-started/supported-providers.md
+++ b/docs/get-started/supported-providers.md
@@ -24,7 +24,7 @@ Every model in the [catalog](/docs/get-started/supported-models) is served by on
 | `github-copilot` | GitHub | US | openai | Subscription | 14 |
 | `gmicloud` | GMI Cloud | US | openai | Per-token | 13 |
 | `google` | Google | US | google, openai | Per-token | 4 |
-| `google-ai` | Google | US | google, openai | Subscription | 3 |
+| `google-ai` | Google | US | antigravity | Subscription | 3 |
 | `minimax` | MiniMax | CN | anthropic, openai | Per-token | 3 |
 | `minimax_cn` | MiniMax | CN | anthropic, openai | Per-token | 3 |
 | `moonshotai` | Moonshot AI | CN | anthropic, openai | Per-token | 3 |

--- a/docs/get-started/supported-providers.zh.md
+++ b/docs/get-started/supported-providers.zh.md
@@ -24,7 +24,7 @@ description: BitRouter 网络上已注册的每个供应商——由任何人都
 | `github-copilot` | GitHub | US | openai | Subscription | 14 |
 | `gmicloud` | GMI Cloud | US | openai | Per-token | 13 |
 | `google` | Google | US | google, openai | Per-token | 4 |
-| `google-ai` | Google | US | google, openai | Subscription | 3 |
+| `google-ai` | Google | US | antigravity | Subscription | 3 |
 | `minimax` | MiniMax | CN | anthropic, openai | Per-token | 3 |
 | `minimax_cn` | MiniMax | CN | anthropic, openai | Per-token | 3 |
 | `moonshotai` | Moonshot AI | CN | anthropic, openai | Per-token | 3 |

--- a/helpers/dist-helper/src/registry.rs
+++ b/helpers/dist-helper/src/registry.rs
@@ -1762,6 +1762,9 @@ enum ApiProtocol {
     Anthropic,
     Google,
     Responses,
+    /// Google Antigravity Code Assist — a custom, externally-registered runtime
+    /// protocol (`bitrouter_providers::antigravity`). No models.dev source.
+    Antigravity,
 }
 
 impl ApiProtocol {
@@ -1771,6 +1774,7 @@ impl ApiProtocol {
             Self::Anthropic => "anthropic",
             Self::Google => "google",
             Self::Responses => "responses",
+            Self::Antigravity => "antigravity",
         }
     }
 
@@ -1780,6 +1784,9 @@ impl ApiProtocol {
             Self::Anthropic => "messages",
             Self::Google => "generate_content",
             Self::Responses => "responses",
+            // The runtime maps any unknown protocol string to `Custom(_)`; this
+            // is the name the antigravity adapter registers under.
+            Self::Antigravity => "antigravity",
         }
     }
 }

--- a/registry/providers/google-ai.yaml
+++ b/registry/providers/google-ai.yaml
@@ -1,11 +1,18 @@
-# Google AI — the Gemini consumer subscription (Google AI Pro / Ultra via
-# gemini.google.com), routed with the user's subscription credentials rather
-# than a metered API key. Flat-rate (no per-token pricing), activated by a local
-# OAuth login — distinct from the metered `google` (Gemini API) provider.
+# Google AI — Google's consumer subscription (Antigravity / Gemini Code Assist),
+# routed with the user's Google login rather than a metered API key. Flat-rate
+# (no per-token pricing), activated by importing the official `agy` CLI session —
+# distinct from the metered `google` (Gemini API) provider.
 #
-# NOTE: the `google-ai` OAuth handler is not yet implemented in bitrouter — this
-# registry entry stages the provider; the handler (client id + endpoints) still
-# needs wiring before it is routable.
+# The `google-ai` handler is implemented in bitrouter_providers::antigravity: it
+# imports the `agy` OS-keyring session (`bitrouter providers login google-ai`),
+# refreshes via the confidential `agy` OAuth client (secret read from the local
+# `agy` binary — never vendored), and speaks the `antigravity` custom protocol,
+# which is Gemini `generateContent` retargeted at
+# `cloudcode-pa.googleapis.com/v1internal:*` with the `{model, project, request}`
+# envelope and `{"response": …}` unwrap.
+#
+# Unofficial: `v1internal` is a private Google surface and this impersonates the
+# `agy` client. Use your own Google account at your own risk.
 name: google-ai
 display_name: Google AI (subscription)
 metadata:
@@ -18,31 +25,36 @@ metadata:
 kind: first_party
 access: local_oauth
 billing: subscription
-api_base: https://generativelanguage.googleapis.com/v1beta
+api_base: https://cloudcode-pa.googleapis.com
+doc_url: https://antigravity.google/docs/cli/install
 api_protocol:
-  - "*": [google, openai]
-protocol_endpoints:
-  openai: https://generativelanguage.googleapis.com/v1beta/openai
+  - "*": antigravity
 rate_limits: []
 models:
-  - id: google/gemini-3.1-pro-preview
-    provider_model_id: gemini-3.1-pro-preview
+  # cloudcode-pa model ids (NOT the generativelanguage/`google` provider ids —
+  # e.g. `gemini-3.1-pro-preview` 404s here). `gemini-2.5-flash` and
+  # `gemini-3-flash` are confirmed routable on the free preview tier;
+  # `gemini-3-pro-high` exists but is paid-tier-gated (500s on free preview).
+  # Availability is account/tier-dependent and resolved live by the `agy`
+  # backend; Antigravity also exposes (BYO) Claude / gpt-oss models not curated here.
+  - id: google/gemini-2.5-flash
+    provider_model_id: gemini-2.5-flash
+    capabilities:
+      - tools
+      - image_input
+  - id: google/gemini-3-flash
+    provider_model_id: gemini-3-flash
     capabilities:
       - reasoning
       - tools
-  - id: google/gemini-3.5-flash
-    provider_model_id: gemini-3.5-flash
+      - image_input
+  - id: google/gemini-3-pro
+    provider_model_id: gemini-3-pro-high
     capabilities:
       - reasoning
       - tools
-  - id: google/gemini-3.1-flash-lite-preview
-    provider_model_id: gemini-3.1-flash-lite-preview
-    capabilities:
-      - tools
+      - image_input
 status: active
 auth:
   kind: oauth
   handler: google-ai
-auto_sync:
-  feed: models_dev
-  key: google

--- a/skills/bitrouter/SKILL.md
+++ b/skills/bitrouter/SKILL.md
@@ -121,6 +121,7 @@ bitrouter providers login claude-code       # Claude Pro/Max via Claude Code ses
 bitrouter providers login openai-codex      # ChatGPT/Codex subscription
 bitrouter providers login github-copilot    # browser device flow, token stored on disk
 bitrouter providers login supergrok         # SuperGrok via the Grok CLI session (~/.grok)
+bitrouter providers login google-ai         # Google AI (Antigravity) via the `agy` CLI keyring session
 ```
 
 ## 4. Connect your SDK
@@ -188,7 +189,7 @@ Read these on demand — don't load them all upfront.
 ## 7. Gotchas
 
 - **Always ask Local-or-Cloud first.** The default of "just install locally" is wrong for users who want managed billing — they should never install the daemon at all.
-- **Cloud sign-in is `bitrouter cloud login`.** Per-provider OAuth is `bitrouter providers login <provider>` (today: `claude-code`, `github-copilot`, `openai-codex`, and `supergrok`), not a top-level `login` command.
+- **Cloud sign-in is `bitrouter cloud login`.** Per-provider OAuth is `bitrouter providers login <provider>` (today: `claude-code`, `github-copilot`, `openai-codex`, `supergrok`, and `google-ai`), not a top-level `login` command.
 - **Cloud management is `bitrouter cloud …`.** After `bitrouter cloud login`, run `bitrouter cloud --help` for the subcommand index: `keys`, `usage`, `requests`, `billing`, `policy`, `budget`, `preset`, `byok`. Every leaf accepts `--json`.
 - **Local port: `127.0.0.1:4356`.** Old docs (and the upstream README) sometimes say 8787 — those are stale.
 - **Cloud endpoints:** `https://api.bitrouter.ai/v1` for the OpenAI shape; `https://api.bitrouter.ai` (no `/v1`) for the Anthropic SDK — same asymmetry as Local.

--- a/skills/bitrouter/references/providers.md
+++ b/skills/bitrouter/references/providers.md
@@ -21,13 +21,14 @@ section). The one in-binary exception is the hosted `bitrouter` cloud gateway.
 | `github-copilot` | — (local OAuth) | Device flow | `bitrouter providers login github-copilot`; per-model protocol map (Claude → Anthropic, gpt-5.x-codex → Responses, rest → Chat) |
 | `openai-codex` | — (local PKCE) | ChatGPT subscription | `bitrouter providers login openai-codex` |
 | `supergrok` | — (local OAuth) | SuperGrok subscription | `bitrouter providers login supergrok`; imports the Grok CLI session (`~/.grok/auth.json`), distinct from `xai` API-key billing |
+| `google-ai` | — (local OAuth) | Google AI (Antigravity) subscription | `bitrouter providers login google-ai`; imports the `agy` CLI keyring session, custom cloudcode-pa protocol, distinct from `google` API-key billing. Unofficial — uses your own Google account |
 | `opencode-zen` | `OPENCODE_ZEN_API_KEY` | Bearer | Per-family protocol routing |
 | `opencode-go` | `OPENCODE_ZEN_API_KEY` (shared) | Bearer | Low-cost subscription tier — same credential as Zen |
 
 Zero-config mode auto-enables every API-key provider whose env var is present;
 an API-key provider without its credential gets `active: false` and falls out of
 the routing table. Local-OAuth/PKCE providers (`claude-code`, `github-copilot`,
-`openai-codex`, `supergrok`) are enabled by `bitrouter providers login`, not an env var. **First run with no network
+`openai-codex`, `supergrok`, `google-ai`) are enabled by `bitrouter providers login`, not an env var. **First run with no network
 and no cache**: the registry is empty, so only fully-specified local providers
 and the in-binary `bitrouter` cloud gateway are available — the known-provider
 shorthand needs one prior successful fetch. Startup still succeeds.


### PR DESCRIPTION
## What

Routes the user's **Google Antigravity** session (the official `agy` CLI) through bitrouter as a first-party subscription provider, distinct from the `google` API-key path. Stacked on #676 (SuperGrok) — review that first; this PR's diff is Antigravity-only.

```
bitrouter providers login antigravity      # imports the `agy` OS-keyring session
… then route:  antigravity:google/gemini-2.5-flash
```

## How it works

Antigravity diverges from the other BYO-subscription providers in three ways, all handled without a `bitrouter-sdk` core change:

1. **Credential = OS keyring, cross-platform.** `agy` stores its Google OAuth token via Go's `go-keyring`. `import/antigravity.rs` reads it through the `keyring` crate (macOS Keychain / Linux Secret Service / Windows Credential Manager), decodes the `go-keyring-base64` envelope, gates on the `consumer` login, and parses the RFC 3339 expiry.
2. **Confidential refresh, secret not vendored.** Refreshing the Google `1//…` token needs `agy`'s client id **and** a `GOCSPX-…` secret. We pin the *public* client id and read the secret from the **local `agy` binary at refresh time** (`antigravity/agy_client.rs`), trying each candidate — bitrouter ships no Google secret. New `oauth::refresh::refresh_with_client_secret`.
3. **Custom protocol, composed not forked.** cloudcode-pa is Gemini `generateContent` with a different envelope. `antigravity/protocol.rs` registers a `Custom("antigravity")` Adapter/Transport that **composes** the built-in `GenerateContentAdapter`: retargets the URL to `.../v1internal:{verb}` and unwraps the `{"response": …}` envelope on the response **and every SSE chunk**. Registered on the dispatch at app startup. The applier (`antigravity/mod.rs`) adds the Bearer + `antigravity/*` spoof headers, a cached `loadCodeAssist` project bootstrap, and the `{model, project, request}` request envelope.

Plus registry (`antigravity.yaml` + a `RegistryProtocol::Antigravity` variant and its dist-helper mirror), rebuilt dist + docs tables (en/zh), CLI dispatch, and skill.

## Test plan

- `cargo test -p bitrouter-providers --features pkce` → **184 pass** (18 antigravity: import decode/expiry/gate, secret scan, protocol unwrap + endpoint, applier bearer/headers); `dist-helper` 23 pass.
- `clippy` (providers + app + dist-helper) clean; `fmt` clean; providers builds with and without `pkce`.
- Cross-platform keyring **interop confirmed live on macOS** (keyring-rs reads `agy`'s go-keyring item). Linux/Windows implemented via the same crate; Windows target-name scheme is **pending live verification** on a real `agy` login.
- **Live end-to-end against a real `agy` subscription**: `antigravity:google/gemini-2.5-flash` returns completions (non-stream + streaming) — exercising import, confidential refresh via the extracted secret, `loadCodeAssist` project, envelope, and the response/stream `.response` unwrap.

## Risk note

Unofficial: `v1internal` is a private Google surface and the request path presents as the `agy` client (UA + Client-Metadata). It uses the user's own Google account and bitrouter embeds no Google secret, but it can violate Google's ToS — documented as at-your-own-risk in the registry entry and skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)