### PR TITLE
feat(registry): add Terminal-Bench 2.1 benchmark shape

### DIFF
--- a/helpers/dist-helper/src/registry.rs
+++ b/helpers/dist-helper/src/registry.rs
@@ -1337,6 +1337,47 @@ fn validate_canonical_model(model: &CanonicalModel, issues: &mut Vec<String>) {
             model.id, date
         ));
     }
+    if let Some(benchmarks) = &model.benchmarks {
+        validate_terminal_bench_2_1(&model.id, benchmarks.terminal_bench_2_1.as_ref(), issues);
+    }
+}
+
+/// Sanity-check any recorded Terminal-Bench 2.1 metrics. Every metric is
+/// optional (they stay absent until measured), so this only fires on values
+/// that are present and out of range — accuracy is a `0..=100` percent,
+/// cost/time are non-negative, and `as_of` is a calendar date.
+fn validate_terminal_bench_2_1(
+    model_id: &str,
+    tb: Option<&TerminalBench21>,
+    issues: &mut Vec<String>,
+) {
+    let Some(tb) = tb else { return };
+    if let Some(accuracy) = tb.accuracy
+        && !(0.0..=100.0).contains(&accuracy)
+    {
+        issues.push(format!(
+            "registry/models: model '{model_id}' terminal_bench_2_1.accuracy {accuracy} is outside 0..=100"
+        ));
+    }
+    for (field, value) in [
+        ("cost_per_task", tb.cost_per_task),
+        ("time_per_task", tb.time_per_task),
+    ] {
+        if let Some(value) = value
+            && value < 0.0
+        {
+            issues.push(format!(
+                "registry/models: model '{model_id}' terminal_bench_2_1.{field} {value} is negative"
+            ));
+        }
+    }
+    if let Some(date) = &tb.as_of
+        && !valid_yyyy_mm_dd(date)
+    {
+        issues.push(format!(
+            "registry/models: model '{model_id}' terminal_bench_2_1.as_of '{date}' is not YYYY-MM-DD"
+        ));
+    }
 }
 
 fn validate_provider<'a>(
@@ -1980,6 +2021,59 @@ struct CanonicalModel {
     open_weights: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     family: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    benchmarks: Option<Benchmarks>,
+}
+
+/// Independent-benchmark results for a canonical model, keyed by benchmark.
+/// Only the benchmarks BitRouter curates on (see `registry/README.md`) get a
+/// field here; the shape is extensible to the other curation benchmarks.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct Benchmarks {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    terminal_bench_2_1: Option<TerminalBench21>,
+}
+
+/// Terminal-Bench 2.1 results — 89 command-line agent tasks, all-or-nothing
+/// pytest scoring (Laude Institute / Stanford + the Terminal-Bench community).
+///
+/// The three metrics are **optional** and stay absent until measured: we
+/// populate them from our own runs of the open harness routed through BitRouter
+/// (`measured_by: bitrouter`), not from unverified numbers. The provenance
+/// fields are first-class on purpose — a benchmark score is meaningless without
+/// them, because the same model on the same benchmark version can differ by
+/// double-digit points across harness and reasoning-effort. `harness` + `config`
+/// pin a run so it is reproducible; `measured_by` + `source_url` keep a
+/// third-party citation from ever being mistaken for a BitRouter measurement.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct TerminalBench21 {
+    /// Score: percent of the 89 tasks passed (`0..=100`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    accuracy: Option<f64>,
+    /// Average cost per task, in USD.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    cost_per_task: Option<f64>,
+    /// Average time per task, in minutes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    time_per_task: Option<f64>,
+    /// Who produced the numbers: `bitrouter` for our own runs, otherwise the
+    /// third-party source (e.g. `artificial-analysis`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    measured_by: Option<String>,
+    /// Agent harness the run used (e.g. `terminus-2`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    harness: Option<String>,
+    /// Reasoning-effort / configuration label the run used (e.g. `max`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    config: Option<String>,
+    /// Citation URL when `measured_by` is a third party.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    source_url: Option<String>,
+    /// Snapshot date (`YYYY-MM-DD`) the numbers were recorded.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    as_of: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -2527,6 +2621,82 @@ api_base: https://api.acme.test/v1
         let ids: Vec<_> = loaded.models().map(|m| m.id.as_str()).collect();
         assert_eq!(ids, vec!["acme/one", "acme/two"]);
         validate_loaded(&loaded).expect("grouped model file validates");
+    }
+
+    #[test]
+    fn canonical_model_parses_terminal_bench_and_validates() {
+        let yaml = r#"
+id: acme/one
+name: "Acme: One"
+input_modalities: [text]
+output_modalities: [text]
+benchmarks:
+  terminal_bench_2_1:
+    accuracy: 61.3
+    cost_per_task: 0.75
+    time_per_task: 4.35
+    measured_by: bitrouter
+    harness: terminus-2
+    config: max
+    as_of: 2026-07-17
+"#;
+        let model: CanonicalModel =
+            serde_saphyr::from_str(yaml).expect("parses terminal_bench_2_1 block");
+        let mut issues = Vec::new();
+        validate_canonical_model(&model, &mut issues);
+        assert!(issues.is_empty(), "unexpected issues: {issues:?}");
+
+        // Filled metrics survive the round-trip; unset fields are omitted.
+        let dist = serde_json::to_value(&model).unwrap();
+        let tb = &dist["benchmarks"]["terminal_bench_2_1"];
+        assert_eq!(tb["accuracy"], json!(61.3));
+        assert_eq!(tb["measured_by"], json!("bitrouter"));
+        assert!(
+            tb.get("source_url").is_none(),
+            "unset field must be omitted"
+        );
+    }
+
+    #[test]
+    fn canonical_model_terminal_bench_metrics_are_optional() {
+        // The shape ships now with metrics unfilled — this must parse + validate,
+        // and must not invent any metric into the dist output.
+        let yaml = r#"
+id: acme/two
+input_modalities: [text]
+output_modalities: [text]
+benchmarks:
+  terminal_bench_2_1: {}
+"#;
+        let model: CanonicalModel =
+            serde_saphyr::from_str(yaml).expect("empty terminal_bench_2_1 parses");
+        let mut issues = Vec::new();
+        validate_canonical_model(&model, &mut issues);
+        assert!(issues.is_empty(), "unexpected issues: {issues:?}");
+        let dist = serde_json::to_value(&model).unwrap();
+        assert_eq!(dist["benchmarks"]["terminal_bench_2_1"], json!({}));
+    }
+
+    #[test]
+    fn canonical_model_rejects_out_of_range_terminal_bench() {
+        let yaml = r#"
+id: acme/three
+input_modalities: [text]
+output_modalities: [text]
+benchmarks:
+  terminal_bench_2_1:
+    accuracy: 142.0
+    cost_per_task: -1.0
+    as_of: 07-2026
+"#;
+        let model: CanonicalModel = serde_saphyr::from_str(yaml).expect("parses");
+        let mut issues = Vec::new();
+        validate_canonical_model(&model, &mut issues);
+        assert_eq!(
+            issues.len(),
+            3,
+            "expected accuracy + cost + as_of issues: {issues:?}"
+        );
     }
 
     #[test]

--- a/registry/README.md
+++ b/registry/README.md
@@ -83,6 +83,36 @@ Source lives in two places; `dist/registry/` is generated — never hand-edit it
   beyond the curated catalog** (BYOK / BYO-subscription extras) — those are
   allowed and surface as non-failing *advisories*, not errors.
 
+### Model benchmarks
+
+A model may carry a `benchmarks:` block recording independent-benchmark
+results, keyed by benchmark. Today that is **Terminal-Bench 2.1**; the shape is
+extensible so the other curation benchmarks can follow.
+
+```yaml
+- id: openai/gpt-5.6-sol
+  # …other model fields…
+  benchmarks:
+    terminal_bench_2_1:
+      accuracy: 88.0        # % of the 89 tasks passed (0–100)
+      cost_per_task: 0.75   # USD, average per task
+      time_per_task: 4.35   # minutes, average per task
+      measured_by: bitrouter        # `bitrouter`, or a third-party source name
+      harness: terminus-2           # agent harness the run used
+      config: max                   # reasoning-effort / config label
+      as_of: 2026-07-17             # snapshot date (YYYY-MM-DD)
+      source_url: https://…         # required when `measured_by` is a third party
+```
+
+The three metrics are **optional and provenance-first**. A raw score is
+meaningless on its own — the same model on the same benchmark version swings by
+double digits across harness and reasoning-effort — so `harness` + `config` pin
+a run for reproducibility, and `measured_by` (with `source_url`) keeps a cited
+third-party number from being mistaken for one we ran. Per the "omit what you
+can't verify" rule above, **leave the metrics unset until measured**: we fill
+them from our own Terminal-Bench 2.1 runs (the open harness routed through
+BitRouter, `measured_by: bitrouter`), not from unverified figures.
+
 ### Provider variants — one file per distinct endpoint
 
 A provider file is **one routable endpoint with its own commercial terms**, not a


### PR DESCRIPTION
## What

Adds an optional, **provenance-first** `benchmarks.terminal_bench_2_1` block to the canonical model schema (`dist-helper`'s `CanonicalModel`). The shape carries the three metrics we want to surface — **accuracy**, **cost_per_task**, **time_per_task** — plus the provenance required to trust them:

```yaml
- id: openai/gpt-5.6-sol
  # …
  benchmarks:
    terminal_bench_2_1:
      accuracy: 88.0        # % of the 89 tasks passed (0–100)
      cost_per_task: 0.75   # USD, average per task
      time_per_task: 4.35   # minutes, average per task
      measured_by: bitrouter        # or a third-party source name
      harness: terminus-2           # agent harness the run used
      config: max                   # reasoning-effort / config label
      as_of: 2026-07-17             # snapshot date (YYYY-MM-DD)
      source_url: https://…         # required when measured_by is a third party
```

## Why the metrics are left unfilled

This PR ships **only the shape** — every metric is optional and currently unset.

A raw benchmark score is meaningless without its harness and reasoning-effort: the *same* model on the *same* Terminal-Bench 2.1 version differs by double-digit points across operators (e.g. Claude Opus 4.8 measures 84.6% / 71.9% / 78.9% on three different public harnesses; a single model's score also swings ~13 points between reasoning-effort settings). Baking in third-party snapshots we can't reproduce would launder a cited number into an apparent first-party fact.

So the provenance fields are first-class on purpose — `harness` + `config` pin a run for reproducibility, and `measured_by` (+ `source_url`) keep a citation from being mistaken for a measurement. We'll populate the metrics from our **own** Terminal-Bench 2.1 runs (the open harness routed through BitRouter, `measured_by: bitrouter`), per the registry's existing "omit what you can't verify" rule.

## Changes

- Typed `Benchmarks` / `TerminalBench21` structs; all fields optional with `skip_serializing_if`, so the built dist is **byte-identical** until a model records real numbers.
- Validation: `accuracy` in `0..=100`, `cost_per_task`/`time_per_task` non-negative, `as_of` a `YYYY-MM-DD` date.
- Tests: the shipped-but-unfilled state, a filled round-trip (unset fields omitted), and out-of-range rejection.
- `registry/README.md`: documents the field in the authoring contract.

## Verification

- `cargo test -p dist-helper` — 32 passed (incl. 3 new).
- `cargo fmt -- --check`, `cargo clippy -p dist-helper --all-features` — clean.
- `registry validate` / `build` / `check` pass; **`dist/registry/` and the `supported-*` docs tables are unchanged.**

## Follow-ups (not in this PR)

- Run Terminal-Bench 2.1 ourselves (Phase 0: one model ≈ $70 to validate the pipeline) and fill the metrics with `measured_by: bitrouter`.
- Wire the numbers into the docs models radar (bitrouter-docs #33), replacing its mock capability axes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)