### PR TITLE
chore: remove dead .cargo xtask alias

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,0 @@
-[alias]
-# `cargo xtask <task>` — workspace automation (schema generation, etc.)
-xtask = "run --package xtask --"


### PR DESCRIPTION
## Summary

`.cargo/config.toml` only defined a `cargo xtask` alias:

```toml
[alias]
xtask = "run --package xtask --"
```

The `xtask` package it targets no longer exists in the workspace — there's no `xtask/` directory, no `xtask` member in `Cargo.toml`, and no `cargo xtask` invocation anywhere in the repo (docs, scripts, CI). Running the alias would just fail with "package `xtask` not found", so this is dead config.

Removing the alias leaves `.cargo/` empty, so the directory is dropped entirely.

## Test plan

- No code or build behavior changes; the alias was unreferenced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)