### PR TITLE
fix(sdk): preserve token limits and upstream errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,6 +770,7 @@ dependencies = [
  "futures",
  "futures-core",
  "http",
+ "httpdate",
  "pin-project-lite",
  "regex",
  "reqwest 0.12.28",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ tokio-util = "0.7"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 http = "1"
+httpdate = "1"
 bytes = "1"
 pin-project-lite = "0.2"
 async-stream = "0.3"

--- a/apps/bitrouter/src/reload.rs
+++ b/apps/bitrouter/src/reload.rs
@@ -279,6 +279,7 @@ providers:
             api_base,
             api_key: "k".into(),
             api_protocol: ApiProtocol::ChatCompletions,
+            chat_token_limit_field: None,
             account_label: None,
             api_key_override: None,
             api_base_override: None,

--- a/crates/bitrouter-cloud-sdk/src/provider/applier.rs
+++ b/crates/bitrouter-cloud-sdk/src/provider/applier.rs
@@ -261,6 +261,7 @@ mod tests {
             api_base: "https://api.bitrouter.ai/v1".to_string(),
             api_key: key.to_string(),
             api_protocol: ApiProtocol::ChatCompletions,
+            chat_token_limit_field: None,
             account_label: None,
             api_key_override: None,
             api_base_override: None,

--- a/crates/bitrouter-providers/src/anthropic/mod.rs
+++ b/crates/bitrouter-providers/src/anthropic/mod.rs
@@ -156,6 +156,7 @@ mod tests {
             api_base: "https://api.anthropic.com/v1".to_string(),
             api_key: String::new(),
             api_protocol: ApiProtocol::Messages,
+            chat_token_limit_field: None,
             account_label: label.map(String::from),
             api_key_override: None,
             api_base_override: None,

--- a/crates/bitrouter-providers/src/claude_code.rs
+++ b/crates/bitrouter-providers/src/claude_code.rs
@@ -540,6 +540,7 @@ mod tests {
             api_base: "https://api.anthropic.com/v1".to_string(),
             api_key: String::new(),
             api_protocol: ApiProtocol::Messages,
+            chat_token_limit_field: None,
             account_label: label.map(String::from),
             api_key_override: None,
             api_base_override: None,

--- a/crates/bitrouter-providers/src/codex/mod.rs
+++ b/crates/bitrouter-providers/src/codex/mod.rs
@@ -481,6 +481,7 @@ mod tests {
             api_base: "https://chatgpt.com/backend-api/codex".to_string(),
             api_key: String::new(),
             api_protocol: ApiProtocol::Responses,
+            chat_token_limit_field: None,
             account_label: label.map(String::from),
             api_key_override: None,
             api_base_override: None,

--- a/crates/bitrouter-providers/src/copilot/mod.rs
+++ b/crates/bitrouter-providers/src/copilot/mod.rs
@@ -218,6 +218,7 @@ mod tests {
             api_base: "https://api.githubcopilot.com".to_string(),
             api_key: String::new(),
             api_protocol: ApiProtocol::Messages,
+            chat_token_limit_field: None,
             account_label: None,
             api_key_override: None,
             api_base_override: None,

--- a/crates/bitrouter-providers/src/registry/apply.rs
+++ b/crates/bitrouter-providers/src/registry/apply.rs
@@ -265,6 +265,7 @@ fn build_models(provider: &RegistryProvider) -> Vec<ProviderModel> {
             api_protocol: Some(m.api_protocol.to_protocol_list()),
             rate_limits: m.rate_limits.as_ref().map(map_rate_limits),
             pricing: m.pricing.as_ref().and_then(map_pricing),
+            compatibility: m.compatibility.clone(),
         })
         .collect()
 }
@@ -316,7 +317,7 @@ mod tests {
         CanonicalModel, InputTokenPricing, OutputTokenPricing, ProtocolSet, RegistryAccess,
         RegistryAuth, RegistryAuthKind, RegistryModel, RegistryProtocol, RequiredConfig,
     };
-    use bitrouter_sdk::language_model::types::{ApiProtocol, ProtocolList};
+    use bitrouter_sdk::language_model::types::{ApiProtocol, ChatTokenLimitField, ProtocolList};
 
     fn provider(name: &str) -> RegistryProvider {
         RegistryProvider {
@@ -337,6 +338,7 @@ mod tests {
                     context_tiers: Vec::new(),
                 }),
                 rate_limits: None,
+                compatibility: Default::default(),
             }],
             status: "active".to_string(),
             kind: None,
@@ -348,6 +350,21 @@ mod tests {
             byok: Some(true),
             billing: Billing::UsageToken,
         }
+    }
+
+    #[test]
+    fn model_compatibility_reaches_provider_model() {
+        let mut registry_provider = provider("regtestprov");
+        registry_provider.models[0]
+            .compatibility
+            .chat_completions
+            .token_limit_field = Some(ChatTokenLimitField::MaxCompletionTokens);
+
+        let models = build_models(&registry_provider);
+        assert_eq!(
+            models[0].compatibility.chat_completions.token_limit_field,
+            Some(ChatTokenLimitField::MaxCompletionTokens)
+        );
     }
 
     fn data_with(providers: Vec<RegistryProvider>, canonical: Vec<&str>) -> RegistryData {
@@ -651,6 +668,7 @@ mod tests {
             api_protocol: None,
             rate_limits: None,
             pricing: None,
+            compatibility: Default::default(),
         }];
         config.providers.insert("regtestprov".to_string(), user);
 

--- a/crates/bitrouter-providers/src/registry/types.rs
+++ b/crates/bitrouter-providers/src/registry/types.rs
@@ -20,6 +20,7 @@ use std::collections::BTreeMap;
 
 use serde::Deserialize;
 
+use bitrouter_sdk::language_model::types::ModelCompatibility;
 use bitrouter_sdk::language_model::types::{ApiProtocol, ProtocolList};
 
 /// The distribution envelope shared by both dist files: `{ "data": [ … ] }`.
@@ -334,6 +335,9 @@ pub struct RegistryModel {
     /// Resolved rate limits for this (provider, model) pair, if any.
     #[serde(default)]
     pub rate_limits: Option<RegistryRateLimits>,
+    /// Provider/model request-shape compatibility settings.
+    #[serde(default)]
+    pub compatibility: ModelCompatibility,
 }
 
 /// Per-token pricing for a registry model. bitrouter consumes the base

--- a/crates/bitrouter-providers/src/supergrok/mod.rs
+++ b/crates/bitrouter-providers/src/supergrok/mod.rs
@@ -273,6 +273,7 @@ mod tests {
             api_base: "https://api.x.ai/v1".to_string(),
             api_key: String::new(),
             api_protocol: ApiProtocol::Responses,
+            chat_token_limit_field: None,
             account_label: label.map(String::from),
             api_key_override: None,
             api_base_override: None,

--- a/crates/bitrouter-sdk/Cargo.toml
+++ b/crates/bitrouter-sdk/Cargo.toml
@@ -22,6 +22,7 @@ tokio-stream.workspace = true
 tokio-util = { workspace = true, features = ["rt"] }
 tracing.workspace = true
 http.workspace = true
+httpdate.workspace = true
 bytes.workspace = true
 pin-project-lite.workspace = true
 async-stream.workspace = true

--- a/crates/bitrouter-sdk/src/config/mod.rs
+++ b/crates/bitrouter-sdk/src/config/mod.rs
@@ -26,7 +26,7 @@ use serde::Deserialize;
 use crate::error::{BitrouterError, Result};
 use crate::language_model::HttpTimeouts;
 use crate::language_model::routing::SortOrder;
-use crate::language_model::types::{ApiProtocol, ProtocolList};
+use crate::language_model::types::{ApiProtocol, ModelCompatibility, ProtocolList};
 
 pub mod pattern;
 pub mod presets;
@@ -662,6 +662,9 @@ pub struct ProviderModel {
     /// Per-model pricing.
     #[serde(default)]
     pub pricing: Option<PricingConfig>,
+    /// Provider/model request-shape quirks that do not change model semantics.
+    #[serde(default)]
+    pub compatibility: ModelCompatibility,
 }
 
 /// An explicit virtual-model definition (Strategy 2).
@@ -1100,6 +1103,7 @@ pub async fn discover_models(config: &mut Config) {
                         api_protocol: None,
                         rate_limits: None,
                         pricing: None,
+                        compatibility: ModelCompatibility::default(),
                     })
                     .collect();
             }

--- a/crates/bitrouter-sdk/src/config/routing_table.rs
+++ b/crates/bitrouter-sdk/src/config/routing_table.rs
@@ -124,6 +124,11 @@ fn build_targets(
         .find(|m| m.id == model_id)
         .and_then(|m| m.provider_model_id.as_deref())
         .unwrap_or(model_id);
+    let chat_token_limit_field = provider
+        .models
+        .iter()
+        .find(|m| m.id == model_id)
+        .and_then(|m| m.compatibility.chat_completions.token_limit_field);
 
     if provider.accounts.is_empty() {
         let api_base = protocol_base
@@ -135,6 +140,7 @@ fn build_targets(
             api_base,
             api_key: provider.api_key.clone(),
             api_protocol: protocol,
+            chat_token_limit_field,
             account_label: None,
             api_key_override: None,
             api_base_override: None,
@@ -172,6 +178,7 @@ fn build_targets(
                 api_base,
                 api_key: account.api_key.clone(),
                 api_protocol: protocol.clone(),
+                chat_token_limit_field,
                 account_label: Some(label),
                 api_key_override: None,
                 api_base_override: None,
@@ -1502,6 +1509,34 @@ providers:
         assert_eq!(chain[0].provider_name, "anthropic");
         // Dispatched against the upstream id, not the canonical match key.
         assert_eq!(chain[0].service_id, "claude-sonnet-4-6");
+    }
+
+    #[tokio::test]
+    async fn model_chat_token_compatibility_reaches_routing_target() {
+        let yaml = r#"
+providers:
+  openai:
+    api_base: https://api.openai.com/v1
+    api_key: k
+    models:
+      - id: openai/gpt-5.5
+        provider_model_id: gpt-5.5
+        compatibility:
+          chat_completions:
+            token_limit_field: max_completion_tokens
+"#;
+        let chain = table(yaml)
+            .route_chain(
+                "openai/gpt-5.5",
+                &RoutingPrefs::default(),
+                &CallerContext::local(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            chain[0].chat_token_limit_field,
+            Some(crate::language_model::types::ChatTokenLimitField::MaxCompletionTokens)
+        );
     }
 
     #[tokio::test]

--- a/crates/bitrouter-sdk/src/error.rs
+++ b/crates/bitrouter-sdk/src/error.rs
@@ -42,6 +42,10 @@ pub enum BitrouterError {
     #[error("payment required: {0}")]
     PaymentRequired(String),
 
+    /// 402 — an upstream provider account has insufficient credit.
+    #[error("upstream payment required")]
+    UpstreamPaymentRequired,
+
     /// 403 — policy violation.
     #[error("forbidden: {0}")]
     Forbidden(String),
@@ -57,12 +61,28 @@ pub enum BitrouterError {
         retry_after: Option<u64>,
     },
 
+    /// 429 — every usable upstream route is temporarily rate limited.
+    #[error("upstream rate limited")]
+    UpstreamRateLimited {
+        /// Seconds the caller should wait before retrying the earliest route.
+        retry_after: Option<u64>,
+    },
+
     /// 502 — upstream provider returned an error.
     #[error("upstream error ({status}): {message}")]
     Upstream {
         /// Upstream HTTP status.
         status: u16,
         /// Upstream error body / detail.
+        message: String,
+    },
+
+    /// 502 — upstream returned a successful HTTP response that did not match
+    /// the selected protocol.
+    #[error("upstream returned an invalid response: {message}")]
+    UpstreamInvalidResponse {
+        /// Internal diagnostic detail. Public HTTP/SSE responses use a fixed
+        /// safe message and never expose this value.
         message: String,
     },
 
@@ -85,6 +105,10 @@ pub enum BitrouterError {
     #[error("upstream timeout")]
     UpstreamTimeout,
 
+    /// 503 — the upstream route set is temporarily unavailable.
+    #[error("upstream unavailable")]
+    UpstreamUnavailable,
+
     /// 500 — internal error.
     #[error("internal error: {0}")]
     Internal(String),
@@ -97,12 +121,16 @@ impl BitrouterError {
             Self::BadRequest { .. } => 400,
             Self::Unauthorized(_) => 401,
             Self::PaymentRequired(_) => 402,
+            Self::UpstreamPaymentRequired => 402,
             Self::Forbidden(_) => 403,
             Self::NotFound(_) => 404,
             Self::RateLimited { .. } => 429,
+            Self::UpstreamRateLimited { .. } => 429,
             Self::Upstream { .. } => 502,
+            Self::UpstreamInvalidResponse { .. } => 502,
             Self::UpstreamAuth { status, .. } => *status,
             Self::UpstreamTimeout => 504,
+            Self::UpstreamUnavailable => 503,
             Self::Internal(_) => 500,
         }
     }
@@ -113,12 +141,37 @@ impl BitrouterError {
             Self::BadRequest { .. } => "invalid_request_error",
             Self::Unauthorized(_) => "authentication_error",
             Self::PaymentRequired(_) => "payment_required",
+            Self::UpstreamPaymentRequired => "payment_required",
             Self::Forbidden(_) => "permission_error",
             Self::NotFound(_) => "not_found_error",
             Self::RateLimited { .. } => "rate_limit_error",
-            Self::Upstream { .. } | Self::UpstreamTimeout => "upstream_error",
+            Self::UpstreamRateLimited { .. } => "rate_limit_error",
+            Self::Upstream { .. }
+            | Self::UpstreamInvalidResponse { .. }
+            | Self::UpstreamTimeout => "upstream_error",
+            Self::UpstreamUnavailable => "upstream_error",
             Self::UpstreamAuth { status: 403, .. } => "permission_error",
             Self::UpstreamAuth { .. } => "authentication_error",
+            Self::Internal(_) => "internal_error",
+        }
+    }
+
+    /// Stable machine-readable code for OpenAI-compatible error envelopes.
+    pub fn error_code(&self) -> &'static str {
+        match self {
+            Self::BadRequest { .. } => "invalid_request",
+            Self::Unauthorized(_) => "authentication_error",
+            Self::PaymentRequired(_) => "payment_required",
+            Self::UpstreamPaymentRequired => "upstream_payment_required",
+            Self::Forbidden(_) => "permission_denied",
+            Self::NotFound(_) => "not_found",
+            Self::RateLimited { .. } => "rate_limit_exceeded",
+            Self::UpstreamRateLimited { .. } => "upstream_rate_limited",
+            Self::Upstream { .. } => "upstream_bad_gateway",
+            Self::UpstreamInvalidResponse { .. } => "upstream_invalid_response",
+            Self::UpstreamAuth { .. } => "upstream_auth_required",
+            Self::UpstreamTimeout => "upstream_timeout",
+            Self::UpstreamUnavailable => "upstream_unavailable",
             Self::Internal(_) => "internal_error",
         }
     }
@@ -141,12 +194,16 @@ impl BitrouterError {
             Self::BadRequest { .. } => ErrorKind::BadRequest,
             Self::Unauthorized(_) => ErrorKind::Unauthorized,
             Self::PaymentRequired(_) => ErrorKind::PaymentRequired,
+            Self::UpstreamPaymentRequired => ErrorKind::UpstreamPaymentRequired,
             Self::Forbidden(_) => ErrorKind::Forbidden,
             Self::NotFound(_) => ErrorKind::NotFound,
             Self::RateLimited { .. } => ErrorKind::RateLimited,
+            Self::UpstreamRateLimited { .. } => ErrorKind::UpstreamRateLimited,
             Self::Upstream { .. } => ErrorKind::Upstream,
+            Self::UpstreamInvalidResponse { .. } => ErrorKind::UpstreamInvalidResponse,
             Self::UpstreamAuth { .. } => ErrorKind::UpstreamAuth,
             Self::UpstreamTimeout => ErrorKind::UpstreamTimeout,
+            Self::UpstreamUnavailable => ErrorKind::UpstreamUnavailable,
             Self::Internal(_) => ErrorKind::Internal,
         }
     }
@@ -164,13 +221,19 @@ impl BitrouterError {
             | Self::NotFound(m)
             | Self::Internal(m) => m.clone(),
             Self::RateLimited { .. } => "rate limited".to_string(),
+            Self::UpstreamPaymentRequired => "upstream payment required".to_string(),
+            Self::UpstreamRateLimited { .. } => "upstream rate limited".to_string(),
             Self::Upstream { status, message } => {
                 format!("upstream error ({status}): {message}")
+            }
+            Self::UpstreamInvalidResponse { message } => {
+                format!("upstream returned an invalid response: {message}")
             }
             Self::UpstreamAuth { status, .. } => {
                 format!("upstream auth required ({status})")
             }
             Self::UpstreamTimeout => "upstream timeout".to_string(),
+            Self::UpstreamUnavailable => "upstream unavailable".to_string(),
         };
         ErrorEnvelope {
             error: ErrorBody {
@@ -179,6 +242,21 @@ impl BitrouterError {
                 context: Vec::new(),
                 hint: None,
             },
+        }
+    }
+
+    /// A message safe to return to an untrusted HTTP/SSE client.
+    ///
+    /// Upstream diagnostics may contain echoed prompts, credentials, provider
+    /// stack traces, or account details. Keep those on the internal error while
+    /// exposing only a stable summary at the public boundary.
+    pub fn public_message(&self) -> String {
+        match self {
+            Self::Upstream { .. } => "upstream request failed".to_string(),
+            Self::UpstreamInvalidResponse { .. } => {
+                "upstream returned an invalid response".to_string()
+            }
+            _ => self.to_string(),
         }
     }
 }
@@ -195,18 +273,26 @@ pub enum ErrorKind {
     Unauthorized,
     /// 402 — payment required.
     PaymentRequired,
+    /// 402 — insufficient credit at every usable upstream route.
+    UpstreamPaymentRequired,
     /// 403 — policy violation.
     Forbidden,
     /// 404 — no route / resource not found.
     NotFound,
     /// 429 — rate limited.
     RateLimited,
+    /// 429 — all usable upstream routes are rate limited.
+    UpstreamRateLimited,
     /// 502 — upstream provider error.
     Upstream,
+    /// 502 — malformed success response from an upstream protocol.
+    UpstreamInvalidResponse,
     /// 401/403 — upstream demanded authorization.
     UpstreamAuth,
     /// 504 — upstream timed out.
     UpstreamTimeout,
+    /// 503 — the upstream route set is temporarily unavailable.
+    UpstreamUnavailable,
     /// 500 — internal error.
     Internal,
 }

--- a/crates/bitrouter-sdk/src/language_model/executor.rs
+++ b/crates/bitrouter-sdk/src/language_model/executor.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 use crate::error::{BitrouterError, Result};
 use crate::language_model::auth::AuthAppliers;
 use crate::language_model::context::PipelineContext;
-use crate::language_model::protocol::{OutboundDispatch, SseEvent};
+use crate::language_model::protocol::{OutboundAdapter, OutboundDispatch, SseEvent};
 use crate::language_model::types::{
     ApiProtocol, ExecutionResult, GenerateResult, Prompt, RoutingTarget, StreamPart,
 };
@@ -215,17 +215,46 @@ fn truncate_upstream_message(text: &str) -> String {
 /// signal it cleanly with `402`, but others (e.g. opencode) return a
 /// `401`/`403` with a `CreditsError` / "insufficient balance" body —
 /// which would otherwise be misread as an auth failure. Recognise that
-/// family and map it to [`BitrouterError::PaymentRequired`] so the
+/// family and map it to [`BitrouterError::UpstreamPaymentRequired`] so the
 /// fallback policy drops to the next account / provider instead of
 /// failing the request outright.
-fn classify_upstream_error(status: u16, body: &str) -> BitrouterError {
+fn classify_upstream_error(status: u16, body: &str, retry_after: Option<u64>) -> BitrouterError {
+    if status == 429 {
+        return BitrouterError::UpstreamRateLimited { retry_after };
+    }
     if matches!(status, 401..=403) && looks_like_credit_exhaustion(body) {
-        return BitrouterError::PaymentRequired(truncate_upstream_message(body));
+        return BitrouterError::UpstreamPaymentRequired;
     }
     BitrouterError::Upstream {
         status,
         message: truncate_upstream_message(body),
     }
+}
+
+/// Parse the standard `Retry-After` response field into a delay in seconds.
+/// Both delay-seconds and HTTP-date are defined by RFC 9110 section 10.2.3:
+/// <https://www.rfc-editor.org/rfc/rfc9110#section-10.2.3>.
+fn parse_retry_after(value: Option<&reqwest::header::HeaderValue>) -> Option<u64> {
+    let value = value?.to_str().ok()?.trim();
+    if let Ok(seconds) = value.parse::<u64>() {
+        return Some(seconds);
+    }
+    let deadline = httpdate::parse_http_date(value).ok()?;
+    match deadline.duration_since(std::time::SystemTime::now()) {
+        Ok(delay) => Some(delay.as_secs() + u64::from(delay.subsec_nanos() > 0)),
+        Err(_) => Some(0),
+    }
+}
+
+fn parse_upstream_success(
+    adapter: &dyn OutboundAdapter,
+    json: serde_json::Value,
+) -> Result<GenerateResult> {
+    adapter
+        .parse_response(json)
+        .map_err(|error| BitrouterError::UpstreamInvalidResponse {
+            message: error.to_string(),
+        })
 }
 
 /// Classify a transport error that surfaces from the SSE decode loop *after*
@@ -542,7 +571,7 @@ impl Executor for HttpExecutor {
         let mut upstream_prompt = prompt.clone();
         upstream_prompt.model = target.service_id.clone();
         upstream_prompt.stream = false;
-        let mut body = adapter.render_request(&upstream_prompt)?;
+        let mut body = adapter.render_request_for_target(&upstream_prompt, target)?;
         self.shape_request_body(&mut body, target).await?;
         let url = transport.endpoint_url(target, false);
 
@@ -570,13 +599,17 @@ impl Executor for HttpExecutor {
         })?;
 
         let status = response.status();
+        let retry_after = parse_retry_after(response.headers().get(reqwest::header::RETRY_AFTER));
+        if status.as_u16() == 429 {
+            return Err(BitrouterError::UpstreamRateLimited { retry_after });
+        }
         let text = response
             .text()
             .await
             .map_err(|e| upstream_body_error("reading upstream body", e))?;
 
         if !status.is_success() {
-            return Err(classify_upstream_error(status.as_u16(), &text));
+            return Err(classify_upstream_error(status.as_u16(), &text, retry_after));
         }
 
         let json: serde_json::Value =
@@ -584,7 +617,7 @@ impl Executor for HttpExecutor {
                 status: 502,
                 message: format!("upstream returned non-JSON body: {e}"),
             })?;
-        let result = adapter.parse_response(json)?;
+        let result = parse_upstream_success(adapter.as_ref(), json)?;
         let elapsed = started.elapsed().as_millis() as u64;
 
         Ok(ExecutionResult {
@@ -614,7 +647,7 @@ impl Executor for HttpExecutor {
         let mut upstream_prompt = prompt.clone();
         upstream_prompt.model = target.service_id.clone();
         upstream_prompt.stream = true;
-        let mut body = adapter.render_request(&upstream_prompt)?;
+        let mut body = adapter.render_request_for_target(&upstream_prompt, target)?;
         self.shape_request_body(&mut body, target).await?;
         let url = transport.endpoint_url(target, true);
 
@@ -641,9 +674,13 @@ impl Executor for HttpExecutor {
         })?;
 
         let status = response.status();
+        let retry_after = parse_retry_after(response.headers().get(reqwest::header::RETRY_AFTER));
+        if status.as_u16() == 429 {
+            return Err(BitrouterError::UpstreamRateLimited { retry_after });
+        }
         if !status.is_success() {
             let text = response.text().await.unwrap_or_default();
-            return Err(classify_upstream_error(status.as_u16(), &text));
+            return Err(classify_upstream_error(status.as_u16(), &text, retry_after));
         }
 
         // Parse the upstream SSE byte stream into canonical stream parts via
@@ -668,7 +705,9 @@ impl Executor for HttpExecutor {
                                 }
                             }
                             Err(e) => {
-                                yield Err(e);
+                                yield Err(BitrouterError::UpstreamInvalidResponse {
+                                    message: e.to_string(),
+                                });
                                 return;
                             }
                         }
@@ -692,7 +731,9 @@ impl Executor for HttpExecutor {
                         yield Ok(p);
                     }
                 }
-                Err(e) => yield Err(e),
+                Err(e) => yield Err(BitrouterError::UpstreamInvalidResponse {
+                    message: e.to_string(),
+                }),
             }
         };
 
@@ -821,6 +862,10 @@ impl Executor for DispatchExecutor {
 #[cfg(test)]
 mod error_classification_tests {
     use super::*;
+    use crate::language_model::protocol::{
+        chat_completions::ChatCompletionsAdapter, generate_content::GenerateContentAdapter,
+        messages::MessagesAdapter, responses::ResponsesAdapter,
+    };
 
     #[test]
     fn credit_exhaustion_401_maps_to_payment_required() {
@@ -829,9 +874,9 @@ mod error_classification_tests {
         // next account rather than treating it as an auth failure.
         let body =
             r#"{"type":"error","error":{"type":"CreditsError","message":"Insufficient balance."}}"#;
-        match classify_upstream_error(401, body) {
-            BitrouterError::PaymentRequired(_) => {}
-            other => panic!("expected PaymentRequired, got {other:?}"),
+        match classify_upstream_error(401, body, None) {
+            BitrouterError::UpstreamPaymentRequired => {}
+            other => panic!("expected UpstreamPaymentRequired, got {other:?}"),
         }
     }
 
@@ -840,7 +885,7 @@ mod error_classification_tests {
         // A genuine auth failure (no credit signal) must NOT become
         // PaymentRequired — it should fail the request, not silently
         // fall through to the next account.
-        match classify_upstream_error(401, r#"{"error":"invalid api key"}"#) {
+        match classify_upstream_error(401, r#"{"error":"invalid api key"}"#, None) {
             BitrouterError::Upstream { status, .. } => assert_eq!(status, 401),
             other => panic!("expected Upstream(401), got {other:?}"),
         }
@@ -848,10 +893,56 @@ mod error_classification_tests {
 
     #[test]
     fn server_error_stays_an_upstream_error() {
-        match classify_upstream_error(503, "service unavailable") {
+        match classify_upstream_error(503, "service unavailable", None) {
             BitrouterError::Upstream { status, .. } => assert_eq!(status, 503),
             other => panic!("expected Upstream(503), got {other:?}"),
         }
+    }
+
+    #[test]
+    fn upstream_429_has_a_distinct_safe_error() {
+        match classify_upstream_error(429, r#"{"secret":"provider quota"}"#, Some(17)) {
+            BitrouterError::UpstreamRateLimited { retry_after } => {
+                assert_eq!(retry_after, Some(17));
+            }
+            other => panic!("expected UpstreamRateLimited, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn malformed_success_is_upstream_502_for_every_builtin_protocol() {
+        let adapters: [&dyn OutboundAdapter; 4] = [
+            &ChatCompletionsAdapter,
+            &MessagesAdapter,
+            &ResponsesAdapter,
+            &GenerateContentAdapter,
+        ];
+        for adapter in adapters {
+            let error = parse_upstream_success(adapter, serde_json::json!({}))
+                .expect_err("empty success body must not parse");
+            assert!(
+                matches!(error, BitrouterError::UpstreamInvalidResponse { .. }),
+                "{} returned {error:?}",
+                adapter.protocol()
+            );
+            assert_eq!(error.status(), 502);
+        }
+    }
+
+    #[test]
+    fn retry_after_accepts_seconds_http_date_and_rejects_invalid_values() {
+        let seconds = reqwest::header::HeaderValue::from_static("42");
+        assert_eq!(parse_retry_after(Some(&seconds)), Some(42));
+
+        let future = std::time::SystemTime::now() + std::time::Duration::from_secs(120);
+        let date =
+            reqwest::header::HeaderValue::from_str(&httpdate::fmt_http_date(future)).unwrap();
+        let parsed = parse_retry_after(Some(&date)).unwrap();
+        assert!((119..=120).contains(&parsed), "parsed delay was {parsed}");
+
+        let invalid = reqwest::header::HeaderValue::from_static("soon-ish");
+        assert_eq!(parse_retry_after(Some(&invalid)), None);
+        assert_eq!(parse_retry_after(None), None);
     }
 
     #[test]
@@ -936,6 +1027,7 @@ mod beta_forward_tests {
             api_base: "https://api.anthropic.com/v1".into(),
             api_key: String::new(),
             api_protocol: proto,
+            chat_token_limit_field: None,
             account_label: None,
             api_key_override: None,
             api_base_override: None,
@@ -1006,6 +1098,7 @@ mod client_selection_tests {
             api_base: "https://api.example.com".into(),
             api_key: String::new(),
             api_protocol: ApiProtocol::ChatCompletions,
+            chat_token_limit_field: None,
             account_label: None,
             api_key_override: None,
             api_base_override: None,
@@ -1124,6 +1217,7 @@ mod client_selection_tests {
             api_base: format!("http://{addr}/v1"),
             api_key: "k".into(),
             api_protocol: ApiProtocol::ChatCompletions,
+            chat_token_limit_field: None,
             account_label: None,
             api_key_override: None,
             api_base_override: None,

--- a/crates/bitrouter-sdk/src/language_model/pipeline.rs
+++ b/crates/bitrouter-sdk/src/language_model/pipeline.rs
@@ -272,6 +272,8 @@ impl Pipeline {
 
         if let Err(e) = self.run_pre_request(&mut ctx).await {
             log_request_resolve_failed(&ctx, &e);
+            self.observe_end(&ctx, RequestOutcome::Failed(e.clone()))
+                .await;
             return Err(e);
         }
         self.observe_after(Phase::PreRequest, &ctx).await;
@@ -280,6 +282,8 @@ impl Pipeline {
             Ok(chain) => chain,
             Err(e) => {
                 log_request_resolve_failed(&ctx, &e);
+                self.observe_end(&ctx, RequestOutcome::Failed(e.clone()))
+                    .await;
                 return Err(e);
             }
         };
@@ -289,7 +293,7 @@ impl Pipeline {
         // Route Stage 3 through the server-side tool loop when configured: the
         // merged stream becomes the "upstream" the settlement guard drains, so
         // settlement is unchanged. Otherwise the pipeline stays single-shot.
-        let upstream = match &self.server_tool_loop {
+        let upstream_result = match &self.server_tool_loop {
             Some(server_loop) => {
                 let tool_ctx = ToolContext::from_pipeline(&ctx);
                 let upstream_impl: Arc<dyn UpstreamStream> = Arc::new(PipelineStreamUpstream {
@@ -300,9 +304,20 @@ impl Pipeline {
                 server_loop
                     .clone()
                     .run_stream(ctx.prompt(), &tool_ctx, upstream_impl)
-                    .await?
+                    .await
             }
-            None => self.execute_stream_with_fallback(&chain, &ctx).await?,
+            None => self.execute_stream_with_fallback(&chain, &ctx).await,
+        };
+        let upstream = match upstream_result {
+            Ok(upstream) => upstream,
+            Err(error) => {
+                self.run_settlement(&mut ctx, false, Some(error.clone()))
+                    .await;
+                self.observe_after(Phase::Settlement, &ctx).await;
+                self.observe_end(&ctx, RequestOutcome::Failed(error.clone()))
+                    .await;
+                return Err(error);
+            }
         };
         // A placeholder execution result so Settlement has provider/model ids;
         // usage is folded in from the StreamContext at stream end.
@@ -450,7 +465,7 @@ impl Pipeline {
         prompt: &Prompt,
         ctx: &PipelineContext,
     ) -> Result<ExecutionResult> {
-        let mut last_error: Option<BitrouterError> = None;
+        let mut errors = Vec::new();
         for target in chain {
             self.observe_hop_start(ctx, target).await;
             let outcome = self.executor.execute(target, prompt, ctx).await;
@@ -473,15 +488,14 @@ impl Pipeline {
                 }
                 Err(e) => match self.classify_failure(ctx, &e, target).await {
                     FallbackDecision::TryNext => {
-                        last_error = Some(e);
+                        errors.push(e);
                         continue;
                     }
                     FallbackDecision::Fail(e) => return Err(e),
                 },
             }
         }
-        Err(last_error
-            .unwrap_or_else(|| BitrouterError::NotFound("empty routing chain".to_string())))
+        Err(aggregate_fallback_errors(errors))
     }
 
     async fn execute_stream_with_fallback(
@@ -489,7 +503,7 @@ impl Pipeline {
         chain: &[RoutingTarget],
         ctx: &PipelineContext,
     ) -> Result<StreamPartStream> {
-        let mut last_error: Option<BitrouterError> = None;
+        let mut errors = Vec::new();
         for target in chain {
             self.observe_hop_start(ctx, target).await;
             let outcome = self
@@ -512,15 +526,14 @@ impl Pipeline {
                 Ok(stream) => return Ok(stream),
                 Err(e) => match self.classify_failure(ctx, &e, target).await {
                     FallbackDecision::TryNext => {
-                        last_error = Some(e);
+                        errors.push(e);
                         continue;
                     }
                     FallbackDecision::Fail(e) => return Err(e),
                 },
             }
         }
-        Err(last_error
-            .unwrap_or_else(|| BitrouterError::NotFound("empty routing chain".to_string())))
+        Err(aggregate_fallback_errors(errors))
     }
 
     /// Decide fallback after an upstream failure. Any registered execution hook
@@ -614,6 +627,75 @@ impl Pipeline {
             }
         }
     }
+}
+
+/// Produce a deterministic terminal error from a fully exhausted fallback
+/// chain. The result describes the route set rather than whichever provider
+/// happened to sort last.
+fn aggregate_fallback_errors(errors: Vec<BitrouterError>) -> BitrouterError {
+    if errors.is_empty() {
+        return BitrouterError::NotFound("empty routing chain".to_string());
+    }
+
+    if errors.iter().all(|error| {
+        matches!(
+            error,
+            BitrouterError::UpstreamRateLimited { .. }
+                | BitrouterError::Upstream { status: 429, .. }
+        )
+    }) {
+        let retry_after = errors
+            .iter()
+            .filter_map(|error| match error {
+                BitrouterError::UpstreamRateLimited { retry_after } => *retry_after,
+                _ => None,
+            })
+            .min();
+        return BitrouterError::UpstreamRateLimited { retry_after };
+    }
+
+    if errors
+        .iter()
+        .all(|error| matches!(error, BitrouterError::UpstreamTimeout))
+    {
+        return BitrouterError::UpstreamTimeout;
+    }
+
+    if errors
+        .iter()
+        .all(|error| matches!(error, BitrouterError::UpstreamPaymentRequired))
+    {
+        return BitrouterError::UpstreamPaymentRequired;
+    }
+
+    if let Some(error) = errors
+        .iter()
+        .find(|error| matches!(error, BitrouterError::UpstreamInvalidResponse { .. }))
+    {
+        return error.clone();
+    }
+
+    let is_availability_failure = |error: &BitrouterError| {
+        matches!(
+            error,
+            BitrouterError::UpstreamRateLimited { .. }
+                | BitrouterError::UpstreamTimeout
+                | BitrouterError::UpstreamUnavailable
+                | BitrouterError::Upstream { status: 408, .. }
+                | BitrouterError::Upstream {
+                    status: 500..=599,
+                    ..
+                }
+        )
+    };
+    if errors.iter().all(is_availability_failure) {
+        return BitrouterError::UpstreamUnavailable;
+    }
+
+    errors
+        .into_iter()
+        .last()
+        .unwrap_or_else(|| BitrouterError::NotFound("empty routing chain".to_string()))
 }
 
 /// Owns the streaming `StreamProcessor` + `PipelineContext` for the lifetime of

--- a/crates/bitrouter-sdk/src/language_model/protocol/chat_completions.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/chat_completions.rs
@@ -19,10 +19,10 @@ use crate::language_model::protocol::{
 };
 use crate::language_model::stream::SseFrame;
 use crate::language_model::types::{
-    ApiProtocol, Content, DataContent, FinishReason, GenerateResult, GenerationParams, Message,
-    Modality, Prompt, ProviderMetadata, ResponseFormat, Role, RoutingTarget, Source, StreamPart,
-    Tool, ToolChoice, ToolResultContentPart, ToolResultOutput, Usage, provider_namespace,
-    set_provider_metadata,
+    ApiProtocol, ChatTokenLimitField, Content, DataContent, FinishReason, GenerateResult,
+    GenerationParams, Message, Modality, Prompt, ProviderMetadata, ResponseFormat, Role,
+    RoutingTarget, Source, StreamPart, Tool, ToolChoice, ToolResultContentPart, ToolResultOutput,
+    Usage, provider_namespace, set_provider_metadata,
 };
 
 /// The Chat Completions inbound + outbound protocol adapter.
@@ -576,6 +576,19 @@ impl InboundAdapter for ChatCompletionsAdapter {
         // reaching an OpenAI upstream). Unmapped shapes stay in `extra`.
         let tool_choice = parse_chat_tool_choice(&mut extra);
 
+        let (max_tokens, chat_token_limit_field) = match (req.max_tokens, req.max_completion_tokens)
+        {
+            (Some(legacy), Some(current)) if legacy != current => {
+                return Err(BitrouterError::bad_request(
+                    "max_tokens and max_completion_tokens must match when both are provided",
+                ));
+            }
+            (Some(value), Some(_)) => (Some(value), Some(ChatTokenLimitField::MaxCompletionTokens)),
+            (Some(value), None) => (Some(value), Some(ChatTokenLimitField::MaxTokens)),
+            (None, Some(value)) => (Some(value), Some(ChatTokenLimitField::MaxCompletionTokens)),
+            (None, None) => (None, None),
+        };
+
         Ok(Prompt {
             model: req.model,
             system,
@@ -586,7 +599,8 @@ impl InboundAdapter for ChatCompletionsAdapter {
             params: GenerationParams {
                 temperature: req.temperature,
                 top_p: req.top_p,
-                max_tokens: req.max_tokens.or(req.max_completion_tokens),
+                max_tokens,
+                chat_token_limit_field,
                 reasoning_effort: req.reasoning_effort,
                 response_modalities,
                 // Chat Completions carries no top-k.
@@ -761,7 +775,11 @@ impl OutboundAdapter for ChatCompletionsAdapter {
             req.insert("top_p".into(), p.into());
         }
         if let Some(mt) = prompt.params.max_tokens {
-            req.insert("max_tokens".into(), mt.into());
+            let field = match prompt.params.chat_token_limit_field {
+                Some(ChatTokenLimitField::MaxCompletionTokens) => "max_completion_tokens",
+                Some(ChatTokenLimitField::MaxTokens) | None => "max_tokens",
+            };
+            req.insert(field.into(), mt.into());
         }
         if let Some(re) = &prompt.params.reasoning_effort {
             req.insert("reasoning_effort".into(), re.clone().into());
@@ -807,6 +825,9 @@ impl OutboundAdapter for ChatCompletionsAdapter {
         // survive the round trip. Typed fields above win over any same-named
         // extra.
         for (k, v) in &prompt.params.extra {
+            if matches!(k.as_str(), "max_tokens" | "max_completion_tokens") {
+                continue;
+            }
             req.entry(k.clone()).or_insert_with(|| v.clone());
         }
         req.insert("stream".into(), prompt.stream.into());
@@ -826,6 +847,18 @@ impl OutboundAdapter for ChatCompletionsAdapter {
             }
         }
         Ok(serde_json::Value::Object(req))
+    }
+
+    fn render_request_for_target(
+        &self,
+        prompt: &Prompt,
+        target: &RoutingTarget,
+    ) -> Result<serde_json::Value> {
+        let mut prompt = prompt.clone();
+        if let Some(field) = target.chat_token_limit_field {
+            prompt.params.chat_token_limit_field = Some(field);
+        }
+        self.render_request(&prompt)
     }
 
     fn parse_response(&self, body: serde_json::Value) -> Result<GenerateResult> {
@@ -1759,6 +1792,26 @@ impl StreamEncoder for ChatStreamEncoder {
                 event: None,
                 data: serde_json::json!({
                     "error": { "message": message, "type": "upstream_error" }
+                })
+                .to_string(),
+            },
+            SseFrame::Event {
+                event: None,
+                data: "[DONE]".to_string(),
+            },
+        ]
+    }
+
+    fn encode_bitrouter_error(&mut self, error: &BitrouterError) -> Vec<SseFrame> {
+        vec![
+            SseFrame::Event {
+                event: None,
+                data: serde_json::json!({
+                    "error": {
+                        "message": error.public_message(),
+                        "type": error.error_type(),
+                        "code": error.error_code(),
+                    }
                 })
                 .to_string(),
             },

--- a/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
@@ -830,6 +830,7 @@ impl InboundAdapter for GenerateContentAdapter {
                         temperature,
                         top_p,
                         max_tokens: max_output_tokens,
+                        chat_token_limit_field: None,
                         reasoning_effort: None,
                         response_modalities,
                         top_k,
@@ -1605,6 +1606,26 @@ impl StreamEncoder for GenerateContentStreamEncoder {
             event: None,
             data: serde_json::json!({
                 "error": { "code": 502, "status": "UNAVAILABLE", "message": message }
+            })
+            .to_string(),
+        }]
+    }
+
+    fn encode_bitrouter_error(&mut self, error: &BitrouterError) -> Vec<SseFrame> {
+        let status = if matches!(error, BitrouterError::UpstreamRateLimited { .. }) {
+            "RESOURCE_EXHAUSTED"
+        } else {
+            "UNAVAILABLE"
+        };
+        vec![SseFrame::Event {
+            event: None,
+            data: serde_json::json!({
+                "error": {
+                    "code": error.status(),
+                    "status": status,
+                    "message": error.public_message(),
+                    "details": [{ "reason": error.error_code() }],
+                }
             })
             .to_string(),
         }]

--- a/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
@@ -1015,6 +1015,7 @@ impl InboundAdapter for MessagesAdapter {
                 temperature: req.temperature,
                 top_p: req.top_p,
                 max_tokens: req.max_tokens,
+                chat_token_limit_field: None,
                 reasoning_effort,
                 response_modalities: Vec::new(),
                 top_k: req.top_k,
@@ -2905,6 +2906,20 @@ impl StreamEncoder for MessagesStreamEncoder {
             serde_json::json!({
                 "type": "error",
                 "error": { "type": "api_error", "message": message },
+            }),
+        )]
+    }
+
+    fn encode_bitrouter_error(&mut self, error: &BitrouterError) -> Vec<SseFrame> {
+        vec![Self::ev(
+            "error",
+            serde_json::json!({
+                "type": "error",
+                "error": {
+                    "type": error.error_type(),
+                    "message": error.public_message(),
+                    "code": error.error_code(),
+                },
             }),
         )]
     }

--- a/crates/bitrouter-sdk/src/language_model/protocol/mod.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/mod.rs
@@ -75,7 +75,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
-use crate::error::Result;
+use crate::error::{BitrouterError, Result};
 use crate::language_model::stream::SseFrame;
 use crate::language_model::types::{
     ApiProtocol, FinishReason, GenerateResult, Prompt, ProviderMetadata, RoutingTarget, StreamPart,
@@ -279,6 +279,19 @@ pub trait OutboundAdapter: Send + Sync {
     /// Render a canonical [`Prompt`] into this protocol's upstream request body.
     fn render_request(&self, prompt: &Prompt) -> Result<serde_json::Value>;
 
+    /// Render a canonical request for one concrete routing target.
+    ///
+    /// The default preserves source compatibility for custom adapters. A
+    /// built-in adapter overrides this only when provider/model compatibility
+    /// changes wire spelling without changing canonical prompt semantics.
+    fn render_request_for_target(
+        &self,
+        prompt: &Prompt,
+        _target: &RoutingTarget,
+    ) -> Result<serde_json::Value> {
+        self.render_request(prompt)
+    }
+
     /// Parse a provider response body into a canonical [`GenerateResult`].
     fn parse_response(&self, body: serde_json::Value) -> Result<GenerateResult>;
 
@@ -349,6 +362,13 @@ pub trait StreamEncoder: Send {
     /// `response.failed`). After this the stream stops.
     fn encode_error(&mut self, message: &str) -> Vec<SseFrame> {
         vec![SseFrame::Comment(format!("error: {message}"))]
+    }
+
+    /// Encode a typed BitRouter error after the HTTP stream has started.
+    /// Custom encoders remain source-compatible and inherit their existing
+    /// string-based terminal frame until they opt into richer error codes.
+    fn encode_bitrouter_error(&mut self, error: &BitrouterError) -> Vec<SseFrame> {
+        self.encode_error(&error.public_message())
     }
 
     /// Called once at clean stream end; emit any trailing frames (e.g. the

--- a/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
@@ -901,6 +901,7 @@ impl InboundAdapter for ResponsesAdapter {
                 temperature: req.temperature,
                 top_p: req.top_p,
                 max_tokens: req.max_output_tokens,
+                chat_token_limit_field: None,
                 reasoning_effort: req.reasoning.and_then(|r| r.effort),
                 response_modalities: Vec::new(),
                 // The Responses API has no top-level top_k / seed / stop /
@@ -3001,6 +3002,20 @@ impl StreamEncoder for ResponsesStreamEncoder {
             "model": self.model,
             "status": "failed",
             "error": { "code": "upstream_error", "message": message },
+        });
+        vec![self.ev(
+            "response.failed",
+            serde_json::json!({ "response": response }),
+        )]
+    }
+
+    fn encode_bitrouter_error(&mut self, error: &BitrouterError) -> Vec<SseFrame> {
+        let response = serde_json::json!({
+            "id": self.request_id,
+            "object": "response",
+            "model": self.model,
+            "status": "failed",
+            "error": { "code": error.error_code(), "message": error.public_message() },
         });
         vec![self.ev(
             "response.failed",

--- a/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
@@ -296,6 +296,61 @@ fn conversion_matrix_4x4_streaming() {
     }
 }
 
+#[test]
+fn upstream_rate_limit_has_typed_terminal_frames_in_every_protocol() {
+    let error = crate::error::BitrouterError::UpstreamRateLimited {
+        retry_after: Some(9),
+    };
+    for protocol in all_protocols() {
+        let mut encoder = adapter_for(protocol.clone()).stream_encoder("resp_429", "m");
+        let frames = encoder.encode_bitrouter_error(&error);
+        let wire = frames
+            .iter()
+            .map(SseFrame::to_wire)
+            .collect::<Vec<_>>()
+            .join("");
+        assert!(
+            wire.contains("upstream_rate_limited"),
+            "{protocol:?} frame lacked stable code: {wire}"
+        );
+        match protocol {
+            ApiProtocol::ChatCompletions | ApiProtocol::Messages => {
+                assert!(wire.contains("rate_limit_error"), "{protocol:?}: {wire}");
+            }
+            ApiProtocol::Responses => {
+                assert!(wire.contains("response.failed"), "{wire}");
+            }
+            ApiProtocol::GenerateContent => {
+                assert!(wire.contains("RESOURCE_EXHAUSTED"), "{wire}");
+                assert!(wire.contains("429"), "{wire}");
+            }
+            ApiProtocol::Custom(_) => unreachable!(),
+        }
+    }
+}
+
+#[test]
+fn upstream_diagnostics_are_not_exposed_in_terminal_frames() {
+    let error = crate::error::BitrouterError::Upstream {
+        status: 500,
+        message: "provider secret stack trace".to_string(),
+    };
+    for protocol in all_protocols() {
+        let mut encoder = adapter_for(protocol.clone()).stream_encoder("resp_502", "m");
+        let wire = encoder
+            .encode_bitrouter_error(&error)
+            .iter()
+            .map(SseFrame::to_wire)
+            .collect::<Vec<_>>()
+            .join("");
+        assert!(!wire.contains("secret"), "{protocol:?}: {wire}");
+        assert!(
+            wire.contains("upstream request failed"),
+            "{protocol:?}: {wire}"
+        );
+    }
+}
+
 // ===== per-adapter unit tests =====
 
 /// Each outbound adapter must extract the provider-native response id
@@ -395,6 +450,209 @@ fn chat_completions_request_roundtrip() {
     let parsed = adapter.parse_request(json).unwrap();
     assert_eq!(parsed.system.as_deref(), Some("be brief"));
     assert_eq!(parsed.tools.len(), 1);
+}
+
+#[test]
+fn chat_token_limit_fields_roundtrip_without_alias_drift() {
+    let adapter = adapter_for(ApiProtocol::ChatCompletions);
+    for (field, expected_hint) in [
+        ("max_tokens", ChatTokenLimitField::MaxTokens),
+        (
+            "max_completion_tokens",
+            ChatTokenLimitField::MaxCompletionTokens,
+        ),
+    ] {
+        let mut body = minimal_request(ApiProtocol::ChatCompletions);
+        body[field] = 321.into();
+        let prompt = adapter.parse_request(body).unwrap();
+        assert_eq!(prompt.params.max_tokens, Some(321));
+        assert_eq!(prompt.params.chat_token_limit_field, Some(expected_hint));
+        let rendered = adapter.render_request(&prompt).unwrap();
+        assert_eq!(rendered[field], 321);
+        let other = if field == "max_tokens" {
+            "max_completion_tokens"
+        } else {
+            "max_tokens"
+        };
+        assert!(rendered.get(other).is_none());
+    }
+}
+
+#[test]
+fn chat_token_limit_alias_conflicts_are_rejected() {
+    let adapter = adapter_for(ApiProtocol::ChatCompletions);
+    let equal = serde_json::json!({
+        "model": "m",
+        "messages": [{"role": "user", "content": "hi"}],
+        "max_tokens": 64,
+        "max_completion_tokens": 64
+    });
+    let prompt = adapter.parse_request(equal).unwrap();
+    assert_eq!(
+        prompt.params.chat_token_limit_field,
+        Some(ChatTokenLimitField::MaxCompletionTokens)
+    );
+    let rendered = adapter.render_request(&prompt).unwrap();
+    assert_eq!(rendered["max_completion_tokens"], 64);
+    assert!(rendered.get("max_tokens").is_none());
+
+    let conflicting = serde_json::json!({
+        "model": "m",
+        "messages": [{"role": "user", "content": "hi"}],
+        "max_tokens": 64,
+        "max_completion_tokens": 65
+    });
+    let error = adapter.parse_request(conflicting).unwrap_err();
+    assert!(matches!(
+        error,
+        crate::error::BitrouterError::BadRequest { .. }
+    ));
+}
+
+#[test]
+fn token_limit_translates_across_every_protocol_pair() {
+    for inbound_protocol in all_protocols() {
+        let mut body = minimal_request(inbound_protocol.clone());
+        match inbound_protocol {
+            ApiProtocol::ChatCompletions => body["max_completion_tokens"] = 777.into(),
+            ApiProtocol::Messages => body["max_tokens"] = 777.into(),
+            ApiProtocol::Responses => body["max_output_tokens"] = 777.into(),
+            ApiProtocol::GenerateContent => {
+                body["generationConfig"] = serde_json::json!({"maxOutputTokens": 777});
+            }
+            ApiProtocol::Custom(_) => unreachable!(),
+        }
+        let prompt = adapter_for(inbound_protocol.clone())
+            .parse_request(body)
+            .unwrap();
+        assert_eq!(prompt.params.max_tokens, Some(777));
+
+        for outbound_protocol in all_protocols() {
+            let rendered = adapter_for(outbound_protocol.clone())
+                .render_request(&prompt)
+                .unwrap();
+            match outbound_protocol {
+                ApiProtocol::ChatCompletions => {
+                    let expected = if inbound_protocol == ApiProtocol::ChatCompletions {
+                        "max_completion_tokens"
+                    } else {
+                        "max_tokens"
+                    };
+                    assert_eq!(rendered[expected], 777, "{inbound_protocol:?} -> chat");
+                    let absent = if expected == "max_tokens" {
+                        "max_completion_tokens"
+                    } else {
+                        "max_tokens"
+                    };
+                    assert!(rendered.get(absent).is_none());
+                }
+                ApiProtocol::Messages => assert_eq!(rendered["max_tokens"], 777),
+                ApiProtocol::Responses => assert_eq!(rendered["max_output_tokens"], 777),
+                ApiProtocol::GenerateContent => {
+                    assert_eq!(rendered["generationConfig"]["maxOutputTokens"], 777)
+                }
+                ApiProtocol::Custom(_) => unreachable!(),
+            }
+        }
+    }
+}
+
+#[test]
+fn target_token_limit_override_wins_over_inbound_spelling() {
+    let adapter = adapter_for(ApiProtocol::ChatCompletions);
+    let cases = [
+        (
+            "max_tokens",
+            ChatTokenLimitField::MaxCompletionTokens,
+            "max_completion_tokens",
+        ),
+        (
+            "max_completion_tokens",
+            ChatTokenLimitField::MaxTokens,
+            "max_tokens",
+        ),
+    ];
+    for (inbound_field, override_field, outbound_field) in cases {
+        let mut body = minimal_request(ApiProtocol::ChatCompletions);
+        body[inbound_field] = 99.into();
+        let prompt = adapter.parse_request(body).unwrap();
+        let target = RoutingTarget {
+            provider_name: "provider".into(),
+            service_id: "m".into(),
+            api_base: "https://example.invalid/v1".into(),
+            api_key: "secret".into(),
+            api_protocol: ApiProtocol::ChatCompletions,
+            chat_token_limit_field: Some(override_field),
+            account_label: None,
+            api_key_override: None,
+            api_base_override: None,
+            auth_scheme: Default::default(),
+        };
+        let rendered = adapter.render_request_for_target(&prompt, &target).unwrap();
+        assert_eq!(rendered[outbound_field], 99);
+        assert!(rendered.get(inbound_field).is_none());
+    }
+}
+
+#[test]
+fn chat_target_emits_one_token_alias_despite_cross_protocol_extra_pollution() {
+    for inbound_protocol in [
+        ApiProtocol::Messages,
+        ApiProtocol::Responses,
+        ApiProtocol::GenerateContent,
+    ] {
+        let mut body = minimal_request(inbound_protocol.clone());
+        match inbound_protocol {
+            ApiProtocol::Messages => body["max_tokens"] = 777.into(),
+            ApiProtocol::Responses => body["max_output_tokens"] = 777.into(),
+            ApiProtocol::GenerateContent => {
+                body["generationConfig"] = serde_json::json!({"maxOutputTokens": 777});
+            }
+            _ => unreachable!(),
+        }
+        let mut prompt = adapter_for(inbound_protocol.clone())
+            .parse_request(body)
+            .unwrap();
+        prompt
+            .params
+            .extra
+            .insert("max_tokens".to_string(), 111.into());
+        prompt
+            .params
+            .extra
+            .insert("max_completion_tokens".to_string(), 222.into());
+
+        for (override_field, expected, absent) in [
+            (
+                ChatTokenLimitField::MaxTokens,
+                "max_tokens",
+                "max_completion_tokens",
+            ),
+            (
+                ChatTokenLimitField::MaxCompletionTokens,
+                "max_completion_tokens",
+                "max_tokens",
+            ),
+        ] {
+            let target = RoutingTarget {
+                provider_name: "provider".into(),
+                service_id: "m".into(),
+                api_base: "https://example.invalid/v1".into(),
+                api_key: "secret".into(),
+                api_protocol: ApiProtocol::ChatCompletions,
+                chat_token_limit_field: Some(override_field),
+                account_label: None,
+                api_key_override: None,
+                api_base_override: None,
+                auth_scheme: Default::default(),
+            };
+            let rendered = adapter_for(ApiProtocol::ChatCompletions)
+                .render_request_for_target(&prompt, &target)
+                .unwrap();
+            assert_eq!(rendered[expected], 777, "{inbound_protocol:?}");
+            assert!(rendered.get(absent).is_none(), "{inbound_protocol:?}");
+        }
+    }
 }
 
 #[test]
@@ -1271,6 +1529,7 @@ fn messages_no_beta_header_is_emitted() {
         api_base: "http://example.invalid".into(),
         api_key: "k".into(),
         api_protocol: ApiProtocol::Messages,
+        chat_token_limit_field: None,
         account_label: None,
         api_key_override: None,
         api_base_override: None,
@@ -1298,6 +1557,7 @@ fn messages_auth_scheme_selects_one_credential_header() {
         api_base: "http://example.invalid".into(),
         api_key: "secret".into(),
         api_protocol: ApiProtocol::Messages,
+        chat_token_limit_field: None,
         account_label: None,
         api_key_override: None,
         api_base_override: None,

--- a/crates/bitrouter-sdk/src/language_model/routing.rs
+++ b/crates/bitrouter-sdk/src/language_model/routing.rs
@@ -145,14 +145,19 @@ impl FallbackPolicy for DefaultFallbackPolicy {
                 FallbackDecision::TryNext
             }
             BitrouterError::UpstreamTimeout => FallbackDecision::TryNext,
-            BitrouterError::RateLimited { .. } => FallbackDecision::TryNext,
+            BitrouterError::UpstreamRateLimited { .. } | BitrouterError::UpstreamUnavailable => {
+                FallbackDecision::TryNext
+            }
             // Payment / credit exhaustion → try the next target. For a
             // multi-account provider this drops to the next account
             // (the "fall back when a subscription runs out" path); for
             // a plain cascade it tries the next provider, which may
             // still have funds. If every target is drained the chain
             // exhausts and the original error is returned.
-            BitrouterError::PaymentRequired(_) => FallbackDecision::TryNext,
+            BitrouterError::PaymentRequired(_) | BitrouterError::UpstreamPaymentRequired => {
+                FallbackDecision::TryNext
+            }
+            BitrouterError::UpstreamInvalidResponse { .. } => FallbackDecision::TryNext,
             // Any other error is the request's own fault — do not retry; the
             // original error is preserved.
             other => FallbackDecision::Fail(other.clone()),

--- a/crates/bitrouter-sdk/src/language_model/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/tests.rs
@@ -22,6 +22,7 @@ fn target(provider: &str) -> RoutingTarget {
         api_base: "https://example.invalid".to_string(),
         api_key: "k".to_string(),
         api_protocol: ApiProtocol::ChatCompletions,
+        chat_token_limit_field: None,
         account_label: None,
         api_key_override: None,
         api_base_override: None,
@@ -233,6 +234,24 @@ impl ObserveHook for PanicObserveHook {
     }
 }
 
+struct OutcomeRecordingObserveHook(Arc<std::sync::Mutex<Vec<&'static str>>>);
+
+#[async_trait]
+impl ObserveHook for OutcomeRecordingObserveHook {
+    async fn after_phase(&self, _phase: Phase, _ctx: &PipelineContext) {}
+
+    async fn on_stream_part(&self, _ctx: &StreamContext, _part: &StreamPart) {}
+
+    async fn on_request_end(&self, _ctx: &PipelineContext, outcome: &RequestOutcome) {
+        let label = match outcome {
+            RequestOutcome::Completed => "completed",
+            RequestOutcome::Failed(_) => "failed",
+            RequestOutcome::ClientDisconnected => "disconnected",
+        };
+        self.0.lock().unwrap().push(label);
+    }
+}
+
 fn pipeline_with(
     rt: Arc<StaticRoutingTable>,
     executor: Arc<dyn Executor>,
@@ -263,6 +282,40 @@ async fn full_pipeline_runs_all_four_stages() {
     let resp = pipeline.execute(request()).await.expect("request succeeds");
     assert_eq!(resp.result.content.len(), 1);
     assert_eq!(recorded.load(Ordering::SeqCst), 1, "recorder ran");
+}
+
+#[tokio::test]
+async fn streaming_preflight_error_runs_settlement_and_observe_end() {
+    let settlements = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let outcomes = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let pipeline = pipeline_with(
+        routing_table(&["openai"]),
+        Arc::new(MockExecutor::new(vec![MockResponse::Error(
+            BitrouterError::UpstreamRateLimited {
+                retry_after: Some(3),
+            },
+        )])),
+        |builder| {
+            builder
+                .settlement_recorder(SettlementSnapshotRecorder(settlements.clone()))
+                .observe_hook(OutcomeRecordingObserveHook(outcomes.clone()));
+        },
+    );
+
+    let error = match pipeline.clone().execute_stream(stream_request()).await {
+        Ok(_) => panic!("preflight rate limit must fail before opening a stream"),
+        Err(error) => error,
+    };
+    assert!(matches!(error, BitrouterError::UpstreamRateLimited { .. }));
+    assert_eq!(
+        settlements.lock().unwrap().as_slice(),
+        &[SettlementSnapshot {
+            prompt_tokens: 0,
+            completion_tokens: 0,
+            has_error: true,
+        }]
+    );
+    assert_eq!(outcomes.lock().unwrap().as_slice(), &["failed"]);
 }
 
 #[tokio::test]
@@ -357,8 +410,8 @@ async fn settlement_recorder_runs_even_on_failure() {
     );
 
     let err = pipeline.execute(request()).await.unwrap_err();
-    // An upstream 500 surfaces to the client as a 502 Bad Gateway.
-    assert_eq!(err.status(), 502);
+    // Exhausting the only temporarily unavailable route is a 503.
+    assert_eq!(err.status(), 503);
     assert_eq!(
         recorded.load(Ordering::SeqCst),
         1,
@@ -398,6 +451,111 @@ async fn fallback_tries_next_on_5xx_then_succeeds() {
             provider_metadata: Default::default(),
         }]
     );
+}
+
+#[tokio::test]
+async fn fallback_tries_next_on_upstream_429_then_succeeds() {
+    let pipeline = pipeline_with(
+        routing_table(&["a-provider", "b-provider"]),
+        Arc::new(MockExecutor::new(vec![
+            MockResponse::Error(BitrouterError::UpstreamRateLimited {
+                retry_after: Some(30),
+            }),
+            MockResponse::Generate(GenerateResult {
+                content: vec![Content::Text {
+                    text: "from b".into(),
+                    provider_metadata: Default::default(),
+                }],
+                usage: None,
+                finish_reason: Some(FinishReason::Stop),
+                response_id: None,
+                stop_details: None,
+                provider_metadata: Default::default(),
+            }),
+        ])),
+        |_b| {},
+    );
+
+    let response = pipeline.execute(request()).await.unwrap();
+    assert_eq!(
+        response.result.content,
+        vec![Content::Text {
+            text: "from b".into(),
+            provider_metadata: Default::default(),
+        }]
+    );
+}
+
+#[tokio::test]
+async fn exhausted_upstream_429s_use_the_earliest_retry_after() {
+    let pipeline = pipeline_with(
+        routing_table(&["a-provider", "b-provider", "c-provider"]),
+        Arc::new(MockExecutor::new(vec![
+            MockResponse::Error(BitrouterError::UpstreamRateLimited {
+                retry_after: Some(30),
+            }),
+            MockResponse::Error(BitrouterError::UpstreamRateLimited { retry_after: None }),
+            MockResponse::Error(BitrouterError::UpstreamRateLimited {
+                retry_after: Some(12),
+            }),
+        ])),
+        |_b| {},
+    );
+
+    assert!(matches!(
+        pipeline.execute(request()).await.unwrap_err(),
+        BitrouterError::UpstreamRateLimited {
+            retry_after: Some(12)
+        }
+    ));
+}
+
+#[tokio::test]
+async fn mixed_retryable_upstream_failures_become_service_unavailable() {
+    let pipeline = pipeline_with(
+        routing_table(&["a-provider", "b-provider"]),
+        Arc::new(MockExecutor::new(vec![
+            MockResponse::Error(BitrouterError::UpstreamRateLimited {
+                retry_after: Some(10),
+            }),
+            MockResponse::Error(BitrouterError::Upstream {
+                status: 503,
+                message: "maintenance".into(),
+            }),
+        ])),
+        |_b| {},
+    );
+    assert!(matches!(
+        pipeline.execute(request()).await.unwrap_err(),
+        BitrouterError::UpstreamUnavailable
+    ));
+}
+
+#[tokio::test]
+async fn local_rate_limit_does_not_fall_back() {
+    let pipeline = pipeline_with(
+        routing_table(&["a-provider", "b-provider"]),
+        Arc::new(MockExecutor::new(vec![
+            MockResponse::Error(BitrouterError::RateLimited {
+                retry_after: Some(5),
+            }),
+            MockResponse::Generate(GenerateResult {
+                content: vec![],
+                usage: None,
+                finish_reason: None,
+                response_id: None,
+                stop_details: None,
+                provider_metadata: Default::default(),
+            }),
+        ])),
+        |_b| {},
+    );
+    assert!(matches!(
+        pipeline.execute(request()).await.unwrap_err(),
+        BitrouterError::RateLimited {
+            retry_after: Some(5)
+        }
+    ));
 }
 
 #[tokio::test]
@@ -1019,6 +1177,7 @@ async fn executor_rejects_response_format_on_unsupported_outbound() {
         api_base: "http://example.invalid".into(),
         api_key: "k".into(),
         api_protocol: ApiProtocol::Custom("fake".into()),
+        chat_token_limit_field: None,
         account_label: None,
         api_key_override: None,
         api_base_override: None,

--- a/crates/bitrouter-sdk/src/language_model/types.rs
+++ b/crates/bitrouter-sdk/src/language_model/types.rs
@@ -1144,6 +1144,38 @@ pub enum Modality {
     Audio,
 }
 
+/// Chat Completions field used to carry the output-token budget.
+///
+/// OpenAI-compatible providers are split between the legacy `max_tokens`
+/// spelling and the current `max_completion_tokens` spelling. The canonical
+/// prompt keeps one semantic token budget; this enum only records which wire
+/// spelling should be used when the prompt is rendered back to Chat
+/// Completions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ChatTokenLimitField {
+    /// Legacy Chat Completions field.
+    MaxTokens,
+    /// Current Chat Completions field, including reasoning tokens.
+    MaxCompletionTokens,
+}
+
+/// Provider/model request-shape compatibility settings.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(default)]
+pub struct ModelCompatibility {
+    /// Chat Completions-specific request settings.
+    pub chat_completions: ChatCompletionsCompatibility,
+}
+
+/// Chat Completions request-shape compatibility settings.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(default)]
+pub struct ChatCompletionsCompatibility {
+    /// Token-limit field required by this upstream model.
+    pub token_limit_field: Option<ChatTokenLimitField>,
+}
+
 /// Sampling / generation parameters, carried verbatim where possible.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct GenerationParams {
@@ -1156,6 +1188,13 @@ pub struct GenerationParams {
     /// Maximum tokens to generate.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_tokens: Option<u32>,
+    /// Inbound Chat Completions wire spelling for [`max_tokens`](Self::max_tokens).
+    ///
+    /// This is transient provenance, not a second generation parameter. Other
+    /// protocols leave it unset, and provider/model compatibility can override
+    /// it at outbound render time.
+    #[serde(skip)]
+    pub chat_token_limit_field: Option<ChatTokenLimitField>,
     /// Reasoning effort hint (`low` / `medium` / `high`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning_effort: Option<String>,
@@ -1843,6 +1882,10 @@ pub struct RoutingTarget {
     pub api_key: String,
     /// The wire protocol this target speaks.
     pub api_protocol: ApiProtocol,
+    /// Provider/model override for the Chat Completions token-limit field.
+    /// `None` preserves the inbound spelling, then falls back to legacy
+    /// `max_tokens` when the request originated on another protocol.
+    pub chat_token_limit_field: Option<ChatTokenLimitField>,
     /// Which account of a multi-account provider this target came from
     /// — `None` for a single-credential provider. Surfaced in the
     /// request log so an operator can see which subscription served a
@@ -1870,6 +1913,7 @@ impl std::fmt::Debug for RoutingTarget {
             .field("api_base", &self.api_base)
             .field("api_key", &redacted(&self.api_key))
             .field("api_protocol", &self.api_protocol)
+            .field("chat_token_limit_field", &self.chat_token_limit_field)
             .field("account_label", &self.account_label)
             .field(
                 "api_key_override",

--- a/crates/bitrouter-sdk/src/server.rs
+++ b/crates/bitrouter-sdk/src/server.rs
@@ -690,6 +690,7 @@ async fn handle(
             inbound.clone(),
             &prompt.model,
         )
+        .await
     } else {
         // `execute_detached`, not `execute`: a non-streaming request must run to
         // completion and settle even if the client disconnects (axum drops this
@@ -708,7 +709,7 @@ async fn handle(
 /// Build a `text/event-stream` response: pipe the canonical part stream through
 /// the inbound protocol's `StreamEncoder`, wrap it in `SseKeepaliveStream`, and
 /// stream the wire bytes.
-fn stream_response(
+async fn stream_response(
     pipeline: Arc<Pipeline>,
     req: PipelineRequest,
     inbound: ApiProtocol,
@@ -727,39 +728,38 @@ fn stream_response(
     let mut encoder = adapter.stream_encoder(&req.request_id, model);
     let keepalive = pipeline.keepalive_interval();
 
+    // Route resolution and the upstream HTTP handshake happen before the SSE
+    // response is constructed. Pre-stream failures therefore retain their real
+    // HTTP status (notably upstream 429) instead of being trapped inside an
+    // already-committed HTTP 200 event stream.
+    let mut parts = match pipeline.execute_stream(req).await {
+        Ok(parts) => parts,
+        Err(error) => return error.into_response(),
+    };
+
     let frame_stream = async_stream::stream! {
-        match pipeline.execute_stream(req).await {
-            Ok(mut parts) => {
-                while let Some(item) = parts.next().await {
-                    match item {
-                        Ok(part) => {
-                            if let Ok(frames) = encoder.encode(&part) {
-                                for f in frames {
-                                    yield f;
-                                }
-                            }
-                        }
-                        Err(e) => {
-                            // Surface the error as a protocol-shaped terminal
-                            // error event the client will actually recognise,
-                            // then stop.
-                            for f in encoder.encode_error(&e.to_string()) {
-                                yield f;
-                            }
-                            return;
+        while let Some(item) = parts.next().await {
+            match item {
+                Ok(part) => {
+                    if let Ok(frames) = encoder.encode(&part) {
+                        for f in frames {
+                            yield f;
                         }
                     }
-                }
-                if let Ok(frames) = encoder.finish() {
-                    for f in frames {
+                },
+                Err(e) => {
+                    // HTTP status is immutable after streaming begins. Emit a
+                    // typed protocol-shaped terminal event instead.
+                    for f in encoder.encode_bitrouter_error(&e) {
                         yield f;
                     }
+                    return;
                 }
             }
-            Err(e) => {
-                for f in encoder.encode_error(&e.to_string()) {
-                    yield f;
-                }
+        }
+        if let Ok(frames) = encoder.finish() {
+            for f in frames {
+                yield f;
             }
         }
     };
@@ -784,8 +784,9 @@ impl IntoResponse for BitrouterError {
             StatusCode::from_u16(self.status()).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
         let body = Json(serde_json::json!({
             "error": {
-                "message": self.to_string(),
+                "message": self.public_message(),
                 "type": self.error_type(),
+                "code": self.error_code(),
             }
         }));
         //.4 — payment / rate-limit responses must carry the headers
@@ -821,6 +822,17 @@ impl IntoResponse for BitrouterError {
                     response.headers_mut().insert(header::RETRY_AFTER, v);
                 }
             }
+            BitrouterError::UpstreamRateLimited { retry_after } => {
+                if let Some(secs) = retry_after
+                    && let Ok(v) = header::HeaderValue::from_str(&secs.to_string())
+                {
+                    response.headers_mut().insert(header::RETRY_AFTER, v);
+                }
+                response.headers_mut().insert(
+                    header::HeaderName::from_static("x-bitrouter-error-source"),
+                    header::HeaderValue::from_static("upstream"),
+                );
+            }
             _ => {}
         }
         response
@@ -831,7 +843,7 @@ impl IntoResponse for BitrouterError {
 mod tests {
     use super::*;
     use crate::language_model::PipelineBuilder;
-    use crate::language_model::executor::MockExecutor;
+    use crate::language_model::executor::{Executor, MockExecutor, MockResponse};
     use crate::language_model::routing::StaticRoutingTable;
     use crate::language_model::types::{ApiProtocol, AuthScheme, RoutingTarget};
     use axum::body::to_bytes;
@@ -839,6 +851,10 @@ mod tests {
     use tower::ServiceExt;
 
     fn test_state_with_models() -> AppState {
+        test_state_with_executor(Arc::new(MockExecutor::always_text("ok")))
+    }
+
+    fn test_state_with_executor(executor: Arc<dyn Executor>) -> AppState {
         let table = StaticRoutingTable::new();
         table.insert(
             "gpt-5.5",
@@ -848,6 +864,7 @@ mod tests {
                 api_base: "https://example.invalid".to_string(),
                 api_key: "test-key".to_string(),
                 api_protocol: ApiProtocol::Responses,
+                chat_token_limit_field: None,
                 account_label: None,
                 api_key_override: None,
                 api_base_override: None,
@@ -855,9 +872,7 @@ mod tests {
             }],
         );
         let mut builder = PipelineBuilder::new();
-        builder
-            .routing_table(Arc::new(table))
-            .executor(Arc::new(MockExecutor::always_text("ok")));
+        builder.routing_table(Arc::new(table)).executor(executor);
         let pipeline = builder.build().unwrap();
         AppState {
             language_model: Arc::new(pipeline),
@@ -920,6 +935,20 @@ mod tests {
         assert!(www_auth.contains("tempo-voucher"));
     }
 
+    #[tokio::test]
+    async fn upstream_diagnostics_are_not_exposed_in_http_errors() {
+        let response = BitrouterError::Upstream {
+            status: 500,
+            message: "provider secret stack trace".to_string(),
+        }
+        .into_response();
+        let bytes = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body["error"]["message"], "upstream request failed");
+        assert_eq!(body["error"]["code"], "upstream_bad_gateway");
+        assert!(!String::from_utf8_lossy(&bytes).contains("secret"));
+    }
+
     #[test]
     fn unauthorized_emits_www_authenticate_bearer() {
         // RFC 7235 §3.1: 401 MUST include WWW-Authenticate.
@@ -961,5 +990,59 @@ mod tests {
             response.headers().get(header::RETRY_AFTER).is_none(),
             "no Retry-After when the daemon doesn't know how long to wait"
         );
+    }
+
+    #[tokio::test]
+    async fn upstream_rate_limit_has_wrapped_code_source_and_retry_after() {
+        let response = BitrouterError::UpstreamRateLimited {
+            retry_after: Some(12),
+        }
+        .into_response();
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(response.headers()[header::RETRY_AFTER], "12");
+        assert_eq!(response.headers()["x-bitrouter-error-source"], "upstream");
+        let value: serde_json::Value =
+            serde_json::from_slice(&to_bytes(response.into_body(), 64 * 1024).await.unwrap())
+                .unwrap();
+        assert_eq!(value["error"]["type"], "rate_limit_error");
+        assert_eq!(value["error"]["code"], "upstream_rate_limited");
+        assert_eq!(value["error"]["message"], "upstream rate limited");
+    }
+
+    #[tokio::test]
+    async fn streaming_preflight_rate_limit_keeps_http_429() {
+        let state =
+            test_state_with_executor(Arc::new(MockExecutor::new(vec![MockResponse::Error(
+                BitrouterError::UpstreamRateLimited {
+                    retry_after: Some(7),
+                },
+            )])));
+        let response = build_router(state)
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/chat/completions")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "model": "gpt-5.5",
+                            "messages": [{"role": "user", "content": "ping"}],
+                            "stream": true
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_ne!(
+            response
+                .headers()
+                .get(header::CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok()),
+            Some("text/event-stream")
+        );
+        assert_eq!(response.headers()[header::RETRY_AFTER], "7");
     }
 }

--- a/dist/schema/bitrouter.config.schema.json
+++ b/dist/schema/bitrouter.config.schema.json
@@ -407,6 +407,15 @@
               "type": "null"
             }
           ]
+        },
+        "compatibility": {
+          "description": "Provider/model request-shape quirks that do not change model semantics.",
+          "$ref": "#/$defs/ModelCompatibility",
+          "default": {
+            "chat_completions": {
+              "token_limit_field": null
+            }
+          }
         }
       },
       "required": [
@@ -463,6 +472,52 @@
       },
       "required": [
         "above_input_tokens"
+      ]
+    },
+    "ModelCompatibility": {
+      "description": "Provider/model request-shape compatibility settings.",
+      "type": "object",
+      "properties": {
+        "chat_completions": {
+          "description": "Chat Completions-specific request settings.",
+          "$ref": "#/$defs/ChatCompletionsCompatibility",
+          "default": {
+            "token_limit_field": null
+          }
+        }
+      }
+    },
+    "ChatCompletionsCompatibility": {
+      "description": "Chat Completions request-shape compatibility settings.",
+      "type": "object",
+      "properties": {
+        "token_limit_field": {
+          "description": "Token-limit field required by this upstream model.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ChatTokenLimitField"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      }
+    },
+    "ChatTokenLimitField": {
+      "description": "Chat Completions field used to carry the output-token budget.\n\nOpenAI-compatible providers are split between the legacy `max_tokens`\nspelling and the current `max_completion_tokens` spelling. The canonical\nprompt keeps one semantic token budget; this enum only records which wire\nspelling should be used when the prompt is rendered back to Chat\nCompletions.",
+      "oneOf": [
+        {
+          "description": "Legacy Chat Completions field.",
+          "type": "string",
+          "const": "max_tokens"
+        },
+        {
+          "description": "Current Chat Completions field, including reasoning tokens.",
+          "type": "string",
+          "const": "max_completion_tokens"
+        }
       ]
     },
     "ProviderAccount": {

--- a/docs/integrations/models.md
+++ b/docs/integrations/models.md
@@ -35,10 +35,15 @@ providers:
     api_protocol:
       - "*": chat_completions          # upstream wire format
     models:
-      - id: openai/gpt-4o
+      - id: openai/gpt-5.5
+        compatibility:
+          chat_completions:
+            token_limit_field: max_completion_tokens
 ```
 
 `providers` is a map keyed by an id you choose; `api_base` is the source's base URL; `api_protocol` is the upstream wire format (`chat_completions` for any OpenAI-compatible host — also the inferred default); each `models` entry is a model that source serves.
+
+Most providers need no `compatibility` block. Set `chat_completions.token_limit_field` only when an upstream requires a particular output-token field: current OpenAI models use `max_completion_tokens`, while some older compatible APIs still require `max_tokens`. BitRouter otherwise preserves the caller's Chat Completions spelling and translates the semantic limit across Messages, Responses, and Generate Content automatically.
 
 ## Scaffold a config
 

--- a/docs/integrations/models.zh.md
+++ b/docs/integrations/models.zh.md
@@ -35,10 +35,15 @@ providers:
     api_protocol:
       - "*": chat_completions          # upstream wire format
     models:
-      - id: openai/gpt-4o
+      - id: openai/gpt-5.5
+        compatibility:
+          chat_completions:
+            token_limit_field: max_completion_tokens
 ```
 
 `providers` 是一个以你自选 id 为键的映射；`api_base` 是该来源的 base URL；`api_protocol` 是上游的传输协议格式（任何 OpenAI 兼容的服务用 `chat_completions`——也是推断出的默认值）；每条 `models` 记录代表该来源提供的一个模型。
+
+大多数 provider 都不需要 `compatibility` 块。只有当上游强制要求特定的输出 token 字段时，才设置 `chat_completions.token_limit_field`：当前 OpenAI 模型使用 `max_completion_tokens`，部分较旧的兼容 API 仍要求 `max_tokens`。在没有显式设置时，BitRouter 会保留调用方在 Chat Completions 中使用的字段拼写，并自动将同一语义上限转换到 Messages、Responses 和 Generate Content。
 
 ## 生成配置脚手架
 

--- a/helpers/dist-helper/src/registry.rs
+++ b/helpers/dist-helper/src/registry.rs
@@ -416,6 +416,7 @@ async fn sync_models_dev_loaded(_root: &Path, loaded: &LoadedRegistry, write: bo
                     api_protocol: None,
                     pricing,
                     rate_limits: None,
+                    compatibility: None,
                     capabilities: Vec::new(),
                     deprecation_date: None,
                 });
@@ -581,6 +582,7 @@ fn v1_models_plan_for_provider(
             api_protocol: None,
             pricing,
             rate_limits: None,
+            compatibility: None,
             capabilities: Vec::new(),
             deprecation_date: None,
         });
@@ -1117,6 +1119,13 @@ fn resolved_models(provider: &ProviderFile) -> Result<Vec<Value>> {
                 obj.insert(
                     "rate_limits".to_string(),
                     serde_json::to_value(rate_limits).context("serializing rate_limits")?,
+                );
+            }
+            if let Some(compatibility) = &model.compatibility {
+                obj.insert(
+                    "compatibility".to_string(),
+                    serde_json::to_value(compatibility)
+                        .context("serializing model compatibility")?,
                 );
             }
             if let Some(deprecation_date) = &model.deprecation_date {
@@ -2048,10 +2057,32 @@ struct ProviderModel {
     pricing: Option<ModelPricing>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     rate_limits: Option<RateLimits>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    compatibility: Option<ModelCompatibility>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     capabilities: Vec<Capability>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     deprecation_date: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct ModelCompatibility {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    chat_completions: Option<ChatCompletionsCompatibility>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct ChatCompletionsCompatibility {
+    token_limit_field: ChatTokenLimitField,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum ChatTokenLimitField {
+    MaxTokens,
+    MaxCompletionTokens,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
@@ -2693,6 +2724,7 @@ auto_sync:
             api_protocol: None,
             pricing: None,
             rate_limits: None,
+            compatibility: None,
             capabilities: Vec::new(),
             deprecation_date: None,
         };

--- a/plugins/bitrouter-attestation/src/tests.rs
+++ b/plugins/bitrouter-attestation/src/tests.rs
@@ -67,6 +67,7 @@ fn target(provider: &str, model: &str) -> RoutingTarget {
         api_base: "https://example.invalid".to_string(),
         api_key: "k".to_string(),
         api_protocol: ApiProtocol::ChatCompletions,
+        chat_token_limit_field: None,
         account_label: None,
         api_key_override: None,
         api_base_override: None,

--- a/plugins/bitrouter-guardrails/src/tests.rs
+++ b/plugins/bitrouter-guardrails/src/tests.rs
@@ -94,6 +94,7 @@ fn target() -> RoutingTarget {
         api_base: "https://example.invalid".to_string(),
         api_key: "k".to_string(),
         api_protocol: ApiProtocol::ChatCompletions,
+        chat_token_limit_field: None,
         account_label: None,
         api_key_override: None,
         api_base_override: None,

--- a/plugins/bitrouter-observe/src/otel/exporter.rs
+++ b/plugins/bitrouter-observe/src/otel/exporter.rs
@@ -1177,6 +1177,7 @@ mod hop_tests {
             api_base: "https://api.example.test:8443/v1".to_string(),
             api_key: "k".to_string(),
             api_protocol: ApiProtocol::ChatCompletions,
+            chat_token_limit_field: None,
             account_label: Some("primary".to_string()),
             api_key_override: None,
             api_base_override: None,


### PR DESCRIPTION
## Summary

- preserve the semantic output-token budget across Chat Completions, Responses, Messages, and GenerateContent while rendering the provider-specific Chat Completions field
- add typed config/registry plumbing so a verified route can declare the required Chat Completions field
- distinguish local rate limits from exhausted upstream rate limits and return a stable, safe downstream error contract
- classify malformed upstream success responses as retryable 502 errors and aggregate exhausted transient routes deterministically

## Root cause

The canonical request model collapsed `max_tokens` and `max_completion_tokens` into one value without retaining the wire spelling required by the selected upstream route. Cross-protocol extras could also reintroduce an alias, causing both fields to be sent.

Separately, provider 429 responses used the same error variant as local policy throttling. That made fallback behavior ambiguous and prevented pre-stream upstream rate limits from reaching clients as real HTTP 429 responses. Upstream error bodies could also leak provider diagnostics through public HTTP or SSE responses.

## Behavior

- a request may use either Chat Completions token-limit field; conflicting values are rejected
- the selected route controls the outbound spelling, and exactly one alias is emitted
- non-Chat protocols continue to use their native token-limit field
- local 429 errors stop immediately; an upstream 429 tries the next route
- if every usable route is rate limited, clients receive HTTP 429 with `error.code=upstream_rate_limited`, `x-bitrouter-error-source: upstream`, and `Retry-After` when known
- exhausted timeouts return 504; mixed transient route failures return 503; malformed upstream success bodies return 502
- public HTTP and terminal SSE errors use safe messages instead of provider response bodies

## Scope

This PR intentionally does not annotate any concrete provider/model route. Those registry changes will follow after each model is tested against its upstream API.

## Validation

- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo run -p dist-helper -- check`
- `cargo fmt -- --check`
- cross-protocol token-limit matrix, alias-pollution, target override, malformed upstream response, fallback aggregation, pre-stream settlement, HTTP header, and typed SSE regression tests
