### PR TITLE
feat(agents): add pi-acp to the ACP catalog

### DIFF
--- a/apps/bitrouter/src/agents.rs
+++ b/apps/bitrouter/src/agents.rs
@@ -66,6 +66,13 @@ pub const CATALOG: &[KnownAgent] = &[
             "--experimental-acp",
         ],
     },
+    KnownAgent {
+        id: "pi-acp",
+        description: "pi coding agent via `pi-acp` (needs `pi` on PATH)",
+        project_url: "https://github.com/svkozak/pi-acp",
+        command: "npx",
+        args: &["-y", "pi-acp@latest"],
+    },
 ];
 
 fn lookup_catalog(id: &str) -> Option<&'static KnownAgent> {
@@ -527,6 +534,17 @@ mod tests {
     fn install_emits_project_url_for_attribution() {
         let out = install("gemini-cli").unwrap();
         assert!(out.contains("github.com"));
+    }
+
+    #[test]
+    fn catalog_includes_pi_acp() {
+        let a = lookup_catalog("pi-acp").expect("pi-acp is in the bundled catalog");
+        assert_eq!(a.command, "npx");
+        assert_eq!(a.args, &["-y", "pi-acp@latest"]);
+        let out = install("pi-acp").unwrap();
+        assert!(out.contains("pi-acp:"));
+        assert!(out.contains("pi-acp@latest"));
+        assert!(out.contains("github.com/svkozak/pi-acp"));
     }
 
     #[test]

--- a/skills/bitrouter/references/providers.md
+++ b/skills/bitrouter/references/providers.md
@@ -355,7 +355,19 @@ agents:
       type: stdio
       command: npx
       args: ["-y", "@zed-industries/codex-acp@latest"]
+
+  pi-acp:
+    name: pi-acp
+    transport:
+      type: stdio
+      command: npx
+      args: ["-y", "pi-acp@latest"]   # spawns `pi --mode rpc`; needs `pi` on PATH
 ```
+
+The bundled catalog ids are `claude-acp`, `codex-acp`, `gemini-cli`, and `pi-acp`.
+`pi-acp` wraps the [`pi`](https://github.com/earendil-works/pi) coding agent — install
+it (`npm i -g @earendil-works/pi-coding-agent`) and point pi at BitRouter with the
+`@bitrouter/pi` provider so pi's own model calls route back through the daemon.
 
 `bitrouter agents list` shows the bundled catalog; `--remote` also lists the official ACP agent registry (50+ agents). `bitrouter agents install <id>` prints a paste-ready stub — catalog first, then registry (`npx`/`uvx` entries, version-pinned; binary-only entries need manual install). `bitrouter agents check` verifies each configured agent answers `initialize`.
 


### PR DESCRIPTION
## What

Adds **`pi-acp`** to BitRouter's bundled ACP agent catalog, next to `claude-acp` / `codex-acp` / `gemini-cli`. This makes the [pi coding agent](https://github.com/earendil-works/pi) a first-class, hostable ACP agent:

```bash
bitrouter agents install pi-acp        # paste-ready stub
bitrouter acp prompt --agent pi-acp …  # substrate hosts pi via pi-acp
```

`pi-acp` ([svkozak/pi-acp](https://github.com/svkozak/pi-acp)) speaks ACP over stdio and spawns `pi --mode rpc`. Users install `pi` (`npm i -g @earendil-works/pi-coding-agent`) and point it at BitRouter with the `@bitrouter/pi` provider, so pi's own model calls route back through the daemon — a full-stack dogfood (substrate → pi-acp → pi → BitRouter routing).

## Changes
- `apps/bitrouter/src/agents.rs` — `pi-acp` entry in `CATALOG` + `catalog_includes_pi_acp` test.
- `skills/bitrouter/references/providers.md` — documents `pi-acp` and the `pi` / `@bitrouter/pi` prerequisite (skill-sync rule).

## Verified live (built binary + pi 0.80.6)
- `agents list` → `pi-acp` present, `in_catalog: true`
- `agents install pi-acp` → correct npx stub
- `agents check` → `pi-acp: ok, 1036 ms` (initialize handshake)
- `acp prompt --agent pi-acp` → `session/new` relayed (cwd + mcpServers) → pi's ACP auth-method negotiation (fresh pi has no provider configured; that's the only gap, not an integration issue)
- `cargo build` / `agents` tests 15/15 / `clippy --all-features` / `fmt --check` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
