### PR TITLE
chore: refresh Rust dependencies and MSRV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: "1.88"
+          toolchain: "1.93"
       - run: cargo check --workspace
 
   doc:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: "1.93"
-      - run: cargo check --workspace
+      - run: cargo check --workspace --all-features
 
   doc:
     name: doc

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ For larger changes, opening an issue before writing code is the fastest way to a
    - `cargo test --workspace --all-features`
 6. Open a pull request with a clear summary and note any follow-up work.
 
-The workspace MSRV is **Rust 1.88**; the `msrv` CI job pins that exact toolchain. Don't rely on a feature stabilised after it.
+The workspace MSRV is **Rust 1.93**; the `msrv` CI job pins that exact toolchain. Don't rely on a feature stabilised after it.
 
 ## Review Guidelines
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -697,7 +697,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tonic",
- "tower-http 0.7.0",
+ "tower-http",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -4192,7 +4192,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-util",
  "tower",
- "tower-http 0.6.11",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -5722,24 +5722,8 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
- "url",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
-dependencies = [
- "bitflags",
- "bytes",
- "http",
- "http-body",
- "percent-encoding",
- "pin-project-lite",
- "tower-layer",
- "tower-service",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -611,7 +611,6 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
- "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tower 0.5.3",
@@ -649,7 +648,6 @@ dependencies = [
  "bitrouter-sdk",
  "serde_json",
  "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -684,7 +682,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -704,7 +701,6 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
- "tracing",
  "wiremock",
 ]
 
@@ -764,16 +760,12 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum 0.8.9",
- "base64 0.22.1",
- "bytes",
- "chrono",
  "eventsource-stream",
  "futures",
  "futures-core",
  "http",
  "httpdate",
  "pin-project-lite",
- "regex",
  "reqwest 0.12.28",
  "reqwest 0.13.3",
  "rmcp",
@@ -781,13 +773,10 @@ dependencies = [
  "serde",
  "serde-saphyr",
  "serde_json",
- "sha2",
  "thiserror 2.0.18",
  "tokio",
- "tokio-stream",
  "tokio-util",
  "tower 0.5.3",
- "tower-http",
  "tracing",
  "url",
  "uuid",
@@ -819,7 +808,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -685,6 +685,7 @@ dependencies = [
  "criterion",
  "dashmap",
  "futures",
+ "futures-core",
  "http",
  "opentelemetry",
  "opentelemetry-http",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,6 +79,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,9 +171,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arraydeque"
@@ -174,9 +183,9 @@ checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "asn1_der"
@@ -327,15 +336,15 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -343,31 +352,32 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
 name = "axoasset"
-version = "1.5.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "448205969ebf1eec16088881b9d309e90e52ceed1bfa92e7efbfb00f3b10982a"
+checksum = "1be1b9c2739b635e04c7bbcde9e89dd5e874b9e86e28f1b41c44eb830635d83e"
 dependencies = [
  "camino",
  "image",
  "lazy_static",
  "miette",
  "mime",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
  "url",
  "walkdir",
 ]
@@ -379,7 +389,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a4b4798a6c02e91378537c63cd6e91726900b595450daa5d487bc3c11e95e1b"
 dependencies = [
  "miette",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
 ]
 
@@ -391,14 +401,14 @@ checksum = "dc923121fbc4cc72e9008436b5650b98e56f94b5799df59a1b4f572b5c6a7e6b"
 dependencies = [
  "miette",
  "semver",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
 name = "axoupdater"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc482a1926df098f4e3806b834f3fe73a1ab54b24ab0ac481f72de479af5e982"
+checksum = "0ab66f118bab79524a27139b7341cdf1c4f839c6274ef89a6d8fb4365cb218cf"
 dependencies = [
  "axoasset",
  "axoprocess",
@@ -409,35 +419,8 @@ dependencies = [
  "self-replace",
  "serde",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror",
  "url",
-]
-
-[[package]]
-name = "axum"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
-dependencies = [
- "async-trait",
- "axum-core 0.4.5",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "itoa",
- "matchit 0.7.3",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "sync_wrapper",
- "tower 0.5.3",
- "tower-layer",
- "tower-service",
 ]
 
 [[package]]
@@ -446,7 +429,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
- "axum-core 0.5.6",
+ "axum-core",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -456,7 +439,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "itoa",
- "matchit 0.8.4",
+ "matchit",
  "memchr",
  "mime",
  "percent-encoding",
@@ -467,30 +450,10 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "rustversion",
- "sync_wrapper",
- "tower-layer",
- "tower-service",
 ]
 
 [[package]]
@@ -514,15 +477,16 @@ dependencies = [
 
 [[package]]
 name = "axum-test"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a86bfe2ef15bee102ac34912f7f4542b0bb37dc464fa55461763999c4d625e7"
+checksum = "3ce104337e4cced59ded9c61f9f18dab0a4670fd339e84f334312686440a9958"
 dependencies = [
  "anyhow",
- "axum 0.8.9",
+ "axum",
  "bytes",
  "bytesize",
  "cookie",
+ "educe",
  "expect-json",
  "http",
  "http-body-util",
@@ -536,7 +500,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tower 0.5.3",
+ "tower",
  "url",
 ]
 
@@ -545,6 +509,12 @@ name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
 
 [[package]]
 name = "base64"
@@ -566,9 +536,9 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 dependencies = [
  "serde_core",
 ]
@@ -581,7 +551,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axoupdater",
- "axum 0.8.9",
+ "axum",
  "axum-test",
  "base64 0.22.1",
  "bitrouter-attestation",
@@ -601,19 +571,19 @@ dependencies = [
  "http",
  "opentelemetry-proto",
  "prost",
- "rand 0.9.4",
- "reqwest 0.12.28",
+ "rand 0.10.2",
+ "reqwest",
  "sea-orm",
  "sea-orm-migration",
  "semver",
  "serde",
  "serde-saphyr",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "tempfile",
  "tokio",
  "tokio-util",
- "tower 0.5.3",
+ "tower",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -629,13 +599,13 @@ dependencies = [
  "hex",
  "jsonwebtoken",
  "k256",
- "rand 0.9.4",
- "reqwest 0.12.28",
+ "rand 0.10.2",
+ "reqwest",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "sha3",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
 ]
 
@@ -659,11 +629,11 @@ dependencies = [
  "base64 0.22.1",
  "bitrouter-sdk",
  "chrono",
- "rand 0.9.4",
- "reqwest 0.12.28",
+ "rand 0.10.2",
+ "reqwest",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tracing",
  "url",
@@ -690,15 +660,15 @@ version = "1.0.0-alpha.24"
 dependencies = [
  "anyhow",
  "async-trait",
- "axum 0.8.9",
+ "axum",
  "bitrouter-cloud-sdk",
  "http",
- "reqwest 0.12.28",
+ "reqwest",
  "rmcp",
  "schemars 1.2.1",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tokio-util",
  "wiremock",
@@ -709,7 +679,7 @@ name = "bitrouter-observe"
 version = "1.0.0-alpha.24"
 dependencies = [
  "async-trait",
- "axum 0.8.9",
+ "axum",
  "bitrouter-sdk",
  "bytes",
  "criterion",
@@ -721,12 +691,12 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "tokio",
  "tonic",
- "tower-http",
+ "tower-http 0.7.0",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -739,12 +709,12 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bitrouter-sdk",
- "rand 0.9.4",
- "reqwest 0.12.28",
+ "rand 0.10.2",
+ "reqwest",
  "serde",
  "serde_json",
- "sha2",
- "thiserror 2.0.18",
+ "sha2 0.11.0",
+ "thiserror",
  "tokio",
  "toml",
  "tracing",
@@ -759,24 +729,23 @@ dependencies = [
  "agent-client-protocol-schema",
  "async-stream",
  "async-trait",
- "axum 0.8.9",
+ "axum",
  "eventsource-stream",
  "futures",
  "futures-core",
  "http",
  "httpdate",
  "pin-project-lite",
- "reqwest 0.12.28",
- "reqwest 0.13.3",
+ "reqwest",
  "rmcp",
  "schemars 1.2.1",
  "serde",
  "serde-saphyr",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tokio-util",
- "tower 0.5.3",
+ "tower",
  "tracing",
  "url",
  "uuid",
@@ -786,11 +755,11 @@ dependencies = [
 name = "bitrouter-skills"
 version = "1.0.0-alpha.24"
 dependencies = [
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde-saphyr",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
 ]
 
@@ -817,9 +786,9 @@ dependencies = [
 
 [[package]]
 name = "bitvec"
-version = "1.0.1"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
 dependencies = [
  "funty",
  "radium",
@@ -837,6 +806,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "blocking"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -851,9 +829,9 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
+checksum = "2f3f6da4992df95bbcd9af42a6c7dcb994498fc9048230405f3b36ff7cd3f145"
 dependencies = [
  "borsh-derive",
  "bytes",
@@ -862,9 +840,9 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
+checksum = "3ae8fb4fb5740e4b2c4884ff95f5f32f5e8479db1e8fd8eb49ddbe09eb09bb7c"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
@@ -884,9 +862,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byte-slice-cast"
@@ -896,9 +874,9 @@ checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "bytemuck"
-version = "1.25.0"
+version = "1.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+checksum = "d6aedf8ae72766347502cf3cb4f41cf5e9cc37d28bee90f1fdaaae15f9cf9424"
 
 [[package]]
 name = "byteorder"
@@ -914,21 +892,21 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "bytesize"
-version = "2.3.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3"
+checksum = "3d7c8918969267b2932ffd5655509bbbea0833823058c378876953217f5fc50e"
 
 [[package]]
 name = "camino"
-version = "1.2.3"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ce8d3bd5823c7504d3f579f13e7b2f3da252fcb938c594d5680ee508bf846f"
+checksum = "5f2d30e4173c4026932d51d31d6b0613b1fd3014bf3f9f8943d4ba139c437ba0"
 dependencies = [
  "serde_core",
 ]
@@ -941,9 +919,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -965,9 +943,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -976,9 +954,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -1065,6 +1043,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1094,6 +1078,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "const_format"
@@ -1137,6 +1127,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -1150,6 +1150,12 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -1186,26 +1192,24 @@ checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
 dependencies = [
+ "alloca",
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "futures",
- "is-terminal",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "num-traits",
- "once_cell",
  "oorandom",
+ "page_size",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "tokio",
@@ -1214,12 +1218,12 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.5.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
- "itertools 0.10.5",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -1230,18 +1234,18 @@ checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -1249,27 +1253,27 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crunchy"
@@ -1290,13 +1294,50 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-common"
-version = "0.1.7"
+name = "crypto-bigint"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
+dependencies = [
+ "cpubits",
+ "ctutils",
+ "getrandom 0.4.3",
+ "hybrid-array",
+ "num-traits",
+ "rand_core 0.10.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "getrandom 0.4.3",
+ "hybrid-array",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+ "subtle",
 ]
 
 [[package]]
@@ -1308,7 +1349,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -1416,9 +1457,9 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "dcap-qvl"
-version = "0.3.12"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67e7842b81018f3b991dc65ec0a95ff347332de58478c4ac43459095af00cc89"
+checksum = "92a14fb8954c867d6855e44d98eab18e769816357738406691ebe60d8fdd005d"
 dependencies = [
  "anyhow",
  "asn1_der",
@@ -1426,9 +1467,9 @@ dependencies = [
  "borsh",
  "byteorder",
  "chrono",
- "const-oid",
+ "const-oid 0.9.6",
  "dcap-qvl-webpki",
- "der",
+ "der 0.7.10",
  "derive_more 2.1.1",
  "futures",
  "hex",
@@ -1436,14 +1477,14 @@ dependencies = [
  "p256",
  "parity-scale-codec",
  "pem",
- "reqwest 0.12.28",
+ "reqwest",
  "rustls-pki-types",
  "scale-info",
  "serde",
  "serde-human-bytes",
  "serde_json",
- "sha2",
- "signature",
+ "sha2 0.10.9",
+ "signature 2.2.0",
  "tracing",
  "urlencoding",
  "wasm-bindgen-futures",
@@ -1456,15 +1497,15 @@ version = "0.103.4+dcap.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0af040afe66c4f26ca05f308482d98bd75a35a80a227d877c2e28c9947a9fa6"
 dependencies = [
- "ecdsa",
+ "ecdsa 0.16.9",
  "ed25519-dalek",
  "p256",
  "p384",
  "ring",
  "rsa",
  "rustls-pki-types",
- "sha2",
- "signature",
+ "sha2 0.10.9",
+ "signature 2.2.0",
  "untrusted",
 ]
 
@@ -1492,10 +1533,20 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "der_derive",
  "flagset",
  "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
+dependencies = [
+ "const-oid 0.10.2",
  "zeroize",
 ]
 
@@ -1516,7 +1567,6 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -1575,17 +1625,29 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.6",
  "subtle",
 ]
 
 [[package]]
-name = "displaydoc"
-version = "0.2.5"
+name = "digest"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
+ "ctutils",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1599,7 +1661,7 @@ dependencies = [
  "anyhow",
  "bitrouter-sdk",
  "clap",
- "reqwest 0.12.28",
+ "reqwest",
  "schemars 1.2.1",
  "serde",
  "serde-saphyr",
@@ -1631,12 +1693,27 @@ version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der",
- "digest",
- "elliptic-curve",
- "rfc6979",
- "signature",
- "spki",
+ "der 0.7.10",
+ "digest 0.10.7",
+ "elliptic-curve 0.13.8",
+ "rfc6979 0.4.0",
+ "signature 2.2.0",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0681a4fc24c767085329728d8dfba959af91228aa4610cca4f8ce317ba46ae0"
+dependencies = [
+ "der 0.8.1",
+ "digest 0.11.3",
+ "elliptic-curve 0.14.1",
+ "rfc6979 0.6.0",
+ "signature 3.0.0",
+ "spki 0.8.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -1645,8 +1722,8 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8",
- "signature",
+ "pkcs8 0.10.2",
+ "signature 2.2.0",
 ]
 
 [[package]]
@@ -1658,16 +1735,28 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
-name = "either"
-version = "1.15.0"
+name = "educe"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 dependencies = [
  "serde",
 ]
@@ -1678,17 +1767,37 @@ version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "base16ct",
- "crypto-bigint",
- "digest",
- "ff",
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.5",
+ "digest 0.10.7",
+ "ff 0.13.1",
  "generic-array",
- "group",
+ "group 0.13.0",
  "hkdf",
  "pem-rfc7468",
- "pkcs8",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
- "sec1",
+ "sec1 0.7.3",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d65aa39b3a5c1c9c1b745c9a019234bb7a21b77abcb4f4d266d706e2d577d65"
+dependencies = [
+ "base16ct 1.0.0",
+ "crypto-bigint 0.7.5",
+ "crypto-common 0.2.2",
+ "digest 0.11.3",
+ "ff 0.14.0",
+ "group 0.14.0",
+ "hybrid-array",
+ "pkcs8 0.11.0",
+ "rand_core 0.10.1",
+ "sec1 0.8.1",
  "subtle",
  "zeroize",
 ]
@@ -1721,12 +1830,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "enum-as-inner"
-version = "0.6.1"
+name = "enum-ordinalize"
+version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+checksum = "07f808d588c10e464ea6f7d3eaed500049eff30aaac103460f61828c2d65b3eb"
 dependencies = [
- "heck 0.5.0",
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e528e2d34ba8a67a1a650b86beae8ef69fc5fdb638016f386b973226590432"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn",
@@ -1804,9 +1921,9 @@ dependencies = [
 
 [[package]]
 name = "expect-json"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "869f97f4abe8e78fc812a94ad6b721d72c4fb5532877c79610f2c238d7ccf6c4"
+checksum = "5e80819dbfe83c8a651f5344b08910d0037dac72988aef27ee4e6bedd7ae2e33"
 dependencies = [
  "chrono",
  "email_address",
@@ -1815,16 +1932,16 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
  "typetag",
  "uuid",
 ]
 
 [[package]]
 name = "expect-json-macros"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e6fdf550180a6c29a28cb9aac262dc0064c25735641d2317f670075e9a469d9"
+checksum = "c0637949cd816934f3b7aab44ff98e7ec1fb903c379e07dcb9eac943ec33499e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1844,6 +1961,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
  "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "ff"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1f686ab92a9fb0eaf188f6c6c87b89490baa6fdb0db4544ba4dc47f7942489f"
+dependencies = [
+ "rand_core 0.10.1",
  "subtle",
 ]
 
@@ -2042,9 +2169,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.7"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
@@ -2080,16 +2207,16 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
- "wasip2",
- "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2100,9 +2227,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "granit-parser"
-version = "0.0.2"
+version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e736dfe3881c53a7dce0685eb18202d0d9fe6911782f9870946eb9ee89d778"
+checksum = "d03f81ad4732830d85cfd417a9f62cde6dadda4354d37d078a6084a19560aa2d"
 dependencies = [
  "arraydeque",
  "smallvec",
@@ -2114,16 +2241,27 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff",
+ "ff 0.13.1",
  "rand_core 0.6.4",
  "subtle",
 ]
 
 [[package]]
-name = "h2"
-version = "0.4.14"
+name = "group"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "7fd1a1c7a5206c5b7a3f5a0d7ccd3ff85d0c8f5133d62a02680255b0004af5f4"
+dependencies = [
+ "ff 0.14.0",
+ "rand_core 0.10.1",
+ "subtle",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2212,24 +2350,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hickory-proto"
-version = "0.25.2"
+name = "hickory-net"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
 dependencies = [
  "async-trait",
  "cfg-if",
  "data-encoding",
- "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
+ "hickory-proto",
  "idna",
  "ipnet",
- "once_cell",
- "rand 0.9.4",
- "ring",
- "thiserror 2.0.18",
+ "jni",
+ "rand 0.10.2",
+ "thiserror",
  "tinyvec",
  "tokio",
  "tracing",
@@ -2237,22 +2374,47 @@ dependencies = [
 ]
 
 [[package]]
-name = "hickory-resolver"
-version = "0.25.2"
+name = "hickory-proto"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.2",
+ "ring",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
 dependencies = [
  "cfg-if",
  "futures-util",
+ "hickory-net",
  "hickory-proto",
  "ipconfig",
+ "ipnet",
+ "jni",
  "moka",
+ "ndk-context",
  "once_cell",
  "parking_lot",
- "rand 0.9.4",
+ "rand 0.10.2",
  "resolv-conf",
  "smallvec",
- "thiserror 2.0.18",
+ "system-configuration",
+ "thiserror",
  "tokio",
  "tracing",
 ]
@@ -2263,7 +2425,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -2272,16 +2434,25 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
 name = "home"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2298,9 +2469,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -2342,10 +2513,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
-name = "hyper"
-version = "1.9.0"
+name = "hybrid-array"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "subtle",
+ "typenum",
+ "zeroize",
+]
+
+[[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2373,11 +2555,9 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -2410,7 +2590,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -2442,12 +2622,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -2455,9 +2636,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -2468,9 +2649,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -2482,15 +2663,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -2502,15 +2683,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -2520,12 +2701,6 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
-
-[[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ident_case"
@@ -2546,9 +2721,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -2626,7 +2801,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
 dependencies = [
- "socket2 0.6.3",
+ "socket2",
  "widestring",
  "windows-registry",
  "windows-result 0.4.1",
@@ -2638,16 +2813,8 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.61.2",
+ "serde",
 ]
 
 [[package]]
@@ -2658,9 +2825,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -2692,7 +2859,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror 2.0.18",
+ "thiserror",
  "walkdir",
  "windows-link 0.2.1",
 ]
@@ -2731,23 +2898,22 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.98"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -2760,42 +2926,44 @@ dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
  "getrandom 0.2.17",
- "hmac",
+ "hmac 0.12.1",
  "js-sys",
  "p256",
  "p384",
  "pem",
- "rand 0.8.6",
+ "rand 0.8.7",
  "rsa",
  "serde",
  "serde_json",
- "sha2",
- "signature",
+ "sha2 0.10.9",
+ "signature 2.2.0",
  "simple_asn1",
  "zeroize",
 ]
 
 [[package]]
 name = "k256"
-version = "0.13.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
+checksum = "93f50113171a713f4a4231ef82eb26703607139b35dcb56241f0ceab2ae1f7d8"
 dependencies = [
- "cfg-if",
- "ecdsa",
- "elliptic-curve",
- "once_cell",
- "sha2",
- "signature",
+ "cpubits",
+ "ecdsa 0.17.0",
+ "elliptic-curve 0.14.1",
+ "primeorder 0.14.0",
+ "sha2 0.11.0",
+ "signature 3.0.0",
+ "wnaf",
 ]
 
 [[package]]
 name = "keccak"
-version = "0.1.6"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
 dependencies = [
- "cpufeatures 0.2.17",
+ "cfg-if",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -2823,12 +2991,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2842,14 +3004,14 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.16"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
  "bitflags",
  "libc",
  "plain",
- "redox_syscall 0.7.5",
+ "redox_syscall 0.9.0",
 ]
 
 [[package]]
@@ -2886,9 +3048,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru-slab"
@@ -2907,12 +3069,6 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
-
-[[package]]
-name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
@@ -2924,14 +3080,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "miette"
@@ -2969,9 +3125,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -3004,6 +3160,12 @@ dependencies = [
  "num-traits",
  "pxfm",
 ]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "nix"
@@ -3070,9 +3232,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -3089,7 +3251,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.6",
+ "rand 0.8.7",
  "smallvec",
  "zeroize",
 ]
@@ -3120,11 +3282,10 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -3190,88 +3351,85 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "opentelemetry"
-version = "0.27.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab70038c28ed37b97d8ed414b6429d343a8bbf44c9f79ec854f3a643029ba6d7"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
 dependencies = [
  "futures-core",
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 1.0.69",
+ "thiserror",
  "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.27.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a8a7f5f6ba7c1b286c2fbca0454eaba116f63bbe69ed250b642d36fbb04d80"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
 dependencies = [
  "async-trait",
  "bytes",
  "http",
  "opentelemetry",
- "reqwest 0.12.28",
+ "reqwest",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.27.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91cf61a1868dacc576bf2b2a1c3e9ab150af7272909e80085c3173384fe11f76"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
- "async-trait",
- "futures-core",
  "http",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest 0.12.28",
- "thiserror 1.0.69",
+ "reqwest",
+ "thiserror",
  "tokio",
  "tonic",
+ "tonic-types",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.27.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e05acbfada5ec79023c85368af14abd0b307c015e9064d249b2a950ef459a6"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
  "prost",
  "tonic",
+ "tonic-prost",
 ]
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.27.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc1b6902ff63b32ef6c489e8048c5e253e2e4a803ea3ea7e783914536eb15c52"
+checksum = "c913ac17a6c451661ee255f4625d143e51647ae78ebd969b75e41c4442f4fe47"
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.27.1"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "231e9d6ceef9b0b2546ddf52335785ce41252bc7474ee8ba05bfad277be13ab8"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
 dependencies = [
- "async-trait",
  "futures-channel",
  "futures-executor",
  "futures-util",
- "glob",
  "opentelemetry",
  "percent-encoding",
- "rand 0.8.6",
- "serde_json",
- "thiserror 1.0.69",
+ "portable-atomic",
+ "rand 0.9.5",
+ "thiserror",
  "tokio",
  "tokio-stream",
- "tracing",
 ]
 
 [[package]]
@@ -3313,10 +3471,10 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
+ "primeorder 0.13.6",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3325,10 +3483,20 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
 dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
+ "primeorder 0.13.6",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -3462,9 +3630,9 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der",
- "pkcs8",
- "spki",
+ "der 0.7.10",
+ "pkcs8 0.10.2",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -3473,8 +3641,18 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.10",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
+dependencies = [
+ "der 0.8.1",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -3562,6 +3740,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "prefix-trie"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
+]
+
+[[package]]
 name = "pretty_assertions"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3572,13 +3761,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
+name = "primefield"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+checksum = "c555a6e4eb7d4e158fcb028c835c3b8642206ddc279b5c6b202ef9a8bdb592f4"
 dependencies = [
- "proc-macro2",
- "syn",
+ "crypto-bigint 0.7.5",
+ "crypto-common 0.2.2",
+ "ff 0.14.0",
+ "rand_core 0.10.1",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -3587,7 +3780,20 @@ version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
- "elliptic-curve",
+ "elliptic-curve 0.13.8",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c9f42978c78a00e3d68f69fc03e57a234debae69da4020a4fb588fcdcd07b06"
+dependencies = [
+ "elliptic-curve 0.14.1",
+ "once_cell",
+ "primefield",
+ "serdect",
+ "wnaf",
 ]
 
 [[package]]
@@ -3596,7 +3802,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.12+spec-1.1.0",
+ "toml_edit",
 ]
 
 [[package]]
@@ -3659,9 +3865,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.5"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -3669,9 +3875,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.13.5"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
@@ -3681,16 +3887,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "pxfm"
-version = "0.1.29"
+name = "prost-types"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
+dependencies = [
+ "prost",
+]
+
+[[package]]
+name = "pxfm"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -3699,8 +3914,8 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
- "thiserror 2.0.18",
+ "socket2",
+ "thiserror",
  "tokio",
  "tracing",
  "web-time",
@@ -3708,21 +3923,22 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3730,23 +3946,23 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -3771,9 +3987,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -3782,9 +3998,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -3792,12 +4008,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
 
@@ -3846,6 +4062,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rayon"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3876,9 +4101,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.5"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
+checksum = "c5102a6aaa05aa011a238e178e6bca86d2cb56fc9f586d37cb80f5bca6e07759"
 dependencies = [
  "bitflags",
 ]
@@ -3905,9 +4130,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3917,9 +4142,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3928,19 +4153,18 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "futures-channel",
  "futures-core",
  "futures-util",
  "hickory-resolver",
@@ -3957,8 +4181,8 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
- "rustls-native-certs",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -3966,64 +4190,23 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
- "tower 0.5.3",
- "tower-http",
+ "tower",
+ "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams 0.4.2",
- "web-sys",
- "webpki-roots 1.0.7",
-]
-
-[[package]]
-name = "reqwest"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-pki-types",
- "rustls-platform-verifier",
- "serde",
- "serde_json",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tokio-util",
- "tower 0.5.3",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-streams 0.5.0",
+ "wasm-streams",
  "web-sys",
 ]
 
 [[package]]
 name = "reserve-port"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94070964579245eb2f76e62a7668fe87bd9969ed6c41256f3bf614e3323dd3cc"
+checksum = "71ea98a177596a4579881992bd2bd4af27772fc95d0e5f5668a8f9535eca6380"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -4038,8 +4221,18 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a459cddafb3fe76b31fd8f1108007566c40301feb64dc7b54656eb7388172b"
+dependencies = [
+ "crypto-bigint 0.7.5",
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -4058,9 +4251,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.7.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
+checksum = "14db48ee17a9ba61810ab1a9c1beb7d06d8136ae39ac25a1137f10d357af01af"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4072,14 +4265,14 @@ dependencies = [
  "pastey",
  "pin-project-lite",
  "process-wrap",
- "rand 0.10.1",
- "reqwest 0.13.3",
+ "rand 0.10.2",
+ "reqwest",
  "rmcp-macros",
  "schemars 1.2.1",
  "serde",
  "serde_json",
  "sse-stream",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -4090,9 +4283,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.7.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
+checksum = "783d787bf21813b285f13019adc49e11af501c658890c1e519f31f937c68b7e3"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -4107,17 +4300,17 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
  "pkcs1",
- "pkcs8",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
- "sha2",
- "signature",
- "spki",
+ "sha2 0.10.9",
+ "signature 2.2.0",
+ "spki 0.7.3",
  "subtle",
  "zeroize",
 ]
@@ -4133,15 +4326,15 @@ dependencies = [
  "futures-util",
  "http",
  "mime",
- "rand 0.10.1",
- "thiserror 2.0.18",
+ "rand 0.10.2",
+ "thiserror",
 ]
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -4167,9 +4360,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -4183,9 +4376,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -4194,19 +4387,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "web-time",
  "zeroize",
@@ -4218,7 +4402,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni",
  "log",
@@ -4253,9 +4437,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ryu"
@@ -4381,7 +4565,7 @@ dependencies = [
  "serde",
  "sqlx",
  "strum 0.26.3",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
  "url",
 ]
@@ -4463,7 +4647,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -4497,10 +4681,24 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct",
- "der",
+ "base16ct 0.2.0",
+ "der 0.7.10",
  "generic-array",
- "pkcs8",
+ "pkcs8 0.10.2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
+dependencies = [
+ "base16ct 1.0.0",
+ "ctutils",
+ "der 0.8.1",
+ "hybrid-array",
  "subtle",
  "zeroize",
 ]
@@ -4512,7 +4710,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -4568,9 +4766,9 @@ dependencies = [
 
 [[package]]
 name = "serde-saphyr"
-version = "0.0.26"
+version = "0.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcc7fe48e34d02a97bc8e6253b8b91e5a47fe2c47eaacb5149cefbb69922eaf0"
+checksum = "7bd22781911de0ca6debda95f073c8f18bec65d1a94f1fa9573f3102e514cea4"
 dependencies = [
  "ahash",
  "annotate-snippets",
@@ -4580,7 +4778,7 @@ dependencies = [
  "granit-parser",
  "nohash-hasher",
  "num-traits",
- "serde",
+ "serde_core",
  "smallvec",
  "zmij",
 ]
@@ -4618,9 +4816,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "indexmap 2.14.0",
  "itoa",
@@ -4643,11 +4841,11 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -4695,14 +4893,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.10.6"
+name = "serdect"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
+dependencies = [
+ "base16ct 1.0.0",
+ "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4713,17 +4921,29 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
 name = "sha3"
-version = "0.10.9"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
+checksum = "bc9bad02c26382724b2d2692c6f179285e4b54eeecd7968f52a50059c3c11759"
 dependencies = [
- "digest",
+ "digest 0.11.3",
  "keccak",
+ "sponge-cursor",
 ]
 
 [[package]]
@@ -4743,9 +4963,9 @@ checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -4763,8 +4983,18 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "signature"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
+dependencies = [
+ "digest 0.11.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4791,7 +5021,7 @@ checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror 2.0.18",
+ "thiserror",
  "time",
 ]
 
@@ -4803,28 +5033,18 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -4846,8 +5066,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
 ]
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der 0.8.1",
+]
+
+[[package]]
+name = "sponge-cursor"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620"
 
 [[package]]
 name = "sqlx"
@@ -4888,9 +5124,9 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -4926,7 +5162,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlx-core",
  "sqlx-mysql",
  "sqlx-postgres",
@@ -4948,7 +5184,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "crc",
- "digest",
+ "digest 0.10.7",
  "dotenvy",
  "either",
  "futures-channel",
@@ -4958,22 +5194,22 @@ dependencies = [
  "generic-array",
  "hex",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "itoa",
  "log",
  "md-5",
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand 0.8.6",
+ "rand 0.8.7",
  "rsa",
  "serde",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
  "whoami",
 ]
@@ -4996,21 +5232,21 @@ dependencies = [
  "futures-util",
  "hex",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "home",
  "itoa",
  "log",
  "md-5",
  "memchr",
  "once_cell",
- "rand 0.8.6",
+ "rand 0.8.7",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
  "whoami",
 ]
@@ -5034,16 +5270,16 @@ dependencies = [
  "serde",
  "serde_urlencoded",
  "sqlx-core",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
  "url",
 ]
 
 [[package]]
 name = "sse-stream"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3962b63f038885f15bce2c6e02c0e7925c072f1ac86bb60fd44c5c6b762fb72"
+checksum = "39f24a9b78c40b90817bbcd1821c74ddfd74916aadd29403d001532a9195532d"
 dependencies = [
  "bytes",
  "futures-util",
@@ -5116,9 +5352,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5146,6 +5382,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5164,19 +5421,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
 ]
 
 [[package]]
@@ -5185,18 +5433,7 @@ version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.18",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -5212,21 +5449,20 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -5236,15 +5472,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",
@@ -5272,9 +5508,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -5297,7 +5533,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -5352,23 +5588,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
- "serde",
+ "indexmap 2.14.0",
+ "serde_core",
  "serde_spanned",
- "toml_datetime 0.6.11",
- "toml_edit 0.22.27",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
 ]
 
 [[package]]
@@ -5382,28 +5612,14 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap 2.14.0",
- "serde",
- "serde_spanned",
- "toml_datetime 0.6.11",
- "toml_write",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap 2.14.0",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
- "winnow 1.0.3",
+ "winnow",
 ]
 
 [[package]]
@@ -5412,27 +5628,24 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.3",
+ "winnow",
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.2"
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
-version = "0.12.3"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
- "async-stream",
  "async-trait",
- "axum 0.7.9",
  "base64 0.22.1",
  "bytes",
- "h2",
  "http",
  "http-body",
  "http-body-util",
@@ -5441,37 +5654,37 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost",
  "rustls-native-certs",
- "rustls-pemfile",
- "socket2 0.5.10",
+ "sync_wrapper",
  "tokio",
  "tokio-rustls",
  "tokio-stream",
- "tower 0.4.13",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
 ]
 
 [[package]]
-name = "tower"
-version = "0.4.13"
+name = "tonic-prost"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
- "futures-core",
- "futures-util",
- "indexmap 1.9.3",
- "pin-project",
- "pin-project-lite",
- "rand 0.8.6",
- "slab",
- "tokio",
- "tokio-util",
- "tower-layer",
- "tower-service",
- "tracing",
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "tonic-types"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab1b02061f83d519bba3caa167f88f261ef05720ab8ebc954ade70de3348e8"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
 ]
 
 [[package]]
@@ -5482,9 +5695,12 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 2.14.0",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -5492,9 +5708,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.10"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags",
  "bytes",
@@ -5502,11 +5718,27 @@ dependencies = [
  "http",
  "http-body",
  "pin-project-lite",
- "tower 0.5.3",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "http",
+ "http-body",
+ "percent-encoding",
+ "pin-project-lite",
  "tower-layer",
  "tower-service",
  "tracing",
- "url",
 ]
 
 [[package]]
@@ -5567,14 +5799,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.28.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a971f6058498b5c0f1affa23e7ea202057a7301dbff68e968b2d578bcbd053"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
 dependencies = [
  "js-sys",
- "once_cell",
  "opentelemetry",
- "opentelemetry_sdk",
  "smallvec",
  "tracing",
  "tracing-core",
@@ -5615,15 +5845,15 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "typetag"
-version = "0.2.21"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be2212c8a9b9bcfca32024de14998494cf9a5dfa59ea1b829de98bac374b86bf"
+checksum = "c5a897b12c6c1151ad0b138b8db50252dc301f93bc3b027db05eec82aeed298c"
 dependencies = [
  "erased-serde",
  "inventory",
@@ -5634,9 +5864,9 @@ dependencies = [
 
 [[package]]
 name = "typetag-impl"
-version = "0.2.21"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27a7a9b72ba121f6f1f6c3632b85604cac41aedb5ddc70accbebb6cac83de846"
+checksum = "cf808357c6ed7e13ba0f3277ec8d8f21b2d501274895104263985330c726c1c5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5732,11 +5962,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -5787,20 +6017,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.46.0",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -5811,9 +6032,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5824,9 +6045,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.71"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5834,9 +6055,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5844,9 +6065,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5857,46 +6078,11 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap 2.14.0",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-streams"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
-dependencies = [
- "futures-util",
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
 ]
 
 [[package]]
@@ -5913,22 +6099,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap 2.14.0",
- "semver",
-]
-
-[[package]]
 name = "web-sys"
-version = "0.3.98"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5946,9 +6120,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5959,14 +6133,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5988,6 +6162,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5995,6 +6185,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
@@ -6208,15 +6404,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -6365,15 +6552,6 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
@@ -6406,96 +6584,19 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.46.0"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
-name = "wit-bindgen"
-version = "0.51.0"
+name = "wnaf"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+checksum = "ab12e7090f27e2ffd9322651492942d50c2926094af30601e1964337db39daf1"
 dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "indexmap 2.14.0",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap 2.14.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.14.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
+ "ff 0.14.0",
+ "group 0.14.0",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -6519,9 +6620,9 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
 dependencies = [
- "const-oid",
- "der",
- "spki",
+ "const-oid 0.9.6",
+ "der 0.7.10",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -6532,9 +6633,9 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -6555,18 +6656,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6596,9 +6697,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,10 @@ edition = "2024"
 license = "Apache-2.0"
 authors = ["Archer <archer@bitrouter.ai>"]
 repository = "https://github.com/bitrouter/bitrouter"
-# MSRV — the oldest toolchain the dependency tree actually compiles on.
-# Floor set by `process-wrap` (needs 1.87). The `msrv` CI job pins this exact
-# version. (Was 1.88 while `bitrouter-bedrock` pulled `aws-sdk-sts`; dropped
-# when Bedrock moved to the registry-based bearer provider.)
-rust-version = "1.87"
+# MSRV — a recent compiler floor verified against the full workspace.
+# The `msrv` CI job pins this exact version; current stable is tested by the
+# rest of CI. The resolved dependency graph itself requires Rust 1.89.
+rust-version = "1.93"
 
 [workspace.dependencies]
 # internal crates
@@ -26,8 +25,8 @@ bitrouter-guardrails = { path = "plugins/bitrouter-guardrails", version = "1.0.0
 bitrouter-observe = { path = "plugins/bitrouter-observe", version = "1.0.0-alpha.24", default-features = false }
 
 # ACP SDK crates
-agent-client-protocol = "1.0"
-agent-client-protocol-schema = "1.1"
+agent-client-protocol = "1.2"
+agent-client-protocol-schema = "1.4"
 
 # shared third-party
 anyhow = "1"
@@ -50,20 +49,22 @@ async-stream = "0.3"
 # http server (sdk `server` feature)
 axum = { version = "0.8", features = ["json"] }
 tower = "0.5"
-tower-http = { version = "0.6", features = ["trace"] }
+tower-http = { version = "0.7", features = ["trace"] }
 
 # http client
-reqwest = { version = "0.12", default-features = false, features = [
+reqwest = { version = "0.13", default-features = false, features = [
     "json",
+    "form",
+    "query",
     "stream",
-    "rustls-tls",
+    "rustls",
 ] }
 eventsource-stream = "0.2"
 url = "2"
 
 # config (sdk `config_file` feature)
-serde-saphyr = "0.0.26"
-toml = "0.8"
+serde-saphyr = "0.0.29"
+toml = "1.1"
 
 # JsonSchema derives for the wire-shape types in `bitrouter-sdk`. Used by
 # downstream crates (notably `bitrouter-cloud`) to publish an OpenAPI spec via
@@ -72,7 +73,7 @@ schemars = "1"
 
 # MCP (sdk `mcp` feature) — official Rust MCP SDK.
 # Source: <https://github.com/modelcontextprotocol/rust-sdk>
-rmcp = { version = "1.7", default-features = false, features = [
+rmcp = { version = "2.2", default-features = false, features = [
     "client",
     "reqwest",
     "transport-streamable-http-client-reqwest",
@@ -107,9 +108,9 @@ sea-orm-migration = { version = "1", default-features = false, features = [
 ] }
 
 # crypto / encoding
-sha2 = "0.10"
+sha2 = "0.11"
 base64 = "0.22"
-rand = "0.9"
+rand = "0.10"
 hex = "0.4"
 chrono = { version = "0.4", default-features = false, features = [
     "std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ bitrouter-providers = { path = "crates/bitrouter-providers", version = "1.0.0-al
 bitrouter-skills = { path = "crates/bitrouter-skills", version = "1.0.0-alpha.24" }
 bitrouter-substrate = { path = "crates/bitrouter-substrate", version = "1.0.0-alpha.24" }
 bitrouter-guardrails = { path = "plugins/bitrouter-guardrails", version = "1.0.0-alpha.24" }
-bitrouter-attestation-plugin = { path = "plugins/bitrouter-attestation", version = "1.0.0-alpha.24" }
 bitrouter-observe = { path = "plugins/bitrouter-observe", version = "1.0.0-alpha.24", default-features = false }
 
 # ACP SDK crates
@@ -45,7 +44,6 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 http = "1"
 httpdate = "1"
-bytes = "1"
 pin-project-lite = "0.2"
 async-stream = "0.3"
 
@@ -124,8 +122,6 @@ tempfile = "3"
 
 # cli / tui
 clap = { version = "4", features = ["derive"] }
-ratatui = "0.29"
-crossterm = "0.28"
 
 [profile.release]
 lto = "thin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ async-stream = "0.3"
 # http server (sdk `server` feature)
 axum = { version = "0.8", features = ["json"] }
 tower = "0.5"
-tower-http = { version = "0.7", features = ["trace"] }
+tower-http = { version = "0.6", features = ["trace"] }
 
 # http client
 reqwest = { version = "0.13", default-features = false, features = [

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -133,4 +133,4 @@ cargo clippy --workspace --all-targets --all-features -- -D warnings
 cargo test --workspace --all-features
 ```
 
-CI additionally runs `doc` (rustdoc under `-D warnings`), `doctest`, `feature-isolation` (plugins must not pull axum), and `msrv` (pinned to Rust 1.88). AI agents should also read [`CLAUDE.md`](CLAUDE.md).
+CI additionally runs `doc` (rustdoc under `-D warnings`), `doctest`, `feature-isolation` (plugins must not pull axum), and `msrv` (pinned to Rust 1.93). AI agents should also read [`CLAUDE.md`](CLAUDE.md).

--- a/apps/bitrouter/Cargo.toml
+++ b/apps/bitrouter/Cargo.toml
@@ -48,7 +48,7 @@ anyhow = "1"
 futures.workspace = true
 agent-client-protocol.workspace = true
 tokio-util = { workspace = true, features = ["compat"] }
-axoupdater = { version = "0.9", default-features = false, features = ["github_releases"] }
+axoupdater = { version = "0.10", default-features = false, features = ["github_releases"] }
 semver = "1"
 
 [dev-dependencies]
@@ -59,11 +59,11 @@ tempfile.workspace = true
 serde_json.workspace = true
 tower = { workspace = true, features = ["util"] }
 axum.workspace = true
-axum-test = "20"
+axum-test = "21"
 http.workspace = true
 serde-saphyr.workspace = true
 # OTLP/HTTP+protobuf decoding for full-stack tests that inspect the trace
 # bodies the observe plugin pushes to the configured collector.
-# https://docs.rs/opentelemetry-proto/0.27/
-opentelemetry-proto = { version = "0.27", default-features = false, features = ["gen-tonic-messages", "trace"] }
-prost = "0.13"
+# https://docs.rs/opentelemetry-proto/0.32/
+opentelemetry-proto = { version = "0.32", default-features = false, features = ["gen-tonic-messages", "trace"] }
+prost = "0.14"

--- a/apps/bitrouter/Cargo.toml
+++ b/apps/bitrouter/Cargo.toml
@@ -50,7 +50,6 @@ agent-client-protocol.workspace = true
 tokio-util = { workspace = true, features = ["compat"] }
 axoupdater = { version = "0.9", default-features = false, features = ["github_releases"] }
 semver = "1"
-thiserror.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }

--- a/apps/bitrouter/src/auth/keys.rs
+++ b/apps/bitrouter/src/auth/keys.rs
@@ -7,7 +7,7 @@
 
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
-use rand::RngCore;
+use rand::Rng;
 use sha2::{Digest, Sha256};
 
 /// The mandatory prefix for every virtual key.

--- a/apps/bitrouter/tests/full_stack.rs
+++ b/apps/bitrouter/tests/full_stack.rs
@@ -73,9 +73,8 @@ impl Drop for PolicyDir {
 
 /// Build the full assembled stack: every plugin + binary module wired into
 /// the router, a brvk_ key minted, the upstream + OTLP collector stood up.
-/// OTLP **metric** export is on (the legacy `otlp_endpoint` shim), so this
-/// path exercises trace + metric export together — the canonical
-/// "did anyone break assembly?" smoke gate.
+/// OTLP **metric** export is on, so this path exercises trace + metric export
+/// together — the canonical "did anyone break assembly?" smoke gate.
 async fn assemble_full_stack() -> FullStack {
     assemble_full_stack_inner(true).await
 }
@@ -84,9 +83,7 @@ async fn assemble_full_stack() -> FullStack {
 /// span-shape decode tests use this so the OTLP collector receives only
 /// trace bodies: trace and metric OTLP messages share the same top-level
 /// proto framing, so a metric body would otherwise decode as a degenerate
-/// trace request and muddy the assertions. Metrics-off needs the nested
-/// `otel:` config block — the only form that carries the `metrics.enabled`
-/// knob (the flat `otlp_endpoint` shim always defaults metrics on).
+/// trace request and muddy the assertions.
 async fn assemble_full_stack_traces_only() -> FullStack {
     assemble_full_stack_inner(false).await
 }
@@ -138,18 +135,13 @@ async fn assemble_full_stack_inner(metrics_enabled: bool) -> FullStack {
         .mount(&otlp_collector)
         .await;
 
-    // The observe block: metrics-on uses the flat `otlp_endpoint` shim;
-    // metrics-off needs the nested `otel:` block (the only form carrying
-    // the `metrics.enabled` knob). Indentation matches the 4-space depth
-    // under `bitrouter-observe:`.
-    let observe_block = if metrics_enabled {
-        format!("    otlp_endpoint: \"{otlp}\"", otlp = otlp_collector.uri())
-    } else {
-        format!(
-            "    otel:\n      endpoint: \"{otlp}\"\n      metrics:\n        enabled: false",
-            otlp = otlp_collector.uri()
-        )
-    };
+    // Use a short explicit trace interval so this test checks export behavior
+    // without racing the production default. Indentation matches the 4-space
+    // depth under `bitrouter-observe:`.
+    let observe_block = format!(
+        "    otel:\n      endpoint: \"{otlp}\"\n      traces:\n        batch:\n          flush_ms: 100\n      metrics:\n        enabled: {metrics_enabled}",
+        otlp = otlp_collector.uri()
+    );
 
     // ── config wiring every plugin + module ──
     let yaml = format!(

--- a/apps/bitrouter/tests/observe_hierarchy.rs
+++ b/apps/bitrouter/tests/observe_hierarchy.rs
@@ -158,6 +158,9 @@ plugins:
   bitrouter-observe:
     otel:
       endpoint: {otlp}
+      traces:
+        batch:
+          flush_ms: 100
       metrics:
         enabled: false
 "#,

--- a/crates/bitrouter-attestation/Cargo.toml
+++ b/crates/bitrouter-attestation/Cargo.toml
@@ -12,7 +12,7 @@ rust-version.workspace = true
 async-trait.workspace = true
 # Pinned to match the version bitrouter ports its DCAP verifier from
 # (private-ai-gateway). Same feature set: offline quote parsing + RustCrypto.
-dcap-qvl = { version = "0.3.12", default-features = false, features = [
+dcap-qvl = { version = "0.5.2", default-features = false, features = [
     "std",
     "report",
     "rustcrypto",
@@ -21,14 +21,14 @@ hex.workspace = true
 jsonwebtoken = { version = "10", features = ["rust_crypto"] }
 # secp256k1 ECDSA recovery for NEAR chat signatures (EIP-191), matching the
 # gateway's k256 usage.
-k256 = { version = "0.13", features = ["ecdsa"] }
+k256 = { version = "0.14", features = ["ecdsa"] }
 rand.workspace = true
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 # keccak256 for the EIP-191 personal_sign digest + Ethereum address derivation.
-sha3 = "0.10"
+sha3 = "0.12"
 thiserror.workspace = true
 
 [dev-dependencies]

--- a/crates/bitrouter-attestation/src/lib.rs
+++ b/crates/bitrouter-attestation/src/lib.rs
@@ -93,7 +93,7 @@ pub trait ConfidentialVerifier: Send + Sync {
 
 /// A fresh 32-byte hex nonce for an attestation challenge.
 pub(crate) fn fresh_nonce_hex() -> String {
-    use rand::RngCore;
+    use rand::Rng;
     let mut nonce = [0u8; 32];
     rand::rng().fill_bytes(&mut nonce);
     hex::encode(nonce)

--- a/crates/bitrouter-attestation/src/near/mod.rs
+++ b/crates/bitrouter-attestation/src/near/mod.rs
@@ -745,7 +745,7 @@ mod tests {
         h.update(text.len().to_string().as_bytes());
         h.update(text.as_bytes());
         let digest: [u8; 32] = h.finalize().into();
-        let (sig, rec) = key.sign_prehash_recoverable(&digest).unwrap();
+        let (sig, rec) = key.sign_prehash_recoverable(&digest);
         let mut out = sig.to_bytes().to_vec();
         out.push(27 + rec.to_byte());
         hex::encode(out)

--- a/crates/bitrouter-attestation/src/near/signature.rs
+++ b/crates/bitrouter-attestation/src/near/signature.rs
@@ -50,7 +50,7 @@ fn eip191_digest(message: &[u8]) -> [u8; 32] {
 /// The 0x-prefixed, lowercase Ethereum address for a recovered public key:
 /// `"0x" ‖ keccak256(uncompressed_pubkey[1..])[12..]`.
 fn address_from_verifying_key(vk: &VerifyingKey) -> String {
-    let encoded = vk.to_encoded_point(false); // 0x04 ‖ X ‖ Y
+    let encoded = vk.to_sec1_point(false); // 0x04 ‖ X ‖ Y
     let hash = Keccak256::digest(&encoded.as_bytes()[1..]);
     format!("0x{}", hex::encode(&hash[12..]))
 }
@@ -100,7 +100,7 @@ mod tests {
 
     fn sign_eip191(key: &SigningKey, message: &[u8]) -> String {
         let digest = eip191_digest(message);
-        let (sig, rec_id) = key.sign_prehash_recoverable(&digest).unwrap();
+        let (sig, rec_id) = key.sign_prehash_recoverable(&digest);
         let mut out = sig.to_bytes().to_vec(); // 64 bytes r ‖ s
         out.push(27 + rec_id.to_byte()); // EIP-191 v
         hex::encode(out)

--- a/crates/bitrouter-attestation/src/near/tdx.rs
+++ b/crates/bitrouter-attestation/src/near/tdx.rs
@@ -108,7 +108,13 @@ pub async fn verify_tdx_quote(
     pccs_url: &str,
     now_unix: u64,
 ) -> Result<TdxMeasurements, VerifyError> {
-    let collateral = dcap_qvl::collateral::get_collateral(pccs_url, raw)
+    let collateral_client = dcap_qvl::collateral::CollateralClient::with_default_http(pccs_url)
+        .map_err(|e| VerifyError::Transport {
+            what: "dcap collateral",
+            source: e.to_string().into(),
+        })?;
+    let collateral = collateral_client
+        .fetch(raw)
         .await
         .map_err(|e| VerifyError::Transport {
             what: "dcap collateral",

--- a/crates/bitrouter-cloud-sdk/src/auth/flow.rs
+++ b/crates/bitrouter-cloud-sdk/src/auth/flow.rs
@@ -16,7 +16,7 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
-use rand::Rng;
+use rand::RngExt;
 use serde::Deserialize;
 
 use super::credentials::Credentials;

--- a/crates/bitrouter-providers/src/oauth/pkce.rs
+++ b/crates/bitrouter-providers/src/oauth/pkce.rs
@@ -18,7 +18,7 @@
 
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
-use rand::RngCore;
+use rand::Rng;
 use sha2::{Digest, Sha256};
 
 /// One PKCE pair: the secret the client keeps (`code_verifier`) and the

--- a/crates/bitrouter-sdk/Cargo.toml
+++ b/crates/bitrouter-sdk/Cargo.toml
@@ -16,30 +16,23 @@ thiserror.workspace = true
 futures.workspace = true
 futures-core.workspace = true
 tokio = { workspace = true, features = ["sync", "rt", "macros", "time"] }
-tokio-stream.workspace = true
 # `rt` feature: `tokio_util::task::TaskTracker`, used to run non-streaming
 # requests to completion after a client disconnect (see `Pipeline::execute_detached`).
 tokio-util = { workspace = true, features = ["rt"] }
 tracing.workspace = true
 http.workspace = true
 httpdate.workspace = true
-bytes.workspace = true
 pin-project-lite.workspace = true
 async-stream.workspace = true
 reqwest.workspace = true
 url.workspace = true
 eventsource-stream.workspace = true
-chrono.workspace = true
 uuid.workspace = true
-regex.workspace = true
-sha2.workspace = true
-base64.workspace = true
 schemars.workspace = true
 
 # `server` feature
 axum = { workspace = true, optional = true }
 tower = { workspace = true, optional = true }
-tower-http = { workspace = true, optional = true }
 
 # `config_file` feature
 serde-saphyr = { workspace = true, optional = true }
@@ -59,7 +52,7 @@ rmcp-reqwest = { package = "reqwest", version = "0.13", default-features = false
 [features]
 default = []
 # axum HTTP server + SSE handlers + admin endpoints
-server = ["dep:axum", "dep:tower", "dep:tower-http", "tokio/signal"]
+server = ["dep:axum", "dep:tower", "tokio/signal"]
 # yaml config loading (serde-saphyr + tokio::fs)
 config_file = ["dep:serde-saphyr", "tokio/fs"]
 # rmcp-backed `RmcpExecutor` + `ConfigMcpRoutingTable` for the `mcp`

--- a/crates/bitrouter-sdk/Cargo.toml
+++ b/crates/bitrouter-sdk/Cargo.toml
@@ -44,11 +44,6 @@ agent-client-protocol-schema = { workspace = true, optional = true }
 # <https://github.com/modelcontextprotocol/rust-sdk>
 rmcp = { workspace = true, optional = true }
 
-# Used ONLY to name rmcp 1.7's transport error type
-# (StreamableHttpError<reqwest::Error>) in the MCP auth-error downcast —
-# rmcp pins reqwest 0.13 while our own client stays on 0.12.
-rmcp-reqwest = { package = "reqwest", version = "0.13", default-features = false, optional = true }
-
 [features]
 default = []
 # axum HTTP server + SSE handlers + admin endpoints
@@ -59,7 +54,7 @@ config_file = ["dep:serde-saphyr", "tokio/fs"]
 # pure-routing pipeline. Without this feature the SDK still exposes
 # `mcp::Pipeline`, hook traits, and the `McpTransport` enum, so a consumer
 # can plug in a custom Executor without pulling rmcp.
-mcp = ["dep:rmcp", "dep:rmcp-reqwest", "tokio/process"]
+mcp = ["dep:rmcp", "tokio/process"]
 # `ConfigAcpRoutingTable` for the `acp` pure-routing pipeline.
 # Without this feature the SDK still exposes `acp::Pipeline`, hook traits,
 # and the `AcpTransport` enum, so a consumer can plug in a custom Executor.

--- a/crates/bitrouter-sdk/src/mcp/rmcp_executor.rs
+++ b/crates/bitrouter-sdk/src/mcp/rmcp_executor.rs
@@ -309,9 +309,8 @@ async fn connect(
             // <https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#streamable-http>.
             //
             // We construct the transport via `from_config`, which uses rmcp's
-            // internally-bundled reqwest client. That keeps rmcp's reqwest
-            // version independent of the workspace reqwest used by the
-            // language_model executor.
+            // reqwest client. rmcp and the workspace intentionally resolve to
+            // the same reqwest line so transport errors can be downcast below.
             use http::{HeaderName, HeaderValue};
             let mut header_map: std::collections::HashMap<HeaderName, HeaderValue> =
                 std::collections::HashMap::new();

--- a/crates/bitrouter-sdk/src/mcp/rmcp_executor.rs
+++ b/crates/bitrouter-sdk/src/mcp/rmcp_executor.rs
@@ -22,11 +22,15 @@ use rmcp::ServiceExt;
 use rmcp::handler::client::ClientHandler;
 use rmcp::handler::client::progress::ProgressDispatcher;
 use rmcp::model::{
-    CallToolRequest, CallToolRequestParams, ClientInfo, ClientRequest,
-    CreateElicitationRequestParams, CreateElicitationResult, CreateMessageRequestParams,
-    CreateMessageResult, ErrorCode, ErrorData as McpError, GetPromptRequestParams, Implementation,
-    ListRootsResult, ProgressNotificationParam, ReadResourceRequestParams, ServerResult,
+    CallToolRequest, CallToolRequestParams, ClientInfo, ClientRequest, ElicitRequestParams,
+    ElicitResult, ErrorCode, ErrorData as McpError, GetPromptRequestParams, Implementation,
+    ProgressNotificationParam, ReadResourceRequestParams, ServerResult,
 };
+#[expect(
+    deprecated,
+    reason = "rmcp ClientHandler still requires the SEP-2577-deprecated request types"
+)]
+use rmcp::model::{CreateMessageRequestParams, CreateMessageResult, ListRootsResult};
 use rmcp::service::{
     NotificationContext, Peer, PeerRequestOptions, RequestContext, RoleClient, RunningService,
 };
@@ -121,6 +125,10 @@ impl ClientHandler for BitrouterMcpClient {
     // defaults (the spec's #1 silent-breakage complaint of MCP-through-gateway
     // in 2026), we surface an explicit, spec-shaped `-32601` so the upstream
     // server's tool-call logic sees the rejection and can branch on it.
+    #[expect(
+        deprecated,
+        reason = "rmcp ClientHandler still requires the SEP-2577-deprecated sampling types"
+    )]
     fn create_message(
         &self,
         _params: CreateMessageRequestParams,
@@ -140,11 +148,10 @@ impl ClientHandler for BitrouterMcpClient {
 
     fn create_elicitation(
         &self,
-        _request: CreateElicitationRequestParams,
+        _request: ElicitRequestParams,
         _context: RequestContext<RoleClient>,
-    ) -> impl std::future::Future<Output = std::result::Result<CreateElicitationResult, McpError>>
-    + Send
-    + '_ {
+    ) -> impl std::future::Future<Output = std::result::Result<ElicitResult, McpError>> + Send + '_
+    {
         let server = self.server_name.clone();
         async move {
             tracing::warn!(
@@ -156,6 +163,10 @@ impl ClientHandler for BitrouterMcpClient {
         }
     }
 
+    #[expect(
+        deprecated,
+        reason = "rmcp ClientHandler still requires the SEP-2577-deprecated roots type"
+    )]
     fn list_roots(
         &self,
         _context: RequestContext<RoleClient>,
@@ -357,7 +368,7 @@ fn bad_params(server: &str, method: &str, msg: impl std::fmt::Display) -> Bitrou
     BitrouterError::bad_request(format!("mcp '{server}' {method}: {msg}"))
 }
 
-/// Inspect a transport error for an upstream auth challenge (rmcp 1.7
+/// Inspect a transport error for an upstream auth challenge (rmcp
 /// classifies these as typed variants). Returns a status-bearing
 /// [`BitrouterError::UpstreamAuth`] for `401`/`403` so the cloud can drive
 /// token refresh / OAuth step-up; `None` for any other transport error
@@ -366,13 +377,11 @@ fn classify_transport_auth_error(
     dte: &rmcp::transport::DynamicTransportError,
 ) -> Option<BitrouterError> {
     use rmcp::transport::streamable_http_client::StreamableHttpError;
-    // regression: rmcp uses reqwest 0.13; downcast must name that type
-    // (rmcp_reqwest = reqwest 0.13). Our own client is reqwest 0.12 — a
-    // distinct, separately-compiled crate with a different TypeId, so naming
-    // bare `reqwest::Error` here would make this downcast silently never match.
+    // rmcp and the SDK intentionally share reqwest 0.13, so the concrete
+    // transport error can be downcast through the SDK's direct dependency.
     let err = dte
         .error
-        .downcast_ref::<StreamableHttpError<rmcp_reqwest::Error>>()?;
+        .downcast_ref::<StreamableHttpError<reqwest::Error>>()?;
     match err {
         StreamableHttpError::AuthRequired(e) => Some(BitrouterError::UpstreamAuth {
             status: 401,
@@ -759,7 +768,7 @@ mod tests {
             InsufficientScopeError, StreamableHttpError,
         };
 
-        let inner: StreamableHttpError<rmcp_reqwest::Error> =
+        let inner: StreamableHttpError<reqwest::Error> =
             StreamableHttpError::InsufficientScope(InsufficientScopeError::new(
                 "Bearer error=\"insufficient_scope\", scope=\"read:files\"".to_string(),
                 Some("read:files".to_string()),
@@ -789,7 +798,7 @@ mod tests {
         use rmcp::transport::DynamicTransportError;
         use rmcp::transport::streamable_http_client::{AuthRequiredError, StreamableHttpError};
 
-        let inner: StreamableHttpError<rmcp_reqwest::Error> =
+        let inner: StreamableHttpError<reqwest::Error> =
             StreamableHttpError::AuthRequired(AuthRequiredError::new("Bearer".to_string()));
         let dte = DynamicTransportError::from_parts(
             "test",
@@ -807,8 +816,7 @@ mod tests {
     fn non_auth_transport_error_is_not_classified() {
         use rmcp::transport::DynamicTransportError;
         use rmcp::transport::streamable_http_client::StreamableHttpError;
-        let inner: StreamableHttpError<rmcp_reqwest::Error> =
-            StreamableHttpError::UnexpectedEndOfStream;
+        let inner: StreamableHttpError<reqwest::Error> = StreamableHttpError::UnexpectedEndOfStream;
         let dte = DynamicTransportError::from_parts(
             "test",
             std::any::TypeId::of::<()>(),
@@ -825,7 +833,7 @@ mod tests {
             InsufficientScopeError, StreamableHttpError,
         };
 
-        let inner: StreamableHttpError<rmcp_reqwest::Error> =
+        let inner: StreamableHttpError<reqwest::Error> =
             StreamableHttpError::InsufficientScope(InsufficientScopeError::new(
                 "Bearer error=\"insufficient_scope\", scope=\"x\"".into(),
                 Some("x".into()),
@@ -854,7 +862,7 @@ mod tests {
             InsufficientScopeError, StreamableHttpError,
         };
 
-        let inner: StreamableHttpError<rmcp_reqwest::Error> =
+        let inner: StreamableHttpError<reqwest::Error> =
             StreamableHttpError::InsufficientScope(InsufficientScopeError::new(
                 "Bearer error=\"insufficient_scope\", scope=\"a\"".into(),
                 Some("a".into()),

--- a/crates/bitrouter-substrate/Cargo.toml
+++ b/crates/bitrouter-substrate/Cargo.toml
@@ -18,7 +18,6 @@ tokio-util = { workspace = true, features = ["compat"] }
 futures.workspace = true
 async-trait.workspace = true
 anyhow.workspace = true
-thiserror.workspace = true
 tracing.workspace = true
 uuid.workspace = true
 serde = { workspace = true }

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -35,7 +35,6 @@ tokio = { workspace = true, features = ["rt-multi-thread", "macros", "signal"] }
 tokio-util.workspace = true
 reqwest.workspace = true
 axum.workspace = true
-tracing.workspace = true
 thiserror.workspace = true
 anyhow.workspace = true
 # Reused for the typed `/v1/billing/balance` wire shape (no cycle: cloud-sdk

--- a/mcp/src/server.rs
+++ b/mcp/src/server.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::handler::server::wrapper::Parameters;
-use rmcp::model::{CallToolResult, Content, ServerCapabilities, ServerInfo};
+use rmcp::model::{CallToolResult, ContentBlock, ServerCapabilities, ServerInfo};
 use rmcp::service::RequestContext;
 use rmcp::{ErrorData as McpError, RoleServer, ServerHandler, tool, tool_handler, tool_router};
 
@@ -78,9 +78,9 @@ impl BitrouterMcp {
 
     /// The extra content item for a successful result, when a footer is
     /// attached and has something to say.
-    async fn footer_content(&self) -> Option<Content> {
+    async fn footer_content(&self) -> Option<ContentBlock> {
         let footer = self.cost_footer.as_ref()?;
-        footer.line().await.map(Content::text)
+        footer.line().await.map(ContentBlock::text)
     }
 
     #[tool(description = "Route a completion through BitRouter and return the full result.")]
@@ -100,17 +100,19 @@ impl BitrouterMcp {
         match self.backend.complete(&caller, req).await {
             Ok(r) => match serde_json::to_string(&r) {
                 Ok(json) => {
-                    let mut contents = vec![Content::text(json)];
+                    let mut contents = vec![ContentBlock::text(json)];
                     if let Some(footer) = self.footer_content().await {
                         contents.push(footer);
                     }
                     Ok(CallToolResult::success(contents))
                 }
-                Err(e) => Ok(CallToolResult::error(vec![Content::text(format!(
+                Err(e) => Ok(CallToolResult::error(vec![ContentBlock::text(format!(
                     "serialization error: {e}"
                 ))])),
             },
-            Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+            Err(e) => Ok(CallToolResult::error(vec![ContentBlock::text(
+                e.to_string(),
+            )])),
         }
     }
 
@@ -122,12 +124,14 @@ impl BitrouterMcp {
         let caller = caller_from_extensions(&ctx.extensions);
         match self.backend.list_models(&caller).await {
             Ok(m) => match serde_json::to_string(&m) {
-                Ok(json) => Ok(CallToolResult::success(vec![Content::text(json)])),
-                Err(e) => Ok(CallToolResult::error(vec![Content::text(format!(
+                Ok(json) => Ok(CallToolResult::success(vec![ContentBlock::text(json)])),
+                Err(e) => Ok(CallToolResult::error(vec![ContentBlock::text(format!(
                     "serialization error: {e}"
                 ))])),
             },
-            Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+            Err(e) => Ok(CallToolResult::error(vec![ContentBlock::text(
+                e.to_string(),
+            )])),
         }
     }
 
@@ -139,17 +143,19 @@ impl BitrouterMcp {
         match self.backend.status(&caller).await {
             Ok(s) => match serde_json::to_string(&s) {
                 Ok(json) => {
-                    let mut contents = vec![Content::text(json)];
+                    let mut contents = vec![ContentBlock::text(json)];
                     if let Some(footer) = self.footer_content().await {
                         contents.push(footer);
                     }
                     Ok(CallToolResult::success(contents))
                 }
-                Err(e) => Ok(CallToolResult::error(vec![Content::text(format!(
+                Err(e) => Ok(CallToolResult::error(vec![ContentBlock::text(format!(
                     "serialization error: {e}"
                 ))])),
             },
-            Err(e) => Ok(CallToolResult::error(vec![Content::text(e.to_string())])),
+            Err(e) => Ok(CallToolResult::error(vec![ContentBlock::text(
+                e.to_string(),
+            )])),
         }
     }
 }

--- a/plugins/bitrouter-attestation/Cargo.toml
+++ b/plugins/bitrouter-attestation/Cargo.toml
@@ -13,7 +13,6 @@ bitrouter-sdk.workspace = true
 bitrouter-attestation.workspace = true
 async-trait.workspace = true
 serde_json.workspace = true
-tracing.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }

--- a/plugins/bitrouter-guardrails/Cargo.toml
+++ b/plugins/bitrouter-guardrails/Cargo.toml
@@ -14,7 +14,6 @@ async-trait.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 regex.workspace = true
-tracing.workspace = true
 # `JsonSchema` derives on the serializable config types (`RuleSpec`,
 # `GuardrailConfig`, `Action`) so a downstream host (e.g. bitrouter-cloud) can
 # embed them in its own OpenAPI-published policy types. Mirrors how

--- a/plugins/bitrouter-observe/Cargo.toml
+++ b/plugins/bitrouter-observe/Cargo.toml
@@ -18,7 +18,13 @@ tracing.workspace = true
 # OpenTelemetry stack for OTLP export (traces + metrics).
 # Pinned to 0.32.x — the API churns minor-to-minor in this stack.
 opentelemetry = { version = "0.32", optional = true }
-opentelemetry_sdk = { version = "0.32", optional = true, features = ["rt-tokio", "trace", "metrics"] }
+opentelemetry_sdk = { version = "0.32", optional = true, features = [
+    "rt-tokio-current-thread",
+    "trace",
+    "metrics",
+    "experimental_trace_batch_span_processor_with_async_runtime",
+    "experimental_metrics_periodicreader_with_async_runtime",
+] }
 # Transport features (`http-proto`, `grpc-tonic`, the reqwest/tonic TLS
 # variants) are NOT enabled here — they are layered on by the `otel-http` /
 # `otel-grpc` sub-features below. `default-features = false` drops the upstream

--- a/plugins/bitrouter-observe/Cargo.toml
+++ b/plugins/bitrouter-observe/Cargo.toml
@@ -16,22 +16,22 @@ serde_json.workspace = true
 tracing.workspace = true
 
 # OpenTelemetry stack for OTLP export (traces + metrics).
-# Pinned to 0.27.x — the API churns minor-to-minor in this stack.
-opentelemetry = { version = "0.27", optional = true }
-opentelemetry_sdk = { version = "0.27", optional = true, features = ["rt-tokio", "trace", "metrics"] }
+# Pinned to 0.32.x — the API churns minor-to-minor in this stack.
+opentelemetry = { version = "0.32", optional = true }
+opentelemetry_sdk = { version = "0.32", optional = true, features = ["rt-tokio", "trace", "metrics"] }
 # Transport features (`http-proto`, `grpc-tonic`, the reqwest/tonic TLS
 # variants) are NOT enabled here — they are layered on by the `otel-http` /
 # `otel-grpc` sub-features below. `default-features = false` drops the upstream
 # defaults (`grpc-tonic`, `logs`, `internal-logs`) so a build only ever pulls
 # in the transport stack it actually selected. `trace` + `metrics` are the
 # signal kinds this plugin emits and are transport-independent.
-opentelemetry-otlp = { version = "0.27", optional = true, default-features = false, features = ["trace", "metrics"] }
-opentelemetry-semantic-conventions = { version = "0.27", optional = true }
-# tracing ↔ OpenTelemetry bridge. Pinned to the 0.28.x line, which targets
-# opentelemetry 0.27. https://crates.io/crates/tracing-opentelemetry
-tracing-opentelemetry = { version = "0.28", optional = true }
+opentelemetry-otlp = { version = "0.32", optional = true, default-features = false, features = ["trace", "metrics"] }
+opentelemetry-semantic-conventions = { version = "0.32", optional = true }
+# tracing ↔ OpenTelemetry bridge. Pinned to the 0.33.x line, which targets
+# opentelemetry 0.32. https://crates.io/crates/tracing-opentelemetry
+tracing-opentelemetry = { version = "0.33", optional = true }
 # Inbound HTTP TraceLayer for the SERVER span. Inherits the workspace
-# pin (0.6) with the `trace` feature.
+# pin (0.7) with the `trace` feature.
 # https://docs.rs/tower-http/latest/tower_http/trace/index.html
 tower-http = { workspace = true, optional = true }
 # axum is the host's HTTP framework; we wrap its Router with the TraceLayer.
@@ -44,15 +44,15 @@ dashmap = { version = "6", optional = true }
 # gRPC stack arrives through `opentelemetry-otlp/grpc-tonic`. We depend on tonic
 # directly solely for `tonic::metadata::MetadataMap`, used to forward the
 # configured headers as gRPC request metadata.
-tonic = { version = "0.12", optional = true, default-features = false }
+tonic = { version = "0.14", optional = true, default-features = false }
 # Custom OTLP/HTTP client that injects a freshly-resolved bearer per export
 # (`otel::auth_client`). Only compiled under `otel-http`. We implement
 # `opentelemetry_http::HttpClient` over a `reqwest::Client`, so we depend on
 # `opentelemetry-http` (with its `reqwest` impl), `reqwest` itself (matching the
 # rustls TLS the `otel-http` otlp stack pins, NOT default-tls), and `bytes` for
 # the trait's `Response<Bytes>` body type.
-# https://docs.rs/opentelemetry-http/0.27/opentelemetry_http/trait.HttpClient.html
-opentelemetry-http = { version = "0.27", optional = true, features = ["reqwest"] }
+# https://docs.rs/opentelemetry-http/0.32/opentelemetry_http/trait.HttpClient.html
+opentelemetry-http = { version = "0.32", optional = true, features = ["reqwest"] }
 reqwest = { workspace = true, optional = true }
 bytes = { version = "1", optional = true }
 
@@ -107,7 +107,7 @@ otel-grpc = [
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }
 futures.workspace = true
-criterion = { version = "0.5", features = ["async_tokio"] }
+criterion = { version = "0.8", features = ["async_tokio"] }
 
 [[bench]]
 name = "observe_overhead"

--- a/plugins/bitrouter-observe/Cargo.toml
+++ b/plugins/bitrouter-observe/Cargo.toml
@@ -44,6 +44,7 @@ tower-http = { workspace = true, optional = true }
 axum = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true, features = ["rt", "sync"] }
+futures-core = { version = "0.3", optional = true }
 http = { workspace = true, optional = true }
 dashmap = { version = "6", optional = true }
 # OTLP/gRPC transport (tonic). Only compiled under `otel-grpc`; the bulk of the
@@ -80,6 +81,7 @@ otel-base = [
     "dep:axum",
     "dep:tracing-subscriber",
     "dep:tokio",
+    "dep:futures-core",
     "dep:http",
     "dep:dashmap",
 ]
@@ -111,7 +113,7 @@ otel-grpc = [
 ]
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "test-util"] }
 futures.workspace = true
 criterion = { version = "0.8", features = ["async_tokio"] }
 

--- a/plugins/bitrouter-observe/benches/observe_overhead.rs
+++ b/plugins/bitrouter-observe/benches/observe_overhead.rs
@@ -3,7 +3,9 @@
 //! against a live collector. End-to-end overhead is better measured against
 //! a real Jaeger / OTel-collector via `scripts/test_observability.sh`.
 
-use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 
 use bitrouter_observe::otel::CardinalityLimiter;
 

--- a/plugins/bitrouter-observe/src/acp.rs
+++ b/plugins/bitrouter-observe/src/acp.rs
@@ -180,10 +180,10 @@ mod tests {
     use std::sync::Arc;
 
     use opentelemetry::Context;
-    use opentelemetry::trace::{TraceResult, TracerProvider as _};
-    use opentelemetry_sdk::export::trace::SpanData;
+    use opentelemetry::trace::TracerProvider as _;
+    use opentelemetry_sdk::error::OTelSdkResult;
     use opentelemetry_sdk::trace::{
-        Span as SdkSpan, SpanProcessor, Tracer as SdkTracer, TracerProvider,
+        SdkTracerProvider, Span as SdkSpan, SpanData, SpanProcessor, Tracer as SdkTracer,
     };
 
     use super::*;
@@ -202,17 +202,17 @@ mod tests {
             };
             guard.push(span);
         }
-        fn force_flush(&self) -> TraceResult<()> {
+        fn force_flush(&self) -> OTelSdkResult {
             Ok(())
         }
-        fn shutdown(&self) -> TraceResult<()> {
+        fn shutdown_with_timeout(&self, _timeout: Duration) -> OTelSdkResult {
             Ok(())
         }
     }
 
     fn capturing_tracer() -> (SdkTracer, Arc<std::sync::Mutex<Vec<SpanData>>>) {
         let captured = Arc::new(std::sync::Mutex::new(Vec::new()));
-        let provider = TracerProvider::builder()
+        let provider = SdkTracerProvider::builder()
             .with_span_processor(CapturingProcessor {
                 captured: Arc::clone(&captured),
             })

--- a/plugins/bitrouter-observe/src/otel/auth_client.rs
+++ b/plugins/bitrouter-observe/src/otel/auth_client.rs
@@ -7,8 +7,8 @@
 //! refreshed account token without a daemon restart, which a static header
 //! ([`crate::otel::config::OtelConfig::bearer_token`]) cannot do.
 //!
-//! `opentelemetry-http` 0.27 trait:
-//! <https://docs.rs/opentelemetry-http/0.27/opentelemetry_http/trait.HttpClient.html>
+//! `opentelemetry-http` 0.32 trait:
+//! <https://docs.rs/opentelemetry-http/0.32/opentelemetry_http/trait.HttpClient.html>
 //!
 //! Best-effort: a bearer-resolution failure (mapped to `None`) leaves the
 //! request unauthenticated rather than dropping the export — telemetry must
@@ -43,7 +43,7 @@ impl AuthRefreshClient {
 /// or an unrepresentable header value, leaves the request unchanged (anonymous).
 ///
 /// Pure (no I/O) so the header policy is unit-testable without a live server.
-fn inject_bearer(req: &mut http::Request<Vec<u8>>, token: Option<&str>) {
+fn inject_bearer<T>(req: &mut http::Request<T>, token: Option<&str>) {
     let Some(token) = token else {
         return;
     };
@@ -60,16 +60,16 @@ fn inject_bearer(req: &mut http::Request<Vec<u8>>, token: Option<&str>) {
 
 #[async_trait::async_trait]
 impl HttpClient for AuthRefreshClient {
-    async fn send(
+    async fn send_bytes(
         &self,
-        mut request: http::Request<Vec<u8>>,
+        mut request: http::Request<Bytes>,
     ) -> Result<http::Response<Bytes>, HttpError> {
         // Best-effort: a resolution failure inside `bearer()` is mapped to
         // `None` by the implementor, so a `None` here simply means "export
         // anonymously" — never a dropped export.
         let token = self.bearer.bearer().await;
         inject_bearer(&mut request, token.as_deref());
-        <reqwest::Client as HttpClient>::send(&self.inner, request).await
+        <reqwest::Client as HttpClient>::send_bytes(&self.inner, request).await
     }
 }
 
@@ -124,7 +124,7 @@ mod tests {
     }
 
     /// Stub `TelemetryBearer` returning a fixed token (or `None`) so the
-    /// `HttpClient::send` path can be exercised without a live server.
+    /// `HttpClient::send_bytes` path can be exercised without a live server.
     #[derive(Debug)]
     struct StubBearer(Option<String>);
 
@@ -137,7 +137,7 @@ mod tests {
 
     #[tokio::test]
     async fn stub_bearer_drives_injection_helper() {
-        // Exercise the same resolve-then-inject sequence `send` uses, proving
+        // Exercise the same resolve-then-inject sequence `send_bytes` uses, proving
         // the trait + helper compose: Some(token) injects, None stays anonymous.
         let some = StubBearer(Some("tok".into()));
         let mut req = empty_request();

--- a/plugins/bitrouter-observe/src/otel/config.rs
+++ b/plugins/bitrouter-observe/src/otel/config.rs
@@ -10,7 +10,6 @@
 //! upstream OTel SDK spec: <https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/>.
 
 use std::collections::HashMap;
-use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 
@@ -69,16 +68,6 @@ pub struct OtelConfig {
 
 /// Default cap for a single captured content attribute (128 KiB).
 pub const DEFAULT_CONTENT_ATTR_MAX_BYTES: usize = 128 * 1024;
-
-/// Compensate for the OpenTelemetry 0.32 async processors waiting twice before
-/// their first scheduled export.
-///
-/// The SDK's interval stream already waits before yielding, while both async
-/// processors still skip the first item. See the upstream implementation:
-/// <https://docs.rs/opentelemetry_sdk/0.32.1/src/opentelemetry_sdk/runtime.rs.html#46-58>.
-pub(super) fn async_processor_interval(configured: Duration) -> Duration {
-    configured / 2
-}
 
 /// Subset of OTel-spec sampler kinds the SDK actually supports. The default
 /// (`parentbased_always_on`) matches the OTel-spec default — every trace is
@@ -437,17 +426,5 @@ mod tests {
         let cfg = OtelConfig::default()
             .with_env_from(env(&[("BITROUTER_OBSERVE_CONTENT_CAPTURE", "bogus")]));
         assert_eq!(cfg.content_capture, ContentCaptureMode::Off);
-    }
-
-    #[test]
-    fn async_processor_interval_offsets_the_skipped_first_tick() {
-        assert_eq!(
-            async_processor_interval(Duration::from_secs(5)),
-            Duration::from_millis(2_500)
-        );
-        assert_eq!(
-            async_processor_interval(Duration::from_millis(1)),
-            Duration::from_micros(500)
-        );
     }
 }

--- a/plugins/bitrouter-observe/src/otel/config.rs
+++ b/plugins/bitrouter-observe/src/otel/config.rs
@@ -10,6 +10,7 @@
 //! upstream OTel SDK spec: <https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/>.
 
 use std::collections::HashMap;
+use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 
@@ -68,6 +69,16 @@ pub struct OtelConfig {
 
 /// Default cap for a single captured content attribute (128 KiB).
 pub const DEFAULT_CONTENT_ATTR_MAX_BYTES: usize = 128 * 1024;
+
+/// Compensate for the OpenTelemetry 0.32 async processors waiting twice before
+/// their first scheduled export.
+///
+/// The SDK's interval stream already waits before yielding, while both async
+/// processors still skip the first item. See the upstream implementation:
+/// <https://docs.rs/opentelemetry_sdk/0.32.1/src/opentelemetry_sdk/runtime.rs.html#46-58>.
+pub(super) fn async_processor_interval(configured: Duration) -> Duration {
+    configured / 2
+}
 
 /// Subset of OTel-spec sampler kinds the SDK actually supports. The default
 /// (`parentbased_always_on`) matches the OTel-spec default — every trace is
@@ -426,5 +437,17 @@ mod tests {
         let cfg = OtelConfig::default()
             .with_env_from(env(&[("BITROUTER_OBSERVE_CONTENT_CAPTURE", "bogus")]));
         assert_eq!(cfg.content_capture, ContentCaptureMode::Off);
+    }
+
+    #[test]
+    fn async_processor_interval_offsets_the_skipped_first_tick() {
+        assert_eq!(
+            async_processor_interval(Duration::from_secs(5)),
+            Duration::from_millis(2_500)
+        );
+        assert_eq!(
+            async_processor_interval(Duration::from_millis(1)),
+            Duration::from_micros(500)
+        );
     }
 }

--- a/plugins/bitrouter-observe/src/otel/exporter.rs
+++ b/plugins/bitrouter-observe/src/otel/exporter.rs
@@ -45,12 +45,12 @@ use opentelemetry::{
     propagation::{Extractor, Injector},
     trace::{Span, SpanKind, Status, TraceContextExt, Tracer},
 };
+use opentelemetry_sdk::Resource;
 use opentelemetry_sdk::propagation::TraceContextPropagator;
 use opentelemetry_sdk::trace::span_processor_with_async_runtime::BatchSpanProcessor;
 use opentelemetry_sdk::trace::{
     BatchConfigBuilder, RandomIdGenerator, Sampler, SdkTracerProvider, Tracer as SdkTracer,
 };
-use opentelemetry_sdk::{Resource, runtime};
 use opentelemetry_semantic_conventions::SCHEMA_URL;
 use opentelemetry_semantic_conventions::attribute::{SERVICE_NAME, SERVICE_VERSION};
 use serde::{Deserialize, Serialize};
@@ -61,7 +61,8 @@ use bitrouter_sdk::language_model::{
 };
 
 use crate::otel::cardinality::CardinalityLimiter;
-use crate::otel::config::{ContentCaptureMode, OtelConfig, SamplerKind, async_processor_interval};
+use crate::otel::config::{ContentCaptureMode, OtelConfig, SamplerKind};
+use crate::otel::processor_runtime::ProcessorRuntime;
 use crate::otel::span_attributes::SpanAttributes;
 
 /// HTTP header extractor for W3C trace context propagation
@@ -181,11 +182,9 @@ impl OtelExporter {
 
         let batch_config = BatchConfigBuilder::default()
             .with_max_queue_size(config.traces.batch.max_queue_size)
-            .with_scheduled_delay(async_processor_interval(Duration::from_millis(
-                config.traces.batch.flush_ms,
-            )))
+            .with_scheduled_delay(Duration::from_millis(config.traces.batch.flush_ms))
             .build();
-        let processor = BatchSpanProcessor::builder(span_exporter, runtime::TokioCurrentThread)
+        let processor = BatchSpanProcessor::builder(span_exporter, ProcessorRuntime::new())
             .with_batch_config(batch_config)
             .build();
 
@@ -266,12 +265,10 @@ impl OtelExporter {
     /// Flush and shut down both the tracer and the metric provider.
     ///
     /// **Synchronous** — must be driven from a context that can park: a
-    /// dedicated thread, `tokio::task::spawn_blocking`, or a
-    /// non‑async `main`. Calling it directly from an `async fn` parks
-    /// the tokio worker that the SDK's `rt-tokio` background tasks need
-    /// to make progress, and on a `current_thread` runtime that's a
-    /// deadlock. The `OtelObserveHook` adapter in the bin crate wraps
-    /// this in `spawn_blocking` for the async path.
+    /// dedicated thread, `tokio::task::spawn_blocking`, or a non-async `main`.
+    /// The SDK waits synchronously for its background processor to acknowledge
+    /// flush and shutdown messages, so the `OtelObserveHook` adapter wraps this
+    /// method in `spawn_blocking` for the async path.
     ///
     /// Idempotent: subsequent calls are no‑ops. The SDK itself panics
     /// on double-shutdown; the `Once` guard makes "shutdown then Drop"

--- a/plugins/bitrouter-observe/src/otel/exporter.rs
+++ b/plugins/bitrouter-observe/src/otel/exporter.rs
@@ -45,12 +45,12 @@ use opentelemetry::{
     propagation::{Extractor, Injector},
     trace::{Span, SpanKind, Status, TraceContextExt, Tracer},
 };
-use opentelemetry_sdk::Resource;
 use opentelemetry_sdk::propagation::TraceContextPropagator;
+use opentelemetry_sdk::trace::span_processor_with_async_runtime::BatchSpanProcessor;
 use opentelemetry_sdk::trace::{
-    BatchConfigBuilder, BatchSpanProcessor, RandomIdGenerator, Sampler, SdkTracerProvider,
-    Tracer as SdkTracer,
+    BatchConfigBuilder, RandomIdGenerator, Sampler, SdkTracerProvider, Tracer as SdkTracer,
 };
+use opentelemetry_sdk::{Resource, runtime};
 use opentelemetry_semantic_conventions::SCHEMA_URL;
 use opentelemetry_semantic_conventions::attribute::{SERVICE_NAME, SERVICE_VERSION};
 use serde::{Deserialize, Serialize};
@@ -61,7 +61,7 @@ use bitrouter_sdk::language_model::{
 };
 
 use crate::otel::cardinality::CardinalityLimiter;
-use crate::otel::config::{ContentCaptureMode, OtelConfig, SamplerKind};
+use crate::otel::config::{ContentCaptureMode, OtelConfig, SamplerKind, async_processor_interval};
 use crate::otel::span_attributes::SpanAttributes;
 
 /// HTTP header extractor for W3C trace context propagation
@@ -181,9 +181,11 @@ impl OtelExporter {
 
         let batch_config = BatchConfigBuilder::default()
             .with_max_queue_size(config.traces.batch.max_queue_size)
-            .with_scheduled_delay(Duration::from_millis(config.traces.batch.flush_ms))
+            .with_scheduled_delay(async_processor_interval(Duration::from_millis(
+                config.traces.batch.flush_ms,
+            )))
             .build();
-        let processor = BatchSpanProcessor::builder(span_exporter)
+        let processor = BatchSpanProcessor::builder(span_exporter, runtime::TokioCurrentThread)
             .with_batch_config(batch_config)
             .build();
 

--- a/plugins/bitrouter-observe/src/otel/exporter.rs
+++ b/plugins/bitrouter-observe/src/otel/exporter.rs
@@ -45,12 +45,12 @@ use opentelemetry::{
     propagation::{Extractor, Injector},
     trace::{Span, SpanKind, Status, TraceContextExt, Tracer},
 };
+use opentelemetry_sdk::Resource;
 use opentelemetry_sdk::propagation::TraceContextPropagator;
 use opentelemetry_sdk::trace::{
-    BatchConfigBuilder, BatchSpanProcessor, RandomIdGenerator, Sampler, Tracer as SdkTracer,
-    TracerProvider,
+    BatchConfigBuilder, BatchSpanProcessor, RandomIdGenerator, Sampler, SdkTracerProvider,
+    Tracer as SdkTracer,
 };
-use opentelemetry_sdk::{Resource, runtime};
 use opentelemetry_semantic_conventions::SCHEMA_URL;
 use opentelemetry_semantic_conventions::attribute::{SERVICE_NAME, SERVICE_VERSION};
 use serde::{Deserialize, Serialize};
@@ -123,7 +123,7 @@ struct HopState {
 /// OpenTelemetry exporter with multi-tenant attribution.
 pub struct OtelExporter {
     tracer: SdkTracer,
-    provider: TracerProvider,
+    provider: SdkTracerProvider,
     metrics: Option<crate::otel::metrics::OtelMetrics>,
 
     /// Snapshot of the config the exporter was built from. Kept so
@@ -183,11 +183,11 @@ impl OtelExporter {
             .with_max_queue_size(config.traces.batch.max_queue_size)
             .with_scheduled_delay(Duration::from_millis(config.traces.batch.flush_ms))
             .build();
-        let processor = BatchSpanProcessor::builder(span_exporter, runtime::Tokio)
+        let processor = BatchSpanProcessor::builder(span_exporter)
             .with_batch_config(batch_config)
             .build();
 
-        let provider = TracerProvider::builder()
+        let provider = SdkTracerProvider::builder()
             .with_span_processor(processor)
             .with_sampler(build_sampler(&config))
             .with_id_generator(RandomIdGenerator::default())
@@ -1040,7 +1040,9 @@ fn build_resource(config: &OtelConfig) -> Resource {
         }
         attrs.push(KeyValue::new(k.clone(), v.clone()));
     }
-    Resource::from_schema_url(attrs, SCHEMA_URL)
+    Resource::builder_empty()
+        .with_schema_url(attrs, SCHEMA_URL)
+        .build()
 }
 
 fn build_sampler(config: &OtelConfig) -> Sampler {
@@ -1193,9 +1195,8 @@ mod hop_tests {
 
     use futures::StreamExt;
     use opentelemetry::Value;
-    use opentelemetry::trace::TraceResult;
-    use opentelemetry_sdk::export::trace::SpanData;
-    use opentelemetry_sdk::trace::{Span as SdkSpan, SpanProcessor};
+    use opentelemetry_sdk::error::OTelSdkResult;
+    use opentelemetry_sdk::trace::{Span as SdkSpan, SpanData, SpanProcessor};
 
     use bitrouter_sdk::caller::CallerContext;
     use bitrouter_sdk::error::BitrouterError;
@@ -1254,11 +1255,11 @@ mod hop_tests {
             guard.push(span);
         }
 
-        fn force_flush(&self) -> TraceResult<()> {
+        fn force_flush(&self) -> OTelSdkResult {
             Ok(())
         }
 
-        fn shutdown(&self) -> TraceResult<()> {
+        fn shutdown_with_timeout(&self, _timeout: Duration) -> OTelSdkResult {
             Ok(())
         }
     }
@@ -1278,7 +1279,7 @@ mod hop_tests {
         };
         global::set_text_map_propagator(TraceContextPropagator::new());
 
-        let provider = TracerProvider::builder()
+        let provider = SdkTracerProvider::builder()
             .with_span_processor(processor)
             .with_sampler(Sampler::AlwaysOn)
             .with_id_generator(RandomIdGenerator::default())
@@ -1451,7 +1452,7 @@ mod hop_tests {
         exporter
             .on_request_end(&ctx, &RequestOutcome::Completed)
             .await;
-        exporter.provider.force_flush();
+        assert!(exporter.provider.force_flush().is_ok());
 
         let spans = captured.lock().unwrap().clone();
         let root_chat = spans
@@ -1477,7 +1478,7 @@ mod hop_tests {
         exporter
             .on_request_end(&ctx, &RequestOutcome::Completed)
             .await;
-        exporter.provider.force_flush();
+        assert!(exporter.provider.force_flush().is_ok());
 
         let spans = captured.lock().unwrap().clone();
         let root_chat = spans
@@ -1505,7 +1506,7 @@ mod hop_tests {
         exporter
             .on_request_end(&ctx, &RequestOutcome::Completed)
             .await;
-        exporter.provider.force_flush();
+        assert!(exporter.provider.force_flush().is_ok());
 
         let spans = captured.lock().unwrap().clone();
         let root_chat = spans
@@ -1628,7 +1629,7 @@ mod hop_tests {
         exporter
             .on_request_end(&ctx, &RequestOutcome::Completed)
             .await;
-        exporter.provider.force_flush();
+        assert!(exporter.provider.force_flush().is_ok());
 
         let spans = captured.lock().unwrap().clone();
         let root_chat = spans
@@ -1697,7 +1698,7 @@ mod hop_tests {
         exporter
             .on_request_end(&ctx, &RequestOutcome::Completed)
             .await;
-        exporter.provider.force_flush();
+        assert!(exporter.provider.force_flush().is_ok());
 
         let spans = captured.lock().unwrap().clone();
         let root_chat = spans
@@ -1763,7 +1764,7 @@ mod hop_tests {
         exporter
             .on_request_end(&ctx, &RequestOutcome::Completed)
             .await;
-        exporter.provider.force_flush();
+        assert!(exporter.provider.force_flush().is_ok());
 
         let spans = captured.lock().unwrap().clone();
         let root_chat = spans
@@ -1807,7 +1808,7 @@ mod hop_tests {
         exporter
             .on_request_end(&ctx, &RequestOutcome::Completed)
             .await;
-        exporter.provider.force_flush();
+        assert!(exporter.provider.force_flush().is_ok());
 
         let spans = captured.lock().unwrap().clone();
         let root_chat = spans
@@ -1840,7 +1841,7 @@ mod hop_tests {
         exporter
             .on_request_end(&ctx, &RequestOutcome::Completed)
             .await;
-        exporter.provider.force_flush();
+        assert!(exporter.provider.force_flush().is_ok());
         let spans = captured.lock().unwrap().clone();
         let root = spans
             .iter()
@@ -1861,7 +1862,7 @@ mod hop_tests {
         exporter
             .on_request_end(&ctx, &RequestOutcome::Completed)
             .await;
-        exporter.provider.force_flush();
+        assert!(exporter.provider.force_flush().is_ok());
         let spans = captured.lock().unwrap().clone();
         let root = spans
             .iter()
@@ -1898,7 +1899,7 @@ mod hop_tests {
         exporter
             .on_request_end(&ctx, &RequestOutcome::Completed)
             .await;
-        exporter.provider.force_flush();
+        assert!(exporter.provider.force_flush().is_ok());
 
         let spans = captured.lock().unwrap().clone();
         let root_chat = spans
@@ -1971,7 +1972,7 @@ mod hop_tests {
         exporter
             .on_hop_end(&ctx, &target, HopOutcome::StreamStarted)
             .await;
-        exporter.provider.force_flush();
+        assert!(exporter.provider.force_flush().is_ok());
 
         assert!(
             captured
@@ -1986,7 +1987,7 @@ mod hop_tests {
         exporter
             .on_request_end(&ctx, &RequestOutcome::Completed)
             .await;
-        exporter.provider.force_flush();
+        assert!(exporter.provider.force_flush().is_ok());
 
         let spans = captured.lock().unwrap().clone();
         let root_chat = spans
@@ -2021,7 +2022,7 @@ mod hop_tests {
             .on_hop_end(&ctx, &first, HopOutcome::StreamStarted)
             .await;
         exporter.on_hop_start(&ctx, &second).await;
-        exporter.provider.force_flush();
+        assert!(exporter.provider.force_flush().is_ok());
 
         let spans = captured.lock().unwrap().clone();
         let clients: Vec<_> = spans
@@ -2043,7 +2044,7 @@ mod hop_tests {
         exporter
             .on_request_end(&ctx, &RequestOutcome::Completed)
             .await;
-        exporter.provider.force_flush();
+        assert!(exporter.provider.force_flush().is_ok());
 
         assert_eq!(
             captured
@@ -2092,7 +2093,7 @@ mod hop_tests {
             .expect("stream starts");
         let parts: Vec<_> = stream.collect().await;
         assert!(parts.iter().all(Result::is_ok));
-        exporter.provider.force_flush();
+        assert!(exporter.provider.force_flush().is_ok());
 
         let spans = captured.lock().unwrap().clone();
         let root_chat = spans
@@ -2141,7 +2142,7 @@ mod hop_tests {
                 &RequestOutcome::Failed(BitrouterError::UpstreamUnavailable),
             )
             .await;
-        exporter.provider.force_flush();
+        assert!(exporter.provider.force_flush().is_ok());
 
         let spans = captured.lock().unwrap().clone();
         let root_chat = spans
@@ -2173,7 +2174,7 @@ mod hop_tests {
             .await
             .expect_err("pre-request rejects");
         assert!(matches!(error, BitrouterError::Unauthorized(_)));
-        exporter.provider.force_flush();
+        assert!(exporter.provider.force_flush().is_ok());
 
         let spans = captured.lock().unwrap().clone();
         let root_chat = spans
@@ -2221,7 +2222,7 @@ mod hop_tests {
             .expect("stream starts");
         let drain = tokio::spawn(async move { stream.collect::<Vec<_>>().await });
         entered.notified().await;
-        exporter.provider.force_flush();
+        assert!(exporter.provider.force_flush().is_ok());
 
         let spans = captured.lock().unwrap().clone();
         assert!(
@@ -2272,7 +2273,7 @@ mod hop_tests {
         exporter
             .on_request_end(&ctx, &RequestOutcome::Completed)
             .await;
-        exporter.provider.force_flush();
+        assert!(exporter.provider.force_flush().is_ok());
 
         let spans = captured.lock().unwrap().clone();
         let root_chat = spans
@@ -2346,7 +2347,7 @@ mod hop_tests {
         exporter
             .on_request_end(&ctx, &RequestOutcome::Completed)
             .await;
-        exporter.provider.force_flush();
+        assert!(exporter.provider.force_flush().is_ok());
 
         let spans = captured.lock().unwrap().clone();
         let root_chat = spans
@@ -2386,7 +2387,7 @@ mod hop_tests {
         exporter
             .on_request_end(&ctx, &RequestOutcome::Completed)
             .await;
-        exporter.provider.force_flush();
+        assert!(exporter.provider.force_flush().is_ok());
 
         let spans = captured.lock().unwrap().clone();
         let root_chat = spans
@@ -2422,7 +2423,7 @@ mod hop_tests {
         exporter
             .on_request_end(&ctx, &RequestOutcome::Failed(err.clone()))
             .await;
-        exporter.provider.force_flush();
+        assert!(exporter.provider.force_flush().is_ok());
 
         let spans = captured.lock().unwrap().clone();
         let hop_chat = spans

--- a/plugins/bitrouter-observe/src/otel/http_layer.rs
+++ b/plugins/bitrouter-observe/src/otel/http_layer.rs
@@ -82,7 +82,9 @@ fn make_http_server_span<B>(request: &http::Request<B>) -> Span {
     let parent = global::get_text_map_propagator(|propagator| {
         propagator.extract(&HeaderExtractor(request.headers()))
     });
-    span.set_parent(parent);
+    if let Err(error) = span.set_parent(parent) {
+        tracing::debug!(?error, "could not attach inbound trace context");
+    }
     span
 }
 

--- a/plugins/bitrouter-observe/src/otel/metrics.rs
+++ b/plugins/bitrouter-observe/src/otel/metrics.rs
@@ -18,7 +18,8 @@ use opentelemetry_sdk::metrics::periodic_reader_with_async_runtime::PeriodicRead
 use bitrouter_sdk::language_model::{PipelineContext, RequestOutcome, StreamPart};
 
 use crate::otel::cardinality::CardinalityLimiter;
-use crate::otel::config::{OtelConfig, async_processor_interval};
+use crate::otel::config::OtelConfig;
+use crate::otel::processor_runtime::ProcessorRuntime;
 
 /// OpenTelemetry metrics with multi-tenant attribution.
 pub struct OtelMetrics {
@@ -49,12 +50,9 @@ impl OtelMetrics {
         // crate's feature flags — see `crate::otel::transport`.
         let exporter = crate::otel::transport::metric_exporter(config)?;
 
-        let reader =
-            PeriodicReader::builder(exporter, opentelemetry_sdk::runtime::TokioCurrentThread)
-                .with_interval(async_processor_interval(Duration::from_millis(
-                    config.metrics.export_interval_ms,
-                )))
-                .build();
+        let reader = PeriodicReader::builder(exporter, ProcessorRuntime::new())
+            .with_interval(Duration::from_millis(config.metrics.export_interval_ms))
+            .build();
 
         let provider = SdkMeterProvider::builder()
             .with_reader(reader)

--- a/plugins/bitrouter-observe/src/otel/metrics.rs
+++ b/plugins/bitrouter-observe/src/otel/metrics.rs
@@ -12,12 +12,13 @@ use std::time::Duration;
 use opentelemetry::KeyValue;
 use opentelemetry::metrics::{Counter, Histogram, Meter, MeterProvider};
 use opentelemetry_sdk::Resource;
-use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
+use opentelemetry_sdk::metrics::SdkMeterProvider;
+use opentelemetry_sdk::metrics::periodic_reader_with_async_runtime::PeriodicReader;
 
 use bitrouter_sdk::language_model::{PipelineContext, RequestOutcome, StreamPart};
 
 use crate::otel::cardinality::CardinalityLimiter;
-use crate::otel::config::OtelConfig;
+use crate::otel::config::{OtelConfig, async_processor_interval};
 
 /// OpenTelemetry metrics with multi-tenant attribution.
 pub struct OtelMetrics {
@@ -48,9 +49,12 @@ impl OtelMetrics {
         // crate's feature flags — see `crate::otel::transport`.
         let exporter = crate::otel::transport::metric_exporter(config)?;
 
-        let reader = PeriodicReader::builder(exporter)
-            .with_interval(Duration::from_millis(config.metrics.export_interval_ms))
-            .build();
+        let reader =
+            PeriodicReader::builder(exporter, opentelemetry_sdk::runtime::TokioCurrentThread)
+                .with_interval(async_processor_interval(Duration::from_millis(
+                    config.metrics.export_interval_ms,
+                )))
+                .build();
 
         let provider = SdkMeterProvider::builder()
             .with_reader(reader)

--- a/plugins/bitrouter-observe/src/otel/metrics.rs
+++ b/plugins/bitrouter-observe/src/otel/metrics.rs
@@ -48,7 +48,7 @@ impl OtelMetrics {
         // crate's feature flags — see `crate::otel::transport`.
         let exporter = crate::otel::transport::metric_exporter(config)?;
 
-        let reader = PeriodicReader::builder(exporter, opentelemetry_sdk::runtime::Tokio)
+        let reader = PeriodicReader::builder(exporter)
             .with_interval(Duration::from_millis(config.metrics.export_interval_ms))
             .build();
 

--- a/plugins/bitrouter-observe/src/otel/mod.rs
+++ b/plugins/bitrouter-observe/src/otel/mod.rs
@@ -22,6 +22,7 @@ mod config;
 mod exporter;
 pub mod http_layer;
 mod metrics;
+mod processor_runtime;
 mod span_attributes;
 mod transport;
 

--- a/plugins/bitrouter-observe/src/otel/processor_runtime.rs
+++ b/plugins/bitrouter-observe/src/otel/processor_runtime.rs
@@ -1,0 +1,145 @@
+//! Runtime adapter for the OpenTelemetry 0.32 async processors.
+
+use std::fmt::Debug;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use futures_core::Stream;
+use opentelemetry_sdk::runtime::{Runtime, RuntimeChannel, TokioCurrentThread};
+
+/// Supplies the immediate first tick expected by the OpenTelemetry 0.32 async
+/// processors, then preserves every configured delay unchanged.
+///
+/// The SDK's interval stream waits before every yield, but its processors still
+/// discard the first yield as though it were immediate. This adapter makes only
+/// that discarded delay immediate. See the upstream interval implementation:
+/// <https://docs.rs/opentelemetry_sdk/0.32.1/src/opentelemetry_sdk/runtime.rs.html#46-58>.
+#[derive(Debug, Clone)]
+pub(super) struct ProcessorRuntime {
+    inner: TokioCurrentThread,
+    initial_delay: Arc<AtomicBool>,
+}
+
+/// Prevents an already-queued export message from reaching the worker before
+/// its ticker consumes the synthetic immediate delay.
+pub(super) struct ProcessorReceiver<T: Debug + Send> {
+    inner: <TokioCurrentThread as RuntimeChannel>::Receiver<T>,
+    initial_delay: Arc<AtomicBool>,
+}
+
+impl<T: Debug + Send> Stream for ProcessorReceiver<T> {
+    type Item = T;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        if self.initial_delay.load(Ordering::Acquire) {
+            cx.waker().wake_by_ref();
+            return Poll::Pending;
+        }
+        Pin::new(&mut self.inner).poll_next(cx)
+    }
+}
+
+impl ProcessorRuntime {
+    pub(super) fn new() -> Self {
+        Self {
+            inner: TokioCurrentThread,
+            initial_delay: Arc::new(AtomicBool::new(true)),
+        }
+    }
+}
+
+impl Runtime for ProcessorRuntime {
+    fn spawn<F>(&self, future: F)
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        self.inner.spawn(future);
+    }
+
+    fn delay(&self, duration: Duration) -> impl Future<Output = ()> + Send + 'static {
+        let inner = self.inner.clone();
+        let is_initial = self.initial_delay.swap(false, Ordering::AcqRel);
+        async move {
+            if !is_initial {
+                inner.delay(duration).await;
+            }
+        }
+    }
+}
+
+impl RuntimeChannel for ProcessorRuntime {
+    type Receiver<T: Debug + Send> = ProcessorReceiver<T>;
+    type Sender<T: Debug + Send> = <TokioCurrentThread as RuntimeChannel>::Sender<T>;
+
+    fn batch_message_channel<T: Debug + Send>(
+        &self,
+        capacity: usize,
+    ) -> (Self::Sender<T>, Self::Receiver<T>) {
+        let (sender, receiver) = self.inner.batch_message_channel(capacity);
+        (
+            sender,
+            ProcessorReceiver {
+                inner: receiver,
+                initial_delay: Arc::clone(&self.initial_delay),
+            },
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::StreamExt;
+    use futures::stream;
+    use opentelemetry_sdk::runtime::Runtime;
+    use opentelemetry_sdk::runtime::RuntimeChannel;
+
+    use super::*;
+
+    #[tokio::test(start_paused = true)]
+    async fn first_delay_is_immediate_and_later_delays_keep_the_full_cadence() {
+        let runtime = ProcessorRuntime::new();
+        let interval = Duration::from_secs(5);
+        let started = tokio::time::Instant::now();
+
+        runtime.delay(interval).await;
+        assert_eq!(started.elapsed(), Duration::ZERO);
+
+        runtime.delay(interval).await;
+        assert_eq!(started.elapsed(), interval);
+
+        runtime.delay(interval).await;
+        assert_eq!(started.elapsed(), interval * 2);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn queued_messages_wait_until_the_ticker_consumes_the_initial_delay() {
+        let runtime = ProcessorRuntime::new();
+        let (sender, receiver) = runtime.batch_message_channel(1);
+        sender.try_send(42_u8).expect("test channel has capacity");
+
+        let ticker_runtime = runtime.clone();
+        let ticker = stream::unfold((), move |()| {
+            let ticker_runtime = ticker_runtime.clone();
+            async move {
+                ticker_runtime.delay(Duration::from_secs(5)).await;
+                Some((0_u8, ()))
+            }
+        })
+        .skip(1);
+        let messages = stream::select(receiver, ticker);
+        futures::pin_mut!(messages);
+        let started = tokio::time::Instant::now();
+
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(1), messages.next())
+                .await
+                .expect("queued message is repolled without waiting for the ticker"),
+            Some(42)
+        );
+        assert_eq!(started.elapsed(), Duration::ZERO);
+    }
+}


### PR DESCRIPTION
## Summary

- remove unused workspace and package dependencies reported by `cargo machete`
- upgrade direct and transitive Rust dependencies, including reqwest 0.13, rmcp 2.2, OpenTelemetry 0.32, toml 1.1, rand 0.10, sha2 0.11, and related SDK stacks
- align the observe middleware with reqwest's `tower-http` 0.6 line so only one `tower-http` version remains
- adapt affected APIs while preserving HTTP, MCP, attestation, telemetry, and cryptographic behavior
- raise the supported Rust floor to 1.93 and keep the dedicated MSRV job, now checking all features

## Compatibility notes

OpenTelemetry 0.32's async processors require an async-runtime implementation for the reqwest/tonic exporters. The processor adapter supplies the immediate first tick expected by the upstream scheduler while preserving configured trace and metric intervals; it also gates queued messages until ticker initialization to avoid startup races.

The resolved dependency graph itself requires Rust 1.89, while Rust 1.93 is intentionally selected as the project's recent supported compiler floor. Current stable remains covered by the regular CI matrix.

The duplicate-version audit removed the only directly controllable duplicate (`tower-http` 0.7/0.6). Remaining duplicate names are semver-incompatible transitive generations: the legacy and current RustCrypto stacks, SeaORM versus RMCP derive stacks, RNG generations, target-specific Windows support crates, and compatibility wrappers such as `webpki-roots`. A full `cargo update --dry-run --verbose` cannot merge any of them under current upstream requirements; forcing them with `[patch]` would violate those APIs.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --all-features` (1,445 passed, 3 skipped)
- `cargo +1.93.0 check --workspace --all-features`
- `cargo +1.93.0 check -p bitrouter-observe --no-default-features --features otel-grpc`
- `cargo machete`
- `cargo test --doc --workspace --all-features`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps`
- feature-isolation and generated distribution checks
- `cargo upgrade --dry-run --incompatible allow --pinned allow`
- duplicate-version inventory and `cargo update --dry-run --verbose`
