### PR TITLE
feat(cli): add guided onboarding wizard

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -102,13 +102,51 @@ Prints pid, listen address, number of routable models, and control socket path. 
 
 ## Config
 
-### `bitrouter init`
+### `bitrouter init` (onboarding wizard)
 
 ```
-bitrouter init [-c <path>]           # default: ./bitrouter.yaml
+bitrouter                            # bare: wizard when unconfigured, else status + hint
+bitrouter init                       # (re-)run the wizard interactively
+bitrouter init --yes [flags]         # headless: emit the JSON envelope, scaffold the config
+bitrouter init --force               # allow overwriting an existing bitrouter.yaml
+bitrouter init --reset               # clear stored credentials, then run
 ```
 
-Writes a commented starter `bitrouter.yaml` with `skip_auth: true`. Edit it to configure providers, routing, guardrails, MCP servers, and agents.
+Bare `bitrouter` (no subcommand) is the front door. It runs a **network-free credential probe** — BYOK env keys (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `OPENROUTER_API_KEY`, `OPENCODE_ZEN_API_KEY`), the cloud session file, and the local credential store — and either launches the guided wizard (nothing configured) or prints a one-line status + a `bitrouter launch` hint (already configured). It never re-onboards a configured user and never silently spawns a daemon or harness. Exit code 0 either way.
+
+The wizard is three steps, each mapping to a flag so an agent can drive it: **credentials** (sign in to BitRouter Cloud, log in to a provider, or paste a BYOK key), **harness** (`claude` / `codex`, installed via the native installer when missing), and **finish** — launch the harness now, start the daemon and print paste-in snippets, or exit. The only durable output is **credentials** (which zero-config auto-detects); the wizard never serializes `bitrouter.yaml` except the canned starter template.
+
+`bitrouter init --yes` runs the whole thing non-interactively and **never blocks on a human**: it consumes the flag-supplied keys, reports-and-skips anything that would need interactive OAuth (in `providers_skipped_interactive`), emits the JSON result envelope on stdout, and reproduces the classic starter-file scaffold (`skip_auth: true`; refuses to overwrite unless `--force`).
+
+| Flag | Step | Description |
+| --- | --- | --- |
+| `-c`, `--config <path>` | — | Starter-config write path (default `bitrouter.yaml`). |
+| `--yes`, `-y` | — | Headless: process the flags, never block, emit the envelope, scaffold the config. |
+| `--force` | — | Overwrite an existing `bitrouter.yaml` when scaffolding. |
+| `--reset` | — | Clear stored credentials first — cloud session always; provider credentials after a confirm, or unconditionally under `--yes`. |
+| `--cloud-login` | 1 | Sign in to BitRouter Cloud (device flow). Skipped-and-reported under `--yes`. |
+| `--api-key <brk_…>` | 1 | Seed the cloud credential from a `brk_` key (non-interactive). |
+| `--provider <id>` | 1 | Log in to an upstream provider (repeatable). |
+| `--provider-api-key <k>` | 1 | Key for the `--provider` at the same position (repeatable). |
+| `--use-detected` | 1 | Accept the auto-detected credential(s) without prompting. |
+| `--harness <claude\|codex>` | 2 | Harness to drive (repeatable). |
+| `--no-install` | 2 | Never install a missing harness. |
+| `--after <launch\|serve\|exit>` | 3 | Finish action (default `exit`; `launch` is honored only when the harness is present). |
+| `--model <id>` | 3 | Model handed to the harness for this session only (not persisted). |
+| `--write-config` | 3 | Write the starter `bitrouter.yaml`. |
+
+The result envelope:
+
+```json
+{
+  "action": "onboarding",
+  "providers_configured": ["bitrouter", "openai"],
+  "providers_skipped_interactive": ["github-copilot"],
+  "harnesses_installed": ["claude"],
+  "after": "launch",
+  "snippet": null
+}
+```
 
 ---
 
@@ -273,9 +311,13 @@ Mints a scoped `brvk_` virtual key for a user. The plaintext secret is printed o
 bitrouter providers login claude-code     # Claude Pro/Max subscription via Claude Code
 bitrouter providers login openai-codex    # ChatGPT subscription via Codex
 bitrouter providers login github-copilot  # GitHub device-code flow
+bitrouter providers login openai --api-key sk-…        # BYOK, non-interactive
+printf %s "$KEY" | bitrouter providers login anthropic --key-stdin
 ```
 
 Runs the provider's OAuth flow (PKCE in a browser or device-code, depending on provider) and stores the token in `$XDG_DATA_HOME/bitrouter/oauth-tokens.json`. The slot is keyed by `(provider_id, label)` — pass `--label <name>` (defaults to `default`) to keep multiple accounts of the same provider side by side. Other providers fall back to a pasted API key.
+
+For a provider that accepts a pasted key, `--api-key <KEY>` (or `--key-stdin`, which reads one line from stdin) seeds it non-interactively — skipping the method menu and the paste prompt. Both conflict with the OAuth-only `--import-existing` / `--no-browser`, and error if the provider has no API-key method. For the built-in `bitrouter` provider the key seeds the cloud credential, exactly as `cloud login --api-key` does.
 
 For `claude-code`, the login menu defaults to the live Claude Code session. For `openai-codex`, the default is **"Import an existing session from the vendor CLI"** — BitRouter reads the credential Codex already stored in `$CODEX_HOME/auth.json` (default `~/.codex/auth.json`) first, then the macOS Keychain, and adopts it with no fresh browser sign-in. The imported token refreshes automatically like any other; choose the browser subscription flow when no local Codex session exists.
 

--- a/ONBOARDING_SPEC.md
+++ b/ONBOARDING_SPEC.md
@@ -1,0 +1,305 @@
+# Spec: `bitrouter` onboarding — a guided CLI wizard over existing verbs
+
+Status: **proposed — not yet implemented** · Author: Claude (with Spikel) ·
+Date: 2026-07-15 · Branch: `claude/cli-onboarding-flow`
+
+v1 is a **deterministic CLI wizard** (scripted prompts, no LLM, no Node, no
+TUI-manager dependency) that *sequences verbs that already exist* and ends in
+first value — a launched harness or a running daemon. Agent-led onboarding is
+deferred (§2). The design was pressure-tested against the current tree
+(2026-07-15); the load-bearing constraint below comes from that review.
+
+**Load-bearing constraint — the wizard writes no config.** `Config`
+(`crates/bitrouter-sdk/src/config/mod.rs`) is `Deserialize`-only; there is no
+serializer and no comment-preserving YAML editor, and the only config write in
+the tree is the `STARTER_CONFIG` string template (`apps/bitrouter/src/commands.rs`).
+So the only durable state onboarding produces is **credentials** (which already
+persist to the credential store, independent of `bitrouter.yaml`, and are
+auto-detected by zero-config). Everything that would need a config write —
+a remembered default model, a default orchestrator, a harness fleet — is
+session-only and **deferred** (§2). This collapses the original six-step vision
+to three.
+
+## 1. Motivation
+
+Onboarding today is command-scattered plus passive stderr hints
+(`announce_zero_config` / `print_onboarding_hint`, `apps/bitrouter/src/main.rs`).
+A fresh user must already know which of `cloud login` / `start` / `providers
+login` / `launch` to run; the hint only appears *after* they run something. The
+skill even documents the absence: *"BitRouter has no interactive setup wizard —
+onboarding is two commands"* (`skills/bitrouter/SKILL.md`). That stance is
+agent-native but leaves humans without a front door.
+
+**Design decision (this spec):** add ONE guided entry that *orchestrates the
+existing verbs* and preserves the agent-native contract — every prompt is
+flag-addressable and `--yes` runs the whole thing non-interactively, emitting
+the standard JSON envelope. The wizard is human sugar over the same commands an
+agent would call, not a second code path.
+
+Why not agent-led onboarding (an LLM agent driving setup in the TUI): it hits a
+**bootstrap paradox** — the onboarding agent routes its own calls through
+BitRouter, but acquiring a credential is precisely what onboarding is *for*, so
+it cannot emit its first token before the thing it sets up exists. It also puts
+npm/Node on the critical path of a self-contained Rust binary. Deferred to a
+later track; v1's payoff is the existing `bitrouter launch` (which wraps the
+harness's own native TUI).
+
+## 2. Goals / non-goals
+
+Goals (v1):
+
+1. One guided entry: bare `bitrouter` when unconfigured, and `bitrouter init`
+   to (re)run it; the wizard ends in first value.
+2. Sequence existing verbs only — the sole new durable state is credentials in
+   the credential store.
+3. Agent-native preserved: every prompt has a flag equivalent; `--yes` runs
+   headless and emits the JSON result envelope; `--yes` never blocks on a human.
+4. Orchestrator choice restricted to `claude | codex` — the harnesses
+   `bitrouter launch` can actually run.
+5. First-run detection is **network-free** — deciding whether to onboard must
+   not fetch the registry or hit the network.
+
+Non-goals (deferred, tracked):
+
+- Persisting a default model / default orchestrator / harness fleet — needs a
+  config writer + schema fields that do not exist (§8). Session-only in v1.
+- ACP agents (`gemini-cli`, `pi-acp`, …) as launch orchestrators — `SpawnAgent`
+  is `claude | codex` only; ACP agents stay `spawn`-only workers.
+- A comment-preserving `bitrouter.yaml` editor / in-file reconfigure.
+- Agent-led / TUI-manager onboarding (bootstrap paradox; separate track).
+- `--yes` completing interactive OAuth — reported-and-skipped, not attempted (§6).
+
+## 3. CLI surface
+
+### 3.1 Entry points
+
+```
+bitrouter                      # no subcommand: run wizard IFF unconfigured; else status + hint
+bitrouter init                 # interactive wizard (first run or re-run / reconfigure)
+bitrouter init --yes [flags]   # non-interactive: today's behavior — scaffold starter bitrouter.yaml
+bitrouter init --force         # allow overwriting an existing bitrouter.yaml when scaffolding
+bitrouter init --reset         # clear stored onboarding credentials, then run the wizard
+```
+
+- clap change: `Cli.command` becomes `Option<Command>` (`main.rs:58-59`). `None`
+  dispatches to `onboarding::entry`, which runs the credential probe (§5) and
+  either launches the wizard (unconfigured) or prints status + a one-line hint
+  (configured). Bare `bitrouter` never re-onboards a configured user and never
+  silently spawns a harness or daemon.
+- `init` keeps `-c/--config <path>` and its default write path, and gains
+  `--yes`, `--force`, `--reset`. **`bitrouter init --yes` reproduces today's
+  `commands::init`** (write `STARTER_CONFIG`; refuse to overwrite unless
+  `--force`) — the sensible headless default when there is nothing to ask.
+  Interactive `bitrouter init` runs the wizard.
+- `announce_zero_config` / `print_onboarding_hint` are superseded for the
+  interactive case; the single-line hint is retained for non-TTY / when a user
+  runs a specific command without onboarding.
+
+### 3.2 The wizard (three steps)
+
+Each prompt maps to a flag (used by `--yes` and scriptable directly).
+
+**Step 1 — Credentials.** Probe (§5) and *prefill*: show detected env keys, an
+active cloud session, and a claude-code session before asking anything.
+
+```
+default → bitrouter cloud login          # device-flow OAuth, one account = every model
+  or   → bitrouter providers login <id>   # claude-code / openai-codex / github-copilot / supergrok
+  or   → paste a BYOK key                 # openai / anthropic / google / openrouter / opencode-*
+  or   → use detected key(s)
+loop   → "add another provider? [y/N]"
+```
+
+Persists to the credential store (cloud credentials file / provider store),
+independent of `bitrouter.yaml`; zero-config picks them up. Flags:
+`--cloud-login`, `--api-key <brk_…>` (cloud), `--provider <id>` (repeatable)
+with `--provider-api-key <k>`, `--use-detected`.
+
+**Step 2 — Harness.** "Which coding agent do you drive?" → `claude | codex`
+(multi-install allowed). Install missing binaries via the native installer
+(`spawn.rs` `ensure_agent_installed` / `confirm_install`), then **re-resolve the
+freshly-installed path** before continuing so the launch exit can't dead-end on
+the PATH-after-install caveat. Flags: `--harness claude|codex` (repeatable),
+`--no-install`.
+
+**Step 3 — Finish (three-way exit).**
+
+```
+(a) launch now      → bitrouter launch -a <harness> [--model <id>]   # native TUI, this-session model
+(b) start + snippet → bitrouter start; print paste-in base_url/env for your existing tool
+(c) exit            → nothing launched  (+ optional "write a starter bitrouter.yaml? [y/N]")
+```
+
+Exit (a) picks `claude|codex` when both are installed; `--model` is handed to
+the harness for this session only (not persisted — see §8). Exit (c)'s optional
+config write calls the existing `init` writer (the one safe config write).
+Flags: `--after launch|serve|exit`, `--model <id>`, `--write-config`.
+
+### 3.3 Result envelope
+
+The wizard (and every `--yes` run) emits the standard JSON result on stdout:
+
+```json
+{
+  "action": "onboarding",
+  "providers_configured": ["bitrouter", "openai"],
+  "providers_skipped_interactive": ["github-copilot"],
+  "harnesses_installed": ["claude"],
+  "after": "launch",
+  "snippet": null
+}
+```
+
+## 4. `--yes` / headless contract
+
+`--yes` runs the whole wizard non-interactively and **never blocks on a human**:
+
+- **Credentials** — consume already-present credentials + flag-supplied keys
+  (`--api-key`, `--provider-api-key`). Any provider that would require
+  interactive OAuth (cloud device flow without `--api-key`; provider PKCE /
+  device-code; the claude-code session import) is **reported-and-skipped** in
+  `providers_skipped_interactive`, not attempted. Grounded: cloud login is
+  non-interactive only via `--api-key` (`cloud/cli.rs`), and the OAuth/PKCE/
+  claude-code flows all require a TTY (`commands.rs`).
+- **Harness** — install runs only for explicitly `--harness`-named agents; a
+  missing, un-named harness is reported, not installed.
+- **After** — defaults to `exit` unless `--after` is given; `launch` is honored
+  only when the chosen harness is already present.
+
+This makes the agent-native promise honest: the parts a machine *can* do run;
+the parts that inherently need a human are surfaced in the envelope, not hung on.
+
+## 5. Network-free credential probe
+
+`onboarding::probe()` decides "configured vs not" without any network call. It
+reads, in order, purely local signals:
+
+1. **BYOK env keys** — `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`
+   (not `GOOGLE_API_KEY`), `OPENROUTER_API_KEY`, `OPENCODE_ZEN_API_KEY`.
+2. **Cloud session** — the credentials file at
+   `$XDG_DATA_HOME/bitrouter/account-credentials.json`.
+3. **Subscription sessions** — the provider credential store (e.g. a
+   claude-code session), via a local marker check.
+
+It must **not** call `merge_registry_into` or load the registry (the serve-path
+`providers.is_empty()` check runs only *after* that merge, so it is unusable
+here). "Configured" = at least one of the three present. The probe also handles
+the `BITROUTER_HOME`-set-but-missing case that `resolve_config` currently treats
+as a hard error (`paths.rs`) — the onboarding entry offers the wizard instead of
+erroring.
+
+## 6. Code changes (grounded)
+
+- `apps/bitrouter/src/main.rs` — `Cli.command: Option<Command>` + `None` →
+  `onboarding::entry`; `Command::Init` gains `--yes` / `--force` / `--reset`.
+- `apps/bitrouter/src/onboarding.rs` (new) — probe (§5), interactive wizard
+  (§3.2), headless runner (§4), result report.
+- `providers login` — add `--api-key <KEY>` / `--key-stdin` to
+  `ProviderAction::Login` (`main.rs:740`) and thread into
+  `login_provider_with_options` (`commands.rs:473`) so the API-key method skips
+  `prompt_method_choice` / stdin paste. (Closes the flag-parity gap: today the
+  API-key path is stdin-only.)
+- Install reuse — `spawn.rs` `ensure_agent_installed`; add a post-install path
+  re-resolve before the launch exit.
+- Snippet — reuse `spawn.rs` `derive_base_url`; template by auth mode
+  (local `skip_auth` placeholder / minted `brvk_` key / cloud `brk_`) and client
+  shape (`ANTHROPIC_BASE_URL`+`ANTHROPIC_AUTH_TOKEN` / `OPENAI_BASE_URL` / Codex
+  `-c` overrides).
+
+## 7. What onboarding does NOT change
+
+- `bitrouter launch` semantics (env-wrap, daemon auto-start, exit summary) —
+  reused as-is for exit (a). No new `launch` flags.
+- The credential store format and the zero-config auto-detect path — the wizard
+  writes credentials the exact way `cloud login` / `providers login` already do.
+- `bitrouter.yaml` — never serialized or rewritten; only the canned starter
+  template is ever written, and only on explicit request.
+
+## 8. Config schema change
+
+**None.** v1 adds no fields. `default_model`, `default_orchestrator`, and a
+harness "selected" marker deliberately do not exist yet — they are the deferred
+persistence layer. When built (separate change), they would land as a
+serializable, purpose-built sidecar or a new `defaults:` block *with* a config
+writer and the `launch`/routing consumers that read them; none of that is in
+scope here.
+
+## 9. Migration & lockstep checklist
+
+Per CLAUDE.md rules, in the same change:
+
+- [ ] `skills/bitrouter/SKILL.md` — revise the "no interactive setup wizard —
+      onboarding is two commands" line; document bare `bitrouter` + `bitrouter
+      init` wizard and `providers login --api-key`.
+- [ ] `skills/bitrouter/references/cli.md` — `init` (interactive / `--yes` /
+      `--force` / `--reset`), the new onboarding entry, `providers login
+      --api-key`.
+- [ ] `CLI.md` — `### init` (new interactive behavior + flags), bare-invocation
+      note, `providers login` flag.
+- [ ] `.claude-plugin/`, `.codex-plugin/`, `.agents/plugins/marketplace.json` —
+      verify none reference a changed surface (MCP command is `mcp serve`,
+      unaffected; confirm no manifest invokes bare `bitrouter` or `init`).
+- [ ] `docs/get-started/*` (+ `.zh.md` siblings) if any page describes the
+      run/onboarding sequence.
+
+## 10. Testing
+
+- **Unit** — probe detection is network-free for each of env / cloud-file /
+  claude-code, and false when none present; `init --yes` == today's write and
+  refuses overwrite without `--force`; `--reset` clears stored credentials;
+  snippet templating per auth mode; result-envelope shape including
+  `providers_skipped_interactive`.
+- **Integration** — bare `bitrouter` unconfigured → wizard entry; configured →
+  status, no wizard, no side effects; `BITROUTER_HOME` set but file missing →
+  wizard offered, not a hard error; `init --yes` with no creds and no key flags
+  → envelope reports zero providers + skipped-interactive and exits non-blocking;
+  install → launch path re-resolve.
+- **E2E** (bitrouter-e2e-test skill) — fresh `HOME`: `bitrouter init --yes
+  --api-key brk_… --harness claude --after exit` → credential stored, claude
+  present-or-reported, JSON envelope emitted; then bare `bitrouter` → status,
+  not the wizard.
+
+## 11. Acceptance criteria (v1 done)
+
+- [ ] Bare `bitrouter` launches the wizard when and only when the probe reports
+      unconfigured; otherwise prints status + hint. Exit code 0 either way.
+- [ ] `bitrouter init` runs the wizard; `bitrouter init --yes` reproduces the
+      current starter-file write (with `--force` overwrite, `--reset` clear).
+- [ ] Every wizard prompt has a working flag equivalent; `--yes` completes
+      without blocking and emits the JSON envelope.
+- [ ] `providers login --api-key` seeds a BYOK provider non-interactively.
+- [ ] Credentials are the only durable output; no path writes or rewrites
+      `bitrouter.yaml` except the explicit starter-template write.
+- [ ] The three finish exits work; "launch now" reaches a running harness on a
+      freshly-installed binary (no re-shell dead-end).
+- [ ] The probe performs no network I/O.
+- [ ] Lockstep docs (§9) updated; `cargo nextest run --all-features`, `cargo
+      clippy --all-features`, `cargo fmt -- --check` clean.
+
+## 12. Decisions log
+
+Resolved with Spikel, 2026-07-15:
+
+1. **CLI-only for v1; agent-led onboarding deferred** — bootstrap paradox +
+   Node on the critical path.
+2. **Wizard writes no config; credentials-only persistence** — `Config` is
+   `Deserialize`-only, no writer exists; default-model/orchestrator/fleet are
+   session-only and deferred.
+3. **Orchestrator restricted to `claude | codex`** — the harnesses `launch`
+   runs; ACP agents stay `spawn`-only.
+4. **Six steps compress to three** — a "default" you don't remember is just an
+   in-session pick for the launch you're about to do.
+5. **Entry: bare `bitrouter` (unconfigured) + `bitrouter init` (re-run)**;
+   `init --yes` = today's scaffold-the-file; `--force`/`--reset` added.
+6. **`--yes` reports-and-skips interactive OAuth** rather than attempting or
+   hanging; `providers login` gains `--api-key`.
+
+## 13. Open questions
+
+1. Bare-configured `bitrouter` output — a compact `status` view, or clap's help?
+   (Leaning: one-line status + "run `bitrouter launch`" hint.)
+2. Snippet client detection for exit (b) — ask "which client?", or emit all
+   three shapes (Anthropic / OpenAI / Codex) and let the user pick? (Leaning:
+   emit all three, labeled.)
+3. Does `--reset` clear *all* provider credentials or only the cloud session?
+   (Leaning: cloud session + a confirm before touching provider creds.)

--- a/apps/bitrouter/src/commands.rs
+++ b/apps/bitrouter/src/commands.rs
@@ -105,15 +105,29 @@ providers:
 inherit_defaults: true
 "#;
 
-/// `bitrouter init` — write a starter config to `path` (refuses to overwrite).
-pub async fn init(path: &std::path::Path) -> Result<()> {
-    if tokio::fs::try_exists(path).await.unwrap_or(false) {
-        anyhow::bail!("{} already exists — refusing to overwrite", path.display());
+/// Outcome of a [`write_starter_config`] scaffold write.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScaffoldOutcome {
+    /// The starter `bitrouter.yaml` was written.
+    Wrote,
+    /// A file already existed and `force` was not set — left untouched.
+    Skipped,
+}
+
+/// `bitrouter init` — write the starter `bitrouter.yaml` to `path`. Without
+/// `force`, an existing file is left untouched (returns
+/// [`ScaffoldOutcome::Skipped`]) so the onboarding wizard's `--yes` run never
+/// clobbers a config the user already tuned; with `force` it overwrites. This
+/// is the single sanctioned `bitrouter.yaml` write — nothing else in the tree
+/// serializes a `Config`.
+pub async fn write_starter_config(path: &std::path::Path, force: bool) -> Result<ScaffoldOutcome> {
+    if !force && tokio::fs::try_exists(path).await.unwrap_or(false) {
+        return Ok(ScaffoldOutcome::Skipped);
     }
     tokio::fs::write(path, STARTER_CONFIG)
         .await
         .with_context(|| format!("writing {}", path.display()))?;
-    Ok(())
+    Ok(ScaffoldOutcome::Wrote)
 }
 
 /// The outcome of `bitrouter key generate` — the plaintext secret is shown to
@@ -459,12 +473,17 @@ pub struct LoginOutcome {
 }
 
 /// Non-interactive provider-login controls.
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct ProviderLoginOptions {
     /// Require importing an already-authenticated vendor CLI session.
     pub import_existing: bool,
     /// Refuse browser-based PKCE flows.
     pub no_browser: bool,
+    /// Seed the credential directly from this API key, skipping the interactive
+    /// method choice and the stdin paste entirely. Set by `providers login
+    /// --api-key` / `--key-stdin` and the onboarding wizard's per-provider
+    /// `--provider-api-key`. The provider must offer the API-key method.
+    pub api_key: Option<String>,
 }
 
 pub async fn login_provider(provider_id: &str, label: &str) -> Result<LoginOutcome> {
@@ -516,7 +535,7 @@ pub async fn login_provider_with_options(
             std::mem::discriminant(&entry.auth)
         );
     }
-    let chosen = choose_auth_method(&entry, &methods, options)?;
+    let chosen = choose_auth_method(&entry, &methods, &options)?;
     eprintln!();
     eprintln!(
         "  Logging in to {} via {}",
@@ -529,7 +548,18 @@ pub async fn login_provider_with_options(
         AuthMethod::PkceSubscription => run_pkce_subscription(provider_id).await?,
         AuthMethod::ImportFromCli => run_cli_import(provider_id)?,
         AuthMethod::DeviceCode => run_device_code(provider_id, &entry).await?,
-        AuthMethod::ApiKey => run_api_key_paste(&entry.display_name)?,
+        // A flag-supplied key (`--api-key` / `--key-stdin` / the wizard) skips
+        // the interactive stdin paste; otherwise prompt for it.
+        AuthMethod::ApiKey => match options.api_key.as_deref() {
+            Some(key) => {
+                let key = key.trim();
+                if key.is_empty() {
+                    anyhow::bail!("the supplied API key is empty — aborting login");
+                }
+                bitrouter_providers::oauth::credential_store::Credential::api_key(key)
+            }
+            None => run_api_key_paste(&entry.display_name)?,
+        },
     };
 
     let mut store = bitrouter_providers::oauth::credential_store::CredentialStore::default_path()
@@ -554,8 +584,22 @@ pub async fn login_provider_with_options(
 fn choose_auth_method(
     entry: &bitrouter_providers::ProviderEntry,
     methods: &[AuthMethod],
-    options: ProviderLoginOptions,
+    options: &ProviderLoginOptions,
 ) -> Result<AuthMethod> {
+    // A supplied API key is the most explicit signal — take the API-key method
+    // directly, or fail clearly if the provider doesn't offer one (OAuth-only
+    // backends reject pasted keys).
+    if options.api_key.is_some() {
+        if methods.contains(&AuthMethod::ApiKey) {
+            return Ok(AuthMethod::ApiKey);
+        }
+        anyhow::bail!(
+            "provider '{}' does not accept a pasted API key — it uses an \
+             interactive OAuth flow; drop --api-key/--key-stdin",
+            entry.id
+        );
+    }
+
     if options.import_existing {
         if methods.contains(&AuthMethod::ImportFromCli) {
             return Ok(AuthMethod::ImportFromCli);
@@ -1157,14 +1201,37 @@ mod tests {
         ));
         tokio::fs::create_dir_all(&dir).await.unwrap();
         let path = dir.join("bitrouter.yaml");
-        init(&path).await.unwrap();
+        assert_eq!(
+            write_starter_config(&path, false).await.unwrap(),
+            ScaffoldOutcome::Wrote
+        );
         let written = tokio::fs::read_to_string(&path).await.unwrap();
         assert!(written.contains("skip_auth: true"));
         // and it parses back into a valid Config
         let cfg = bitrouter_sdk::config::parse_with(&written, |_| Some("x".to_string())).unwrap();
         assert!(cfg.server.skip_auth);
-        // refuses to overwrite
-        assert!(init(&path).await.is_err());
+        // Without --force, an existing file is left untouched (Skipped) — the
+        // wizard's `--yes` run must never clobber a tuned config.
+        tokio::fs::write(&path, "# hand-edited\n").await.unwrap();
+        assert_eq!(
+            write_starter_config(&path, false).await.unwrap(),
+            ScaffoldOutcome::Skipped
+        );
+        assert_eq!(
+            tokio::fs::read_to_string(&path).await.unwrap(),
+            "# hand-edited\n"
+        );
+        // With --force it overwrites.
+        assert_eq!(
+            write_starter_config(&path, true).await.unwrap(),
+            ScaffoldOutcome::Wrote
+        );
+        assert!(
+            tokio::fs::read_to_string(&path)
+                .await
+                .unwrap()
+                .contains("skip_auth: true")
+        );
         let _ = tokio::fs::remove_dir_all(&dir).await;
     }
 
@@ -1324,13 +1391,64 @@ mod tests {
         let chosen = choose_auth_method(
             &entry,
             &methods,
-            ProviderLoginOptions {
+            &ProviderLoginOptions {
                 import_existing: true,
                 no_browser: true,
+                api_key: None,
             },
         )
         .unwrap();
         assert_eq!(chosen, AuthMethod::ImportFromCli);
+    }
+
+    #[test]
+    fn api_key_option_selects_api_key_method_without_prompting() {
+        // A `--api-key`/`--key-stdin`-supplied key drives the non-interactive
+        // BYOK path: `anthropic` offers the API-key method, so it's chosen.
+        let entry = entry_for(serde_json::json!({
+            "name": "anthropic",
+            "api_base": "https://api.anthropic.com/v1",
+            "status": "active",
+            "auth": { "kind": "header", "header": "x-api-key", "env": "ANTHROPIC_API_KEY" },
+            "models": []
+        }));
+        let methods = available_methods(&entry);
+        let chosen = choose_auth_method(
+            &entry,
+            &methods,
+            &ProviderLoginOptions {
+                import_existing: false,
+                no_browser: false,
+                api_key: Some("sk-ant-test".to_string()),
+            },
+        )
+        .unwrap();
+        assert_eq!(chosen, AuthMethod::ApiKey);
+    }
+
+    #[test]
+    fn api_key_option_rejects_oauth_only_providers() {
+        // `openai-codex` is OAuth-only (no API-key method); a supplied key is a
+        // clear error rather than a silently-ignored flag.
+        let entry = entry_for(serde_json::json!({
+            "name": "openai-codex",
+            "api_base": "https://chatgpt.com/backend-api/codex",
+            "status": "active",
+            "auth": { "kind": "oauth", "handler": "openai-codex" },
+            "models": []
+        }));
+        let methods = available_methods(&entry);
+        let err = choose_auth_method(
+            &entry,
+            &methods,
+            &ProviderLoginOptions {
+                import_existing: false,
+                no_browser: false,
+                api_key: Some("sk-whatever".to_string()),
+            },
+        )
+        .unwrap_err();
+        assert!(format!("{err:#}").contains("does not accept a pasted API key"));
     }
 
     #[test]
@@ -1346,9 +1464,10 @@ mod tests {
         let err = choose_auth_method(
             &entry,
             &methods,
-            ProviderLoginOptions {
+            &ProviderLoginOptions {
                 import_existing: true,
                 no_browser: true,
+                api_key: None,
             },
         )
         .unwrap_err();

--- a/apps/bitrouter/src/lib.rs
+++ b/apps/bitrouter/src/lib.rs
@@ -26,6 +26,7 @@ pub mod fleet;
 pub mod fleet_mcp;
 pub mod harness;
 pub mod metering;
+pub mod onboarding;
 pub mod output;
 pub mod paths;
 pub mod policy;

--- a/apps/bitrouter/src/main.rs
+++ b/apps/bitrouter/src/main.rs
@@ -28,7 +28,7 @@ use bitrouter::output::reports::agents::{
     AgentCheckRow, AgentInstallReport, AgentRegistryRow, AgentRow, AgentsCheckReport,
     AgentsListReport,
 };
-use bitrouter::output::reports::config::{InitReport, UnsetVar, ValidateReport};
+use bitrouter::output::reports::config::{UnsetVar, ValidateReport};
 use bitrouter::output::reports::daemon::{
     DaemonActionReport, RouteHopView, RouteReport, StatusReport,
 };
@@ -55,8 +55,11 @@ struct Cli {
     /// Compatibility spelling for `--human` when placed before the subcommand.
     #[arg(short = 'H', hide = true, conflicts_with = "json")]
     human_short: bool,
+    /// No subcommand dispatches to the onboarding entry (`onboarding::entry`):
+    /// the wizard when unconfigured, a one-line status + `bitrouter launch`
+    /// hint when configured.
     #[command(subcommand)]
-    command: Command,
+    command: Option<Command>,
 }
 
 #[derive(Subcommand)]
@@ -142,11 +145,66 @@ enum Command {
         #[arg(long)]
         socket: Option<PathBuf>,
     },
-    /// Write a starter `bitrouter.yaml` (with `skip_auth: true`).
+    /// Guided onboarding wizard that sequences credential, harness, and finish
+    /// steps to first value. Interactive by default; `--yes` (or no TTY) runs
+    /// it headlessly, emitting the JSON result envelope and never blocking on a
+    /// human. Every prompt has a flag equivalent (below) so an agent can drive
+    /// the whole thing. With `--yes` this also reproduces the classic
+    /// starter-`bitrouter.yaml` scaffold (refusing to overwrite unless
+    /// `--force`).
     Init {
-        /// Path to write.
+        /// Path for the starter `bitrouter.yaml` write.
         #[arg(short, long, default_value = "bitrouter.yaml")]
         config: PathBuf,
+        /// Run non-interactively: process the flags below, never block, emit
+        /// the JSON envelope, and scaffold the starter config.
+        #[arg(short = 'y', long)]
+        yes: bool,
+        /// Allow overwriting an existing `bitrouter.yaml` when scaffolding.
+        #[arg(long)]
+        force: bool,
+        /// Clear stored onboarding credentials (cloud session always; provider
+        /// credentials after a confirm, or unconditionally under `--yes`) before
+        /// running.
+        #[arg(long)]
+        reset: bool,
+        /// (Step 1) Sign in to BitRouter Cloud via device-flow OAuth. Skipped
+        /// and reported under `--yes` (a machine can't complete the device flow).
+        #[arg(long)]
+        cloud_login: bool,
+        /// (Step 1) Seed the cloud credential from a `brk_` API key
+        /// (non-interactive).
+        #[arg(long, value_name = "BRK_KEY")]
+        api_key: Option<String>,
+        /// (Step 1) Log in to an upstream provider by id (repeatable). A paired
+        /// `--provider-api-key` seeds it non-interactively; otherwise it is
+        /// reported-and-skipped under `--yes`.
+        #[arg(long = "provider", value_name = "ID")]
+        providers: Vec<String>,
+        /// (Step 1) API key for the `--provider` at the same position
+        /// (repeatable).
+        #[arg(long = "provider-api-key", value_name = "KEY")]
+        provider_api_keys: Vec<String>,
+        /// (Step 1) Accept the auto-detected credential(s) without prompting.
+        #[arg(long)]
+        use_detected: bool,
+        /// (Step 2) Harness to drive: `claude` or `codex` (repeatable).
+        #[arg(long = "harness", value_enum)]
+        harnesses: Vec<bitrouter::spawn::SpawnAgent>,
+        /// (Step 2) Never install a missing harness.
+        #[arg(long)]
+        no_install: bool,
+        /// (Step 3) What to do at the end: `launch` | `serve` | `exit`.
+        #[arg(long, value_enum)]
+        after: Option<bitrouter::onboarding::AfterAction>,
+        /// (Step 3) Model handed to the harness for this session only (not
+        /// persisted).
+        #[arg(long, value_name = "ID")]
+        model: Option<String>,
+        /// (Step 3) Write a starter `bitrouter.yaml` (the one sanctioned config
+        /// write).
+        #[arg(long)]
+        write_config: bool,
     },
     /// Configuration tooling (validation against the published schema).
     Config {
@@ -796,6 +854,16 @@ enum ProviderAction {
         /// Do not run a browser-based provider OAuth flow.
         #[arg(long)]
         no_browser: bool,
+        /// Seed a BYOK provider non-interactively from this API key — skips the
+        /// method menu and the stdin paste. The provider must accept a pasted
+        /// key (OAuth-only backends reject it).
+        #[arg(long, value_name = "KEY", conflicts_with_all = ["import_existing", "no_browser", "key_stdin"])]
+        api_key: Option<String>,
+        /// Read the API key from stdin (one line) instead of prompting — for
+        /// pipelines, e.g. `printf %s "$KEY" | bitrouter providers login openai
+        /// --key-stdin`.
+        #[arg(long, conflicts_with_all = ["import_existing", "no_browser"])]
+        key_stdin: bool,
     },
     /// Log out of an upstream provider — clears every stored credential for
     /// it. For the built-in `bitrouter` provider this is `cloud logout`.
@@ -936,9 +1004,9 @@ async fn main() {
     let cli = Cli::parse();
     let raw_cloud_api = matches!(
         &cli.command,
-        Command::Cloud {
+        Some(Command::Cloud {
             action: bitrouter::cloud::cli::CloudAction::Api(_)
-        }
+        })
     );
     let output = bitrouter::output::Output::from_flags(cli.json, cli.human || cli.human_short);
     match run(cli, &output).await {
@@ -972,8 +1040,8 @@ async fn run(cli: Cli, output: &bitrouter::output::Output) -> Result<()> {
     // would interleave with and corrupt that stream. The exclusion of
     // `Command::Serve` mirrors how it defers its subscriber init to after the
     // OTel exporter is available.
-    let is_acp = matches!(&cli.command, Command::Acp { .. });
-    if matches!(cli.command, Command::Serve { .. }) {
+    let is_acp = matches!(&cli.command, Some(Command::Acp { .. }));
+    if matches!(cli.command, Some(Command::Serve { .. })) {
         // `Command::Serve` defers its init — handled inside `serve()`.
     } else if is_acp {
         // Any `acp` subcommand: init with stderr so stdout stays pristine.
@@ -982,7 +1050,14 @@ async fn run(cli: Cli, output: &bitrouter::output::Output) -> Result<()> {
         init_basic_tracing_subscriber();
     }
 
-    match cli.command {
+    let Some(command) = cli.command else {
+        // Bare `bitrouter` — the onboarding front door (wizard when
+        // unconfigured; status + hint when configured). Never re-onboards a
+        // configured user, never silently spawns a daemon/harness.
+        return bitrouter::onboarding::entry(output).await;
+    };
+
+    match command {
         Command::Serve { config } => {
             let source = bitrouter::paths::resolve_config(config.as_deref())?;
             serve(&source).await
@@ -1029,9 +1104,39 @@ async fn run(cli: Cli, output: &bitrouter::output::Output) -> Result<()> {
             output.emit(&route(&model, &source, &socket).await?)?;
             Ok(())
         }
-        Command::Init { config } => {
-            output.emit(&init(&config).await?)?;
-            Ok(())
+        Command::Init {
+            config,
+            yes,
+            force,
+            reset,
+            cloud_login,
+            api_key,
+            providers,
+            provider_api_keys,
+            use_detected,
+            harnesses,
+            no_install,
+            after,
+            model,
+            write_config,
+        } => {
+            let flags = bitrouter::onboarding::OnboardingFlags {
+                config,
+                yes,
+                force,
+                reset,
+                cloud_login,
+                api_key,
+                providers,
+                provider_api_keys,
+                use_detected,
+                harnesses,
+                no_install,
+                after,
+                model,
+                write_config,
+            };
+            bitrouter::onboarding::run(flags, output).await
         }
         Command::Config { action } => {
             let report = config_cmd(action).await?;
@@ -2445,13 +2550,20 @@ fn route_report(model: &str, resolved_via: &str, chain: Vec<RouteHop>) -> RouteR
 
 // ===== management commands =====
 
-async fn init(config_path: &Path) -> Result<InitReport> {
-    commands::init(config_path).await?;
-    Ok(InitReport {
-        action: "init",
-        path: config_path.display().to_string(),
-        skip_auth: true,
-    })
+/// Read a provider API key from stdin (for `providers login --key-stdin`).
+/// Consumes the whole stream and trims surrounding whitespace/newline so a
+/// `printf %s "$KEY" | …` pipe and an `echo "$KEY" | …` pipe both work.
+fn read_api_key_from_stdin() -> Result<String> {
+    use std::io::Read;
+    let mut buf = String::new();
+    std::io::stdin()
+        .read_to_string(&mut buf)
+        .context("reading API key from stdin")?;
+    let key = buf.trim().to_string();
+    if key.is_empty() {
+        anyhow::bail!("no API key on stdin (--key-stdin)");
+    }
+    Ok(key)
 }
 
 async fn key(action: KeyAction) -> Result<KeySignReport> {
@@ -2670,7 +2782,16 @@ async fn providers(action: ProviderAction, output: &Output) -> Result<()> {
             label,
             import_existing,
             no_browser,
+            api_key,
+            key_stdin,
         } => {
+            // `--key-stdin` reads the key from stdin (one line); it funnels into
+            // the same non-interactive API-key path as `--api-key`.
+            let api_key = if key_stdin {
+                Some(read_api_key_from_stdin()?)
+            } else {
+                api_key
+            };
             // The built-in `bitrouter` provider authenticates with the cloud
             // OAuth credential, so logging into it IS the cloud sign-in
             // (`cloud login`); other providers use the per-provider store.
@@ -2681,12 +2802,14 @@ async fn providers(action: ProviderAction, output: &Output) -> Result<()> {
                          --import-existing/--no-browser apply to upstream provider logins"
                     );
                 }
+                // A supplied key seeds the cloud credential the same way
+                // `cloud login --api-key` does.
                 bitrouter::cloud::cli::run(
                     bitrouter::cloud::cli::CloudAction::Login {
                         authorization_server: None,
                         client_id: None,
                         scope: None,
-                        api_key: None,
+                        api_key,
                     },
                     output.format(),
                 )
@@ -2698,6 +2821,7 @@ async fn providers(action: ProviderAction, output: &Output) -> Result<()> {
                     bitrouter::commands::ProviderLoginOptions {
                         import_existing,
                         no_browser,
+                        api_key,
                     },
                 )
                 .await?;
@@ -3152,14 +3276,14 @@ mod tests {
         ])
         .expect("parse");
         match cli.command {
-            Command::Mcp {
+            Some(Command::Mcp {
                 action:
                     McpAction::Serve {
                         backend,
                         budget_usd,
                         ..
                     },
-            } => {
+            }) => {
                 assert_eq!(backend, Some(McpBackend::Fleet));
                 assert_eq!(budget_usd, Some(12.5));
             }
@@ -3174,19 +3298,137 @@ mod tests {
             Cli::try_parse_from(["bitrouter", "update", "--check", "--tag", "1.0.0-alpha.18"])
                 .expect("parse");
         match cli.command {
-            Command::Update {
+            Some(Command::Update {
                 check,
                 tag,
                 stable,
                 restart,
                 yes,
-            } => {
+            }) => {
                 assert!(check);
                 assert_eq!(tag.as_deref(), Some("1.0.0-alpha.18"));
                 assert!(!stable && !restart && !yes);
             }
             _ => panic!("expected Update"),
         }
+    }
+
+    #[test]
+    fn bare_invocation_parses_to_no_subcommand() {
+        use clap::Parser;
+        // Bare `bitrouter` → no subcommand → onboarding entry dispatch.
+        let cli = Cli::try_parse_from(["bitrouter"]).expect("parse");
+        assert!(cli.command.is_none());
+        // Global flags still parse without a subcommand.
+        let human = Cli::try_parse_from(["bitrouter", "--human"]).expect("parse");
+        assert!(human.command.is_none() && human.human);
+    }
+
+    #[test]
+    fn init_wizard_flags_parse() {
+        use clap::Parser;
+        let cli = Cli::try_parse_from([
+            "bitrouter",
+            "init",
+            "--yes",
+            "--force",
+            "--reset",
+            "--api-key",
+            "brk_abc.secret",
+            "--provider",
+            "openai",
+            "--provider-api-key",
+            "sk-openai",
+            "--harness",
+            "claude",
+            "--harness",
+            "codex",
+            "--after",
+            "exit",
+            "--model",
+            "openai/gpt-5",
+            "--write-config",
+        ])
+        .expect("parse");
+        match cli.command {
+            Some(Command::Init {
+                yes,
+                force,
+                reset,
+                api_key,
+                providers,
+                provider_api_keys,
+                harnesses,
+                after,
+                model,
+                write_config,
+                ..
+            }) => {
+                assert!(yes && force && reset && write_config);
+                assert_eq!(api_key.as_deref(), Some("brk_abc.secret"));
+                assert_eq!(providers, vec!["openai"]);
+                assert_eq!(provider_api_keys, vec!["sk-openai"]);
+                assert_eq!(
+                    harnesses,
+                    vec![
+                        bitrouter::spawn::SpawnAgent::Claude,
+                        bitrouter::spawn::SpawnAgent::Codex
+                    ]
+                );
+                assert_eq!(after, Some(bitrouter::onboarding::AfterAction::Exit));
+                assert_eq!(model.as_deref(), Some("openai/gpt-5"));
+            }
+            _ => panic!("expected Init"),
+        }
+    }
+
+    #[test]
+    fn providers_login_api_key_flag_parses() {
+        use clap::Parser;
+        let cli = Cli::try_parse_from([
+            "bitrouter",
+            "providers",
+            "login",
+            "openai",
+            "--api-key",
+            "sk-abc",
+        ])
+        .expect("parse");
+        match cli.command {
+            Some(Command::Providers {
+                action:
+                    ProviderAction::Login {
+                        provider,
+                        api_key,
+                        key_stdin,
+                        ..
+                    },
+            }) => {
+                assert_eq!(provider, "openai");
+                assert_eq!(api_key.as_deref(), Some("sk-abc"));
+                assert!(!key_stdin);
+            }
+            _ => panic!("expected provider login"),
+        }
+    }
+
+    #[test]
+    fn providers_login_api_key_conflicts_with_oauth_flags() {
+        use clap::Parser;
+        let parsed = Cli::try_parse_from([
+            "bitrouter",
+            "providers",
+            "login",
+            "openai",
+            "--api-key",
+            "sk-abc",
+            "--no-browser",
+        ]);
+        let err = match parsed {
+            Ok(_) => panic!("api-key + oauth flags must conflict"),
+            Err(err) => err,
+        };
+        assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
     }
 
     #[test]
@@ -3204,15 +3446,16 @@ mod tests {
         ])
         .expect("parse");
         match cli.command {
-            Command::Providers {
+            Some(Command::Providers {
                 action:
                     ProviderAction::Login {
                         provider,
                         label,
                         import_existing,
                         no_browser,
+                        ..
                     },
-            } => {
+            }) => {
                 assert_eq!(provider, "openai-codex");
                 assert_eq!(label, "work");
                 assert!(import_existing);
@@ -3239,7 +3482,7 @@ mod tests {
         ])
         .expect("parse init");
         match init.command {
-            Command::Policy {
+            Some(Command::Policy {
                 action:
                     PolicyAction::Init {
                         name,
@@ -3248,7 +3491,7 @@ mod tests {
                         economy,
                         config,
                     },
-            } => {
+            }) => {
                 assert_eq!(name, "terminal-bench");
                 assert_eq!(preset, "coding");
                 assert_eq!(strong, None);
@@ -3262,9 +3505,9 @@ mod tests {
             .expect("parse evolve");
         assert!(matches!(
             evolve.command,
-            Command::Policy {
+            Some(Command::Policy {
                 action: PolicyAction::Evolve { apply: true, .. }
-            }
+            })
         ));
     }
 
@@ -3281,9 +3524,9 @@ mod tests {
         .unwrap();
 
         match cli.command {
-            Command::Cloud {
+            Some(Command::Cloud {
                 action: bitrouter::cloud::cli::CloudAction::Api(args),
-            } => assert_eq!(args.headers, ["X-Test: value"]),
+            }) => assert_eq!(args.headers, ["X-Test: value"]),
             _ => panic!("expected cloud API command"),
         }
 

--- a/apps/bitrouter/src/main.rs
+++ b/apps/bitrouter/src/main.rs
@@ -1009,7 +1009,14 @@ async fn main() {
         })
     );
     let output = bitrouter::output::Output::from_flags(cli.json, cli.human || cli.human_short);
-    match run(cli, &output).await {
+    // Box the dispatch future onto the heap. `run` is a large `async fn` whose
+    // state machine inlines the biggest per-command futures (the onboarding
+    // wizard, `spawn`, …), and `#[tokio::main]` polls it on the main thread —
+    // whose stack is only ~1 MiB on Windows. Keeping that state off the stack
+    // leaves headroom for the deep synchronous call chains (rustls/reqwest on
+    // the `cloud` path) that would otherwise overflow the main-thread stack on
+    // Windows (macOS/Linux's 8 MiB default hides it).
+    match Box::pin(run(cli, &output)).await {
         Ok(()) => {}
         Err(e) => {
             if raw_cloud_api {

--- a/apps/bitrouter/src/onboarding.rs
+++ b/apps/bitrouter/src/onboarding.rs
@@ -1,0 +1,1281 @@
+//! `bitrouter` onboarding — a deterministic, scripted wizard (no LLM, no Node,
+//! no TUI-manager) that *sequences verbs that already exist* and ends in first
+//! value: a launched harness, a running daemon, or a printed paste-in snippet.
+//!
+//! Two entry points, both landing here:
+//! - bare `bitrouter` ([`entry`]) runs the credential [`probe`] and either
+//!   launches the wizard (unconfigured) or prints a one-line status + a
+//!   `bitrouter launch` hint (configured). It never re-onboards a configured
+//!   user and never silently spawns a harness or daemon.
+//! - `bitrouter init` ([`run`]) runs the wizard interactively, or — with
+//!   `--yes` (or no TTY) — headlessly, emitting the JSON result envelope and
+//!   never blocking on a human.
+//!
+//! **The wizard writes no config.** `Config` is `Deserialize`-only, so the sole
+//! durable state onboarding produces is **credentials** (which already persist
+//! to the credential store, independent of `bitrouter.yaml`, and are
+//! auto-detected by zero-config). The one sanctioned `bitrouter.yaml` write is
+//! the canned starter template via [`crate::commands::write_starter_config`],
+//! and only on explicit request (`--yes` / `--write-config` / the exit-(c)
+//! prompt).
+
+use std::collections::BTreeSet;
+use std::io::IsTerminal;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use bitrouter_cloud_sdk::auth::commands::{LoginInputs, login as cloud_login};
+use bitrouter_cloud_sdk::auth::credentials::default_credentials_path;
+use bitrouter_providers::oauth::credential_store::CredentialStore;
+use clap::ValueEnum;
+use serde::Serialize;
+
+use crate::commands::{ProviderLoginOptions, ScaffoldOutcome, login_provider_with_options};
+use crate::output::CliReport;
+use crate::output::Output;
+use crate::output::human::Human;
+use crate::spawn::SpawnAgent;
+
+// =====================================================================
+// §5 — network-free credential probe
+// =====================================================================
+
+/// The BYOK env vars the probe checks, each paired with the provider id it
+/// enables. `GEMINI_API_KEY` (Google's own name), **not** `GOOGLE_API_KEY`;
+/// `OPENCODE_ZEN_API_KEY` is shared by opencode-zen and opencode-go.
+const PROBE_ENV_VARS: &[(&str, &str)] = &[
+    ("OPENAI_API_KEY", "openai"),
+    ("ANTHROPIC_API_KEY", "anthropic"),
+    ("GEMINI_API_KEY", "google"),
+    ("OPENROUTER_API_KEY", "openrouter"),
+    ("OPENCODE_ZEN_API_KEY", "opencode-zen"),
+];
+
+/// Purely-local signals that decide "configured vs not" without any network
+/// call, registry load, or `merge_registry_into`. See [`probe`].
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct ProbeSignals {
+    /// BYOK env var **names** present in the environment (e.g. `OPENAI_API_KEY`).
+    pub env_keys: Vec<String>,
+    /// Whether the cloud session file (`account-credentials.json`) exists.
+    pub cloud_session: bool,
+    /// Provider ids with at least one stored credential (subscription session,
+    /// pasted key, …) in the local credential store.
+    pub subscription_providers: Vec<String>,
+}
+
+impl ProbeSignals {
+    /// "Configured" = at least one of the three local signals is present.
+    pub fn is_configured(&self) -> bool {
+        !self.env_keys.is_empty() || self.cloud_session || !self.subscription_providers.is_empty()
+    }
+
+    /// The provider ids implied by the detected env keys (e.g. `OPENAI_API_KEY`
+    /// → `openai`), used to populate the result envelope.
+    fn env_provider_ids(&self) -> Vec<String> {
+        self.env_keys
+            .iter()
+            .filter_map(|var| {
+                PROBE_ENV_VARS
+                    .iter()
+                    .find(|(v, _)| *v == var)
+                    .map(|(_, id)| (*id).to_string())
+            })
+            .collect()
+    }
+
+    /// Every provider id onboarding can treat as already-usable: detected env
+    /// providers, an active cloud session (`bitrouter`), and store providers.
+    fn already_configured(&self) -> BTreeSet<String> {
+        let mut set: BTreeSet<String> = self.env_provider_ids().into_iter().collect();
+        if self.cloud_session {
+            set.insert(bitrouter_cloud_sdk::provider::PROVIDER_ID.to_string());
+        }
+        for id in &self.subscription_providers {
+            set.insert(id.clone());
+        }
+        set
+    }
+}
+
+/// Run the network-free credential probe (§5). Reads, in order: the BYOK env
+/// vars, the cloud credentials file's existence, and the local credential
+/// store's provider list. Performs **no** network I/O and never loads the
+/// registry.
+pub fn probe() -> ProbeSignals {
+    let env_keys = detected_env_keys(|name| std::env::var(name).ok().filter(|v| !v.is_empty()));
+    // File-existence check only — never reads/validates the token, never calls
+    // the network.
+    let cloud_session = default_credentials_path()
+        .map(|p| p.exists())
+        .unwrap_or(false);
+    // A local marker check: the credential store is a single on-disk JSON file;
+    // `providers()` lists ids with a stored credential without any refresh or
+    // network call. An unresolved/unreadable store is simply "none".
+    let subscription_providers = CredentialStore::default_path()
+        .map(|store| store.providers().into_iter().map(String::from).collect())
+        .unwrap_or_default();
+    ProbeSignals {
+        env_keys,
+        cloud_session,
+        subscription_providers,
+    }
+}
+
+/// The subset of [`PROBE_ENV_VARS`] whose var is present, per the injected
+/// lookup. Factored out so the detection can be unit-tested without touching
+/// the process environment.
+fn detected_env_keys(lookup: impl Fn(&str) -> Option<String>) -> Vec<String> {
+    PROBE_ENV_VARS
+        .iter()
+        .filter(|(var, _)| lookup(var).is_some())
+        .map(|(var, _)| (*var).to_string())
+        .collect()
+}
+
+// =====================================================================
+// Flags (§3.2) — every wizard prompt has a flag equivalent
+// =====================================================================
+
+/// The three-way finish exit (§3.2 step 3).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum AfterAction {
+    /// Launch the harness's native TUI now (`bitrouter launch`).
+    Launch,
+    /// Start the daemon and print a paste-in snippet for an existing tool.
+    Serve,
+    /// Do nothing further.
+    Exit,
+}
+
+impl AfterAction {
+    fn as_str(self) -> &'static str {
+        match self {
+            AfterAction::Launch => "launch",
+            AfterAction::Serve => "serve",
+            AfterAction::Exit => "exit",
+        }
+    }
+}
+
+/// Every wizard prompt mapped to a flag — consumed by `--yes` and scriptable
+/// directly. Built from `Command::Init` in `main.rs`.
+#[derive(Debug, Clone)]
+pub struct OnboardingFlags {
+    /// Starter-config write path (`-c/--config`, default `bitrouter.yaml`).
+    pub config: PathBuf,
+    /// Run headlessly, emitting the JSON envelope and never blocking.
+    pub yes: bool,
+    /// Allow overwriting an existing `bitrouter.yaml` when scaffolding.
+    pub force: bool,
+    /// Clear stored onboarding credentials before running.
+    pub reset: bool,
+    /// (Step 1) Sign in to BitRouter Cloud via device-flow OAuth.
+    pub cloud_login: bool,
+    /// (Step 1) Seed the cloud credential from a `brk_` API key (headless).
+    pub api_key: Option<String>,
+    /// (Step 1) Log in to these upstream providers by id (repeatable).
+    pub providers: Vec<String>,
+    /// (Step 1) API keys paired by position with `providers` (repeatable).
+    pub provider_api_keys: Vec<String>,
+    /// (Step 1) Accept the auto-detected credentials without prompting.
+    pub use_detected: bool,
+    /// (Step 2) Harnesses to drive: `claude` / `codex` (repeatable).
+    pub harnesses: Vec<SpawnAgent>,
+    /// (Step 2) Never install a missing harness.
+    pub no_install: bool,
+    /// (Step 3) What to do at the end.
+    pub after: Option<AfterAction>,
+    /// (Step 3) Model handed to the harness for this session (not persisted).
+    pub model: Option<String>,
+    /// (Step 3) Write a starter `bitrouter.yaml`.
+    pub write_config: bool,
+}
+
+impl Default for OnboardingFlags {
+    fn default() -> Self {
+        Self {
+            config: PathBuf::from("bitrouter.yaml"),
+            yes: false,
+            force: false,
+            reset: false,
+            cloud_login: false,
+            api_key: None,
+            providers: Vec::new(),
+            provider_api_keys: Vec::new(),
+            use_detected: false,
+            harnesses: Vec::new(),
+            no_install: false,
+            after: None,
+            model: None,
+            write_config: false,
+        }
+    }
+}
+
+// =====================================================================
+// Result envelope (§3.3) + configured-status view (§13 Q1)
+// =====================================================================
+
+/// Paste-in wiring for `after: serve` (§13 Q2 — all three shapes, labeled).
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct Snippet {
+    /// The daemon base URL the snippets point at.
+    pub base_url: String,
+    /// `ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN` export lines.
+    pub anthropic: String,
+    /// `OPENAI_BASE_URL` + `OPENAI_API_KEY` export lines.
+    pub openai: String,
+    /// The Codex `-c` provider-override invocation.
+    pub codex: String,
+}
+
+/// The standard onboarding result envelope, emitted on stdout by the wizard and
+/// every `--yes` run.
+#[derive(Debug, Clone, Serialize)]
+pub struct OnboardingReport {
+    /// Always `"onboarding"`.
+    pub action: &'static str,
+    /// Provider ids now usable (detected, pre-existing, or freshly set up).
+    pub providers_configured: Vec<String>,
+    /// Providers that would need an interactive human (OAuth device/PKCE, a
+    /// claude-code session import) and were reported-and-skipped, not attempted.
+    pub providers_skipped_interactive: Vec<String>,
+    /// Harnesses confirmed available after step 2.
+    pub harnesses_installed: Vec<String>,
+    /// `"launch"` | `"serve"` | `"exit"`.
+    pub after: String,
+    /// The paste-in snippet for `after: serve`; `null` otherwise.
+    pub snippet: Option<Snippet>,
+}
+
+impl CliReport for OnboardingReport {
+    fn render(&self, h: &mut Human<'_>) -> std::io::Result<()> {
+        h.line("onboarding complete")?;
+        h.field(
+            "providers",
+            if self.providers_configured.is_empty() {
+                "(none)".to_string()
+            } else {
+                self.providers_configured.join(", ")
+            },
+        )?;
+        if !self.providers_skipped_interactive.is_empty() {
+            h.field("skipped", self.providers_skipped_interactive.join(", "))?;
+        }
+        h.field(
+            "harnesses",
+            if self.harnesses_installed.is_empty() {
+                "(none)".to_string()
+            } else {
+                self.harnesses_installed.join(", ")
+            },
+        )?;
+        h.field("after", &self.after)?;
+        if let Some(snippet) = &self.snippet {
+            h.blank()?;
+            h.line(&format!("paste-in wiring ({}):", snippet.base_url))?;
+            h.blank()?;
+            h.line("  Anthropic / Claude Code:")?;
+            for l in snippet.anthropic.lines() {
+                h.line(&format!("    {l}"))?;
+            }
+            h.line("  OpenAI SDK:")?;
+            for l in snippet.openai.lines() {
+                h.line(&format!("    {l}"))?;
+            }
+            h.line("  Codex:")?;
+            for l in snippet.codex.lines() {
+                h.line(&format!("    {l}"))?;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// The configured-user status view for bare `bitrouter` (§13 Q1): a compact
+/// status plus a `bitrouter launch` hint — never clap help, never the wizard.
+#[derive(Debug, Clone, Serialize)]
+pub struct OnboardingStatusReport {
+    /// Always `"status"`.
+    pub action: &'static str,
+    /// Always `true` here — this report is only built for a configured user.
+    pub configured: bool,
+    /// The local credential signals that made the probe report "configured".
+    pub signals: Vec<String>,
+    /// The one-line next-step hint.
+    pub hint: String,
+}
+
+impl OnboardingStatusReport {
+    fn from_signals(signals: &ProbeSignals) -> Self {
+        let mut parts = Vec::new();
+        if signals.cloud_session {
+            parts.push("cloud session".to_string());
+        }
+        if !signals.subscription_providers.is_empty() {
+            parts.push(format!(
+                "providers: {}",
+                signals.subscription_providers.join(", ")
+            ));
+        }
+        if !signals.env_keys.is_empty() {
+            parts.push(format!("env: {}", signals.env_keys.join(", ")));
+        }
+        Self {
+            action: "status",
+            configured: true,
+            signals: parts,
+            hint: "run `bitrouter launch` to start a coding session".to_string(),
+        }
+    }
+}
+
+impl CliReport for OnboardingStatusReport {
+    fn render(&self, h: &mut Human<'_>) -> std::io::Result<()> {
+        h.line(&format!(
+            "bitrouter is configured ({}) — {}",
+            if self.signals.is_empty() {
+                "credentials present".to_string()
+            } else {
+                self.signals.join("; ")
+            },
+            self.hint,
+        ))
+    }
+}
+
+// =====================================================================
+// Entry points
+// =====================================================================
+
+/// Bare `bitrouter` (no subcommand): probe, then status (configured) or the
+/// wizard (unconfigured). Exit code 0 either way; never writes config, never
+/// spawns a daemon/harness on its own.
+pub async fn entry(output: &Output) -> Result<()> {
+    let signals = probe();
+    if signals.is_configured() {
+        return emit(output, &OnboardingStatusReport::from_signals(&signals));
+    }
+    if std::io::stdin().is_terminal() {
+        run_interactive(OnboardingFlags::default(), &signals, output).await
+    } else {
+        // No TTY and nothing configured: the interactive wizard can't run.
+        // Print the multi-line hint to stderr and emit an inert envelope so
+        // the invocation stays machine-observable and exits 0.
+        print_hint();
+        emit(output, &empty_report())
+    }
+}
+
+/// `bitrouter init [flags]`. Runs the wizard interactively, or headlessly when
+/// `--yes` is set (or no TTY is attached). `--reset` clears credentials first.
+pub async fn run(flags: OnboardingFlags, output: &Output) -> Result<()> {
+    if flags.reset {
+        reset_credentials(flags.yes, std::io::stdin().is_terminal()).await?;
+    }
+    if flags.yes {
+        return run_headless(flags, output).await;
+    }
+    if std::io::stdin().is_terminal() {
+        let signals = probe();
+        run_interactive(flags, &signals, output).await
+    } else {
+        // No TTY and no `--yes`: fall back to the headless runner. Preserve the
+        // historical `bitrouter init` behavior (scaffold the starter file) by
+        // forcing the config write, and still emit the envelope.
+        run_headless(
+            OnboardingFlags {
+                write_config: true,
+                ..flags
+            },
+            output,
+        )
+        .await
+    }
+}
+
+fn empty_report() -> OnboardingReport {
+    OnboardingReport {
+        action: "onboarding",
+        providers_configured: Vec::new(),
+        providers_skipped_interactive: Vec::new(),
+        harnesses_installed: Vec::new(),
+        after: AfterAction::Exit.as_str().to_string(),
+        snippet: None,
+    }
+}
+
+// =====================================================================
+// §4 — headless runner
+// =====================================================================
+
+async fn run_headless(flags: OnboardingFlags, output: &Output) -> Result<()> {
+    let signals = probe();
+    // Already-present credentials always count (spec §4: "consume
+    // already-present credentials + flag-supplied keys").
+    let mut configured = signals.already_configured();
+    let mut skipped: Vec<String> = Vec::new();
+
+    // --- Step 1: credentials (flag-driven; interactive OAuth reported-and-skipped) ---
+    apply_flag_credentials(&flags, &mut configured, &mut skipped, true).await?;
+
+    // --- Step 2: harness (resolve only; headless never installs — see §13
+    // resolution notes: keeps `--yes` non-blocking and network-free) ---
+    let mut installed: Vec<String> = Vec::new();
+    for agent in &flags.harnesses {
+        // `no_install: true` makes `ensure_agent_installed` resolve-or-error
+        // without ever prompting or shelling out to an installer.
+        match crate::spawn::ensure_agent_installed(*agent, true).await {
+            Ok(_) => installed.push(agent.spec().id.to_string()),
+            Err(_) => note(&format!(
+                "harness '{}' is not installed — skipped (install it, or run \
+                 `bitrouter launch -a {}` interactively)",
+                agent.spec().id,
+                agent.spec().id
+            )),
+        }
+    }
+
+    // --- Config scaffold (the one sanctioned bitrouter.yaml write) ---
+    if flags.yes || flags.write_config {
+        match crate::commands::write_starter_config(&flags.config, flags.force).await? {
+            ScaffoldOutcome::Wrote => note(&format!(
+                "wrote starter config to {}",
+                flags.config.display()
+            )),
+            ScaffoldOutcome::Skipped => note(&format!(
+                "{} already exists — left untouched (pass --force to overwrite)",
+                flags.config.display()
+            )),
+        }
+    }
+
+    // --- Step 3: finish ---
+    let after = flags.after.unwrap_or(AfterAction::Exit);
+    let mut report = OnboardingReport {
+        action: "onboarding",
+        providers_configured: configured.into_iter().collect(),
+        providers_skipped_interactive: skipped,
+        harnesses_installed: installed.clone(),
+        after: after.as_str().to_string(),
+        snippet: None,
+    };
+
+    match after {
+        AfterAction::Launch => {
+            // Honor launch only when the chosen harness is already present.
+            match pick_launch_harness(&flags.harnesses, &installed) {
+                Some(agent) => {
+                    finish_launch(
+                        agent,
+                        flags.model.as_deref(),
+                        flags.no_install,
+                        report,
+                        output,
+                    )
+                    .await
+                }
+                None => {
+                    note("no requested harness is installed — nothing to launch; exiting");
+                    report.after = AfterAction::Exit.as_str().to_string();
+                    emit(output, &report)
+                }
+            }
+        }
+        AfterAction::Serve => finish_serve(report, output).await,
+        AfterAction::Exit => emit(output, &report),
+    }
+}
+
+/// Apply the flag-supplied credentials shared by both the headless runner and
+/// the interactive wizard's step-1 pre-pass. `headless` controls the parts a
+/// machine can't do: a bare `--cloud-login` (device flow) and a `--provider`
+/// with no key are reported-and-skipped headlessly, but drive the real
+/// interactive flows when a human is present.
+async fn apply_flag_credentials(
+    flags: &OnboardingFlags,
+    configured: &mut BTreeSet<String>,
+    skipped: &mut Vec<String>,
+    headless: bool,
+) -> Result<()> {
+    let cloud = bitrouter_cloud_sdk::provider::PROVIDER_ID;
+    // Cloud: a brk_ key is non-interactive; a bare --cloud-login needs the
+    // device flow (headless skips, interactive runs it).
+    if let Some(key) = flags.api_key.as_deref() {
+        seed_cloud_api_key(key).await?;
+        configured.insert(cloud.to_string());
+    } else if flags.cloud_login {
+        if headless {
+            skipped.push(cloud.to_string());
+        } else {
+            match seed_cloud_interactive().await {
+                Ok(()) => {
+                    configured.insert(cloud.to_string());
+                }
+                Err(e) => note(&format!("cloud sign-in did not complete: {e:#}")),
+            }
+        }
+    }
+
+    // Per-provider: a paired key seeds it non-interactively; without one it
+    // needs an interactive OAuth/PKCE/session flow (headless skips; interactive
+    // runs the provider's login menu).
+    for (i, provider) in flags.providers.iter().enumerate() {
+        match flags.provider_api_keys.get(i) {
+            Some(key) => match seed_provider_api_key(provider, key).await {
+                Ok(()) => {
+                    configured.insert(provider.clone());
+                }
+                Err(e) => {
+                    note(&format!("provider '{provider}' not configured: {e:#}"));
+                    skipped.push(provider.clone());
+                }
+            },
+            None if headless => skipped.push(provider.clone()),
+            None => match login_provider_with_options(
+                provider,
+                bitrouter_providers::oauth::credential_store::DEFAULT_LABEL,
+                ProviderLoginOptions::default(),
+            )
+            .await
+            {
+                Ok(_) => {
+                    configured.insert(provider.clone());
+                }
+                Err(e) => {
+                    note(&format!(
+                        "provider '{provider}' login did not complete: {e:#}"
+                    ));
+                    skipped.push(provider.clone());
+                }
+            },
+        }
+    }
+    Ok(())
+}
+
+/// Seed the cloud credential from a `brk_` key. Calls the cloud SDK's `login`
+/// directly (not `cloud::cli::run`) so onboarding emits a single result
+/// envelope on stdout — `login` writes only progress to stderr and persists
+/// the credential to the store.
+async fn seed_cloud_api_key(key: &str) -> Result<()> {
+    cloud_login(LoginInputs {
+        authorization_server: None,
+        client_id: None,
+        scope: None,
+        api_key: Some(key.to_string()),
+    })
+    .await
+    .map(|_| ())
+    .context("seeding the cloud credential from --api-key")
+}
+
+/// Seed one upstream provider non-interactively from a pasted key, via the
+/// same `providers login --api-key` path.
+async fn seed_provider_api_key(provider: &str, key: &str) -> Result<()> {
+    login_provider_with_options(
+        provider,
+        bitrouter_providers::oauth::credential_store::DEFAULT_LABEL,
+        ProviderLoginOptions {
+            import_existing: false,
+            no_browser: true,
+            api_key: Some(key.to_string()),
+        },
+    )
+    .await
+    .map(|_| ())
+}
+
+// =====================================================================
+// Interactive wizard
+// =====================================================================
+
+async fn run_interactive(
+    flags: OnboardingFlags,
+    signals: &ProbeSignals,
+    output: &Output,
+) -> Result<()> {
+    eprintln!();
+    eprintln!("Welcome to BitRouter — let's get you to first value.");
+    eprintln!();
+
+    // --- Step 1: credentials ---
+    let mut configured = signals.already_configured();
+    let mut skipped: Vec<String> = Vec::new();
+    // Apply any flag-supplied credentials first (so `bitrouter init --api-key …`
+    // / `--provider …` seed before we prompt), then either accept the detected
+    // set (`--use-detected`) or open the interactive credential menu.
+    apply_flag_credentials(&flags, &mut configured, &mut skipped, false).await?;
+    let seeded_from_flags =
+        flags.api_key.is_some() || flags.cloud_login || !flags.providers.is_empty();
+    if flags.use_detected && signals.is_configured() {
+        eprintln!("Step 1/3 — Credentials");
+        note("using the detected credential(s)");
+    } else if !seeded_from_flags {
+        interactive_credentials(signals, &mut configured, &mut skipped).await?;
+    }
+
+    // --- Step 2: harness ---
+    let installed = interactive_harness(&flags).await?;
+
+    // --- Step 3: finish ---
+    let after = interactive_after(&flags, &installed)?;
+
+    let mut report = OnboardingReport {
+        action: "onboarding",
+        providers_configured: configured.into_iter().collect(),
+        providers_skipped_interactive: skipped,
+        harnesses_installed: installed.clone(),
+        after: after.as_str().to_string(),
+        snippet: None,
+    };
+
+    match after {
+        AfterAction::Launch => match pick_launch_harness(&flags.harnesses, &installed)
+            .or_else(|| installed.first().and_then(|id| agent_by_id(id)))
+        {
+            Some(agent) => {
+                finish_launch(
+                    agent,
+                    flags.model.as_deref(),
+                    flags.no_install,
+                    report,
+                    output,
+                )
+                .await
+            }
+            None => {
+                note("no harness available to launch; exiting");
+                report.after = AfterAction::Exit.as_str().to_string();
+                emit(output, &report)
+            }
+        },
+        AfterAction::Serve => finish_serve(report, output).await,
+        AfterAction::Exit => {
+            // Optional starter-config write (the one safe config write).
+            if flags.write_config
+                || prompt_yes_no("Write a starter bitrouter.yaml to edit later?", false)
+            {
+                match crate::commands::write_starter_config(&flags.config, flags.force).await? {
+                    ScaffoldOutcome::Wrote => note(&format!(
+                        "wrote starter config to {}",
+                        flags.config.display()
+                    )),
+                    ScaffoldOutcome::Skipped => note(&format!(
+                        "{} already exists — left untouched (pass --force to overwrite)",
+                        flags.config.display()
+                    )),
+                }
+            }
+            emit(output, &report)
+        }
+    }
+}
+
+async fn interactive_credentials(
+    signals: &ProbeSignals,
+    configured: &mut BTreeSet<String>,
+    skipped: &mut Vec<String>,
+) -> Result<()> {
+    eprintln!("Step 1/3 — Credentials");
+    if signals.is_configured() {
+        eprintln!(
+            "  Detected: {}",
+            OnboardingStatusReport::from_signals(signals)
+                .signals
+                .join("; ")
+        );
+    }
+    loop {
+        eprintln!();
+        eprintln!("  How would you like to authenticate?");
+        eprintln!("    1) Sign in to BitRouter Cloud — one account, every model [default]");
+        eprintln!("    2) Log in to a specific provider (claude-code / openai-codex / …)");
+        if signals.is_configured() {
+            eprintln!("    3) Use the detected credential(s) and continue");
+        }
+        eprintln!("    0) Skip for now");
+        match prompt_line("  Choose [1]: ")?.as_str() {
+            "" | "1" => match seed_cloud_interactive().await {
+                Ok(()) => {
+                    configured.insert(bitrouter_cloud_sdk::provider::PROVIDER_ID.to_string());
+                }
+                Err(e) => note(&format!("cloud sign-in did not complete: {e:#}")),
+            },
+            "2" => {
+                let id = prompt_line("  Provider id: ")?;
+                if id.is_empty() {
+                    note("no provider id entered — skipping");
+                } else {
+                    match login_provider_with_options(
+                        &id,
+                        bitrouter_providers::oauth::credential_store::DEFAULT_LABEL,
+                        ProviderLoginOptions::default(),
+                    )
+                    .await
+                    {
+                        Ok(_) => {
+                            configured.insert(id);
+                        }
+                        Err(e) => {
+                            note(&format!("provider '{id}' login did not complete: {e:#}"));
+                            skipped.push(id);
+                        }
+                    }
+                }
+            }
+            "3" if signals.is_configured() => break,
+            "0" => break,
+            other => {
+                note(&format!("'{other}' is not a choice"));
+                continue;
+            }
+        }
+        if !prompt_yes_no("  Add another provider?", false) {
+            break;
+        }
+    }
+    Ok(())
+}
+
+/// The cloud device-flow sign-in. Calls the cloud SDK's `login` directly (not
+/// `cloud::cli::run`) so onboarding emits a single result envelope on stdout;
+/// `login` drives the device-flow prompts on stderr and persists the token.
+async fn seed_cloud_interactive() -> Result<()> {
+    cloud_login(LoginInputs {
+        authorization_server: None,
+        client_id: None,
+        scope: None,
+        api_key: None,
+    })
+    .await
+    .map(|_| ())
+    .context("BitRouter Cloud sign-in")
+}
+
+async fn interactive_harness(flags: &OnboardingFlags) -> Result<Vec<String>> {
+    eprintln!();
+    eprintln!("Step 2/3 — Harness");
+    // Honor flag-provided harnesses non-interactively; otherwise ask.
+    let chosen: Vec<SpawnAgent> = if !flags.harnesses.is_empty() {
+        flags.harnesses.clone()
+    } else {
+        let answer = prompt_line("  Which coding agent do you drive? [claude/codex/skip]: ")?;
+        match answer.to_ascii_lowercase().as_str() {
+            "" | "claude" => vec![SpawnAgent::Claude],
+            "codex" => vec![SpawnAgent::Codex],
+            "skip" | "none" => Vec::new(),
+            other => {
+                note(&format!("'{other}' is not a known harness — skipping"));
+                Vec::new()
+            }
+        }
+    };
+
+    let mut installed = Vec::new();
+    for agent in chosen {
+        // `ensure_agent_installed` offers the native installer when missing (a
+        // TTY + not --no-install) and re-resolves the freshly-installed path,
+        // so the launch exit can't dead-end on the PATH-after-install caveat.
+        match crate::spawn::ensure_agent_installed(agent, flags.no_install).await {
+            Ok(_) => installed.push(agent.spec().id.to_string()),
+            Err(e) => note(&format!("{}: {e:#}", agent.spec().id)),
+        }
+    }
+    Ok(installed)
+}
+
+fn interactive_after(flags: &OnboardingFlags, installed: &[String]) -> Result<AfterAction> {
+    if let Some(after) = flags.after {
+        return Ok(after);
+    }
+    eprintln!();
+    eprintln!("Step 3/3 — Finish");
+    let can_launch = !installed.is_empty();
+    if can_launch {
+        eprintln!("    1) Launch now [default]");
+    }
+    eprintln!("    2) Start the daemon and print a paste-in snippet");
+    eprintln!("    3) Exit");
+    let default_choice = if can_launch { "1" } else { "2" };
+    let choice = prompt_line(&format!("  Choose [{default_choice}]: "))?;
+    let choice = if choice.is_empty() {
+        default_choice.to_string()
+    } else {
+        choice
+    };
+    Ok(match choice.as_str() {
+        "1" if can_launch => AfterAction::Launch,
+        "2" => AfterAction::Serve,
+        _ => AfterAction::Exit,
+    })
+}
+
+// =====================================================================
+// Finish exits (a) launch / (b) serve+snippet
+// =====================================================================
+
+/// Exit (a): emit the envelope, then hand the terminal to the harness. The
+/// launch diverges (it exits the process with the child's status), so the
+/// envelope must be emitted first.
+async fn finish_launch(
+    agent: SpawnAgent,
+    model: Option<&str>,
+    no_install: bool,
+    report: OnboardingReport,
+    output: &Output,
+) -> Result<()> {
+    let source = crate::paths::resolve_config(None)?;
+    let cfg = crate::paths::load_config(&source).await?;
+    emit(output, &report)?;
+    let agent_args = match model {
+        Some(m) if !m.is_empty() => vec!["--model".to_string(), m.to_string()],
+        _ => Vec::new(),
+    };
+    let opts = crate::spawn::SpawnOptions {
+        agent,
+        agent_args,
+        base_url: None,
+        no_install,
+        no_start: false,
+        check: false,
+    };
+    crate::spawn::run(&source, &cfg, opts).await
+}
+
+/// Exit (b): start the local daemon (best-effort, reusing the launch path's
+/// auto-start), build the paste-in snippet, and emit the envelope with it.
+async fn finish_serve(mut report: OnboardingReport, output: &Output) -> Result<()> {
+    let source = crate::paths::resolve_config(None)?;
+    let cfg = crate::paths::load_config(&source).await?;
+    crate::spawn::ensure_local_daemon(&source, &cfg, false).await;
+    report.snippet = Some(build_snippet(&cfg.server.listen));
+    emit(output, &report)
+}
+
+/// Build the three labeled paste-in shapes (§13 Q2). Templates the bearer by
+/// auth mode: a real exported `BITROUTER_API_KEY` (`brk_`) when present, else
+/// the local `skip_auth` placeholder. The Codex form is taken from the shared
+/// harness catalog so it stays in lockstep with `bitrouter launch`.
+fn build_snippet(listen: &str) -> Snippet {
+    let base_url = crate::spawn::derive_base_url(listen);
+    let token = crate::spawn::nonempty_env(crate::harness::BITROUTER_API_KEY_ENV)
+        .unwrap_or_else(|| crate::harness::PLACEHOLDER_API_KEY.to_string());
+    let v1 = {
+        let trimmed = base_url.trim_end_matches('/');
+        if trimmed.ends_with("/v1") {
+            trimmed.to_string()
+        } else {
+            format!("{trimmed}/v1")
+        }
+    };
+    let anthropic =
+        format!("export ANTHROPIC_BASE_URL={base_url}\nexport ANTHROPIC_AUTH_TOKEN={token}");
+    let openai = format!("export OPENAI_BASE_URL={v1}\nexport OPENAI_API_KEY={token}");
+    let codex = match crate::harness::by_id("codex-acp") {
+        Some(h) => {
+            let overlay = h.routing_overlay(&base_url, &token, None);
+            let mut parts = vec!["codex".to_string()];
+            parts.extend(overlay.args);
+            parts.join(" ")
+        }
+        None => String::new(),
+    };
+    Snippet {
+        base_url,
+        anthropic,
+        openai,
+        codex,
+    }
+}
+
+// =====================================================================
+// --reset (§13 Q3)
+// =====================================================================
+
+/// Clears the cloud session (always) and — after a confirm, unless `--yes` —
+/// the stored provider credentials.
+async fn reset_credentials(assume_yes: bool, interactive: bool) -> Result<()> {
+    let cloud_path = default_credentials_path().ok();
+    let mut store = CredentialStore::default_path().ok();
+
+    let provider_ids: Vec<String> = store
+        .as_ref()
+        .map(|s| s.providers().into_iter().map(String::from).collect())
+        .unwrap_or_default();
+
+    // Cloud session is cleared unconditionally; provider credentials only after
+    // an explicit confirm (or under --yes).
+    let remove_providers = if provider_ids.is_empty() {
+        false
+    } else if assume_yes {
+        true
+    } else if interactive {
+        prompt_yes_no(
+            &format!(
+                "  --reset: also remove {} stored provider credential(s) ({})?",
+                provider_ids.len(),
+                provider_ids.join(", ")
+            ),
+            false,
+        )
+    } else {
+        false
+    };
+
+    let outcome = reset_with(cloud_path.as_deref(), store.as_mut(), remove_providers)?;
+    if outcome.cloud_cleared {
+        note("cleared the cloud session");
+    }
+    if outcome.providers_removed > 0 {
+        note(&format!(
+            "removed {} provider credential(s)",
+            outcome.providers_removed
+        ));
+    } else if !provider_ids.is_empty() && !remove_providers {
+        note("kept provider credentials");
+    }
+    Ok(())
+}
+
+/// Outcome of [`reset_with`].
+#[derive(Debug, Default, PartialEq, Eq)]
+struct ResetOutcome {
+    cloud_cleared: bool,
+    providers_removed: usize,
+}
+
+/// The testable core of [`reset_credentials`]: delete the cloud credentials
+/// file if present, and (when asked) remove every provider credential from the
+/// store. Purely local — no network.
+fn reset_with(
+    cloud_path: Option<&std::path::Path>,
+    store: Option<&mut CredentialStore>,
+    remove_providers: bool,
+) -> Result<ResetOutcome> {
+    let mut outcome = ResetOutcome::default();
+    if let Some(path) = cloud_path
+        && path.exists()
+    {
+        std::fs::remove_file(path)
+            .with_context(|| format!("removing cloud credentials {}", path.display()))?;
+        outcome.cloud_cleared = true;
+    }
+    if remove_providers && let Some(store) = store {
+        let ids: Vec<String> = store.providers().into_iter().map(String::from).collect();
+        for id in ids {
+            outcome.providers_removed += store
+                .remove_all_for(&id)
+                .with_context(|| format!("removing credentials for {id}"))?;
+        }
+    }
+    Ok(outcome)
+}
+
+// =====================================================================
+// Small helpers
+// =====================================================================
+
+/// Map a harness id back to its [`SpawnAgent`].
+fn agent_by_id(id: &str) -> Option<SpawnAgent> {
+    SpawnAgent::value_variants()
+        .iter()
+        .copied()
+        .find(|a| a.spec().id == id)
+}
+
+/// The first requested harness that is actually installed (§3.2: "picks
+/// claude|codex when both are installed").
+fn pick_launch_harness(requested: &[SpawnAgent], installed: &[String]) -> Option<SpawnAgent> {
+    requested
+        .iter()
+        .copied()
+        .find(|a| installed.iter().any(|id| id == a.spec().id))
+}
+
+/// A dim, indented note to stderr (diagnostics never touch stdout).
+fn note(msg: &str) {
+    let p = crate::style::Palette::for_stderr();
+    eprintln!("  {dim}{msg}{reset}", dim = p.dim, reset = p.reset);
+}
+
+/// Emit a report to stdout, mapping `Output::emit`'s `io::Result` into the
+/// `anyhow::Result` this module threads.
+fn emit(output: &Output, report: &dyn CliReport) -> Result<()> {
+    Output::emit(output, report).map_err(anyhow::Error::from)
+}
+
+/// Prompt on stderr, read one trimmed line from stdin. EOF yields an empty
+/// string (so non-interactive contexts fall through to defaults, never hang).
+fn prompt_line(prompt: &str) -> Result<String> {
+    use std::io::{BufRead, Write};
+    eprint!("{prompt}");
+    std::io::stderr().flush().ok();
+    let mut line = String::new();
+    let n = std::io::stdin()
+        .lock()
+        .read_line(&mut line)
+        .context("reading input from stdin")?;
+    if n == 0 {
+        return Ok(String::new());
+    }
+    Ok(line.trim().to_string())
+}
+
+/// A `[y/N]` (or `[Y/n]`) confirm. EOF / blank returns `default_yes`.
+fn prompt_yes_no(prompt: &str, default_yes: bool) -> bool {
+    let suffix = if default_yes { "[Y/n]" } else { "[y/N]" };
+    match prompt_line(&format!("{prompt} {suffix}: ")) {
+        Ok(answer) => match answer.to_ascii_lowercase().as_str() {
+            "" => default_yes,
+            "y" | "yes" => true,
+            _ => false,
+        },
+        Err(_) => default_yes,
+    }
+}
+
+/// The multi-line onboarding hint (unconfigured, non-TTY). Mirrors the recovery
+/// chain of the former `print_onboarding_hint`.
+fn print_hint() {
+    let p = crate::style::Palette::for_stderr();
+    eprintln!(
+        "{cyan}{bold}info:{reset} no credentials detected yet. Get started with one of:",
+        cyan = p.cyan,
+        bold = p.bold,
+        reset = p.reset,
+    );
+    eprintln!();
+    eprintln!("  bitrouter init                 # guided setup wizard (interactive)");
+    eprintln!("  bitrouter cloud login          # one BitRouter Cloud account, every model");
+    eprintln!("  bitrouter providers login claude-code   # a subscription you already pay for");
+    eprintln!("  export OPENAI_API_KEY=…        # or any BYOK provider key, then re-run");
+    eprintln!();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detected_env_keys_reports_present_vars_only() {
+        // Only OPENAI + GEMINI "present" in the injected lookup.
+        let present = |name: &str| {
+            matches!(name, "OPENAI_API_KEY" | "GEMINI_API_KEY").then(|| "x".to_string())
+        };
+        let keys = detected_env_keys(present);
+        assert_eq!(keys, vec!["OPENAI_API_KEY", "GEMINI_API_KEY"]);
+    }
+
+    #[test]
+    fn detected_env_keys_ignores_empty_values() {
+        // The probe's real lookup filters empties; here nothing is present.
+        let keys = detected_env_keys(|_| None);
+        assert!(keys.is_empty());
+    }
+
+    #[test]
+    fn probe_uses_gemini_not_google_key() {
+        // GOOGLE_API_KEY must NOT be a probe signal (Google's own SDKs use
+        // GEMINI_API_KEY); guard against a regression to the wrong var.
+        assert!(PROBE_ENV_VARS.iter().any(|(v, _)| *v == "GEMINI_API_KEY"));
+        assert!(!PROBE_ENV_VARS.iter().any(|(v, _)| *v == "GOOGLE_API_KEY"));
+    }
+
+    #[test]
+    fn is_configured_is_false_when_no_signal_present() {
+        assert!(!ProbeSignals::default().is_configured());
+    }
+
+    #[test]
+    fn is_configured_true_for_each_signal_independently() {
+        // env key alone
+        assert!(
+            ProbeSignals {
+                env_keys: vec!["OPENAI_API_KEY".to_string()],
+                ..Default::default()
+            }
+            .is_configured()
+        );
+        // cloud session file alone
+        assert!(
+            ProbeSignals {
+                cloud_session: true,
+                ..Default::default()
+            }
+            .is_configured()
+        );
+        // a stored subscription/provider credential alone
+        assert!(
+            ProbeSignals {
+                subscription_providers: vec!["claude-code".to_string()],
+                ..Default::default()
+            }
+            .is_configured()
+        );
+    }
+
+    #[test]
+    fn already_configured_maps_env_cloud_and_store() {
+        let signals = ProbeSignals {
+            env_keys: vec!["OPENAI_API_KEY".to_string(), "GEMINI_API_KEY".to_string()],
+            cloud_session: true,
+            subscription_providers: vec!["claude-code".to_string()],
+        };
+        let set = signals.already_configured();
+        assert!(set.contains("openai"));
+        assert!(set.contains("google")); // GEMINI_API_KEY → google
+        assert!(set.contains("bitrouter")); // cloud session
+        assert!(set.contains("claude-code"));
+    }
+
+    #[test]
+    fn envelope_shape_includes_skipped_interactive() {
+        let report = OnboardingReport {
+            action: "onboarding",
+            providers_configured: vec!["bitrouter".to_string(), "openai".to_string()],
+            providers_skipped_interactive: vec!["github-copilot".to_string()],
+            harnesses_installed: vec!["claude".to_string()],
+            after: "launch".to_string(),
+            snippet: None,
+        };
+        let v = serde_json::to_value(&report).unwrap();
+        assert_eq!(v["action"], "onboarding");
+        assert_eq!(
+            v["providers_configured"],
+            serde_json::json!(["bitrouter", "openai"])
+        );
+        assert_eq!(
+            v["providers_skipped_interactive"],
+            serde_json::json!(["github-copilot"])
+        );
+        assert_eq!(v["harnesses_installed"], serde_json::json!(["claude"]));
+        assert_eq!(v["after"], "launch");
+        // `snippet` is present-but-null when there is nothing to paste.
+        assert!(v.get("snippet").is_some());
+        assert!(v["snippet"].is_null());
+    }
+
+    #[test]
+    fn snippet_uses_placeholder_when_no_bitrouter_key() {
+        // With no BITROUTER_API_KEY exported, the local `skip_auth` placeholder
+        // is templated into all three shapes.
+        // (This test process does not set BITROUTER_API_KEY.)
+        if crate::spawn::nonempty_env(crate::harness::BITROUTER_API_KEY_ENV).is_some() {
+            return; // environment is non-hermetic; skip rather than false-fail
+        }
+        let snippet = build_snippet("127.0.0.1:4356");
+        assert_eq!(snippet.base_url, "http://127.0.0.1:4356");
+        assert!(
+            snippet
+                .anthropic
+                .contains("ANTHROPIC_BASE_URL=http://127.0.0.1:4356")
+        );
+        assert!(snippet.anthropic.contains(&format!(
+            "ANTHROPIC_AUTH_TOKEN={}",
+            crate::harness::PLACEHOLDER_API_KEY
+        )));
+        // OpenAI shape carries the /v1 suffix.
+        assert!(
+            snippet
+                .openai
+                .contains("OPENAI_BASE_URL=http://127.0.0.1:4356/v1")
+        );
+        // Codex shape is the `-c` provider override, in lockstep with launch.
+        assert!(snippet.codex.starts_with("codex "));
+        assert!(snippet.codex.contains("model_provider=\"bitrouter\""));
+        assert!(snippet.codex.contains("http://127.0.0.1:4356/v1"));
+    }
+
+    #[test]
+    fn pick_launch_harness_prefers_first_installed() {
+        let requested = vec![SpawnAgent::Codex, SpawnAgent::Claude];
+        // Only claude installed → codex requested first but skipped.
+        let picked = pick_launch_harness(&requested, &["claude".to_string()]);
+        assert_eq!(picked, Some(SpawnAgent::Claude));
+        // Neither installed → None (launch downgrades to exit).
+        assert_eq!(pick_launch_harness(&requested, &[]), None);
+    }
+
+    #[test]
+    fn agent_by_id_round_trips() {
+        assert_eq!(agent_by_id("claude"), Some(SpawnAgent::Claude));
+        assert_eq!(agent_by_id("codex"), Some(SpawnAgent::Codex));
+        assert_eq!(agent_by_id("nope"), None);
+    }
+
+    fn tmp_dir(label: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "bitrouter-onboarding-{label}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn reset_clears_cloud_session_and_optionally_providers() {
+        let dir = tmp_dir("reset");
+        let cloud = dir.join("account-credentials.json");
+        std::fs::write(&cloud, "{}").unwrap();
+        let mut store = CredentialStore::load(dir.join("oauth-tokens.json")).unwrap();
+        store
+            .set(
+                "claude-code",
+                "default",
+                bitrouter_providers::oauth::credential_store::Credential::ClaudeCodeCli,
+            )
+            .unwrap();
+        store
+            .set(
+                "openai",
+                "default",
+                bitrouter_providers::oauth::credential_store::Credential::api_key("sk-x"),
+            )
+            .unwrap();
+
+        // remove_providers = false: cloud cleared, provider creds kept (Q3).
+        let outcome = reset_with(Some(&cloud), Some(&mut store), false).unwrap();
+        assert!(outcome.cloud_cleared);
+        assert_eq!(outcome.providers_removed, 0);
+        assert!(!cloud.exists());
+        assert_eq!(store.providers().len(), 2, "provider creds must survive");
+
+        // remove_providers = true: every provider credential is dropped.
+        let outcome = reset_with(None, Some(&mut store), true).unwrap();
+        assert!(!outcome.cloud_cleared); // no cloud file this call
+        assert_eq!(outcome.providers_removed, 2);
+        assert!(store.providers().is_empty());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn reset_is_a_noop_when_nothing_stored() {
+        let dir = tmp_dir("reset-empty");
+        let missing_cloud = dir.join("account-credentials.json");
+        let mut store = CredentialStore::load(dir.join("oauth-tokens.json")).unwrap();
+        let outcome = reset_with(Some(&missing_cloud), Some(&mut store), true).unwrap();
+        assert_eq!(outcome, ResetOutcome::default());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn status_report_lists_signals_and_hint() {
+        let signals = ProbeSignals {
+            env_keys: vec!["OPENAI_API_KEY".to_string()],
+            cloud_session: true,
+            subscription_providers: vec![],
+        };
+        let report = OnboardingStatusReport::from_signals(&signals);
+        assert!(report.configured);
+        assert!(report.hint.contains("bitrouter launch"));
+        let v = serde_json::to_value(&report).unwrap();
+        assert_eq!(v["action"], "status");
+        assert_eq!(v["configured"], true);
+    }
+}

--- a/apps/bitrouter/src/output/reports/config.rs
+++ b/apps/bitrouter/src/output/reports/config.rs
@@ -1,24 +1,10 @@
-//! Reports for `init` and `config validate`.
+//! Reports for `config validate`. (`bitrouter init` now emits the onboarding
+//! result envelope via `crate::onboarding` rather than a dedicated report.)
 
 use serde::Serialize;
 
 use crate::output::CliReport;
 use crate::output::human::Human;
-
-/// Result of `bitrouter init`.
-#[derive(Serialize)]
-pub struct InitReport {
-    pub action: &'static str,
-    pub path: String,
-    pub skip_auth: bool,
-}
-
-impl CliReport for InitReport {
-    fn render(&self, h: &mut Human<'_>) -> std::io::Result<()> {
-        h.line(&format!("wrote starter config to {}", self.path))?;
-        h.note("skip_auth is on — credential-less local requests are admitted")
-    }
-}
 
 /// One unset `${VAR}` substituted with a placeholder during validation.
 #[derive(Serialize)]

--- a/apps/bitrouter/tests/onboarding.rs
+++ b/apps/bitrouter/tests/onboarding.rs
@@ -1,0 +1,201 @@
+//! Binary-level coverage for the `bitrouter` onboarding front door — bare
+//! invocation (wizard-vs-status decision), the `init --yes` headless contract,
+//! and the network-free / `BITROUTER_HOME`-tolerant probe. Every case here is
+//! hermetic: an isolated `HOME` + `XDG_DATA_HOME`, all BYOK env vars removed,
+//! stdin nulled (non-TTY), and no network.
+
+use std::path::Path;
+use std::process::{Command, Output, Stdio};
+
+use serde_json::Value;
+use tempfile::TempDir;
+
+/// The BYOK env vars the probe reads — removed so the test's own environment
+/// can't make an "unconfigured" case look configured.
+const PROBE_VARS: &[&str] = &[
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GEMINI_API_KEY",
+    "OPENROUTER_API_KEY",
+    "OPENCODE_ZEN_API_KEY",
+    "BITROUTER_API_KEY",
+];
+
+/// Run the compiled binary with an isolated home/data dir and a null (non-TTY)
+/// stdin. `extra_env` layers provider-key or `BITROUTER_HOME` overrides on top.
+fn run_cli(home: &Path, data_home: &Path, args: &[&str], extra_env: &[(&str, &str)]) -> Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_bitrouter"));
+    command
+        .args(args)
+        .env("HOME", home)
+        .env("XDG_DATA_HOME", data_home)
+        .env_remove("BITROUTER_HOME")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    for var in PROBE_VARS {
+        command.env_remove(var);
+    }
+    for (k, v) in extra_env {
+        command.env(k, v);
+    }
+    command.output().unwrap()
+}
+
+fn stdout_json(output: &Output) -> Value {
+    let text = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(&text).unwrap_or_else(|e| panic!("stdout was not JSON ({e}): {text}"))
+}
+
+#[test]
+fn bare_unconfigured_emits_inert_envelope_and_exits_zero() {
+    let home = TempDir::new().unwrap();
+    let data = TempDir::new().unwrap();
+    // Nothing configured + no TTY: the wizard can't run, so onboarding prints
+    // the hint to stderr and emits an inert envelope — never hangs, exit 0.
+    let out = run_cli(home.path(), data.path(), &[], &[]);
+    assert!(out.status.success(), "bare bitrouter must exit 0");
+    let v = stdout_json(&out);
+    assert_eq!(v["action"], "onboarding");
+    assert_eq!(v["providers_configured"], serde_json::json!([]));
+    assert_eq!(v["after"], "exit");
+}
+
+#[test]
+fn bare_configured_prints_status_not_wizard() {
+    let home = TempDir::new().unwrap();
+    let data = TempDir::new().unwrap();
+    // A detected BYOK env key makes the probe report "configured": bare
+    // bitrouter prints a status view (action=status), never the wizard.
+    let out = run_cli(
+        home.path(),
+        data.path(),
+        &[],
+        &[("OPENAI_API_KEY", "sk-detected")],
+    );
+    assert!(out.status.success());
+    let v = stdout_json(&out);
+    assert_eq!(v["action"], "status");
+    assert_eq!(v["configured"], true);
+    // No config file is written as a side effect of a status view.
+    assert!(!home.path().join("bitrouter.yaml").exists());
+}
+
+#[test]
+fn bitrouter_home_set_but_missing_offers_onboarding_not_a_hard_error() {
+    let home = TempDir::new().unwrap();
+    let data = TempDir::new().unwrap();
+    // BITROUTER_HOME points at a directory with no bitrouter.yaml — which
+    // `resolve_config` treats as a hard error. The probe-based onboarding entry
+    // must sidestep that: exit 0, emit the envelope, and never surface the
+    // "BITROUTER_HOME is set … but … is missing" error.
+    let br_home = TempDir::new().unwrap();
+    let out = run_cli(
+        home.path(),
+        data.path(),
+        &[],
+        &[("BITROUTER_HOME", br_home.path().to_str().unwrap())],
+    );
+    assert!(
+        out.status.success(),
+        "BITROUTER_HOME-missing must not hard-error bare bitrouter"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.contains("BITROUTER_HOME is set"),
+        "must not surface the resolve_config hard error: {stderr}"
+    );
+    let v = stdout_json(&out);
+    assert_eq!(v["action"], "onboarding");
+}
+
+#[test]
+fn init_yes_no_creds_reports_zero_providers_and_scaffolds() {
+    let home = TempDir::new().unwrap();
+    let data = TempDir::new().unwrap();
+    let cfg = home.path().join("bitrouter.yaml");
+    // Headless with no credential flags: completes without blocking, emits the
+    // envelope with zero providers, and reproduces the classic starter-file
+    // scaffold at the -c path.
+    let out = run_cli(
+        home.path(),
+        data.path(),
+        &["init", "--yes", "-c", cfg.to_str().unwrap()],
+        &[],
+    );
+    assert!(out.status.success(), "init --yes must exit 0");
+    let v = stdout_json(&out);
+    assert_eq!(v["action"], "onboarding");
+    assert_eq!(v["providers_configured"], serde_json::json!([]));
+    assert_eq!(v["harnesses_installed"], serde_json::json!([]));
+    assert_eq!(v["after"], "exit");
+    assert!(v["snippet"].is_null());
+    assert!(cfg.exists(), "init --yes scaffolds the starter config");
+    assert!(
+        std::fs::read_to_string(&cfg)
+            .unwrap()
+            .contains("skip_auth: true"),
+        "the scaffolded file is the starter config"
+    );
+}
+
+#[test]
+fn init_yes_cloud_login_without_key_is_reported_and_skipped() {
+    let home = TempDir::new().unwrap();
+    let data = TempDir::new().unwrap();
+    let cfg = home.path().join("bitrouter.yaml");
+    // A bare --cloud-login can't be completed by a machine (device flow), so
+    // headless reports-and-skips it rather than attempting/hanging.
+    let out = run_cli(
+        home.path(),
+        data.path(),
+        &[
+            "init",
+            "--yes",
+            "--cloud-login",
+            "--after",
+            "exit",
+            "-c",
+            cfg.to_str().unwrap(),
+        ],
+        &[],
+    );
+    assert!(out.status.success());
+    let v = stdout_json(&out);
+    assert_eq!(
+        v["providers_skipped_interactive"],
+        serde_json::json!(["bitrouter"])
+    );
+}
+
+#[test]
+fn init_yes_refuses_overwrite_without_force() {
+    let home = TempDir::new().unwrap();
+    let data = TempDir::new().unwrap();
+    let cfg = home.path().join("bitrouter.yaml");
+    std::fs::write(&cfg, "# hand-tuned\n").unwrap();
+
+    // Without --force, an existing config is left untouched.
+    let out = run_cli(
+        home.path(),
+        data.path(),
+        &["init", "--yes", "-c", cfg.to_str().unwrap()],
+        &[],
+    );
+    assert!(out.status.success());
+    assert_eq!(std::fs::read_to_string(&cfg).unwrap(), "# hand-tuned\n");
+
+    // With --force it overwrites with the starter template.
+    let out = run_cli(
+        home.path(),
+        data.path(),
+        &["init", "--yes", "--force", "-c", cfg.to_str().unwrap()],
+        &[],
+    );
+    assert!(out.status.success());
+    assert!(
+        std::fs::read_to_string(&cfg)
+            .unwrap()
+            .contains("skip_auth: true")
+    );
+}

--- a/docs/get-started/configuration.md
+++ b/docs/get-started/configuration.md
@@ -61,7 +61,7 @@ For terminal-first setup, launch the wizard:
 bitrouter
 ```
 
-The wizard asks **Cloud or local?** (default Cloud), prompts for keys if you choose local, then starts the proxy at `http://127.0.0.1:4356`. Toggle between modes with a single keypress.
+The wizard walks three steps — **credentials** (sign in to BitRouter Cloud by default, log in to a provider, or paste a BYOK key), **harness** (Claude Code or Codex), and **finish** (launch the agent, start the proxy at `http://127.0.0.1:4356`, or exit). Re-run it any time with `bitrouter init`; add `--yes` to drive it non-interactively (it emits a JSON result envelope and never blocks).
 
 ## Run self-hosted
 

--- a/docs/get-started/configuration.zh.md
+++ b/docs/get-started/configuration.zh.md
@@ -61,7 +61,7 @@ npx skills add bitrouter/bitrouter
 bitrouter
 ```
 
-向导会询问 **Cloud 还是本地？**（默认 Cloud），如果选择本地则提示输入密钥，随后在 `http://127.0.0.1:4356` 启动代理。按一个键即可在两种模式间切换。
+向导分为三步——**凭据**（默认登录 BitRouter Cloud，或登录某个提供方，或粘贴 BYOK 密钥）、**Harness**（Claude Code 或 Codex）、**收尾**（立即启动 agent、在 `http://127.0.0.1:4356` 启动代理，或退出）。随时用 `bitrouter init` 重新运行；加上 `--yes` 即可非交互式驱动（它会输出 JSON 结果信封且从不阻塞）。
 
 ## 自托管运行
 

--- a/skills/bitrouter/SKILL.md
+++ b/skills/bitrouter/SKILL.md
@@ -79,7 +79,7 @@ Verify: `bitrouter --version`. If `command not found`, see `references/diagnose.
 
 ## 3. Run (Local only)
 
-BitRouter has no interactive setup wizard — onboarding is two commands.
+**Guided onboarding.** Bare `bitrouter` (no subcommand) is the front door: a network-free credential probe launches a scripted wizard (credentials → harness → launch/serve/exit) when nothing is configured, or prints a one-line status + `bitrouter launch` hint when it already is (never re-onboards, never auto-spawns). `bitrouter init` re-runs it; every prompt has a flag, so `bitrouter init --yes [flags]` runs headlessly, emits the JSON envelope, never blocks, and scaffolds the starter `bitrouter.yaml` (`--force` overwrites, `--reset` clears credentials first). `--yes` reports-and-skips anything needing interactive OAuth (bare `--cloud-login`, provider PKCE/device) in `providers_skipped_interactive`. The two commands below remain the fast path.
 
 **Zero-config (BYOK).** Export any of the supported env vars and start the daemon. It auto-enables every provider whose key is present.
 
@@ -123,6 +123,8 @@ bitrouter providers login github-copilot    # browser device flow, token stored 
 bitrouter providers login supergrok         # SuperGrok via the Grok CLI session (~/.grok)
 bitrouter providers login google-ai         # Google AI (Antigravity) via the `agy` CLI keyring session
 ```
+
+Seed a BYOK provider (any that accepts a pasted key — `openai`, `anthropic`, `google`, `openrouter`, `opencode-*`) non-interactively with `--api-key sk-…` or `--key-stdin` (`printf %s "$KEY" | bitrouter providers login anthropic --key-stdin`). Both skip the method menu, conflict with the OAuth-only `--import-existing` / `--no-browser`, and error if the provider has no API-key method.
 
 ## 4. Connect your SDK
 

--- a/skills/bitrouter/references/cli.md
+++ b/skills/bitrouter/references/cli.md
@@ -2,6 +2,8 @@
 
 Every subcommand the v1 binary actually exposes. Anything not listed here doesn't exist — don't suggest `bitrouter doctor`, `bitrouter providers add`, `bitrouter cloud connect`, or the old auth subcommand tree (cloud identity is `bitrouter cloud whoami`, see below).
 
+Bare `bitrouter` (no subcommand) is the onboarding front door: it runs the network-free credential probe and either launches the setup wizard (unconfigured) or prints a one-line status + a `bitrouter launch` hint (configured), exit 0 either way. See `bitrouter init` under *Setup helpers*.
+
 ## Daemon lifecycle
 
 | Command | Effect |
@@ -70,7 +72,7 @@ See `references/sessions.md` for the full per-session model (identity, turn queu
 
 | Command | Effect |
 |---|---|
-| `bitrouter init [--config PATH]` | Write a starter `bitrouter.yaml` (default `./bitrouter.yaml`). Refuses to overwrite. Mirrors the zero-config defaults — `skip_auth: true`, `listen: 127.0.0.1:4356`, and common registry providers stubbed as `{}` so they can inherit registry defaults and auto-enable when their credential is available. |
+| `bitrouter init [flags]` | Guided onboarding wizard: **credentials** → **harness** → **finish** (launch / serve+snippet / exit). Interactive by default; `--yes` runs it headlessly — process the flags below, never block on a human, emit the JSON result envelope (`action: onboarding`, `providers_configured`, `providers_skipped_interactive`, `harnesses_installed`, `after`, `snippet`), and scaffold the starter `bitrouter.yaml` (`skip_auth: true`, `listen: 127.0.0.1:4356`, common providers stubbed `{}`). The scaffold refuses to overwrite unless `--force`; `--reset` clears stored credentials first (cloud session always, provider creds after a confirm / unconditionally under `--yes`). Flags mirror every prompt: `--cloud-login`, `--api-key <brk_…>` (cloud), `--provider <id>` + `--provider-api-key <k>` (repeatable), `--use-detected`, `--harness claude\|codex` (repeatable), `--no-install`, `--after launch\|serve\|exit`, `--model <id>`, `--write-config`, `-c/--config PATH`. Under `--yes`, anything needing interactive OAuth (bare `--cloud-login`, a `--provider` with no key) is reported in `providers_skipped_interactive`, not attempted. |
 | `bitrouter config validate [--config PATH]` | Validate a config file by running the real parse path: structure (deserialization), `derives` resolution, the upstream-URL (SSRF) gate, and any referenced `policy-lock.yaml`. Exits non-zero on an invalid config — **CI-safe**. Does *not* load the JSON Schema (that artifact, at `dist/schema/bitrouter.config.schema.json` / regenerated with `cargo run -p dist-helper -- generate-schema`, is for IDE autocomplete + the drift check). Unset `${VAR}` references are substituted with a `.invalid` placeholder and reported as warnings, so secrets need not be present; a value that embeds one mid-string is not authoritatively checked. |
 | `bitrouter policy create <id> [--dir DIR]` | Write a starter access-control policy file under `--dir` (default `./policies`). Bind to a key with `bitrouter key sign --user <id> --policy <id>`. |
 | `bitrouter policy init <name> --preset <preset> --economy <model> [--strong <model>] [--config PATH]` | Create or extend the deterministic `policy-lock.yaml`, bind the named policy to a preset, and leave programmatic writeback locked. The strong model is inferred from an existing preset when omitted. |
@@ -86,6 +88,7 @@ See `references/sessions.md` for the full per-session model (identity, turn queu
 | Command | Effect |
 |---|---|
 | `bitrouter providers login <provider>` | Per-provider OAuth. Supported providers include **`claude-code`**, **`github-copilot`**, and **`openai-codex`** — runs or adopts the provider's login flow and stores the refreshing token under `$XDG_DATA_HOME/bitrouter/oauth-tokens.json`. |
+| `bitrouter providers login <provider> --api-key <KEY>` / `--key-stdin` | Seed a BYOK provider (any that accepts a pasted key — `openai`, `anthropic`, `google`, `openrouter`, `opencode-*`) non-interactively: skips the method menu and the stdin paste. `--key-stdin` reads one line from stdin instead. Both conflict with the OAuth-only `--import-existing` / `--no-browser`, and error if the provider has no API-key method. For `bitrouter`, the key seeds the cloud credential (same as `cloud login --api-key`). |
 | `bitrouter providers logout <provider>` | Remove the stored OAuth token or credential for `<provider>`. |
 
 ## BitRouter Cloud sign-in (`bitrouter cloud …`)


### PR DESCRIPTION
> **Stacked on #715** (base = `claude/bitrouter-tui-production-bb62f6`) — this PR's diff is only the onboarding wizard. Review/merge #715 first; this then retargets to `main`.

## What

A deterministic CLI onboarding wizard that sequences existing verbs (credential sign-in, harness install, launch/serve) and ends in first value. No LLM/agent, no Node, no config writeback — **credentials are the only durable output**; agent-led onboarding is deferred.

## Flow

- **Entry:** bare `bitrouter` runs the wizard only when unconfigured (no config *and* no usable credential); otherwise prints status + a `bitrouter launch` hint. `bitrouter init` (re)runs it; `init --yes` reproduces the starter-file scaffold, plus `--force` (overwrite) and `--reset` (clear creds).
- **Step 1 — Credentials:** network-free probe (env keys, cloud session, provider store — no registry/network), default `cloud login`, multi-provider loop.
- **Step 2 — Harness:** install the coding agent(s) you drive (`claude`/`codex`) via the native installer.
- **Step 3 — Finish:** launch the harness TUI, start the daemon + print a paste-in snippet (Anthropic/OpenAI/Codex), or exit.
- **Agent-native:** every prompt has a flag; `--yes` runs headless, never blocks, reports-and-skips interactive OAuth, and emits a single JSON envelope.

## Surface changes

- New `apps/bitrouter/src/onboarding.rs` (+ integration tests).
- `Cli.command` is now `Option<Command>` so bare invocation dispatches to onboarding.
- `providers login` gains `--api-key` / `--key-stdin` for non-interactive BYOK.
- Docs in lockstep (SKILL.md, references/cli.md, CLI.md, configuration.md + .zh.md). Design in `ONBOARDING_SPEC.md`.

## Deferred (ONBOARDING_SPEC.md §2)

- Persisting default model / default orchestrator / harness fleet (needs a config writer + schema fields — `Config` is `Deserialize`-only today).
- ACP agents as launch orchestrators (`launch` runs `claude|codex` only).
- Agent-led / TUI-manager onboarding.

## Verification

- Full workspace gate green on `main` (1653 tests) before stacking; on this stack the bitrouter-crate gate is green (**758 passed**, clippy + fmt clean).
- Live e2e: bare unconfigured→hint, configured→status, `init --yes` scaffold/`--force`/`--reset`, `providers login --api-key` no-prompt, `BITROUTER_HOME`-missing→onboarding, `--after serve` snippet — all single-envelope, no hangs, probe confirmed network-free.
- Independently audited; the one finding (cloud `--yes` double-JSON emit) is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
