### PR TITLE
fix(sdk): preserve upstream bad requests

### DIFF
--- a/apps/bitrouter/src/adequacy/observer.rs
+++ b/apps/bitrouter/src/adequacy/observer.rs
@@ -799,7 +799,7 @@ mod tests {
         );
         assert_eq!(
             classify_failure(&BitrouterError::UpstreamBadRequest {
-                message: "unsupported parameter".to_string(),
+                error: serde_json::json!("unsupported parameter"),
             }),
             InadequacyCause::ProviderPermanent
         );

--- a/apps/bitrouter/src/adequacy/observer.rs
+++ b/apps/bitrouter/src/adequacy/observer.rs
@@ -264,6 +264,7 @@ pub(crate) fn classify_failure(error: &BitrouterError) -> InadequacyCause {
             401 | 403 => InadequacyCause::Auth,
             _ => InadequacyCause::ProviderPermanent,
         },
+        BitrouterError::UpstreamBadRequest { .. } => InadequacyCause::ProviderPermanent,
         BitrouterError::UpstreamTimeout
         | BitrouterError::UpstreamRateLimited { .. }
         | BitrouterError::UpstreamUnavailable
@@ -795,6 +796,12 @@ mod tests {
                 message: "invalid response".to_string(),
             }),
             InadequacyCause::Protocol
+        );
+        assert_eq!(
+            classify_failure(&BitrouterError::UpstreamBadRequest {
+                message: "unsupported parameter".to_string(),
+            }),
+            InadequacyCause::ProviderPermanent
         );
     }
 }

--- a/crates/bitrouter-sdk/src/error.rs
+++ b/crates/bitrouter-sdk/src/error.rs
@@ -184,7 +184,7 @@ impl BitrouterError {
             Self::NotFound(_) => "not_found",
             Self::RateLimited { .. } => "rate_limit_exceeded",
             Self::UpstreamRateLimited { .. } => "upstream_rate_limited",
-            Self::UpstreamBadRequest { .. } => "upstream_bad_request",
+            Self::UpstreamBadRequest { .. } => "invalid_request",
             Self::Upstream { .. } => "upstream_bad_gateway",
             Self::UpstreamInvalidResponse { .. } => "upstream_invalid_response",
             Self::UpstreamAuth { .. } => "upstream_auth_required",
@@ -267,12 +267,13 @@ impl BitrouterError {
 
     /// A message safe to return to an untrusted HTTP/SSE client.
     ///
-    /// Upstream diagnostics may contain echoed prompts, credentials, provider
-    /// stack traces, or account details. Keep those on the internal error while
-    /// exposing only a stable summary at the public boundary.
+    /// Provider bad-request payloads are intentionally preserved so callers can
+    /// correct rejected parameters. Other upstream diagnostics may contain
+    /// echoed prompts, credentials, provider stack traces, or account details,
+    /// so they expose only a stable summary at the public boundary.
     pub fn public_message(&self) -> String {
         match self {
-            Self::UpstreamBadRequest { .. } => "upstream rejected the request".to_string(),
+            Self::UpstreamBadRequest { error } => upstream_payload_text(error),
             Self::Upstream { .. } => "upstream request failed".to_string(),
             Self::UpstreamInvalidResponse { .. } => {
                 "upstream returned an invalid response".to_string()
@@ -357,13 +358,13 @@ mod tests {
 
         assert_eq!(error.status(), 400);
         assert_eq!(error.error_type(), "invalid_request_error");
-        assert_eq!(error.error_code(), "upstream_bad_request");
+        assert_eq!(error.error_code(), "invalid_request");
         assert_eq!(error.kind(), ErrorKind::BadRequest);
         assert_eq!(
             serde_json::to_value(error.kind()).unwrap(),
             serde_json::json!("bad_request")
         );
-        assert_eq!(error.public_message(), "upstream rejected the request");
+        assert_eq!(error.public_message(), "provider secret");
         assert!(
             error
                 .to_envelope()

--- a/crates/bitrouter-sdk/src/error.rs
+++ b/crates/bitrouter-sdk/src/error.rs
@@ -68,6 +68,14 @@ pub enum BitrouterError {
         retry_after: Option<u64>,
     },
 
+    /// 400 — an upstream provider rejected the request parameters.
+    #[error("upstream rejected the request")]
+    UpstreamBadRequest {
+        /// Internal diagnostic detail. Public HTTP/SSE responses use a fixed
+        /// safe message and never expose this value.
+        message: String,
+    },
+
     /// 502 — upstream provider returned an error.
     #[error("upstream error ({status}): {message}")]
     Upstream {
@@ -126,6 +134,7 @@ impl BitrouterError {
             Self::NotFound(_) => 404,
             Self::RateLimited { .. } => 429,
             Self::UpstreamRateLimited { .. } => 429,
+            Self::UpstreamBadRequest { .. } => 400,
             Self::Upstream { .. } => 502,
             Self::UpstreamInvalidResponse { .. } => 502,
             Self::UpstreamAuth { status, .. } => *status,
@@ -146,6 +155,7 @@ impl BitrouterError {
             Self::NotFound(_) => "not_found_error",
             Self::RateLimited { .. } => "rate_limit_error",
             Self::UpstreamRateLimited { .. } => "rate_limit_error",
+            Self::UpstreamBadRequest { .. } => "invalid_request_error",
             Self::Upstream { .. }
             | Self::UpstreamInvalidResponse { .. }
             | Self::UpstreamTimeout => "upstream_error",
@@ -167,6 +177,7 @@ impl BitrouterError {
             Self::NotFound(_) => "not_found",
             Self::RateLimited { .. } => "rate_limit_exceeded",
             Self::UpstreamRateLimited { .. } => "upstream_rate_limited",
+            Self::UpstreamBadRequest { .. } => "upstream_bad_request",
             Self::Upstream { .. } => "upstream_bad_gateway",
             Self::UpstreamInvalidResponse { .. } => "upstream_invalid_response",
             Self::UpstreamAuth { .. } => "upstream_auth_required",
@@ -199,6 +210,7 @@ impl BitrouterError {
             Self::NotFound(_) => ErrorKind::NotFound,
             Self::RateLimited { .. } => ErrorKind::RateLimited,
             Self::UpstreamRateLimited { .. } => ErrorKind::UpstreamRateLimited,
+            Self::UpstreamBadRequest { .. } => ErrorKind::UpstreamBadRequest,
             Self::Upstream { .. } => ErrorKind::Upstream,
             Self::UpstreamInvalidResponse { .. } => ErrorKind::UpstreamInvalidResponse,
             Self::UpstreamAuth { .. } => ErrorKind::UpstreamAuth,
@@ -223,6 +235,9 @@ impl BitrouterError {
             Self::RateLimited { .. } => "rate limited".to_string(),
             Self::UpstreamPaymentRequired => "upstream payment required".to_string(),
             Self::UpstreamRateLimited { .. } => "upstream rate limited".to_string(),
+            Self::UpstreamBadRequest { message } => {
+                format!("upstream rejected the request: {message}")
+            }
             Self::Upstream { status, message } => {
                 format!("upstream error ({status}): {message}")
             }
@@ -252,6 +267,7 @@ impl BitrouterError {
     /// exposing only a stable summary at the public boundary.
     pub fn public_message(&self) -> String {
         match self {
+            Self::UpstreamBadRequest { .. } => "upstream rejected the request".to_string(),
             Self::Upstream { .. } => "upstream request failed".to_string(),
             Self::UpstreamInvalidResponse { .. } => {
                 "upstream returned an invalid response".to_string()
@@ -283,6 +299,8 @@ pub enum ErrorKind {
     RateLimited,
     /// 429 — all usable upstream routes are rate limited.
     UpstreamRateLimited,
+    /// 400 — an upstream provider rejected the request parameters.
+    UpstreamBadRequest,
     /// 502 — upstream provider error.
     Upstream,
     /// 502 — malformed success response from an upstream protocol.
@@ -327,6 +345,26 @@ pub struct ErrorEnvelope {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn upstream_bad_request_error_contract() {
+        let error = BitrouterError::UpstreamBadRequest {
+            message: "provider secret".into(),
+        };
+
+        assert_eq!(error.status(), 400);
+        assert_eq!(error.error_type(), "invalid_request_error");
+        assert_eq!(error.error_code(), "upstream_bad_request");
+        assert_eq!(error.kind(), ErrorKind::UpstreamBadRequest);
+        assert_eq!(error.public_message(), "upstream rejected the request");
+        assert!(
+            error
+                .to_envelope()
+                .error
+                .message
+                .contains("provider secret")
+        );
+    }
 
     #[test]
     fn upstream_auth_status_and_type() {

--- a/crates/bitrouter-sdk/src/error.rs
+++ b/crates/bitrouter-sdk/src/error.rs
@@ -9,8 +9,9 @@
 //!
 //! [`BitrouterError::to_envelope`] projects an error into the canonical,
 //! serializable [`ErrorEnvelope`] (`{"error": {"kind": …, "message": …}}`) —
-//! the stable shape the CLI prints on stdout and the daemon/cloud HTTP
-//! surfaces converge on.
+//! the stable typed shape the CLI prints on stdout. HTTP surfaces use their
+//! protocol-specific projections; provider bad requests preserve the selected
+//! upstream `error` object or string.
 
 use std::fmt;
 
@@ -283,9 +284,10 @@ impl BitrouterError {
     }
 }
 
-/// A machine-readable error category — the stable taxonomy shared across the
-/// CLI, the daemon HTTP API, and (in future) the cloud API. Mirrors the
-/// [`BitrouterError`] variants; serialized in `snake_case`.
+/// A machine-readable error category — the stable taxonomy shared across typed
+/// error consumers. This is a many-to-one projection of [`BitrouterError`];
+/// for example, provider and local bad requests both map to [`Self::BadRequest`].
+/// Serialized in `snake_case`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ErrorKind {
@@ -337,9 +339,9 @@ pub struct ErrorBody {
     pub hint: Option<String>,
 }
 
-/// The top-level error envelope emitted on stdout by the CLI (and the shape the
-/// daemon/cloud HTTP surfaces converge on). Wraps a single [`ErrorBody`] under
-/// an `error` key: `{"error": {"kind": …, "message": …}}`.
+/// The top-level typed error envelope emitted on stdout by the CLI. Wraps a
+/// single [`ErrorBody`] under an `error` key:
+/// `{"error": {"kind": …, "message": …}}`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ErrorEnvelope {
     /// The error detail.

--- a/crates/bitrouter-sdk/src/error.rs
+++ b/crates/bitrouter-sdk/src/error.rs
@@ -356,6 +356,10 @@ mod tests {
         assert_eq!(error.error_type(), "invalid_request_error");
         assert_eq!(error.error_code(), "upstream_bad_request");
         assert_eq!(error.kind(), ErrorKind::UpstreamBadRequest);
+        assert_eq!(
+            serde_json::to_value(error.kind()).unwrap(),
+            serde_json::json!("upstream_bad_request")
+        );
         assert_eq!(error.public_message(), "upstream rejected the request");
         assert!(
             error

--- a/crates/bitrouter-sdk/src/error.rs
+++ b/crates/bitrouter-sdk/src/error.rs
@@ -69,11 +69,11 @@ pub enum BitrouterError {
     },
 
     /// 400 — an upstream provider rejected the request parameters.
-    #[error("upstream rejected the request")]
+    #[error("upstream bad request")]
     UpstreamBadRequest {
-        /// Internal diagnostic detail. Public HTTP/SSE responses use a fixed
-        /// safe message and never expose this value.
-        message: String,
+        /// Upstream-selected error payload. Executor-produced values are
+        /// always a JSON object or JSON string.
+        error: serde_json::Value,
     },
 
     /// 502 — upstream provider returned an error.
@@ -120,6 +120,13 @@ pub enum BitrouterError {
     /// 500 — internal error.
     #[error("internal error: {0}")]
     Internal(String),
+}
+
+fn upstream_payload_text(error: &serde_json::Value) -> String {
+    match error {
+        serde_json::Value::String(message) => message.clone(),
+        other => other.to_string(),
+    }
 }
 
 impl BitrouterError {
@@ -210,7 +217,7 @@ impl BitrouterError {
             Self::NotFound(_) => ErrorKind::NotFound,
             Self::RateLimited { .. } => ErrorKind::RateLimited,
             Self::UpstreamRateLimited { .. } => ErrorKind::UpstreamRateLimited,
-            Self::UpstreamBadRequest { .. } => ErrorKind::UpstreamBadRequest,
+            Self::UpstreamBadRequest { .. } => ErrorKind::BadRequest,
             Self::Upstream { .. } => ErrorKind::Upstream,
             Self::UpstreamInvalidResponse { .. } => ErrorKind::UpstreamInvalidResponse,
             Self::UpstreamAuth { .. } => ErrorKind::UpstreamAuth,
@@ -235,9 +242,7 @@ impl BitrouterError {
             Self::RateLimited { .. } => "rate limited".to_string(),
             Self::UpstreamPaymentRequired => "upstream payment required".to_string(),
             Self::UpstreamRateLimited { .. } => "upstream rate limited".to_string(),
-            Self::UpstreamBadRequest { message } => {
-                format!("upstream rejected the request: {message}")
-            }
+            Self::UpstreamBadRequest { error } => upstream_payload_text(error),
             Self::Upstream { status, message } => {
                 format!("upstream error ({status}): {message}")
             }
@@ -299,8 +304,6 @@ pub enum ErrorKind {
     RateLimited,
     /// 429 — all usable upstream routes are rate limited.
     UpstreamRateLimited,
-    /// 400 — an upstream provider rejected the request parameters.
-    UpstreamBadRequest,
     /// 502 — upstream provider error.
     Upstream,
     /// 502 — malformed success response from an upstream protocol.
@@ -349,16 +352,16 @@ mod tests {
     #[test]
     fn upstream_bad_request_error_contract() {
         let error = BitrouterError::UpstreamBadRequest {
-            message: "provider secret".into(),
+            error: serde_json::json!("provider secret"),
         };
 
         assert_eq!(error.status(), 400);
         assert_eq!(error.error_type(), "invalid_request_error");
         assert_eq!(error.error_code(), "upstream_bad_request");
-        assert_eq!(error.kind(), ErrorKind::UpstreamBadRequest);
+        assert_eq!(error.kind(), ErrorKind::BadRequest);
         assert_eq!(
             serde_json::to_value(error.kind()).unwrap(),
-            serde_json::json!("upstream_bad_request")
+            serde_json::json!("bad_request")
         );
         assert_eq!(error.public_message(), "upstream rejected the request");
         assert!(

--- a/crates/bitrouter-sdk/src/language_model/executor.rs
+++ b/crates/bitrouter-sdk/src/language_model/executor.rs
@@ -210,17 +210,20 @@ fn truncate_upstream_message(text: &str) -> String {
 
 /// Turn a non-2xx upstream response into the right [`BitrouterError`].
 ///
-/// Most non-2xx maps to [`BitrouterError::Upstream`] carrying the
-/// status. The exception: credit / balance exhaustion. Some gateways
-/// signal it cleanly with `402`, but others (e.g. opencode) return a
-/// `401`/`403` with a `CreditsError` / "insufficient balance" body —
-/// which would otherwise be misread as an auth failure. Recognise that
-/// family and map it to [`BitrouterError::UpstreamPaymentRequired`] so the
-/// fallback policy drops to the next account / provider instead of
-/// failing the request outright.
+/// Most non-2xx maps to [`BitrouterError::Upstream`] carrying the status.
+/// Request rejection, rate limiting, and credit exhaustion use distinct
+/// variants so callers can apply explicit fallback and response policies.
 fn classify_upstream_error(status: u16, body: &str, retry_after: Option<u64>) -> BitrouterError {
     if status == 429 {
         return BitrouterError::UpstreamRateLimited { retry_after };
+    }
+    // RFC 9110 section 15.5.1 defines 400 as the server being unable or
+    // unwilling to process the request because of a perceived client error:
+    // <https://www.rfc-editor.org/rfc/rfc9110#section-15.5.1>.
+    if status == 400 {
+        return BitrouterError::UpstreamBadRequest {
+            message: truncate_upstream_message(body),
+        };
     }
     if matches!(status, 401..=403) && looks_like_credit_exhaustion(body) {
         return BitrouterError::UpstreamPaymentRequired;
@@ -985,6 +988,17 @@ mod error_classification_tests {
                 assert_eq!(retry_after, Some(17));
             }
             other => panic!("expected UpstreamRateLimited, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn upstream_400_has_a_distinct_safe_error() {
+        let body = r#"{"error":"max_tokens must be greater than one"}"#;
+        match classify_upstream_error(400, body, None) {
+            BitrouterError::UpstreamBadRequest { message } => {
+                assert_eq!(message, body);
+            }
+            other => panic!("expected UpstreamBadRequest, got {other:?}"),
         }
     }
 

--- a/crates/bitrouter-sdk/src/language_model/executor.rs
+++ b/crates/bitrouter-sdk/src/language_model/executor.rs
@@ -208,6 +208,22 @@ fn truncate_upstream_message(text: &str) -> String {
     }
 }
 
+fn normalize_upstream_error_payload(body: &str) -> serde_json::Value {
+    let parsed = match serde_json::from_str::<serde_json::Value>(body) {
+        Ok(value) => value,
+        Err(_) => return serde_json::Value::String(body.to_string()),
+    };
+    let nested_error = parsed
+        .as_object()
+        .and_then(|object| object.get("error"))
+        .filter(|error| !error.is_null())
+        .cloned();
+    match nested_error.unwrap_or(parsed) {
+        value @ (serde_json::Value::Object(_) | serde_json::Value::String(_)) => value,
+        other => serde_json::Value::String(other.to_string()),
+    }
+}
+
 /// Turn a non-2xx upstream response into the right [`BitrouterError`].
 ///
 /// Most non-2xx maps to [`BitrouterError::Upstream`] carrying the status.
@@ -222,7 +238,7 @@ fn classify_upstream_error(status: u16, body: &str, retry_after: Option<u64>) ->
     // <https://www.rfc-editor.org/rfc/rfc9110#section-15.5.1>.
     if status == 400 {
         return BitrouterError::UpstreamBadRequest {
-            message: truncate_upstream_message(body),
+            error: normalize_upstream_error_payload(body),
         };
     }
     if matches!(status, 401..=403) && looks_like_credit_exhaustion(body) {
@@ -992,11 +1008,57 @@ mod error_classification_tests {
     }
 
     #[test]
-    fn upstream_400_has_a_distinct_safe_error() {
-        let body = r#"{"error":"max_tokens must be greater than one"}"#;
-        match classify_upstream_error(400, body, None) {
-            BitrouterError::UpstreamBadRequest { message } => {
-                assert_eq!(message, body);
+    fn upstream_error_payload_selection_prefers_non_null_nested_error() {
+        assert_eq!(
+            normalize_upstream_error_payload(
+                r#"{"error":{"message":"bad","param":"max_tokens"},"request_id":"req_1"}"#,
+            ),
+            serde_json::json!({"message": "bad", "param": "max_tokens"})
+        );
+        assert_eq!(
+            normalize_upstream_error_payload(r#"{"error":"bad temperature"}"#),
+            serde_json::json!("bad temperature")
+        );
+    }
+
+    #[test]
+    fn upstream_error_payload_selection_uses_whole_object_without_non_null_error() {
+        assert_eq!(
+            normalize_upstream_error_payload(r#"{"message":"bad","status":400}"#),
+            serde_json::json!({"message": "bad", "status": 400})
+        );
+        assert_eq!(
+            normalize_upstream_error_payload(r#"{"error":null,"message":"bad"}"#),
+            serde_json::json!({"error": null, "message": "bad"})
+        );
+    }
+
+    #[test]
+    fn upstream_error_payload_selection_normalizes_non_object_values_to_strings() {
+        for (body, expected) in [
+            (r#""bad request""#, "bad request"),
+            ("not json", "not json"),
+            ("[1,2]", "[1,2]"),
+            ("42", "42"),
+            ("true", "true"),
+            ("null", "null"),
+        ] {
+            assert_eq!(
+                normalize_upstream_error_payload(body),
+                serde_json::Value::String(expected.to_string())
+            );
+        }
+    }
+
+    #[test]
+    fn upstream_400_carries_selected_error_payload() {
+        match classify_upstream_error(
+            400,
+            r#"{"error":{"message":"max_tokens rejected"},"ignored":"value"}"#,
+            None,
+        ) {
+            BitrouterError::UpstreamBadRequest { error } => {
+                assert_eq!(error, serde_json::json!({"message": "max_tokens rejected"}));
             }
             other => panic!("expected UpstreamBadRequest, got {other:?}"),
         }

--- a/crates/bitrouter-sdk/src/language_model/pipeline.rs
+++ b/crates/bitrouter-sdk/src/language_model/pipeline.rs
@@ -863,14 +863,6 @@ fn aggregate_fallback_errors(errors: Vec<BitrouterError>) -> BitrouterError {
         return BitrouterError::UpstreamPaymentRequired;
     }
 
-    if errors
-        .iter()
-        .all(|error| matches!(error, BitrouterError::UpstreamBadRequest { .. }))
-        && let Some(error) = errors.first()
-    {
-        return error.clone();
-    }
-
     if let Some(error) = errors
         .iter()
         .find(|error| matches!(error, BitrouterError::UpstreamInvalidResponse { .. }))

--- a/crates/bitrouter-sdk/src/language_model/pipeline.rs
+++ b/crates/bitrouter-sdk/src/language_model/pipeline.rs
@@ -863,6 +863,14 @@ fn aggregate_fallback_errors(errors: Vec<BitrouterError>) -> BitrouterError {
         return BitrouterError::UpstreamPaymentRequired;
     }
 
+    if errors
+        .iter()
+        .all(|error| matches!(error, BitrouterError::UpstreamBadRequest { .. }))
+        && let Some(error) = errors.first()
+    {
+        return error.clone();
+    }
+
     if let Some(error) = errors
         .iter()
         .find(|error| matches!(error, BitrouterError::UpstreamInvalidResponse { .. }))

--- a/crates/bitrouter-sdk/src/language_model/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/tests.rs
@@ -468,6 +468,19 @@ fn pipeline_with(
     Arc::new(b.build().expect("pipeline builds"))
 }
 
+struct RetryUpstreamRequestErrors;
+
+impl FallbackPolicy for RetryUpstreamRequestErrors {
+    fn classify(&self, error: &BitrouterError, _attempted: &RoutingTarget) -> FallbackDecision {
+        match error {
+            BitrouterError::UpstreamBadRequest { .. } | BitrouterError::Upstream { .. } => {
+                FallbackDecision::TryNext
+            }
+            other => FallbackDecision::Fail(other.clone()),
+        }
+    }
+}
+
 // ===== tests =====
 
 #[tokio::test]
@@ -746,6 +759,105 @@ async fn exhausted_upstream_429s_use_the_earliest_retry_after() {
         BitrouterError::UpstreamRateLimited {
             retry_after: Some(12)
         }
+    ));
+}
+
+#[tokio::test]
+async fn default_fallback_stops_on_upstream_bad_request() {
+    let pipeline = pipeline_with(
+        routing_table(&["a-provider", "b-provider"]),
+        Arc::new(MockExecutor::new(vec![
+            MockResponse::Error(BitrouterError::UpstreamBadRequest {
+                message: "provider rejected max_tokens".into(),
+            }),
+            MockResponse::Generate(gen_result(Vec::new())),
+        ])),
+        |_builder| {},
+    );
+
+    assert!(matches!(
+        pipeline.execute(request()).await.unwrap_err(),
+        BitrouterError::UpstreamBadRequest { .. }
+    ));
+}
+
+#[tokio::test]
+async fn custom_fallback_retries_upstream_bad_request_then_succeeds() {
+    let pipeline = pipeline_with(
+        routing_table(&["a-provider", "b-provider"]),
+        Arc::new(MockExecutor::new(vec![
+            MockResponse::Error(BitrouterError::UpstreamBadRequest {
+                message: "provider rejected temperature".into(),
+            }),
+            MockResponse::Generate(gen_result(vec![Content::Text {
+                text: "from b".into(),
+                provider_metadata: Default::default(),
+            }])),
+        ])),
+        |builder| {
+            builder.fallback_policy(Arc::new(RetryUpstreamRequestErrors));
+        },
+    );
+
+    let response = pipeline.execute(request()).await.unwrap();
+    assert_eq!(
+        response.result.content,
+        vec![Content::Text {
+            text: "from b".into(),
+            provider_metadata: Default::default(),
+        }]
+    );
+}
+
+#[tokio::test]
+async fn exhausted_upstream_bad_requests_preserve_the_first_diagnostic() {
+    let pipeline = pipeline_with(
+        routing_table(&["a-provider", "b-provider"]),
+        Arc::new(MockExecutor::new(vec![
+            MockResponse::Error(BitrouterError::UpstreamBadRequest {
+                message: "first diagnostic".into(),
+            }),
+            MockResponse::Error(BitrouterError::UpstreamBadRequest {
+                message: "second diagnostic".into(),
+            }),
+        ])),
+        |builder| {
+            builder.fallback_policy(Arc::new(RetryUpstreamRequestErrors));
+        },
+    );
+
+    match pipeline.execute(request()).await.unwrap_err() {
+        BitrouterError::UpstreamBadRequest { message } => {
+            assert_eq!(message, "first diagnostic");
+        }
+        other => panic!("expected UpstreamBadRequest, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn mixed_upstream_bad_request_and_server_error_keep_last_error_semantics() {
+    let pipeline = pipeline_with(
+        routing_table(&["a-provider", "b-provider"]),
+        Arc::new(MockExecutor::new(vec![
+            MockResponse::Error(BitrouterError::UpstreamBadRequest {
+                message: "bad parameters".into(),
+            }),
+            MockResponse::Error(BitrouterError::Upstream {
+                status: 503,
+                message: "maintenance".into(),
+            }),
+        ])),
+        |builder| {
+            builder.fallback_policy(Arc::new(RetryUpstreamRequestErrors));
+        },
+    );
+
+    assert!(matches!(
+        pipeline.execute(request()).await.unwrap_err(),
+        BitrouterError::Upstream {
+            status: 503,
+            message
+        } if message == "maintenance"
     ));
 }
 

--- a/crates/bitrouter-sdk/src/language_model/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/tests.rs
@@ -835,6 +835,35 @@ async fn exhausted_upstream_bad_requests_preserve_the_first_diagnostic() {
 }
 
 #[tokio::test]
+async fn exhausted_streaming_upstream_bad_requests_preserve_the_first_diagnostic() {
+    let pipeline = pipeline_with(
+        routing_table(&["a-provider", "b-provider"]),
+        Arc::new(MockExecutor::new(vec![
+            MockResponse::Error(BitrouterError::UpstreamBadRequest {
+                message: "first streaming diagnostic".into(),
+            }),
+            MockResponse::Error(BitrouterError::UpstreamBadRequest {
+                message: "second streaming diagnostic".into(),
+            }),
+        ])),
+        |builder| {
+            builder.fallback_policy(Arc::new(RetryUpstreamRequestErrors));
+        },
+    );
+
+    let error = match pipeline.clone().execute_stream(stream_request()).await {
+        Ok(_) => panic!("bad requests must fail before opening a stream"),
+        Err(error) => error,
+    };
+    match error {
+        BitrouterError::UpstreamBadRequest { message } => {
+            assert_eq!(message, "first streaming diagnostic");
+        }
+        other => panic!("expected UpstreamBadRequest, got {other:?}"),
+    }
+}
+
+#[tokio::test]
 async fn mixed_upstream_bad_request_and_server_error_keep_last_error_semantics() {
     let pipeline = pipeline_with(
         routing_table(&["a-provider", "b-provider"]),

--- a/crates/bitrouter-sdk/src/language_model/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/tests.rs
@@ -810,15 +810,15 @@ async fn custom_fallback_retries_upstream_bad_request_then_succeeds() {
 }
 
 #[tokio::test]
-async fn exhausted_upstream_bad_requests_preserve_the_first_diagnostic() {
+async fn exhausted_upstream_bad_requests_preserve_the_last_payload() {
     let pipeline = pipeline_with(
         routing_table(&["a-provider", "b-provider"]),
         Arc::new(MockExecutor::new(vec![
             MockResponse::Error(BitrouterError::UpstreamBadRequest {
-                error: serde_json::json!("first diagnostic"),
+                error: serde_json::json!({"message": "first"}),
             }),
             MockResponse::Error(BitrouterError::UpstreamBadRequest {
-                error: serde_json::json!("second diagnostic"),
+                error: serde_json::json!({"message": "second"}),
             }),
         ])),
         |builder| {
@@ -828,22 +828,22 @@ async fn exhausted_upstream_bad_requests_preserve_the_first_diagnostic() {
 
     match pipeline.execute(request()).await.unwrap_err() {
         BitrouterError::UpstreamBadRequest { error } => {
-            assert_eq!(error, serde_json::json!("first diagnostic"));
+            assert_eq!(error, serde_json::json!({"message": "second"}));
         }
         other => panic!("expected UpstreamBadRequest, got {other:?}"),
     }
 }
 
 #[tokio::test]
-async fn exhausted_streaming_upstream_bad_requests_preserve_the_first_diagnostic() {
+async fn exhausted_streaming_upstream_bad_requests_preserve_the_last_payload() {
     let pipeline = pipeline_with(
         routing_table(&["a-provider", "b-provider"]),
         Arc::new(MockExecutor::new(vec![
             MockResponse::Error(BitrouterError::UpstreamBadRequest {
-                error: serde_json::json!("first streaming diagnostic"),
+                error: serde_json::json!({"message": "first"}),
             }),
             MockResponse::Error(BitrouterError::UpstreamBadRequest {
-                error: serde_json::json!("second streaming diagnostic"),
+                error: serde_json::json!({"message": "second"}),
             }),
         ])),
         |builder| {
@@ -857,7 +857,7 @@ async fn exhausted_streaming_upstream_bad_requests_preserve_the_first_diagnostic
     };
     match error {
         BitrouterError::UpstreamBadRequest { error } => {
-            assert_eq!(error, serde_json::json!("first streaming diagnostic"));
+            assert_eq!(error, serde_json::json!({"message": "second"}));
         }
         other => panic!("expected UpstreamBadRequest, got {other:?}"),
     }

--- a/crates/bitrouter-sdk/src/language_model/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/tests.rs
@@ -768,7 +768,7 @@ async fn default_fallback_stops_on_upstream_bad_request() {
         routing_table(&["a-provider", "b-provider"]),
         Arc::new(MockExecutor::new(vec![
             MockResponse::Error(BitrouterError::UpstreamBadRequest {
-                message: "provider rejected max_tokens".into(),
+                error: serde_json::json!("provider rejected max_tokens"),
             }),
             MockResponse::Generate(gen_result(Vec::new())),
         ])),
@@ -787,7 +787,7 @@ async fn custom_fallback_retries_upstream_bad_request_then_succeeds() {
         routing_table(&["a-provider", "b-provider"]),
         Arc::new(MockExecutor::new(vec![
             MockResponse::Error(BitrouterError::UpstreamBadRequest {
-                message: "provider rejected temperature".into(),
+                error: serde_json::json!("provider rejected temperature"),
             }),
             MockResponse::Generate(gen_result(vec![Content::Text {
                 text: "from b".into(),
@@ -815,10 +815,10 @@ async fn exhausted_upstream_bad_requests_preserve_the_first_diagnostic() {
         routing_table(&["a-provider", "b-provider"]),
         Arc::new(MockExecutor::new(vec![
             MockResponse::Error(BitrouterError::UpstreamBadRequest {
-                message: "first diagnostic".into(),
+                error: serde_json::json!("first diagnostic"),
             }),
             MockResponse::Error(BitrouterError::UpstreamBadRequest {
-                message: "second diagnostic".into(),
+                error: serde_json::json!("second diagnostic"),
             }),
         ])),
         |builder| {
@@ -827,8 +827,8 @@ async fn exhausted_upstream_bad_requests_preserve_the_first_diagnostic() {
     );
 
     match pipeline.execute(request()).await.unwrap_err() {
-        BitrouterError::UpstreamBadRequest { message } => {
-            assert_eq!(message, "first diagnostic");
+        BitrouterError::UpstreamBadRequest { error } => {
+            assert_eq!(error, serde_json::json!("first diagnostic"));
         }
         other => panic!("expected UpstreamBadRequest, got {other:?}"),
     }
@@ -840,10 +840,10 @@ async fn exhausted_streaming_upstream_bad_requests_preserve_the_first_diagnostic
         routing_table(&["a-provider", "b-provider"]),
         Arc::new(MockExecutor::new(vec![
             MockResponse::Error(BitrouterError::UpstreamBadRequest {
-                message: "first streaming diagnostic".into(),
+                error: serde_json::json!("first streaming diagnostic"),
             }),
             MockResponse::Error(BitrouterError::UpstreamBadRequest {
-                message: "second streaming diagnostic".into(),
+                error: serde_json::json!("second streaming diagnostic"),
             }),
         ])),
         |builder| {
@@ -856,8 +856,8 @@ async fn exhausted_streaming_upstream_bad_requests_preserve_the_first_diagnostic
         Err(error) => error,
     };
     match error {
-        BitrouterError::UpstreamBadRequest { message } => {
-            assert_eq!(message, "first streaming diagnostic");
+        BitrouterError::UpstreamBadRequest { error } => {
+            assert_eq!(error, serde_json::json!("first streaming diagnostic"));
         }
         other => panic!("expected UpstreamBadRequest, got {other:?}"),
     }
@@ -869,7 +869,7 @@ async fn mixed_upstream_bad_request_and_server_error_keep_last_error_semantics()
         routing_table(&["a-provider", "b-provider"]),
         Arc::new(MockExecutor::new(vec![
             MockResponse::Error(BitrouterError::UpstreamBadRequest {
-                message: "bad parameters".into(),
+                error: serde_json::json!("bad parameters"),
             }),
             MockResponse::Error(BitrouterError::Upstream {
                 status: 503,

--- a/crates/bitrouter-sdk/src/server.rs
+++ b/crates/bitrouter-sdk/src/server.rs
@@ -1280,6 +1280,49 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn streaming_preflight_upstream_bad_request_keeps_http_400() {
+        let state =
+            test_state_with_executor(Arc::new(MockExecutor::new(vec![MockResponse::Error(
+                BitrouterError::UpstreamBadRequest {
+                    message: "provider secret: temperature is unsupported".into(),
+                },
+            )])));
+        let response = build_router(state)
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/chat/completions")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "model": "gpt-5.5",
+                            "messages": [{"role": "user", "content": "ping"}],
+                            "stream": true
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_ne!(
+            response
+                .headers()
+                .get(header::CONTENT_TYPE)
+                .and_then(|value| value.to_str().ok()),
+            Some("text/event-stream")
+        );
+        assert_eq!(response.headers()["x-bitrouter-error-source"], "upstream");
+        let value: serde_json::Value =
+            serde_json::from_slice(&to_bytes(response.into_body(), 64 * 1024).await.unwrap())
+                .unwrap();
+        assert_eq!(value["error"]["message"], "upstream rejected the request");
+        assert!(!value.to_string().contains("provider secret"));
+    }
+
+    #[tokio::test]
     async fn streaming_preflight_rate_limit_with_server_tools_keeps_http_429()
     -> std::result::Result<(), Box<dyn std::error::Error>> {
         let state = test_state_with_executor_and_server_tools(

--- a/crates/bitrouter-sdk/src/server.rs
+++ b/crates/bitrouter-sdk/src/server.rs
@@ -1227,7 +1227,7 @@ mod tests {
     #[tokio::test]
     async fn upstream_bad_request_has_safe_400_contract() {
         let response = BitrouterError::UpstreamBadRequest {
-            message: "provider secret: max_tokens must be greater than one".into(),
+            error: serde_json::json!("provider secret: max_tokens must be greater than one"),
         }
         .into_response();
 
@@ -1284,7 +1284,7 @@ mod tests {
         let state =
             test_state_with_executor(Arc::new(MockExecutor::new(vec![MockResponse::Error(
                 BitrouterError::UpstreamBadRequest {
-                    message: "provider secret: temperature is unsupported".into(),
+                    error: serde_json::json!("provider secret: temperature is unsupported"),
                 },
             )])));
         let response = build_router(state)

--- a/crates/bitrouter-sdk/src/server.rs
+++ b/crates/bitrouter-sdk/src/server.rs
@@ -811,22 +811,31 @@ async fn stream_response(
 
 impl IntoResponse for BitrouterError {
     fn into_response(self) -> Response {
-        let status =
-            StatusCode::from_u16(self.status()).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
-        let body = Json(serde_json::json!({
-            "error": {
-                "message": self.public_message(),
-                "type": self.error_type(),
-                "code": self.error_code(),
+        match self {
+            BitrouterError::UpstreamBadRequest { error } => (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": error})),
+            )
+                .into_response(),
+            error => {
+                let status = StatusCode::from_u16(error.status())
+                    .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+                let body = Json(serde_json::json!({
+                    "error": {
+                        "message": error.public_message(),
+                        "type": error.error_type(),
+                        "code": error.error_code(),
+                    }
+                }));
+                //.4 — payment / rate-limit responses must carry the headers
+                // that auto-paying clients (e.g. the MPP autopay flow,) and
+                // well-behaved API consumers expect. RFC 7235 §4.1 for
+                // WWW-Authenticate, RFC 7231 §7.1.3 for Retry-After.
+                let mut response = (status, body).into_response();
+                apply_error_headers(&mut response, &error);
+                response
             }
-        }));
-        //.4 — payment / rate-limit responses must carry the headers
-        // that auto-paying clients (e.g. the MPP autopay flow,) and
-        // well-behaved API consumers expect. RFC 7235 §4.1 for
-        // WWW-Authenticate, RFC 7231 §7.1.3 for Retry-After.
-        let mut response = (status, body).into_response();
-        apply_error_headers(&mut response, &self);
-        response
+        }
     }
 }
 
@@ -868,12 +877,6 @@ fn apply_error_headers(response: &mut Response, error: &BitrouterError) {
             if let Ok(v) = header::HeaderValue::from_str(&secs.to_string()) {
                 response.headers_mut().insert(header::RETRY_AFTER, v);
             }
-        }
-        BitrouterError::UpstreamBadRequest { .. } => {
-            response.headers_mut().insert(
-                header::HeaderName::from_static("x-bitrouter-error-source"),
-                header::HeaderValue::from_static("upstream"),
-            );
         }
         BitrouterError::UpstreamRateLimited { retry_after } => {
             if let Some(secs) = retry_after
@@ -1225,21 +1228,42 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn upstream_bad_request_has_safe_400_contract() {
+    async fn upstream_bad_request_passthroughs_object_without_invented_metadata() {
         let response = BitrouterError::UpstreamBadRequest {
-            error: serde_json::json!("provider secret: max_tokens must be greater than one"),
+            error: serde_json::json!({
+                "message": "max_tokens rejected",
+                "param": "max_tokens"
+            }),
         }
         .into_response();
 
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-        assert_eq!(response.headers()["x-bitrouter-error-source"], "upstream");
+        assert!(response.headers().get("x-bitrouter-error-source").is_none());
         let value: serde_json::Value =
             serde_json::from_slice(&to_bytes(response.into_body(), 64 * 1024).await.unwrap())
                 .unwrap();
-        assert_eq!(value["error"]["type"], "invalid_request_error");
-        assert_eq!(value["error"]["code"], "upstream_bad_request");
-        assert_eq!(value["error"]["message"], "upstream rejected the request");
-        assert!(!value.to_string().contains("provider secret"));
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "error": {
+                    "message": "max_tokens rejected",
+                    "param": "max_tokens"
+                }
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn upstream_bad_request_passthroughs_string() {
+        let response = BitrouterError::UpstreamBadRequest {
+            error: serde_json::json!("bad temperature"),
+        }
+        .into_response();
+
+        let value: serde_json::Value =
+            serde_json::from_slice(&to_bytes(response.into_body(), 64 * 1024).await.unwrap())
+                .unwrap();
+        assert_eq!(value, serde_json::json!({"error": "bad temperature"}));
     }
 
     #[tokio::test]
@@ -1284,7 +1308,10 @@ mod tests {
         let state =
             test_state_with_executor(Arc::new(MockExecutor::new(vec![MockResponse::Error(
                 BitrouterError::UpstreamBadRequest {
-                    error: serde_json::json!("provider secret: temperature is unsupported"),
+                    error: serde_json::json!({
+                        "message": "temperature is unsupported",
+                        "param": "temperature"
+                    }),
                 },
             )])));
         let response = build_router(state)
@@ -1314,12 +1341,19 @@ mod tests {
                 .and_then(|value| value.to_str().ok()),
             Some("text/event-stream")
         );
-        assert_eq!(response.headers()["x-bitrouter-error-source"], "upstream");
+        assert!(response.headers().get("x-bitrouter-error-source").is_none());
         let value: serde_json::Value =
             serde_json::from_slice(&to_bytes(response.into_body(), 64 * 1024).await.unwrap())
                 .unwrap();
-        assert_eq!(value["error"]["message"], "upstream rejected the request");
-        assert!(!value.to_string().contains("provider secret"));
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "error": {
+                    "message": "temperature is unsupported",
+                    "param": "temperature"
+                }
+            })
+        );
     }
 
     #[tokio::test]

--- a/crates/bitrouter-sdk/src/server.rs
+++ b/crates/bitrouter-sdk/src/server.rs
@@ -869,6 +869,12 @@ fn apply_error_headers(response: &mut Response, error: &BitrouterError) {
                 response.headers_mut().insert(header::RETRY_AFTER, v);
             }
         }
+        BitrouterError::UpstreamBadRequest { .. } => {
+            response.headers_mut().insert(
+                header::HeaderName::from_static("x-bitrouter-error-source"),
+                header::HeaderValue::from_static("upstream"),
+            );
+        }
         BitrouterError::UpstreamRateLimited { retry_after } => {
             if let Some(secs) = retry_after
                 && let Ok(v) = header::HeaderValue::from_str(&secs.to_string())
@@ -1216,6 +1222,24 @@ mod tests {
         assert_eq!(value["error"]["type"], "rate_limit_error");
         assert_eq!(value["error"]["code"], "upstream_rate_limited");
         assert_eq!(value["error"]["message"], "upstream rate limited");
+    }
+
+    #[tokio::test]
+    async fn upstream_bad_request_has_safe_400_contract() {
+        let response = BitrouterError::UpstreamBadRequest {
+            message: "provider secret: max_tokens must be greater than one".into(),
+        }
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(response.headers()["x-bitrouter-error-source"], "upstream");
+        let value: serde_json::Value =
+            serde_json::from_slice(&to_bytes(response.into_body(), 64 * 1024).await.unwrap())
+                .unwrap();
+        assert_eq!(value["error"]["type"], "invalid_request_error");
+        assert_eq!(value["error"]["code"], "upstream_bad_request");
+        assert_eq!(value["error"]["message"], "upstream rejected the request");
+        assert!(!value.to_string().contains("provider secret"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- classify provider HTTP 400 responses as a dedicated internal `UpstreamBadRequest` while keeping local `BadRequest` fail-fast
- select a non-null upstream `error` value when present, otherwise select the whole upstream response
- preserve selected JSON objects and strings; represent invalid or non-object JSON payloads as strings
- render terminal provider rejections as exactly `{"error": <object-or-string>}` with HTTP 400, without new fields or headers
- allow custom fallback policies to retry provider 400s and preserve the last provider payload when all routes reject the request
- keep streaming preflight failures as normal JSON 400 responses before SSE starts

## Root cause

The executor represented every provider HTTP 400 as generic `BitrouterError::Upstream`. That variant intentionally renders as HTTP 502, so BitRouter Cloud could retry intermediate routes but returned 502 when the fallback chain was exhausted, even though the terminal failure was a request-parameter rejection such as an unsupported `max_tokens` or `temperature` value.

## Error contract

For a provider HTTP 400 response:

1. If the parsed root object has a non-null `error`, that value is selected.
2. Otherwise the whole parsed response is selected.
3. JSON objects remain objects and JSON strings remain strings.
4. Invalid JSON response text remains a string; arrays, numbers, booleans, and null become compact JSON text strings.

The HTTP response is status 400 with exactly the existing top-level envelope:

```json
{"error": {"message": "max_tokens rejected", "param": "max_tokens"}}
```

or:

```json
{"error": "temperature is unsupported"}
```

This change does not add an `ErrorKind`, public code/type, fabricated message, or provider-specific header. Existing behavior for unrelated 401, 403, 404, 408, 429, 5xx, timeout, payment, invalid-response, and redacted 502/504 errors is unchanged.

## Fallback behavior

- the SDK default policy remains fail-fast for provider 400 responses
- an explicit policy may retry another provider, and a later success wins
- when fallback is exhausted, the existing last-error semantics return the last attempted provider's selected payload
- local validation `BadRequest` responses remain fail-fast

## Validation

- `cargo nextest run --all-features` — 1583 passed, 11 skipped
- `cargo clippy --all-features -- -D warnings`
- `cargo fmt -- --check`
- `git diff --check origin/main...HEAD`
- independent read-only review — ready to merge; no Critical or Important findings

## Follow-up

BitRouter Cloud will consume the released SDK alpha and opt `UpstreamBadRequest` into its anonymous fallback policy. This PR is the crates.io release prerequisite for that cloud change.
