### PR TITLE
docs: refresh README model showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,17 +172,17 @@ Native desktop app for driving multi-agent loops — coming soon.
 
 ## Models & providers
 
-BitRouter routes to a *model*, not a provider. Each open-weight family below is served by many providers — its own lab, hyperscalers (AWS Bedrock, Alibaba Cloud), gateways (OpenRouter, OpenCode), and serverless clouds — and BitRouter picks the cheapest route per call. **Bring your own key** to any of them, or use one **BitRouter Cloud** account with no keys at all.
+BitRouter routes to a *model*, not a provider. Each family below is served by many providers — its own lab, hyperscalers (AWS Bedrock, Alibaba Cloud), gateways (OpenRouter, OpenCode), and serverless clouds — and BitRouter picks the cheapest route per call. **Bring your own key** to any of them, or use one **BitRouter Cloud** account with no keys at all.
 
-| Open model            | Lab      |
-| --------------------- | -------- |
-| DeepSeek V3.2 / V4    | DeepSeek |
-| Qwen3 / Qwen3-Coder   | Alibaba  |
-| Kimi K2               | Moonshot |
-| GLM-5 / 5.1           | Z.ai     |
-| MiniMax M2–M3         | MiniMax  |
-| MiMo V2               | Xiaomi   |
-| Step 3.5              | StepFun  |
+| Lab      | Latest models                    |
+| -------- | -------------------------------- |
+| DeepSeek | DeepSeek V4 Pro / Flash          |
+| Alibaba  | Qwen3.7 Max / Plus               |
+| Moonshot | Kimi K2.7 Code / K2.6            |
+| Z.ai     | GLM-5.2 / 5.1                    |
+| MiniMax  | MiniMax M3 / M2.7                |
+| Xiaomi   | MiMo V2.5 Pro / V2.5             |
+| StepFun  | Step 3.7 Flash / 3.5 Flash       |
 
 Plus every frontier model from OpenAI, Anthropic, Google, and xAI — over your own keys, a subscription sign-in (Claude Pro/Max, GitHub Copilot, ChatGPT Codex), or BitRouter Cloud. Full catalog in the [registry/](registry/).
 


### PR DESCRIPTION
## What

Refreshes the **Models & providers** table in the top-level README:

- puts the lab column first;
- keeps the model names concise and reader-friendly;
- replaces stale families with the current DeepSeek V4, Qwen3.7, Kimi K2.7, GLM-5.2, MiniMax M3, MiMo V2.5, and Step 3.7 generations;
- updates the introductory sentence so the table can include both open-weight families and hosted frontier variants such as Qwen3.7.

## Why

The previous table still highlighted older or overly broad names such as DeepSeek V3.2, Qwen3/Qwen3-Coder, Kimi K2, MiMo V2, and Step 3.5. The new entries match models present in the current registry and are cross-checked against the labs' current model releases.

## Scope

README-only documentation change. No registry, runtime, or automated-test changes.

## Checks

- `git diff --check`
- Confirmed every displayed generation has corresponding current model entries and BitRouter provider mappings in `registry/`.
