### PR TITLE
fix: record canonical stream timing and OTEL latency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -718,6 +718,7 @@ dependencies = [
  "bytes",
  "criterion",
  "dashmap",
+ "futures",
  "http",
  "opentelemetry",
  "opentelemetry-http",

--- a/apps/bitrouter/src/metering/tests.rs
+++ b/apps/bitrouter/src/metering/tests.rs
@@ -37,6 +37,8 @@ fn ctx(api_key: &str, prompt: u64, completion: u64) -> SettlementContext {
         streamed: false,
         latency_ms: 100,
         generation_time_ms: 80,
+        first_token_latency_ms: None,
+        first_token_kind: None,
         error: None,
         events: bitrouter_sdk::EventBus::new(),
     }

--- a/crates/bitrouter-sdk/src/language_model/context.rs
+++ b/crates/bitrouter-sdk/src/language_model/context.rs
@@ -69,6 +69,7 @@ pub struct PipelineContext {
     /// a native, same-protocol upstream. `None` when the request was built
     /// without a known inbound protocol.
     inbound_protocol: Option<ApiProtocol>,
+    request_started_at: Instant,
 
     // ===== accumulated: written per stage, readable downstream =====
     /// The resolved fallback chain (Stage 2).
@@ -78,6 +79,7 @@ pub struct PipelineContext {
     pub execution_result: Option<ExecutionResult>,
     stream_provider_started_at: Option<Instant>,
     first_token_timing: Option<FirstTokenTiming>,
+    finalized_request_latency_ms: Option<u64>,
 
     // ===== plugin extension data =====
     metadata: HashMap<PluginId, serde_json::Value>,
@@ -112,10 +114,12 @@ impl PipelineContext {
             headers: req.headers,
             prompt: req.prompt,
             inbound_protocol: req.inbound_protocol,
+            request_started_at: Instant::now(),
             route_chain: None,
             execution_result: None,
             stream_provider_started_at: None,
             first_token_timing: None,
+            finalized_request_latency_ms: None,
             metadata: HashMap::new(),
             extensions: Extensions::default(),
             events: EventBus::new(),
@@ -135,10 +139,12 @@ impl PipelineContext {
             headers: self.headers.clone(),
             prompt,
             inbound_protocol: self.inbound_protocol.clone(),
+            request_started_at: self.request_started_at,
             route_chain: self.route_chain.clone(),
             execution_result: None,
             stream_provider_started_at: None,
             first_token_timing: None,
+            finalized_request_latency_ms: None,
             metadata: self.metadata.clone(),
             extensions: self.extensions.clone(),
             events: self.events.clone(),
@@ -165,9 +171,42 @@ impl PipelineContext {
         self.stream_provider_started_at = Some(started_at);
     }
 
+    pub(crate) fn finalize_request_latency(&mut self) {
+        let latency_ms = elapsed_millis(self.request_started_at);
+        self.finalized_request_latency_ms = Some(latency_ms);
+        if let Some(result) = self.execution_result.as_mut() {
+            result.latency_ms = latency_ms;
+        }
+    }
+
+    pub(crate) fn finalize_stream_generation_time(&mut self) {
+        let Some(provider_started_at) = self.stream_provider_started_at else {
+            return;
+        };
+        if let Some(result) = self.execution_result.as_mut() {
+            result.generation_time_ms = elapsed_millis(provider_started_at);
+        }
+    }
+
     /// The first semantic output timing captured for a streamed request.
     pub fn first_token_timing(&self) -> Option<FirstTokenTiming> {
         self.first_token_timing
+    }
+
+    fn execution_target(&self) -> Option<RoutingTarget> {
+        let chain = self.route_chain.as_ref()?;
+        let Some(result) = self.execution_result.as_ref() else {
+            return chain.first().cloned();
+        };
+        chain
+            .iter()
+            .find(|target| {
+                target.provider_name == result.provider_id
+                    && target.service_id == result.model_id
+                    && target.account_label == result.account_label
+            })
+            .cloned()
+            .or_else(|| chain.first().cloned())
     }
 
     /// Store outbound HTTP headers for the next upstream request. The
@@ -413,7 +452,10 @@ impl PipelineContext {
                 .map(|e| e.server_tool_calls.clone())
                 .unwrap_or_default(),
             streamed: false,
-            latency_ms: exec.map(|e| e.latency_ms).unwrap_or(0),
+            latency_ms: self
+                .finalized_request_latency_ms
+                .or_else(|| exec.map(|e| e.latency_ms))
+                .unwrap_or(0),
             generation_time_ms: exec.map(|e| e.generation_time_ms).unwrap_or(0),
             first_token_latency_ms: self.first_token_timing.map(|timing| timing.latency_ms),
             first_token_kind: self.first_token_timing.map(|timing| timing.kind),

--- a/crates/bitrouter-sdk/src/language_model/context.rs
+++ b/crates/bitrouter-sdk/src/language_model/context.rs
@@ -6,14 +6,16 @@
 use std::any::{Any, TypeId};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
+use std::time::Instant;
 
 use crate::caller::CallerContext;
 use crate::event::{EventBus, PipelineEvent};
 use crate::language_model::settlement::SettlementContext;
 use crate::language_model::stream::UsageAccumulator;
+use crate::language_model::timing::{FirstTokenKind, FirstTokenTiming, elapsed_millis};
 use crate::language_model::types::{
     ApiProtocol, Content, ExecutionResult, PipelineRequest, PipelineResponse, Prompt,
-    RoutingTarget, Usage,
+    RoutingTarget, StreamPart, Usage,
 };
 use crate::plugin::PluginId;
 
@@ -74,6 +76,8 @@ pub struct PipelineContext {
     /// The execution result (Stage 3). Stored here rather than moved out so
     /// Settlement can borrow it without an ownership fight.
     pub execution_result: Option<ExecutionResult>,
+    stream_provider_started_at: Option<Instant>,
+    first_token_timing: Option<FirstTokenTiming>,
 
     // ===== plugin extension data =====
     metadata: HashMap<PluginId, serde_json::Value>,
@@ -110,6 +114,8 @@ impl PipelineContext {
             inbound_protocol: req.inbound_protocol,
             route_chain: None,
             execution_result: None,
+            stream_provider_started_at: None,
+            first_token_timing: None,
             metadata: HashMap::new(),
             extensions: Extensions::default(),
             events: EventBus::new(),
@@ -131,6 +137,8 @@ impl PipelineContext {
             inbound_protocol: self.inbound_protocol.clone(),
             route_chain: self.route_chain.clone(),
             execution_result: None,
+            stream_provider_started_at: None,
+            first_token_timing: None,
             metadata: self.metadata.clone(),
             extensions: self.extensions.clone(),
             events: self.events.clone(),
@@ -151,6 +159,15 @@ impl PipelineContext {
             })
             .or_else(|| chain.first())
             .cloned()
+    }
+
+    pub(crate) fn set_stream_provider_started_at(&mut self, started_at: Instant) {
+        self.stream_provider_started_at = Some(started_at);
+    }
+
+    /// The first semantic output timing captured for a streamed request.
+    pub fn first_token_timing(&self) -> Option<FirstTokenTiming> {
+        self.first_token_timing
     }
 
     /// Store outbound HTTP headers for the next upstream request. The
@@ -342,6 +359,8 @@ impl PipelineContext {
             accumulated_usage: UsageAccumulator::with_prompt_chars(self.prompt_text_chars()),
             parts_emitted: 0,
             final_usage: None,
+            provider_started_at: self.stream_provider_started_at,
+            first_token_timing: self.first_token_timing,
             events: EventBus::new(),
             metadata: HashMap::new(),
             // Refcount-bump copy: a value a pre-request hook deposited (e.g. the
@@ -356,6 +375,7 @@ impl PipelineContext {
         if let (Some(exec), Some(usage)) = (self.execution_result.as_mut(), stream.final_usage) {
             exec.result.usage = Some(usage);
         }
+        self.first_token_timing = stream.first_token_timing;
         self.events.merge_from(stream.events);
     }
 
@@ -395,6 +415,8 @@ impl PipelineContext {
             streamed: false,
             latency_ms: exec.map(|e| e.latency_ms).unwrap_or(0),
             generation_time_ms: exec.map(|e| e.generation_time_ms).unwrap_or(0),
+            first_token_latency_ms: self.first_token_timing.map(|timing| timing.latency_ms),
+            first_token_kind: self.first_token_timing.map(|timing| timing.kind),
             error: None,
             events: std::mem::take(&mut self.events),
         }
@@ -440,12 +462,35 @@ pub struct StreamContext {
     pub parts_emitted: u64,
     /// Usage finalised at `on_stream_end`, folded back into `PipelineContext`.
     pub final_usage: Option<Usage>,
+    provider_started_at: Option<Instant>,
+    first_token_timing: Option<FirstTokenTiming>,
     events: EventBus,
     metadata: HashMap<PluginId, serde_json::Value>,
     extensions: Extensions,
 }
 
 impl StreamContext {
+    pub(crate) fn observe_first_token(&mut self, part: &StreamPart) {
+        if self.first_token_timing.is_some() {
+            return;
+        }
+        let Some(provider_started_at) = self.provider_started_at else {
+            return;
+        };
+        let Some(kind) = FirstTokenKind::from_part(part) else {
+            return;
+        };
+        self.first_token_timing = Some(FirstTokenTiming {
+            latency_ms: elapsed_millis(provider_started_at),
+            kind,
+        });
+    }
+
+    /// The first semantic output timing captured so far.
+    pub fn first_token_timing(&self) -> Option<FirstTokenTiming> {
+        self.first_token_timing
+    }
+
     /// Emit a typed event from within the StreamHook stage.
     pub fn emit<E: PipelineEvent>(&mut self, event: E) {
         self.events.emit(event);

--- a/crates/bitrouter-sdk/src/language_model/context.rs
+++ b/crates/bitrouter-sdk/src/language_model/context.rs
@@ -193,22 +193,6 @@ impl PipelineContext {
         self.first_token_timing
     }
 
-    fn execution_target(&self) -> Option<RoutingTarget> {
-        let chain = self.route_chain.as_ref()?;
-        let Some(result) = self.execution_result.as_ref() else {
-            return chain.first().cloned();
-        };
-        chain
-            .iter()
-            .find(|target| {
-                target.provider_name == result.provider_id
-                    && target.service_id == result.model_id
-                    && target.account_label == result.account_label
-            })
-            .cloned()
-            .or_else(|| chain.first().cloned())
-    }
-
     /// Store outbound HTTP headers for the next upstream request. The
     /// executor merges them into the request just before issuing it.
     /// Typically called by an `ObserveHook` from `on_hop_start` to inject

--- a/crates/bitrouter-sdk/src/language_model/context.rs
+++ b/crates/bitrouter-sdk/src/language_model/context.rs
@@ -179,6 +179,19 @@ impl PipelineContext {
         }
     }
 
+    /// End-to-end request time in milliseconds. Once settlement begins this is
+    /// the finalized value; before then it is the current elapsed duration.
+    pub fn request_latency_ms(&self) -> u64 {
+        self.finalized_request_latency_ms
+            .or_else(|| {
+                self.execution_result
+                    .as_ref()
+                    .map(|result| result.latency_ms)
+                    .filter(|latency| *latency > 0)
+            })
+            .unwrap_or_else(|| elapsed_millis(self.request_started_at))
+    }
+
     pub(crate) fn finalize_stream_generation_time(&mut self) {
         let Some(provider_started_at) = self.stream_provider_started_at else {
             return;
@@ -436,10 +449,7 @@ impl PipelineContext {
                 .map(|e| e.server_tool_calls.clone())
                 .unwrap_or_default(),
             streamed: false,
-            latency_ms: self
-                .finalized_request_latency_ms
-                .or_else(|| exec.map(|e| e.latency_ms))
-                .unwrap_or(0),
+            latency_ms: self.request_latency_ms(),
             generation_time_ms: exec.map(|e| e.generation_time_ms).unwrap_or(0),
             first_token_latency_ms: self.first_token_timing.map(|timing| timing.latency_ms),
             first_token_kind: self.first_token_timing.map(|timing| timing.kind),

--- a/crates/bitrouter-sdk/src/language_model/hooks.rs
+++ b/crates/bitrouter-sdk/src/language_model/hooks.rs
@@ -166,12 +166,29 @@ pub enum HopOutcome<'a> {
     Failed(&'a BitrouterError),
 }
 
+/// Terminal outcome of a streaming upstream response body.
+#[derive(Debug, Clone, Copy)]
+pub enum StreamHopOutcome<'a> {
+    /// The provider body reached EOF normally.
+    Completed,
+    /// The provider body yielded an error.
+    Failed(&'a BitrouterError),
+    /// The body was dropped before a terminal item/EOF was observed.
+    Dropped,
+}
+
 /// A cross-cutting, read-only observation hook. Invoked at every stage boundary
 /// (including the StreamHook stage). It returns no decision, cannot mutate data,
 /// and **errors / panics inside it never affect the request** — the pipeline
 /// swallows them.
 #[async_trait]
 pub trait ObserveHook: Send + Sync {
+    /// Called once when the pipeline accepts a request, before pre-request
+    /// checks run. Default: no-op.
+    async fn on_request_start(&self, _ctx: &PipelineContext) {
+        let _ = _ctx;
+    }
+
     /// Called after each non-streaming stage completes.
     async fn after_phase(&self, phase: Phase, ctx: &PipelineContext);
 
@@ -199,6 +216,18 @@ pub trait ObserveHook: Send + Sync {
         _outcome: HopOutcome<'_>,
     ) {
         let _ = (_ctx, _target, _outcome);
+    }
+
+    /// Called synchronously when a successfully opened provider stream body
+    /// ends. This boundary excludes later StreamHook and Settlement work.
+    fn on_stream_hop_end(
+        &self,
+        _request_id: &str,
+        _target: &RoutingTarget,
+        _outcome: StreamHopOutcome<'_>,
+        _duration_ms: u64,
+    ) {
+        let _ = (_request_id, _target, _outcome, _duration_ms);
     }
 
     /// Which stream part kinds this hook wants observed. Defaults to none.

--- a/crates/bitrouter-sdk/src/language_model/mod.rs
+++ b/crates/bitrouter-sdk/src/language_model/mod.rs
@@ -84,7 +84,7 @@ pub use executor::{
 };
 pub use hooks::{
     DenyReason, ExecutionHook, FallbackDecision, HookDecision, HopOutcome, ObserveHook, Phase,
-    PreRequestHook, RequestOutcome, RouteHook, StreamHook,
+    PreRequestHook, RequestOutcome, RouteHook, StreamHook, StreamHopOutcome,
 };
 pub use pipeline::{DEFAULT_KEEPALIVE, Pipeline};
 pub use protocol::{

--- a/crates/bitrouter-sdk/src/language_model/mod.rs
+++ b/crates/bitrouter-sdk/src/language_model/mod.rs
@@ -67,6 +67,7 @@ pub mod routing;
 pub mod server_tools;
 pub mod settlement;
 pub mod stream;
+pub mod timing;
 pub mod types;
 
 #[cfg(test)]

--- a/crates/bitrouter-sdk/src/language_model/pipeline.rs
+++ b/crates/bitrouter-sdk/src/language_model/pipeline.rs
@@ -3,7 +3,7 @@
 
 use std::pin::Pin;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use futures::{FutureExt, StreamExt};
@@ -29,6 +29,18 @@ use crate::language_model::types::{
 
 /// The default SSE keepalive interval.
 pub const DEFAULT_KEEPALIVE: Duration = Duration::from_secs(30);
+
+struct StreamingExecution {
+    stream: StreamPartStream,
+    target: RoutingTarget,
+    provider_started_at: Instant,
+}
+
+#[derive(Clone)]
+struct StreamAttempt {
+    target: RoutingTarget,
+    provider_started_at: Instant,
+}
 
 /// The `language_model` flight pipeline. Holds the registered hooks for every
 /// stage plus the routing table, fallback policy and executor. Built via
@@ -90,48 +102,54 @@ struct PipelineStreamUpstream {
     pipeline: Arc<Pipeline>,
     chain: Vec<RoutingTarget>,
     context: PipelineContext,
-    serving_target: SharedServingTarget,
+    latest_attempt: SharedStreamAttempt,
 }
 
 #[async_trait]
 impl UpstreamStream for PipelineStreamUpstream {
     async fn run(&self, prompt: &Prompt) -> Result<StreamPartStream> {
         let ctx = self.context.fork_for_prompt(prompt.clone());
-        let (target, stream) = self
+        let execution = self
             .pipeline
             .execute_stream_with_fallback(&self.chain, &ctx)
             .await?;
-        store_serving_target(&self.serving_target, target);
-        Ok(stream)
+        store_stream_attempt(
+            &self.latest_attempt,
+            StreamAttempt {
+                target: execution.target,
+                provider_started_at: execution.provider_started_at,
+            },
+        );
+        Ok(execution.stream)
     }
 }
 
-type SharedServingTarget = Arc<std::sync::Mutex<Option<RoutingTarget>>>;
+type SharedStreamAttempt = Arc<std::sync::Mutex<Option<StreamAttempt>>>;
 
-fn store_serving_target(slot: &SharedServingTarget, target: RoutingTarget) {
+fn store_stream_attempt(slot: &SharedStreamAttempt, attempt: StreamAttempt) {
     match slot.lock() {
-        Ok(mut current) => *current = Some(target),
-        Err(poisoned) => *poisoned.into_inner() = Some(target),
+        Ok(mut current) => *current = Some(attempt),
+        Err(poisoned) => *poisoned.into_inner() = Some(attempt),
     }
 }
 
-fn load_serving_target(slot: &SharedServingTarget) -> Option<RoutingTarget> {
+fn load_stream_attempt(slot: &SharedStreamAttempt) -> Option<StreamAttempt> {
     match slot.lock() {
         Ok(current) => current.clone(),
         Err(poisoned) => poisoned.into_inner().clone(),
     }
 }
 
-fn sync_execution_target(ctx: &mut PipelineContext, slot: &SharedServingTarget) {
-    let Some(target) = load_serving_target(slot) else {
+fn sync_execution_target(ctx: &mut PipelineContext, slot: &SharedStreamAttempt) {
+    let Some(attempt) = load_stream_attempt(slot) else {
         return;
     };
     let Some(execution) = ctx.execution_result.as_mut() else {
         return;
     };
-    execution.provider_id = target.provider_name;
-    execution.model_id = target.service_id;
-    execution.account_label = target.account_label;
+    execution.provider_id = attempt.target.provider_name;
+    execution.model_id = attempt.target.service_id;
+    execution.account_label = attempt.target.account_label;
 }
 
 impl Pipeline {
@@ -250,6 +268,7 @@ impl Pipeline {
         log_request_received(&ctx, chain.first(), false);
 
         // ---- Stage 3: execution (with the server-side tool loop when configured) ----
+        let execution_started_at = Instant::now();
         let exec_outcome = match &self.server_tool_loop {
             Some(server_loop) => {
                 let tool_ctx = ToolContext::from_pipeline(&ctx);
@@ -263,7 +282,11 @@ impl Pipeline {
             None => self.execute_with_fallback(&chain, ctx.prompt(), &ctx).await,
         };
         match exec_outcome {
-            Ok(result) => {
+            Ok(mut result) => {
+                if self.server_tool_loop.is_some() {
+                    result.generation_time_ms =
+                        crate::language_model::timing::elapsed_millis(execution_started_at);
+                }
                 ctx.execution_result = Some(result);
                 self.observe_after(Phase::Execution, &ctx).await;
             }
@@ -313,7 +336,7 @@ impl Pipeline {
         };
         self.observe_after(Phase::Route, &ctx).await;
         log_request_received(&ctx, chain.first(), true);
-        let serving_target: SharedServingTarget = Arc::new(std::sync::Mutex::new(None));
+        let latest_attempt: SharedStreamAttempt = Arc::new(std::sync::Mutex::new(None));
 
         // Route Stage 3 through the server-side tool loop when configured: the
         // merged stream becomes the "upstream" the settlement guard drains, so
@@ -325,17 +348,37 @@ impl Pipeline {
                     pipeline: self.clone(),
                     chain: chain.clone(),
                     context: ctx.fork_for_prompt(ctx.prompt().clone()),
-                    serving_target: serving_target.clone(),
+                    latest_attempt: latest_attempt.clone(),
                 });
-                server_loop
+                match server_loop
                     .clone()
                     .run_stream(ctx.prompt(), &tool_ctx, upstream_impl)
                     .await
+                {
+                    Ok(stream) => load_stream_attempt(&latest_attempt)
+                        .map(|attempt| StreamingExecution {
+                            stream,
+                            target: attempt.target,
+                            provider_started_at: attempt.provider_started_at,
+                        })
+                        .ok_or_else(|| {
+                            BitrouterError::internal(
+                                "server-tool stream opened without a successful upstream attempt",
+                            )
+                        }),
+                    Err(error) => Err(error),
+                }
             }
             None => match self.execute_stream_with_fallback(&chain, &ctx).await {
-                Ok((target, stream)) => {
-                    store_serving_target(&serving_target, target);
-                    Ok(stream)
+                Ok(execution) => {
+                    store_stream_attempt(
+                        &latest_attempt,
+                        StreamAttempt {
+                            target: execution.target.clone(),
+                            provider_started_at: execution.provider_started_at,
+                        },
+                    );
+                    Ok(execution)
                 }
                 Err(error) => Err(error),
             },
@@ -353,25 +396,23 @@ impl Pipeline {
         };
         // A placeholder execution result so Settlement has provider/model ids;
         // usage is folded in from the StreamContext at stream end.
-        let head = load_serving_target(&serving_target).or_else(|| chain.first().cloned());
-        if let Some(target) = &head {
-            ctx.execution_result = Some(ExecutionResult {
-                provider_id: target.provider_name.clone(),
-                model_id: target.service_id.clone(),
-                account_label: target.account_label.clone(),
-                result: crate::language_model::types::GenerateResult {
-                    content: Vec::new(),
-                    usage: None,
-                    finish_reason: None,
-                    response_id: None,
-                    stop_details: None,
-                    provider_metadata: Default::default(),
-                },
-                latency_ms: 0,
-                generation_time_ms: 0,
-                server_tool_calls: Vec::new(),
-            });
-        }
+        ctx.set_stream_provider_started_at(upstream.provider_started_at);
+        ctx.execution_result = Some(ExecutionResult {
+            provider_id: upstream.target.provider_name.clone(),
+            model_id: upstream.target.service_id.clone(),
+            account_label: upstream.target.account_label.clone(),
+            result: crate::language_model::types::GenerateResult {
+                content: Vec::new(),
+                usage: None,
+                finish_reason: None,
+                response_id: None,
+                stop_details: None,
+                provider_metadata: Default::default(),
+            },
+            latency_ms: 0,
+            generation_time_ms: 0,
+            server_tool_calls: Vec::new(),
+        });
         self.observe_after(Phase::Execution, &ctx).await;
 
         let processor = StreamProcessor::new(
@@ -386,11 +427,11 @@ impl Pipeline {
         // so streaming settlement is never lost.
         let guard = StreamSettlementGuard {
             pipeline: self.clone(),
-            serving_target,
+            latest_attempt,
             state: Some((processor, ctx)),
         };
 
-        Ok(Box::pin(self.drive_stream(upstream, guard)))
+        Ok(Box::pin(self.drive_stream(upstream.stream, guard)))
     }
 
     /// The streaming driver: feeds upstream parts through the guard's
@@ -535,9 +576,10 @@ impl Pipeline {
         &self,
         chain: &[RoutingTarget],
         ctx: &PipelineContext,
-    ) -> Result<(RoutingTarget, StreamPartStream)> {
+    ) -> Result<StreamingExecution> {
         let mut errors = Vec::new();
         for target in chain {
+            let provider_started_at = Instant::now();
             self.observe_hop_start(ctx, target).await;
             let outcome = self
                 .executor
@@ -556,7 +598,13 @@ impl Pipeline {
             match outcome {
                 // Once the stream starts, the SSE response is committed — no
                 // more fallback.
-                Ok(stream) => return Ok((target.clone(), stream)),
+                Ok(stream) => {
+                    return Ok(StreamingExecution {
+                        stream,
+                        target: target.clone(),
+                        provider_started_at,
+                    });
+                }
                 Err(e) => match self.classify_failure(ctx, &e, target).await {
                     FallbackDecision::TryNext => {
                         errors.push(e);
@@ -599,6 +647,7 @@ impl Pipeline {
         streamed: bool,
         error: Option<BitrouterError>,
     ) {
+        ctx.finalize_request_latency();
         let mut settle = ctx.settlement_context();
         settle.streamed = streamed;
         settle.error = error;
@@ -737,7 +786,7 @@ fn aggregate_fallback_errors(errors: Vec<BitrouterError>) -> BitrouterError {
 /// normally or the client drops it early.
 struct StreamSettlementGuard {
     pipeline: Arc<Pipeline>,
-    serving_target: SharedServingTarget,
+    latest_attempt: SharedStreamAttempt,
     /// `Some` until finalised; `take`n by `finalize` or `drop`, whichever fires
     /// first, so finalisation is exactly-once.
     state: Option<(StreamProcessor, PipelineContext)>,
@@ -760,8 +809,9 @@ impl StreamSettlementGuard {
         if let Some((mut processor, mut ctx)) = self.state.take() {
             let (settlement_error, request_outcome) = stream_terminal_metadata(&outcome);
             processor.finish(outcome).await;
-            sync_execution_target(&mut ctx, &self.serving_target);
+            sync_execution_target(&mut ctx, &self.latest_attempt);
             ctx.absorb_stream(processor.into_context());
+            ctx.finalize_stream_generation_time();
             self.pipeline
                 .run_settlement(&mut ctx, true, settlement_error)
                 .await;
@@ -793,11 +843,12 @@ impl Drop for StreamSettlementGuard {
         // could cut a settlement task mid-await and the receipt would be lost.
         if let Some((mut processor, mut ctx)) = self.state.take() {
             let pipeline = self.pipeline.clone();
-            let serving_target = self.serving_target.clone();
+            let latest_attempt = self.latest_attempt.clone();
             let fut = async move {
                 processor.finish(StreamOutcome::ClientDisconnected).await;
-                sync_execution_target(&mut ctx, &serving_target);
+                sync_execution_target(&mut ctx, &latest_attempt);
                 ctx.absorb_stream(processor.into_context());
+                ctx.finalize_stream_generation_time();
                 pipeline.run_settlement(&mut ctx, true, None).await;
                 pipeline
                     .observe_end(&ctx, RequestOutcome::ClientDisconnected)

--- a/crates/bitrouter-sdk/src/language_model/pipeline.rs
+++ b/crates/bitrouter-sdk/src/language_model/pipeline.rs
@@ -15,7 +15,7 @@ use crate::language_model::context::PipelineContext;
 use crate::language_model::executor::{Executor, StreamPartStream};
 use crate::language_model::hooks::{
     ExecutionHook, FallbackDecision, HookDecision, HopOutcome, ObserveHook, Phase, PreRequestHook,
-    RequestOutcome, RouteHook, StreamHook,
+    RequestOutcome, RouteHook, StreamHook, StreamHopOutcome,
 };
 use crate::language_model::routing::{FallbackPolicy, RoutingPrefs, RoutingTable};
 use crate::language_model::server_tools::loop_controller::{ServerToolLoop, UpstreamTurn};
@@ -34,6 +34,61 @@ struct StreamingExecution {
     stream: StreamPartStream,
     target: RoutingTarget,
     provider_started_at: Instant,
+}
+
+struct ObservedUpstreamStream {
+    inner: StreamPartStream,
+    hooks: Vec<Arc<dyn ObserveHook>>,
+    request_id: String,
+    target: RoutingTarget,
+    provider_started_at: Instant,
+    terminal: bool,
+}
+
+impl ObservedUpstreamStream {
+    fn notify(&mut self, outcome: StreamHopOutcome<'_>) {
+        if self.terminal {
+            return;
+        }
+        self.terminal = true;
+        let duration_ms = crate::language_model::timing::elapsed_millis(self.provider_started_at);
+        for hook in &self.hooks {
+            let callback = std::panic::AssertUnwindSafe(|| {
+                hook.on_stream_hop_end(&self.request_id, &self.target, outcome, duration_ms)
+            });
+            if std::panic::catch_unwind(callback).is_err() {
+                tracing::warn!("ObserveHook::on_stream_hop_end panicked; swallowed");
+            }
+        }
+    }
+}
+
+impl Stream for ObservedUpstreamStream {
+    type Item = Result<StreamPart>;
+
+    fn poll_next(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        let item = self.inner.as_mut().poll_next(cx);
+        match &item {
+            std::task::Poll::Ready(None) => self.notify(StreamHopOutcome::Completed),
+            std::task::Poll::Ready(Some(Err(error))) => {
+                self.notify(StreamHopOutcome::Failed(error));
+            }
+            std::task::Poll::Ready(Some(Ok(part))) if part.is_terminal() => {
+                self.notify(StreamHopOutcome::Completed);
+            }
+            std::task::Poll::Ready(Some(Ok(_))) | std::task::Poll::Pending => {}
+        }
+        item
+    }
+}
+
+impl Drop for ObservedUpstreamStream {
+    fn drop(&mut self) {
+        self.notify(StreamHopOutcome::Dropped);
+    }
 }
 
 #[derive(Clone)]
@@ -244,6 +299,7 @@ impl Pipeline {
     /// Execute a non-streaming request: the four stages, in order.
     pub async fn execute(&self, req: PipelineRequest) -> Result<PipelineResponse> {
         let mut ctx = PipelineContext::new(req);
+        self.observe_start(&ctx).await;
 
         // ---- Stage 1: pre-request checks ----
         if let Err(e) = self.run_pre_request(&mut ctx).await {
@@ -316,6 +372,7 @@ impl Pipeline {
         req: PipelineRequest,
     ) -> Result<Pin<Box<dyn Stream<Item = Result<StreamPart>> + Send>>> {
         let mut ctx = PipelineContext::new(req);
+        self.observe_start(&ctx).await;
 
         if let Err(e) = self.run_pre_request(&mut ctx).await {
             log_request_resolve_failed(&ctx, &e);
@@ -599,6 +656,14 @@ impl Pipeline {
                 // Once the stream starts, the SSE response is committed — no
                 // more fallback.
                 Ok(stream) => {
+                    let stream = Box::pin(ObservedUpstreamStream {
+                        inner: stream,
+                        hooks: self.observe_hooks.clone(),
+                        request_id: ctx.request_id().to_string(),
+                        target: target.clone(),
+                        provider_started_at,
+                        terminal: false,
+                    });
                     return Ok(StreamingExecution {
                         stream,
                         target: target.clone(),
@@ -668,6 +733,15 @@ impl Pipeline {
     }
 
     // ===== observe helpers (read-only, swallow errors AND panics) =====
+
+    async fn observe_start(&self, ctx: &PipelineContext) {
+        for hook in &self.observe_hooks {
+            let fut = std::panic::AssertUnwindSafe(hook.on_request_start(ctx));
+            if fut.catch_unwind().await.is_err() {
+                tracing::warn!("ObserveHook::on_request_start panicked; swallowed");
+            }
+        }
+    }
 
     async fn observe_after(&self, phase: Phase, ctx: &PipelineContext) {
         for hook in &self.observe_hooks {

--- a/crates/bitrouter-sdk/src/language_model/pipeline.rs
+++ b/crates/bitrouter-sdk/src/language_model/pipeline.rs
@@ -679,12 +679,7 @@ impl Pipeline {
     }
 
     async fn observe_hop_start(&self, ctx: &PipelineContext, target: &RoutingTarget) {
-        for hook in &self.observe_hooks {
-            let fut = std::panic::AssertUnwindSafe(hook.on_hop_start(ctx, target));
-            if fut.catch_unwind().await.is_err() {
-                tracing::warn!("ObserveHook::on_hop_start panicked; swallowed");
-            }
-        }
+        observe_hop_start_with(&self.observe_hooks, ctx, target).await;
     }
 
     async fn observe_hop_end(
@@ -693,12 +688,7 @@ impl Pipeline {
         target: &RoutingTarget,
         outcome: HopOutcome<'_>,
     ) {
-        for hook in &self.observe_hooks {
-            let fut = std::panic::AssertUnwindSafe(hook.on_hop_end(ctx, target, outcome));
-            if fut.catch_unwind().await.is_err() {
-                tracing::warn!("ObserveHook::on_hop_end panicked; swallowed");
-            }
-        }
+        observe_hop_end_with(&self.observe_hooks, ctx, target, outcome).await;
     }
 
     async fn observe_end(&self, ctx: &PipelineContext, outcome: RequestOutcome) {
@@ -707,6 +697,33 @@ impl Pipeline {
             if fut.catch_unwind().await.is_err() {
                 tracing::warn!("ObserveHook::on_request_end panicked; swallowed");
             }
+        }
+    }
+}
+
+async fn observe_hop_start_with(
+    hooks: &[Arc<dyn ObserveHook>],
+    ctx: &PipelineContext,
+    target: &RoutingTarget,
+) {
+    for hook in hooks {
+        let fut = std::panic::AssertUnwindSafe(hook.on_hop_start(ctx, target));
+        if fut.catch_unwind().await.is_err() {
+            tracing::warn!("ObserveHook::on_hop_start panicked; swallowed");
+        }
+    }
+}
+
+async fn observe_hop_end_with(
+    hooks: &[Arc<dyn ObserveHook>],
+    ctx: &PipelineContext,
+    target: &RoutingTarget,
+    outcome: HopOutcome<'_>,
+) {
+    for hook in hooks {
+        let fut = std::panic::AssertUnwindSafe(hook.on_hop_end(ctx, target, outcome));
+        if fut.catch_unwind().await.is_err() {
+            tracing::warn!("ObserveHook::on_hop_end panicked; swallowed");
         }
     }
 }

--- a/crates/bitrouter-sdk/src/language_model/settlement.rs
+++ b/crates/bitrouter-sdk/src/language_model/settlement.rs
@@ -13,6 +13,7 @@ use crate::caller::CallerContext;
 use crate::error::BitrouterError;
 use crate::error::Result;
 use crate::event::{EventBus, PipelineEvent};
+use crate::language_model::timing::FirstTokenKind;
 use crate::language_model::types::RoutingTarget;
 
 /// The Settlement-stage view, borrowed from `PipelineContext`. Carries
@@ -62,6 +63,11 @@ pub struct SettlementContext {
     pub latency_ms: u64,
     /// Upstream generation time in milliseconds.
     pub generation_time_ms: u64,
+    /// Time from the successful provider attempt start to the first semantic
+    /// stream delta.
+    pub first_token_latency_ms: Option<u64>,
+    /// Kind of the first semantic stream delta.
+    pub first_token_kind: Option<FirstTokenKind>,
     /// The error, if the request failed (Settlement still runs).
     pub error: Option<BitrouterError>,
     /// Events carried over from the request lifecycle (so recorders can
@@ -139,6 +145,8 @@ mod tests {
             streamed: false,
             latency_ms: 0,
             generation_time_ms: 0,
+            first_token_latency_ms: None,
+            first_token_kind: None,
             error: None,
             events: EventBus::default(),
         }

--- a/crates/bitrouter-sdk/src/language_model/stream.rs
+++ b/crates/bitrouter-sdk/src/language_model/stream.rs
@@ -350,6 +350,7 @@ impl StreamProcessor {
     /// upstream part so usage is never lost to a rewrite.
     pub async fn process_part(&mut self, part: StreamPart) -> Result<Vec<StreamPart>> {
         self.ctx.accumulated_usage.observe(&part);
+        self.ctx.observe_first_token(&part);
         self.ctx.parts_emitted += 1;
 
         let mut current = vec![part];
@@ -447,8 +448,81 @@ impl StreamProcessor {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::caller::CallerContext;
+    use crate::language_model::context::PipelineContext;
+    use crate::language_model::timing::FirstTokenKind;
     use crate::language_model::types::FinishReason;
+    use crate::language_model::types::{GenerationParams, Message, PipelineRequest, Prompt, Role};
     use futures::StreamExt;
+
+    fn timed_stream_context() -> StreamContext {
+        let prompt = Prompt {
+            model: "test-model".into(),
+            system: None,
+            system_provider_metadata: Default::default(),
+            messages: vec![Message::text(Role::User, "hello")],
+            tools: Vec::new(),
+            params: GenerationParams::default(),
+            response_format: None,
+            tool_choice: None,
+            stream: true,
+        };
+        let mut ctx = PipelineContext::new(PipelineRequest::new(
+            "test-model",
+            CallerContext::local(),
+            prompt,
+        ));
+        ctx.set_stream_provider_started_at(std::time::Instant::now());
+        ctx.stream_context()
+    }
+
+    #[tokio::test]
+    async fn first_original_semantic_delta_sets_timing_once() {
+        let mut processor = StreamProcessor::new(Vec::new(), Vec::new(), timed_stream_context());
+
+        processor
+            .process_part(StreamPart::ResponseStarted { id: "r".into() })
+            .await
+            .unwrap();
+        processor
+            .process_part(StreamPart::ReasoningDelta {
+                text: "think".into(),
+            })
+            .await
+            .unwrap();
+        processor
+            .process_part(StreamPart::TextDelta {
+                text: "answer".into(),
+            })
+            .await
+            .unwrap();
+
+        let timing = processor
+            .context()
+            .first_token_timing()
+            .expect("first token timing");
+        assert_eq!(timing.kind, FirstTokenKind::Reasoning);
+        assert!(timing.latency_ms >= 1);
+    }
+
+    #[tokio::test]
+    async fn metadata_usage_and_terminal_parts_do_not_set_first_token_timing() {
+        let mut processor = StreamProcessor::new(Vec::new(), Vec::new(), timed_stream_context());
+
+        for part in [
+            StreamPart::ResponseStarted { id: "r".into() },
+            StreamPart::Usage {
+                usage: Usage::default(),
+            },
+            StreamPart::Finish {
+                reason: FinishReason::Stop,
+            },
+        ] {
+            processor.process_part(part).await.unwrap();
+        }
+
+        assert!(processor.context().first_token_timing().is_none());
+    }
 
     #[test]
     fn interest_matches_only_declared_kinds() {

--- a/crates/bitrouter-sdk/src/language_model/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/tests.rs
@@ -157,6 +157,35 @@ impl SettlementRecorder for ProviderCapturingRecorder {
     }
 }
 
+#[derive(Debug, Clone)]
+struct TimingSnapshot {
+    provider_id: String,
+    model_id: String,
+    latency_ms: u64,
+    generation_time_ms: u64,
+    first_token_latency_ms: Option<u64>,
+    first_token_kind: Option<timing::FirstTokenKind>,
+    has_error: bool,
+}
+
+struct TimingSnapshotRecorder(Arc<std::sync::Mutex<Vec<TimingSnapshot>>>);
+
+#[async_trait]
+impl SettlementRecorder for TimingSnapshotRecorder {
+    async fn record(&self, ctx: &mut SettlementContext) -> Result<()> {
+        self.0.lock().unwrap().push(TimingSnapshot {
+            provider_id: ctx.provider_id.clone(),
+            model_id: ctx.model_id.clone(),
+            latency_ms: ctx.latency_ms,
+            generation_time_ms: ctx.generation_time_ms,
+            first_token_latency_ms: ctx.first_token_latency_ms,
+            first_token_kind: ctx.first_token_kind,
+            has_error: ctx.error.is_some(),
+        });
+        Ok(())
+    }
+}
+
 struct ContextCheckingExecutionHook {
     expected_request_id: String,
     seen: Arc<std::sync::Mutex<Vec<bool>>>,
@@ -180,6 +209,16 @@ impl ExecutionHook for ContextCheckingExecutionHook {
             Err(poisoned) => poisoned.into_inner().push(context_preserved),
         }
         FallbackDecision::TryNext
+    }
+}
+
+struct DelayPreHook(std::time::Duration);
+
+#[async_trait]
+impl PreRequestHook for DelayPreHook {
+    async fn check(&self, _ctx: &mut PipelineContext) -> Result<HookDecision> {
+        tokio::time::sleep(self.0).await;
+        Ok(HookDecision::Allow)
     }
 }
 
@@ -762,6 +801,209 @@ async fn collect_stream(
 ) -> Vec<Result<StreamPart>> {
     use futures::StreamExt;
     stream.collect().await
+}
+
+#[tokio::test]
+async fn streamed_settlement_has_positive_canonical_timing() {
+    let captured = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let pipeline = pipeline_with(
+        routing_table(&["openai"]),
+        Arc::new(MockExecutor::new(vec![MockResponse::Stream(vec![
+            StreamPart::TextDelta {
+                text: "hello".into(),
+            },
+            StreamPart::Finish {
+                reason: FinishReason::Stop,
+            },
+        ])])),
+        |builder| {
+            builder.settlement_recorder(TimingSnapshotRecorder(captured.clone()));
+        },
+    );
+
+    let stream = pipeline
+        .execute_stream(stream_request())
+        .await
+        .expect("stream starts");
+    let parts = collect_stream(stream).await;
+    assert!(parts.iter().all(Result::is_ok));
+
+    let snapshots = captured.lock().unwrap();
+    let snapshot = snapshots.first().expect("settlement snapshot");
+    assert_eq!(snapshot.provider_id, "openai");
+    assert_eq!(snapshot.model_id, "test-model");
+    assert!(snapshot.latency_ms >= 1);
+    assert!(snapshot.generation_time_ms >= 1);
+    assert!(
+        snapshot
+            .first_token_latency_ms
+            .is_some_and(|value| value >= 1)
+    );
+    assert_eq!(
+        snapshot.first_token_kind,
+        Some(timing::FirstTokenKind::Text)
+    );
+    assert!(!snapshot.has_error);
+}
+
+#[tokio::test]
+async fn streamed_fallback_attributes_timing_to_successful_target() {
+    let captured = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let pipeline = pipeline_with(
+        routing_table(&["first", "second"]),
+        Arc::new(MockExecutor::new(vec![
+            MockResponse::Error(BitrouterError::UpstreamUnavailable),
+            MockResponse::Stream(vec![
+                StreamPart::ReasoningDelta {
+                    text: "thinking".into(),
+                },
+                StreamPart::Finish {
+                    reason: FinishReason::Stop,
+                },
+            ]),
+        ])),
+        |builder| {
+            builder.settlement_recorder(TimingSnapshotRecorder(captured.clone()));
+        },
+    );
+
+    let stream = pipeline
+        .execute_stream(stream_request())
+        .await
+        .expect("fallback stream starts");
+    let _parts = collect_stream(stream).await;
+
+    let snapshots = captured.lock().unwrap();
+    let snapshot = snapshots.first().expect("settlement snapshot");
+    assert_eq!(snapshot.provider_id, "second");
+    assert_eq!(snapshot.model_id, "test-model");
+    assert!(snapshot.generation_time_ms >= 1);
+    assert_eq!(
+        snapshot.first_token_kind,
+        Some(timing::FirstTokenKind::Reasoning)
+    );
+}
+
+#[tokio::test]
+async fn streamed_upstream_error_finalizes_timing_before_settlement() {
+    let captured = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let pipeline = pipeline_with(
+        routing_table(&["openai"]),
+        Arc::new(StreamErrorExecutor {
+            error: BitrouterError::UpstreamUnavailable,
+        }),
+        |builder| {
+            builder.settlement_recorder(TimingSnapshotRecorder(captured.clone()));
+        },
+    );
+
+    let stream = pipeline
+        .execute_stream(stream_request())
+        .await
+        .expect("stream starts before body error");
+    let _parts = collect_stream(stream).await;
+
+    let snapshots = captured.lock().unwrap();
+    let snapshot = snapshots.first().expect("settlement snapshot");
+    assert!(snapshot.latency_ms >= 1);
+    assert!(snapshot.generation_time_ms >= 1);
+    assert!(snapshot.has_error);
+}
+
+#[tokio::test]
+async fn streamed_hook_abort_finalizes_timing_before_settlement() {
+    let captured = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let ended = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let pipeline = pipeline_with(
+        routing_table(&["openai"]),
+        Arc::new(MockExecutor::new(vec![MockResponse::Stream(vec![
+            StreamPart::ToolCallDelta {
+                id: "call-1".into(),
+                name: Some("lookup".into()),
+                arguments: "{}".into(),
+            },
+            StreamPart::TextDelta {
+                text: "blocked".into(),
+            },
+        ])])),
+        |builder| {
+            builder
+                .stream_hook(ScriptedStreamHook {
+                    interest: StreamInterest::all(),
+                    mode: StreamMode::AbortOnText,
+                    ended_with: ended.clone(),
+                })
+                .settlement_recorder(TimingSnapshotRecorder(captured.clone()));
+        },
+    );
+
+    let stream = pipeline
+        .execute_stream(stream_request())
+        .await
+        .expect("stream starts");
+    let _parts = collect_stream(stream).await;
+
+    let snapshots = captured.lock().unwrap();
+    let snapshot = snapshots.first().expect("settlement snapshot");
+    assert!(snapshot.latency_ms >= 1);
+    assert!(snapshot.generation_time_ms >= 1);
+    assert_eq!(
+        snapshot.first_token_kind,
+        Some(timing::FirstTokenKind::Tool)
+    );
+    assert!(snapshot.has_error);
+}
+
+#[tokio::test]
+async fn dropped_stream_finalizes_timing_before_detached_settlement() {
+    let captured = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let pipeline = pipeline_with(
+        routing_table(&["openai"]),
+        Arc::new(MockExecutor::new(vec![MockResponse::Stream(vec![
+            StreamPart::TextDelta { text: "hi".into() },
+            StreamPart::Finish {
+                reason: FinishReason::Stop,
+            },
+        ])])),
+        |builder| {
+            builder.settlement_recorder(TimingSnapshotRecorder(captured.clone()));
+        },
+    );
+
+    let stream = pipeline
+        .clone()
+        .execute_stream(stream_request())
+        .await
+        .expect("stream starts");
+    drop(stream);
+    pipeline.drain_pending_settlements().await;
+
+    let snapshots = captured.lock().unwrap();
+    let snapshot = snapshots.first().expect("detached settlement snapshot");
+    assert!(snapshot.latency_ms >= 1);
+    assert!(snapshot.generation_time_ms >= 1);
+    assert!(!snapshot.has_error);
+}
+
+#[tokio::test]
+async fn non_stream_latency_includes_pre_request_pipeline_time() {
+    let captured = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let pipeline = pipeline_with(
+        routing_table(&["openai"]),
+        Arc::new(MockExecutor::always_text("hello")),
+        |builder| {
+            builder
+                .pre_request_hook(DelayPreHook(std::time::Duration::from_millis(20)))
+                .settlement_recorder(TimingSnapshotRecorder(captured.clone()));
+        },
+    );
+
+    pipeline.execute(request()).await.expect("request succeeds");
+
+    let snapshots = captured.lock().unwrap();
+    let snapshot = snapshots.first().expect("settlement snapshot");
+    assert!(snapshot.latency_ms >= 20);
+    assert!(snapshot.generation_time_ms >= 1);
 }
 
 #[tokio::test]

--- a/crates/bitrouter-sdk/src/language_model/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/tests.rs
@@ -212,6 +212,52 @@ impl ExecutionHook for ContextCheckingExecutionHook {
     }
 }
 
+struct HopEventRecorder(Arc<std::sync::Mutex<Vec<String>>>);
+
+#[async_trait]
+impl ObserveHook for HopEventRecorder {
+    async fn after_phase(&self, _phase: Phase, _ctx: &PipelineContext) {}
+
+    async fn on_hop_start(&self, _ctx: &PipelineContext, target: &RoutingTarget) {
+        self.0
+            .lock()
+            .unwrap()
+            .push(format!("start:{}", target.provider_name));
+    }
+
+    async fn on_hop_end(
+        &self,
+        _ctx: &PipelineContext,
+        target: &RoutingTarget,
+        outcome: HopOutcome<'_>,
+    ) {
+        let outcome = match outcome {
+            HopOutcome::Generated(_) => "generated",
+            HopOutcome::StreamStarted => "stream_started",
+            HopOutcome::Failed(_) => "failed",
+        };
+        self.0
+            .lock()
+            .unwrap()
+            .push(format!("end:{}:{outcome}", target.provider_name));
+    }
+
+    fn stream_interest(&self) -> StreamInterest {
+        StreamInterest::none()
+    }
+
+    async fn on_stream_part(&self, _ctx: &StreamContext, _part: &StreamPart) {}
+
+    async fn on_request_end(&self, _ctx: &PipelineContext, outcome: &RequestOutcome) {
+        let outcome = match outcome {
+            RequestOutcome::Completed => "completed",
+            RequestOutcome::Failed(_) => "failed",
+            RequestOutcome::ClientDisconnected => "disconnected",
+        };
+        self.0.lock().unwrap().push(format!("request:{outcome}"));
+    }
+}
+
 struct DelayPreHook(std::time::Duration);
 
 #[async_trait]
@@ -2073,8 +2119,10 @@ async fn server_tool_loop_streams_router_tool_activity() {
         }
     }
 
-    // Iteration 1 streams a router tool call; iteration 2 streams the answer.
+    // Each iteration fails over from `first` to `second`. Nested streaming
+    // turns must retain hop observability and final target attribution.
     let executor = Arc::new(MockExecutor::new(vec![
+        MockResponse::Error(BitrouterError::UpstreamUnavailable),
         MockResponse::Stream(vec![
             StreamPart::TextDelta {
                 text: "searching ".to_string(),
@@ -2088,6 +2136,7 @@ async fn server_tool_loop_streams_router_tool_activity() {
                 reason: FinishReason::ToolCalls,
             },
         ]),
+        MockResponse::Error(BitrouterError::UpstreamUnavailable),
         MockResponse::Stream(vec![
             StreamPart::TextDelta {
                 text: "answer".to_string(),
@@ -2102,8 +2151,12 @@ async fn server_tool_loop_streams_router_tool_activity() {
         ServerToolLoopConfig::default(),
         Arc::new(AllowAll),
     ));
-    let pipeline = pipeline_with(routing_table(&["openai"]), executor, |b| {
-        b.server_tool_loop(server_loop);
+    let timings = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let hops = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let pipeline = pipeline_with(routing_table(&["first", "second"]), executor, |b| {
+        b.server_tool_loop(server_loop)
+            .settlement_recorder(TimingSnapshotRecorder(timings.clone()))
+            .observe_hook(HopEventRecorder(hops.clone()));
     });
 
     let mut stream = pipeline
@@ -2141,4 +2194,81 @@ async fn server_tool_loop_streams_router_tool_activity() {
         })
         .collect();
     assert_eq!(text, "searching answer");
+
+    let snapshots = timings.lock().unwrap();
+    let snapshot = snapshots.first().expect("server-tool settlement timing");
+    assert_eq!(snapshot.provider_id, "second");
+    assert!(snapshot.latency_ms >= 1);
+    assert!(snapshot.generation_time_ms >= 1);
+    assert!(
+        snapshot
+            .first_token_latency_ms
+            .is_some_and(|value| value >= 1)
+    );
+
+    assert_eq!(
+        *hops.lock().unwrap(),
+        vec![
+            "start:first",
+            "end:first:failed",
+            "start:second",
+            "end:second:stream_started",
+            "start:first",
+            "end:first:failed",
+            "start:second",
+            "end:second:stream_started",
+            "request:completed",
+        ],
+        "every nested upstream attempt is observable"
+    );
+}
+
+#[tokio::test]
+async fn server_tool_stream_handshake_failure_still_settles_and_observes_end() {
+    use crate::language_model::server_tools::approval::AllowAll;
+    use crate::language_model::server_tools::config::ServerToolLoopConfig;
+    use crate::language_model::server_tools::loop_controller::ServerToolLoop;
+    use crate::language_model::server_tools::toolset::ToolsetRegistry;
+
+    let server_loop = Arc::new(ServerToolLoop::new(
+        ToolsetRegistry::new(Vec::new()),
+        ServerToolLoopConfig::default(),
+        Arc::new(AllowAll),
+    ));
+    let timings = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let hops = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let pipeline = pipeline_with(
+        routing_table(&["first", "second"]),
+        Arc::new(MockExecutor::new(vec![
+            MockResponse::Error(BitrouterError::UpstreamUnavailable),
+            MockResponse::Error(BitrouterError::UpstreamUnavailable),
+        ])),
+        |builder| {
+            builder
+                .server_tool_loop(server_loop)
+                .settlement_recorder(TimingSnapshotRecorder(timings.clone()))
+                .observe_hook(HopEventRecorder(hops.clone()));
+        },
+    );
+
+    let error = match pipeline.execute_stream(stream_request()).await {
+        Ok(_) => panic!("all nested upstream handshakes should fail"),
+        Err(error) => error,
+    };
+    assert!(matches!(error, BitrouterError::UpstreamUnavailable));
+
+    let snapshots = timings.lock().unwrap();
+    let snapshot = snapshots.first().expect("failed stream still settles");
+    assert!(snapshot.has_error);
+    assert!(snapshot.latency_ms >= 1);
+    assert_eq!(
+        *hops.lock().unwrap(),
+        vec![
+            "start:first",
+            "end:first:failed",
+            "start:second",
+            "end:second:failed",
+            "request:failed",
+        ]
+    );
 }

--- a/crates/bitrouter-sdk/src/language_model/timing.rs
+++ b/crates/bitrouter-sdk/src/language_model/timing.rs
@@ -44,9 +44,13 @@ impl FirstTokenKind {
 
     pub(crate) fn from_part(part: &StreamPart) -> Option<Self> {
         match part {
-            StreamPart::ReasoningDelta { .. } => Some(Self::Reasoning),
-            StreamPart::TextDelta { .. } => Some(Self::Text),
-            StreamPart::ToolCallDelta { .. } => Some(Self::Tool),
+            StreamPart::ReasoningDelta { text } if !text.is_empty() => Some(Self::Reasoning),
+            StreamPart::TextDelta { text } if !text.is_empty() => Some(Self::Text),
+            StreamPart::ToolCallDelta {
+                name, arguments, ..
+            } if name.as_ref().is_some_and(|name| !name.is_empty()) || !arguments.is_empty() => {
+                Some(Self::Tool)
+            }
             _ => None,
         }
     }
@@ -66,7 +70,8 @@ pub struct FirstTokenTiming {
 mod tests {
     use std::time::Duration;
 
-    use super::duration_millis;
+    use super::{FirstTokenKind, duration_millis};
+    use crate::language_model::types::StreamPart;
 
     #[test]
     fn positive_sub_millisecond_duration_rounds_to_one() {
@@ -81,5 +86,28 @@ mod tests {
     #[test]
     fn whole_milliseconds_are_preserved() {
         assert_eq!(duration_millis(Duration::from_millis(42)), 42);
+    }
+
+    #[test]
+    fn empty_deltas_are_not_semantic_tokens() {
+        let empty_parts = [
+            StreamPart::ReasoningDelta {
+                text: String::new(),
+            },
+            StreamPart::TextDelta {
+                text: String::new(),
+            },
+            StreamPart::ToolCallDelta {
+                id: "call-1".into(),
+                name: None,
+                arguments: String::new(),
+            },
+        ];
+
+        assert!(
+            empty_parts
+                .iter()
+                .all(|part| FirstTokenKind::from_part(part).is_none())
+        );
     }
 }

--- a/crates/bitrouter-sdk/src/language_model/timing.rs
+++ b/crates/bitrouter-sdk/src/language_model/timing.rs
@@ -1,0 +1,85 @@
+//! Canonical request-timing values shared by the pipeline and plugins.
+
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
+
+use crate::language_model::types::StreamPart;
+
+/// Convert a duration to integer milliseconds without losing a positive
+/// sub-millisecond measurement to truncation.
+pub(crate) fn duration_millis(duration: Duration) -> u64 {
+    if duration.is_zero() {
+        return 0;
+    }
+    let millis = duration.as_millis().max(1);
+    u64::try_from(millis).unwrap_or(u64::MAX)
+}
+
+pub(crate) fn elapsed_millis(started_at: Instant) -> u64 {
+    duration_millis(started_at.elapsed())
+}
+
+/// The first semantic output produced by a streamed generation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FirstTokenKind {
+    /// A reasoning/thinking delta.
+    Reasoning,
+    /// A visible text delta.
+    Text,
+    /// A tool-call delta.
+    Tool,
+}
+
+impl FirstTokenKind {
+    /// Stable snake-case storage representation.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Reasoning => "reasoning",
+            Self::Text => "text",
+            Self::Tool => "tool",
+        }
+    }
+
+    pub(crate) fn from_part(part: &StreamPart) -> Option<Self> {
+        match part {
+            StreamPart::ReasoningDelta { .. } => Some(Self::Reasoning),
+            StreamPart::TextDelta { .. } => Some(Self::Text),
+            StreamPart::ToolCallDelta { .. } => Some(Self::Tool),
+            _ => None,
+        }
+    }
+}
+
+/// Time from the successful provider attempt start to its first semantic
+/// streamed output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FirstTokenTiming {
+    /// Elapsed provider time in milliseconds.
+    pub latency_ms: u64,
+    /// Which semantic delta arrived first.
+    pub kind: FirstTokenKind,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::duration_millis;
+
+    #[test]
+    fn positive_sub_millisecond_duration_rounds_to_one() {
+        assert_eq!(duration_millis(Duration::from_nanos(1)), 1);
+    }
+
+    #[test]
+    fn zero_duration_stays_zero() {
+        assert_eq!(duration_millis(Duration::ZERO), 0);
+    }
+
+    #[test]
+    fn whole_milliseconds_are_preserved() {
+        assert_eq!(duration_millis(Duration::from_millis(42)), 42);
+    }
+}

--- a/plugins/bitrouter-observe/Cargo.toml
+++ b/plugins/bitrouter-observe/Cargo.toml
@@ -106,6 +106,7 @@ otel-grpc = [
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }
+futures.workspace = true
 criterion = { version = "0.5", features = ["async_tokio"] }
 
 [[bench]]

--- a/plugins/bitrouter-observe/src/otel/exporter.rs
+++ b/plugins/bitrouter-observe/src/otel/exporter.rs
@@ -113,12 +113,11 @@ struct SpanEntry {
     stream_reasoning: Mutex<String>,
 }
 
-/// In-flight per-hop span state — created on `on_hop_start`, consumed on
-/// `on_hop_end`. `started_at` is the elapsed-timer source for TTFB
-/// propagation to the root chat span on a streaming hop.
+/// In-flight per-hop span state — created on `on_hop_start`. Non-streaming
+/// hops are consumed by `on_hop_end`; a streaming hop remains open across the
+/// response body and is consumed by `on_request_end`.
 struct HopState {
     context: Context,
-    started_at: Instant,
 }
 
 /// OpenTelemetry exporter with multi-tenant attribution.
@@ -564,10 +563,19 @@ impl ObserveHook for OtelExporter {
         });
         ctx.set_outbound_trace_headers(headers);
 
-        entry.hop = Some(HopState {
+        let previous_hop = entry.hop.replace(HopState {
             context: hop_context,
-            started_at: Instant::now(),
         });
+        drop(entry);
+
+        // A server-tool stream may open multiple upstream turns inside one
+        // caller-visible response. Starting the next turn is the terminal
+        // boundary for the previous successful CLIENT span.
+        if let Some(previous_hop) = previous_hop {
+            let previous_span = previous_hop.context.span();
+            previous_span.set_status(Status::Ok);
+            previous_span.end();
+        }
     }
 
     async fn on_hop_end(
@@ -576,20 +584,25 @@ impl ObserveHook for OtelExporter {
         _target: &RoutingTarget,
         outcome: HopOutcome<'_>,
     ) {
-        // Borrow the map only long enough to take the hop state + clone the
-        // root context. Holding the DashMap guard across the span work would
-        // serialise unrelated requests sharing a shard.
-        let (hop, root_context) = {
+        // A successful stream handshake only means response headers arrived.
+        // Keep the CLIENT span open across the response body; `on_request_end`
+        // closes it with the finalized execution result and terminal outcome.
+        if matches!(outcome, HopOutcome::StreamStarted) {
+            return;
+        }
+
+        // Borrow the map only long enough to take the hop state. Holding the
+        // DashMap guard across the span work would serialise unrelated
+        // requests sharing a shard.
+        let hop = {
             let Some(mut entry) = self.active_spans.get_mut(ctx.request_id()) else {
                 return;
             };
             let Some(hop) = entry.hop.take() else {
                 return;
             };
-            (hop, entry.context.clone())
+            hop
         };
-        let hop_elapsed = hop.started_at.elapsed();
-        let is_stream_start = matches!(outcome, HopOutcome::StreamStarted);
 
         // Close the hop CLIENT span. Access via `Context::span()` instead of
         // attaching the context + `get_active_span` — same effect, fewer
@@ -600,11 +613,7 @@ impl ObserveHook for OtelExporter {
                 set_hop_client_attrs(&hop_span, result);
                 hop_span.set_status(Status::Ok);
             }
-            HopOutcome::StreamStarted => {
-                // Stream handshake reached (TTFB). Body-level attrs land on
-                // the root span via `on_request_end`.
-                hop_span.set_status(Status::Ok);
-            }
+            HopOutcome::StreamStarted => unreachable!("stream start returned above"),
             HopOutcome::Failed(err) => {
                 let err_class = error_type(err);
                 hop_span.set_attribute(KeyValue::new("error.type", err_class.clone()));
@@ -621,16 +630,6 @@ impl ObserveHook for OtelExporter {
             }
         }
         hop_span.end();
-
-        // For a streaming hop that just reached TTFB, propagate the latency
-        // to the root chat span. Spec:
-        // gen_ai.response.time_to_first_chunk is in seconds (f64).
-        if is_stream_start {
-            root_context.span().set_attribute(KeyValue::new(
-                "gen_ai.response.time_to_first_chunk",
-                hop_elapsed.as_secs_f64(),
-            ));
-        }
     }
 
     fn stream_interest(&self) -> StreamInterest {
@@ -725,6 +724,37 @@ impl ObserveHook for OtelExporter {
             .lock()
             .map(|buf| buf.clone())
             .unwrap_or_default();
+
+        // Streaming hops deliberately survive `HopOutcome::StreamStarted` so
+        // the CLIENT span covers the complete upstream response body. Close
+        // that span now, after the SDK has finalized request/generation time.
+        if let Some(hop) = &entry.hop {
+            let hop_span = hop.context.span();
+            if let Some(result) = &ctx.execution_result {
+                set_hop_client_attrs(&hop_span, result);
+            }
+            match outcome {
+                RequestOutcome::Completed => hop_span.set_status(Status::Ok),
+                RequestOutcome::Failed(err) => {
+                    let err_class = error_type(err);
+                    hop_span.set_attribute(KeyValue::new("error.type", err_class.clone()));
+                    hop_span.add_event(
+                        "exception",
+                        vec![
+                            KeyValue::new("exception.type", err_class),
+                            KeyValue::new("exception.message", err.to_string()),
+                        ],
+                    );
+                    hop_span.set_status(Status::error(err.to_string()));
+                }
+                RequestOutcome::ClientDisconnected => {
+                    hop_span.set_attribute(KeyValue::new("error.type", "client_disconnected"));
+                    hop_span.set_status(Status::error("client_disconnected"));
+                }
+            }
+            hop_span.end();
+        }
+
         opentelemetry::trace::get_active_span(|span| {
             // PostHog's "URL / Screen" column reads `$screen_name`. Set it once,
             // here at request end, to the resolved `<provider>/<model>` route —
@@ -794,6 +824,23 @@ impl ObserveHook for OtelExporter {
                         ])),
                     ));
                 }
+            }
+
+            if let Some(first_token) = ctx.first_token_timing() {
+                span.set_attribute(KeyValue::new(
+                    "bitrouter.first_token_latency_ms",
+                    first_token.latency_ms as i64,
+                ));
+                span.set_attribute(KeyValue::new(
+                    "bitrouter.first_token_kind",
+                    first_token.kind.as_str(),
+                ));
+                // GenAI semconv uses seconds for time-to-first-chunk. The SDK
+                // source is the first reasoning/text/tool delta, never headers.
+                span.set_attribute(KeyValue::new(
+                    "gen_ai.response.time_to_first_chunk",
+                    first_token.latency_ms as f64 / 1000.0,
+                ));
             }
 
             // Cloud-forwarded attributes (cost / namespace / routing / …). A
@@ -1092,6 +1139,7 @@ mod hop_tests {
 
     use std::sync::Mutex;
 
+    use futures::StreamExt;
     use opentelemetry::Value;
     use opentelemetry::trace::TraceResult;
     use opentelemetry_sdk::export::trace::SpanData;
@@ -1101,7 +1149,8 @@ mod hop_tests {
     use bitrouter_sdk::error::BitrouterError;
     use bitrouter_sdk::language_model::{
         ApiProtocol, Content, FinishReason, GenerateResult, GenerationParams, Message,
-        PipelineRequest, Prompt, Role, Usage,
+        MockExecutor, MockResponse, PipelineBuilder, PipelineRequest, Prompt, Role,
+        StaticRoutingTable, Usage,
     };
 
     /// In-process span processor that appends every ended span to a shared
@@ -1828,23 +1877,31 @@ mod hop_tests {
     }
 
     #[tokio::test]
-    async fn streaming_hop_propagates_ttfb_to_root_chat() {
-        // `HopOutcome::StreamStarted` is the TTFB moment for a streaming
-        // request. The exporter writes `gen_ai.response.time_to_first_chunk`
-        // (seconds) on the root chat INTERNAL span, not the hop CLIENT span.
+    async fn streaming_hop_remains_open_until_request_end() {
+        // `HopOutcome::StreamStarted` only means that HTTP response headers
+        // arrived. The provider CLIENT span must stay open until the streamed
+        // body reaches its terminal request outcome.
         let (exporter, captured) = make_test_exporter();
-        let ctx = PipelineContext::new(fresh_request());
+        let mut ctx = PipelineContext::new(fresh_request());
         let target = fresh_target("openai");
 
         exporter.after_phase(Phase::PreRequest, &ctx).await;
         exporter.on_hop_start(&ctx, &target).await;
-        // Brief sleep so the elapsed time TTFB is > 0 — the attribute is
-        // an `f64` of seconds; even a few milliseconds is enough to make
-        // a non-zero assertion meaningful.
-        tokio::time::sleep(Duration::from_millis(5)).await;
         exporter
             .on_hop_end(&ctx, &target, HopOutcome::StreamStarted)
             .await;
+        exporter.provider.force_flush();
+
+        assert!(
+            captured
+                .lock()
+                .unwrap()
+                .iter()
+                .all(|span| span.span_kind != SpanKind::Client),
+            "stream handshake must not end the provider CLIENT span"
+        );
+
+        ctx.execution_result = Some(fresh_result(&target));
         exporter
             .on_request_end(&ctx, &RequestOutcome::Completed)
             .await;
@@ -1860,26 +1917,133 @@ mod hop_tests {
             .find(|s| s.name == "chat test-model" && s.span_kind == SpanKind::Client)
             .expect("per-hop chat CLIENT span");
 
-        // TTFB lives on the ROOT chat span, not on the hop.
-        let ttfb = root_chat
-            .attributes
-            .iter()
-            .find(|kv| kv.key.as_str() == "gen_ai.response.time_to_first_chunk")
-            .and_then(|kv| match kv.value {
-                Value::F64(v) => Some(v),
-                _ => None,
-            })
-            .expect("root chat carries gen_ai.response.time_to_first_chunk on stream start");
+        assert_eq!(i64_attr(hop_chat, "bitrouter.latency_ms"), Some(42));
         assert!(
-            ttfb > 0.0,
-            "time_to_first_chunk should be positive seconds; got {ttfb}"
-        );
-        assert!(
-            hop_chat
+            root_chat
                 .attributes
                 .iter()
                 .all(|kv| kv.key.as_str() != "gen_ai.response.time_to_first_chunk"),
-            "TTFB belongs on the root chat span, not the hop"
+            "HTTP headers alone must not be reported as the first semantic chunk"
+        );
+    }
+
+    #[tokio::test]
+    async fn next_nested_streaming_hop_closes_the_previous_client_span() {
+        let (exporter, captured) = make_test_exporter();
+        let mut ctx = PipelineContext::new(fresh_request());
+        let first = fresh_target("first");
+        let second = fresh_target("second");
+
+        exporter.after_phase(Phase::PreRequest, &ctx).await;
+        exporter.on_hop_start(&ctx, &first).await;
+        exporter
+            .on_hop_end(&ctx, &first, HopOutcome::StreamStarted)
+            .await;
+        exporter.on_hop_start(&ctx, &second).await;
+        exporter.provider.force_flush();
+
+        let spans = captured.lock().unwrap().clone();
+        let clients: Vec<_> = spans
+            .iter()
+            .filter(|span| span.span_kind == SpanKind::Client)
+            .collect();
+        assert_eq!(clients.len(), 1, "the prior nested stream span is closed");
+        assert_eq!(str_attr(clients[0], "bitrouter.provider_id"), Some("first"));
+        assert_eq!(
+            clients[0].status,
+            Status::Ok,
+            "a completed intermediate stream turn is successful"
+        );
+
+        exporter
+            .on_hop_end(&ctx, &second, HopOutcome::StreamStarted)
+            .await;
+        ctx.execution_result = Some(fresh_result(&second));
+        exporter
+            .on_request_end(&ctx, &RequestOutcome::Completed)
+            .await;
+        exporter.provider.force_flush();
+
+        assert_eq!(
+            captured
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|span| span.span_kind == SpanKind::Client)
+                .count(),
+            2,
+            "the final nested stream span closes at request end"
+        );
+    }
+
+    #[tokio::test]
+    async fn streamed_pipeline_exports_canonical_latency_and_first_token_timing() {
+        let (exporter, captured) = make_test_exporter();
+        let exporter = Arc::new(exporter);
+        let target = fresh_target("openai");
+        let routes = Arc::new(StaticRoutingTable::new());
+        routes.insert("test-model", vec![target]);
+
+        let mut builder = PipelineBuilder::new();
+        builder
+            .routing_table(routes)
+            .executor(Arc::new(MockExecutor::new(vec![MockResponse::Stream(
+                vec![
+                    StreamPart::ResponseStarted {
+                        id: "chatcmpl-streamed".into(),
+                    },
+                    StreamPart::TextDelta {
+                        text: "hello".into(),
+                    },
+                    StreamPart::Finish {
+                        reason: FinishReason::Stop,
+                    },
+                ],
+            )])))
+            .observe_hook(OtelObserveHook::new(exporter.clone()));
+        let pipeline = Arc::new(builder.build().expect("pipeline builds"));
+
+        let mut request = fresh_request();
+        request.prompt.stream = true;
+        let stream = pipeline
+            .execute_stream(request)
+            .await
+            .expect("stream starts");
+        let parts: Vec<_> = stream.collect().await;
+        assert!(parts.iter().all(Result::is_ok));
+        exporter.provider.force_flush();
+
+        let spans = captured.lock().unwrap().clone();
+        let root_chat = spans
+            .iter()
+            .find(|s| s.name == "chat test-model" && s.span_kind == SpanKind::Internal)
+            .expect("root chat span");
+        let hop_chat = spans
+            .iter()
+            .find(|s| s.name == "chat test-model" && s.span_kind == SpanKind::Client)
+            .expect("provider CLIENT span");
+
+        let latency_ms = i64_attr(root_chat, "bitrouter.latency_ms")
+            .expect("root carries canonical request latency");
+        let generation_ms = i64_attr(root_chat, "bitrouter.generation_time_ms")
+            .expect("root carries canonical provider generation time");
+        let first_token_ms = i64_attr(root_chat, "bitrouter.first_token_latency_ms")
+            .expect("root carries canonical first semantic token latency");
+        assert!(latency_ms >= 1);
+        assert!(generation_ms >= 1);
+        assert!(first_token_ms >= 1);
+        assert_eq!(
+            str_attr(root_chat, "bitrouter.first_token_kind"),
+            Some("text")
+        );
+        assert_eq!(
+            f64_attr(root_chat, "gen_ai.response.time_to_first_chunk"),
+            Some(first_token_ms as f64 / 1000.0)
+        );
+        assert_eq!(
+            i64_attr(hop_chat, "bitrouter.latency_ms"),
+            Some(latency_ms),
+            "streaming provider span closes with the finalized result"
         );
     }
 

--- a/plugins/bitrouter-observe/src/otel/exporter.rs
+++ b/plugins/bitrouter-observe/src/otel/exporter.rs
@@ -57,7 +57,7 @@ use serde::{Deserialize, Serialize};
 
 use bitrouter_sdk::language_model::{
     Content, ExecutionResult, HopOutcome, ObserveHook, Phase, PipelineContext, Prompt,
-    RequestOutcome, RoutingTarget, StreamContext, StreamInterest, StreamPart,
+    RequestOutcome, RoutingTarget, StreamContext, StreamHopOutcome, StreamInterest, StreamPart,
 };
 
 use crate::otel::cardinality::CardinalityLimiter;
@@ -363,6 +363,10 @@ impl OtelObserveHook {
 
 #[async_trait]
 impl ObserveHook for OtelObserveHook {
+    async fn on_request_start(&self, ctx: &PipelineContext) {
+        self.0.on_request_start(ctx).await
+    }
+
     async fn after_phase(&self, phase: Phase, ctx: &PipelineContext) {
         self.0.after_phase(phase, ctx).await
     }
@@ -380,6 +384,17 @@ impl ObserveHook for OtelObserveHook {
         self.0.on_hop_end(ctx, target, outcome).await
     }
 
+    fn on_stream_hop_end(
+        &self,
+        request_id: &str,
+        target: &RoutingTarget,
+        outcome: StreamHopOutcome<'_>,
+        duration_ms: u64,
+    ) {
+        self.0
+            .on_stream_hop_end(request_id, target, outcome, duration_ms)
+    }
+
     fn stream_interest(&self) -> StreamInterest {
         self.0.stream_interest()
     }
@@ -393,80 +408,107 @@ impl ObserveHook for OtelObserveHook {
     }
 }
 
+impl OtelExporter {
+    fn start_request_span(&self, ctx: &PipelineContext) {
+        if self.active_spans.contains_key(ctx.request_id()) {
+            return;
+        }
+
+        // Prefer the host ingress SERVER span, then inbound W3C trace context.
+        use tracing_opentelemetry::OpenTelemetrySpanExt as _;
+        let bridge_cx = tracing::Span::current().context();
+        let parent_context = if bridge_cx.span().span_context().is_valid() {
+            bridge_cx
+        } else {
+            global::get_text_map_propagator(|p| p.extract(&HeaderExtractor(ctx.headers())))
+        };
+
+        let model = ctx.model().to_string();
+        let span_name = format!("chat {model}");
+        let mut attributes = vec![
+            KeyValue::new("bitrouter.request_id", ctx.request_id().to_string()),
+            KeyValue::new(
+                "bitrouter.api_key_id",
+                ctx.caller().api_key_id().to_string(),
+            ),
+            KeyValue::new("bitrouter.user_id", ctx.caller().user_id().to_string()),
+            KeyValue::new("gen_ai.operation.name", "chat"),
+            KeyValue::new("gen_ai.request.model", model),
+        ];
+        attributes.extend(request_param_attrs(ctx.prompt()));
+
+        let builder = self
+            .tracer
+            .span_builder(span_name)
+            .with_kind(SpanKind::Internal)
+            .with_attributes(attributes);
+        let span = if parent_context.span().span_context().is_valid() {
+            builder.start_with_context(&self.tracer, &parent_context)
+        } else {
+            builder.start(&self.tracer)
+        };
+
+        self.active_spans.insert(
+            ctx.request_id().to_string(),
+            SpanEntry {
+                context: Context::current_with_span(span),
+                created_at: Instant::now(),
+                hop: None,
+                stream_text: Mutex::new(String::new()),
+                stream_reasoning: Mutex::new(String::new()),
+            },
+        );
+        self.gc_expired_spans();
+    }
+
+    fn finish_stream_hop(&self, request_id: &str, outcome: StreamHopOutcome<'_>, duration_ms: u64) {
+        let hop = {
+            let Some(mut entry) = self.active_spans.get_mut(request_id) else {
+                return;
+            };
+            let Some(hop) = entry.hop.take() else {
+                return;
+            };
+            hop
+        };
+
+        let span = hop.context.span();
+        span.set_attribute(KeyValue::new(
+            "bitrouter.latency_ms",
+            i64::try_from(duration_ms).unwrap_or(i64::MAX),
+        ));
+        match outcome {
+            StreamHopOutcome::Completed => span.set_status(Status::Ok),
+            StreamHopOutcome::Failed(error) => {
+                let error_class = error_type(error);
+                span.set_attribute(KeyValue::new("error.type", error_class.clone()));
+                span.add_event(
+                    "exception",
+                    vec![
+                        KeyValue::new("exception.type", error_class),
+                        KeyValue::new("exception.message", error.to_string()),
+                    ],
+                );
+                span.set_status(Status::error(error.to_string()));
+            }
+            StreamHopOutcome::Dropped => {
+                span.set_attribute(KeyValue::new("error.type", "stream_dropped"));
+                span.set_status(Status::error("stream_dropped"));
+            }
+        }
+        span.end();
+    }
+}
+
 #[async_trait]
 impl ObserveHook for OtelExporter {
+    async fn on_request_start(&self, ctx: &PipelineContext) {
+        self.start_request_span(ctx);
+    }
+
     async fn after_phase(&self, phase: Phase, ctx: &PipelineContext) {
         match phase {
-            Phase::PreRequest => {
-                // Pick a parent for the root `chat` INTERNAL span:
-                //   1. If the host's `tower-http` `TraceLayer` +
-                //      `tracing-opentelemetry` bridge wrapped this request in
-                //      a SERVER span, parent on it. The bridge does NOT
-                //      synchronise `opentelemetry::Context::current()` with
-                //      tracing's current span across async awaits — it stores
-                //      the OTel data in the tracing-span extensions instead.
-                //      `tracing::Span::current().context()` does the lookup.
-                //   2. Otherwise (no ingress layer — typical in unit tests),
-                //      fall back to extracting an inbound `traceparent` from
-                //      the request headers via the W3C propagator. Spec:
-                //      <https://www.w3.org/TR/trace-context/>
-                use tracing_opentelemetry::OpenTelemetrySpanExt as _;
-                let bridge_cx = tracing::Span::current().context();
-                let parent_context = if bridge_cx.span().span_context().is_valid() {
-                    bridge_cx
-                } else {
-                    global::get_text_map_propagator(|p| p.extract(&HeaderExtractor(ctx.headers())))
-                };
-
-                let model = ctx.model().to_string();
-                // GenAI semconv span name: "{operation} {model}".
-                let span_name = format!("chat {model}");
-
-                let mut attributes = vec![
-                    KeyValue::new("bitrouter.request_id", ctx.request_id().to_string()),
-                    // Raw values on spans — capping is a metrics concern.
-                    KeyValue::new(
-                        "bitrouter.api_key_id",
-                        ctx.caller().api_key_id().to_string(),
-                    ),
-                    KeyValue::new("bitrouter.user_id", ctx.caller().user_id().to_string()),
-                    // GenAI semconv from the start so the operation is
-                    // identifiable even when execution never completes.
-                    KeyValue::new("gen_ai.operation.name", "chat"),
-                    KeyValue::new("gen_ai.request.model", model),
-                ];
-                // The root `chat` span is the single gen_ai *generation* for the
-                // request, so the request parameters (temperature, max_tokens, …)
-                // live here — not on the per-hop CLIENT span, which is no longer a
-                // gen_ai generation (see `build_hop_client_attrs`).
-                attributes.extend(request_param_attrs(ctx.prompt()));
-
-                let builder = self
-                    .tracer
-                    .span_builder(span_name)
-                    .with_kind(SpanKind::Internal)
-                    .with_attributes(attributes);
-
-                let span = if parent_context.span().span_context().is_valid() {
-                    builder.start_with_context(&self.tracer, &parent_context)
-                } else {
-                    builder.start(&self.tracer)
-                };
-
-                let cx = Context::current_with_span(span);
-                self.active_spans.insert(
-                    ctx.request_id().to_string(),
-                    SpanEntry {
-                        context: cx,
-                        created_at: Instant::now(),
-                        hop: None,
-                        stream_text: Mutex::new(String::new()),
-                        stream_reasoning: Mutex::new(String::new()),
-                    },
-                );
-                // Best-effort GC — only walks the map, not held across awaits.
-                self.gc_expired_spans();
-            }
+            Phase::PreRequest => self.start_request_span(ctx),
             Phase::Route => {
                 // Brief INTERNAL span recording the routing decision. Parented
                 // to the root `chat` span.
@@ -632,6 +674,16 @@ impl ObserveHook for OtelExporter {
         hop_span.end();
     }
 
+    fn on_stream_hop_end(
+        &self,
+        request_id: &str,
+        _target: &RoutingTarget,
+        outcome: StreamHopOutcome<'_>,
+        duration_ms: u64,
+    ) {
+        self.finish_stream_hop(request_id, outcome, duration_ms);
+    }
+
     fn stream_interest(&self) -> StreamInterest {
         StreamInterest::all()
     }
@@ -725,9 +777,9 @@ impl ObserveHook for OtelExporter {
             .map(|buf| buf.clone())
             .unwrap_or_default();
 
-        // Streaming hops deliberately survive `HopOutcome::StreamStarted` so
-        // the CLIENT span covers the complete upstream response body. Close
-        // that span now, after the SDK has finalized request/generation time.
+        // Normally the provider body wrapper closes streaming CLIENT spans at
+        // EOF/error/drop. Keep this fallback for observers attached to a
+        // non-standard executor that did not emit the body-terminal callback.
         if let Some(hop) = &entry.hop {
             let hop_span = hop.context.span();
             if let Some(result) = &ctx.execution_result {
@@ -766,16 +818,16 @@ impl ObserveHook for OtelExporter {
                 None => ctx.model().to_string(),
             };
             span.set_attribute(KeyValue::new("$screen_name", screen_name));
+            span.set_attribute(KeyValue::new(
+                "bitrouter.latency_ms",
+                i64::try_from(ctx.request_latency_ms()).unwrap_or(i64::MAX),
+            ));
             if let Some(result) = &ctx.execution_result {
                 span.set_attribute(KeyValue::new(
                     "bitrouter.provider_id",
                     result.provider_id.clone(),
                 ));
                 span.set_attribute(KeyValue::new("bitrouter.model_id", result.model_id.clone()));
-                span.set_attribute(KeyValue::new(
-                    "bitrouter.latency_ms",
-                    result.latency_ms as i64,
-                ));
                 span.set_attribute(KeyValue::new(
                     "bitrouter.generation_time_ms",
                     result.generation_time_ms as i64,
@@ -1148,10 +1200,39 @@ mod hop_tests {
     use bitrouter_sdk::caller::CallerContext;
     use bitrouter_sdk::error::BitrouterError;
     use bitrouter_sdk::language_model::{
-        ApiProtocol, Content, FinishReason, GenerateResult, GenerationParams, Message,
-        MockExecutor, MockResponse, PipelineBuilder, PipelineRequest, Prompt, Role,
-        StaticRoutingTable, Usage,
+        ApiProtocol, Content, DenyReason, FinishReason, GenerateResult, GenerationParams,
+        HookDecision, Message, MockExecutor, MockResponse, PipelineBuilder, PipelineRequest,
+        PreRequestHook, Prompt, Role, SettlementContext, SettlementRecorder, StaticRoutingTable,
+        Usage,
     };
+
+    struct RejectingPreRequestHook;
+
+    #[async_trait]
+    impl PreRequestHook for RejectingPreRequestHook {
+        async fn check(
+            &self,
+            _ctx: &mut PipelineContext,
+        ) -> bitrouter_sdk::error::Result<HookDecision> {
+            Ok(HookDecision::Deny(DenyReason::Unauthorized(
+                "rejected".into(),
+            )))
+        }
+    }
+
+    struct BlockingSettlementRecorder {
+        entered: Arc<tokio::sync::Notify>,
+        release: Arc<tokio::sync::Notify>,
+    }
+
+    #[async_trait]
+    impl SettlementRecorder for BlockingSettlementRecorder {
+        async fn record(&self, _ctx: &mut SettlementContext) -> bitrouter_sdk::error::Result<()> {
+            self.entered.notify_one();
+            self.release.notified().await;
+            Ok(())
+        }
+    }
 
     /// In-process span processor that appends every ended span to a shared
     /// vector. Replaces the OTLP/HTTP exporter for tests so assertions can
@@ -2045,6 +2126,118 @@ mod hop_tests {
             Some(latency_ms),
             "streaming provider span closes with the finalized result"
         );
+    }
+
+    #[tokio::test]
+    async fn failed_preflight_exports_request_latency_without_execution_result() {
+        let (exporter, captured) = make_test_exporter();
+        let ctx = PipelineContext::new(fresh_request());
+
+        exporter.after_phase(Phase::PreRequest, &ctx).await;
+        tokio::time::sleep(Duration::from_millis(2)).await;
+        exporter
+            .on_request_end(
+                &ctx,
+                &RequestOutcome::Failed(BitrouterError::UpstreamUnavailable),
+            )
+            .await;
+        exporter.provider.force_flush();
+
+        let spans = captured.lock().unwrap().clone();
+        let root_chat = spans
+            .iter()
+            .find(|span| span.name == "chat test-model" && span.span_kind == SpanKind::Internal)
+            .expect("root chat span");
+        assert!(
+            i64_attr(root_chat, "bitrouter.latency_ms").is_some_and(|latency| latency >= 1),
+            "an early failure still carries end-to-end request latency"
+        );
+    }
+
+    #[tokio::test]
+    async fn pre_request_rejection_still_exports_a_root_request_span() {
+        let (exporter, captured) = make_test_exporter();
+        let exporter = Arc::new(exporter);
+        let routes = Arc::new(StaticRoutingTable::new());
+        routes.insert("test-model", vec![fresh_target("openai")]);
+        let mut builder = PipelineBuilder::new();
+        builder
+            .routing_table(routes)
+            .executor(Arc::new(MockExecutor::always_text("unused")))
+            .pre_request_hook(RejectingPreRequestHook)
+            .observe_hook(OtelObserveHook::new(exporter.clone()));
+        let pipeline = Arc::new(builder.build().expect("pipeline builds"));
+
+        let error = pipeline
+            .execute(fresh_request())
+            .await
+            .expect_err("pre-request rejects");
+        assert!(matches!(error, BitrouterError::Unauthorized(_)));
+        exporter.provider.force_flush();
+
+        let spans = captured.lock().unwrap().clone();
+        let root_chat = spans
+            .iter()
+            .find(|span| span.name == "chat test-model" && span.span_kind == SpanKind::Internal)
+            .expect("rejected request still has a root chat span");
+        assert!(i64_attr(root_chat, "bitrouter.latency_ms").is_some_and(|latency| latency >= 1));
+    }
+
+    #[tokio::test]
+    async fn provider_stream_span_ends_before_settlement_io() {
+        let (exporter, captured) = make_test_exporter();
+        let exporter = Arc::new(exporter);
+        let target = fresh_target("openai");
+        let routes = Arc::new(StaticRoutingTable::new());
+        routes.insert("test-model", vec![target]);
+        let entered = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+
+        let mut builder = PipelineBuilder::new();
+        builder
+            .routing_table(routes)
+            .executor(Arc::new(MockExecutor::new(vec![MockResponse::Stream(
+                vec![
+                    StreamPart::TextDelta {
+                        text: "hello".into(),
+                    },
+                    StreamPart::Finish {
+                        reason: FinishReason::Stop,
+                    },
+                ],
+            )])))
+            .settlement_recorder(BlockingSettlementRecorder {
+                entered: entered.clone(),
+                release: release.clone(),
+            })
+            .observe_hook(OtelObserveHook::new(exporter.clone()));
+        let pipeline = Arc::new(builder.build().expect("pipeline builds"));
+
+        let mut request = fresh_request();
+        request.prompt.stream = true;
+        let stream = pipeline
+            .execute_stream(request)
+            .await
+            .expect("stream starts");
+        let drain = tokio::spawn(async move { stream.collect::<Vec<_>>().await });
+        entered.notified().await;
+        exporter.provider.force_flush();
+
+        let spans = captured.lock().unwrap().clone();
+        assert!(
+            spans.iter().any(|span| span.span_kind == SpanKind::Client),
+            "provider CLIENT span ends when its response body ends"
+        );
+        assert!(
+            spans
+                .iter()
+                .all(|span| !(span.name == "chat test-model"
+                    && span.span_kind == SpanKind::Internal)),
+            "root request span stays open while settlement is blocked"
+        );
+
+        release.notify_one();
+        assert!(drain.await.expect("drain task").iter().all(Result::is_ok));
     }
 
     #[tokio::test]

--- a/plugins/bitrouter-observe/src/otel/metrics.rs
+++ b/plugins/bitrouter-observe/src/otel/metrics.rs
@@ -130,8 +130,11 @@ impl OtelMetrics {
             }
 
             // GenAI semconv: operation.duration is a histogram in seconds.
-            self.latency_histogram
-                .record(result.latency_ms as f64 / 1000.0, &attributes);
+            // `execution_result.latency_ms` is finalized by the SDK before
+            // settlement for both streamed and non-streamed requests.
+            if let Some(latency_seconds) = request_latency_seconds(ctx) {
+                self.latency_histogram.record(latency_seconds, &attributes);
+            }
 
             if let Some(usage) = &result.result.usage {
                 let mut input_attrs = attributes.clone();
@@ -176,6 +179,12 @@ impl OtelMetrics {
     }
 }
 
+fn request_latency_seconds(ctx: &PipelineContext) -> Option<f64> {
+    ctx.execution_result
+        .as_ref()
+        .map(|result| result.latency_ms as f64 / 1000.0)
+}
+
 fn stream_part_type(part: &StreamPart) -> &'static str {
     match part {
         StreamPart::TextStart { .. } => "text_start",
@@ -193,5 +202,51 @@ fn stream_part_type(part: &StreamPart) -> &'static str {
         StreamPart::ResponseStarted { .. } => "response_started",
         StreamPart::Finish { .. } => "finish",
         StreamPart::ResponseCompleted { .. } => "response_completed",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bitrouter_sdk::caller::CallerContext;
+    use bitrouter_sdk::language_model::{
+        ExecutionResult, GenerateResult, GenerationParams, PipelineRequest, Prompt,
+    };
+
+    use super::*;
+
+    #[test]
+    fn request_latency_histogram_uses_finalized_milliseconds_as_seconds() {
+        let prompt = Prompt {
+            model: "test-model".into(),
+            system: None,
+            system_provider_metadata: Default::default(),
+            messages: Vec::new(),
+            tools: Vec::new(),
+            params: GenerationParams::default(),
+            response_format: None,
+            tool_choice: None,
+            stream: true,
+        };
+        let request =
+            PipelineRequest::new("test-model", CallerContext::new("api-key", "user"), prompt);
+        let mut ctx = PipelineContext::new(request);
+        ctx.execution_result = Some(ExecutionResult {
+            provider_id: "openai".into(),
+            model_id: "test-model".into(),
+            account_label: None,
+            result: GenerateResult {
+                content: Vec::new(),
+                usage: None,
+                finish_reason: None,
+                response_id: None,
+                stop_details: None,
+                provider_metadata: Default::default(),
+            },
+            latency_ms: 42,
+            generation_time_ms: 40,
+            server_tool_calls: Vec::new(),
+        });
+
+        assert_eq!(request_latency_seconds(&ctx), Some(0.042));
     }
 }

--- a/plugins/bitrouter-observe/src/otel/metrics.rs
+++ b/plugins/bitrouter-observe/src/otel/metrics.rs
@@ -129,13 +129,6 @@ impl OtelMetrics {
                 attributes.push(KeyValue::new("bitrouter.account_label", label.clone()));
             }
 
-            // GenAI semconv: operation.duration is a histogram in seconds.
-            // `execution_result.latency_ms` is finalized by the SDK before
-            // settlement for both streamed and non-streamed requests.
-            if let Some(latency_seconds) = request_latency_seconds(ctx) {
-                self.latency_histogram.record(latency_seconds, &attributes);
-            }
-
             if let Some(usage) = &result.result.usage {
                 let mut input_attrs = attributes.clone();
                 input_attrs.push(KeyValue::new("gen_ai.token.type", "input"));
@@ -147,6 +140,12 @@ impl OtelMetrics {
                     .record(usage.completion_tokens, &output_attrs);
             }
         }
+
+        // GenAI semconv: operation.duration is a histogram in seconds. The SDK
+        // exposes elapsed time even when an early failure produced no
+        // `ExecutionResult`, so failed preflight requests are included too.
+        self.latency_histogram
+            .record(request_latency_seconds(ctx), &attributes);
 
         self.request_counter.add(1, &attributes);
 
@@ -179,10 +178,8 @@ impl OtelMetrics {
     }
 }
 
-fn request_latency_seconds(ctx: &PipelineContext) -> Option<f64> {
-    ctx.execution_result
-        .as_ref()
-        .map(|result| result.latency_ms as f64 / 1000.0)
+fn request_latency_seconds(ctx: &PipelineContext) -> f64 {
+    ctx.request_latency_ms() as f64 / 1000.0
 }
 
 fn stream_part_type(part: &StreamPart) -> &'static str {
@@ -247,6 +244,27 @@ mod tests {
             server_tool_calls: Vec::new(),
         });
 
-        assert_eq!(request_latency_seconds(&ctx), Some(0.042));
+        assert_eq!(request_latency_seconds(&ctx), 0.042);
+    }
+
+    #[test]
+    fn request_latency_histogram_includes_early_failures() {
+        let prompt = Prompt {
+            model: "test-model".into(),
+            system: None,
+            system_provider_metadata: Default::default(),
+            messages: Vec::new(),
+            tools: Vec::new(),
+            params: GenerationParams::default(),
+            response_format: None,
+            tool_choice: None,
+            stream: true,
+        };
+        let request =
+            PipelineRequest::new("test-model", CallerContext::new("api-key", "user"), prompt);
+        let ctx = PipelineContext::new(request);
+        std::thread::sleep(Duration::from_millis(2));
+
+        assert!(request_latency_seconds(&ctx) > 0.0);
     }
 }


### PR DESCRIPTION
## Summary
- make SDK request latency, provider generation time, and first semantic token timing authoritative for streamed and non-streamed requests
- attribute fallback and nested server-tool streams to the actual successful provider and finalize every terminal path
- keep streaming CLIENT spans open through the body and export canonical timing to OTEL spans and duration metrics

## Verification
- cargo fmt --all -- --check
- cargo clippy --all-features --all-targets -- -D warnings
- cargo nextest run --all-features: 1441 passed, 3 skipped

## Downstream
- bitrouter-cloud will pin revision 9398b1c0dcf4a6ee37ccd59b0e4419e6bdf4a769
