### PR TITLE
docs(benchmarks): correct cache cost accounting

### DIFF
--- a/benchmarks/001-2026-07-10-tbench-v2.1-codex-gpt55-kimi-k27.md
+++ b/benchmarks/001-2026-07-10-tbench-v2.1-codex-gpt55-kimi-k27.md
@@ -16,9 +16,11 @@ exploration on top of an unchanged strong-model workload.
 The clearest mechanism result appeared in r2. Relative to the strong-only
 control, r2 made 373 fewer GPT-5.5 calls, introduced 219 Kimi calls, reduced
 total calls by 154, reduced total tokens by 21.2%, and reduced normalized
-API-equivalent cost by 32.8%. Its score was one task lower on the 88-task
-comparable set. The later r3 round produced the highest raw score while still
-costing 8.2% less than control, but its weak-model share fell back to 2.16%, so
+zero-cache API-equivalent cost by 32.8%. A post-publication accounting audit
+places the r2 reduction at 28.62%-32.80% when control and r2 have equal
+cache-read shares. Its score was one task lower on the 88-task comparable set.
+The later r3 round produced the highest raw score while retaining a lower
+zero-cache cost than control, but its weak-model share fell back to 2.16%, so
 the optimization did not converge monotonically.
 
 ## Hypothesis
@@ -47,14 +49,14 @@ applied only after the preceding round passed the artifact integrity gates.
 | Sandbox | Harbor EC2 provider; `m7i-flex.large` with four-vCPU recovery on `m7i-flex.xlarge` |
 | Harbor retries | 0 |
 | Timeout multiplier | 1.5 |
-| Strong imputed price | $5/M input, $30/M output |
-| Weak imputed price | $0.7125/M input, $3/M output |
+| Strong imputed price | $5/M non-cached input, $0.50/M cache read, $30/M output |
+| Weak imputed price | $0.7125/M non-cached input, $0.1425/M cache read, $3/M output |
 
 ## Results
 
-All figures use the same 88-task comparable set. Cost is normalized,
-API-equivalent imputed cost calculated from measured token usage and the frozen
-prices above. It is not the cash cost of the Codex subscription.
+All figures use the same 88-task comparable set. The displayed cost is the
+originally published zero-cache upper-bound API-equivalent imputation. It is
+not the cash cost of the Codex subscription or an exact cache-aware estimate.
 
 | Group | Passed | Score | Requests | GPT-5.5 | Kimi | Kimi share | Input tokens | Output tokens | Total tokens | Cost | Cost vs control |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
@@ -63,11 +65,40 @@ prices above. It is not the cash cost of the Codex subscription.
 | r2 | 67/88 | 76.14% | 1,512 | 1,293 | 219 | 14.48% | 47,161,445 | 814,059 | 47,975,504 | $222.22 | -32.80% |
 | r3 | 73/88 | 82.95% | 1,571 | 1,537 | 34 | 2.16% | 55,203,065 | 996,900 | 56,199,965 | $303.60 | -8.19% |
 
-Cost per successful task was $4.86 for control, $5.01 for r1, $3.32 for
-r2, and $4.16 for r3. Across the complete policy lifecycle, r1-r3 cost $876.74
-versus a $992.09 three-control counterfactual, an 11.63% reduction. The policy
-rounds produced 210 aggregate successes versus 204 for the counterfactual and
-reduced cost per success from $4.86 to $4.17.
+### Cost accounting correction (2026-07-14)
+
+A post-publication audit found that the metering export dropped
+`cache_read_tokens` and `cache_write_tokens`, while the imputation path charged
+every prompt token at the non-cached input rate. The table therefore reports
+reproducible zero-cache upper bounds. Exact cache-aware costs cannot be
+reconstructed from the released usage rows or request-side traces because the
+cache-token split was not archived.
+
+Using the frozen cache-read prices and assuming equal cache-read shares for
+control and r2 gives the following sensitivity range:
+
+| Equal cache-read share | Control | r2 | r2 vs control |
+| ---: | ---: | ---: | ---: |
+| 0% | $330.70 | $222.22 | -32.80% |
+| 25% | $263.36 | $177.61 | -32.56% |
+| 50% | $196.02 | $133.01 | -32.15% |
+| 75% | $128.69 | $88.40 | -31.31% |
+| 90% | $88.28 | $61.63 | -30.19% |
+| 100% | $61.35 | $43.79 | -28.62% |
+
+The correction does not change benchmark scores, request counts, model
+selection, or measured total tokens. Under equal cache behavior, it also does
+not change the direction of the r2 result. If cache-hit rates differ materially
+between rounds, the exact cost reduction is unknown. The next run will export
+cache read/write buckets, retain settlement evidence, and publish cache-aware
+costs.
+
+Under the original zero-cache imputation, cost per successful task was $4.86
+for control, $5.01 for r1, $3.32 for r2, and $4.16 for r3. Across the complete
+policy lifecycle, r1-r3 cost $876.74 versus a $992.09 three-control
+counterfactual, an 11.63% reduction. The policy rounds produced 210 aggregate
+successes versus 204 for the counterfactual and reduced zero-cache imputed cost
+per success from $4.86 to $4.17.
 
 ## What r2 Demonstrated
 
@@ -77,7 +108,7 @@ exploration. Compared with control:
 - strong calls fell by 373, or 22.39%;
 - total calls fell by 154, or 9.24%;
 - total tokens fell by 12,927,270, or 21.23%;
-- imputed cost fell by $108.48, or 32.80%;
+- zero-cache imputed cost fell by $108.48, or 32.80% (28.62%-32.80% under equal cache-read shares);
 - score fell by one task, or 1.14 percentage points.
 
 The weak calls therefore replaced part of the strong workload rather than
@@ -88,8 +119,9 @@ the one-task score difference is statistically meaningful.
 ## Evolution Finding
 
 r1 behaved mainly as an exploration round: it added 31 Kimi trials, scored two
-tasks above control, and cost 6.11% more. r3 scored five tasks above control and
-cost 8.19% less, but only seven of its 34 Kimi calls came from learned locks.
+tasks above control, and had 6.11% higher zero-cache imputed cost. r3 scored
+five tasks above control and had 8.19% lower zero-cache imputed cost, but only
+seven of its 34 Kimi calls came from learned locks.
 
 The change from 204 learned-lock calls in r2 to seven in r3 indicates a policy
 stability limitation. Workflow fingerprints were broad and shared across
@@ -115,6 +147,8 @@ or hysteresis, and more precise reward attribution.
   evidence. The invalid artifact is not part of the accepted dataset.
 - One unsettled r2 request was explicitly excluded from accepted cost evidence;
   no settled usage was discarded.
+- Cache read/write buckets were stored in daemon settlement state but omitted
+  from the accepted export, so published costs are zero-cache upper bounds.
 
 ## Published Data
 
@@ -142,14 +176,18 @@ were preserved.
 - `timeout_multiplier` was 1.5 and sandbox resource overrides were used.
 - One provider-incompatible task was excluded, leaving an identical 88-task
   comparable set for all groups.
-- Cost is imputed from measured tokens at frozen list prices. It is a routing
-  economics estimate, not a billing statement.
+- Cost was imputed by charging all prompt tokens at frozen non-cached list
+  prices. It is a zero-cache routing-economics upper bound, not a billing
+  statement; exact cache-aware values require a rerun with bucket-level usage.
 
 ## Conclusion
 
 The experiment establishes that the current prototype can replace strong-model
-calls with cheaper Kimi calls and materially reduce token use and imputed cost
-without adding weak exploration on top of the original strong-call volume. It
-also shows that the learned routing state is not yet stable across successive
-reward rounds. The next validation needs repeated seeds, a tuning/held-out
-split, and a policy update that scopes confidence more narrowly.
+calls with cheaper Kimi calls and materially reduce token use and zero-cache
+imputed cost without adding weak exploration on top of the original strong-call
+volume.
+Under equal cache behavior, r2 retains a 28.62%-32.80% estimated cost advantage.
+It also shows that the learned routing state is not yet stable across successive
+reward rounds. The next validation needs cache-complete metering, repeated
+seeds, a tuning/held-out split, and a policy update that scopes confidence more
+narrowly.


### PR DESCRIPTION
## Summary

- disclose that the published experiment costs are zero-cache upper-bound imputations because cache token buckets were not exported
- add a cache-read sensitivity analysis showing r2 retains a 28.62%-32.80% estimated advantage under equal cache behavior
- clarify which findings remain unchanged and require cache-complete metering in the next run
- keep the repository-level README unchanged

## Why

A post-publication audit found that the experiment charged all prompt tokens at non-cached input rates. The correction preserves the reproducible original figures while making their accounting scope explicit.

The matching Hugging Face experiment documents were updated in dataset commit `cbfb4d36ad1a99961df7a3050850105cb3e11c63`.

## Verification

- `git diff --check`
- experiment-document marker and sensitivity-table assertions
- Hugging Face experiment and collection SHA-256 manifests rebuilt and verified
- updated HTML report parsed and rendered locally