### PR TITLE
fix(sdk): preserve streaming preflight errors

### DIFF
--- a/crates/bitrouter-sdk/src/event.rs
+++ b/crates/bitrouter-sdk/src/event.rs
@@ -11,6 +11,7 @@
 
 use serde::Serialize;
 use std::any::{Any, TypeId};
+use std::sync::Arc;
 
 /// A typed pipeline event. Each event is an independent struct declared by the
 /// crate that emits it.
@@ -23,17 +24,18 @@ pub trait PipelineEvent: Serialize + Any + Send + Sync + 'static {
 ///
 /// `typed` backs the compile-time-safe `has::<E>()` / `get::<E>()` queries;
 /// `json` backs `dump_json()` and is always available without re-deriving.
+#[derive(Clone)]
 struct EventEntry {
     type_id: TypeId,
     name: &'static str,
-    typed: Box<dyn Any + Send + Sync>,
+    typed: Arc<dyn Any + Send + Sync>,
     json: serde_json::Value,
 }
 
 /// Per-request, pull-based event bus. Stores every event emitted during the
 /// pipeline lifecycle. Used only for in-request hook coordination — it never
 /// leaves the process and there is no app-level subscription.
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct EventBus {
     events: Vec<EventEntry>,
 }
@@ -52,7 +54,7 @@ impl EventBus {
         self.events.push(EventEntry {
             type_id: TypeId::of::<E>(),
             name,
-            typed: Box::new(event),
+            typed: Arc::new(event),
             json,
         });
     }

--- a/crates/bitrouter-sdk/src/language_model/context.rs
+++ b/crates/bitrouter-sdk/src/language_model/context.rs
@@ -117,6 +117,42 @@ impl PipelineContext {
         }
     }
 
+    /// Fork the immutable request and accumulated hook state for a later
+    /// server-tool model turn. The fork keeps the original request identity,
+    /// headers, protocol, metadata, extensions, events, and resolved route;
+    /// only the evolving prompt and per-turn execution/trace state are fresh.
+    pub(crate) fn fork_for_prompt(&self, prompt: Prompt) -> Self {
+        Self {
+            request_id: self.request_id.clone(),
+            model: self.model.clone(),
+            caller: self.caller.clone(),
+            headers: self.headers.clone(),
+            prompt,
+            inbound_protocol: self.inbound_protocol.clone(),
+            route_chain: self.route_chain.clone(),
+            execution_result: None,
+            metadata: self.metadata.clone(),
+            extensions: self.extensions.clone(),
+            events: self.events.clone(),
+            outbound_trace_headers: Mutex::new(None),
+        }
+    }
+
+    fn serving_target(&self) -> Option<RoutingTarget> {
+        let chain = self.route_chain.as_ref()?;
+        self.execution_result
+            .as_ref()
+            .and_then(|execution| {
+                chain.iter().find(|target| {
+                    target.provider_name == execution.provider_id
+                        && target.service_id == execution.model_id
+                        && target.account_label == execution.account_label
+                })
+            })
+            .or_else(|| chain.first())
+            .cloned()
+    }
+
     /// Store outbound HTTP headers for the next upstream request. The
     /// executor merges them into the request just before issuing it.
     /// Typically called by an `ObserveHook` from `on_hop_start` to inject
@@ -298,7 +334,7 @@ impl PipelineContext {
 
     /// Borrow a `StreamContext` for the StreamHook stage.
     pub fn stream_context(&self) -> StreamContext {
-        let target = self.route_chain.as_ref().and_then(|c| c.first()).cloned();
+        let target = self.serving_target();
         StreamContext {
             request_id: self.request_id.clone(),
             caller: self.caller.clone(),
@@ -327,7 +363,7 @@ impl PipelineContext {
     /// bus out (so recorders can inspect events emitted by earlier stages);
     /// `absorb_settlement` moves it back.
     pub fn settlement_context(&mut self) -> SettlementContext {
-        let target = self.route_chain.as_ref().and_then(|c| c.first()).cloned();
+        let target = self.serving_target();
         let exec = self.execution_result.as_ref();
         let usage = exec.and_then(|e| e.result.usage).unwrap_or_default();
         SettlementContext {

--- a/crates/bitrouter-sdk/src/language_model/pipeline.rs
+++ b/crates/bitrouter-sdk/src/language_model/pipeline.rs
@@ -10,7 +10,6 @@ use futures::{FutureExt, StreamExt};
 use futures_core::Stream;
 use tracing::Instrument;
 
-use crate::caller::CallerContext;
 use crate::error::{BitrouterError, Result};
 use crate::language_model::context::PipelineContext;
 use crate::language_model::executor::{Executor, StreamPartStream};
@@ -83,31 +82,56 @@ impl UpstreamTurn for PipelineUpstream<'_> {
 }
 
 /// Drives one upstream **streaming** turn for the server-side tool loop. Each
-/// iteration tries the routing `chain` in order until one stream starts
-/// (commit-on-start failover, mirroring the single-shot path), and uses a fresh
-/// throwaway [`PipelineContext`] (the executor reads it only for outbound trace
-/// headers), so the real request context stays owned by the settlement guard.
+/// iteration uses the pipeline's standard fallback policy over the routing
+/// `chain` until one stream starts. A fresh throwaway [`PipelineContext`] keeps
+/// per-turn fallback/observation state separate while the real request context
+/// stays owned by the settlement guard.
 struct PipelineStreamUpstream {
-    executor: Arc<dyn Executor>,
+    pipeline: Arc<Pipeline>,
     chain: Vec<RoutingTarget>,
-    caller: CallerContext,
+    context: PipelineContext,
+    serving_target: SharedServingTarget,
 }
 
 #[async_trait]
 impl UpstreamStream for PipelineStreamUpstream {
     async fn run(&self, prompt: &Prompt) -> Result<StreamPartStream> {
-        let req = PipelineRequest::new(prompt.model.clone(), self.caller.clone(), prompt.clone());
-        let ctx = PipelineContext::new(req);
-        let mut last_error: Option<BitrouterError> = None;
-        for target in &self.chain {
-            match self.executor.execute_stream(target, prompt, &ctx).await {
-                Ok(stream) => return Ok(stream),
-                Err(e) => last_error = Some(e),
-            }
-        }
-        Err(last_error
-            .unwrap_or_else(|| BitrouterError::NotFound("empty routing chain".to_string())))
+        let ctx = self.context.fork_for_prompt(prompt.clone());
+        let (target, stream) = self
+            .pipeline
+            .execute_stream_with_fallback(&self.chain, &ctx)
+            .await?;
+        store_serving_target(&self.serving_target, target);
+        Ok(stream)
     }
+}
+
+type SharedServingTarget = Arc<std::sync::Mutex<Option<RoutingTarget>>>;
+
+fn store_serving_target(slot: &SharedServingTarget, target: RoutingTarget) {
+    match slot.lock() {
+        Ok(mut current) => *current = Some(target),
+        Err(poisoned) => *poisoned.into_inner() = Some(target),
+    }
+}
+
+fn load_serving_target(slot: &SharedServingTarget) -> Option<RoutingTarget> {
+    match slot.lock() {
+        Ok(current) => current.clone(),
+        Err(poisoned) => poisoned.into_inner().clone(),
+    }
+}
+
+fn sync_execution_target(ctx: &mut PipelineContext, slot: &SharedServingTarget) {
+    let Some(target) = load_serving_target(slot) else {
+        return;
+    };
+    let Some(execution) = ctx.execution_result.as_mut() else {
+        return;
+    };
+    execution.provider_id = target.provider_name;
+    execution.model_id = target.service_id;
+    execution.account_label = target.account_label;
 }
 
 impl Pipeline {
@@ -289,6 +313,7 @@ impl Pipeline {
         };
         self.observe_after(Phase::Route, &ctx).await;
         log_request_received(&ctx, chain.first(), true);
+        let serving_target: SharedServingTarget = Arc::new(std::sync::Mutex::new(None));
 
         // Route Stage 3 through the server-side tool loop when configured: the
         // merged stream becomes the "upstream" the settlement guard drains, so
@@ -297,16 +322,23 @@ impl Pipeline {
             Some(server_loop) => {
                 let tool_ctx = ToolContext::from_pipeline(&ctx);
                 let upstream_impl: Arc<dyn UpstreamStream> = Arc::new(PipelineStreamUpstream {
-                    executor: self.executor.clone(),
+                    pipeline: self.clone(),
                     chain: chain.clone(),
-                    caller: ctx.caller().clone(),
+                    context: ctx.fork_for_prompt(ctx.prompt().clone()),
+                    serving_target: serving_target.clone(),
                 });
                 server_loop
                     .clone()
                     .run_stream(ctx.prompt(), &tool_ctx, upstream_impl)
                     .await
             }
-            None => self.execute_stream_with_fallback(&chain, &ctx).await,
+            None => match self.execute_stream_with_fallback(&chain, &ctx).await {
+                Ok((target, stream)) => {
+                    store_serving_target(&serving_target, target);
+                    Ok(stream)
+                }
+                Err(error) => Err(error),
+            },
         };
         let upstream = match upstream_result {
             Ok(upstream) => upstream,
@@ -321,7 +353,7 @@ impl Pipeline {
         };
         // A placeholder execution result so Settlement has provider/model ids;
         // usage is folded in from the StreamContext at stream end.
-        let head = chain.first().cloned();
+        let head = load_serving_target(&serving_target).or_else(|| chain.first().cloned());
         if let Some(target) = &head {
             ctx.execution_result = Some(ExecutionResult {
                 provider_id: target.provider_name.clone(),
@@ -354,6 +386,7 @@ impl Pipeline {
         // so streaming settlement is never lost.
         let guard = StreamSettlementGuard {
             pipeline: self.clone(),
+            serving_target,
             state: Some((processor, ctx)),
         };
 
@@ -502,7 +535,7 @@ impl Pipeline {
         &self,
         chain: &[RoutingTarget],
         ctx: &PipelineContext,
-    ) -> Result<StreamPartStream> {
+    ) -> Result<(RoutingTarget, StreamPartStream)> {
         let mut errors = Vec::new();
         for target in chain {
             self.observe_hop_start(ctx, target).await;
@@ -523,7 +556,7 @@ impl Pipeline {
             match outcome {
                 // Once the stream starts, the SSE response is committed — no
                 // more fallback.
-                Ok(stream) => return Ok(stream),
+                Ok(stream) => return Ok((target.clone(), stream)),
                 Err(e) => match self.classify_failure(ctx, &e, target).await {
                     FallbackDecision::TryNext => {
                         errors.push(e);
@@ -704,6 +737,7 @@ fn aggregate_fallback_errors(errors: Vec<BitrouterError>) -> BitrouterError {
 /// normally or the client drops it early.
 struct StreamSettlementGuard {
     pipeline: Arc<Pipeline>,
+    serving_target: SharedServingTarget,
     /// `Some` until finalised; `take`n by `finalize` or `drop`, whichever fires
     /// first, so finalisation is exactly-once.
     state: Option<(StreamProcessor, PipelineContext)>,
@@ -726,6 +760,7 @@ impl StreamSettlementGuard {
         if let Some((mut processor, mut ctx)) = self.state.take() {
             let (settlement_error, request_outcome) = stream_terminal_metadata(&outcome);
             processor.finish(outcome).await;
+            sync_execution_target(&mut ctx, &self.serving_target);
             ctx.absorb_stream(processor.into_context());
             self.pipeline
                 .run_settlement(&mut ctx, true, settlement_error)
@@ -758,8 +793,10 @@ impl Drop for StreamSettlementGuard {
         // could cut a settlement task mid-await and the receipt would be lost.
         if let Some((mut processor, mut ctx)) = self.state.take() {
             let pipeline = self.pipeline.clone();
+            let serving_target = self.serving_target.clone();
             let fut = async move {
                 processor.finish(StreamOutcome::ClientDisconnected).await;
+                sync_execution_target(&mut ctx, &serving_target);
                 ctx.absorb_stream(processor.into_context());
                 pipeline.run_settlement(&mut ctx, true, None).await;
                 pipeline

--- a/crates/bitrouter-sdk/src/language_model/server_tools/stream.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/stream.rs
@@ -47,11 +47,19 @@ impl ServerToolLoop {
         upstream: Arc<dyn UpstreamStream>,
     ) -> Result<StreamPartStream> {
         let (working, owned) = self.inject(base, ctx).await?;
+        // `Result<StreamPartStream>` is the boundary between fallible request
+        // setup and an HTTP response whose status may already be committed.
+        // Open the first upstream turn eagerly so an HTTP 429/auth/availability
+        // failure can still retain its real downstream status. Later turns are
+        // driven inside the stream because earlier narration/tool activity may
+        // already have reached the caller.
+        let first_upstream_stream = upstream.run(&working).await?;
         let ctx = ctx.clone();
         let loop_ = self;
 
         let stream = async_stream::stream! {
             let mut working = working;
+            let mut first_upstream_stream = Some(first_upstream_stream);
             let mut total = Usage::default();
             let mut had_usage = false;
             let start = Instant::now();
@@ -59,12 +67,15 @@ impl ServerToolLoop {
             let mut consecutive_errors = 0u32;
 
             loop {
-                let mut upstream_stream = match upstream.run(&working).await {
-                    Ok(s) => s,
-                    Err(e) => {
-                        yield Err(e);
-                        return;
-                    }
+                let mut upstream_stream = match first_upstream_stream.take() {
+                    Some(stream) => stream,
+                    None => match upstream.run(&working).await {
+                        Ok(stream) => stream,
+                        Err(error) => {
+                            yield Err(error);
+                            return;
+                        }
+                    },
                 };
 
                 let mut buffered: Vec<BufferedCall> = Vec::new();
@@ -259,6 +270,7 @@ mod tests {
     use crate::language_model::types::{Tool, ToolResultOutput};
     use std::collections::VecDeque;
     use std::sync::Mutex;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     struct OneTool;
 
@@ -303,6 +315,41 @@ mod tests {
         }
     }
 
+    struct FailingStartStream;
+
+    #[async_trait]
+    impl UpstreamStream for FailingStartStream {
+        async fn run(&self, _prompt: &Prompt) -> Result<StreamPartStream> {
+            Err(crate::error::BitrouterError::UpstreamRateLimited {
+                retry_after: Some(9),
+            })
+        }
+    }
+
+    struct FailingSecondTurnStream {
+        calls: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl UpstreamStream for FailingSecondTurnStream {
+        async fn run(&self, _prompt: &Prompt) -> Result<StreamPartStream> {
+            if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                let parts = vec![
+                    StreamPart::ToolCallDelta {
+                        id: "c1".into(),
+                        name: Some("search".into()),
+                        arguments: "{}".into(),
+                    },
+                    StreamPart::Finish {
+                        reason: FinishReason::ToolCalls,
+                    },
+                ];
+                return Ok(Box::pin(futures::stream::iter(parts.into_iter().map(Ok))));
+            }
+            Err(crate::error::BitrouterError::UpstreamTimeout)
+        }
+    }
+
     fn loop_() -> Arc<ServerToolLoop> {
         Arc::new(ServerToolLoop::new(
             ToolsetRegistry::new(vec![Arc::new(OneTool)]),
@@ -336,6 +383,53 @@ mod tests {
             out.push(item.unwrap());
         }
         out
+    }
+
+    #[tokio::test]
+    async fn first_upstream_failure_is_returned_before_stream_start() {
+        let result = loop_()
+            .run_stream(&base_prompt(), &tool_ctx(), Arc::new(FailingStartStream))
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(crate::error::BitrouterError::UpstreamRateLimited {
+                retry_after: Some(9)
+            })
+        ));
+    }
+
+    #[tokio::test]
+    async fn later_turn_failure_remains_an_in_stream_error() {
+        let result = loop_()
+            .run_stream(
+                &base_prompt(),
+                &tool_ctx(),
+                Arc::new(FailingSecondTurnStream {
+                    calls: AtomicUsize::new(0),
+                }),
+            )
+            .await;
+        assert!(
+            result.is_ok(),
+            "first turn unexpectedly failed: {:?}",
+            result.as_ref().err()
+        );
+        let Ok(mut stream) = result else {
+            return;
+        };
+        let mut terminal_error = None;
+        while let Some(item) = stream.next().await {
+            if let Err(error) = item {
+                terminal_error = Some(error);
+                break;
+            }
+        }
+
+        assert!(matches!(
+            terminal_error,
+            Some(crate::error::BitrouterError::UpstreamTimeout)
+        ));
     }
 
     #[tokio::test]

--- a/crates/bitrouter-sdk/src/language_model/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/tests.rs
@@ -143,6 +143,46 @@ impl SettlementRecorder for SettlementSnapshotRecorder {
     }
 }
 
+struct ProviderCapturingRecorder(Arc<std::sync::Mutex<Vec<(String, String)>>>);
+
+#[async_trait]
+impl SettlementRecorder for ProviderCapturingRecorder {
+    async fn record(&self, ctx: &mut SettlementContext) -> Result<()> {
+        let value = (ctx.provider_id.clone(), ctx.model_id.clone());
+        match self.0.lock() {
+            Ok(mut captured) => captured.push(value),
+            Err(poisoned) => poisoned.into_inner().push(value),
+        }
+        Ok(())
+    }
+}
+
+struct ContextCheckingExecutionHook {
+    expected_request_id: String,
+    seen: Arc<std::sync::Mutex<Vec<bool>>>,
+}
+
+#[async_trait]
+impl ExecutionHook for ContextCheckingExecutionHook {
+    async fn on_success(&self, _ctx: &PipelineContext, _result: &ExecutionResult) -> Result<()> {
+        Ok(())
+    }
+
+    async fn on_failure(&self, ctx: &PipelineContext, _error: &BitrouterError) -> FallbackDecision {
+        let context_preserved = ctx.request_id() == self.expected_request_id
+            && ctx
+                .headers()
+                .get("x-test-context")
+                .is_some_and(|value| value == "preserved")
+            && ctx.has_event::<TestRouteEvent>();
+        match self.seen.lock() {
+            Ok(mut seen) => seen.push(context_preserved),
+            Err(poisoned) => poisoned.into_inner().push(context_preserved),
+        }
+        FallbackDecision::TryNext
+    }
+}
+
 struct StreamErrorExecutor {
     error: BitrouterError,
 }
@@ -1328,6 +1368,242 @@ async fn nonstream_disconnect_still_runs_to_completion_and_bills_full() {
 }
 
 // ===== server-side tool loop wiring =====
+
+fn empty_server_tool_loop() -> Arc<server_tools::loop_controller::ServerToolLoop> {
+    Arc::new(server_tools::loop_controller::ServerToolLoop::new(
+        server_tools::toolset::ToolsetRegistry::new(Vec::new()),
+        server_tools::config::ServerToolLoopConfig::default(),
+        Arc::new(server_tools::approval::AllowAll),
+    ))
+}
+
+struct SearchTool;
+
+#[async_trait]
+impl server_tools::toolset::RouterToolset for SearchTool {
+    async fn list_tools(&self, _ctx: &server_tools::toolset::ToolContext) -> Result<Vec<Tool>> {
+        Ok(vec![Tool::Function {
+            name: "search".into(),
+            description: None,
+            parameters: serde_json::json!({"type": "object"}),
+            strict: None,
+            provider_metadata: Default::default(),
+        }])
+    }
+
+    async fn call_tool(
+        &self,
+        _name: &str,
+        _arguments: &str,
+        _ctx: &server_tools::toolset::ToolContext,
+    ) -> Result<ToolResultOutput> {
+        Ok(ToolResultOutput::Text {
+            value: "result".into(),
+        })
+    }
+
+    fn owns(&self, name: &str) -> bool {
+        name == "search"
+    }
+}
+
+fn search_server_tool_loop() -> Arc<server_tools::loop_controller::ServerToolLoop> {
+    Arc::new(server_tools::loop_controller::ServerToolLoop::new(
+        server_tools::toolset::ToolsetRegistry::new(vec![Arc::new(SearchTool)]),
+        server_tools::config::ServerToolLoopConfig::default(),
+        Arc::new(server_tools::approval::AllowAll),
+    ))
+}
+
+#[tokio::test]
+async fn server_tool_streaming_preflight_respects_fail_decision() {
+    let pipeline = pipeline_with(
+        routing_table(&["a-provider", "b-provider"]),
+        Arc::new(MockExecutor::new(vec![
+            MockResponse::Error(BitrouterError::bad_request("invalid request")),
+            MockResponse::Stream(vec![StreamPart::Finish {
+                reason: FinishReason::Stop,
+            }]),
+        ])),
+        |builder| {
+            builder.server_tool_loop(empty_server_tool_loop());
+        },
+    );
+
+    let result = pipeline.execute_stream(stream_request()).await;
+    assert!(matches!(result, Err(BitrouterError::BadRequest { .. })));
+}
+
+#[tokio::test]
+async fn server_tool_streaming_preflight_aggregates_rate_limits() {
+    let pipeline = pipeline_with(
+        routing_table(&["a-provider", "b-provider"]),
+        Arc::new(MockExecutor::new(vec![
+            MockResponse::Error(BitrouterError::UpstreamRateLimited {
+                retry_after: Some(12),
+            }),
+            MockResponse::Error(BitrouterError::UpstreamRateLimited {
+                retry_after: Some(30),
+            }),
+        ])),
+        |builder| {
+            builder.server_tool_loop(empty_server_tool_loop());
+        },
+    );
+
+    let result = pipeline.execute_stream(stream_request()).await;
+    assert!(matches!(
+        result,
+        Err(BitrouterError::UpstreamRateLimited {
+            retry_after: Some(12)
+        })
+    ));
+}
+
+#[tokio::test]
+async fn server_tool_streaming_preflight_aggregates_mixed_availability_failures() {
+    let pipeline = pipeline_with(
+        routing_table(&["a-provider", "b-provider"]),
+        Arc::new(MockExecutor::new(vec![
+            MockResponse::Error(BitrouterError::UpstreamRateLimited {
+                retry_after: Some(12),
+            }),
+            MockResponse::Error(BitrouterError::Upstream {
+                status: 503,
+                message: "maintenance".into(),
+            }),
+        ])),
+        |builder| {
+            builder.server_tool_loop(empty_server_tool_loop());
+        },
+    );
+
+    let result = pipeline.execute_stream(stream_request()).await;
+    assert!(matches!(result, Err(BitrouterError::UpstreamUnavailable)));
+}
+
+#[tokio::test]
+async fn server_tool_streaming_fallback_settles_the_winning_target()
+-> std::result::Result<(), Box<dyn std::error::Error>> {
+    let captured = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let pipeline = pipeline_with(
+        routing_table(&["a-provider", "b-provider"]),
+        Arc::new(MockExecutor::new(vec![
+            MockResponse::Error(BitrouterError::UpstreamRateLimited {
+                retry_after: Some(12),
+            }),
+            MockResponse::Stream(vec![StreamPart::Finish {
+                reason: FinishReason::Stop,
+            }]),
+        ])),
+        |builder| {
+            builder
+                .server_tool_loop(empty_server_tool_loop())
+                .settlement_recorder(ProviderCapturingRecorder(captured.clone()));
+        },
+    );
+
+    let stream = pipeline.execute_stream(stream_request()).await?;
+    let parts = collect_stream(stream).await;
+    assert!(parts.into_iter().all(|part| part.is_ok()));
+    let captured = match captured.lock() {
+        Ok(captured) => captured.clone(),
+        Err(poisoned) => poisoned.into_inner().clone(),
+    };
+    assert_eq!(
+        captured.as_slice(),
+        &[("b-provider".to_string(), "test-model".to_string())]
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn server_tool_streaming_fallback_preserves_request_context()
+-> std::result::Result<(), Box<dyn std::error::Error>> {
+    let seen = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let request_id = "stable-request-id".to_string();
+    let pipeline = pipeline_with(
+        routing_table(&["a-provider", "b-provider"]),
+        Arc::new(MockExecutor::new(vec![
+            MockResponse::Error(BitrouterError::UpstreamRateLimited {
+                retry_after: Some(12),
+            }),
+            MockResponse::Stream(vec![StreamPart::Finish {
+                reason: FinishReason::Stop,
+            }]),
+        ])),
+        |builder| {
+            builder
+                .route_hook(EmitRouteHook)
+                .execution_hook(ContextCheckingExecutionHook {
+                    expected_request_id: request_id.clone(),
+                    seen: seen.clone(),
+                })
+                .server_tool_loop(empty_server_tool_loop());
+        },
+    );
+    let mut request = stream_request();
+    request.request_id = request_id;
+    request.headers.insert(
+        "x-test-context",
+        http::HeaderValue::from_static("preserved"),
+    );
+
+    let stream = pipeline.execute_stream(request).await?;
+    let parts = collect_stream(stream).await;
+    assert!(parts.into_iter().all(|part| part.is_ok()));
+    let seen = match seen.lock() {
+        Ok(seen) => seen.clone(),
+        Err(poisoned) => poisoned.into_inner().clone(),
+    };
+    assert_eq!(seen.as_slice(), &[true]);
+    Ok(())
+}
+
+#[tokio::test]
+async fn server_tool_streaming_settles_the_final_turn_winner()
+-> std::result::Result<(), Box<dyn std::error::Error>> {
+    let captured = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let pipeline = pipeline_with(
+        routing_table(&["a-provider", "b-provider"]),
+        Arc::new(MockExecutor::new(vec![
+            MockResponse::Stream(vec![
+                StreamPart::ToolCallDelta {
+                    id: "c1".into(),
+                    name: Some("search".into()),
+                    arguments: "{}".into(),
+                },
+                StreamPart::Finish {
+                    reason: FinishReason::ToolCalls,
+                },
+            ]),
+            MockResponse::Error(BitrouterError::UpstreamRateLimited {
+                retry_after: Some(12),
+            }),
+            MockResponse::Stream(vec![StreamPart::Finish {
+                reason: FinishReason::Stop,
+            }]),
+        ])),
+        |builder| {
+            builder
+                .server_tool_loop(search_server_tool_loop())
+                .settlement_recorder(ProviderCapturingRecorder(captured.clone()));
+        },
+    );
+
+    let stream = pipeline.execute_stream(stream_request()).await?;
+    let parts = collect_stream(stream).await;
+    assert!(parts.into_iter().all(|part| part.is_ok()));
+    let captured = match captured.lock() {
+        Ok(captured) => captured.clone(),
+        Err(poisoned) => poisoned.into_inner().clone(),
+    };
+    assert_eq!(
+        captured.as_slice(),
+        &[("b-provider".to_string(), "test-model".to_string())]
+    );
+    Ok(())
+}
 
 fn router_tool_call() -> Content {
     Content::ToolCall {

--- a/crates/bitrouter-sdk/src/mcp/rmcp_executor.rs
+++ b/crates/bitrouter-sdk/src/mcp/rmcp_executor.rs
@@ -29,7 +29,6 @@ use rmcp::model::{
 };
 use rmcp::service::{
     NotificationContext, Peer, PeerRequestOptions, RequestContext, RoleClient, RunningService,
-    ServiceError,
 };
 use tokio::sync::{Mutex, broadcast};
 
@@ -443,8 +442,16 @@ impl Executor for RmcpExecutor {
             return Ok(stream::once(async move { Ok(McpStreamPart::Final(response)) }).boxed());
         }
         let (server_name, transport) = direct_target(target)?;
+        let call_params: CallToolRequestParams = serde_json::from_value(request.params.clone())
+            .map_err(|error| bad_params(server_name, "tools/call", error))?;
         let conn = self.connection_for(server_name, transport).await?;
-        Ok(stream_tools_call(conn, server_name.to_string(), request.clone()).boxed())
+        Ok(stream_tools_call(
+            conn,
+            server_name.to_string(),
+            request.request_id.clone(),
+            call_params,
+        )
+        .boxed())
     }
 }
 
@@ -470,41 +477,35 @@ fn direct_target(target: &McpTarget) -> Result<(&str, &McpTransport)> {
 /// request hits the wire. We use `send_cancellable_request` instead so the
 /// returned `RequestHandle` tells us the token rmcp actually chose, then
 /// subscribe to it on the [`ProgressDispatcher`] before awaiting the response.
+/// Parameter validation and connection setup happen before this stream is
+/// returned; the JSON-RPC call itself starts on first poll so dropping an
+/// unconsumed downstream response never leaves a detached upstream call.
 fn stream_tools_call(
     conn: PooledConnection,
     server_name: String,
-    request: McpRequest,
+    request_id: String,
+    call_params: CallToolRequestParams,
 ) -> impl futures::Stream<Item = Result<McpStreamPart>> + Send + 'static {
     async_stream::stream! {
-        let call_params: CallToolRequestParams =
-            match serde_json::from_value(request.params.clone()) {
-                Ok(p) => p,
-                Err(e) => {
-                    yield Err(bad_params(&server_name, "tools/call", e));
-                    return;
-                }
-            };
         let call_request = ClientRequest::CallToolRequest(CallToolRequest::new(call_params));
-
         let peer = conn.service.peer().clone();
         let handle = match peer
             .send_cancellable_request(call_request, PeerRequestOptions::no_options())
             .await
         {
-            Ok(h) => h,
-            Err(e) => {
-                yield Err(upstream(&server_name, format!("tools/call: {e}")));
+            Ok(handle) => handle,
+            Err(error) => {
+                yield Err(map_service_error(&server_name, "tools/call", error));
                 return;
             }
         };
         let mut subscriber = Some(conn.progress.subscribe(handle.progress_token.clone()).await);
-        let request_id = request.request_id.clone();
         let server = server_name.clone();
         let call_fut = async move {
-            handle.await_response().await.map_err(|e| match e {
-                ServiceError::McpError(err) => upstream(&server, format!("tools/call: {err}")),
-                other => upstream(&server, format!("tools/call: {other}")),
-            })
+            handle
+                .await_response()
+                .await
+                .map_err(|error| map_service_error(&server, "tools/call", error))
         };
         tokio::pin!(call_fut);
 
@@ -657,6 +658,28 @@ mod tests {
     #[test]
     fn executor_constructs_with_empty_pool() {
         let _ = RmcpExecutor::new();
+    }
+
+    #[tokio::test]
+    async fn streaming_tools_call_validates_params_before_connecting() {
+        let exec = RmcpExecutor::new();
+        let target = McpTarget::Direct {
+            server_name: "ghost".into(),
+            transport: McpTransport::Stdio {
+                command: "/bin/false".into(),
+                args: vec![],
+                env: HashMap::new(),
+            },
+        };
+        let request = McpRequest::direct(
+            "ghost",
+            "tools/call",
+            serde_json::json!({"arguments": {}}),
+            CallerContext::new("k", "u"),
+        );
+
+        let result = exec.execute_streaming(&target, &request).await;
+        assert!(matches!(result, Err(BitrouterError::BadRequest { .. })));
     }
 
     /// `/bin/false` exits immediately with status 1 — rmcp's `serve()` sees

--- a/crates/bitrouter-sdk/src/server.rs
+++ b/crates/bitrouter-sdk/src/server.rs
@@ -399,23 +399,26 @@ async fn mcp_invoke_inner(
 /// proxies still surface them — but the body remains a JSON-RPC error object
 /// for the spec-aware client.
 fn mcp_pipeline_error_response(inbound_id: serde_json::Value, e: &BitrouterError) -> Response {
-    let (status, code) = match e {
-        BitrouterError::NotFound(_) => (axum::http::StatusCode::NOT_FOUND, -32601),
-        BitrouterError::BadRequest { .. } => (axum::http::StatusCode::BAD_REQUEST, -32602),
-        BitrouterError::Unauthorized(_) => (axum::http::StatusCode::UNAUTHORIZED, -32000),
-        BitrouterError::Forbidden(_) => (axum::http::StatusCode::FORBIDDEN, -32000),
-        BitrouterError::PaymentRequired(_) => (axum::http::StatusCode::PAYMENT_REQUIRED, -32000),
-        _ => (axum::http::StatusCode::INTERNAL_SERVER_ERROR, -32603),
+    let status = StatusCode::from_u16(e.status()).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+    let code = match e {
+        BitrouterError::NotFound(_) => -32601,
+        BitrouterError::BadRequest { .. } => -32602,
+        BitrouterError::Unauthorized(_)
+        | BitrouterError::Forbidden(_)
+        | BitrouterError::PaymentRequired(_) => -32000,
+        _ => -32603,
     };
-    (
+    let mut response = (
         status,
         Json(serde_json::json!({
             "jsonrpc": "2.0",
             "id": inbound_id,
-            "error": { "code": code, "message": e.to_string() },
+            "error": { "code": code, "message": e.public_message() },
         })),
     )
-        .into_response()
+        .into_response();
+    apply_error_headers(&mut response, e);
+    response
 }
 
 /// True if the client opted into the SSE response variant.
@@ -477,7 +480,7 @@ fn sse_response(
                 let payload = serde_json::json!({
                     "jsonrpc": "2.0",
                     "id": &*inbound_id,
-                    "error": { "code": -32603, "message": e.to_string() },
+                    "error": { "code": -32603, "message": e.public_message() },
                 });
                 Ok(Event::default().data(payload.to_string()))
             }
@@ -794,48 +797,62 @@ impl IntoResponse for BitrouterError {
         // well-behaved API consumers expect. RFC 7235 §4.1 for
         // WWW-Authenticate, RFC 7231 §7.1.3 for Retry-After.
         let mut response = (status, body).into_response();
-        match &self {
-            BitrouterError::Unauthorized(_) => {
-                // RFC 7235 §3.1: a 401 MUST include a `WWW-Authenticate`
-                // header field containing at least one challenge applicable
-                // to the resource. BitRouter's primary credential is a virtual
-                // API key (`Authorization: Bearer <brvk_...>`).
-                if let Ok(v) = header::HeaderValue::from_str("Bearer realm=\"bitrouter\"") {
-                    response.headers_mut().insert(header::WWW_AUTHENTICATE, v);
-                }
-            }
-            BitrouterError::PaymentRequired(_) => {
-                // 402 + WWW-Authenticate: our scheme name (`Bitrouter-MPP`)
-                // and params predate the mpp.dev finalised wire format and
-                // remain compatible with v0 clients ( will revisit
-                // alignment with <https://mpp.dev/protocol/http-402>).
-                if let Ok(v) = header::HeaderValue::from_str(
-                    "Bitrouter-MPP realm=\"bitrouter\", scheme=\"tempo-voucher\"",
-                ) {
-                    response.headers_mut().insert(header::WWW_AUTHENTICATE, v);
-                }
-            }
-            BitrouterError::RateLimited {
-                retry_after: Some(secs),
-            } => {
-                if let Ok(v) = header::HeaderValue::from_str(&secs.to_string()) {
-                    response.headers_mut().insert(header::RETRY_AFTER, v);
-                }
-            }
-            BitrouterError::UpstreamRateLimited { retry_after } => {
-                if let Some(secs) = retry_after
-                    && let Ok(v) = header::HeaderValue::from_str(&secs.to_string())
-                {
-                    response.headers_mut().insert(header::RETRY_AFTER, v);
-                }
-                response.headers_mut().insert(
-                    header::HeaderName::from_static("x-bitrouter-error-source"),
-                    header::HeaderValue::from_static("upstream"),
-                );
-            }
-            _ => {}
-        }
+        apply_error_headers(&mut response, &self);
         response
+    }
+}
+
+fn apply_error_headers(response: &mut Response, error: &BitrouterError) {
+    match error {
+        BitrouterError::Unauthorized(_) => {
+            // RFC 7235 §3.1: a 401 MUST include a `WWW-Authenticate`
+            // header field containing at least one challenge applicable
+            // to the resource. BitRouter's primary credential is a virtual
+            // API key (`Authorization: Bearer <brvk_...>`).
+            if let Ok(v) = header::HeaderValue::from_str("Bearer realm=\"bitrouter\"") {
+                response.headers_mut().insert(header::WWW_AUTHENTICATE, v);
+            }
+        }
+        BitrouterError::PaymentRequired(_) => {
+            // 402 + WWW-Authenticate: our scheme name (`Bitrouter-MPP`)
+            // and params predate the mpp.dev finalised wire format and
+            // remain compatible with v0 clients ( will revisit
+            // alignment with <https://mpp.dev/protocol/http-402>).
+            if let Ok(v) = header::HeaderValue::from_str(
+                "Bitrouter-MPP realm=\"bitrouter\", scheme=\"tempo-voucher\"",
+            ) {
+                response.headers_mut().insert(header::WWW_AUTHENTICATE, v);
+            }
+        }
+        BitrouterError::UpstreamAuth {
+            www_authenticate: Some(challenge),
+            ..
+        } => {
+            if let Ok(value) = header::HeaderValue::from_str(challenge) {
+                response
+                    .headers_mut()
+                    .insert(header::WWW_AUTHENTICATE, value);
+            }
+        }
+        BitrouterError::RateLimited {
+            retry_after: Some(secs),
+        } => {
+            if let Ok(v) = header::HeaderValue::from_str(&secs.to_string()) {
+                response.headers_mut().insert(header::RETRY_AFTER, v);
+            }
+        }
+        BitrouterError::UpstreamRateLimited { retry_after } => {
+            if let Some(secs) = retry_after
+                && let Ok(v) = header::HeaderValue::from_str(&secs.to_string())
+            {
+                response.headers_mut().insert(header::RETRY_AFTER, v);
+            }
+            response.headers_mut().insert(
+                header::HeaderName::from_static("x-bitrouter-error-source"),
+                header::HeaderValue::from_static("upstream"),
+            );
+        }
+        _ => {}
     }
 }
 
@@ -855,6 +872,13 @@ mod tests {
     }
 
     fn test_state_with_executor(executor: Arc<dyn Executor>) -> AppState {
+        test_state_with_executor_and_server_tools(executor, false)
+    }
+
+    fn test_state_with_executor_and_server_tools(
+        executor: Arc<dyn Executor>,
+        enable_server_tools: bool,
+    ) -> AppState {
         let table = StaticRoutingTable::new();
         table.insert(
             "gpt-5.5",
@@ -873,6 +897,15 @@ mod tests {
         );
         let mut builder = PipelineBuilder::new();
         builder.routing_table(Arc::new(table)).executor(executor);
+        if enable_server_tools {
+            builder.server_tool_loop(Arc::new(
+                crate::language_model::server_tools::loop_controller::ServerToolLoop::new(
+                    crate::language_model::server_tools::toolset::ToolsetRegistry::new(Vec::new()),
+                    crate::language_model::server_tools::config::ServerToolLoopConfig::default(),
+                    Arc::new(crate::language_model::server_tools::approval::AllowAll),
+                ),
+            ));
+        }
         let pipeline = builder.build().unwrap();
         AppState {
             language_model: Arc::new(pipeline),
@@ -947,6 +980,101 @@ mod tests {
         assert_eq!(body["error"]["message"], "upstream request failed");
         assert_eq!(body["error"]["code"], "upstream_bad_gateway");
         assert!(!String::from_utf8_lossy(&bytes).contains("secret"));
+    }
+
+    #[tokio::test]
+    async fn mcp_preflight_rate_limit_keeps_status_headers_and_safe_message()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let response = mcp_pipeline_error_response(
+            serde_json::json!(7),
+            &BitrouterError::UpstreamRateLimited {
+                retry_after: Some(12),
+            },
+        );
+
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(response.headers()[header::RETRY_AFTER], "12");
+        assert_eq!(response.headers()["x-bitrouter-error-source"], "upstream");
+        let bytes = to_bytes(response.into_body(), 64 * 1024).await?;
+        let value: serde_json::Value = serde_json::from_slice(&bytes)?;
+        assert_eq!(value["error"]["message"], "upstream rate limited");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn mcp_preflight_upstream_diagnostics_are_not_exposed()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let response = mcp_pipeline_error_response(
+            serde_json::json!(7),
+            &BitrouterError::Upstream {
+                status: 502,
+                message: "provider secret stack trace".into(),
+            },
+        );
+
+        assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+        let bytes = to_bytes(response.into_body(), 64 * 1024).await?;
+        let value: serde_json::Value = serde_json::from_slice(&bytes)?;
+        assert_eq!(value["error"]["message"], "upstream request failed");
+        assert!(!String::from_utf8_lossy(&bytes).contains("secret"));
+        Ok(())
+    }
+
+    #[test]
+    fn mcp_preflight_upstream_auth_preserves_valid_challenges() {
+        for status in [401, 403] {
+            let response = mcp_pipeline_error_response(
+                serde_json::json!(7),
+                &BitrouterError::UpstreamAuth {
+                    status,
+                    www_authenticate: Some(
+                        "Bearer realm=\"upstream\", scope=\"files:read\"".into(),
+                    ),
+                    required_scope: Some("files:read".into()),
+                },
+            );
+
+            assert_eq!(response.status().as_u16(), status);
+            assert_eq!(
+                response.headers()[header::WWW_AUTHENTICATE],
+                "Bearer realm=\"upstream\", scope=\"files:read\""
+            );
+        }
+    }
+
+    #[test]
+    fn mcp_preflight_upstream_auth_omits_malformed_challenge() {
+        let response = mcp_pipeline_error_response(
+            serde_json::json!(7),
+            &BitrouterError::UpstreamAuth {
+                status: 401,
+                www_authenticate: Some("Bearer\nsecret".into()),
+                required_scope: None,
+            },
+        );
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        assert!(response.headers().get(header::WWW_AUTHENTICATE).is_none());
+    }
+
+    #[tokio::test]
+    async fn mcp_midstream_upstream_diagnostics_are_not_exposed()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let stream = futures::stream::once(async {
+            Err(BitrouterError::Upstream {
+                status: 502,
+                message: "provider secret stack trace".into(),
+            })
+        })
+        .boxed();
+        let response = sse_response(serde_json::json!(7), stream);
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = to_bytes(response.into_body(), 64 * 1024).await?;
+        let body = String::from_utf8_lossy(&bytes);
+        assert!(body.contains("upstream request failed"));
+        assert!(!body.contains("secret"));
+        Ok(())
     }
 
     #[test]
@@ -1044,5 +1172,42 @@ mod tests {
             Some("text/event-stream")
         );
         assert_eq!(response.headers()[header::RETRY_AFTER], "7");
+    }
+
+    #[tokio::test]
+    async fn streaming_preflight_rate_limit_with_server_tools_keeps_http_429()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let state = test_state_with_executor_and_server_tools(
+            Arc::new(MockExecutor::new(vec![MockResponse::Error(
+                BitrouterError::UpstreamRateLimited {
+                    retry_after: Some(7),
+                },
+            )])),
+            true,
+        );
+        let request = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(
+                serde_json::json!({
+                    "model": "gpt-5.5",
+                    "messages": [{"role": "user", "content": "ping"}],
+                    "stream": true
+                })
+                .to_string(),
+            ))?;
+        let response = build_router(state).oneshot(request).await?;
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_ne!(
+            response
+                .headers()
+                .get(header::CONTENT_TYPE)
+                .and_then(|value| value.to_str().ok()),
+            Some("text/event-stream")
+        );
+        assert_eq!(response.headers()[header::RETRY_AFTER], "7");
+        assert_eq!(response.headers()["x-bitrouter-error-source"], "upstream");
+        Ok(())
     }
 }


### PR DESCRIPTION
## Summary

- eagerly open the first language-model stream when server tools are enabled so preflight upstream failures retain their HTTP status
- reuse the canonical fallback path for every server-tool turn while preserving request context and settling usage against the actual winning provider
- align MCP preflight errors with the public error contract, including safe messages, `Retry-After`, and valid upstream authentication challenges
- add regression coverage for upstream 429 aggregation, mixed failures, fallback winner attribution, context preservation, disconnect settlement, and MCP error handling

## Behavior

- an upstream 429 before the first streaming response now returns HTTP 429 JSON with the appropriate public headers instead of HTTP 200 plus an SSE error frame
- failures after streaming has begun remain protocol error frames because the HTTP response has already started
- fallback decisions and hooks are identical between direct streaming and server-tool streaming, and settlement records the final successful serving target
- MCP validates deterministic request parameters and connection setup before streaming; execution-time failures remain safe in-stream JSON-RPC frames by contract

## Scope

- OSS SDK code and tests only
- no registry or bitrouter-cloud configuration changes

## Verification

- `cargo nextest run --all-features` — 1421 passed, 3 skipped
- `cargo clippy --all-features -- -D warnings`
- `cargo fmt -- --check`
- independent code review: no Critical or Important findings
