### PR TITLE
docs: add reusable benchmark skill

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -1,9 +1,10 @@
 # Agent Skills
 
-This directory is the **source of truth** for BitRouter's [Agent Skill](https://agentskills.io).
-It lives in the monorepo so the skill's facts (port `4356`, env var names, CLI
-subcommands, harness wiring) stay in lockstep with the code that defines them —
-a skill change ships in the same PR as the change that motivates it.
+This directory is the **source of truth** for BitRouter's [Agent Skills](https://agentskills.io).
+They live in the monorepo so each skill's facts (port `4356`, env var names, CLI
+subcommands, harness wiring, benchmark evidence contracts) stay in lockstep with
+the code that defines them — a skill change ships in the same PR as the change
+that motivates it.
 
 ## What's here
 
@@ -26,10 +27,23 @@ skills/bitrouter/
 Covers the Local-or-Cloud decision, install, daemon lifecycle, cloud onboarding,
 provider config, migration off other gateways, diagnostics, and per-harness wiring.
 
+### `/run-bitrouter-benchmark`, at [`run-bitrouter-benchmark/`](run-bitrouter-benchmark/)
+
+```
+skills/run-bitrouter-benchmark/
+├── SKILL.md          # decision and navigation layer — keep under ~200 lines
+└── references/       # methodology, configuration, operations, acceptance, Q&A
+```
+
+Runs or audits reproducible BitRouter Terminal-Bench 2.1 experiments with
+Harbor, Terminus 2, a centralized EC2 daemon, and ephemeral EC2 sandboxes. It
+keeps AWS identity, models, provider secrets, source revisions, task/trial scale,
+and prices configurable while fixing the experimental and evidence method.
+
 ## Install
 
-Every install rail resolves this directory by its repo path —
-`bitrouter/bitrouter` → `skills/bitrouter` — so no separate package is needed.
+Both skills are installable directly from this repository; select the benchmark
+skill explicitly because the source now exposes more than one `SKILL.md`.
 
 ```bash
 # BitRouter's own installer (subdir-aware via the registry hub)
@@ -40,13 +54,22 @@ npx skills add bitrouter/bitrouter
 
 # Claude Code (manual)
 cp -r skills/bitrouter ~/.claude/skills/
+
+# Reproducible Terminal-Bench runner skill (BitRouter installer)
+bitrouter skills add bitrouter/bitrouter --skill run-bitrouter-benchmark
+
+# Reproducible Terminal-Bench runner skill (generic skills CLI)
+npx skills add bitrouter/bitrouter --skill run-bitrouter-benchmark
+
+# Reproducible Terminal-Bench runner skill (Claude Code manual)
+cp -r skills/run-bitrouter-benchmark ~/.claude/skills/
 ```
 
 ## Editing conventions
 
-- Keep `SKILL.md` under ~200 lines; deep detail goes in `references/`.
+- Keep each `SKILL.md` under ~200 lines; deep detail goes in `references/`.
 - Each reference file is independently consumable — don't assume a sibling was loaded.
 - When you change a CLI flag, port, env var, or harness step in the code, update
   the matching fact here in the same change. See the "Facts that are easy to get
   wrong" section in the repo's agent guidance.
-- Validate with the [skills-ref](https://github.com/agentskills/agentskills/tree/main/skills-ref) library: `skills-ref validate ./skills/bitrouter`.
+- Validate with the [skills-ref](https://github.com/agentskills/agentskills/tree/main/skills-ref) library: `skills-ref validate ./skills/bitrouter` and `skills-ref validate ./skills/run-bitrouter-benchmark`.

--- a/skills/run-bitrouter-benchmark/SKILL.md
+++ b/skills/run-bitrouter-benchmark/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: run-bitrouter-benchmark
+description: Use when planning, launching, resuming, auditing, or reproducing a BitRouter Terminal-Bench 2.1 benchmark with Harbor, Terminus 2, and AWS EC2, including short policy iterations, one-time controls, model comparisons, or public full runs.
+---
+
+# Run BitRouter Benchmark
+
+## Core rule
+
+Treat the benchmark as a fail-closed experiment, not a best-effort load test. Keep the validated method fixed, make environment-specific inputs explicit, and accept no quality or cost claim until trial, routing, settlement, attribution, and cleanup evidence all agree.
+
+This skill is an operational document. It does not supply a runner, infrastructure module, or historical configuration. Inspect the selected BitRouter and Harbor revisions, adapt commands to their current interfaces, and freeze the resulting inputs before spending.
+
+## Start here
+
+1. Read [configuration.md](references/configuration.md). Collect names and locations of credential sources, never secret values in chat or artifacts. Produce a frozen run manifest and a redacted review copy.
+2. Read [methodology.md](references/methodology.md). Classify the run and state exactly what its result may claim.
+3. Before any AWS mutation or benchmark launch, read [operations.md](references/operations.md) completely and execute its gates in order.
+4. After every group, read [acceptance-and-reporting.md](references/acceptance-and-reporting.md), independently validate the evidence, and record an accepted or rejected terminal result.
+5. Use [qna.md](references/qna.md) when a symptom matches a known failure. Do not improvise around a failed gate.
+
+## Classify the run
+
+| Class | Typical scale | Trials | Valid use |
+| --- | --- | ---: | --- |
+| Mechanism iteration | short 13 or a predeclared small slice | 1 per case | Debug routing, learning, metering, and runtime behavior |
+| Replicated experiment | predeclared slice or full set | At least 3 per case | Estimate paired variation across clean policy lineages |
+| Public reproduction | full 89-task set | 5 per case | Publish a reproducible Terminal-Bench result with provenance |
+
+Never describe a one-trial tuning run as a public model score. Never describe r3 on tasks that taught r1-r2 as held-out generalization.
+
+## Preserve the fixed rail
+
+Keep these invariant unless deliberately starting a different benchmark method:
+
+- Terminal-Bench 2.1 dataset and verifier;
+- Harbor with the neutral Terminus 2 agent;
+- a separate central BitRouter daemon EC2 host;
+- one ephemeral EC2 sandbox per trial, deleted after the trial;
+- immutable case/trial identities and append-only controller/control records;
+- request-level traces, policy decisions, four-bucket usage, rewards, and explicit workflow sessions;
+- strict settlement, join, and AWS residue gates.
+
+Configure AWS identity, account, region, network, instance shapes, source revisions, models, providers, secret sources, prices, task manifest, trial count, concurrency, timeouts, and central-host provision/reuse mode for each environment.
+
+## Execute the lifecycle
+
+1. **Freeze.** Record every input, source commit, checksum, task/trial identity, price snapshot, stop limit, retry rule, path, port, and resource tag before launch.
+2. **Authenticate.** Select one explicit AWS identity, prove it with STS, and propagate the same selection to the controller and every Harbor subprocess. Fail before touching EC2 if identity is ambiguous.
+3. **Preflight.** Validate configs through the pinned software, check quota immediately before each batch, prove network reachability, run provider sentinels, and verify that all run-scoped paths are new.
+4. **Prepare the central host.** Provision or reuse it under the same source, health, isolation, credential, and network gates.
+5. **Canary.** Run a predeclared non-evaluation trial through the real Terminus 2 and EC2 path. Require complete attribution and zero resource residue.
+6. **Resolve control.** Reuse a matching accepted immutable control. Launch absent control identities once only; a started identity is consumed even if it terminates unsuccessfully.
+7. **Run policy.** Start a fresh policy database, keep it across r1-r3, freeze concurrency for the lineage, and run the rounds in order. Apply feedback only after the preceding round is strictly accepted.
+8. **Settle and assemble.** Reconcile by stable request ID, wait for authoritative terminal charges, build the evidence bundle, and reject missing or ambiguous rows.
+9. **Clean up.** Audit instances, volumes, and network interfaces by exact run tags after every group. Preserve cleanup evidence even for rejected groups.
+10. **Report.** Publish every predeclared round, failure, raw usage bucket, price source, actual/notional distinction, checksum, and limitation. Never select only the best round.
+
+## Hard stops
+
+Stop the current lineage, preserve partial evidence, and clean up when any of these is true:
+
+- the AWS identity, source revision, binary checksum, task manifest, or price snapshot differs from the frozen manifest;
+- quota, daemon health, provider sentinel, sandbox bootstrap, or session canary fails before a batch;
+- a group has a missing TrialResult, runtime exception, duplicate request ID, incomplete settlement, weak session attribution, or unmatched join;
+- exact-tag resource cleanup does not reach zero;
+- a predeclared spend or severe quality stop limit is crossed.
+
+Do not apply feedback after a rejected round. Do not relaunch a started identity, rerun a control to improve its score, estimate unknown cost, delete failed attempts, or change concurrency inside a lineage.
+
+## Quick reference
+
+| Need | Read |
+| --- | --- |
+| Experimental meaning, controls, trials, held-out design | [methodology.md](references/methodology.md) |
+| Required inputs, AWS/IAM, source/model/price checklist | [configuration.md](references/configuration.md) |
+| EC2/Harbor/Terminus lifecycle, resume, settlement, cleanup | [operations.md](references/operations.md) |
+| Strict gates, calculations, report and registry fields | [acceptance-and-reporting.md](references/acceptance-and-reporting.md) |
+| Diagnosing known benchmark failures | [qna.md](references/qna.md) |

--- a/skills/run-bitrouter-benchmark/references/acceptance-and-reporting.md
+++ b/skills/run-bitrouter-benchmark/references/acceptance-and-reporting.md
@@ -1,0 +1,272 @@
+# Acceptance and Reporting
+
+This reference defines when a benchmark group is usable and how to report it without overstating quality, savings, or reproducibility. Apply it independently to control and every policy round.
+
+## Contents
+
+- [Evidence inventory](#evidence-inventory)
+- [Strict group gate](#strict-group-gate)
+- [Four-bucket settlement](#four-bucket-settlement)
+- [Exact joins and runtime validity](#exact-joins-and-runtime-validity)
+- [Reward and reliability semantics](#reward-and-reliability-semantics)
+- [AWS cleanup gate](#aws-cleanup-gate)
+- [Metrics and formulas](#metrics-and-formulas)
+- [Actual and notional economics](#actual-and-notional-economics)
+- [Uncertainty and comparison](#uncertainty-and-comparison)
+- [Required report](#required-report)
+- [Scenario walkthroughs](#scenario-walkthroughs)
+- [Registry and public archive](#registry-and-public-archive)
+
+## Evidence inventory
+
+An independently reviewable group contains:
+
+- frozen private manifest plus sanitized manifest;
+- task/trial manifest and hash;
+- BitRouter, Harbor, Terminus 2, config, patch, and binary provenance;
+- append-only controller events and process records;
+- Harbor config, logs, and one result per case/trial;
+- daemon logs, request traces, policy decisions, metering rows, provider receipts, outcomes, and workflow-session evidence;
+- reconciliation record and strict bundle result;
+- cleanup monitor and authenticated AWS residue query;
+- feedback output and policy snapshots for accepted r1/r2 only;
+- per-group and per-case summary, checksums, and secret-scan result.
+
+Do not treat a summary JSON or Harbor exit code as a substitute for the underlying evidence.
+
+## Strict group gate
+
+Accept a group only when every row below is true.
+
+| Gate | Required evidence |
+| --- | --- |
+| Manifest | Frozen input hash matches the launched configuration |
+| Attempts | Expected case/trial identities equal controller identities; no duplicate `started` event |
+| TrialResult | Exactly one complete TrialResult per expected identity, verifier reward present, no unexplained exception |
+| Runtime | All started cases are `terminal_valid`; runtime-invalid count is zero |
+| Requests | Stable request IDs are unique and equal across expected trace/settlement membership |
+| Decisions | One policy decision per policy request where the pinned schema requires it |
+| Settlement | Every request is authoritative `computed` or authoritative `not_charged` |
+| Cost join | Every trace matches exactly one usage/charge row; no unmatched trace or usage row |
+| Reward join | Every trace maps to exactly one intended task outcome; no unmatched outcome |
+| Session join | Every request maps to the exact Harbor `session_key` with High confidence |
+| Replay | Offline reconstruction covers every policy request and agrees with online decisions |
+| Cleanup | Observed sandbox peak respects frozen concurrency; final instances, volumes, and interfaces are zero |
+| Secrets | Sanitized archive contains no live credential or private key material |
+
+Record the terminal status as one of:
+
+- `accepted`;
+- `rejected_runtime`;
+- `rejected_settlement`;
+- `rejected_join`;
+- `rejected_cleanup`;
+- `rejected_manifest`;
+- `rejected_safety_limit`.
+
+A rejected group may still produce a diagnostic report. It must not drive policy feedback, a cost claim, or the next round.
+
+The cost join, reward join, and session join are exact set-and-identity checks, not best-effort ratios.
+
+## Four-bucket settlement
+
+Every request row contains numeric values for all four fields:
+
+- `uncached_input_tokens`;
+- `cache_read_tokens`;
+- `cache_write_tokens`;
+- `output_tokens`.
+
+Zero is valid only when it is an observed/authoritative value. Missing is not zero. Record separately billed reasoning tokens and fixed/request charges in additional fields without folding them silently into output tokens.
+
+For route $r$, define prices per token as $p_{u,r}$ for uncached input, $p_{cr,r}$ for cache read, $p_{cw,r}$ for cache write, $p_{o,r}$ for output, and $p_{reason,r}$ for separately billed reasoning. The reconstructed variable charge is:
+
+$$
+C_r = n_u p_{u,r} + n_{cr} p_{cr,r} + n_{cw} p_{cw,r}
+      + n_o p_{o,r} + n_{reason} p_{reason,r}
+$$
+
+Add an explicitly sourced fixed charge only when the provider's billing contract requires it.
+
+Price precedence is:
+
+1. an explicit valid route-specific cache price;
+2. when the pinned product behavior declares it, the same route's valid base input price;
+3. otherwise `unknown`.
+
+Never borrow a price from another route/model, replace an invalid base price with zero, infer cache splits from prompt length, or estimate missing provider usage from historical averages.
+
+`computed` requires reconstructable usage and price evidence or an authoritative provider charge. `not_charged` requires an authoritative terminal receipt proving no charge. `pending` and `unknown` reject the group after the frozen reconciliation budget expires.
+
+## Exact joins and runtime validity
+
+Let $T$, $U$, $D$, and $R$ be the request-ID sets in traces, usage, decisions, and request-level reward attribution. For a policy group, require:
+
+$$
+T = U = D = R
+$$
+
+For control, omit $D$ only when the frozen control schema intentionally emits no policy decision. Require uniqueness in every set and reject extra rows as well as missing rows.
+
+For each trace, require:
+
+- one authoritative settlement row;
+- one routing decision when applicable;
+- one explicit workflow session equal to the outcome `session_key`;
+- one task outcome selected by that session;
+- an HTTP/runtime outcome consistent across logs and artifacts.
+
+Do not join by overlapping timestamps when trials run in parallel. A time window may bound a scan but cannot establish membership.
+
+TrialResult completeness means the verifier ran, reward is present, and exception metadata is empty or an explicitly accepted typed terminal condition. A typed `TerminalSessionEnded` may still yield a valid TrialResult when the environment remains reachable and the verifier completes. An environment disconnect, missing verifier result, corrupt output, or generic agent exception is runtime-invalid.
+
+## Reward and reliability semantics
+
+Maintain two evidence planes:
+
+| Plane | Key | Positive/negative signal |
+| --- | --- | --- |
+| Provider reliability | Provider + model + credential class + region/protocol | Timeout, 429, 5xx, successful completion, half-open probe |
+| Semantic adequacy | Workflow/task capability state + model transition | Verifier reward after a successfully completed, attributable request |
+
+Do not let task success give semantic success to an earlier timed-out/ejected weak request. Do not let a provider timeout permanently prove that the model lacks task capability. Require successful transport, attributable outcome, and authoritative settlement before writing positive semantic evidence.
+
+Report exploration trials, learned selections, static route choices, escalations, and fallbacks separately. Savings attributed only to fallbacks are reliability behavior, not learned replacement.
+
+## AWS cleanup gate
+
+After every group, independently query exact run tags and tracked IDs for:
+
+- EC2 sandbox instances in all non-terminated states;
+- EBS volumes created for those instances;
+- elastic network interfaces created for those instances.
+
+Acceptance requires an observed peak no greater than frozen concurrency and a final monitor tail of zero. Save empty query results, UTC timestamps, region, and redacted identity proof.
+
+Do not infer cleanup from Harbor logs. Do not search by broad project tag alone. A retained central host must be excluded only by an explicit role/instance identity in the frozen manifest.
+
+## Metrics and formulas
+
+Report per group and per task/trial:
+
+- passed attempts, total attempts, and score;
+- total/strong/balanced/economy request counts;
+- request counts by decision reason;
+- all token/charge buckets by route;
+- actual cost, notional cost, and unpriced/unknown count;
+- cost per successful attempt;
+- latency and provider error counts;
+- failed tasks and paired control outcomes.
+
+For binary or scalar verifier rewards $q_i$ across $N$ predeclared trials:
+
+$$
+\text{score} = \frac{1}{N}\sum_{i=1}^{N} q_i
+$$
+
+For accepted comparable policy and control totals:
+
+$$
+\text{cost delta \%} =
+\left(\frac{C_{policy}}{C_{control}} - 1\right) \times 100
+$$
+
+$$
+\text{strong-call delta \%} =
+\left(\frac{N_{strong,policy}}{N_{strong,control}} - 1\right) \times 100
+$$
+
+$$
+\text{cost per success} =
+\frac{C_{group}}{\text{successful trial count}}
+$$
+
+For learning-lifecycle economics through round $K$:
+
+$$
+C_{policy,1:K} = \sum_{k=1}^{K} C_{policy,k}
+$$
+
+$$
+C_{control,1:K} = K \times C_{frozen\ control}
+$$
+
+$$
+\text{cumulative delta \%} =
+\left(\frac{C_{policy,1:K}}{C_{control,1:K}} - 1\right) \times 100
+$$
+
+Keep steady-state savings and cumulative adaptation cost in separate rows. A cheap r3 does not erase expensive or low-quality r1-r2 behavior.
+
+## Actual and notional economics
+
+Label every cost series:
+
+- **actual cost:** an authoritative provider/platform charge attributable to the request;
+- **notional cost:** raw usage multiplied by a cited list or registry price;
+- **subscription counterfactual:** usage priced as if billed per token even though marginal cash spend may be zero;
+- **incomplete:** any pending, unknown, or unpriced request.
+
+Do not add actual and notional costs into one total. Subscription-backed control costs are normally notional routing-economics comparisons unless the provider exposes an attributable charge. Publish both when both are useful, with source date and assumptions.
+
+## Uncertainty and comparison
+
+Compare only identical case/trial identities. If a historical quota/runtime incident permanently consumed some control identities, restrict the paired comparison to the exact intersection and report excluded identities and reasons.
+
+For replicated runs, compute paired task/trial deltas and a predeclared 95% interval, such as a bootstrap over task/trial pairs. Requests are not independent benchmark samples. Because policy state is path-dependent, include independent clean-database lineages in stability analysis.
+
+Report the time gap between immutable control and policy. Sentinel telemetry can describe provider drift; it cannot turn a historical control into a contemporaneous randomized sample.
+
+## Required report
+
+Publish sections in this order:
+
+1. hypothesis, run class, allowed claim, and predeclared quality/cost tolerances;
+2. tuning/held-out role and reward availability assumptions;
+3. immutable experiment tuple, source/config hashes, and EC2 topology;
+4. control artifact resolution and case/trial intersection;
+5. one table containing control and every predeclared policy round;
+6. paired per-task/trial quality, cost, and request deltas;
+7. strong/balanced/economy decisions and learned-replacement evidence;
+8. four-bucket settlement and exact join audit;
+9. runtime, provider, retry, concurrency, and cleanup evidence;
+10. steady-state and cumulative adaptation economics;
+11. discarded/failed attempts, limitations, and temporal drift;
+12. go/no-go decision and artifact/checksum locations.
+
+Never publish only the best round. Never delete a failed attempt from denominators. Keep runtime acceptance separate from whether the policy met the product target.
+
+## Scenario walkthroughs
+
+### Internal short13 walkthrough
+
+Freeze 13 tasks, one trial per case, an existing verified central host, one BitRouter/Harbor/Terminus source tuple, and fixed concurrency. Resolve a matching accepted control and launch zero control cases. Create a fresh policy database, run r1-r3 in sequence, strictly accept every round before feedback, and report all 39 TrialResults plus exact joins and cleanup. Describe the result as mechanism evidence.
+
+### Teammate 20-case walkthrough
+
+Freeze the teammate's explicit AWS identity, region, provider secret sources, strong/balanced/economy models, source commits, prices, approximately 20 predeclared tasks, trial count, and concurrency. Reuse a control only when its complete key matches; otherwise launch only absent control identities once. Prove the new environment with a non-evaluation canary and staged concurrency canary before scored work. Publish configuration and evidence without exposing secrets.
+
+### External full 89-task walkthrough
+
+Provision a new central host from public instructions, freeze all 89 tasks and five predeclared trials per task, and build from published BitRouter/Harbor commits. Create or resolve the immutable control, run the declared policy/evaluation design, accept every group strictly, and publish sanitized raw evidence, checksums, price provenance, limitations, and registry fields. This is the path for an externally reproducible result.
+
+## Registry and public archive
+
+When contributing a Terminal-Bench 2.1 result to BitRouter's model registry, use the repository's current schema. At the time of this contract it includes:
+
+```yaml
+benchmarks:
+  terminal_bench_2_1:
+    accuracy: 0.0
+    cost_per_task: 0.0
+    time_per_task: 0.0
+    measured_by: bitrouter
+    harness: terminus-2
+    config: operator-declared-config
+    as_of: 2026-01-01
+    source_url: https://example.invalid/public-evidence
+```
+
+Replace example values with verified results. Omit optional metrics that cannot be proven. `source_url` is required for third-party `measured_by` values and is recommended for first-party evidence as well. Check current registry documentation before editing generated catalogs.
+
+The public archive should contain raw messages/tool calls only when policy and privacy permit, plus sanitized configs, request/session IDs, usage buckets, decisions, outcomes, receipts, controller events, cleanup proofs, reports, and checksums. Run a secret scan before upload and again on the downloaded release. Record archive byte count and verify every published checksum.

--- a/skills/run-bitrouter-benchmark/references/configuration.md
+++ b/skills/run-bitrouter-benchmark/references/configuration.md
@@ -1,0 +1,246 @@
+# Configuration Contract
+
+This reference lists every value an operator must discover, choose, and freeze before a BitRouter benchmark. It is a review contract, not a machine-readable schema and not an infrastructure template.
+
+## Contents
+
+- [Configuration principles](#configuration-principles)
+- [Run identity](#run-identity)
+- [AWS IAM identity](#aws-iam-identity)
+- [Central host mode](#central-host-mode)
+- [EC2 and network inputs](#ec2-and-network-inputs)
+- [BitRouter source and daemon](#bitrouter-source-and-daemon)
+- [Models, providers, and secrets](#models-providers-and-secrets)
+- [Harbor and Terminus 2](#harbor-and-terminus-2)
+- [Tasks, trials, and controller](#tasks-trials-and-controller)
+- [Prices and settlement](#prices-and-settlement)
+- [Paths, ports, and tags](#paths-ports-and-tags)
+- [Stop limits and final review](#stop-limits-and-final-review)
+
+## Configuration principles
+
+Freeze configuration before any scored case is marked `started`.
+
+- Record explicit values, not ambient defaults.
+- Record a secret source name or protected location, never its value.
+- Keep an operator-only manifest and a redacted publication manifest.
+- Hash the task manifest, configs, binaries, and policy-state snapshots.
+- Validate inputs through the exact pinned software that will run the benchmark.
+- Treat a changed value as a new lineage unless the methodology explicitly identifies it as postprocessing-only.
+
+Do not reuse a historical manifest unchanged. Its source revisions, credentials, prices, resource identifiers, and paths belong to a different environment.
+
+## Run identity
+
+Record:
+
+| Field | Required value |
+| --- | --- |
+| Benchmark | `terminal-bench/terminal-bench-2-1` and its resolved dataset revision |
+| Run class | Non-evaluation canary, mechanism, replicated, or public reproduction |
+| Lineage and round | New immutable names for control, r1, r2, and r3 as applicable |
+| Task manifest | Ordered task names and a content hash |
+| Trial manifest | Explicit trial identities per task and a content hash |
+| Tuning/held-out role | Tuning, held-out, diagnostic, or non-evaluation |
+| Control key | Canonical fields plus catalog lookup result |
+| Start window | Planned UTC window and maximum allowed duration |
+| Owner and reviewer | Operator and independent evidence reviewer |
+
+Names must be unique without embedding credentials, account identifiers, or model secrets.
+
+## AWS IAM identity
+
+Choose one explicit identity mechanism for the whole run. Supported examples include:
+
+- a named AWS CLI profile backed by operator-provided IAM access keys;
+- a named profile using `credential_process` or explicit role assumption;
+- an EC2 instance profile attached to the central host;
+- another AWS-supported method that can be selected deterministically and propagated to every subprocess.
+
+Record the mechanism type and its selector, not credential contents. The selector may be a profile name, role ARN, instance-profile ARN, or environment contract. Do not assume the `default` profile or silently fall back to another source.
+
+Before any quota or EC2 call, prove the explicit identity with STS. Compare the returned account and principal with the private manifest, write only a redacted identity proof to public artifacts, and stop on mismatch. The controller and each Harbor process must use the same explicit identity selection.
+
+Grant the dedicated AWS IAM principal only the permissions required to:
+
+- read caller identity and regional Service Quotas;
+- create, tag, describe, stop, and terminate the selected EC2 instances;
+- create, inspect, attach, detach, and delete the required volumes and network interfaces;
+- inspect the selected images, subnets, security groups, key pair, and instance profiles.
+
+Root credentials are unnecessary. If credentials must be copied to a central host, use a protected channel and restrictive file permissions, remove them during decommissioning, and never place them in an AMI, user data, shell history, repository, config bundle, log, or archive.
+
+## Central host mode
+
+Choose exactly one mode: provision a central host or reuse a central host.
+
+### Provision a central host
+
+Freeze the image, instance type, volume, subnet, security groups, SSH path, instance profile or credential transfer method, bootstrap procedure, and teardown/retention decision. Tag the host separately from ephemeral sandboxes.
+
+Provisioning is not complete until the host proves:
+
+- the expected AWS identity;
+- the pinned BitRouter, Harbor, and Terminus 2 revisions;
+- the expected binary and configuration hashes;
+- private reachability from a canary sandbox;
+- sufficient disk, memory, ports, and file permissions;
+- protected secret sources and sanitized logging.
+
+### Reuse a central host
+
+Freeze the instance identity and re-run every proof above. Also prove that no stale benchmark process, port listener, database, socket, trace file, controller event log, or output directory can overlap the new lineage.
+
+Reuse saves provisioning time. It does not permit weaker evidence or reuse of run-scoped state.
+
+## EC2 and network inputs
+
+Record:
+
+- AWS account selector and region;
+- central and sandbox AMI IDs and architecture;
+- central and sandbox instance types and vCPU counts;
+- root-volume type and size;
+- subnet and availability-zone strategy;
+- central, sandbox, and controller security groups;
+- SSH key source and authorized source range;
+- whether sandboxes use public IPv4, NAT, or a prebuilt image for bootstrap;
+- private daemon address, ports, and allowed source security group;
+- resource tags for project, role, lineage, round, case, and trial;
+- observed Standard On-Demand vCPU quota and headroom.
+
+Use Service Quotas code `L-1216C47A`. Freeze the calculation:
+
+```text
+required vCPU = central-host vCPU
+              + max-parallel-sandboxes * sandbox vCPU
+              + declared headroom
+```
+
+If a central host is retained and already consumes quota, count its actual live vCPU rather than adding it twice. Check both the quota ceiling and current tagged/non-tagged consumption before every batch.
+
+Restrict sandbox-to-daemon ingress to the sandbox security group and benchmark ports. If the subnet has an Internet Gateway but no NAT route, decide explicitly whether ephemeral sandboxes receive public IPs for bootstrap and controller SSH. Keep model traffic on the private daemon address.
+
+## BitRouter source and daemon
+
+Freeze:
+
+- repository URL and full source commit;
+- dirty-tree status and patch hash when the source is not pristine;
+- toolchain and dependency lockfile hash;
+- exact build command and feature set;
+- serving binary SHA-256;
+- postprocessing binary SHA-256 when it differs from the serving binary;
+- daemon configuration hash and redacted copy;
+- control and policy listen addresses;
+- control database path and a separate policy database path;
+- trace, policy-decision, daemon-log, and settlement-log paths per group;
+- health endpoint, startup timeout, graceful shutdown timeout, and settlement grace period;
+- workflow-state and metering commands available at that source revision.
+
+Build on the central host or transfer a checksummed binary. Never hot-swap the serving binary inside a lineage. A newer postprocessing binary may repair evidence only when it launches zero cases, does not mutate routing state, is separately pinned, and produces an audit trail.
+
+## Models, providers, and secrets
+
+Record every route as provider, model, API protocol, base URL class, credential class, and intended tier:
+
+| Tier | Role | Selection guidance |
+| --- | --- | --- |
+| Strong | Fixed control and escalation | Frontier-quality route used by the immutable baseline |
+| Balanced | Default cost/quality tradeoff | Mid-price route selected for general work |
+| Economy | Aggressive savings | Lowest-price eligible route with task/capability safeguards |
+
+Do not infer tiers from marketing names. Freeze a price snapshot and capability hypothesis, then validate tool use, context length, protocol behavior, and reliability through canaries.
+
+For each credential, record only:
+
+- the provider and credential class;
+- the secret source name or protected path;
+- the renewal/expiry check;
+- which process reads it;
+- the public redaction rule.
+
+Provider API keys, subscription OAuth material, AWS keys, and SSH keys stay out of Harbor configs and evidence archives. Sandboxes receive only the private daemon URL and, when local daemon authentication is disabled, a non-secret local token required by the client library.
+
+## Harbor and Terminus 2
+
+Freeze:
+
+- Harbor repository and full commit;
+- any applied patch hash and installation command;
+- Python version and dependency lock/freeze hash;
+- Terminal-Bench dataset name and resolved revision;
+- Terminus 2 agent name, package version, reasoning configuration, context limits, and timeouts;
+- entry model name and API protocol exposed by BitRouter;
+- `api_base` placement and `llm_kwargs` passed by the pinned Harbor version;
+- the non-secret daemon key field required by the Terminus 2 LiteLLM client;
+- the exact workflow-session propagation mechanism;
+- EC2 environment fields and Pydantic validation command.
+
+Record whether a multi-trial Harbor `JobConfig` or a one-case `TrialConfig` will be used. The two shapes differ; do not translate between them by string editing after validation.
+
+## Tasks, trials, and controller
+
+Freeze:
+
+- exact ordered task list and dataset revision;
+- trial identities, random seeds when exposed, and attempts per task;
+- control versus policy group membership;
+- `max_parallel_sandboxes` for the entire lineage;
+- Harbor retry count, normally zero for mechanism runs;
+- task, agent-setup, verifier, settlement, and group timeouts;
+- pre-batch quota, health, and sentinel gates;
+- append-only case event store and atomic `started` rule;
+- resume rule allowing only `not_started` cases;
+- predeclared spend and severe-quality stop limits;
+- provider-rate-limit and latency thresholds for canaries.
+
+The manifest must distinguish a predeclared trial from a retry and must state how any public-protocol replacement attempt will be labeled and reported.
+
+## Prices and settlement
+
+Freeze one price record per provider/model/credential class and effective period:
+
+- uncached-input price;
+- cache-read price;
+- cache-write price;
+- output price;
+- reasoning-token price when billed separately;
+- fixed request, subscription, credit, or platform charges when relevant;
+- currency, tax treatment, unit, source URL, source date, and retrieval timestamp;
+- whether the result is an actual charge or a notional list-price comparison.
+
+Explicit cache prices take precedence. If the selected BitRouter revision supports same-route fallback for a missing cache rate, document that behavior: only the same route's valid base input price may be used. A missing or invalid base price remains unknown.
+
+Freeze settlement states accepted by the run. Cost-bearing evidence must resolve to authoritative `computed` or authoritative `not_charged`. `pending`, `unknown`, inferred zero, or model-estimated usage is not accepted.
+
+## Paths, ports, and tags
+
+Allocate new run-scoped values for:
+
+- controller state and append-only case events;
+- control database and policy database;
+- per-group daemon logs, traces, decisions, usage, outcomes, and artifacts;
+- sockets and PID files;
+- control and policy ports;
+- Harbor jobs directory and job name;
+- secret-free manifest and private operator manifest;
+- archive, checksum manifest, and secret-scan result.
+
+Use the same immutable run tag on controller events, sandbox resources, artifacts, and cleanup queries. Use a separate role tag for the retained central host so sandbox cleanup cannot terminate it accidentally.
+
+## Stop limits and final review
+
+Before launch, have the operator and reviewer sign off on:
+
+- identity and permission proof;
+- source commits, patches, and hashes;
+- task/trial/control manifests;
+- model routes, protocols, and credential sources;
+- quota calculation and concurrency;
+- prices and actual/notional classification;
+- retry, timeout, settlement, feedback, and cleanup rules;
+- maximum spend and severe-quality stop conditions;
+- new paths, ports, tags, and secret redaction.
+
+After sign-off, make the manifest immutable. If an input must change, stop before starting another case and create a new lineage manifest.

--- a/skills/run-bitrouter-benchmark/references/methodology.md
+++ b/skills/run-bitrouter-benchmark/references/methodology.md
@@ -1,0 +1,171 @@
+# Benchmark Methodology
+
+This reference defines the experiment independently of any private run, AWS account, provider, model, or runner implementation.
+
+## Contents
+
+- [Question and evidence boundary](#question-and-evidence-boundary)
+- [Fixed experimental topology](#fixed-experimental-topology)
+- [Run classes and scale](#run-classes-and-scale)
+- [Immutable identities](#immutable-identities)
+- [Control policy](#control-policy)
+- [Policy evolution](#policy-evolution)
+- [Trials and retries](#trials-and-retries)
+- [Tuning and held-out evaluation](#tuning-and-held-out-evaluation)
+- [Concurrency and temporal drift](#concurrency-and-temporal-drift)
+- [Allowed claims](#allowed-claims)
+
+## Question and evidence boundary
+
+Ask one causal question:
+
+> Can BitRouter replace strong-model calls with cheaper-model calls while preserving Terminal-Bench task quality?
+
+Answer it only when the same case/trial identities have:
+
+- a fixed-strong quality and cost baseline;
+- complete policy-round quality and cost;
+- request-level model selections and decision reasons;
+- exact trace, decision, usage, reward, and workflow-session attribution;
+- authoritative cache-aware settlement;
+- comparable harness, sandbox, protocol, and pricing inputs.
+
+The result is a set of points: control, r1, r2, and r3. Report all of them. A cheaper round is not a success if quality falls outside the predeclared tolerance, and a high-quality round is not a routing-economics result if its cost evidence is incomplete.
+
+## Fixed experimental topology
+
+Use all of the following for benchmark evidence:
+
+1. Terminal-Bench 2.1 tasks and verifier.
+2. Harbor as the orchestration framework.
+3. Terminus 2 as the neutral agent harness, avoiding a first-party Anthropic or OpenAI agent as the experiment controller.
+4. One ephemeral AWS EC2 sandbox for each trial.
+5. A separate central EC2 host running the pinned BitRouter daemon and the benchmark controller.
+6. Private sandbox-to-daemon traffic; public network access only where package bootstrap or controller SSH requires it.
+7. Request-level BitRouter traces, decisions, metering, reward attribution, and explicit workflow sessions.
+
+Local Docker, direct model probes, and fixture tests are useful smoke evidence. They do not satisfy the benchmark gate because they omit the production EC2 lifecycle and cleanup behavior.
+
+## Run classes and scale
+
+| Class | Tasks | Trials | State reset | What it measures |
+| --- | ---: | ---: | --- | --- |
+| Non-evaluation canary | A task not in the scored manifest | 1 | Fresh | Infrastructure, agent, attribution, and cleanup only |
+| Mechanism iteration | Short 13 or another predeclared 8-20 task slice | One trial per case | Fresh control/policy separation | Whether routing and learning work |
+| Replicated mechanism | Predeclared slice or 89 tasks | At least 3 | Replicate the complete clean policy lineage | Paired uncertainty and path dependence |
+| Public reproduction | 89 tasks | Five predeclared trials | As declared by the public protocol | Reproducible full Terminal-Bench result |
+
+A teammate may choose approximately 20 tasks for broader iteration, but must publish the exact task manifest before observing results. The full dataset has 89 tasks. Changing task membership or trial count creates a different experiment identity.
+
+In concise terms: an internal mechanism run may use one trial per case, while a public reproduction uses five predeclared trials for each of the 89 tasks.
+
+## Immutable identities
+
+Define a policy lineage with:
+
+```text
+benchmark version + exact task/trial manifest
+Terminus 2 and Harbor revision/configuration
+strong, balanced, and economy provider/model/protocol/credential classes
+BitRouter source revision, binary checksum, and configuration
+sandbox AMI, instance type, region, and network shape
+policy-state lineage
+price snapshot and source date
+fixed concurrency, retry rule, and timeouts
+```
+
+Changing any item starts a new policy lineage. Give every lineage and round a new label, directory, port set, trace set, log set, and controller state. Never reuse a partial run directory or policy database.
+
+Define the control key separately:
+
+```text
+benchmark version + exact case/trial identity
+Terminus 2 and Harbor revision/configuration
+fixed-strong provider/model/protocol/credential class
+sandbox AMI, instance type, region, and network shape
+```
+
+Do not include the policy implementation commit in the control key. This separation lets multiple BitRouter policy revisions reuse the same immutable control without rerunning it.
+
+## Control policy
+
+Use a dedicated, clean fixed-strong database and no learning feedback. Keep tasks, trials, agent configuration, entry protocol, timeouts, sandbox shape, and pricing basis identical to policy comparison groups.
+
+Maintain an append-only control catalog. Each record contains:
+
+- a canonical control key and task/trial manifest hash;
+- accepted and terminal-failed case/trial identities;
+- harness, model, protocol, sandbox, and timestamp provenance;
+- raw usage buckets and the pricing snapshot used at publication time;
+- an artifact identifier and checksums.
+
+For a control key, launch each case/trial identity at most once. Once the controller records `started`, retain its accepted outcome or terminal failure permanently. Never rerun it to repair quality, compensate for provider drift, or search for a better score. A preflight probe or explicitly non-evaluation canary is not a control case.
+
+When prices change, reprice the archived raw usage under a new declared snapshot. Do not call the model again.
+
+## Policy evolution
+
+Use a clean policy database for r1 and share exactly that database with r2 and r3:
+
+| Group | Database | Feedback | Interpretation |
+| --- | --- | --- | --- |
+| r1 | New clean policy DB | Apply only after strict acceptance | Cold exploration |
+| r2 | Same policy DB | Apply only after strict acceptance | First adapted policy |
+| r3 | Same policy DB | None needed for this evaluation lineage | Learned replacement and stability |
+
+Run `r1 -> feedback -> r2 -> feedback -> r3`. Do not skip a round because an intermediate point is expensive or lower quality; non-monotonic behavior is part of the finding. Do not continue after a rejected round, and do not add an unplanned r4 to search for a favorable outcome.
+
+Apply benchmark reward only when the group has complete quality, settlement, join, and cleanup evidence. Never apply reward to the control database, a held-out evaluation, a diagnostic-only artifact, or a rejected group.
+
+Distinguish request reasons:
+
+- an exploration trial is learning cost;
+- a learned lock or promoted weak selection is replacement evidence;
+- a static economy route is operator-authored behavior;
+- a fallback is reliability behavior, not learned optimization.
+
+## Trials and retries
+
+A trial is a predeclared independent sample. A retry is an additional attempt caused by failure. They are not interchangeable.
+
+Use Harbor retry count zero for mechanism validation. Within a lineage, never relaunch a started case/trial identity. Preserve its failure, cost, request IDs, and zero or missing verifier outcome according to the evidence contract.
+
+If a public protocol permits a replacement after a proven transient infrastructure failure, assign a new explicit identity, retain the failed attempt, and report attempted trials and retry cost separately. Never overwrite the original or retry an immutable control for score improvement.
+
+## Tuning and held-out evaluation
+
+Rounds r1-r3 on the same tasks use verifier reward as an optimization signal. They measure adaptation, not unbiased generalization.
+
+For a held-out claim:
+
+1. Select tuning and held-out tasks before policy results are visible.
+2. Learn only from tuning tasks.
+3. Freeze and checksum the resulting policy database and configuration.
+4. Clone that exact snapshot for each held-out attempt so held-out trials cannot teach one another.
+5. Never apply held-out rewards.
+6. Compare frozen policy and immutable control on the same held-out case/trial identities.
+
+If the sample is too small for one holdout, predeclare cross-validation. Reset state for every fold and aggregate only untouched-fold results.
+
+Benchmark verifier reward is an oracle unavailable in normal product traffic unless an equivalent production reward source exists. Describe experiments without such a source as reward-supervised policy optimization.
+
+## Concurrency and temporal drift
+
+Treat concurrency as a frozen lineage input. Establish explicit workflow-session attribution at concurrency 1, then test higher values with separate non-evaluation canaries. A cautious ladder may evaluate 3, 4, 6, and 8 in new identities; no historical result makes those values safe in another AWS account or provider environment.
+
+Never raise or lower concurrency inside r1-r3. If a canary fails, diagnose it and start a new canary or lineage with a newly frozen value.
+
+Because an immutable control is not rerun contemporaneously, record the time gap between it and policy groups. Send non-scoring strong-route sentinels around policy rounds to observe availability, latency, and rate-limit drift. Sentinel data explains temporal confounding but never mutates or replaces the control.
+
+## Allowed claims
+
+| Evidence | Allowed statement | Not allowed |
+| --- | --- | --- |
+| Direct probe | Endpoint/protocol works at that moment | Benchmark quality or cost |
+| Non-evaluation canary | EC2, agent, attribution, settlement, and cleanup path works | Scored model comparison |
+| One-trial short run | Routing/learning mechanism produced an observed point | Stable model ranking or public score |
+| Replicated tuning run | Mechanism behavior with paired variation | Held-out generalization |
+| Frozen held-out run | Generalization on the declared held-out sample | Broader production performance without external evidence |
+| Full 89-task, five-trial public run | Reproducible Terminal-Bench result under the frozen configuration | Cash-spend claim when costs are only notional |
+
+Keep runtime acceptance and product success separate. A perfectly assembled run can show that a policy is unstable; that is valid evidence, not a failed measurement.

--- a/skills/run-bitrouter-benchmark/references/operations.md
+++ b/skills/run-bitrouter-benchmark/references/operations.md
@@ -1,0 +1,313 @@
+# Operations Runbook
+
+This reference describes the fixed Terminal-Bench 2.1 + Harbor + Terminus 2 + AWS EC2 lifecycle. Replace shell variables with values from the approved manifest, verify every command against the pinned source revisions, and stop at the first failed gate.
+
+## Contents
+
+- [Lifecycle at a glance](#lifecycle-at-a-glance)
+- [1. Freeze and authenticate](#1-freeze-and-authenticate)
+- [2. Gate quota before case consumption](#2-gate-quota-before-case-consumption)
+- [3. Prepare the central host](#3-prepare-the-central-host)
+- [4. Build and start BitRouter](#4-build-and-start-bitrouter)
+- [5. Validate Harbor and Terminus 2](#5-validate-harbor-and-terminus-2)
+- [6. Run non-evaluation canaries](#6-run-non-evaluation-canaries)
+- [7. Resolve or create the immutable control](#7-resolve-or-create-the-immutable-control)
+- [8. Run policy rounds](#8-run-policy-rounds)
+- [9. Reconcile and assemble evidence](#9-reconcile-and-assemble-evidence)
+- [10. Resume safely](#10-resume-safely)
+- [11. Clean up AWS resources](#11-clean-up-aws-resources)
+- [12. Archive and scale concurrency](#12-archive-and-scale-concurrency)
+
+## Lifecycle at a glance
+
+```text
+freeze manifest
+  -> prove explicit AWS identity
+  -> quota/network/source/config preflight
+  -> provision or verify central host
+  -> direct strong and weak sentinels
+  -> one real non-evaluation Terminus 2 canary
+  -> resolve immutable control
+  -> launch only missing control identities, once
+  -> r1 -> feedback -> r2 -> feedback -> r3
+  -> settle and strictly accept each group
+  -> exact-tag cleanup after every group
+  -> sanitize, checksum, archive, and report
+```
+
+Run no scored case merely to test installation, credentials, networking, concurrency, or cleanup. Use probes and predeclared non-evaluation canaries for those purposes.
+
+## 1. Freeze and authenticate
+
+Create a new run root and write the approved private manifest plus a redacted review copy. Verify that no run label, port, database, socket, trace, decision, log, Harbor output, or controller event path already exists.
+
+Select one AWS credential mechanism. For a named profile, a non-printing identity preflight can use:
+
+```bash
+aws --profile "$AWS_PROFILE" sts get-caller-identity \
+  --output json >"$PRIVATE_IDENTITY_PROOF"
+```
+
+For an instance profile or explicit assumed role, omit `--profile` and use the manifest's deterministic selector. In every mode:
+
+1. compare account and principal with the private manifest;
+2. produce a redacted proof for the archive;
+3. pass the same selector to all controller calls;
+4. propagate the same environment/profile to every Harbor subprocess;
+5. stop before any quota or EC2 call on mismatch or fallback.
+
+Do not print credentials or include them in process arguments that will be archived. Check secret-file permissions without displaying contents.
+
+## 2. Gate quota before case consumption
+
+Query Standard On-Demand vCPU quota code `L-1216C47A` in the selected region. A named-profile example is:
+
+```bash
+aws --profile "$AWS_PROFILE" service-quotas get-service-quota \
+  --region "$AWS_REGION" \
+  --service-code ec2 \
+  --quota-code L-1216C47A \
+  --query 'Quota.Value' \
+  --output text
+```
+
+Calculate:
+
+```text
+required vCPU = live central-host vCPU
+              + max_parallel_sandboxes * sandbox vCPU
+              + declared headroom
+```
+
+Also inspect current running/pending instances because quota availability is the ceiling minus current use. Immediately before every canary or benchmark batch:
+
+1. prove identity again if the credential could have rotated;
+2. query quota and current usage;
+3. query live sandboxes for the exact run tag;
+4. check daemon health and provider sentinels;
+5. only then atomically append `started` and call Harbor.
+
+If the gate fails, leave the case `not_started`. A rejected `RunInstances` call must not accidentally consume a control identity.
+
+## 3. Prepare the central host
+
+### Provisioning mode
+
+Create the central instance with the frozen AMI, instance type, volume, subnet, security groups, role or credential channel, and tags. Restrict SSH to the operator/controller source. Restrict daemon ingress to the sandbox security group and declared ports.
+
+Bootstrap through a reproducible command log that contains no secrets. Install the pinned toolchain, BitRouter source, Harbor source, Terminal-Bench dependencies, and Terminus 2 dependencies. Store secrets only after the image/bootstrap stage so they cannot enter an AMI or user data.
+
+### Reuse mode
+
+Verify the existing instance ID, source revisions, binary hashes, Python environment, credential mechanism, network, disk, and clock. Reject reuse if any run-scoped process or file overlaps the new manifest.
+
+For both modes, prove:
+
+- central-host private and optional public addresses match the manifest;
+- the host can create/tag/delete a disposable sandbox;
+- the sandbox can bootstrap packages using its declared public-IP/NAT/image path;
+- the sandbox reaches BitRouter only through the private address;
+- the central host has no unexpected listener on selected ports;
+- controller, daemon, Harbor, and archive paths are writable by the intended user only.
+
+## 4. Build and start BitRouter
+
+Checkout the full frozen commit and confirm the worktree/patch state. Build with the recorded command, compute the serving binary hash, and compare it with `binary SHA-256` in the manifest.
+
+Validate control and policy configs through that binary:
+
+```bash
+"$BITROUTER_BIN" config validate --config "$CONTROL_CONFIG"
+"$BITROUTER_BIN" config validate --config "$POLICY_CONFIG"
+```
+
+Use a dedicated control database and a separate new policy database. The policy database persists across r1-r3; per-group traces, decisions, logs, and process lifetimes do not.
+
+Before starting a group, set new output paths and the harness identifier expected by the pinned BitRouter revision. Start the daemon, wait on its health endpoint with a bounded timeout, and record start time, PID, config hash, binary hash, database, port, and output paths in an append-only group manifest.
+
+Never hot-swap the serving binary, config, provider credential class, or policy database within a lineage.
+
+## 5. Validate Harbor and Terminus 2
+
+Inspect the selected Harbor models before generating configs. In the validated shape:
+
+- a multi-case `JobConfig` uses the plural `agents` field;
+- a directly launched one-case `TrialConfig` uses the singular `agent` field.
+
+The distinction is `JobConfig.agents` versus `TrialConfig.agent`. Validate generated YAML/JSON through Harbor's own Pydantic model before marking a case `started`.
+
+For Terminus 2, the agent configuration must express the same non-secret data as:
+
+```yaml
+agent:
+  name: terminus-2
+  model_name: "$ENTRY_MODEL"
+  extra_allowed_hosts:
+    - "$DAEMON_PRIVATE_HOST"
+  env:
+    OPENAI_API_KEY: bitrouter-local
+  kwargs:
+    api_base: "http://$DAEMON_PRIVATE_HOST:$DAEMON_PORT/v1"
+    parser_name: json
+    session_id: "$EXACT_TRIAL_SESSION"
+    llm_kwargs:
+      api_key: bitrouter-local
+    llm_call_kwargs:
+      extra_headers:
+        x-bitrouter-workflow-session: "$EXACT_TRIAL_SESSION"
+```
+
+Render variables before Pydantic validation. `api_base` belongs in `agent.kwargs` for the pinned Harbor implementation. Keep the non-secret local key in `agent.kwargs.llm_kwargs.api_key`; `agent.env.OPENAI_API_KEY` alone is insufficient in affected Harbor versions.
+
+Set `x-bitrouter-workflow-session` to the exact value later emitted as the Harbor outcome `session_key`. Confirm the header on a captured canary request. Do not use prompt hashes, body metadata, response IDs, or overlapping time windows as the primary parallel attribution key.
+
+Set the EC2 environment to ephemeral deletion and include exact run, role, case, and trial tags. Explicitly choose public-IP/NAT bootstrap behavior. Keep the daemon host in `extra_allowed_hosts` and do not broaden network policy unnecessarily.
+
+Pin a Harbor revision that treats a vanished tmux pane/session as typed `TerminalSessionEnded`, ends agent interaction, and still runs the verifier when the environment remains accessible. Do not recreate a pane automatically: recreation loses working directory, environment variables, and process state. An environment transport failure remains runtime-invalid.
+
+## 6. Run non-evaluation canaries
+
+Run these gates without consuming the scored manifest:
+
+1. one direct strong-route request through BitRouter;
+2. one direct balanced/economy request through BitRouter;
+3. one real Terminus 2 trial in an ephemeral EC2 sandbox;
+4. one session-end fixture if the Harbor revision changed;
+5. one cleanup cycle proving zero sandbox residue.
+
+The canary passes only when:
+
+- Harbor emits a complete TrialResult and verifier reward;
+- every request has one trace, decision when policy applies, settlement row, and High-confidence session;
+- the outcome session key equals the explicit header;
+- all four usage buckets are numeric, including observed zeros;
+- charge status is authoritative;
+- the sandbox is gone and no run-tagged volume or network interface remains.
+
+Keep concurrency 1 until explicit sessions are proven. Test higher concurrency only in separate non-evaluation identities.
+
+## 7. Resolve or create the immutable control
+
+Build the canonical control key from the frozen manifest and query the append-only control catalog.
+
+### Matching accepted control exists
+
+Verify artifact checksum, task/trial manifest hash, harness/model/protocol key, sandbox shape, raw usage, and pricing provenance. Record its artifact ID in every policy group. Launch zero control cases.
+
+### No matching control exists
+
+Compute the missing case/trial identities by exact key. Re-run all preflight gates. Launch each missing identity once through the same Terminus 2 and EC2 topology used by policy groups.
+
+Append `started` atomically immediately before Harbor launch. After launch, the identity is permanently consumed. Store a complete accepted outcome or terminal failure in the catalog; never remove a poor result or rerun it.
+
+Control uses a clean dedicated database, routes every request to the frozen strong model, disables policy learning, and receives no reward feedback.
+
+## 8. Run policy rounds
+
+Create a new policy database and use this exact sequence:
+
+```text
+r1 -> feedback -> r2 -> feedback -> r3
+```
+
+For each round:
+
+1. create new daemon/process/log/trace/decision/outcome/artifact paths;
+2. keep the same policy database and frozen concurrency;
+3. send a non-scoring strong-route sentinel before the batch;
+4. gate identity, quota, current usage, daemon health, provider health, and sandbox residue before each batch;
+5. launch only the batch's `not_started` cases;
+6. wait for every started process to reach a terminal state;
+7. stop the daemon gracefully and allow the declared settlement grace;
+8. reconcile usage and build the strict evidence bundle;
+9. audit exact-tag AWS cleanup;
+10. accept or reject the group independently.
+
+Apply reward feedback once after accepted r1 and once after accepted r2. Snapshot policy state before and after feedback. Do not apply feedback after r3 for this evaluation lineage, after a rejected group, to a control, or to held-out evidence.
+
+If an intermediate accepted round loses quality or costs more, continue through the predeclared r3 unless a severe stop limit was crossed. If a round fails evidence integrity, stop the lineage before feedback or the next round.
+
+## 9. Reconcile and assemble evidence
+
+Inspect `bitrouter workflow-state --help` at the pinned source revision. The established command family includes:
+
+```bash
+"$BITROUTER_BIN" workflow-state harbor-outcomes \
+  --harbor-run-dir "$HARBOR_RUN_DIR" \
+  --output "$OUTCOMES_FILE"
+
+"$BITROUTER_BIN" workflow-state metering-usage \
+  --database-url "$DATABASE_URL" \
+  --since "$SCAN_START" \
+  --until "$SCAN_END" \
+  --output "$USAGE_FILE"
+
+"$BITROUTER_BIN" workflow-state bundle \
+  --run-label "$RUN_LABEL" \
+  --traces "$TRACE_FILE" \
+  --cloud-usage "$USAGE_FILE" \
+  --outcomes "$OUTCOMES_FILE" \
+  --policy-decisions "$DECISION_FILE" \
+  --output-dir "$ARTIFACT_DIR"
+```
+
+Use the exact options supported by the pinned binary. A broad time window may locate candidates, but final membership is the manifest's exact request ID set. Require set equality and uniqueness; reject missing, duplicate, or extra usage.
+
+For timeout or client-disconnect paths, use the pinned reconciliation interface to query authoritative receipts with the same stable request ID. Poll only within the frozen grace/attempt budget. Accept `computed` or authoritative `not_charged`; retain `pending` or `unknown` as a rejection, never as zero.
+
+Build and validate the bundle before reward mutates policy state. Independently reconstruct it from the database/request IDs and compare totals. A postprocess-only recovery may use a separately pinned binary, but it must launch zero cases, preserve original artifacts, avoid routing-state mutation, and record its own hash and actions.
+
+For accepted policy groups, apply feedback through the pinned `workflow-state apply-reward-feedback` interface and archive the result plus policy-state snapshots.
+
+## 10. Resume safely
+
+Use an append-only case state machine:
+
+| State | Meaning | May launch? |
+| --- | --- | --- |
+| `not_started` | Harbor was never called for this identity | Yes, after all current gates pass |
+| `started` | Identity was atomically consumed; process may need reconciliation | No |
+| `terminal_valid` | Complete TrialResult and runtime evidence exist | No |
+| `terminal_invalid` | Started, but runtime or TrialResult is incomplete | No |
+
+A crash-resume entrypoint must derive candidates from the manifest and event log, then assert that every candidate is `not_started` and absent from Harbor outputs. Wait for all processes from an interrupted batch to settle before classifying them.
+
+Do not infer "not started" from a missing final result alone. Inspect the event log, process record, Harbor job directory, EC2 tags, and provider request IDs. Preserve old attempts and use a new lineage after code/config fixes when the group is rejected.
+
+Postprocessing recovery is different: it may reconcile or rebuild artifacts for already-started cases while launching no Harbor trial.
+
+## 11. Clean up AWS resources
+
+Set Harbor environment deletion true, then independently verify cleanup. Query by exact run tags and tracked resource IDs, not by name fragments or age.
+
+A named-profile instance query can use:
+
+```bash
+aws --profile "$AWS_PROFILE" ec2 describe-instances \
+  --region "$AWS_REGION" \
+  --filters \
+    "Name=tag:bitrouter-benchmark-run-id,Values=$RUN_ID" \
+    "Name=tag:bitrouter-role,Values=sandbox" \
+    "Name=instance-state-name,Values=pending,running,stopping,stopped" \
+  --query 'Reservations[].Instances[].InstanceId' \
+  --output json
+```
+
+Run equivalent exact-tag/ID checks for EBS volumes and elastic network interfaces. Follow attachments from tracked instances because tag propagation can differ by resource type. Terminate/delete only resources proven to belong to the run; never clean up by a broad project tag alone.
+
+Acceptance requires:
+
+- no live or stopped run-scoped sandbox instances;
+- no available/in-use run-scoped volume outside the retained central host contract;
+- no run-scoped network interface outside the retained central host contract;
+- sandbox-count monitor peak at or below frozen concurrency and a final tail of zero.
+
+Save the authenticated cleanup query, timestamp, redacted identity proof, and empty result. A cleanup failure rejects the group even when quality and cost data are complete.
+
+## 12. Archive and scale concurrency
+
+Archive accepted and rejected groups. Include manifests, sanitized configs, controller events, Harbor results/logs, daemon logs, traces, decisions, usage, outcomes, reconciliation records, evidence bundles, feedback records, policy snapshots, cleanup proofs, summaries, checksums, and a secret-scan result.
+
+Do not archive live credentials, prompt/provider secrets, SSH keys, credential-store databases, or shell history. Keep request IDs, session IDs, timestamps, raw usage, decisions, and rewards needed for reproducibility unless a public privacy policy requires a documented transformation.
+
+Raise concurrency with new non-evaluation canaries, not inside a scored lineage. A cautious sequence is 1 for session validation, then separately frozen 3, 4, 6, and 8 candidates. At each step require complete TrialResults, authoritative settlement, strict joins, acceptable provider latency/error behavior, observed peak equal to the declared value, and zero AWS residue. A successful canary authorizes only a future new lineage at that fixed value.

--- a/skills/run-bitrouter-benchmark/references/qna.md
+++ b/skills/run-bitrouter-benchmark/references/qna.md
@@ -1,0 +1,246 @@
+# Benchmark Operations Q&A
+
+Use this symptom-driven reference during preflight, execution, recovery, and publication. Every safe action preserves case identity and evidence rather than routing around a failed gate.
+
+## Index
+
+| Questions | Area |
+| --- | --- |
+| Q1-Q2 | Fixed method and smoke-versus-benchmark evidence |
+| Q3-Q10 | AWS identity, quota, network, central host, and source pins |
+| Q11-Q15 | Harbor, Terminus 2, session attribution, and terminal lifecycle |
+| Q16-Q20 | Isolation, resume, postprocessing, controls, and trials |
+| Q21-Q26 | Provider errors, settlement, cache-aware cost, and reward semantics |
+| Q27-Q29 | Concurrency, cleanup, and publication |
+
+## Q1. Which parts of the benchmark are fixed, and which are configurable?
+
+**Symptom:** An operator copies an old run wholesale or proposes replacing EC2/Terminus 2 to fit the local environment.
+
+**Cause / diagnostic:** The fixed method and environment inputs were not separated. Terminal-Bench 2.1, Harbor, Terminus 2, a central EC2 BitRouter daemon, per-trial ephemeral EC2 sandboxes, immutable controls, and strict evidence gates are fixed. Identity, account, region, source, models, providers, secrets, tasks, trials, prices, concurrency, and provision/reuse mode are configurable.
+
+**Safe action:** Preserve the fixed rail, collect every configurable value into a new frozen manifest, and start a different explicitly labeled method if a fixed component must change.
+
+## Q2. Why is a local Docker or direct-provider result not a benchmark result?
+
+**Symptom:** A smoke run passes locally and is presented as evidence that a short/full run will pass.
+
+**Cause / diagnostic:** Local tests omit EC2 sandbox creation, bootstrap, private daemon reachability, Harbor's EC2 adapter, AWS quota, and resource cleanup. Direct probes also omit the real Terminus 2 workflow and verifier.
+
+**Safe action:** Use local tests for protocol/fixture smoke evidence, then run a non-evaluation canary and all scored trials through the fixed AWS topology before accepting benchmark evidence.
+
+## Q3. How should different operators supply AWS IAM credentials?
+
+**Symptom:** A command uses the ambient default identity, or instructions assume one person's credential path/profile.
+
+**Cause / diagnostic:** The authentication mechanism was treated as a global default. Operators may use different named IAM access-key profiles, explicit role assumptions, credential processes, or central-host instance profiles.
+
+**Safe action:** Freeze one explicit identity selector per run, prove it with STS, propagate it to the controller and every Harbor subprocess, record only a redacted identity proof, and never hardcode or archive the credential source/value.
+
+## Q4. What if STS fails or returns an unexpected principal?
+
+**Symptom:** `get-caller-identity` errors, resolves another account/role, or succeeds only after removing the explicit selector.
+
+**Cause / diagnostic:** The selected credential is missing, expired, misconfigured, or silently falling back. Removing the selector proves ambiguity rather than fixing it.
+
+**Safe action:** Stop before quota/EC2 calls and before any case is `started`. Repair the declared credential mechanism, repeat STS, and compare the exact account/principal with the private manifest.
+
+## Q5. How is the EC2 quota gate calculated?
+
+**Symptom:** Sandbox launches fail despite the account showing a positive quota.
+
+**Cause / diagnostic:** The operator ignored the central host, sandbox vCPU shape, current running instances, or headroom. The relevant Standard On-Demand vCPU quota is `L-1216C47A` in the target region.
+
+**Safe action:** Immediately before every batch, require available quota for live central-host vCPU plus frozen concurrency times sandbox vCPU plus declared headroom, after subtracting current regional use.
+
+## Q6. What should happen on `VcpuLimitExceeded`?
+
+**Symptom:** EC2 rejects `RunInstances`, sometimes after the controller has consumed a case identity.
+
+**Cause / diagnostic:** Quota was checked too early or `started` was written before the quota/health gates.
+
+**Safe action:** Gate immediately before each batch and append `started` only after quota, usage, daemon health, provider sentinel, and residue checks pass. If the identity is already `started`, preserve the terminal failure and never relaunch it; repair the controller for the next lineage.
+
+## Q7. Why can an EC2 sandbox start but fail during bootstrap or SSH?
+
+**Symptom:** The instance is running, yet package installation, Docker bootstrap, or controller SSH times out.
+
+**Cause / diagnostic:** The subnet has no effective egress path, or the sandbox lacks the public IPv4/NAT route declared by the manifest. Route tables, Internet Gateway/NAT, security groups, network ACLs, DNS, and SSH source range may disagree.
+
+**Safe action:** Choose public-IP, NAT, or prebuilt-image behavior explicitly; prove it with a disposable non-evaluation sandbox; restrict SSH to the controller source; and do not spend a scored identity on network diagnosis.
+
+## Q8. Why can the sandbox not reach the central BitRouter daemon?
+
+**Symptom:** Terminus 2 reports connection refused/timeout while central-host health is green locally.
+
+**Cause / diagnostic:** The daemon listens only on loopback, the config uses a public/wrong address, the sandbox security group is not allowed, the port differs, or Harbor network policy omitted the private host.
+
+**Safe action:** Bind the declared private interface, authorize only the sandbox security group/port, add the private daemon host to the agent's allowed hosts, and prove sandbox-to-daemon health before a scored batch.
+
+## Q9. When is reusing a central host safe?
+
+**Symptom:** Reuse saves time but produces port conflicts, old policy behavior, or mixed logs.
+
+**Cause / diagnostic:** A previous process, database, socket, trace, decision log, controller event store, or credential remained active. Reuse was treated as permission to reuse run state.
+
+**Safe action:** Verify instance/source/binary identity, kill only proven stale run processes, require new paths/ports/databases, repeat network and credential gates, and reject reuse if isolation cannot be proven.
+
+## Q10. What if source commits or binary hashes differ from the manifest?
+
+**Symptom:** The repo is at the right branch but the executable or Harbor behavior differs across groups.
+
+**Cause / diagnostic:** A branch moved, a dirty patch was omitted, build flags/toolchain changed, or a binary was hot-swapped.
+
+**Safe action:** Freeze full commits, patch/lock hashes, build command, and serving binary SHA-256. Stop the lineage on mismatch. Permit a separate postprocessing binary only with its own hash, zero case launches, and no routing-state mutation.
+
+## Q11. Why does Harbor reject a generated config mentioning `agent` or `agents`?
+
+**Symptom:** Pydantic reports a missing or extra agent field before launch.
+
+**Cause / diagnostic:** Harbor's multi-case `JobConfig.agents` is plural, while a directly launched one-case `TrialConfig.agent` is singular.
+
+**Safe action:** Generate the correct model shape deliberately and validate it through the pinned Harbor Pydantic class before the controller records `started`; never patch the field name after validation.
+
+## Q12. Why does Terminus 2 ignore the BitRouter endpoint or report a missing API key?
+
+**Symptom:** The agent calls another endpoint, or LiteLLM fails even though `OPENAI_API_KEY` is present.
+
+**Cause / diagnostic:** In affected Harbor versions, `api_base` must be in `agent.kwargs`, and the non-secret daemon key must also be in `agent.kwargs.llm_kwargs.api_key`; environment-only configuration is insufficient.
+
+**Safe action:** Inspect the pinned constructor, render and Pydantic-validate both fields, keep the upstream provider secret on the central daemon, and use only a non-secret local token in the sandbox/agent config.
+
+## Q13. Why do request traces fail to join the Harbor outcome?
+
+**Symptom:** Requests have timing/model data but the artifact reports Low/ambiguous session confidence or unmatched outcomes.
+
+**Cause / diagnostic:** `x-bitrouter-workflow-session` is absent or differs from the Harbor outcome `session_key`. Prompt hashes, provider response IDs, and body metadata are weaker fallbacks.
+
+**Safe action:** Generate one exact trial session value, place it in Terminus 2 `session_id` and the explicit header, capture a canary request, and assert equality with the emitted outcome before enabling parallelism.
+
+## Q14. Why is time-window attribution unsafe with parallel trials?
+
+**Symptom:** Multiple outcomes can plausibly own the same request because trial windows overlap.
+
+**Cause / diagnostic:** The assembler used timestamps as identity rather than a high-confidence session/request key.
+
+**Safe action:** Keep concurrency 1 until explicit sessions are proven. Use time only to bound scans; use stable request IDs and exact workflow sessions for final set membership and reward joins.
+
+## Q15. What should happen when the Terminus 2 tmux session disappears?
+
+**Symptom:** A model call returns, then `send-keys` fails because the pane/session ended.
+
+**Cause / diagnostic:** The session may exit during the model wait, creating a time-of-check/time-of-use race. Recreating a pane would lose cwd, environment, and process state.
+
+**Safe action:** Pin Harbor behavior that raises typed `TerminalSessionEnded`, stops agent interaction, and still runs the verifier when the environment is reachable. Do not recreate the pane; treat environment disconnect as runtime-invalid.
+
+## Q16. Why must paths, databases, sockets, and ports be new?
+
+**Symptom:** Counts exceed expected values, policy appears pre-trained, traces truncate, or a daemon binds the wrong state.
+
+**Cause / diagnostic:** A partial/failed run was resumed in place or control and policy state overlapped.
+
+**Safe action:** Allocate new run/group paths and ports, use a dedicated control database and one fresh shared r1-r3 policy database, archive the old attempt unchanged, and start a new lineage after implementation/config fixes.
+
+## Q17. Which cases may a crash-resume entrypoint launch?
+
+**Symptom:** A controller restart sees no final result and proposes rerunning that case.
+
+**Cause / diagnostic:** Missing result was mistaken for `not_started`; the case may already have a `started` event, Harbor directory, process, EC2 resource, or provider request.
+
+**Safe action:** Resume only identities proven `not_started` across manifest, append-only events, Harbor outputs, processes, EC2 tags, and request IDs. Never relaunch `started`, `terminal_valid`, or `terminal_invalid` identities.
+
+## Q18. Can postprocessing repair an artifact without rerunning cases?
+
+**Symptom:** Serving completed but settlement arrived late or the original bundler had a deterministic assembly bug.
+
+**Cause / diagnostic:** Runtime evidence may be intact while postprocessing is incomplete; rerunning would violate identity immutability.
+
+**Safe action:** Use a separately pinned/checksummed recovery binary that launches zero cases, selects the original stable request IDs, preserves original files, records every mutation/query, and does not change the serving database or routing state.
+
+## Q19. What if the control catalog has no match or only a partial match?
+
+**Symptom:** Policy work is ready, but exact control case/trial identities are absent, failed, or use another harness/model/sandbox key.
+
+**Cause / diagnostic:** Control reuse requires exact key equality; policy code revision alone neither matches nor invalidates a control.
+
+**Safe action:** Reuse accepted matching identities, preserve terminal failures, and launch only truly absent identities once after all gates pass. Never rerun accepted/failed controls or substitute a near-match silently.
+
+## Q20. Are five public trials retries of one case?
+
+**Symptom:** The runner uses Harbor retries to reach a five-trial target or discards failed samples.
+
+**Cause / diagnostic:** Predeclared trials are independent identities; retries are failure-driven extra attempts with different statistical/cost meaning.
+
+**Safe action:** Declare every trial identity before launch, keep mechanism retries at zero, preserve every failure, and label/report any protocol-permitted replacement attempt and its cost separately.
+
+## Q21. How should provider `401` or `403` errors be handled?
+
+**Symptom:** Strong/economy sentinels or benchmark requests return authentication/authorization errors.
+
+**Cause / diagnostic:** Credential expiry, wrong secret source, missing entitlement, protocol/base-URL mismatch, or accidental credential forwarding is more likely than model incapability.
+
+**Safe action:** Stop the group, inspect redacted provider logs and secret-source metadata, refresh/repair credentials outside configs, repeat non-evaluation sentinels, and start a new lineage if any scored identity was consumed.
+
+## Q22. How should `429`, `5xx`, and timeout failures be interpreted?
+
+**Symptom:** Weak calls fail under concurrency, then strong fallback completes the task.
+
+**Cause / diagnostic:** Rate limits, upstream availability, or client timeout are provider reliability signals, not direct semantic evidence. Request IDs and provider timing distinguish transient failure from model output inadequacy.
+
+**Safe action:** Preserve the failed request/charge, write reliability evidence, respect frozen circuit/backpressure rules, and do not award semantic success to the failed route. Change concurrency only in a new canary/lineage.
+
+## Q23. What if a timed-out request remains `pending`?
+
+**Symptom:** The local client stopped waiting but the provider may complete and charge later.
+
+**Cause / diagnostic:** Client timeout is not authoritative settlement. The upstream receipt may still transition to `computed` or `not_charged` under the same request ID.
+
+**Safe action:** Poll the pinned receipt/reconciliation interface within the frozen grace budget. Accept only authoritative terminal status; if it remains `pending` or becomes `unknown`, reject cost evidence and do not apply feedback.
+
+## Q24. Why require all four usage buckets even when cache writes are zero?
+
+**Symptom:** An exporter provides prompt/output totals but omits cache fields, or a report treats absence as zero.
+
+**Cause / diagnostic:** Cached input can materially change cost, and an observed zero differs from a missing field. The required fields are `uncached_input_tokens`, `cache_read_tokens`, `cache_write_tokens`, and `output_tokens`.
+
+**Safe action:** Require numeric authoritative values for every field on every request, retain observed zeros, report reasoning/fixed charges separately, and reject rows whose cache split cannot be reconstructed.
+
+## Q25. Which price applies when a cache-read or cache-write rate is missing?
+
+**Symptom:** A row cannot be priced, or code borrows a rate from another route.
+
+**Cause / diagnostic:** Price precedence was not frozen. Explicit route-specific cache rates must win; only declared product behavior may fall back to that same route's valid base input rate.
+
+**Safe action:** Use explicit cache price first, documented same-route base input second, otherwise mark unknown. Never use another model's price, an invalid base, zero, or a historical average.
+
+## Q26. Why separate provider reliability from semantic reward?
+
+**Symptom:** A successful task gives positive evidence to a weak request that timed out before strong fallback solved it, or a timeout permanently marks the model incapable.
+
+**Cause / diagnostic:** Transport outcome and verifier task quality were written into one ledger without request-level eligibility.
+
+**Safe action:** Write timeout/429/5xx to a provider/model/credential/region/protocol reliability key. Write semantic evidence only for successfully completed, attributable, authoritatively settled requests tied to verifier reward.
+
+## Q27. Can concurrency be raised from 3 to 4, 6, or 8 during a run?
+
+**Symptom:** Extra regional quota becomes available and the operator wants to speed up r2/r3 mid-lineage.
+
+**Cause / diagnostic:** Concurrency changes provider pressure and runtime conditions, breaking comparability. Prior canaries in another environment are not authorization for this one.
+
+**Safe action:** Keep the lineage's frozen value. Test 4, then 6, then 8 gradually in separate non-evaluation identities, require strict settlement/joins/cleanup at each step, and use a successful value only for a new lineage.
+
+## Q28. Why does cleanup fail when Harbor says `delete: true`?
+
+**Symptom:** Harbor exits but stopped instances, detached volumes, or network interfaces remain.
+
+**Cause / diagnostic:** Adapter cleanup can be interrupted, tag propagation may differ, or broad queries miss attached resources. Harbor logs are not independent AWS evidence.
+
+**Safe action:** Query instances, volumes, and interfaces by exact run tags plus tracked IDs/attachments, delete only proven run resources, preserve the authenticated empty result, and reject the group until residue is zero.
+
+## Q29. What changes between an internal run and a public reproduction?
+
+**Symptom:** A one-trial tuning result is prepared for publication as a stable model benchmark, with mixed subscription/list-price costs or an over-broad archive.
+
+**Cause / diagnostic:** Internal mechanism evidence may use short13/~20 tasks and one trial per case; public reproduction uses all 89 tasks and five predeclared trials, declared held-out semantics, provenance, and uncertainty. Actual charge and notional list-price cost are different series, and raw archives may contain secrets.
+
+**Safe action:** Match the claim to the run class, report tuning versus held-out behavior, separate actual/notional economics, publish every round/failure and registry provenance, sanitize credentials/keys/private paths without deleting request/session/usage evidence, checksum the release, and secret-scan both upload and download.


### PR DESCRIPTION
## Summary

- add the documentation-only `run-bitrouter-benchmark` skill
- fix the benchmark protocol around Terminal-Bench 2.1, Harbor, Terminus 2, one central EC2 BitRouter daemon, and ephemeral EC2 sandboxes
- separate fixed methodology from operator-configurable AWS identity, source pins, cases, trials, models, providers, pricing, concurrency, and paths
- preserve the complete lifecycle, strict acceptance/reporting gates, and a 29-question troubleshooting guide
- document repository-specific installation

## Reuse scenarios

- internal short13: reuse only a fully matching accepted control, then run policy r1-r3
- teammate runs: customize AWS account, source/model/provider tuple, case count, trial count, and staged concurrency
- external reproduction: provision from public instructions and run the full 89-task, five-trial protocol with public evidence

## Validation

- official `skill-creator` `quick_validate.py` — `Skill is valid!`
- `git diff --check origin/main...HEAD` — clean
- branch history contains one commit and only seven Markdown files
- private-path, credential-shape, historical-run, placeholder, and IPv4 scans — clean

## Scope

The entire PR contains Markdown only: the skills README, one skill entrypoint, and five references. It includes no runner, test code, script, schema, IaC, credential, `docs/superpowers` artifact, or live benchmark artifact. No scored benchmark cases were launched while preparing this PR.
