### PR TITLE
ci(dist): publish homebrew + npm on prerelease tags

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -17,6 +17,10 @@ targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-da
 install-path = "CARGO_HOME"
 # Publish jobs to run in CI
 publish-jobs = ["homebrew", "npm"]
+# Publish Homebrew + npm for prerelease tags too. The project ships only
+# `1.0.0-alpha.*` prereleases today; without this, cargo-dist skips both publish
+# jobs on every alpha, stranding the tap and npm on old versions.
+publish-prereleases = true
 # Whether to install an updater program
 install-updater = false
 # Whether dist should create a Github Release or use an existing draft


### PR DESCRIPTION
## Problem

Homebrew and npm were stranded on old versions while the project shipped up to `alpha.22`:
- **Homebrew tap** stuck at `1.0.0-alpha.4`
- **npm** `latest` stuck at `0.33.0` (no `1.0.0-alpha.*` ever published)

cargo-dist marks every `1.0.0-alpha.*` tag as a prerelease. The `publish-homebrew-formula` and `publish-npm` jobs in `release.yml` are both gated on:

```
if: !announcement_is_prerelease || publish_prereleases
```

`publish-prereleases` was unset (defaults to `false`), so **both jobs were skipped on every alpha**. The built `bitrouter.rb` and npm tarball were still attached to each GitHub Release, but nothing pushed them to the tap or npm. Confirmed on the `alpha.21` run: `build` / `host` / `announce` succeeded, `publish-homebrew-formula` and `publish-npm` both `skipped`.

## Fix

Set `publish-prereleases = true` in `dist-workspace.toml`. This flips the runtime gate; `dist generate` produces **no change** to `release.yml` (the `if:` already reads the flag from the plan manifest), and `dist plan` confirms `publish_prereleases: true`. Future alpha tags now publish both channels automatically.

## npm dist-tag behavior

Publishes use cargo-dist's default (`latest`) tag — intentional. bitrouter-on-npm is a global CLI shim, `0.33.0` is abandoned, and `npm i bitrouter` should give the current version. A `latest`/`next` split can be revisited when a protected `1.0.0` stable ships (0.31 has no config knob for the npm tag, so it would need a workflow patch).

## Out of scope / follow-ups

- The current `alpha.21` formula was pushed to `bitrouter/homebrew-tap` manually to unstick brew immediately; npm backfill and all future tags flow through CI.
- `alpha.22`'s release failed on the `x86_64-unknown-linux-gnu` build target (separate transient issue, not the gate).
- `bitrouter update` misdetects npm installs as `Unknown` and routes them to the shell installer — tracked separately.