### PR TITLE
feat(tui): wire MCP and skills gateways into harnesses

### DIFF
--- a/apps/bitrouter/src/fleet_mcp.rs
+++ b/apps/bitrouter/src/fleet_mcp.rs
@@ -271,6 +271,10 @@ struct FleetInner {
     /// conversation instead of the human-bridge / deny fallback. `None` when the
     /// seam isn't wired (default behavior unchanged).
     escalation: Option<Arc<EscalationState>>,
+    /// Gateway MCP descriptors (`bitrouter_tools`/`bitrouter_skills`, see
+    /// `crate::gateways`) passed to every spawned subagent's `session/new`,
+    /// so subagents reach the same tool/skill surface as the orchestrator.
+    subagent_mcp: Vec<agent_client_protocol::schema::v1::McpServer>,
     /// The live subagent registry, under one lock. Also serializes
     /// integration: `apply`/`merge` hold this lock, so branches integrate one
     /// at a time.
@@ -469,6 +473,7 @@ impl SubstrateFleet {
         allow_writes: bool,
         budget: Option<BudgetCeiling>,
         escalation: Option<Arc<EscalationState>>,
+        subagent_mcp: Vec<agent_client_protocol::schema::v1::McpServer>,
     ) -> Self {
         #[cfg(unix)]
         let link = match std::env::var(crate::fleet::TUI_SOCK_ENV) {
@@ -482,6 +487,7 @@ impl SubstrateFleet {
             allow_writes,
             budget,
             escalation,
+            subagent_mcp,
             registry: tokio::sync::Mutex::new(Registry::default()),
             reserving: Arc::new(AtomicUsize::new(0)),
             #[cfg(unix)]
@@ -586,6 +592,9 @@ impl SubstrateFleet {
             worktree: isolate.then(|| crate::fleet::worktree_spec(&tag)),
             worktree_bootstrap: if bootstrap_gated { None } else { bootstrap_cmd },
             env: crate::fleet::port_env(port.as_ref().map(|l| l.port())),
+            // Subagents get the gateway servers (tools/skills) in their
+            // `session/new` — the same surface the orchestrator has.
+            mcp_servers: inner.subagent_mcp.clone(),
             ..Default::default()
         };
         let base_ref = crate::fleet::base_head(&inner.base_repo).await;
@@ -1244,8 +1253,9 @@ mod tests {
             PathBuf::from("/tmp"),
             WorktreesConfig::default(),
             false,
-            None, // no budget ceiling in this test
-            None, // no escalation seam in this test
+            None,       // no budget ceiling in this test
+            None,       // no escalation seam in this test
+            Vec::new(), // no gateway descriptors in this test
         )
         .await;
         let err = fleet
@@ -1260,8 +1270,9 @@ mod tests {
             PathBuf::from("/tmp"),
             WorktreesConfig::default(),
             true,
-            None, // no budget ceiling in this test
-            None, // no escalation seam in this test
+            None,       // no budget ceiling in this test
+            None,       // no escalation seam in this test
+            Vec::new(), // no gateway descriptors in this test
         )
         .await;
         assert!(granted.require_write_grant("merge_subagent").is_ok());
@@ -1278,8 +1289,9 @@ mod tests {
             PathBuf::from("/tmp"),
             WorktreesConfig::default(),
             false,
-            None, // no budget ceiling in this test
-            None, // no escalation seam in this test
+            None,       // no budget ceiling in this test
+            None,       // no escalation seam in this test
+            Vec::new(), // no gateway descriptors in this test
         )
         .await;
         let out = fleet.notify("heads up").await.expect("notify ok");
@@ -1304,8 +1316,9 @@ mod tests {
             PathBuf::from("/tmp"),
             WorktreesConfig::default(),
             false,
-            None, // no budget ceiling in this test
-            None, // no escalation seam in this test
+            None,       // no budget ceiling in this test
+            None,       // no escalation seam in this test
+            Vec::new(), // no gateway descriptors in this test
         )
         .await;
         for res in [
@@ -1476,9 +1489,10 @@ mod e2e_tests {
             worker_catalog(),
             repo.path().to_path_buf(),
             WorktreesConfig::default(),
-            true, // write autonomy granted for this test
-            None, // no budget ceiling in this test
-            None, // no escalation seam in this test
+            true,       // write autonomy granted for this test
+            None,       // no budget ceiling in this test
+            None,       // no escalation seam in this test
+            Vec::new(), // no gateway descriptors in this test
         )
         .await;
 
@@ -1557,8 +1571,9 @@ mod e2e_tests {
             repo.path().to_path_buf(),
             WorktreesConfig::default(),
             true,
-            None, // no budget ceiling in this test
-            None, // no escalation seam in this test
+            None,       // no budget ceiling in this test
+            None,       // no escalation seam in this test
+            Vec::new(), // no gateway descriptors in this test
         )
         .await;
         let summary = fleet
@@ -1598,8 +1613,9 @@ mod e2e_tests {
             repo.path().to_path_buf(),
             WorktreesConfig::default(),
             false,
-            None, // no budget ceiling in this test
-            None, // no escalation seam in this test
+            None,       // no budget ceiling in this test
+            None,       // no escalation seam in this test
+            Vec::new(), // no gateway descriptors in this test
         )
         .await;
         // Fill the fleet to the cap (no worktrees: keep the test light).
@@ -1665,8 +1681,9 @@ mod e2e_tests {
                 repo.path().to_path_buf(),
                 WorktreesConfig::default(),
                 false,
-                None, // no budget ceiling in this test
-                None, // no escalation seam in this test
+                None,       // no budget ceiling in this test
+                None,       // no escalation seam in this test
+                Vec::new(), // no gateway descriptors in this test
             )
             .await,
         );
@@ -1796,7 +1813,8 @@ mod e2e_tests {
             WorktreesConfig::default(),
             false,
             Some(BudgetCeiling::new(10_000_000, spend.clone())),
-            None, // no escalation seam in this test
+            None,       // no escalation seam in this test
+            Vec::new(), // no gateway descriptors in this test
         )
         .await;
 
@@ -1858,8 +1876,9 @@ mod e2e_tests {
             repo.path().to_path_buf(),
             WorktreesConfig::default(),
             false,
-            None, // no ceiling
-            None, // no escalation seam in this test
+            None,       // no ceiling
+            None,       // no escalation seam in this test
+            Vec::new(), // no gateway descriptors in this test
         )
         .await;
         let summary = fleet

--- a/apps/bitrouter/src/gateways.rs
+++ b/apps/bitrouter/src/gateways.rs
@@ -1,0 +1,128 @@
+//! The gateway MCP servers injected into TUI-launched harnesses.
+//!
+//! Two of BitRouter's four gateways reach a launched harness as injected MCP
+//! servers (the other two — models and ACP — ride the routing overlay and
+//! the fleet bridge):
+//!
+//! - **`bitrouter_tools`** — the MCP gateway: the daemon's aggregate endpoint
+//!   (`mcp.aggregate.route`, default `POST /mcp`), which fans out to every
+//!   configured `mcp_servers` upstream with `{server}__` tool prefixes.
+//!   Injected as a streamable-HTTP server so the harness's own MCP client
+//!   dials the daemon directly.
+//! - **`bitrouter_skills`** — the AgentSkills gateway: this binary running
+//!   `mcp serve --backend skills` (stdio), serving `skills_search` /
+//!   `skills_get` over the installed-skills root.
+//!
+//! Both harness roles get the same pair — the interactive orchestrator via
+//! config synthesis ([`crate::harness::Harness::orchestrator_overlay`]) and
+//! ACP subagents via `session/new` `mcpServers` descriptors ([`to_acp`]).
+//! One spec, two renderers, so the roles can't drift.
+
+use agent_client_protocol::schema::v1 as acp;
+
+use crate::harness::{McpServer, McpTransport};
+
+/// The gateway servers for a daemon at `base_url`, authenticating with
+/// `auth`. `aggregate_route` is the daemon's aggregate MCP path
+/// (`mcp.aggregate.route`); `None` (aggregate disabled) omits the
+/// `bitrouter_tools` server.
+pub fn gateway_servers(
+    base_url: &str,
+    auth: &str,
+    aggregate_route: Option<&str>,
+) -> Vec<McpServer> {
+    let mut servers = Vec::new();
+    if let Some(route) = aggregate_route {
+        servers.push(McpServer {
+            name: "bitrouter_tools".to_string(),
+            transport: McpTransport::Http {
+                url: join_route(base_url, route),
+                // Same convention as the models routing overlay: always send
+                // the credential — ignored by the daemon under `skip_auth:
+                // true` (the local default), validated when auth is on.
+                headers: vec![("Authorization".to_string(), format!("Bearer {auth}"))],
+            },
+        });
+    }
+    servers.push(McpServer {
+        name: "bitrouter_skills".to_string(),
+        transport: McpTransport::Stdio {
+            command: std::env::current_exe()
+                .map(|p| p.display().to_string())
+                .unwrap_or_else(|_| "bitrouter".to_string()),
+            args: ["mcp", "serve", "--backend", "skills"]
+                .map(str::to_string)
+                .to_vec(),
+        },
+    });
+    servers
+}
+
+/// Render a harness-facing server spec as the ACP `session/new` `mcpServers`
+/// descriptor for a spawned subagent. Descriptor headers are the ACP wire
+/// shape — an array of `{name, value}` — where harness config files carry an
+/// object; both render from the same [`McpTransport`].
+pub fn to_acp(server: &McpServer) -> acp::McpServer {
+    match &server.transport {
+        McpTransport::Stdio { command, args } => acp::McpServer::Stdio(
+            acp::McpServerStdio::new(server.name.clone(), command.clone()).args(args.clone()),
+        ),
+        McpTransport::Http { url, headers } => acp::McpServer::Http(
+            acp::McpServerHttp::new(server.name.clone(), url.clone()).headers(
+                headers
+                    .iter()
+                    .map(|(name, value)| acp::HttpHeader::new(name.clone(), value.clone()))
+                    .collect(),
+            ),
+        ),
+    }
+}
+
+/// Join the daemon base URL and the aggregate route without doubling or
+/// dropping the separating slash.
+fn join_route(base_url: &str, route: &str) -> String {
+    let base = base_url.trim_end_matches('/');
+    if route.starts_with('/') {
+        format!("{base}{route}")
+    } else {
+        format!("{base}/{route}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tools_rides_the_aggregate_route_with_bearer_auth() {
+        let servers = gateway_servers("http://127.0.0.1:4356/", "tok", Some("/mcp"));
+        assert_eq!(servers.len(), 2);
+        // Serialize the ACP rendering to lock the wire shape: tagged http
+        // variant, headers as a {name, value} array.
+        let wire = serde_json::to_value(to_acp(&servers[0])).expect("serialize");
+        assert_eq!(wire["type"], "http");
+        assert_eq!(wire["name"], "bitrouter_tools");
+        assert_eq!(wire["url"], "http://127.0.0.1:4356/mcp");
+        assert_eq!(wire["headers"][0]["name"], "Authorization");
+        assert_eq!(wire["headers"][0]["value"], "Bearer tok");
+    }
+
+    #[test]
+    fn skills_is_stdio_and_survives_a_disabled_aggregate() {
+        let servers = gateway_servers("http://127.0.0.1:4356", "tok", None);
+        assert_eq!(servers.len(), 1, "aggregate off drops bitrouter_tools");
+        let wire = serde_json::to_value(to_acp(&servers[0])).expect("serialize");
+        assert_eq!(wire["name"], "bitrouter_skills");
+        assert!(wire.get("type").is_none(), "stdio is the untagged variant");
+        assert_eq!(
+            wire["args"],
+            serde_json::json!(["mcp", "serve", "--backend", "skills"])
+        );
+    }
+
+    #[test]
+    fn join_route_normalizes_slashes() {
+        assert_eq!(join_route("http://x:1/", "/mcp"), "http://x:1/mcp");
+        assert_eq!(join_route("http://x:1", "mcp"), "http://x:1/mcp");
+    }
+}

--- a/apps/bitrouter/src/harness.rs
+++ b/apps/bitrouter/src/harness.rs
@@ -375,31 +375,44 @@ impl Harness {
     /// synthesized providers' model lists so the harness's own model picker
     /// shows what the daemon can serve. `model` pins the model (and becomes
     /// the synthesized default); when absent, the first catalog entry is
-    /// the default. `mcp` is the bridge to inject where the harness has an
-    /// MCP mechanism — pi has none, so its orchestrator runs without fleet
-    /// tools.
+    /// the default. `mcp` lists the servers to inject where the harness has
+    /// an MCP mechanism — pi has none, so its orchestrator runs without
+    /// them.
     pub fn orchestrator_overlay(
         &self,
         base_url: &str,
         auth: &str,
         model: Option<&str>,
         catalog: &[String],
-        mcp: Option<&McpServer>,
+        mcp: &[McpServer],
         state_dir: &std::path::Path,
     ) -> anyhow::Result<RoutingOverlay> {
         match self.id {
             // Claude Code loads extra MCP servers from `--mcp-config <file>`.
+            // Stdio entries are `{command, args}`; HTTP entries need an
+            // explicit `"type": "http"` (a `url` without `type` is a hard
+            // error) plus a `headers` object.
             "claude-acp" => {
                 let mut overlay = self.routing_overlay(base_url, auth, model);
-                if let Some(mcp) = mcp {
+                if !mcp.is_empty() {
                     std::fs::create_dir_all(state_dir)
                         .with_context(|| format!("creating {}", state_dir.display()))?;
-                    let path = state_dir.join("fleet-mcp.json");
-                    let config = serde_json::json!({
-                        "mcpServers": {
-                            &mcp.name: { "command": mcp.command, "args": mcp.args }
-                        }
-                    });
+                    let path = state_dir.join("mcp.json");
+                    let mut servers = serde_json::Map::new();
+                    for s in mcp {
+                        let entry = match &s.transport {
+                            McpTransport::Stdio { command, args } => {
+                                serde_json::json!({ "command": command, "args": args })
+                            }
+                            McpTransport::Http { url, headers } => serde_json::json!({
+                                "type": "http",
+                                "url": url,
+                                "headers": headers_map(headers),
+                            }),
+                        };
+                        servers.insert(s.name.clone(), entry);
+                    }
+                    let config = serde_json::json!({ "mcpServers": servers });
                     std::fs::write(&path, serde_json::to_string_pretty(&config)?)
                         .context("writing claude MCP config")?;
                     overlay
@@ -409,20 +422,39 @@ impl Harness {
                 Ok(overlay)
             }
             // codex takes MCP servers as `-c mcp_servers.*` TOML overrides.
+            // `url` presence selects the streamable-HTTP transport (codex
+            // 0.144+); auth rides `http_headers.<Name>` overrides.
             "codex-acp" => {
                 let mut overlay = self.routing_overlay(base_url, auth, model);
-                if let Some(mcp) = mcp {
-                    let items: Vec<String> = mcp.args.iter().map(|a| toml_string(a)).collect();
-                    overlay.args.extend([
-                        "-c".to_string(),
-                        format!(
-                            "mcp_servers.{}.command={}",
-                            mcp.name,
-                            toml_string(&mcp.command)
-                        ),
-                        "-c".to_string(),
-                        format!("mcp_servers.{}.args=[{}]", mcp.name, items.join(",")),
-                    ]);
+                for s in mcp {
+                    match &s.transport {
+                        McpTransport::Stdio { command, args } => {
+                            let items: Vec<String> = args.iter().map(|a| toml_string(a)).collect();
+                            overlay.args.extend([
+                                "-c".to_string(),
+                                format!("mcp_servers.{}.command={}", s.name, toml_string(command)),
+                                "-c".to_string(),
+                                format!("mcp_servers.{}.args=[{}]", s.name, items.join(",")),
+                            ]);
+                        }
+                        McpTransport::Http { url, headers } => {
+                            overlay.args.extend([
+                                "-c".to_string(),
+                                format!("mcp_servers.{}.url={}", s.name, toml_string(url)),
+                            ]);
+                            for (name, value) in headers {
+                                overlay.args.extend([
+                                    "-c".to_string(),
+                                    format!(
+                                        "mcp_servers.{}.http_headers.{}={}",
+                                        s.name,
+                                        name,
+                                        toml_string(value)
+                                    ),
+                                ]);
+                            }
+                        }
+                    }
                 }
                 Ok(overlay)
             }
@@ -514,10 +546,23 @@ impl Harness {
                 if let Some(default) = default {
                     config["model"]["default"] = serde_json::Value::String(default);
                 }
-                if let Some(mcp) = mcp {
-                    config["mcp_servers"] = serde_json::json!({
-                        &mcp.name: { "command": mcp.command, "args": mcp.args }
-                    });
+                if !mcp.is_empty() {
+                    let mut entries = serde_json::Map::new();
+                    for s in mcp {
+                        let entry = match &s.transport {
+                            McpTransport::Stdio { command, args } => {
+                                serde_json::json!({ "command": command, "args": args })
+                            }
+                            // hermes selects the HTTP transport by `url`
+                            // presence.
+                            McpTransport::Http { url, headers } => serde_json::json!({
+                                "url": url,
+                                "headers": headers_map(headers),
+                            }),
+                        };
+                        entries.insert(s.name.clone(), entry);
+                    }
+                    config["mcp_servers"] = serde_json::Value::Object(entries);
                 }
                 std::fs::write(
                     dir.join("config.yaml"),
@@ -616,25 +661,49 @@ impl Harness {
     }
 }
 
-/// A stdio MCP server to inject into an orchestrator harness (the TUI's
-/// fleet bridge).
+/// An MCP server to inject into an orchestrator harness — the TUI's fleet
+/// bridge plus the gateway servers (`bitrouter_tools` / `bitrouter_skills`,
+/// see `crate::gateways`).
 #[derive(Debug, Clone)]
 pub struct McpServer {
     /// Server name as the harness will list it (e.g. `bitrouter_fleet`).
     pub name: String,
-    pub command: String,
-    pub args: Vec<String>,
+    /// How the harness dials it.
+    pub transport: McpTransport,
+}
+
+/// How a harness dials an injected MCP server. Headers are an ordered list
+/// (not a map) so synthesized configs and `-c` overrides stay deterministic.
+#[derive(Debug, Clone)]
+pub enum McpTransport {
+    /// Spawn `command` with `args` and exchange JSON-RPC over stdio.
+    Stdio { command: String, args: Vec<String> },
+    /// Streamable HTTP at `url`, sending the static request `headers`
+    /// (e.g. `Authorization`) on every call.
+    Http {
+        url: String,
+        headers: Vec<(String, String)>,
+    },
+}
+
+/// Render ordered header pairs as the JSON object shape harness config files
+/// expect (`{"Authorization": "Bearer …"}`).
+fn headers_map(headers: &[(String, String)]) -> serde_json::Map<String, serde_json::Value> {
+    headers
+        .iter()
+        .map(|(k, v)| (k.clone(), serde_json::Value::String(v.clone())))
+        .collect()
 }
 
 /// The synthesized opencode config: a `bitrouter` provider over the OpenAI
 /// wire, the daemon's catalog as its model list, an optional default model,
-/// and the MCP bridge.
+/// and the injected MCP servers.
 fn opencode_config(
     base_url: &str,
     auth: &str,
     model: Option<&str>,
     catalog: &[String],
-    mcp: Option<&McpServer>,
+    mcp: &[McpServer],
 ) -> serde_json::Value {
     let mut models = serde_json::Map::new();
     for id in catalog {
@@ -662,12 +731,26 @@ fn opencode_config(
     {
         config["model"] = serde_json::json!(format!("bitrouter/{default}"));
     }
-    if let Some(mcp) = mcp {
-        let mut command = vec![mcp.command.clone()];
-        command.extend(mcp.args.iter().cloned());
-        config["mcp"] = serde_json::json!({
-            &mcp.name: { "type": "local", "command": command, "enabled": true }
-        });
+    if !mcp.is_empty() {
+        let mut entries = serde_json::Map::new();
+        for s in mcp {
+            let entry = match &s.transport {
+                // opencode folds command+args into one invocation array.
+                McpTransport::Stdio { command, args } => {
+                    let mut invocation = vec![command.clone()];
+                    invocation.extend(args.iter().cloned());
+                    serde_json::json!({ "type": "local", "command": invocation, "enabled": true })
+                }
+                McpTransport::Http { url, headers } => serde_json::json!({
+                    "type": "remote",
+                    "url": url,
+                    "enabled": true,
+                    "headers": headers_map(headers),
+                }),
+            };
+            entries.insert(s.name.clone(), entry);
+        }
+        config["mcp"] = serde_json::Value::Object(entries);
     }
     config
 }
@@ -802,14 +885,14 @@ mod tests {
                     "t",
                     Some("some-model"),
                     &[],
-                    Some(&mcp()),
+                    &[mcp()],
                     dir.path(),
                 )
                 .expect("overlay");
             assert!(o.env.is_empty(), "{id}: no redirection env");
             assert_eq!(o.args, vec![flag, "some-model"], "{id}");
             let bare = h
-                .orchestrator_overlay("http://x:1", "t", None, &[], None, dir.path())
+                .orchestrator_overlay("http://x:1", "t", None, &[], &[], dir.path())
                 .expect("overlay");
             assert_eq!(bare, RoutingOverlay::default(), "{id}: bare launch");
         }
@@ -975,13 +1058,27 @@ mod tests {
     fn mcp() -> McpServer {
         McpServer {
             name: "bitrouter_fleet".into(),
-            command: "/bin/bitrouter".into(),
-            args: vec![
-                "mcp".into(),
-                "serve".into(),
-                "--backend".into(),
-                "fleet".into(),
-            ],
+            transport: McpTransport::Stdio {
+                command: "/bin/bitrouter".into(),
+                args: vec![
+                    "mcp".into(),
+                    "serve".into(),
+                    "--backend".into(),
+                    "fleet".into(),
+                ],
+            },
+        }
+    }
+
+    /// An HTTP gateway server (the `bitrouter_tools` shape) for the
+    /// synthesizer tests.
+    fn tools() -> McpServer {
+        McpServer {
+            name: "bitrouter_tools".into(),
+            transport: McpTransport::Http {
+                url: "http://127.0.0.1:4356/mcp".into(),
+                headers: vec![("Authorization".into(), "Bearer tok".into())],
+            },
         }
     }
 
@@ -990,12 +1087,24 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let h = by_id("claude-acp").unwrap();
         let o = h
-            .orchestrator_overlay("http://x:1", "t", None, &[], Some(&mcp()), dir.path())
+            .orchestrator_overlay("http://x:1", "t", None, &[], &[mcp(), tools()], dir.path())
             .expect("overlay");
         assert_eq!(o.args[0], "--mcp-config");
-        let written = std::fs::read_to_string(&o.args[1]).expect("config written");
-        assert!(written.contains("bitrouter_fleet"), "{written}");
-        assert!(written.contains("\"fleet\""), "fleet backend: {written}");
+        let config: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&o.args[1]).expect("config written"))
+                .expect("json");
+        // Stdio entry: bare command/args.
+        assert_eq!(
+            config["mcpServers"]["bitrouter_fleet"]["command"],
+            "/bin/bitrouter"
+        );
+        assert_eq!(config["mcpServers"]["bitrouter_fleet"]["args"][3], "fleet");
+        // HTTP entry: explicit type (a url without type is a hard error in
+        // Claude Code) plus the auth header as an object.
+        let tools = &config["mcpServers"]["bitrouter_tools"];
+        assert_eq!(tools["type"], "http");
+        assert_eq!(tools["url"], "http://127.0.0.1:4356/mcp");
+        assert_eq!(tools["headers"]["Authorization"], "Bearer tok");
         // Routing env comes through unchanged.
         assert!(o.env.iter().any(|(k, _)| k == "ANTHROPIC_BASE_URL"));
     }
@@ -1005,7 +1114,7 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let h = by_id("codex-acp").unwrap();
         let o = h
-            .orchestrator_overlay("http://x:1", "t", None, &[], Some(&mcp()), dir.path())
+            .orchestrator_overlay("http://x:1", "t", None, &[], &[mcp(), tools()], dir.path())
             .expect("overlay");
         assert!(
             o.args
@@ -1016,6 +1125,23 @@ mod tests {
         assert!(
             o.args.contains(
                 &"mcp_servers.bitrouter_fleet.args=[\"mcp\",\"serve\",\"--backend\",\"fleet\"]"
+                    .to_string()
+            ),
+            "{:?}",
+            o.args
+        );
+        // HTTP entry: url selects the streamable-HTTP transport, auth rides
+        // http_headers.
+        assert!(
+            o.args.contains(
+                &"mcp_servers.bitrouter_tools.url=\"http://127.0.0.1:4356/mcp\"".to_string()
+            ),
+            "{:?}",
+            o.args
+        );
+        assert!(
+            o.args.contains(
+                &"mcp_servers.bitrouter_tools.http_headers.Authorization=\"Bearer tok\""
                     .to_string()
             ),
             "{:?}",
@@ -1033,7 +1159,7 @@ mod tests {
                 "tok",
                 Some("supergrok:grok-4.5"),
                 &[],
-                Some(&mcp()),
+                &[mcp(), tools()],
                 dir.path(),
             )
             .expect("overlay");
@@ -1052,6 +1178,11 @@ mod tests {
             config["mcp_servers"]["bitrouter_fleet"]["command"],
             "/bin/bitrouter"
         );
+        // HTTP entry: url presence selects the transport; auth is a header.
+        let tools = &config["mcp_servers"]["bitrouter_tools"];
+        assert_eq!(tools["url"], "http://127.0.0.1:4356/mcp");
+        assert_eq!(tools["headers"]["Authorization"], "Bearer tok");
+        assert!(tools.get("command").is_none(), "http entry has no command");
     }
 
     #[test]
@@ -1064,7 +1195,7 @@ mod tests {
                 "tok",
                 Some("supergrok:grok-4.5"),
                 &["x-ai/grok-4.5".to_string()],
-                None,
+                &[],
                 dir.path(),
             )
             .expect("overlay");
@@ -1105,7 +1236,7 @@ mod tests {
                 "tok",
                 Some("supergrok:grok-4.5"),
                 &catalog,
-                Some(&mcp()),
+                &[mcp(), tools()],
                 dir.path(),
             )
             .expect("overlay");
@@ -1122,12 +1253,19 @@ mod tests {
         assert_eq!(config["model"], "bitrouter/supergrok:grok-4.5");
         assert!(config["provider"]["bitrouter"]["models"]["supergrok:grok-4.5"].is_object());
         assert!(config["provider"]["bitrouter"]["models"]["x-ai/grok-4.5"].is_object());
-        // The MCP bridge rides the same file.
+        // The MCP bridge rides the same file, command+args folded into one
+        // invocation array.
         assert_eq!(config["mcp"]["bitrouter_fleet"]["type"], "local");
         assert_eq!(
             config["mcp"]["bitrouter_fleet"]["command"][0],
             "/bin/bitrouter"
         );
+        // HTTP entry: opencode's remote type with the auth header.
+        let tools = &config["mcp"]["bitrouter_tools"];
+        assert_eq!(tools["type"], "remote");
+        assert_eq!(tools["url"], "http://127.0.0.1:4356/mcp");
+        assert_eq!(tools["enabled"], true);
+        assert_eq!(tools["headers"]["Authorization"], "Bearer tok");
     }
 
     #[test]
@@ -1136,13 +1274,13 @@ mod tests {
         let h = by_id("opencode").unwrap();
         let catalog = vec!["a/one".to_string(), "b/two".to_string()];
         let o = h
-            .orchestrator_overlay("http://x:1", "t", None, &catalog, None, dir.path())
+            .orchestrator_overlay("http://x:1", "t", None, &catalog, &[], dir.path())
             .expect("overlay");
         let config: serde_json::Value =
             serde_json::from_str(&std::fs::read_to_string(&o.env[0].1).expect("written"))
                 .expect("json");
         assert_eq!(config["model"], "bitrouter/a/one");
-        assert!(config.get("mcp").is_none(), "no bridge requested");
+        assert!(config.get("mcp").is_none(), "no servers requested");
     }
 
     #[test]
@@ -1156,7 +1294,7 @@ mod tests {
                 "tok",
                 Some("supergrok:grok-4.5"),
                 &catalog,
-                Some(&mcp()), // pi has no MCP mechanism — ignored
+                &[mcp(), tools()], // pi has no MCP mechanism — ignored
                 dir.path(),
             )
             .expect("overlay");
@@ -1185,7 +1323,7 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let h = by_id("pi-acp").unwrap();
         let o = h
-            .orchestrator_overlay("http://x:1", "t", None, &[], None, dir.path())
+            .orchestrator_overlay("http://x:1", "t", None, &[], &[], dir.path())
             .expect("overlay");
         assert!(
             o.args.is_empty(),

--- a/apps/bitrouter/src/lib.rs
+++ b/apps/bitrouter/src/lib.rs
@@ -24,6 +24,7 @@ pub mod db;
 pub mod error_report;
 pub mod fleet;
 pub mod fleet_mcp;
+pub mod gateways;
 pub mod harness;
 pub mod metering;
 pub mod onboarding;

--- a/apps/bitrouter/src/main.rs
+++ b/apps/bitrouter/src/main.rs
@@ -565,7 +565,8 @@ enum McpAction {
         /// `stdio` (local daemon) or `http` (cloud).
         #[arg(long, value_enum, default_value_t = McpTransport::Stdio)]
         transport: McpTransport,
-        /// `local` or `cloud`. Defaults: stdio→local, http→cloud.
+        /// `local`, `cloud`, `fleet`, or `skills`. Defaults: stdio→local,
+        /// http→cloud.
         #[arg(long, value_enum)]
         backend: Option<McpBackend>,
         /// Local daemon root.
@@ -621,6 +622,10 @@ enum McpBackend {
     /// The fleet bridge: tools that spawn/manage worktree-isolated ACP
     /// subagents for an orchestrating harness (TUI_SPEC §4). Stdio only.
     Fleet,
+    /// The origin AgentSkills server: `skills_search`/`skills_get` over the
+    /// installed-skills root (the `bitrouter_skills` gateway server every
+    /// TUI-launched harness gets). Stdio only.
+    Skills,
 }
 
 /// MCP client targeted by `bitrouter mcp install`.
@@ -1747,9 +1752,6 @@ async fn mcp_cmd(action: McpAction) -> Result<()> {
                     &cfg,
                     route_socket,
                 ));
-                let skills = std::sync::Arc::new(bitrouter::skills_query::InstalledSkills::new(
-                    base_repo.clone(),
-                ));
                 // Spend circuit breaker (TUI_SPEC §5). The ceiling is enforced
                 // (in `SubstrateFleet`) and displayed (in `fleet_cost`) against
                 // the same figure — today's machine-wide spend — so both agree.
@@ -1770,6 +1772,28 @@ async fn mcp_cmd(action: McpAction) -> Result<()> {
                 // permission path. Off for every client that hasn't declared
                 // the capability — default escalation behavior is unchanged.
                 let escalation = bitrouter_mcp::capabilities::escalation::EscalationState::new();
+                // Gateway descriptors for every spawned subagent's
+                // `session/new`: the aggregate MCP endpoint (when enabled)
+                // and the skills origin server — the same pair the
+                // orchestrator gets via config synthesis.
+                let auth = bitrouter::harness::resolve_gateway_auth(
+                    std::env::var(bitrouter::harness::BITROUTER_API_KEY_ENV).ok(),
+                    false,
+                )
+                .unwrap_or_else(|| bitrouter::harness::PLACEHOLDER_API_KEY.to_string());
+                let aggregate_route = cfg
+                    .mcp
+                    .aggregate
+                    .enabled
+                    .then(|| cfg.mcp.aggregate.route.clone());
+                let subagent_mcp: Vec<_> = bitrouter::gateways::gateway_servers(
+                    &local_url,
+                    &auth,
+                    aggregate_route.as_deref(),
+                )
+                .iter()
+                .map(bitrouter::gateways::to_acp)
+                .collect();
                 // One `SubstrateFleet` backs both the `Fleet` and `HumanBridge`
                 // ports (the human bridge rides the same fleet socket).
                 let fleet = std::sync::Arc::new(
@@ -1780,15 +1804,18 @@ async fn mcp_cmd(action: McpAction) -> Result<()> {
                         allow_writes,
                         budget,
                         Some(escalation.clone()),
+                        subagent_mcp,
                     )
                     .await,
                 );
                 // The orchestrator profile is the union — completion + fleet +
                 // cost + the tier-2 introspection/escalation ports, stdio-only.
                 // Completion routes to the same local daemon the TUI runs; cost
-                // reads the shared metering database; routing/skills read the
-                // config + installed skills; the human bridge rides the fleet
-                // socket.
+                // reads the shared metering database; routing reads the config;
+                // the human bridge rides the fleet socket. Skills are NOT wired
+                // here: they ship as the separate `bitrouter_skills` server
+                // (`--backend skills`) every harness gets, so wiring them into
+                // this bridge too would list the tools twice.
                 let server = bitrouter_mcp::server::BitrouterMcp::builder()
                     .completion_local(&local_url)
                     .fleet(fleet.clone())
@@ -1798,7 +1825,6 @@ async fn mcp_cmd(action: McpAction) -> Result<()> {
                         budget_micro_usd,
                     )))
                     .routing(routing)
-                    .skills(skills)
                     // Source the cap value from the app so the instructions
                     // quote the real cap (no cross-crate magic number).
                     .subagent_cap(bitrouter::fleet_mcp::MAX_CONCURRENT_SUBAGENTS)
@@ -1815,14 +1841,33 @@ async fn mcp_cmd(action: McpAction) -> Result<()> {
             for flag in non_fleet_flag_notes(allow_writes, budget_usd) {
                 eprintln!("note: {flag} only applies to --backend fleet; ignored");
             }
+            // The skills backend is the origin AgentSkills server
+            // (`skills_search`/`skills_get` over the installed-skills root) —
+            // the `bitrouter_skills` gateway server harnesses launch as a
+            // subprocess. Stdio-only, mirroring the fleet bridge's transport
+            // posture.
+            if backend == Some(McpBackend::Skills) {
+                if matches!(transport, McpTransport::Http) {
+                    anyhow::bail!(
+                        "the skills backend is stdio-only (harnesses launch it as a subprocess)"
+                    );
+                }
+                let base_repo = std::env::current_dir().context("resolving current directory")?;
+                let server = bitrouter_mcp::server::BitrouterMcp::builder()
+                    .skills(std::sync::Arc::new(
+                        bitrouter::skills_query::InstalledSkills::new(base_repo),
+                    ))
+                    .build();
+                return bitrouter_mcp::server::serve_stdio(server, None).await;
+            }
             let transport = bitrouter_mcp::Transport::from(transport);
-            // Fleet was handled and returned above. Local/Cloud map straight
-            // across; an unset backend takes the transport default
-            // (stdio→local, http→cloud).
+            // Fleet and skills were handled and returned above. Local/Cloud
+            // map straight across; an unset backend takes the transport
+            // default (stdio→local, http→cloud).
             let backend = match backend {
                 Some(McpBackend::Local) => bitrouter_mcp::BackendKind::Local,
                 Some(McpBackend::Cloud) => bitrouter_mcp::BackendKind::Cloud,
-                Some(McpBackend::Fleet) | None => match transport {
+                Some(McpBackend::Fleet) | Some(McpBackend::Skills) | None => match transport {
                     bitrouter_mcp::Transport::Stdio => bitrouter_mcp::BackendKind::Local,
                     bitrouter_mcp::Transport::Http => bitrouter_mcp::BackendKind::Cloud,
                 },

--- a/apps/bitrouter/src/tui/mod.rs
+++ b/apps/bitrouter/src/tui/mod.rs
@@ -91,6 +91,13 @@ pub async fn run(agent_id: &str, worktree: Option<&str>, model: Option<&str>) ->
         }
     });
     let base_url = crate::spawn::derive_base_url(&cfg.server.listen);
+    // The daemon's aggregate MCP route — the `bitrouter_tools` gateway URL
+    // tail. `None` (aggregate disabled) drops that server from every launch.
+    let mcp_route = cfg
+        .mcp
+        .aggregate
+        .enabled
+        .then(|| cfg.mcp.aggregate.route.clone());
     let initial_pane = if let Some(h) = orchestrator {
         // ── Orchestrator: the native harness TUI in a PTY pane. ──
         if worktree.is_some() {
@@ -106,6 +113,7 @@ pub async fn run(agent_id: &str, worktree: Option<&str>, model: Option<&str>) ->
                 model,
                 models: &models,
                 fleet_sock: fleet_sock_path.as_deref(),
+                mcp_route: mcp_route.as_deref(),
             },
             tx.clone(),
             "orchestrator",
@@ -126,6 +134,9 @@ pub async fn run(agent_id: &str, worktree: Option<&str>, model: Option<&str>) ->
                 remove_on_shutdown: false,
             }),
             env: crate::fleet::port_env(initial_port),
+            // The gateway servers (tools/skills) ride `session/new`, same
+            // surface as an orchestrator launch.
+            mcp_servers: gateway_acp_descriptors(&base_url, mcp_route.as_deref()),
             ..Default::default()
         };
         let session = Session::launch(&catalog, agent_id, base_repo.clone(), options)
@@ -220,6 +231,7 @@ pub async fn run(agent_id: &str, worktree: Option<&str>, model: Option<&str>) ->
             catalog: &catalog,
             base_repo,
             gateway_base: base_url,
+            mcp_route,
             models,
             model: model.map(str::to_string),
             fleet_sock: fleet_sock_path,
@@ -415,22 +427,28 @@ fn attach_interactive(record_id: &str, state: &mut AppState, rt: &mut Runtime<'_
     )
     .unwrap_or_else(|| crate::harness::PLACEHOLDER_API_KEY.to_string());
     // Same overlay family as the orchestrator (synthesizes config for
-    // opencode/pi), but no MCP bridge — an attach drives one agent, it
-    // doesn't orchestrate. Synth files live under the BASE repo's
-    // .bitrouter (never the agent's worktree, where they would dirty the
-    // review diff), in a per-attach dir so attaches don't clobber the
-    // orchestrator's own synth config.
+    // opencode/pi), but no fleet bridge — an attach drives one agent, it
+    // doesn't orchestrate; the gateway servers (tools/skills) still ride
+    // along. Synth files live under the BASE repo's .bitrouter (never the
+    // agent's worktree, where they would dirty the review diff), in a
+    // per-attach dir so attaches don't clobber the orchestrator's own synth
+    // config.
     let state_dir = rt
         .spawner
         .base_repo
         .join(".bitrouter")
         .join(format!("attach-{record_id}"));
+    let gateways = crate::gateways::gateway_servers(
+        &rt.spawner.gateway_base,
+        &auth,
+        rt.spawner.mcp_route.as_deref(),
+    );
     let overlay = match h.orchestrator_overlay(
         &rt.spawner.gateway_base,
         &auth,
         None,
         &rt.spawner.models,
-        None,
+        &gateways,
         &state_dir,
     ) {
         Ok(o) => o,
@@ -475,6 +493,9 @@ struct OrchestratorCtx<'a> {
     model: Option<&'a str>,
     models: &'a [String],
     fleet_sock: Option<&'a std::path::Path>,
+    /// The aggregate MCP route (the `bitrouter_tools` gateway URL tail);
+    /// `None` when the aggregate endpoint is disabled.
+    mcp_route: Option<&'a str>,
 }
 
 /// Launch the orchestrator: the harness's interactive binary on a PTY, its
@@ -493,6 +514,7 @@ fn launch_orchestrator(
         model,
         models,
         fleet_sock,
+        mcp_route,
     } = *ctx;
     let Some(binary) = h.interactive_binary else {
         anyhow::bail!("harness '{}' has no interactive binary", h.id);
@@ -510,15 +532,12 @@ fn launch_orchestrator(
     } else {
         base_repo.join(".bitrouter").join(record_id)
     };
+    // The fleet bridge plus the gateway servers (tools/skills) — the
+    // orchestrator's full injected MCP surface.
+    let mut mcp_servers = vec![fleet_mcp_server()];
+    mcp_servers.extend(crate::gateways::gateway_servers(base_url, &auth, mcp_route));
     let overlay = h
-        .orchestrator_overlay(
-            base_url,
-            &auth,
-            model,
-            models,
-            Some(&fleet_mcp_server()),
-            &state_dir,
-        )
+        .orchestrator_overlay(base_url, &auth, model, models, &mcp_servers, &state_dir)
         .with_context(|| format!("assembling the '{}' orchestrator overlay", h.id))?;
     let args = overlay.args.clone();
     // The fleet-socket path rides the PTY env: the harness inherits it, and
@@ -644,13 +663,33 @@ async fn bridge_write(writer: &mut tokio::net::unix::OwnedWriteHalf, msg: &crate
 fn fleet_mcp_server() -> crate::harness::McpServer {
     crate::harness::McpServer {
         name: "bitrouter_fleet".to_string(),
-        command: std::env::current_exe()
-            .map(|p| p.display().to_string())
-            .unwrap_or_else(|_| "bitrouter".to_string()),
-        args: ["mcp", "serve", "--backend", "fleet"]
-            .map(str::to_string)
-            .to_vec(),
+        transport: crate::harness::McpTransport::Stdio {
+            command: std::env::current_exe()
+                .map(|p| p.display().to_string())
+                .unwrap_or_else(|_| "bitrouter".to_string()),
+            args: ["mcp", "serve", "--backend", "fleet"]
+                .map(str::to_string)
+                .to_vec(),
+        },
     }
+}
+
+/// The gateway servers (tools/skills) as ACP `session/new` descriptors, for
+/// the TUI's own ACP launches (the primary-agent pane and `Effect::SpawnAgent`
+/// subagents). Auth resolves by the same precedence as the routing overlay.
+fn gateway_acp_descriptors(
+    base_url: &str,
+    mcp_route: Option<&str>,
+) -> Vec<agent_client_protocol::schema::v1::McpServer> {
+    let auth = crate::harness::resolve_gateway_auth(
+        std::env::var(crate::harness::BITROUTER_API_KEY_ENV).ok(),
+        false,
+    )
+    .unwrap_or_else(|| crate::harness::PLACEHOLDER_API_KEY.to_string());
+    crate::gateways::gateway_servers(base_url, &auth, mcp_route)
+        .iter()
+        .map(crate::gateways::to_acp)
+        .collect()
 }
 
 /// Best-effort fetch of the daemon's advertised model ids (`/v1/models`) —
@@ -805,6 +844,10 @@ struct Spawner<'a> {
     /// The daemon gateway base URL (derived from `server.listen`) — routing
     /// overlay for interactive attaches.
     gateway_base: String,
+    /// The daemon's aggregate MCP route (`mcp.aggregate.route` when enabled)
+    /// — the `bitrouter_tools` gateway URL tail for every launch; `None`
+    /// drops that server.
+    mcp_route: Option<String>,
     /// The daemon's advertised model ids at startup (may be empty) — fills
     /// synthesized provider catalogs on attach.
     models: Vec<String>,
@@ -1413,6 +1456,12 @@ async fn apply_effect(effect: Effect, state: &mut AppState, rt: &mut Runtime<'_>
                     _ => None,
                 },
                 env: crate::fleet::port_env(port),
+                // The gateway servers (tools/skills) ride `session/new` —
+                // subagents get the same surface as the orchestrator.
+                mcp_servers: gateway_acp_descriptors(
+                    &rt.spawner.gateway_base,
+                    rt.spawner.mcp_route.as_deref(),
+                ),
                 ..Default::default()
             };
             let catalog = (*rt.spawner.catalog).clone();
@@ -1464,6 +1513,7 @@ async fn apply_effect(effect: Effect, state: &mut AppState, rt: &mut Runtime<'_>
                     model: model.as_deref(),
                     models: &rt.spawner.models,
                     fleet_sock: rt.spawner.fleet_sock.as_deref(),
+                    mcp_route: rt.spawner.mcp_route.as_deref(),
                 },
                 rt.spawner.tx.clone(),
                 &record_id,
@@ -1856,8 +1906,13 @@ mod tests {
     fn fleet_mcp_server_spec_names_the_fleet_backend() {
         let mcp = super::fleet_mcp_server();
         assert_eq!(mcp.name, "bitrouter_fleet");
-        assert_eq!(mcp.args, vec!["mcp", "serve", "--backend", "fleet"]);
-        assert!(!mcp.command.is_empty());
+        match mcp.transport {
+            crate::harness::McpTransport::Stdio { command, args } => {
+                assert_eq!(args, vec!["mcp", "serve", "--backend", "fleet"]);
+                assert!(!command.is_empty());
+            }
+            other => panic!("fleet bridge must be stdio, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/crates/bitrouter-substrate/src/engine.rs
+++ b/crates/bitrouter-substrate/src/engine.rs
@@ -98,6 +98,12 @@ pub struct LaunchOptions {
     /// cooperatively (`session/cancel`); if it does not comply within
     /// `TURN_CANCEL_GRACE` (3s) the turn errors.
     pub turn_timeout: Option<Duration>,
+    /// MCP servers passed to the agent in `session/new` (`mcpServers`) — the
+    /// caller's tool surface for the session, e.g. the TUI's gateway servers.
+    /// Only the immediate-open launch path consumes this; a deferred launch
+    /// (`launch_deferred`) relays the **manager's** descriptors via
+    /// [`Session::open`] instead.
+    pub mcp_servers: Vec<McpServer>,
 }
 
 impl Default for LaunchOptions {
@@ -108,6 +114,7 @@ impl Default for LaunchOptions {
             env: Vec::new(),
             transcript: true,
             turn_timeout: None,
+            mcp_servers: Vec::new(),
         }
     }
 }
@@ -130,6 +137,9 @@ struct BuildArgs {
     env: Vec<(String, String)>,
     transcript: bool,
     turn_timeout: Option<Duration>,
+    /// `mcpServers` for the immediate `session/new` (unused when deferring —
+    /// [`Session::open`] then carries the manager's descriptors).
+    mcp_servers: Vec<McpServer>,
     /// Run the upstream `session/new` right away (headless/prompt path) rather
     /// than deferring to [`Session::open`] (serve path).
     open_now: bool,
@@ -196,9 +206,10 @@ impl Session {
     /// Launch a session and **open it immediately**: resolve `agent_id` in
     /// `catalog`, optionally provision a worktree, spawn the upstream
     /// connection, run `initialize` + `session/new` (cwd = worktree or
-    /// `base_repo`, no MCP servers), build the pipeline, turn queue, and
-    /// transcript, and record the session identity. Used by the headless
-    /// `prompt` path and library callers that have no manager to relay from.
+    /// `base_repo`, `mcpServers` from [`LaunchOptions::mcp_servers`]), build
+    /// the pipeline, turn queue, and transcript, and record the session
+    /// identity. Used by the headless `prompt` path and library callers that
+    /// have no manager to relay from.
     pub async fn launch(
         catalog: &ConfigAcpRoutingTable,
         agent_id: &str,
@@ -236,6 +247,7 @@ impl Session {
             env,
             transcript,
             turn_timeout,
+            mcp_servers,
         } = options;
         // ── Resolve the agent's stdio transport ────────────────────────────
         let transport = catalog
@@ -299,6 +311,7 @@ impl Session {
                     env,
                     transcript,
                     turn_timeout,
+                    mcp_servers,
                     open_now,
                 },
             )
@@ -377,6 +390,7 @@ impl Session {
             env: extra_env,
             transcript,
             turn_timeout,
+            mcp_servers,
             open_now,
         } = args;
         let AcpTransport::Stdio { command, args, env } = &transport;
@@ -409,7 +423,7 @@ impl Session {
         let wire: Arc<OnceLock<UpstreamSessionIds>> = Arc::new(OnceLock::new());
         if open_now {
             let cwd = worktree_path.clone().unwrap_or_else(|| base_repo.clone());
-            let ids = conn.new_session(cwd, Vec::new()).await?;
+            let ids = conn.new_session(cwd, mcp_servers).await?;
             state.set_acp_session_id(ids.acp_session_id.clone());
             if let Some(agent_sid) = &ids.agent_session_id {
                 state.set_agent_session_id(agent_sid.clone());
@@ -1311,6 +1325,61 @@ mod tests {
             .await
             .expect("second open is a no-op");
 
+        session.shutdown().await.expect("shutdown");
+    }
+
+    /// Immediate launch: `LaunchOptions::mcp_servers` rides the upstream
+    /// `session/new` — the same stub echoes a marker session id when the
+    /// request carried the probe server.
+    #[tokio::test]
+    async fn launch_passes_options_mcp_servers_in_session_new() {
+        use agent_client_protocol_schema::v1::{McpServer, McpServerStdio};
+
+        const RELAY_STUB: &str = r#"
+            while read line; do
+              id=$(echo "$line" | sed -n 's/.*"id":"\([^"]*\)".*/\1/p')
+              case "$line" in
+                *initialize*) printf '{"jsonrpc":"2.0","id":"%s","result":{"protocolVersion":1}}\n' "$id";;
+                *session/new*)
+                    case "$line" in
+                      *launch-probe-server*) sid="saw-mcp";;
+                      *) sid="no-mcp";;
+                    esac
+                    printf '{"jsonrpc":"2.0","id":"%s","result":{"sessionId":"%s"}}\n' "$id" "$sid";;
+              esac
+            done
+        "#;
+        let cfg = bitrouter_sdk::acp::AcpAgentConfig {
+            name: "relay".to_string(),
+            transport: AcpTransport::Stdio {
+                command: "bash".to_string(),
+                args: vec!["-c".to_string(), RELAY_STUB.to_string()],
+                env: HashMap::new(),
+            },
+        };
+        let catalog =
+            ConfigAcpRoutingTable::from_configs([("relay".to_string(), cfg)]).expect("catalog");
+        let base = tempfile::tempdir().expect("tempdir");
+
+        let session = Session::launch(
+            &catalog,
+            "relay",
+            base.path().to_path_buf(),
+            LaunchOptions {
+                mcp_servers: vec![McpServer::Stdio(McpServerStdio::new(
+                    "launch-probe-server",
+                    "probe-cmd",
+                ))],
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("launch");
+        assert_eq!(
+            session.state().acp_session_id.as_deref(),
+            Some("saw-mcp"),
+            "immediate session/new must carry LaunchOptions::mcp_servers"
+        );
         session.shutdown().await.expect("shutdown");
     }
 

--- a/skills/bitrouter/SKILL.md
+++ b/skills/bitrouter/SKILL.md
@@ -155,6 +155,9 @@ bitrouter mcp serve
 # no --token on the server side; each MCP client sets "Authorization: Bearer brk_..." in its remote config
 bitrouter mcp serve --transport http
 
+# stdio: origin AgentSkills server (skills_search/skills_get over installed skills)
+bitrouter mcp serve --backend skills
+
 # print the Claude/Cursor mcpServers config block
 bitrouter mcp install --client claude
 

--- a/skills/bitrouter/references/mcp-server.md
+++ b/skills/bitrouter/references/mcp-server.md
@@ -18,7 +18,7 @@ Starts the origin MCP server.
 | Flag | Default | Description |
 |---|---|---|
 | `--transport` | `stdio` | `stdio` or `http` |
-| `--backend` | *(derived)* | `local`, `cloud`, or `fleet`. Omit to auto-derive: `stdio`→`local`, `http`→`cloud`. `fleet` is the **orchestrator profile** — the *union* of the completion tools (`complete`/`list_models`/`status`, routed to the local daemon), the subagent spawn/manage tools over the ACP substrate (see `references/orchestration.md`), `fleet_cost`, the routing-preview tool (`route_preview`), the skills tools (`skills_search`/`skills_get`), and the human-bridge tools (`notify_human`/`request_attach`/`request_review`). It is **stdio-only** |
+| `--backend` | *(derived)* | `local`, `cloud`, `fleet`, or `skills`. Omit to auto-derive: `stdio`→`local`, `http`→`cloud`. `fleet` is the **orchestrator profile** — the *union* of the completion tools (`complete`/`list_models`/`status`, routed to the local daemon), the subagent spawn/manage tools over the ACP substrate (see `references/orchestration.md`), `fleet_cost`, the routing-preview tool (`route_preview`), and the human-bridge tools (`notify_human`/`request_attach`/`request_review`). `skills` is the **origin AgentSkills server** — just `skills_search`/`skills_get` over the installed-skills root of the current directory; it is the `bitrouter_skills` server the TUI injects into every launched harness. Both `fleet` and `skills` are **stdio-only** |
 | `--allow-writes` | off | (`fleet` only) grant the orchestrator write autonomy: `apply_subagent`/`merge_subagent` may integrate into the base repo. Off = writes are human-gated |
 | `--budget-usd` | *(unlimited)* | (`fleet` only) spend ceiling in USD. `spawn_subagent`/`prompt_subagent` refuse once **today's machine-wide spend** reaches it (a circuit breaker, TUI_SPEC §5); `fleet_cost` reports `budget_usd`/`remaining_usd`. Not scoped to one session — other spend today counts; a new UTC day is the fresh window. Ignored (with a note) off `--backend fleet` |
 | `--local-url` | `http://127.0.0.1:4356` | Root URL of the local BitRouter daemon |
@@ -45,6 +45,9 @@ bitrouter mcp serve --transport http --backend local --local-url http://127.0.0.
 bitrouter mcp serve --backend fleet            # writes human-gated
 bitrouter mcp serve --backend fleet --allow-writes
 bitrouter mcp serve --backend fleet --budget-usd 20   # refuse spawns past $20 today
+
+# stdio — origin AgentSkills server (skills_search/skills_get over ./skills installs)
+bitrouter mcp serve --backend skills
 ```
 
 ### `bitrouter mcp install`

--- a/skills/bitrouter/references/orchestration.md
+++ b/skills/bitrouter/references/orchestration.md
@@ -30,6 +30,14 @@ completion tools (`complete` / `list_models` / `status`, routed to the local
 daemon) **plus** `fleet_cost`. So the one bridge lets you both delegate and run
 your own completions / check spend without a second MCP server.
 
+Under `bitrouter tui`, the bridge is injected alongside two **gateway
+servers** — `bitrouter_tools` (streamable HTTP to the daemon's aggregate
+`/mcp`, fanning out to every `mcp_servers` upstream with `{server}__` tool
+prefixes) and `bitrouter_skills` (stdio `mcp serve --backend skills`, the
+`skills_search`/`skills_get` pair) — and every spawned subagent receives the
+same two in its `session/new`, so the fleet shares your tool and skill
+surface. Use `skills_get` to paste a skill into a `spawn_subagent` task.
+
 ## Tools
 
 | Tool | Effect |
@@ -49,8 +57,6 @@ escalation** tools:
 | Tool | Effect |
 |---|---|
 | `route_preview(model, prompt?)` | Preview how BitRouter would route `model` (with the opening `prompt`, if given): the resolved provider fallback chain and the registry's per-token rates for the top hop. Resolves through the **live daemon first** (like `bitrouter route`) so it reflects `reload`s and subscription-backed providers, falling back to static config when the daemon is unreachable — `resolved_via` (`live daemon`/`config`) records which. When config-resolved it also reports the static policy decision. Nothing is sent upstream. Use it to pick a model/tier before delegating. |
-| `skills_search(query)` | Installed skills whose name/description match `query` (`{name, description, path}`). |
-| `skills_get(name)` | One skill's frontmatter + SKILL.md body — paste it into a `spawn_subagent` task to hand the subagent a skill. |
 | `notify_human(message)` | Post a one-line notice in the human's TUI. Headless (no TUI), it returns `{"delivered": false}` — no error. |
 | `request_attach(handle)` | Ask the human to attach to a subagent's pane and drive it. The subagent is flagged for attention in the rail. |
 | `request_review(handle)` | Flag a subagent's work into the human's review queue. **Advisory when bridge-mirrored:** a subagent surfaced into the TUI over the fleet socket has no review-queue metadata there, so the queue's load-diff/merge/apply verbs no-op on it — the human drives integration from the owning process (this bridge's `merge_subagent`/`apply_subagent`, or the orchestrator). |


### PR DESCRIPTION
## What & why

The TUI is BitRouter's control tower, but it only wired **two** of the four product gateways into the harnesses it launches — Models (routing overlay) and ACP (the `bitrouter_fleet` bridge). This wires in the other two:

- **MCP gateway** → `bitrouter_tools`: streamable HTTP to the daemon's aggregate `/mcp`, so a launched harness reaches *your* configured upstream MCP servers (with `{server}__` tool prefixes).
- **AgentSkills gateway** → `bitrouter_skills`: a new `mcp serve --backend skills` origin server (`skills_search`/`skills_get` over the installed-skills root).

Both harness **roles** get the same pair, by their respective transports:

| | Interactive orchestrator (PTY) | Subagents (ACP) |
|---|---|---|
| Channel | none → **config-file synthesis** | `session/new` → **`mcpServers` descriptor** |
| Seam | `Harness::orchestrator_overlay` | `LaunchOptions.mcp_servers` |

## Design notes

- **Descriptor-passing HTTP, not MCP-over-ACP tunneling.** Our pinned `agent-client-protocol-schema` 1.4.0 has `McpServer::Http` first-class; the `Acp` (tunnel) variant is behind `unstable_mcp_over_acp` and no shipping harness advertises `mcpCapabilities.acp`, so it's deferred.
- **All four synthesizer harnesses support HTTP MCP** — claude, codex (0.144+ is no longer stdio-only), opencode, hermes — verified against their config schemas and ACP adapters. No stdio-proxy fallback needed.
- Header shape differs by path (config files want a map; codex `-c` wants `http_headers.<H>`; ACP descriptors want a `[{name,value}]` array) — one spec in `gateways.rs`, two renderers.
- Skills **dropped from the fleet bridge** so the orchestrator doesn't list `skills_*` twice.

## Changes

- `harness.rs`: `McpServer` gains `McpTransport` (stdio/http); `orchestrator_overlay` takes a slice; four synthesizers emit per-transport entries.
- `gateways.rs` (new): shared spec + `to_harness`/`to_acp` renderers.
- `engine.rs`: `LaunchOptions.mcp_servers` threads to the immediate `session/new` (was hardwired empty).
- `fleet_mcp.rs` + `tui/mod.rs`: fleet-spawned, TUI-native, and attach launches all pass the pair.
- `main.rs`: `--backend skills`; fleet-bridge `.skills()` removed.
- Skill + reference docs updated in lockstep.

## Verification

- `cargo nextest run --all-features`: **1960 passed**; clippy + fmt clean.
- Live e2e against real binaries: aggregate `/mcp` fan-out with Bearer header; `--backend skills` over stdio finds installs; fleet `spawn_subagent` captured `session/new` carrying both descriptors; **real `claude mcp list` and `codex mcp list` connected** to the synthesized shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)