### PR TITLE
fix: harden provider fallback errors

### DIFF
--- a/apps/bitrouter/src/adequacy/observer.rs
+++ b/apps/bitrouter/src/adequacy/observer.rs
@@ -271,7 +271,7 @@ pub(crate) fn classify_failure(error: &BitrouterError) -> InadequacyCause {
         | BitrouterError::UpstreamUnavailable
         | BitrouterError::RateLimited { .. }
         | BitrouterError::Internal(_) => InadequacyCause::ProviderTransient,
-        BitrouterError::UpstreamPaymentRequired
+        BitrouterError::UpstreamPaymentRequired { .. }
         | BitrouterError::UpstreamAuth { .. }
         | BitrouterError::Unauthorized(_)
         | BitrouterError::Forbidden(_)
@@ -815,6 +815,7 @@ mod tests {
         assert_eq!(
             classify_failure(&BitrouterError::UpstreamRateLimited {
                 retry_after: Some(30),
+                detail: None,
             }),
             InadequacyCause::ProviderTransient
         );
@@ -827,7 +828,7 @@ mod tests {
     #[test]
     fn classifies_upstream_billing_and_protocol_errors() {
         assert_eq!(
-            classify_failure(&BitrouterError::UpstreamPaymentRequired),
+            classify_failure(&BitrouterError::UpstreamPaymentRequired { detail: None }),
             InadequacyCause::Auth
         );
         assert_eq!(

--- a/crates/bitrouter-sdk/src/error.rs
+++ b/crates/bitrouter-sdk/src/error.rs
@@ -45,7 +45,11 @@ pub enum BitrouterError {
 
     /// 402 — an upstream provider account has insufficient credit.
     #[error("upstream payment required")]
-    UpstreamPaymentRequired,
+    UpstreamPaymentRequired {
+        /// Bounded provider diagnostic retained for trusted observers. Public
+        /// protocol surfaces never expose this value.
+        detail: Option<String>,
+    },
 
     /// 403 — policy violation.
     #[error("forbidden: {0}")]
@@ -67,6 +71,9 @@ pub enum BitrouterError {
     UpstreamRateLimited {
         /// Seconds the caller should wait before retrying the earliest route.
         retry_after: Option<u64>,
+        /// Bounded provider diagnostic retained for trusted observers. Public
+        /// protocol surfaces never expose this value.
+        detail: Option<String>,
     },
 
     /// 400 — an upstream provider rejected the request parameters.
@@ -145,7 +152,7 @@ impl BitrouterError {
             Self::BadRequest { .. } => 400,
             Self::Unauthorized(_) => 401,
             Self::PaymentRequired(_) => 402,
-            Self::UpstreamPaymentRequired => 402,
+            Self::UpstreamPaymentRequired { .. } => 402,
             Self::Forbidden(_) => 403,
             Self::NotFound(_) => 404,
             Self::RateLimited { .. } => 429,
@@ -167,7 +174,7 @@ impl BitrouterError {
             Self::BadRequest { .. } => "invalid_request_error",
             Self::Unauthorized(_) => "authentication_error",
             Self::PaymentRequired(_) => "payment_required",
-            Self::UpstreamPaymentRequired => "payment_required",
+            Self::UpstreamPaymentRequired { .. } => "payment_required",
             Self::Forbidden(_) => "permission_error",
             Self::NotFound(_) => "not_found_error",
             Self::RateLimited { .. } => "rate_limit_error",
@@ -190,7 +197,7 @@ impl BitrouterError {
             Self::BadRequest { .. } => "invalid_request",
             Self::Unauthorized(_) => "authentication_error",
             Self::PaymentRequired(_) => "payment_required",
-            Self::UpstreamPaymentRequired => "upstream_payment_required",
+            Self::UpstreamPaymentRequired { .. } => "upstream_payment_required",
             Self::Forbidden(_) => "permission_denied",
             Self::NotFound(_) => "not_found",
             Self::RateLimited { .. } => "rate_limit_exceeded",
@@ -218,13 +225,27 @@ impl BitrouterError {
         Self::Internal(message.to_string())
     }
 
+    /// Provider diagnostic retained for trusted telemetry. HTTP/SSE protocol
+    /// renderers deliberately use [`Self::public_message`] instead.
+    pub fn upstream_detail(&self) -> Option<&str> {
+        match self {
+            Self::UpstreamPaymentRequired { detail } | Self::UpstreamRateLimited { detail, .. } => {
+                detail.as_deref()
+            }
+            Self::UpstreamPolicyViolation { message }
+            | Self::Upstream { message, .. }
+            | Self::UpstreamInvalidResponse { message } => Some(message),
+            _ => None,
+        }
+    }
+
     /// The machine-readable [`ErrorKind`] for this error.
     pub fn kind(&self) -> ErrorKind {
         match self {
             Self::BadRequest { .. } => ErrorKind::BadRequest,
             Self::Unauthorized(_) => ErrorKind::Unauthorized,
             Self::PaymentRequired(_) => ErrorKind::PaymentRequired,
-            Self::UpstreamPaymentRequired => ErrorKind::UpstreamPaymentRequired,
+            Self::UpstreamPaymentRequired { .. } => ErrorKind::UpstreamPaymentRequired,
             Self::Forbidden(_) => ErrorKind::Forbidden,
             Self::NotFound(_) => ErrorKind::NotFound,
             Self::RateLimited { .. } => ErrorKind::RateLimited,
@@ -253,7 +274,7 @@ impl BitrouterError {
             | Self::NotFound(m)
             | Self::Internal(m) => m.clone(),
             Self::RateLimited { .. } => "rate limited".to_string(),
-            Self::UpstreamPaymentRequired => "upstream payment required".to_string(),
+            Self::UpstreamPaymentRequired { .. } => "upstream payment required".to_string(),
             Self::UpstreamRateLimited { .. } => "upstream rate limited".to_string(),
             Self::UpstreamBadRequest { error } => upstream_payload_text(error),
             Self::UpstreamPolicyViolation { .. } => "upstream content policy violation".to_string(),
@@ -387,6 +408,33 @@ mod tests {
                 .error
                 .message
                 .contains("provider secret")
+        );
+    }
+
+    #[test]
+    fn upstream_payment_and_rate_details_stay_private() {
+        let payment = BitrouterError::UpstreamPaymentRequired {
+            detail: Some("account balance exhausted".into()),
+        };
+        assert_eq!(payment.upstream_detail(), Some("account balance exhausted"));
+        assert_eq!(payment.public_message(), "upstream payment required");
+        assert_eq!(
+            payment.to_envelope().error.message,
+            "upstream payment required"
+        );
+
+        let rate_limited = BitrouterError::UpstreamRateLimited {
+            retry_after: Some(30),
+            detail: Some("provider quota for tenant-123".into()),
+        };
+        assert_eq!(
+            rate_limited.upstream_detail(),
+            Some("provider quota for tenant-123")
+        );
+        assert_eq!(rate_limited.public_message(), "upstream rate limited");
+        assert_eq!(
+            rate_limited.to_envelope().error.message,
+            "upstream rate limited"
         );
     }
 

--- a/crates/bitrouter-sdk/src/language_model/executor.rs
+++ b/crates/bitrouter-sdk/src/language_model/executor.rs
@@ -209,6 +209,15 @@ fn truncate_upstream_message(text: &str) -> String {
     }
 }
 
+fn bounded_upstream_detail(body: &str) -> Option<String> {
+    let body = body.trim();
+    if body.is_empty() {
+        None
+    } else {
+        Some(truncate_upstream_message(body))
+    }
+}
+
 fn normalize_upstream_error_payload(body: &str) -> serde_json::Value {
     let parsed = match serde_json::from_str::<serde_json::Value>(body) {
         Ok(value) => value,
@@ -232,7 +241,10 @@ fn normalize_upstream_error_payload(body: &str) -> serde_json::Value {
 /// variants so callers can apply explicit fallback and response policies.
 fn classify_upstream_error(status: u16, body: &str, retry_after: Option<u64>) -> BitrouterError {
     if status == 429 {
-        return BitrouterError::UpstreamRateLimited { retry_after };
+        return BitrouterError::UpstreamRateLimited {
+            retry_after,
+            detail: bounded_upstream_detail(body),
+        };
     }
     // RFC 9110 section 15.5.1 defines 400 as the server being unable or
     // unwilling to process the request because of a perceived client error:
@@ -243,7 +255,9 @@ fn classify_upstream_error(status: u16, body: &str, retry_after: Option<u64>) ->
         };
     }
     if matches!(status, 401..=403) && looks_like_credit_exhaustion(body) {
-        return BitrouterError::UpstreamPaymentRequired;
+        return BitrouterError::UpstreamPaymentRequired {
+            detail: bounded_upstream_detail(body),
+        };
     }
     BitrouterError::Upstream {
         status,
@@ -1171,7 +1185,9 @@ mod error_classification_tests {
         let body =
             r#"{"type":"error","error":{"type":"CreditsError","message":"Insufficient balance."}}"#;
         match classify_upstream_error(401, body, None) {
-            BitrouterError::UpstreamPaymentRequired => {}
+            BitrouterError::UpstreamPaymentRequired { detail } => {
+                assert_eq!(detail.as_deref(), Some(body));
+            }
             other => panic!("expected UpstreamPaymentRequired, got {other:?}"),
         }
     }
@@ -1198,8 +1214,12 @@ mod error_classification_tests {
     #[test]
     fn upstream_429_has_a_distinct_safe_error() {
         match classify_upstream_error(429, r#"{"secret":"provider quota"}"#, Some(17)) {
-            BitrouterError::UpstreamRateLimited { retry_after } => {
+            BitrouterError::UpstreamRateLimited {
+                retry_after,
+                detail,
+            } => {
                 assert_eq!(retry_after, Some(17));
+                assert_eq!(detail.as_deref(), Some(r#"{"secret":"provider quota"}"#));
             }
             other => panic!("expected UpstreamRateLimited, got {other:?}"),
         }

--- a/crates/bitrouter-sdk/src/language_model/pipeline.rs
+++ b/crates/bitrouter-sdk/src/language_model/pipeline.rs
@@ -838,11 +838,18 @@ fn aggregate_fallback_errors(errors: Vec<BitrouterError>) -> BitrouterError {
         let retry_after = errors
             .iter()
             .filter_map(|error| match error {
-                BitrouterError::UpstreamRateLimited { retry_after } => *retry_after,
+                BitrouterError::UpstreamRateLimited { retry_after, .. } => *retry_after,
                 _ => None,
             })
             .min();
-        return BitrouterError::UpstreamRateLimited { retry_after };
+        let detail = errors
+            .iter()
+            .find_map(BitrouterError::upstream_detail)
+            .map(str::to_owned);
+        return BitrouterError::UpstreamRateLimited {
+            retry_after,
+            detail,
+        };
     }
 
     if errors
@@ -854,14 +861,29 @@ fn aggregate_fallback_errors(errors: Vec<BitrouterError>) -> BitrouterError {
 
     if errors
         .iter()
-        .all(|error| matches!(error, BitrouterError::UpstreamPaymentRequired))
+        .all(|error| matches!(error, BitrouterError::UpstreamPaymentRequired { .. }))
     {
-        return BitrouterError::UpstreamPaymentRequired;
+        let detail = errors
+            .iter()
+            .find_map(BitrouterError::upstream_detail)
+            .map(str::to_owned);
+        return BitrouterError::UpstreamPaymentRequired { detail };
     }
 
-    if let Some(error) = errors
+    if errors.iter().all(|error| {
+        matches!(
+            error,
+            BitrouterError::UpstreamBadRequest { .. }
+                | BitrouterError::UpstreamPolicyViolation { .. }
+        )
+    }) && let Some(error) = errors.last()
+    {
+        return error.clone();
+    }
+    if errors
         .iter()
-        .find(|error| matches!(error, BitrouterError::UpstreamInvalidResponse { .. }))
+        .all(|error| matches!(error, BitrouterError::UpstreamInvalidResponse { .. }))
+        && let Some(error) = errors.first()
     {
         return error.clone();
     }
@@ -883,10 +905,88 @@ fn aggregate_fallback_errors(errors: Vec<BitrouterError>) -> BitrouterError {
         return BitrouterError::UpstreamUnavailable;
     }
 
+    let is_provider_failure = |error: &BitrouterError| {
+        matches!(
+            error,
+            BitrouterError::UpstreamPaymentRequired { .. }
+                | BitrouterError::UpstreamRateLimited { .. }
+                | BitrouterError::Upstream { .. }
+                | BitrouterError::UpstreamAuth { .. }
+                | BitrouterError::UpstreamTimeout
+                | BitrouterError::UpstreamUnavailable
+        )
+    };
+    if errors.iter().all(is_provider_failure) {
+        return BitrouterError::UpstreamUnavailable;
+    }
+
     errors
         .into_iter()
         .last()
         .unwrap_or_else(|| BitrouterError::NotFound("empty routing chain".to_string()))
+}
+
+#[cfg(test)]
+mod fallback_error_tests {
+    use super::aggregate_fallback_errors;
+    use crate::error::BitrouterError;
+
+    #[test]
+    fn mixed_provider_failures_aggregate_to_unavailable() {
+        let error = aggregate_fallback_errors(vec![
+            BitrouterError::UpstreamPaymentRequired {
+                detail: Some("insufficient balance".to_owned()),
+            },
+            BitrouterError::UpstreamRateLimited {
+                retry_after: Some(30),
+                detail: Some("quota exceeded".to_owned()),
+            },
+            BitrouterError::Upstream {
+                status: 503,
+                message: "service unavailable".to_owned(),
+            },
+        ]);
+
+        assert!(matches!(error, BitrouterError::UpstreamUnavailable));
+    }
+
+    #[test]
+    fn homogeneous_rate_limits_keep_retry_and_diagnostic() {
+        let error = aggregate_fallback_errors(vec![
+            BitrouterError::UpstreamRateLimited {
+                retry_after: Some(60),
+                detail: Some("requests exhausted".to_owned()),
+            },
+            BitrouterError::UpstreamRateLimited {
+                retry_after: Some(15),
+                detail: None,
+            },
+        ]);
+
+        assert!(matches!(
+            error,
+            BitrouterError::UpstreamRateLimited {
+                retry_after: Some(15),
+                detail: Some(ref detail),
+            } if detail == "requests exhausted"
+        ));
+    }
+
+    #[test]
+    fn homogeneous_payment_failures_keep_diagnostic() {
+        let error = aggregate_fallback_errors(vec![
+            BitrouterError::UpstreamPaymentRequired {
+                detail: Some("insufficient credit".to_owned()),
+            },
+            BitrouterError::UpstreamPaymentRequired { detail: None },
+        ]);
+
+        assert!(matches!(
+            error,
+            BitrouterError::UpstreamPaymentRequired { detail: Some(ref detail) }
+                if detail == "insufficient credit"
+        ));
+    }
 }
 
 /// Owns the streaming `StreamProcessor` + `PipelineContext` for the lifetime of

--- a/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
@@ -300,6 +300,7 @@ fn conversion_matrix_4x4_streaming() {
 fn upstream_rate_limit_has_typed_terminal_frames_in_every_protocol() {
     let error = crate::error::BitrouterError::UpstreamRateLimited {
         retry_after: Some(9),
+        detail: None,
     };
     for protocol in all_protocols() {
         let mut encoder = adapter_for(protocol.clone()).stream_encoder("resp_429", "m");

--- a/crates/bitrouter-sdk/src/language_model/routing.rs
+++ b/crates/bitrouter-sdk/src/language_model/routing.rs
@@ -212,7 +212,7 @@ impl FallbackPolicy for DefaultFallbackPolicy {
             // a plain cascade it tries the next provider, which may
             // still have funds. If every target is drained the chain
             // exhausts and the original error is returned.
-            BitrouterError::PaymentRequired(_) | BitrouterError::UpstreamPaymentRequired => {
+            BitrouterError::PaymentRequired(_) | BitrouterError::UpstreamPaymentRequired { .. } => {
                 FallbackDecision::TryNext
             }
             BitrouterError::UpstreamInvalidResponse { .. } => FallbackDecision::TryNext,

--- a/crates/bitrouter-sdk/src/language_model/server_tools/stream.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/stream.rs
@@ -322,6 +322,7 @@ mod tests {
         async fn run(&self, _prompt: &Prompt) -> Result<StreamPartStream> {
             Err(crate::error::BitrouterError::UpstreamRateLimited {
                 retry_after: Some(9),
+                detail: None,
             })
         }
     }
@@ -394,7 +395,8 @@ mod tests {
         assert!(matches!(
             result,
             Err(crate::error::BitrouterError::UpstreamRateLimited {
-                retry_after: Some(9)
+                retry_after: Some(9),
+                ..
             })
         ));
     }

--- a/crates/bitrouter-sdk/src/language_model/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/tests.rs
@@ -573,6 +573,7 @@ async fn streaming_preflight_error_runs_settlement_and_observe_end() {
         Arc::new(MockExecutor::new(vec![MockResponse::Error(
             BitrouterError::UpstreamRateLimited {
                 retry_after: Some(3),
+                detail: None,
             },
         )])),
         |builder| {
@@ -745,6 +746,7 @@ async fn fallback_tries_next_on_upstream_429_then_succeeds() {
         Arc::new(MockExecutor::new(vec![
             MockResponse::Error(BitrouterError::UpstreamRateLimited {
                 retry_after: Some(30),
+                detail: None,
             }),
             MockResponse::Generate(GenerateResult {
                 content: vec![Content::Text {
@@ -778,10 +780,15 @@ async fn exhausted_upstream_429s_use_the_earliest_retry_after() {
         Arc::new(MockExecutor::new(vec![
             MockResponse::Error(BitrouterError::UpstreamRateLimited {
                 retry_after: Some(30),
+                detail: None,
             }),
-            MockResponse::Error(BitrouterError::UpstreamRateLimited { retry_after: None }),
+            MockResponse::Error(BitrouterError::UpstreamRateLimited {
+                retry_after: None,
+                detail: None,
+            }),
             MockResponse::Error(BitrouterError::UpstreamRateLimited {
                 retry_after: Some(12),
+                detail: None,
             }),
         ])),
         |_b| {},
@@ -790,7 +797,8 @@ async fn exhausted_upstream_429s_use_the_earliest_retry_after() {
     assert!(matches!(
         pipeline.execute(request()).await.unwrap_err(),
         BitrouterError::UpstreamRateLimited {
-            retry_after: Some(12)
+            retry_after: Some(12),
+            ..
         }
     ));
 }
@@ -930,6 +938,7 @@ async fn mixed_retryable_upstream_failures_become_service_unavailable() {
         Arc::new(MockExecutor::new(vec![
             MockResponse::Error(BitrouterError::UpstreamRateLimited {
                 retry_after: Some(10),
+                detail: None,
             }),
             MockResponse::Error(BitrouterError::Upstream {
                 status: 503,
@@ -2500,9 +2509,11 @@ async fn server_tool_streaming_preflight_aggregates_rate_limits() {
         Arc::new(MockExecutor::new(vec![
             MockResponse::Error(BitrouterError::UpstreamRateLimited {
                 retry_after: Some(12),
+                detail: None,
             }),
             MockResponse::Error(BitrouterError::UpstreamRateLimited {
                 retry_after: Some(30),
+                detail: None,
             }),
         ])),
         |builder| {
@@ -2514,7 +2525,8 @@ async fn server_tool_streaming_preflight_aggregates_rate_limits() {
     assert!(matches!(
         result,
         Err(BitrouterError::UpstreamRateLimited {
-            retry_after: Some(12)
+            retry_after: Some(12),
+            ..
         })
     ));
 }
@@ -2526,6 +2538,7 @@ async fn server_tool_streaming_preflight_aggregates_mixed_availability_failures(
         Arc::new(MockExecutor::new(vec![
             MockResponse::Error(BitrouterError::UpstreamRateLimited {
                 retry_after: Some(12),
+                detail: None,
             }),
             MockResponse::Error(BitrouterError::Upstream {
                 status: 503,
@@ -2550,6 +2563,7 @@ async fn server_tool_streaming_fallback_settles_the_winning_target()
         Arc::new(MockExecutor::new(vec![
             MockResponse::Error(BitrouterError::UpstreamRateLimited {
                 retry_after: Some(12),
+                detail: None,
             }),
             MockResponse::Stream(vec![StreamPart::Finish {
                 reason: FinishReason::Stop,
@@ -2586,6 +2600,7 @@ async fn server_tool_streaming_fallback_preserves_request_context()
         Arc::new(MockExecutor::new(vec![
             MockResponse::Error(BitrouterError::UpstreamRateLimited {
                 retry_after: Some(12),
+                detail: None,
             }),
             MockResponse::Stream(vec![StreamPart::Finish {
                 reason: FinishReason::Stop,
@@ -2638,6 +2653,7 @@ async fn server_tool_streaming_settles_the_final_turn_winner()
             ]),
             MockResponse::Error(BitrouterError::UpstreamRateLimited {
                 retry_after: Some(12),
+                detail: None,
             }),
             MockResponse::Stream(vec![StreamPart::Finish {
                 reason: FinishReason::Stop,

--- a/crates/bitrouter-sdk/src/server.rs
+++ b/crates/bitrouter-sdk/src/server.rs
@@ -878,7 +878,7 @@ fn apply_error_headers(response: &mut Response, error: &BitrouterError) {
                 response.headers_mut().insert(header::RETRY_AFTER, v);
             }
         }
-        BitrouterError::UpstreamRateLimited { retry_after } => {
+        BitrouterError::UpstreamRateLimited { retry_after, .. } => {
             if let Some(secs) = retry_after
                 && let Ok(v) = header::HeaderValue::from_str(&secs.to_string())
             {
@@ -1028,6 +1028,7 @@ mod tests {
             serde_json::json!(7),
             &BitrouterError::UpstreamRateLimited {
                 retry_after: Some(12),
+                detail: None,
             },
         );
 
@@ -1216,6 +1217,7 @@ mod tests {
     async fn upstream_rate_limit_has_wrapped_code_source_and_retry_after() {
         let response = BitrouterError::UpstreamRateLimited {
             retry_after: Some(12),
+            detail: None,
         }
         .into_response();
         assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
@@ -1274,6 +1276,7 @@ mod tests {
             test_state_with_executor(Arc::new(MockExecutor::new(vec![MockResponse::Error(
                 BitrouterError::UpstreamRateLimited {
                     retry_after: Some(7),
+                    detail: None,
                 },
             )])));
         let response = build_router(state)
@@ -1365,6 +1368,7 @@ mod tests {
             Arc::new(MockExecutor::new(vec![MockResponse::Error(
                 BitrouterError::UpstreamRateLimited {
                     retry_after: Some(7),
+                    detail: None,
                 },
             )])),
             true,

--- a/dist/registry/models.json
+++ b/dist/registry/models.json
@@ -7594,27 +7594,6 @@
           }
         },
         {
-          "api_protocol": "openai",
-          "capabilities": [
-            "reasoning",
-            "structured_outputs",
-            "tools"
-          ],
-          "pricing": {
-            "input_tokens": {
-              "no_cache": 1.5
-            },
-            "output_tokens": {
-              "text": 5.25
-            }
-          },
-          "provider": "tinfoil",
-          "provider_model_id": "glm-5-1",
-          "rate_limits": {
-            "requests_per_minute": 60
-          }
-        },
-        {
           "api_protocol": [
             "openai",
             "anthropic"

--- a/dist/registry/providers.json
+++ b/dist/registry/providers.json
@@ -8228,27 +8228,6 @@
             "structured_outputs",
             "tools"
           ],
-          "id": "z-ai/glm-5.1",
-          "pricing": {
-            "input_tokens": {
-              "no_cache": 1.5
-            },
-            "output_tokens": {
-              "text": 5.25
-            }
-          },
-          "provider_model_id": "glm-5-1",
-          "rate_limits": {
-            "requests_per_minute": 60
-          }
-        },
-        {
-          "api_protocol": "openai",
-          "capabilities": [
-            "reasoning",
-            "structured_outputs",
-            "tools"
-          ],
           "id": "moonshotai/kimi-k2.6",
           "pricing": {
             "input_tokens": {

--- a/registry/providers/tinfoil.yaml
+++ b/registry/providers/tinfoil.yaml
@@ -24,17 +24,6 @@ models:
       - reasoning
       - structured_outputs
       - tools
-  - id: z-ai/glm-5.1
-    provider_model_id: glm-5-1
-    pricing:
-      input_tokens:
-        no_cache: 1.5
-      output_tokens:
-        text: 5.25
-    capabilities:
-      - reasoning
-      - structured_outputs
-      - tools
   - id: moonshotai/kimi-k2.6
     provider_model_id: kimi-k2-6
     pricing:


### PR DESCRIPTION
## Summary

- Retain bounded upstream 402/429 response details for trusted telemetry while keeping public HTTP and SSE error messages generic.
- Preserve homogeneous 402/429 diagnostics and return a stable 503 for mixed route-health failures instead of whichever provider error happened last.
- Remove the unavailable Tinfoil GLM 5.1 route and rebuild the generated registry artifacts.

## Why

Fallback was executing, but typed 402/429 classification discarded the provider response body needed to distinguish quota, account, and credit failures. Mixed provider failures also surfaced an arbitrary terminal error. Separately, the registry advertised Tinfoil glm-5-1 even though the current upstream catalog no longer exposes it.

## Validation

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo nextest run --workspace --all-features --no-fail-fast: 2104 passed, 11 skipped
- cargo run -p dist-helper -- registry validate
- cargo run -p dist-helper -- registry build