### PR TITLE
fix(registry): set verified GPT token fields

### DIFF
--- a/dist/registry/models.json
+++ b/dist/registry/models.json
@@ -4591,6 +4591,11 @@
             "structured_outputs",
             "tools"
           ],
+          "compatibility": {
+            "chat_completions": {
+              "token_limit_field": "max_completion_tokens"
+            }
+          },
           "pricing": {
             "input_tokens": {
               "cache_read": 0.25,
@@ -4715,6 +4720,11 @@
             "structured_outputs",
             "tools"
           ],
+          "compatibility": {
+            "chat_completions": {
+              "token_limit_field": "max_completion_tokens"
+            }
+          },
           "pricing": {
             "input_tokens": {
               "cache_read": 0.075,
@@ -4851,6 +4861,11 @@
         },
         {
           "api_protocol": "openai",
+          "compatibility": {
+            "chat_completions": {
+              "token_limit_field": "max_completion_tokens"
+            }
+          },
           "pricing": {
             "input_tokens": {
               "cache_read": 0.5,
@@ -4873,6 +4888,11 @@
             "structured_outputs",
             "tools"
           ],
+          "compatibility": {
+            "chat_completions": {
+              "token_limit_field": "max_completion_tokens"
+            }
+          },
           "pricing": {
             "input_tokens": {
               "cache_read": 0.5,
@@ -4973,6 +4993,11 @@
             "structured_outputs",
             "tools"
           ],
+          "compatibility": {
+            "chat_completions": {
+              "token_limit_field": "max_completion_tokens"
+            }
+          },
           "pricing": {
             "context_tiers": [
               {
@@ -5074,6 +5099,11 @@
             "structured_outputs",
             "tools"
           ],
+          "compatibility": {
+            "chat_completions": {
+              "token_limit_field": "max_completion_tokens"
+            }
+          },
           "pricing": {
             "context_tiers": [
               {
@@ -5175,6 +5205,11 @@
             "structured_outputs",
             "tools"
           ],
+          "compatibility": {
+            "chat_completions": {
+              "token_limit_field": "max_completion_tokens"
+            }
+          },
           "pricing": {
             "context_tiers": [
               {

--- a/dist/registry/providers.json
+++ b/dist/registry/providers.json
@@ -3362,6 +3362,11 @@
         },
         {
           "api_protocol": "openai",
+          "compatibility": {
+            "chat_completions": {
+              "token_limit_field": "max_completion_tokens"
+            }
+          },
           "id": "openai/gpt-5.5",
           "pricing": {
             "input_tokens": {
@@ -4354,6 +4359,11 @@
             "structured_outputs",
             "tools"
           ],
+          "compatibility": {
+            "chat_completions": {
+              "token_limit_field": "max_completion_tokens"
+            }
+          },
           "id": "openai/gpt-5.6-sol",
           "pricing": {
             "context_tiers": [
@@ -4393,6 +4403,11 @@
             "structured_outputs",
             "tools"
           ],
+          "compatibility": {
+            "chat_completions": {
+              "token_limit_field": "max_completion_tokens"
+            }
+          },
           "id": "openai/gpt-5.6-terra",
           "pricing": {
             "context_tiers": [
@@ -4432,6 +4447,11 @@
             "structured_outputs",
             "tools"
           ],
+          "compatibility": {
+            "chat_completions": {
+              "token_limit_field": "max_completion_tokens"
+            }
+          },
           "id": "openai/gpt-5.6-luna",
           "pricing": {
             "context_tiers": [
@@ -4471,6 +4491,11 @@
             "structured_outputs",
             "tools"
           ],
+          "compatibility": {
+            "chat_completions": {
+              "token_limit_field": "max_completion_tokens"
+            }
+          },
           "id": "openai/gpt-5.5",
           "pricing": {
             "input_tokens": {
@@ -4496,6 +4521,11 @@
             "structured_outputs",
             "tools"
           ],
+          "compatibility": {
+            "chat_completions": {
+              "token_limit_field": "max_completion_tokens"
+            }
+          },
           "id": "openai/gpt-5.4",
           "pricing": {
             "input_tokens": {
@@ -4521,6 +4551,11 @@
             "structured_outputs",
             "tools"
           ],
+          "compatibility": {
+            "chat_completions": {
+              "token_limit_field": "max_completion_tokens"
+            }
+          },
           "id": "openai/gpt-5.4-mini",
           "pricing": {
             "input_tokens": {

--- a/registry/providers/gmicloud.yaml
+++ b/registry/providers/gmicloud.yaml
@@ -97,6 +97,9 @@ models:
         text: 3.08
   - id: openai/gpt-5.5
     provider_model_id: openai/gpt-5.5
+    compatibility:
+      chat_completions:
+        token_limit_field: max_completion_tokens
     pricing:
       input_tokens:
         no_cache: 5

--- a/registry/providers/openai.yaml
+++ b/registry/providers/openai.yaml
@@ -20,6 +20,9 @@ models:
   # input rate; cache_write is the one-time cost to populate the prompt cache.
   - id: openai/gpt-5.6-sol
     provider_model_id: gpt-5.6-sol
+    compatibility: &modern_openai_chat
+      chat_completions:
+        token_limit_field: max_completion_tokens
     pricing:
       input_tokens:
         no_cache: 5
@@ -41,6 +44,7 @@ models:
       - tools
   - id: openai/gpt-5.6-terra
     provider_model_id: gpt-5.6-terra
+    compatibility: *modern_openai_chat
     pricing:
       input_tokens:
         no_cache: 2.5
@@ -62,6 +66,7 @@ models:
       - tools
   - id: openai/gpt-5.6-luna
     provider_model_id: gpt-5.6-luna
+    compatibility: *modern_openai_chat
     pricing:
       input_tokens:
         no_cache: 1
@@ -83,6 +88,7 @@ models:
       - tools
   - id: openai/gpt-5.5
     provider_model_id: gpt-5.5
+    compatibility: *modern_openai_chat
     pricing:
       input_tokens:
         no_cache: 5
@@ -95,6 +101,7 @@ models:
       - tools
   - id: openai/gpt-5.4
     provider_model_id: gpt-5.4
+    compatibility: *modern_openai_chat
     pricing:
       input_tokens:
         no_cache: 2.5
@@ -107,6 +114,7 @@ models:
       - tools
   - id: openai/gpt-5.4-mini
     provider_model_id: gpt-5.4-mini
+    compatibility: *modern_openai_chat
     pricing:
       input_tokens:
         no_cache: 0.75


### PR DESCRIPTION
## Summary

- mark six OpenAI GPT-5.4/5.5/5.6 Chat Completions routes as requiring `max_completion_tokens`
- mark the GMI Cloud GPT-5.5 Chat Completions route with the same compatibility requirement
- regenerate the resolved registry artifacts

## Production verification

Each result below came from a direct upstream Chat Completions request using the corresponding key configured on the Railway production `bitrouter-api` service. Requests differed only in whether the output limit was sent as `max_tokens` or `max_completion_tokens`.

| Provider | Models | `max_tokens` | `max_completion_tokens` | Registry change |
| --- | --- | --- | --- | --- |
| OpenAI | GPT-5.4, GPT-5.4 Mini, GPT-5.5, GPT-5.6 Luna, Sol, Terra | 400 `unsupported_parameter` | 200 | Required |
| GMI Cloud | GPT-5.5 | 400 backend rejection | 200 | Required |
| Cerebras | GPT-OSS-120B | 200 | 200 | None |
| SiliconFlow | GPT-OSS-120B | 200 | 200 | None |

Providers without a production key were intentionally not tested or changed: Azure, AWS Bedrock, GitHub Copilot, Novita, OpenAI Codex, OpenCode Zen, and OpenRouter. The public BitRouter provider is skipped by bitrouter-cloud to prevent a self-loop and is not part of its upstream route set.

## Dependency

This follows merged #692, which introduced the typed compatibility field and outbound rendering behavior. This PR contains only two provider YAML files and two generated registry artifacts.

## Validation

- `cargo run -p dist-helper -- registry validate`
- `cargo run -p dist-helper -- registry build`
- `cargo run -p dist-helper -- check`
- `cargo test -p dist-helper`
- `cargo test -p bitrouter-providers --all-features`
- `git diff --check`
