### PR TITLE
ci: notify bitrouter-docs on release

### DIFF
--- a/.github/workflows/notify-release.yml
+++ b/.github/workflows/notify-release.yml
@@ -1,0 +1,27 @@
+# Notify the bitrouter-docs site the moment a release is published.
+# Fires a repository_dispatch (event_type: bitrouter-release) that the docs
+# repo's sync-changelog.yml + on-bitrouter-release.yml already listen for —
+# turning "changelog synced by the daily cron" into "synced within seconds of
+# the release". The docs side fetches the release body itself from this public
+# repo, so the payload only carries the tag (+ product, for forward-compat with
+# bitrouter-cloud).
+#
+# Reuses the existing DOCS_DISPATCH_TOKEN secret (the same fine-grained PAT that
+# notify-docs.yml uses to dispatch on bitrouter/bitrouter-docs).
+name: Notify docs of release
+on:
+  release:
+    types: [published]   # fires for stable AND prereleases
+permissions: {}
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch bitrouter-release to bitrouter-docs
+        run: |
+          curl -fsSL -X POST \
+            -H "Authorization: Bearer ${{ secrets.DOCS_DISPATCH_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/bitrouter/bitrouter-docs/dispatches \
+            -d "$(jq -n --arg tag '${{ github.event.release.tag_name }}' \
+                  '{event_type:"bitrouter-release", client_payload:{tag:$tag, product:"oss"}}')"


### PR DESCRIPTION
## What

Fires a `repository_dispatch` (`event_type: bitrouter-release`) to **bitrouter-docs** the moment a release is published, so the changelog sync + announce pipeline there runs within seconds instead of waiting for the docs repo's daily cron.

- **Trigger:** `release: published` (stable + prereleases).
- **Payload:** `{ tag, product: "oss" }` — the docs repo fetches the release body itself from this public repo.
- **Token:** reuses the existing `DOCS_DISPATCH_TOKEN` secret (same PAT `notify-docs.yml` uses to dispatch on bitrouter/bitrouter-docs).

Mirrors the existing `notify-docs.yml` pattern. The docs side ([bitrouter-docs#29](https://github.com/bitrouter/bitrouter-docs/pull/29)) already listens for `bitrouter-release`; bitrouter-cloud sends the same event with `product: cloud` ([bitrouter-cloud#574](https://github.com/bitrouter/bitrouter-cloud/pull/574)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
