### PR TITLE
feat(mcp): upgrade to stable rmcp 3.1 for MCP 2026-07-28

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - run: cargo check -p bitrouter-sdk --no-default-features
+      - run: cargo check -p bitrouter-sdk --no-default-features --features config_file
       - run: cargo check -p bitrouter-guardrails
       - run: cargo check -p bitrouter-observe
       - name: assert axum not in default hook-crate dep trees

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4311,9 +4311,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "3.0.0-beta.4"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c48b92a95ce730ac6ed5a1e580b17d57fc0304b0909aa3be04071669262e529"
+checksum = "ad26b216c966e987e80e86daf784a455c039c43d98575ceed57b8faa259e5695"
 dependencies = [
  "async-trait",
  "base64 0.23.0",
@@ -4345,9 +4345,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "3.0.0-beta.4"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d453e2aeeadec7c004084e2cedc73efdd3b0204028bde50afa00145449283964"
+checksum = "41bc748630c2be2a71b614c2f40d27bc0df0060696d224e1692c72345b7e0b79"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4304,11 +4304,12 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "2.2.0"
+version = "3.0.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14db48ee17a9ba61810ab1a9c1beb7d06d8136ae39ac25a1137f10d357af01af"
+checksum = "3875f7c471c2d709062bc2165d8dc883b021b44255bd00bb4d8025f5108178c8"
 dependencies = [
  "async-trait",
+ "base64",
  "bytes",
  "chrono",
  "futures",
@@ -4337,9 +4338,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "2.2.0"
+version = "3.0.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "783d787bf21813b285f13019adc49e11af501c658890c1e519f31f937c68b7e3"
+checksum = "37a5ce7541aff2f3df9e8c3c48c7241800fa6fa68e2fbcba386c0d7dcdfc953c"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46319972e74179d707445f64aaa2893bbf6a111de3a9af29b7eb382f8b39e282"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bitflags 2.13.0",
  "home",
  "libc",
@@ -604,6 +604,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -674,7 +680,7 @@ dependencies = [
  "axoupdater",
  "axum",
  "axum-test",
- "base64",
+ "base64 0.22.1",
  "bitrouter-cloud-sdk",
  "bitrouter-guardrails",
  "bitrouter-mcp",
@@ -728,7 +734,7 @@ version = "1.0.0-alpha.27"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bitrouter-sdk",
  "chrono",
  "rand 0.10.2",
@@ -764,6 +770,7 @@ dependencies = [
  "async-trait",
  "axum",
  "bitrouter-cloud-sdk",
+ "bitrouter-sdk",
  "http",
  "reqwest",
  "rmcp",
@@ -810,7 +817,7 @@ name = "bitrouter-providers"
 version = "1.0.0-alpha.27"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bitrouter-sdk",
  "keyring",
  "rand 0.10.2",
@@ -2492,7 +2499,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -3726,7 +3733,7 @@ version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "indexmap 2.14.0",
  "quick-xml",
  "serde",
@@ -4244,7 +4251,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -4304,12 +4311,12 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "3.0.0-beta.2"
+version = "3.0.0-beta.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3875f7c471c2d709062bc2165d8dc883b021b44255bd00bb4d8025f5108178c8"
+checksum = "6c48b92a95ce730ac6ed5a1e580b17d57fc0304b0909aa3be04071669262e529"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.23.0",
  "bytes",
  "chrono",
  "futures",
@@ -4338,9 +4345,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "3.0.0-beta.2"
+version = "3.0.0-beta.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37a5ce7541aff2f3df9e8c3c48c7241800fa6fa68e2fbcba386c0d7dcdfc953c"
+checksum = "d453e2aeeadec7c004084e2cedc73efdd3b0204028bde50afa00145449283964"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -4818,7 +4825,7 @@ checksum = "7bd22781911de0ca6debda95f073c8f18bec65d1a94f1fa9573f3102e514cea4"
 dependencies = [
  "ahash",
  "annotate-snippets",
- "base64",
+ "base64 0.22.1",
  "encoding_rs_io",
  "getrandom 0.3.4",
  "granit-parser",
@@ -4923,7 +4930,7 @@ version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bs58",
  "chrono",
  "hex",
@@ -5162,7 +5169,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "crc",
  "crossbeam-queue",
@@ -5237,7 +5244,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
- "base64",
+ "base64 0.22.1",
  "bitflags 2.13.0",
  "byteorder",
  "bytes",
@@ -5279,7 +5286,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
- "base64",
+ "base64 0.22.1",
  "bitflags 2.13.0",
  "byteorder",
  "crc",
@@ -5528,7 +5535,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.22.1",
  "bitflags 2.13.0",
  "fancy-regex 0.11.0",
  "filedescriptor",
@@ -5800,7 +5807,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "http",
  "http-body",
@@ -6938,7 +6945,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
 dependencies = [
  "assert-json-diff",
- "base64",
+ "base64 0.22.1",
  "deadpool",
  "futures",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,11 +88,15 @@ schemars = "1"
 # MCP (sdk `mcp` feature) — official Rust MCP SDK.
 # Source: <https://github.com/modelcontextprotocol/rust-sdk>
 #
-# Exact-pinned on the 3.0 beta line on purpose: beta.2 shipped a breaking
-# change one day after beta.1 (#1038, "omit resultType for legacy protocol
-# sessions"), so a caret range would let a breaking beta.3 land silently in
-# CI. Relax to "3.0" once 3.0 is stable — see `docs/MCP_2026_07_28_SPEC.md`.
-rmcp = { version = "=3.0.0-beta.2", default-features = false, features = [
+# Exact-pinned on the 3.0 beta line on purpose: this line has already shipped
+# breaking changes on consecutive days (beta.2's #1038 "omit resultType for
+# legacy protocol sessions", beta.3's #1054 auth-metadata `issuer`), so a caret
+# range would let a breaking beta land silently in CI.
+#
+# The MCP `2026-07-28` *spec* is released; rmcp's latest *stable* is still
+# 2.2.0. Relax to "3.0" once the 3.0 line itself is stable — the checklist is
+# in `docs/MCP_2026_07_28_SPEC.md`.
+rmcp = { version = "=3.0.0-beta.4", default-features = false, features = [
     "client",
     "reqwest",
     "transport-streamable-http-client-reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,12 @@ schemars = "1"
 
 # MCP (sdk `mcp` feature) — official Rust MCP SDK.
 # Source: <https://github.com/modelcontextprotocol/rust-sdk>
-rmcp = { version = "2.2", default-features = false, features = [
+#
+# Exact-pinned on the 3.0 beta line on purpose: beta.2 shipped a breaking
+# change one day after beta.1 (#1038, "omit resultType for legacy protocol
+# sessions"), so a caret range would let a breaking beta.3 land silently in
+# CI. Relax to "3.0" once 3.0 is stable — see `docs/MCP_2026_07_28_SPEC.md`.
+rmcp = { version = "=3.0.0-beta.2", default-features = false, features = [
     "client",
     "reqwest",
     "transport-streamable-http-client-reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,16 +87,7 @@ schemars = "1"
 
 # MCP (sdk `mcp` feature) — official Rust MCP SDK.
 # Source: <https://github.com/modelcontextprotocol/rust-sdk>
-#
-# Exact-pinned on the 3.0 beta line on purpose: this line has already shipped
-# breaking changes on consecutive days (beta.2's #1038 "omit resultType for
-# legacy protocol sessions", beta.3's #1054 auth-metadata `issuer`), so a caret
-# range would let a breaking beta land silently in CI.
-#
-# The MCP `2026-07-28` *spec* is released; rmcp's latest *stable* is still
-# 2.2.0. Relax to "3.0" once the 3.0 line itself is stable — the checklist is
-# in `docs/MCP_2026_07_28_SPEC.md`.
-rmcp = { version = "=3.0.0-beta.4", default-features = false, features = [
+rmcp = { version = "3.0", default-features = false, features = [
     "client",
     "reqwest",
     "transport-streamable-http-client-reqwest",

--- a/apps/bitrouter/src/assemble.rs
+++ b/apps/bitrouter/src/assemble.rs
@@ -392,7 +392,9 @@ pub async fn build_app_with_path(
     // Caches sit at the leaves so a single-server `notifications/*` only
     // invalidates that server's slice.
     let mcp_executor = mcp_routing.as_ref().map(|_| {
-        let rmcp: Arc<RmcpExecutor> = Arc::new(RmcpExecutor::new());
+        let rmcp: Arc<RmcpExecutor> = Arc::new(RmcpExecutor::new().with_protocol_version(
+            bitrouter_sdk::mcp::upstream_protocol_version(config.mcp.upstream_protocol),
+        ));
         let inner_for_cache: Arc<RmcpExecutor> = rmcp.clone();
         if config.mcp.cache.enabled {
             let ttls: CacheTtls = (&config.mcp.cache).into();

--- a/crates/bitrouter-mcp/Cargo.toml
+++ b/crates/bitrouter-mcp/Cargo.toml
@@ -49,3 +49,8 @@ bitrouter-cloud-sdk.workspace = true
 [dev-dependencies]
 wiremock = "0.6"
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util"] }
+# Dev-only, for `tests/gateway_roundtrip.rs`: drives this crate's stdio server
+# with the gateway's own MCP *client* so both halves are exercised against each
+# other over a real transport. No dependency cycle — `bitrouter-sdk` does not
+# depend on this crate.
+bitrouter-sdk = { workspace = true, features = ["mcp"] }

--- a/crates/bitrouter-mcp/examples/mcp-stdio-local.rs
+++ b/crates/bitrouter-mcp/examples/mcp-stdio-local.rs
@@ -1,12 +1,93 @@
 //! Test-only stdio entrypoint: serves the BitRouter origin MCP server over
 //! stdio against a `LocalBackend`. Exists so the `stdio_smoke` integration
-//! test can spawn a real process and drive the MCP handshake. Not a product
-//! binary — the shipping CLI lives in `apps/bitrouter`.
+//! tests can spawn a real process and drive lifecycle and pagination behavior.
+//! Not a product binary — the shipping CLI lives in `apps/bitrouter`.
+
+use std::sync::Arc;
 
 use bitrouter_mcp::server::BitrouterMcp;
+use rmcp::model::{
+    CacheScope, ListToolsResult, PaginatedRequestParams, ResultType, ServerCapabilities,
+    ServerInfo, Tool,
+};
+use rmcp::{ErrorData, ServerHandler, ServiceExt};
+
+#[derive(Clone, Copy)]
+enum PaginationScenario {
+    Private,
+    ZeroTtl,
+    ShorterTtl,
+}
+
+#[derive(Clone)]
+struct PaginatedServer {
+    scenario: PaginationScenario,
+}
+
+impl ServerHandler for PaginatedServer {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+    }
+
+    async fn list_tools(
+        &self,
+        request: Option<PaginatedRequestParams>,
+        _context: rmcp::service::RequestContext<rmcp::RoleServer>,
+    ) -> Result<ListToolsResult, ErrorData> {
+        let cursor = request.and_then(|params| params.cursor);
+        let (name, next_cursor, ttl_ms, cache_scope) = match cursor.as_deref() {
+            None => (
+                "first",
+                Some("next".to_string()),
+                60_000,
+                CacheScope::Public,
+            ),
+            Some("next") => match self.scenario {
+                PaginationScenario::Private => ("second", None, 60_000, CacheScope::Private),
+                PaginationScenario::ZeroTtl => ("second", None, 0, CacheScope::Public),
+                PaginationScenario::ShorterTtl => ("second", None, 1_000, CacheScope::Public),
+            },
+            Some(other) => {
+                return Err(ErrorData::invalid_params(
+                    format!("unknown test cursor: {other}"),
+                    None,
+                ));
+            }
+        };
+        Ok(ListToolsResult {
+            result_type: Some(ResultType::COMPLETE),
+            meta: None,
+            next_cursor,
+            ttl_ms: Some(ttl_ms),
+            cache_scope: Some(cache_scope),
+            tools: vec![Tool::new(
+                name,
+                "pagination fixture",
+                Arc::new(Default::default()),
+            )],
+        })
+    }
+}
+
+async fn serve_paginated(scenario: PaginationScenario) -> anyhow::Result<()> {
+    let service = PaginatedServer { scenario }
+        .serve(rmcp::transport::stdio())
+        .await?;
+    service.waiting().await?;
+    Ok(())
+}
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    let scenario = std::env::args().nth(1);
+    match scenario.as_deref() {
+        Some("private") => return serve_paginated(PaginationScenario::Private).await,
+        Some("zero-ttl") => return serve_paginated(PaginationScenario::ZeroTtl).await,
+        Some("shorter-ttl") => return serve_paginated(PaginationScenario::ShorterTtl).await,
+        Some(other) => anyhow::bail!("unknown pagination scenario: {other}"),
+        None => {}
+    }
+
     let server = BitrouterMcp::builder()
         .completion_local("http://127.0.0.1:4356")
         .build();

--- a/crates/bitrouter-mcp/src/capabilities/escalation.rs
+++ b/crates/bitrouter-mcp/src/capabilities/escalation.rs
@@ -21,6 +21,23 @@
 //!   the escalation branch is never taken — the default, guaranteed path stays
 //!   the HumanBridge / deny fallback. A failed/declined round-trip maps to
 //!   `Deny` (never silently "allow").
+//!
+//! ## This seam is legacy-lifecycle only
+//!
+//! MCP `2026-07-28` removed server-initiated requests, replacing them with
+//! Multi Round-Trip Requests (SEP-2322): a server that needs input returns an
+//! `InputRequiredResult` and the client retries with `inputResponses`. There is
+//! no channel on which to issue `elicitation/create` to a client on that
+//! version, so this seam is inert there **by construction** — capability
+//! detection reads the `initialize` handshake info, which a stateless client
+//! never produces, so `can_escalate` stays `false` and the HumanBridge / deny
+//! fallback takes every gated permission.
+//!
+//! That is the correct behavior, not a gap to paper over: see the note on
+//! `BitrouterMcp::record_escalation` for why widening the capability read would
+//! make things worse. Carrying escalation onto the modern lifecycle means
+//! returning an MRTR `InputRequiredResult` from the fleet tools instead — a
+//! different design, tracked in `docs/MCP_2026_07_28_SPEC.md`.
 
 use std::sync::Arc;
 use std::sync::Mutex;

--- a/crates/bitrouter-mcp/src/capabilities/escalation.rs
+++ b/crates/bitrouter-mcp/src/capabilities/escalation.rs
@@ -32,14 +32,20 @@ use rmcp::service::Peer;
 
 /// Whether a connecting client declared a capability that lets a gated
 /// permission be routed back to it for a decision — plain elicitation
-/// (`capabilities.elicitation`) or task-augmented elicitation
-/// (`capabilities.tasks.requests.elicitation.create`, SEP-1686 / SEP-2577).
+/// (`capabilities.elicitation`) or the Tasks extension
+/// (`capabilities.extensions["io.modelcontextprotocol/tasks"]`, SEP-2663).
+///
+/// `supports_tasks` is coarser than the `tasks.requests.elicitation.create`
+/// probe it replaces: SEP-2663 moved Tasks off a dedicated capability field
+/// into the SEP-1724 extensions map, which carries no per-request granularity,
+/// so "declares the extension" no longer implies "will answer an
+/// `elicitation/create`". We accept that looseness because the failure mode is
+/// bounded — a client that declares Tasks but never answers leaves
+/// [`EscalationState::escalate`] to time out or error, and both map to `Deny`
+/// (see the fail-safe note in the module docs), so a false positive costs
+/// latency rather than safety.
 pub fn client_supports_escalation(caps: &ClientCapabilities) -> bool {
-    caps.elicitation.is_some()
-        || caps
-            .tasks
-            .as_ref()
-            .is_some_and(|t| t.supports_elicitation_create())
+    caps.elicitation.is_some() || caps.supports_tasks()
 }
 
 /// A gated permission to put to the human via the orchestrator conversation.
@@ -211,14 +217,21 @@ mod tests {
             serde_json::json!({ "elicitation": {} })
         )));
 
-        // Task-augmented elicitation (`tasks.requests.elicitation.create`).
+        // The Tasks extension, declared through the SEP-2663 extensions map.
         assert!(client_supports_escalation(&caps(serde_json::json!({
-            "tasks": { "requests": { "elicitation": { "create": {} } } }
+            "extensions": { "io.modelcontextprotocol/tasks": {} }
         }))));
 
-        // Tasks present but without elicitation/create → not escalatable.
+        // A different extension → not escalatable.
         assert!(!client_supports_escalation(&caps(serde_json::json!({
-            "tasks": { "requests": {} }
+            "extensions": { "io.modelcontextprotocol/ui": {} }
+        }))));
+
+        // The pre-SEP-2663 `capabilities.tasks` field is no longer a
+        // declaration — a client still sending it reads as no capability, and
+        // falls back to the HumanBridge / deny path.
+        assert!(!client_supports_escalation(&caps(serde_json::json!({
+            "tasks": { "requests": { "elicitation": { "create": {} } } }
         }))));
     }
 

--- a/crates/bitrouter-mcp/src/server.rs
+++ b/crates/bitrouter-mcp/src/server.rs
@@ -10,8 +10,12 @@ use std::sync::Arc;
 
 use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::handler::server::wrapper::Parameters;
-use rmcp::model::{CallToolResult, ContentBlock, ServerCapabilities, ServerInfo};
+use rmcp::model::{
+    CallToolResult, ClientJsonRpcMessage, ClientRequest, ContentBlock, ErrorData, GetMeta,
+    ProtocolVersion, RequestId, ServerCapabilities, ServerInfo, ServerJsonRpcMessage,
+};
 use rmcp::service::RequestContext;
+use rmcp::transport::Transport;
 use rmcp::{ErrorData as McpError, RoleServer, ServerHandler, tool, tool_handler, tool_router};
 
 use crate::backend::{Backend, BackendError, CallerAuth, CompleteRequest};
@@ -949,6 +953,58 @@ pub async fn serve_http_on(
     Ok(())
 }
 
+/// Transport wrapper that replays one message already read during stdio
+/// lifecycle preflight, then delegates every operation to rmcp's transport.
+struct PrefetchedTransport<T> {
+    first: Option<ClientJsonRpcMessage>,
+    inner: T,
+}
+
+impl<T> Transport<RoleServer> for PrefetchedTransport<T>
+where
+    T: Transport<RoleServer>,
+{
+    type Error = T::Error;
+
+    fn send(
+        &mut self,
+        item: ServerJsonRpcMessage,
+    ) -> impl std::future::Future<Output = Result<(), Self::Error>> + Send + 'static {
+        self.inner.send(item)
+    }
+
+    async fn receive(&mut self) -> Option<ClientJsonRpcMessage> {
+        match self.first.take() {
+            Some(first) => Some(first),
+            None => self.inner.receive().await,
+        }
+    }
+
+    fn close(&mut self) -> impl std::future::Future<Output = Result<(), Self::Error>> + Send {
+        self.inner.close()
+    }
+}
+
+/// Identify an inline-lifecycle opener whose `_meta` announces that lifecycle
+/// but does not contain its required client context.
+fn malformed_inline_opener(
+    message: &ClientJsonRpcMessage,
+) -> Option<(RequestId, Vec<&'static str>)> {
+    let ClientJsonRpcMessage::Request(request) = message else {
+        return None;
+    };
+    let meta = request.request.get_meta();
+    let inline = matches!(&request.request, ClientRequest::DiscoverRequest(_))
+        || rmcp::model::RequestMetaObject::DRAFT_REQUIRED_KEYS
+            .iter()
+            .any(|key| meta.contains_key(*key));
+    if !inline {
+        return None;
+    }
+    let missing = meta.missing_required_keys(&ProtocolVersion::V_2026_07_28);
+    (!missing.is_empty()).then(|| (request.id.clone(), missing))
+}
+
 /// Serve `server` over stdio until the client disconnects. `cost_footer`, when
 /// given, annotates successful `complete` / `status` results with one spend
 /// line (the HTTP transport is multi-tenant and gets no footer).
@@ -956,30 +1012,47 @@ pub async fn serve_stdio(
     server: BitrouterMcp,
     cost_footer: Option<Arc<dyn CostFooter>>,
 ) -> anyhow::Result<()> {
-    use rmcp::transport::stdio;
+    use rmcp::ServiceExt;
+    use rmcp::transport::async_rw::AsyncRwTransport;
     let server = match cost_footer {
         Some(footer) => server.with_cost_footer(footer),
         None => server,
     };
-    // `serve_directly` rather than `serve`: MCP `2026-07-28` removed the
-    // `initialize` / `notifications/initialized` handshake (SEP-2575), and a
-    // client on that version opens a stdio connection by sending
-    // `server/discover` — or an ordinary request carrying its protocol version
-    // in `_meta`. rmcp's `serve` waits for `initialize` and hard-errors on
-    // anything else ("expect initialized request"), which would reject every
-    // conformant `2026-07-28` client outright.
-    //
-    // Skipping the handshake costs nothing for older clients: `initialize` is
-    // dispatched to the handler as an ordinary request, and rmcp's default
-    // implementation still negotiates the version and records peer info. So
-    // one entry point serves both lifecycles — covered by the stdio tests.
-    let service = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, _, _>(
-        server,
-        stdio(),
-        // No pre-seeded peer info: a legacy client's `initialize` fills it in,
-        // and a modern one carries identity per request in `_meta`.
-        None,
-    );
+    let mut transport =
+        AsyncRwTransport::<RoleServer, _, _>::new_server(tokio::io::stdin(), tokio::io::stdout());
+    let first = loop {
+        let Some(message) = transport.receive().await else {
+            return Ok(());
+        };
+        let Some((id, missing)) = malformed_inline_opener(&message) else {
+            break message;
+        };
+        transport
+            .send(ServerJsonRpcMessage::error(
+                ErrorData::invalid_params(
+                    format!(
+                        "request _meta is missing or has malformed required fields: {}",
+                        missing.join(", ")
+                    ),
+                    None,
+                ),
+                Some(id),
+            ))
+            .await?;
+    };
+    // rmcp 3.1's normal startup accepts both lifecycle openers. A legacy
+    // `initialize` negotiates and stores the agreed fallback version; a
+    // self-contained modern request enables required per-request metadata for
+    // the rest of the connection. Keeping those transitions inside rmcp is
+    // essential — direct mode intentionally bypasses both. The preflight above
+    // preserves the JSON-RPC `-32602` response for a malformed modern opener;
+    // rmcp's startup otherwise closes before it can dispatch that request.
+    let service = server
+        .serve(PrefetchedTransport {
+            first: Some(first),
+            inner: transport,
+        })
+        .await?;
     service.waiting().await?;
     Ok(())
 }

--- a/crates/bitrouter-mcp/src/server.rs
+++ b/crates/bitrouter-mcp/src/server.rs
@@ -761,11 +761,51 @@ impl Builder {
     }
 }
 
+/// How long a client may treat our `tools/list` as fresh (SEP-2549).
+///
+/// The router is frozen at [`Builder::build`] from the wired capabilities and
+/// never varies per caller or over a connection's life, so this is bounded only
+/// by how quickly a client should notice a *restarted* server with a different
+/// profile. Five minutes keeps a re-dial cheap without pinning a stale list.
+const TOOLS_LIST_TTL_MS: u64 = 5 * 60 * 1000;
+
 #[tool_handler(router = self.tool_router)]
 impl ServerHandler for BitrouterMcp {
     fn get_info(&self) -> ServerInfo {
         ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
             .with_instructions(self.instructions())
+    }
+
+    /// Same as the `#[tool_handler]`-generated implementation (the macro skips
+    /// generating one when the impl already defines it), plus SEP-2549 cache
+    /// hints for peers that negotiated `2026-07-28`.
+    ///
+    /// `cacheScope: public` is accurate here and worth stating explicitly: the
+    /// tool set is fixed at [`Builder::build`] from the wired capabilities, so
+    /// every caller of a given server instance sees the same list. It would
+    /// *not* be accurate if tool visibility ever became caller-dependent — that
+    /// change must revisit this scope.
+    ///
+    /// The hints are version-gated because rmcp only strips `resultType` for
+    /// legacy peers (`ServerResult::strip_result_type_for_legacy_peer`), not
+    /// `ttlMs`/`cacheScope`; emitting them unconditionally would send
+    /// draft-only fields to a `2025-11-25` client.
+    async fn list_tools(
+        &self,
+        _request: Option<rmcp::model::PaginatedRequestParams>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<rmcp::model::ListToolsResult, McpError> {
+        let draft = context
+            .protocol_version()
+            .is_some_and(|v| v.as_str() >= rmcp::model::ProtocolVersion::V_2026_07_28.as_str());
+        Ok(rmcp::model::ListToolsResult {
+            result_type: Some(rmcp::model::ResultType::COMPLETE),
+            tools: self.tool_router.list_all(),
+            meta: None,
+            next_cursor: None,
+            ttl_ms: draft.then_some(TOOLS_LIST_TTL_MS),
+            cache_scope: draft.then_some(rmcp::model::CacheScope::Public),
+        })
     }
 }
 
@@ -839,6 +879,17 @@ async fn require_bearer(
 /// change — take a handler factory, keep the profile strictly loopback and
 /// incompatible with the cloud backend, and prefer modeling that read-only
 /// data as MCP resources over widening the tool surface.
+///
+/// That invariant is now load-bearing for a second reason. Under SEP-2567 a
+/// peer negotiating `2026-07-28` is **always served statelessly**, regardless
+/// of `StreamableHttpServerConfig::legacy_session_mode` — each request gets a
+/// fresh handler from the factory below, so nothing connection-scoped
+/// survives between requests. The orchestrator tools are exactly the
+/// connection-scoped ones (`EscalationState` captures the live server→client
+/// peer at the first fleet call), and they stay correct only because stdio
+/// sessions are long-lived. Adding a stateful tool to this HTTP profile would
+/// therefore break under draft-version clients even though it works today
+/// against `2025-11-25`.
 fn build_http_router(
     backend: Arc<dyn Backend>,
     require_auth: bool,

--- a/crates/bitrouter-mcp/src/server.rs
+++ b/crates/bitrouter-mcp/src/server.rs
@@ -638,6 +638,18 @@ impl BitrouterMcp {
     /// Reads the capabilities the client declared at `initialize` (available on
     /// the recorded peer handshake info). A no-op when no escalation state is
     /// wired (public profile) or before the peer info is recorded.
+    ///
+    /// Reading `peer_info` — rather than `ctx.client_capabilities()`, which
+    /// would also see the per-request `_meta` capabilities of a `2026-07-28`
+    /// client — is deliberate, and must stay that way. Escalation delivers its
+    /// question as a server→client `elicitation/create`, and `2026-07-28`
+    /// removed server-initiated requests entirely in favour of MRTR (SEP-2322):
+    /// on a stateless connection there is no channel to ask on. Detecting the
+    /// capability there would route a gated permission into a round-trip that
+    /// cannot be answered, and our fail-safe would turn that into `Deny` —
+    /// strictly worse than the HumanBridge prompt the no-op leaves in place.
+    /// Making this seam work on the modern lifecycle means rebuilding it as an
+    /// MRTR `InputRequiredResult`, not widening the capability read.
     fn record_escalation(&self, ctx: &RequestContext<RoleServer>) {
         if let Some(escalation) = &self.caps.escalation
             && let Some(info) = ctx.peer.peer_info()
@@ -773,6 +785,16 @@ const TOOLS_LIST_TTL_MS: u64 = 5 * 60 * 1000;
 impl ServerHandler for BitrouterMcp {
     fn get_info(&self) -> ServerInfo {
         ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+            // Without this the identity defaults to `Implementation::from_build_env()`,
+            // which resolves against *rmcp's* build environment — every client
+            // asking who we are (via `server/discover`, `initialize`, or the
+            // SEP-2575 `io.modelcontextprotocol/serverInfo` result metadata)
+            // would be told it is talking to "rmcp". The client half of the
+            // gateway has always identified itself; this is the matching half.
+            .with_server_info(rmcp::model::Implementation::new(
+                "bitrouter",
+                env!("CARGO_PKG_VERSION"),
+            ))
             .with_instructions(self.instructions())
     }
 
@@ -934,12 +956,30 @@ pub async fn serve_stdio(
     server: BitrouterMcp,
     cost_footer: Option<Arc<dyn CostFooter>>,
 ) -> anyhow::Result<()> {
-    use rmcp::{ServiceExt, transport::stdio};
+    use rmcp::transport::stdio;
     let server = match cost_footer {
         Some(footer) => server.with_cost_footer(footer),
         None => server,
     };
-    let service = server.serve(stdio()).await?;
+    // `serve_directly` rather than `serve`: MCP `2026-07-28` removed the
+    // `initialize` / `notifications/initialized` handshake (SEP-2575), and a
+    // client on that version opens a stdio connection by sending
+    // `server/discover` — or an ordinary request carrying its protocol version
+    // in `_meta`. rmcp's `serve` waits for `initialize` and hard-errors on
+    // anything else ("expect initialized request"), which would reject every
+    // conformant `2026-07-28` client outright.
+    //
+    // Skipping the handshake costs nothing for older clients: `initialize` is
+    // dispatched to the handler as an ordinary request, and rmcp's default
+    // implementation still negotiates the version and records peer info. So
+    // one entry point serves both lifecycles — covered by the stdio tests.
+    let service = rmcp::service::serve_directly::<rmcp::RoleServer, _, _, _, _>(
+        server,
+        stdio(),
+        // No pre-seeded peer info: a legacy client's `initialize` fills it in,
+        // and a modern one carries identity per request in `_meta`.
+        None,
+    );
     service.waiting().await?;
     Ok(())
 }

--- a/crates/bitrouter-mcp/src/server.rs
+++ b/crates/bitrouter-mcp/src/server.rs
@@ -993,6 +993,15 @@ fn malformed_inline_opener(
     let ClientJsonRpcMessage::Request(request) = message else {
         return None;
     };
+    // These requests belong to stable startup regardless of extension keys in
+    // `_meta`. Replaying them unchanged lets rmcp answer a pre-init ping or
+    // negotiate the legacy initialize instead of guessing an inline lifecycle.
+    if matches!(
+        &request.request,
+        ClientRequest::InitializeRequest(_) | ClientRequest::PingRequest(_)
+    ) {
+        return None;
+    }
     let meta = request.request.get_meta();
     let inline = matches!(&request.request, ClientRequest::DiscoverRequest(_))
         || rmcp::model::RequestMetaObject::DRAFT_REQUIRED_KEYS

--- a/crates/bitrouter-mcp/tests/gateway_roundtrip.rs
+++ b/crates/bitrouter-mcp/tests/gateway_roundtrip.rs
@@ -30,6 +30,17 @@ fn origin_server_target() -> McpTarget {
     }
 }
 
+fn paginated_server_target(scenario: &str) -> McpTarget {
+    McpTarget::Direct {
+        server_name: format!("pagination-{scenario}"),
+        transport: McpTransport::Stdio {
+            command: env!("CARGO_BIN_EXE_mcp-stdio-local").to_string(),
+            args: vec![scenario.to_string()],
+            env: HashMap::new(),
+        },
+    }
+}
+
 fn tools_list() -> McpRequest {
     McpRequest::direct(
         "origin",
@@ -46,6 +57,20 @@ fn tool_names(result: &serde_json::Value) -> Vec<String> {
         .iter()
         .filter_map(|t| t["name"].as_str().map(str::to_owned))
         .collect()
+}
+
+async fn paginated_tools(scenario: &str) -> anyhow::Result<serde_json::Value> {
+    let executor =
+        RmcpExecutor::new().with_protocol_version(rmcp::model::ProtocolVersion::V_2026_07_28);
+    Ok(executor
+        .execute(&paginated_server_target(scenario), &tools_list())
+        .await?
+        .result)
+}
+
+fn assert_complete_two_page_result(result: &serde_json::Value) {
+    assert_eq!(tool_names(result), ["first", "second"]);
+    assert!(result.get("nextCursor").is_none(), "got: {result}");
 }
 
 /// The default path, unchanged by the `2026-07-28` work: the client dials with
@@ -85,4 +110,28 @@ async fn gateway_client_reaches_origin_server_on_2026_07_28() {
     // round-trip, which is what lets `CachingExecutor` honour them.
     assert_eq!(result.result["ttlMs"], 5 * 60 * 1000);
     assert_eq!(result.result["cacheScope"], "public");
+}
+
+#[tokio::test]
+async fn later_private_cache_scope_wins_across_pages() -> anyhow::Result<()> {
+    let result = paginated_tools("private").await?;
+    assert_complete_two_page_result(&result);
+    assert_eq!(result["cacheScope"], "private", "got: {result}");
+    Ok(())
+}
+
+#[tokio::test]
+async fn later_zero_ttl_wins_across_pages() -> anyhow::Result<()> {
+    let result = paginated_tools("zero-ttl").await?;
+    assert_complete_two_page_result(&result);
+    assert_eq!(result["ttlMs"], 0, "got: {result}");
+    Ok(())
+}
+
+#[tokio::test]
+async fn positive_page_ttls_merge_to_minimum() -> anyhow::Result<()> {
+    let result = paginated_tools("shorter-ttl").await?;
+    assert_complete_two_page_result(&result);
+    assert_eq!(result["ttlMs"], 1_000, "got: {result}");
+    Ok(())
 }

--- a/crates/bitrouter-mcp/tests/gateway_roundtrip.rs
+++ b/crates/bitrouter-mcp/tests/gateway_roundtrip.rs
@@ -1,0 +1,88 @@
+//! Both halves of the gateway, talking to each other over a real stdio
+//! transport: `bitrouter-sdk`'s `RmcpExecutor` (the client BitRouter uses to
+//! reach upstream MCP servers) driving this crate's origin server.
+//!
+//! The server-side lifecycle tests in `stdio_smoke.rs` hand-write JSON-RPC, so
+//! they prove the server answers correctly but say nothing about whether our
+//! *client* speaks the same dialect. These close that loop — in particular for
+//! MCP `2026-07-28`, where opting in changes the client's whole lifecycle
+//! (`server/discover` instead of the removed `initialize` handshake) rather
+//! than just a version string.
+//!
+//! Only `tools/list` is exercised: it needs no backend, so no daemon has to be
+//! running.
+
+use std::collections::HashMap;
+
+use bitrouter_sdk::caller::CallerContext;
+use bitrouter_sdk::mcp::rmcp_executor::RmcpExecutor;
+use bitrouter_sdk::mcp::transport::McpTransport;
+use bitrouter_sdk::mcp::{Executor, McpRequest, McpTarget};
+
+fn origin_server_target() -> McpTarget {
+    McpTarget::Direct {
+        server_name: "origin".into(),
+        transport: McpTransport::Stdio {
+            command: env!("CARGO_BIN_EXE_mcp-stdio-local").to_string(),
+            args: vec![],
+            env: HashMap::new(),
+        },
+    }
+}
+
+fn tools_list() -> McpRequest {
+    McpRequest::direct(
+        "origin",
+        "tools/list",
+        serde_json::json!({}),
+        CallerContext::new("k", "u"),
+    )
+}
+
+fn tool_names(result: &serde_json::Value) -> Vec<String> {
+    result["tools"]
+        .as_array()
+        .expect("tools array")
+        .iter()
+        .filter_map(|t| t["name"].as_str().map(str::to_owned))
+        .collect()
+}
+
+/// The default path, unchanged by the `2026-07-28` work: the client dials with
+/// the `initialize` handshake and the server answers it.
+#[tokio::test]
+async fn gateway_client_reaches_origin_server_on_latest() {
+    let executor = RmcpExecutor::new();
+    let result = executor
+        .execute(&origin_server_target(), &tools_list())
+        .await
+        .expect("tools/list over the default lifecycle");
+    assert_eq!(
+        tool_names(&result.result),
+        ["complete", "list_models", "status"]
+    );
+}
+
+/// The opt-in path. This is the test that would have caught the original
+/// mistake: setting only `ClientInfo.protocol_version` still sent an
+/// `initialize`, a method `2026-07-28` does not define. Here the client must
+/// open with `server/discover` and then send self-contained requests, and the
+/// server must serve that lifecycle — neither half can regress without this
+/// failing.
+#[tokio::test]
+async fn gateway_client_reaches_origin_server_on_2026_07_28() {
+    let executor =
+        RmcpExecutor::new().with_protocol_version(rmcp::model::ProtocolVersion::V_2026_07_28);
+    let result = executor
+        .execute(&origin_server_target(), &tools_list())
+        .await
+        .expect("tools/list over the 2026-07-28 lifecycle");
+    assert_eq!(
+        tool_names(&result.result),
+        ["complete", "list_models", "status"]
+    );
+    // The SEP-2549 hints the server attaches for draft peers survive the client
+    // round-trip, which is what lets `CachingExecutor` honour them.
+    assert_eq!(result.result["ttlMs"], 5 * 60 * 1000);
+    assert_eq!(result.result["cacheScope"], "public");
+}

--- a/crates/bitrouter-mcp/tests/multitenant_http.rs
+++ b/crates/bitrouter-mcp/tests/multitenant_http.rs
@@ -119,3 +119,92 @@ async fn missing_bearer_is_rejected_401() {
 
     server.abort();
 }
+
+/// Drive the endpoint the way a conformant `2026-07-28` client does: one
+/// self-contained POST, no `initialize`, no `Mcp-Session-Id` (SEP-2567 removed
+/// protocol-level sessions), SEP-2243 routing headers, and the lifecycle fields
+/// in `_meta` (SEP-2575).
+///
+/// Returns the response body so the caller can assert on it.
+async fn stateless_call_list_models(base: &str, bearer: &str) -> String {
+    let body = serde_json::json!({
+        "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+        "params": {
+            "name": "list_models",
+            "arguments": {},
+            "_meta": {
+                "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                "io.modelcontextprotocol/clientInfo": { "name": "t", "version": "0" },
+                "io.modelcontextprotocol/clientCapabilities": {},
+            },
+        },
+    });
+    let resp = reqwest::Client::new()
+        .post(format!("{base}/mcp-control"))
+        .header("authorization", format!("Bearer {bearer}"))
+        .header("content-type", "application/json")
+        .header("accept", "application/json, text/event-stream")
+        // SEP-2243 standard routing headers, required on 2026-07-28 POSTs.
+        .header("mcp-method", "tools/call")
+        .header("mcp-name", "list_models")
+        // Must agree with `_meta`'s protocolVersion — the transport rejects a
+        // body/header mismatch (or a missing header) with -32600 rather than
+        // picking one of the two to believe.
+        .header("mcp-protocol-version", "2026-07-28")
+        .body(body.to_string())
+        .send()
+        .await
+        .expect("stateless call send");
+    let status = resp.status();
+    let body = resp.text().await.expect("body");
+    assert!(
+        status.is_success(),
+        "stateless call failed: {status}: {body}"
+    );
+    body
+}
+
+/// Multi-tenancy is the whole point of the HTTP profile, and `2026-07-28`
+/// changes how it has to hold: with sessions gone every request is served on a
+/// fresh handler, so the per-caller bearer has to be read off the request
+/// itself rather than anything remembered from a handshake.
+#[tokio::test]
+async fn stateless_callers_forward_distinct_bearers() {
+    let cloud = MockServer::start().await;
+    for tok in ["ccc", "ddd"] {
+        Mock::given(method("GET"))
+            .and(path("/v1/models"))
+            .and(header("authorization", format!("Bearer {tok}").as_str()))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"object":"list","data":[]})),
+            )
+            .expect(1)
+            .mount(&cloud)
+            .await;
+    }
+
+    let backend: Arc<dyn Backend> = Arc::new(CloudBackend::new(cloud.uri(), CloudAuth::PerCaller));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    let server = tokio::spawn(async move {
+        let _ = bitrouter_mcp::server::serve_http_on(backend, listener, true).await;
+    });
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    let base = format!("http://{addr}");
+    for tok in ["ccc", "ddd"] {
+        let body = stateless_call_list_models(&base, tok).await;
+        assert!(
+            !body.contains("\"error\""),
+            "stateless tools/call returned an error for {tok}: {body}"
+        );
+    }
+
+    // `.expect(1)` per bearer is verified on drop: each caller's own token
+    // reached the cloud exactly once, with no session to confuse them.
+    drop(cloud);
+    server.abort();
+}

--- a/crates/bitrouter-mcp/tests/stdio_smoke.rs
+++ b/crates/bitrouter-mcp/tests/stdio_smoke.rs
@@ -143,6 +143,18 @@ async fn draft_peer_via_legacy_handshake_gets_cache_hints() {
     assert_eq!(list["cacheScope"], "public");
 }
 
+/// An unsupported legacy version is negotiated down to the server fallback,
+/// and that negotiated version — not the client's raw request — governs every
+/// later metadata-free request on the connection.
+#[tokio::test]
+async fn legacy_future_version_uses_fallback_for_following_requests() {
+    let (init, list) = legacy_handshake_and_list("2099-01-01").await;
+    assert_eq!(init["protocolVersion"], "2025-11-25");
+    assert!(list.get("resultType").is_none(), "got: {list}");
+    assert!(list.get("ttlMs").is_none(), "got: {list}");
+    assert!(list.get("cacheScope").is_none(), "got: {list}");
+}
+
 /// SEP-2575: servers MUST implement `server/discover`. This is how a
 /// `2026-07-28` client opens a stdio connection, so a `-32601` here means no
 /// conformant client can talk to us at all.
@@ -176,6 +188,28 @@ async fn server_discover_advertises_versions_and_bitrouter_identity() {
     );
     assert!(result.get("serverInfo").is_none(), "got: {result}");
     assert_eq!(result["capabilities"]["tools"], serde_json::json!({}));
+}
+
+/// Once `server/discover` selects the inline lifecycle, every later request on
+/// that connection must remain self-contained. Missing metadata is invalid;
+/// it must not silently switch the connection back to legacy semantics.
+#[tokio::test]
+async fn discover_requires_metadata_on_following_requests() {
+    let mut server = Server::spawn();
+    let discover = server
+        .request(serde_json::json!({
+            "jsonrpc": "2.0", "id": 1, "method": "server/discover",
+            "params": { "_meta": draft_meta() },
+        }))
+        .await;
+    assert!(discover.get("error").is_none(), "got: {discover}");
+
+    let response = server
+        .request(serde_json::json!({
+            "jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {},
+        }))
+        .await;
+    assert_eq!(response["error"]["code"], -32602, "got: {response}");
 }
 
 /// The real `2026-07-28` shape: no handshake at all, every request

--- a/crates/bitrouter-mcp/tests/stdio_smoke.rs
+++ b/crates/bitrouter-mcp/tests/stdio_smoke.rs
@@ -15,9 +15,8 @@ use std::process::Stdio;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 
 /// `_meta` a conformant `2026-07-28` client puts on every request (SEP-2575).
-/// All three keys are mandatory on an inline-lifecycle request; omitting any is
-/// an `invalid_params` rejection, which `stateless_request_missing_required_meta_is_rejected`
-/// pins.
+/// Protocol version and client capabilities are mandatory on an inline-lifecycle
+/// request; client info is optional.
 fn draft_meta() -> serde_json::Value {
     serde_json::json!({
         "io.modelcontextprotocol/protocolVersion": "2026-07-28",
@@ -171,7 +170,11 @@ async fn server_discover_advertises_versions_and_bitrouter_identity() {
     // Identity must be ours, not the SDK's. `InitializeResult::new` defaults to
     // `Implementation::from_build_env()`, which resolves inside rmcp and would
     // otherwise report this server as "rmcp".
-    assert_eq!(result["serverInfo"]["name"], "bitrouter");
+    assert_eq!(
+        result["_meta"]["io.modelcontextprotocol/serverInfo"]["name"],
+        "bitrouter"
+    );
+    assert!(result.get("serverInfo").is_none(), "got: {result}");
     assert_eq!(result["capabilities"]["tools"], serde_json::json!({}));
 }
 
@@ -213,6 +216,30 @@ async fn stateless_request_missing_required_meta_is_rejected() {
     let error = &response["error"];
     assert_eq!(error["code"], -32602, "got: {response}");
     let message = error["message"].as_str().unwrap_or_default();
-    assert!(message.contains("clientInfo"), "got: {message}");
-    assert!(message.contains("clientCapabilities"), "got: {message}");
+    assert!(
+        message.contains("io.modelcontextprotocol/clientCapabilities"),
+        "got: {message}"
+    );
+}
+
+/// `clientInfo` is optional for a self-contained `2026-07-28` request; the
+/// protocol version and client capabilities establish the required context.
+#[tokio::test]
+async fn stateless_request_accepts_missing_optional_client_info() {
+    let response = oneshot(serde_json::json!({
+        "jsonrpc": "2.0", "id": 1, "method": "tools/list",
+        "params": { "_meta": {
+            "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+            "io.modelcontextprotocol/clientCapabilities": {},
+        } },
+    }))
+    .await;
+    assert!(
+        response.get("error").is_none(),
+        "stateless tools/list failed: {response}"
+    );
+    let result = &response["result"];
+    assert_eq!(result["resultType"], "complete");
+    assert_eq!(result["ttlMs"], 5 * 60 * 1000);
+    assert_eq!(result["cacheScope"], "public");
 }

--- a/crates/bitrouter-mcp/tests/stdio_smoke.rs
+++ b/crates/bitrouter-mcp/tests/stdio_smoke.rs
@@ -1,13 +1,19 @@
 //! Smoke test: spawn the stdio MCP server, perform the `initialize` handshake,
 //! then `tools/list`, and assert the three BitRouter tools are advertised.
 //! Does not require a running daemon — it only lists tools, never calls them.
+//!
+//! Also pins the protocol version the handshake actually settles on, and the
+//! SEP-2549 cache hints that ride on `tools/list` only for draft-version peers.
 
 use std::process::Stdio;
 
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 
-#[tokio::test]
-async fn stdio_lists_three_tools() {
+/// Drive `initialize` → `notifications/initialized` → `tools/list` against a
+/// freshly spawned stdio server, asking for `protocol_version`.
+///
+/// Returns the parsed `initialize` and `tools/list` results.
+async fn handshake_and_list(protocol_version: &str) -> (serde_json::Value, serde_json::Value) {
     let mut child = tokio::process::Command::new(env!("CARGO_BIN_EXE_mcp-stdio-local"))
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -17,12 +23,25 @@ async fn stdio_lists_three_tools() {
     let mut stdin = child.stdin.take().expect("stdin");
     let mut out = BufReader::new(child.stdout.take().expect("stdout")).lines();
 
-    let init = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"t","version":"0"}}}"#;
+    let init = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": protocol_version,
+            "capabilities": {},
+            "clientInfo": { "name": "t", "version": "0" },
+        },
+    });
     stdin
         .write_all(format!("{init}\n").as_bytes())
         .await
         .expect("write init");
-    let _ = out.next_line().await.expect("read init"); // init result
+    let init_line = out
+        .next_line()
+        .await
+        .expect("read init")
+        .expect("init line");
 
     // The server expects the client to confirm initialization before it will
     // service further requests.
@@ -37,10 +56,53 @@ async fn stdio_lists_three_tools() {
         .write_all(format!("{listed}\n").as_bytes())
         .await
         .expect("write list");
-    let line = out.next_line().await.expect("read list").expect("line");
-    assert!(
-        line.contains("complete") && line.contains("list_models") && line.contains("status"),
-        "got: {line}"
-    );
+    let list_line = out
+        .next_line()
+        .await
+        .expect("read list")
+        .expect("list line");
     let _ = child.kill().await;
+
+    let parse = |line: String| -> serde_json::Value {
+        let v: serde_json::Value = serde_json::from_str(&line).expect("json-rpc response");
+        v["result"].clone()
+    };
+    (parse(init_line), parse(list_line))
+}
+
+#[tokio::test]
+async fn stdio_lists_three_tools() {
+    let (_, list) = handshake_and_list("2025-11-25").await;
+    let names: Vec<&str> = list["tools"]
+        .as_array()
+        .expect("tools array")
+        .iter()
+        .filter_map(|t| t["name"].as_str())
+        .collect();
+    for expected in ["complete", "list_models", "status"] {
+        assert!(names.contains(&expected), "missing {expected} in {names:?}");
+    }
+}
+
+/// A `2025-11-25` peer must not see the SEP-2549 hints: rmcp strips only
+/// `resultType` for legacy peers, so the version gate in `list_tools` is the
+/// only thing keeping draft-only fields off this response.
+#[tokio::test]
+async fn stable_peer_gets_no_cache_hints_on_tools_list() {
+    let (init, list) = handshake_and_list("2025-11-25").await;
+    assert_eq!(init["protocolVersion"], "2025-11-25");
+    assert!(list.get("ttlMs").is_none(), "got: {list}");
+    assert!(list.get("cacheScope").is_none(), "got: {list}");
+}
+
+/// The draft peer gets the hints — and note the server agrees to `2026-07-28`
+/// without any opt-in on our side, because rmcp negotiates any version in
+/// `ProtocolVersion::KNOWN_VERSIONS`. That is exactly why the bump matters:
+/// before it, we accepted this version while implementing none of it.
+#[tokio::test]
+async fn draft_peer_gets_public_cache_hints_on_tools_list() {
+    let (init, list) = handshake_and_list("2026-07-28").await;
+    assert_eq!(init["protocolVersion"], "2026-07-28");
+    assert_eq!(list["ttlMs"], 5 * 60 * 1000);
+    assert_eq!(list["cacheScope"], "public");
 }

--- a/crates/bitrouter-mcp/tests/stdio_smoke.rs
+++ b/crates/bitrouter-mcp/tests/stdio_smoke.rs
@@ -1,87 +1,126 @@
-//! Smoke test: spawn the stdio MCP server, perform the `initialize` handshake,
-//! then `tools/list`, and assert the three BitRouter tools are advertised.
-//! Does not require a running daemon — it only lists tools, never calls them.
+//! Lifecycle conformance for the stdio origin server, across both MCP
+//! lifecycles it has to serve.
 //!
-//! Also pins the protocol version the handshake actually settles on, and the
-//! SEP-2549 cache hints that ride on `tools/list` only for draft-version peers.
+//! MCP `2026-07-28` removed the `initialize` / `notifications/initialized`
+//! handshake (SEP-2575): a client on that version opens a stdio connection with
+//! `server/discover`, or simply sends a request carrying its protocol version,
+//! identity, and capabilities in `_meta`. Older clients still handshake. These
+//! tests pin both, because serving only one is a silent interop failure — the
+//! server either rejects every modern client or every legacy one.
+//!
+//! Needs no running daemon: it lists tools and discovers, never calls a tool.
 
 use std::process::Stdio;
 
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 
-/// Drive `initialize` → `notifications/initialized` → `tools/list` against a
-/// freshly spawned stdio server, asking for `protocol_version`.
+/// `_meta` a conformant `2026-07-28` client puts on every request (SEP-2575).
+/// All three keys are mandatory on an inline-lifecycle request; omitting any is
+/// an `invalid_params` rejection, which `stateless_request_missing_required_meta_is_rejected`
+/// pins.
+fn draft_meta() -> serde_json::Value {
+    serde_json::json!({
+        "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+        "io.modelcontextprotocol/clientInfo": { "name": "t", "version": "0" },
+        "io.modelcontextprotocol/clientCapabilities": {},
+    })
+}
+
+/// A spawned stdio server you can drive request-by-request.
 ///
-/// Returns the parsed `initialize` and `tools/list` results.
-async fn handshake_and_list(protocol_version: &str) -> (serde_json::Value, serde_json::Value) {
-    let mut child = tokio::process::Command::new(env!("CARGO_BIN_EXE_mcp-stdio-local"))
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .spawn()
-        .expect("spawn");
-    let mut stdin = child.stdin.take().expect("stdin");
-    let mut out = BufReader::new(child.stdout.take().expect("stdout")).lines();
+/// Requests are written and awaited one at a time rather than pipelined.
+/// That models how clients actually behave, and it keeps responses
+/// unambiguous: since the server no longer queues everything behind a
+/// handshake, concurrently-issued requests may complete out of order.
+struct Server {
+    child: tokio::process::Child,
+    stdin: tokio::process::ChildStdin,
+    out: tokio::io::Lines<BufReader<tokio::process::ChildStdout>>,
+}
 
-    let init = serde_json::json!({
-        "jsonrpc": "2.0",
-        "id": 1,
-        "method": "initialize",
-        "params": {
-            "protocolVersion": protocol_version,
-            "capabilities": {},
-            "clientInfo": { "name": "t", "version": "0" },
-        },
-    });
-    stdin
-        .write_all(format!("{init}\n").as_bytes())
-        .await
-        .expect("write init");
-    let init_line = out
-        .next_line()
-        .await
-        .expect("read init")
-        .expect("init line");
+impl Server {
+    fn spawn() -> Self {
+        let mut child = tokio::process::Command::new(env!("CARGO_BIN_EXE_mcp-stdio-local"))
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn");
+        let stdin = child.stdin.take().expect("stdin");
+        let out = BufReader::new(child.stdout.take().expect("stdout")).lines();
+        Self { child, stdin, out }
+    }
 
-    // The server expects the client to confirm initialization before it will
-    // service further requests.
-    let initialized = r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#;
-    stdin
-        .write_all(format!("{initialized}\n").as_bytes())
-        .await
-        .expect("write initialized");
+    async fn notify(&mut self, notification: serde_json::Value) {
+        self.stdin
+            .write_all(format!("{notification}\n").as_bytes())
+            .await
+            .expect("write notification");
+    }
 
-    let listed = r#"{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}"#;
-    stdin
-        .write_all(format!("{listed}\n").as_bytes())
-        .await
-        .expect("write list");
-    let list_line = out
-        .next_line()
-        .await
-        .expect("read list")
-        .expect("list line");
-    let _ = child.kill().await;
+    /// Send one request and read its response. Returns the whole JSON-RPC
+    /// envelope so error-path tests can read `error` as well as `result`.
+    async fn request(&mut self, request: serde_json::Value) -> serde_json::Value {
+        self.notify(request).await;
+        let line = self
+            .out
+            .next_line()
+            .await
+            .expect("read response")
+            .expect("response line");
+        serde_json::from_str(&line).expect("json-rpc response")
+    }
+}
 
-    let parse = |line: String| -> serde_json::Value {
-        let v: serde_json::Value = serde_json::from_str(&line).expect("json-rpc response");
-        v["result"].clone()
-    };
-    (parse(init_line), parse(list_line))
+impl Drop for Server {
+    fn drop(&mut self) {
+        let _ = self.child.start_kill();
+    }
+}
+
+/// One-shot: spawn, send a single request, return its envelope.
+async fn oneshot(request: serde_json::Value) -> serde_json::Value {
+    Server::spawn().request(request).await
+}
+
+/// `initialize` → `notifications/initialized` → `tools/list`, the pre-2026-07-28
+/// lifecycle, awaiting the handshake response before proceeding as a real
+/// client does.
+async fn legacy_handshake_and_list(version: &str) -> (serde_json::Value, serde_json::Value) {
+    let mut server = Server::spawn();
+    let init = server
+        .request(serde_json::json!({
+            "jsonrpc": "2.0", "id": 1, "method": "initialize",
+            "params": {
+                "protocolVersion": version,
+                "capabilities": {},
+                "clientInfo": { "name": "t", "version": "0" },
+            },
+        }))
+        .await;
+    server
+        .notify(serde_json::json!({ "jsonrpc": "2.0", "method": "notifications/initialized" }))
+        .await;
+    let list = server
+        .request(serde_json::json!({
+            "jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {},
+        }))
+        .await;
+    (init["result"].clone(), list["result"].clone())
 }
 
 #[tokio::test]
 async fn stdio_lists_three_tools() {
-    let (_, list) = handshake_and_list("2025-11-25").await;
+    let (_, list) = legacy_handshake_and_list("2025-11-25").await;
     let names: Vec<&str> = list["tools"]
         .as_array()
         .expect("tools array")
         .iter()
         .filter_map(|t| t["name"].as_str())
         .collect();
-    for expected in ["complete", "list_models", "status"] {
-        assert!(names.contains(&expected), "missing {expected} in {names:?}");
-    }
+    // Sorted: SEP-2575 asks servers to return a deterministic order so clients
+    // can cache the list, which is also what makes our `ttlMs` hint honest.
+    assert_eq!(names, ["complete", "list_models", "status"]);
 }
 
 /// A `2025-11-25` peer must not see the SEP-2549 hints: rmcp strips only
@@ -89,20 +128,91 @@ async fn stdio_lists_three_tools() {
 /// only thing keeping draft-only fields off this response.
 #[tokio::test]
 async fn stable_peer_gets_no_cache_hints_on_tools_list() {
-    let (init, list) = handshake_and_list("2025-11-25").await;
+    let (init, list) = legacy_handshake_and_list("2025-11-25").await;
     assert_eq!(init["protocolVersion"], "2025-11-25");
     assert!(list.get("ttlMs").is_none(), "got: {list}");
     assert!(list.get("cacheScope").is_none(), "got: {list}");
 }
 
-/// The draft peer gets the hints — and note the server agrees to `2026-07-28`
-/// without any opt-in on our side, because rmcp negotiates any version in
-/// `ProtocolVersion::KNOWN_VERSIONS`. That is exactly why the bump matters:
-/// before it, we accepted this version while implementing none of it.
+/// The legacy handshake still reaches `2026-07-28` if a client asks for it that
+/// way — rmcp negotiates any version in `KNOWN_VERSIONS`.
 #[tokio::test]
-async fn draft_peer_gets_public_cache_hints_on_tools_list() {
-    let (init, list) = handshake_and_list("2026-07-28").await;
+async fn draft_peer_via_legacy_handshake_gets_cache_hints() {
+    let (init, list) = legacy_handshake_and_list("2026-07-28").await;
     assert_eq!(init["protocolVersion"], "2026-07-28");
     assert_eq!(list["ttlMs"], 5 * 60 * 1000);
     assert_eq!(list["cacheScope"], "public");
+}
+
+/// SEP-2575: servers MUST implement `server/discover`. This is how a
+/// `2026-07-28` client opens a stdio connection, so a `-32601` here means no
+/// conformant client can talk to us at all.
+#[tokio::test]
+async fn server_discover_advertises_versions_and_bitrouter_identity() {
+    let response = oneshot(serde_json::json!({
+        "jsonrpc": "2.0", "id": 1, "method": "server/discover",
+        "params": { "_meta": draft_meta() },
+    }))
+    .await;
+    assert!(
+        response.get("error").is_none(),
+        "discover failed: {response}"
+    );
+    let result = &response["result"];
+
+    let versions = result["supportedVersions"]
+        .as_array()
+        .expect("supportedVersions");
+    assert!(
+        versions.iter().any(|v| v == "2026-07-28"),
+        "got: {versions:?}"
+    );
+
+    // Identity must be ours, not the SDK's. `InitializeResult::new` defaults to
+    // `Implementation::from_build_env()`, which resolves inside rmcp and would
+    // otherwise report this server as "rmcp".
+    assert_eq!(result["serverInfo"]["name"], "bitrouter");
+    assert_eq!(result["capabilities"]["tools"], serde_json::json!({}));
+}
+
+/// The real `2026-07-28` shape: no handshake at all, every request
+/// self-contained. This is the path a conformant client actually takes, so it
+/// is the one that has to carry the cache hints.
+#[tokio::test]
+async fn stateless_draft_tools_list_needs_no_handshake_and_carries_hints() {
+    let response = oneshot(serde_json::json!({
+        "jsonrpc": "2.0", "id": 1, "method": "tools/list",
+        "params": { "_meta": draft_meta() },
+    }))
+    .await;
+    assert!(
+        response.get("error").is_none(),
+        "stateless tools/list failed: {response}"
+    );
+    let result = &response["result"];
+    assert_eq!(result["resultType"], "complete");
+    assert_eq!(result["ttlMs"], 5 * 60 * 1000);
+    assert_eq!(result["cacheScope"], "public");
+    assert_eq!(
+        result["tools"].as_array().expect("tools array").len(),
+        3,
+        "got: {result}"
+    );
+}
+
+/// An inline-lifecycle request must be self-contained; a half-populated `_meta`
+/// is a client bug and gets `invalid_params` rather than being served on
+/// guessed defaults.
+#[tokio::test]
+async fn stateless_request_missing_required_meta_is_rejected() {
+    let response = oneshot(serde_json::json!({
+        "jsonrpc": "2.0", "id": 1, "method": "tools/list",
+        "params": { "_meta": { "io.modelcontextprotocol/protocolVersion": "2026-07-28" } },
+    }))
+    .await;
+    let error = &response["error"];
+    assert_eq!(error["code"], -32602, "got: {response}");
+    let message = error["message"].as_str().unwrap_or_default();
+    assert!(message.contains("clientInfo"), "got: {message}");
+    assert!(message.contains("clientCapabilities"), "got: {message}");
 }

--- a/crates/bitrouter-mcp/tests/stdio_smoke.rs
+++ b/crates/bitrouter-mcp/tests/stdio_smoke.rs
@@ -155,6 +155,84 @@ async fn legacy_future_version_uses_fallback_for_following_requests() {
     assert!(list.get("cacheScope").is_none(), "got: {list}");
 }
 
+/// Draft-namespaced metadata is legal extension data on a legacy initialize;
+/// one key alone must not make the request an inline-lifecycle opener.
+#[tokio::test]
+async fn legacy_initialize_with_partial_draft_meta_is_accepted() {
+    let mut server = Server::spawn();
+    let init = server
+        .request(serde_json::json!({
+            "jsonrpc": "2.0", "id": 1, "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-11-25",
+                "capabilities": {},
+                "clientInfo": { "name": "t", "version": "0" },
+                "_meta": { "io.modelcontextprotocol/clientCapabilities": {} },
+            },
+        }))
+        .await;
+    assert!(init.get("error").is_none(), "initialize failed: {init}");
+    assert_eq!(init["result"]["protocolVersion"], "2025-11-25");
+
+    server
+        .notify(serde_json::json!({ "jsonrpc": "2.0", "method": "notifications/initialized" }))
+        .await;
+    let list = server
+        .request(serde_json::json!({
+            "jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {},
+        }))
+        .await;
+    assert!(list.get("error").is_none(), "tools/list failed: {list}");
+    let result = &list["result"];
+    assert!(result.get("resultType").is_none(), "got: {result}");
+    assert!(result.get("ttlMs").is_none(), "got: {result}");
+    assert!(result.get("cacheScope").is_none(), "got: {result}");
+}
+
+/// A pre-initialize ping is lifecycle-neutral even when extension metadata is
+/// only partially populated. After it, the connection must still initialize.
+#[tokio::test]
+async fn pre_init_ping_with_partial_draft_meta_then_initializes() {
+    let mut server = Server::spawn();
+    let ping = server
+        .request(serde_json::json!({
+            "jsonrpc": "2.0", "id": 1, "method": "ping",
+            "params": { "_meta": {
+                "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+            } },
+        }))
+        .await;
+    assert!(ping.get("error").is_none(), "ping failed: {ping}");
+    assert_eq!(ping["result"], serde_json::json!({}));
+
+    let init = server
+        .request(serde_json::json!({
+            "jsonrpc": "2.0", "id": 2, "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-11-25",
+                "capabilities": {},
+                "clientInfo": { "name": "t", "version": "0" },
+            },
+        }))
+        .await;
+    assert!(init.get("error").is_none(), "initialize failed: {init}");
+    assert_eq!(init["result"]["protocolVersion"], "2025-11-25");
+
+    server
+        .notify(serde_json::json!({ "jsonrpc": "2.0", "method": "notifications/initialized" }))
+        .await;
+    let list = server
+        .request(serde_json::json!({
+            "jsonrpc": "2.0", "id": 3, "method": "tools/list", "params": {},
+        }))
+        .await;
+    assert!(list.get("error").is_none(), "tools/list failed: {list}");
+    let result = &list["result"];
+    assert!(result.get("resultType").is_none(), "got: {result}");
+    assert!(result.get("ttlMs").is_none(), "got: {result}");
+    assert!(result.get("cacheScope").is_none(), "got: {result}");
+}
+
 /// SEP-2575: servers MUST implement `server/discover`. This is how a
 /// `2026-07-28` client opens a stdio connection, so a `-32601` here means no
 /// conformant client can talk to us at all.

--- a/crates/bitrouter-sdk/src/config/mod.rs
+++ b/crates/bitrouter-sdk/src/config/mod.rs
@@ -450,28 +450,30 @@ pub struct McpConfig {
     pub aggregate: McpAggregateConfig,
     /// List-call cache settings.
     pub cache: McpCacheConfig,
-    /// MCP protocol version to request when dialing upstream servers.
+    /// MCP startup lifecycle and protocol version for upstream servers.
     pub upstream_protocol: McpUpstreamProtocol,
 }
 
-/// `mcp.upstream_protocol` — the protocol version the gateway asks for in its
-/// upstream `initialize` handshake.
+/// `mcp.upstream_protocol` — the startup lifecycle and protocol version the
+/// gateway uses when dialing upstream MCP servers.
 ///
-/// A server that does not know the requested version answers with one it does
-/// support, and the connection proceeds on that; nothing here can strand a
-/// working upstream. The setting only raises the *ceiling* of what may be
-/// negotiated.
+/// `latest` keeps the legacy `initialize` path. `2026-07-28` starts with
+/// `server/discover` and falls back to `initialize` only when discovery returns
+/// JSON-RPC `METHOD_NOT_FOUND`. Any other discovery error fails the connection,
+/// so opt in only for upstreams expected to support the modern lifecycle.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub enum McpUpstreamProtocol {
-    /// The latest version the MCP SDK treats as current — today `2025-11-25`.
-    /// The default, and what every release before the rmcp 3.0 upgrade used.
+    /// Use the legacy `initialize` lifecycle with the latest version the MCP
+    /// SDK treats as current — today `2025-11-25`. This is the default.
     #[default]
     Latest,
-    /// `2026-07-28`. Opting in lets upstreams answer `tools/call` with MRTR
-    /// `input_required` or a Tasks `task` handle. Neither is a shape this
-    /// gateway can carry — see `docs/MCP_2026_07_28_SPEC.md` (D1) — so both
-    /// surface as explicit errors rather than silent failures.
+    /// Use `server/discover` and the modern `2026-07-28` lifecycle, falling
+    /// back to legacy `initialize` only on `METHOD_NOT_FOUND`. Other discovery
+    /// errors fail the connection. Opting in also lets upstreams answer
+    /// `tools/call` with MRTR `input_required` or a Tasks `task` handle;
+    /// neither is a shape this gateway can carry, so both surface as explicit
+    /// errors (see `docs/MCP_2026_07_28_SPEC.md` D1).
     #[serde(rename = "2026-07-28")]
     V2026_07_28,
 }

--- a/crates/bitrouter-sdk/src/config/mod.rs
+++ b/crates/bitrouter-sdk/src/config/mod.rs
@@ -450,6 +450,30 @@ pub struct McpConfig {
     pub aggregate: McpAggregateConfig,
     /// List-call cache settings.
     pub cache: McpCacheConfig,
+    /// MCP protocol version to request when dialing upstream servers.
+    pub upstream_protocol: McpUpstreamProtocol,
+}
+
+/// `mcp.upstream_protocol` — the protocol version the gateway asks for in its
+/// upstream `initialize` handshake.
+///
+/// A server that does not know the requested version answers with one it does
+/// support, and the connection proceeds on that; nothing here can strand a
+/// working upstream. The setting only raises the *ceiling* of what may be
+/// negotiated.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum McpUpstreamProtocol {
+    /// The latest version the MCP SDK treats as current — today `2025-11-25`.
+    /// The default, and what every release before the rmcp 3.0 upgrade used.
+    #[default]
+    Latest,
+    /// `2026-07-28`. Opting in lets upstreams answer `tools/call` with MRTR
+    /// `input_required` or a Tasks `task` handle. Neither is a shape this
+    /// gateway can carry — see `docs/MCP_2026_07_28_SPEC.md` (D1) — so both
+    /// surface as explicit errors rather than silent failures.
+    #[serde(rename = "2026-07-28")]
+    V2026_07_28,
 }
 
 /// `mcp.aggregate` — the virtual aggregate endpoint.

--- a/crates/bitrouter-sdk/src/config/tests.rs
+++ b/crates/bitrouter-sdk/src/config/tests.rs
@@ -1031,3 +1031,28 @@ providers:
         "unset provider field stays None"
     );
 }
+
+#[test]
+fn mcp_upstream_protocol_defaults_to_latest() {
+    // Absent `mcp:` and present-but-silent `mcp:` must agree, and both must
+    // leave upstream dialing on the pre-upgrade version.
+    assert_eq!(
+        Config::default().mcp.upstream_protocol,
+        McpUpstreamProtocol::Latest
+    );
+    let cfg = parse("mcp:\n  cache:\n    enabled: true\n").expect("parse");
+    assert_eq!(cfg.mcp.upstream_protocol, McpUpstreamProtocol::Latest);
+}
+
+#[test]
+fn mcp_upstream_protocol_opts_in_by_version_string() {
+    let cfg = parse("mcp:\n  upstream_protocol: \"2026-07-28\"\n").expect("parse");
+    assert_eq!(cfg.mcp.upstream_protocol, McpUpstreamProtocol::V2026_07_28);
+
+    // The version is spelled as itself, so an unknown one is a config error
+    // rather than a silent downgrade to the default.
+    assert!(
+        parse("mcp:\n  upstream_protocol: \"2099-01-01\"\n").is_err(),
+        "unknown protocol version must not parse"
+    );
+}

--- a/crates/bitrouter-sdk/src/mcp/caching_executor.rs
+++ b/crates/bitrouter-sdk/src/mcp/caching_executor.rs
@@ -10,7 +10,7 @@
 //! [`CachingExecutor::with_invalidation`], affected entries are also evicted
 //! on demand. The TTL on each entry honours the MCP spec's SEP-2549
 //! `ttlMs` / `cacheScope` cache-control hints when the upstream supplies them
-//! — see [`extract_cache_hint`].
+//! — see `extract_cache_hint`.
 //!
 //! Caching applies per [`McpTarget::Direct`] member; when used inside an
 //! [`super::aggregating_executor::AggregatingExecutor`], the cache key

--- a/crates/bitrouter-sdk/src/mcp/caching_executor.rs
+++ b/crates/bitrouter-sdk/src/mcp/caching_executor.rs
@@ -8,8 +8,9 @@
 //! Cache entries expire on TTL. When the inner executor is hooked up to a
 //! `notifications/*_list_changed` source via
 //! [`CachingExecutor::with_invalidation`], affected entries are also evicted
-//! on demand. The TTL on each entry honours the MCP spec's `ttlMs`
-//! cache-control hint when present in the upstream `_meta`.
+//! on demand. The TTL on each entry honours the MCP spec's SEP-2549
+//! `ttlMs` / `cacheScope` cache-control hints when the upstream supplies them
+//! — see [`extract_cache_hint`].
 //!
 //! Caching applies per [`McpTarget::Direct`] member; when used inside an
 //! [`super::aggregating_executor::AggregatingExecutor`], the cache key
@@ -269,9 +270,8 @@ fn apply_invalidation(
     }
 }
 
-/// Identify which method the executor will cache for, if any, and the TTL to
-/// stamp on the entry. Honours the MCP spec's `_meta.ttlMs` cache-control
-/// hint when present (`upstream_hint`).
+/// Identify which method the executor will cache for, if any. The TTL to stamp
+/// on the entry comes from [`extract_cache_hint`].
 fn cached_method(method: &str) -> Option<&'static str> {
     match method {
         "tools/list" => Some("tools/list"),
@@ -282,12 +282,46 @@ fn cached_method(method: &str) -> Option<&'static str> {
     }
 }
 
-fn extract_ttl_hint(result: &serde_json::Value) -> Option<Duration> {
-    let ms = result
-        .get("_meta")
-        .and_then(|m| m.get("ttlMs"))
-        .and_then(|v| v.as_u64())?;
-    Some(Duration::from_millis(ms))
+/// What an upstream's SEP-2549 cache-control hint tells us to do with a result.
+enum CacheHint {
+    /// Do not cache at all. Either the upstream scoped the result `private`, or
+    /// it gave a TTL of zero (spec: "immediately stale").
+    Uncacheable,
+    /// Cache it. `Some(ttl)` when the upstream supplied one, `None` to fall
+    /// back to our configured per-method default.
+    Cacheable(Option<Duration>),
+}
+
+/// Read the SEP-2549 cache-control hint off an upstream result.
+///
+/// `ttlMs` and `cacheScope` are **top-level fields on the result**, siblings of
+/// `_meta` — not nested inside it (MCP `2026-07-28` schema; rmcp models them on
+/// `ListToolsResult`/`ReadResourceResult` et al). Servers that shipped the
+/// earlier draft put `ttlMs` under `_meta`, so that location is still honoured
+/// as a fallback.
+///
+/// `cacheScope: "private"` means only the requesting user's client may cache
+/// the response. Our cache sits behind a connection pool keyed by server name
+/// alone, so a cached entry is visible to *every* downstream caller — which is
+/// exactly what `private` forbids. We therefore decline to cache those results
+/// rather than trying to partition them.
+///
+/// Per spec a negative `ttlMs` is treated as `0` rather than an error, matching
+/// rmcp's `deserialize_ttl_ms`.
+fn extract_cache_hint(result: &serde_json::Value) -> CacheHint {
+    if result.get("cacheScope").and_then(|v| v.as_str()) == Some("private") {
+        return CacheHint::Uncacheable;
+    }
+    let raw = result
+        .get("ttlMs")
+        .or_else(|| result.get("_meta").and_then(|m| m.get("ttlMs")))
+        .and_then(|v| v.as_i64());
+    match raw {
+        // Negative clamps to zero, and zero means immediately stale.
+        Some(ms) if ms <= 0 => CacheHint::Uncacheable,
+        Some(ms) => CacheHint::Cacheable(Some(Duration::from_millis(ms as u64))),
+        None => CacheHint::Cacheable(None),
+    }
 }
 
 fn params_hash(params: &serde_json::Value) -> u64 {
@@ -377,8 +411,18 @@ impl<E: Executor + 'static> Executor for CachingExecutor<E> {
             "mcp cache: miss",
         );
         let response = self.inner.execute(target, request).await?;
-        let ttl = extract_ttl_hint(&response.result).unwrap_or(default_ttl);
-        self.cache_insert(key, response.result.clone(), ttl);
+        match extract_cache_hint(&response.result) {
+            CacheHint::Uncacheable => {
+                tracing::debug!(
+                    server = %key.server_name,
+                    method = %key.method,
+                    "mcp cache: upstream declined caching (private scope or zero ttl)",
+                );
+            }
+            CacheHint::Cacheable(hint) => {
+                self.cache_insert(key, response.result.clone(), hint.unwrap_or(default_ttl));
+            }
+        }
         Ok(response)
     }
 
@@ -422,21 +466,21 @@ impl<E: Executor + 'static> Executor for CachingExecutor<E> {
         let max_entries = self.ttls.max_entries_per_server;
         let key_for_stream = key.clone();
         let wrapped = inner_stream.map(move |item| {
-            if let Ok(McpStreamPart::Final(ref response)) = item {
-                let ttl = extract_ttl_hint(&response.result).unwrap_or(default_ttl);
-                if let Ok(mut map) = caches.lock() {
-                    let sc = map
-                        .entry(key_for_stream.server_name.clone())
-                        .or_insert_with(|| ServerCache::new(max_entries));
-                    sc.insert(
-                        key_for_stream.clone(),
-                        CacheEntry {
-                            value: response.result.clone(),
-                            inserted_at: Instant::now(),
-                            ttl,
-                        },
-                    );
-                }
+            if let Ok(McpStreamPart::Final(ref response)) = item
+                && let CacheHint::Cacheable(hint) = extract_cache_hint(&response.result)
+                && let Ok(mut map) = caches.lock()
+            {
+                let sc = map
+                    .entry(key_for_stream.server_name.clone())
+                    .or_insert_with(|| ServerCache::new(max_entries));
+                sc.insert(
+                    key_for_stream.clone(),
+                    CacheEntry {
+                        value: response.result.clone(),
+                        inserted_at: Instant::now(),
+                        ttl: hint.unwrap_or(default_ttl),
+                    },
+                );
             }
             item
         });
@@ -632,13 +676,87 @@ mod tests {
         );
     }
 
+    /// SEP-2549 puts `ttlMs` at the *top level* of the result, beside `_meta`
+    /// rather than inside it. Reading the wrong location is silent — the cache
+    /// just falls back to its configured default — so pin both spellings.
+    #[test]
+    fn cache_hint_reads_top_level_ttl_ms_and_falls_back_to_meta() {
+        let ttl = |v: serde_json::Value| match extract_cache_hint(&v) {
+            CacheHint::Cacheable(hint) => hint,
+            CacheHint::Uncacheable => panic!("expected cacheable, got uncacheable"),
+        };
+
+        // The shipped SEP-2549 shape.
+        assert_eq!(
+            ttl(serde_json::json!({ "tools": [], "ttlMs": 50 })),
+            Some(Duration::from_millis(50)),
+        );
+        // The earlier draft shape, still honoured as a fallback.
+        assert_eq!(
+            ttl(serde_json::json!({ "tools": [], "_meta": { "ttlMs": 50 } })),
+            Some(Duration::from_millis(50)),
+        );
+        // Top level wins when a server somehow sends both.
+        assert_eq!(
+            ttl(serde_json::json!({
+                "ttlMs": 50,
+                "_meta": { "ttlMs": 9000 }
+            })),
+            Some(Duration::from_millis(50)),
+        );
+        // No hint at all → fall back to the configured default.
+        assert_eq!(ttl(serde_json::json!({ "tools": [] })), None);
+    }
+
+    #[test]
+    fn cache_hint_declines_private_scope_and_non_positive_ttl() {
+        let uncacheable =
+            |v: serde_json::Value| matches!(extract_cache_hint(&v), CacheHint::Uncacheable);
+
+        // `private` means only the requesting user's client may cache. Our
+        // cache is shared across every downstream caller, so we must not.
+        assert!(uncacheable(
+            serde_json::json!({ "tools": [], "cacheScope": "private" })
+        ));
+        // ...even when the upstream also supplies a generous TTL.
+        assert!(uncacheable(serde_json::json!({
+            "cacheScope": "private",
+            "ttlMs": 60_000
+        })));
+        // `public` is the default and stays cacheable.
+        assert!(!uncacheable(
+            serde_json::json!({ "tools": [], "cacheScope": "public" })
+        ));
+        // Zero means immediately stale.
+        assert!(uncacheable(serde_json::json!({ "ttlMs": 0 })));
+        // Per spec a negative value is clamped to zero, not an error.
+        assert!(uncacheable(serde_json::json!({ "ttlMs": -42 })));
+    }
+
+    #[tokio::test]
+    async fn private_scoped_result_is_not_cached() {
+        let inner = Arc::new(CountingExecutor {
+            calls: AtomicUsize::new(0),
+            value: serde_json::json!({ "tools": [], "cacheScope": "private" }),
+        });
+        let exec = CachingExecutor::new(inner.clone(), CacheTtls::default());
+        for _ in 0..2 {
+            let _ = exec
+                .execute(&target("a"), &list_req("a", "tools/list"))
+                .await
+                .unwrap();
+        }
+        // Both calls went upstream — no entry was ever stamped.
+        assert_eq!(inner.calls.load(Ordering::SeqCst), 2);
+    }
+
     #[tokio::test]
     async fn upstream_ttl_hint_is_honoured() {
         let inner = Arc::new(CountingExecutor {
             calls: AtomicUsize::new(0),
             value: serde_json::json!({
                 "tools": [],
-                "_meta": { "ttlMs": 50 }
+                "ttlMs": 50
             }),
         });
         let exec = CachingExecutor::new(inner.clone(), CacheTtls::default());

--- a/crates/bitrouter-sdk/src/mcp/mod.rs
+++ b/crates/bitrouter-sdk/src/mcp/mod.rs
@@ -61,7 +61,7 @@ pub mod rmcp_executor;
 /// Lives here rather than as a `From` impl in `config` so the config module
 /// stays free of an rmcp dependency — `config` is compiled without the `mcp`
 /// feature too.
-#[cfg(feature = "config_file")]
+#[cfg(all(feature = "config_file", feature = "mcp"))]
 pub fn upstream_protocol_version(
     setting: crate::config::McpUpstreamProtocol,
 ) -> rmcp::model::ProtocolVersion {

--- a/crates/bitrouter-sdk/src/mcp/mod.rs
+++ b/crates/bitrouter-sdk/src/mcp/mod.rs
@@ -55,6 +55,24 @@ pub mod config_routing;
 #[cfg(feature = "mcp")]
 pub mod rmcp_executor;
 
+/// The rmcp [`ProtocolVersion`](rmcp::model::ProtocolVersion) a
+/// [`crate::config::McpUpstreamProtocol`] selects.
+///
+/// Lives here rather than as a `From` impl in `config` so the config module
+/// stays free of an rmcp dependency — `config` is compiled without the `mcp`
+/// feature too.
+#[cfg(feature = "config_file")]
+pub fn upstream_protocol_version(
+    setting: crate::config::McpUpstreamProtocol,
+) -> rmcp::model::ProtocolVersion {
+    match setting {
+        crate::config::McpUpstreamProtocol::Latest => rmcp::model::ProtocolVersion::LATEST,
+        crate::config::McpUpstreamProtocol::V2026_07_28 => {
+            rmcp::model::ProtocolVersion::V_2026_07_28
+        }
+    }
+}
+
 // Per CLAUDE.md guideline #2 we do not `pub use` from these submodules.
 // Downstream code reaches the types directly:
 // - `mcp::transport::{McpServerConfig, McpTransport}`

--- a/crates/bitrouter-sdk/src/mcp/rmcp_executor.rs
+++ b/crates/bitrouter-sdk/src/mcp/rmcp_executor.rs
@@ -7,11 +7,11 @@
 //! (`-32601`). The MCP spec method catalogue is at
 //! <https://modelcontextprotocol.io/specification/2025-06-18>.
 //!
-//! Connections are pooled per server-name and lazily initialised. The first
-//! request to each server triggers the MCP `initialize` handshake (handled
-//! transparently by rmcp's `serve()`); subsequent requests reuse the same
-//! [`RunningService`]. There is no idle eviction in v1.0 — the pool grows to
-//! the number of distinct servers reached.
+//! Connections are pooled per server-name and lazily started through the
+//! configured lifecycle: legacy `initialize` for `latest`, or
+//! `server/discover` with narrowly-defined legacy fallback for `2026-07-28`.
+//! Subsequent requests reuse the same [`RunningService`]. There is no idle
+//! eviction in v1.0 — the pool grows to the number of distinct servers reached.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -57,7 +57,7 @@ struct BitrouterMcpClient {
     server_name: String,
     progress: Arc<ProgressDispatcher>,
     invalidation: Arc<broadcast::Sender<InvalidationEvent>>,
-    /// Version to request in the upstream `initialize` handshake.
+    /// Version and lifecycle to select when starting the upstream connection.
     protocol_version: ProtocolVersion,
 }
 
@@ -251,16 +251,15 @@ impl RmcpExecutor {
         Self::default()
     }
 
-    /// Request `version` in the upstream `initialize` handshake instead of
+    /// Select `version` and its startup lifecycle instead of
     /// [`ProtocolVersion::LATEST`].
     ///
-    /// This is the whole of the client-side `2026-07-28` opt-in. It is a
-    /// ceiling, not a demand: a server that does not know the version answers
-    /// with one it does support and the connection proceeds on that, so
-    /// raising it cannot strand a working upstream. What it *does* change is
-    /// which response shapes an upstream is permitted to send — at
-    /// `2026-07-28` a `tools/call` may come back as MRTR `input_required` or a
-    /// Tasks handle, which `map_call_tool_result` turns into explicit errors.
+    /// `LATEST` uses the legacy `initialize` path. `2026-07-28` uses
+    /// `server/discover` and falls back to legacy initialization only when the
+    /// peer returns `METHOD_NOT_FOUND`; any other discovery error fails the
+    /// connection. The modern version also permits `tools/call` to return MRTR
+    /// `input_required` or a Tasks handle, which `map_call_tool_result` turns
+    /// into explicit errors.
     ///
     /// Applies to connections opened after this call; pooled ones keep the
     /// version they negotiated.
@@ -278,9 +277,9 @@ impl RmcpExecutor {
     }
 
     /// Drop the pooled connection for `server_name`, if any. The next request
-    /// for that server will re-dial — running the MCP `initialize` handshake
-    /// against the upstream again and (for HTTP transports) rebuilding the
-    /// transport with whatever headers the new connect call supplies.
+    /// for that server will re-dial — running the configured MCP startup
+    /// lifecycle again and (for HTTP transports) rebuilding the transport with
+    /// whatever headers the new connect call supplies.
     ///
     /// The SDK does not interpret *when* to evict — that policy lives in a
     /// downstream decorator. The canonical use case is an OAuth-refresh
@@ -308,7 +307,7 @@ impl RmcpExecutor {
             return Ok(existing);
         }
         // Slow path: dial. We drop the lock across the network round-trip so
-        // a slow `initialize` against one server can't block lookups for
+        // a slow startup against one server can't block lookups for
         // another. If two requests race to dial the same server, both will
         // dial; the second one's value silently replaces the first in the
         // pool — fine because either RunningService is correct.
@@ -695,6 +694,28 @@ fn map_call_tool_result(server: &str, result: ServerResult) -> Result<serde_json
     }
 }
 
+/// Fold one page's cache policy into the aggregate policy for a paginated
+/// result. The aggregate can never be shared or kept fresh more broadly than
+/// any page it contains.
+fn merge_paginated_cache_hints(
+    ttl_ms: &mut Option<u64>,
+    cache_scope: &mut Option<rmcp::model::CacheScope>,
+    page_ttl_ms: Option<u64>,
+    page_cache_scope: Option<rmcp::model::CacheScope>,
+) {
+    if let Some(page_ttl_ms) = page_ttl_ms {
+        *ttl_ms = Some(match *ttl_ms {
+            Some(current) => current.min(page_ttl_ms),
+            None => page_ttl_ms,
+        });
+    }
+    if matches!(page_cache_scope, Some(rmcp::model::CacheScope::Private)) {
+        *cache_scope = Some(rmcp::model::CacheScope::Private);
+    } else if cache_scope.is_none() {
+        *cache_scope = page_cache_scope;
+    }
+}
+
 async fn dispatch(
     peer: &Peer<RoleClient>,
     server: &str,
@@ -712,10 +733,10 @@ async fn dispatch(
     /// `_meta`. `CachingExecutor` reads those hints, so the gateway was
     /// discarding the upstream's cache policy before anything could honour it.
     ///
-    /// Hints are taken from the first page and applied to the aggregate: the
-    /// pages compose into one logical result, so the freshness the server
-    /// stated for it governs the whole thing. `next_cursor` is cleared because
-    /// the aggregate has no further pages.
+    /// The pages compose into one logical result, so their cache policies are
+    /// merged conservatively: private scope wins and the shortest TTL governs
+    /// the whole aggregate. `next_cursor` is cleared because the aggregate has
+    /// no further pages.
     macro_rules! list_all_preserving {
         ($call:ident, $items:ident) => {{
             let mut result = peer
@@ -730,6 +751,12 @@ async fn dispatch(
                     ))
                     .await
                     .map_err(|e| map_service_error(server, method, e))?;
+                merge_paginated_cache_hints(
+                    &mut result.ttl_ms,
+                    &mut result.cache_scope,
+                    page.ttl_ms,
+                    page.cache_scope,
+                );
                 result.$items.append(&mut page.$items);
                 cursor = page.next_cursor;
             }
@@ -823,7 +850,7 @@ mod tests {
     /// lets it answer `tools/call` with shapes this gateway can only turn into
     /// errors, so it has to be a choice someone makes.
     #[test]
-    fn upstream_handshake_requests_latest_by_default() {
+    fn upstream_startup_uses_latest_by_default() {
         let exec = RmcpExecutor::new();
         assert_eq!(
             client_for(&exec).get_info().protocol_version,
@@ -832,7 +859,7 @@ mod tests {
     }
 
     #[test]
-    fn with_protocol_version_is_carried_into_the_handshake() {
+    fn configured_protocol_version_is_carried_into_client_info() {
         let exec = RmcpExecutor::new().with_protocol_version(ProtocolVersion::V_2026_07_28);
         assert_eq!(
             client_for(&exec).get_info().protocol_version,

--- a/crates/bitrouter-sdk/src/mcp/rmcp_executor.rs
+++ b/crates/bitrouter-sdk/src/mcp/rmcp_executor.rs
@@ -24,7 +24,7 @@ use rmcp::handler::client::progress::ProgressDispatcher;
 use rmcp::model::{
     CallToolRequest, CallToolRequestParams, ClientInfo, ClientRequest, ElicitRequestParams,
     ElicitResult, ErrorCode, ErrorData as McpError, GetPromptRequestParams, Implementation,
-    ProgressNotificationParam, ReadResourceRequestParams, ServerResult,
+    ProgressNotificationParam, ProtocolVersion, ReadResourceRequestParams, ServerResult,
 };
 #[expect(
     deprecated,
@@ -57,12 +57,15 @@ struct BitrouterMcpClient {
     server_name: String,
     progress: Arc<ProgressDispatcher>,
     invalidation: Arc<broadcast::Sender<InvalidationEvent>>,
+    /// Version to request in the upstream `initialize` handshake.
+    protocol_version: ProtocolVersion,
 }
 
 impl ClientHandler for BitrouterMcpClient {
     fn get_info(&self) -> ClientInfo {
         let mut info = ClientInfo::default();
         info.client_info = Implementation::new("bitrouter", env!("CARGO_PKG_VERSION"));
+        info.protocol_version = self.protocol_version.clone();
         info
     }
 
@@ -227,6 +230,7 @@ const INVALIDATION_CHANNEL_CAPACITY: usize = 256;
 pub struct RmcpExecutor {
     pool: Pool,
     invalidation_tx: Arc<broadcast::Sender<InvalidationEvent>>,
+    protocol_version: ProtocolVersion,
 }
 
 impl Default for RmcpExecutor {
@@ -235,14 +239,34 @@ impl Default for RmcpExecutor {
         Self {
             pool: Default::default(),
             invalidation_tx: Arc::new(tx),
+            protocol_version: ProtocolVersion::LATEST,
         }
     }
 }
 
 impl RmcpExecutor {
-    /// Fresh executor with an empty connection pool.
+    /// Fresh executor with an empty connection pool, dialing upstreams at
+    /// [`ProtocolVersion::LATEST`].
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Request `version` in the upstream `initialize` handshake instead of
+    /// [`ProtocolVersion::LATEST`].
+    ///
+    /// This is the whole of the client-side `2026-07-28` opt-in. It is a
+    /// ceiling, not a demand: a server that does not know the version answers
+    /// with one it does support and the connection proceeds on that, so
+    /// raising it cannot strand a working upstream. What it *does* change is
+    /// which response shapes an upstream is permitted to send — at
+    /// `2026-07-28` a `tools/call` may come back as MRTR `input_required` or a
+    /// Tasks handle, which [`map_call_tool_result`] turns into explicit errors.
+    ///
+    /// Applies to connections opened after this call; pooled ones keep the
+    /// version they negotiated.
+    pub fn with_protocol_version(mut self, version: ProtocolVersion) -> Self {
+        self.protocol_version = version;
+        self
     }
 
     /// Subscribe to upstream cache-invalidation notifications. Each
@@ -293,6 +317,7 @@ impl RmcpExecutor {
             server_name: server_name.to_string(),
             progress: progress.clone(),
             invalidation: self.invalidation_tx.clone(),
+            protocol_version: self.protocol_version.clone(),
         };
         let service = connect(server_name, transport, client).await?;
         // rmcp 3.x allocates a per-`Peer` SEP-2549 response cache that is
@@ -733,6 +758,36 @@ mod tests {
     #[test]
     fn executor_constructs_with_empty_pool() {
         let _ = RmcpExecutor::new();
+    }
+
+    fn client_for(exec: &RmcpExecutor) -> BitrouterMcpClient {
+        BitrouterMcpClient {
+            server_name: "srv".into(),
+            progress: Arc::new(ProgressDispatcher::new()),
+            invalidation: exec.invalidation_tx.clone(),
+            protocol_version: exec.protocol_version.clone(),
+        }
+    }
+
+    /// The default must stay `LATEST`: opting an upstream into `2026-07-28`
+    /// lets it answer `tools/call` with shapes this gateway can only turn into
+    /// errors, so it has to be a choice someone makes.
+    #[test]
+    fn upstream_handshake_requests_latest_by_default() {
+        let exec = RmcpExecutor::new();
+        assert_eq!(
+            client_for(&exec).get_info().protocol_version,
+            ProtocolVersion::LATEST,
+        );
+    }
+
+    #[test]
+    fn with_protocol_version_is_carried_into_the_handshake() {
+        let exec = RmcpExecutor::new().with_protocol_version(ProtocolVersion::V_2026_07_28);
+        assert_eq!(
+            client_for(&exec).get_info().protocol_version,
+            ProtocolVersion::V_2026_07_28,
+        );
     }
 
     /// Build a `ServerResult` from JSON. The rmcp result types are

--- a/crates/bitrouter-sdk/src/mcp/rmcp_executor.rs
+++ b/crates/bitrouter-sdk/src/mcp/rmcp_executor.rs
@@ -32,7 +32,8 @@ use rmcp::model::{
 )]
 use rmcp::model::{CreateMessageRequestParams, CreateMessageResult, ListRootsResult};
 use rmcp::service::{
-    NotificationContext, Peer, PeerRequestOptions, RequestContext, RoleClient, RunningService,
+    ClientCacheConfig, NotificationContext, Peer, PeerRequestOptions, RequestContext, RoleClient,
+    RunningService,
 };
 use tokio::sync::{Mutex, broadcast};
 
@@ -205,7 +206,15 @@ struct PooledConnection {
     progress: Arc<ProgressDispatcher>,
 }
 
-/// Pooled rmcp client used by [`RmcpExecutor`].
+/// Pooled rmcp client used by [`RmcpExecutor`], keyed by server name.
+///
+/// The key is deliberately *only* the server name: upstream credentials come
+/// from static per-server config (see [`connect`]), so one pooled connection
+/// carries exactly one upstream principal and every downstream caller of that
+/// server shares it. Anything that makes the upstream identity vary per caller
+/// — forwarding a caller's own token upstream, say — invalidates that and must
+/// widen this key, because SEP-2549 `private`-scoped responses and any
+/// per-principal upstream state would otherwise be shared across callers.
 type Pool = Mutex<HashMap<String, PooledConnection>>;
 
 /// Broadcast capacity for the invalidation channel. Sized to absorb a burst
@@ -286,6 +295,17 @@ impl RmcpExecutor {
             invalidation: self.invalidation_tx.clone(),
         };
         let service = connect(server_name, transport, client).await?;
+        // rmcp 3.x allocates a per-`Peer` SEP-2549 response cache that is
+        // *enabled by default*. We already cache upstream results one layer up
+        // in `CachingExecutor`, which rmcp's cannot replace: ours evicts on
+        // `notifications/*_list_changed`, bounds itself per server with an LRU,
+        // and keys by aggregate member. Stacking the two would also inherit
+        // rmcp's `serve_stale_on_error: true` — a failed re-fetch silently
+        // returning a stale response underneath us. One cache, ours.
+        service
+            .peer()
+            .set_response_cache_config(ClientCacheConfig::disabled())
+            .await;
         let entry = PooledConnection {
             service: Arc::new(service),
             progress,
@@ -549,19 +569,12 @@ fn stream_tools_call(
                     }
                 }
                 call_result = &mut call_fut => {
-                    match call_result {
-                        Ok(ServerResult::CallToolResult(result)) => {
-                            let value = serde_json::to_value(&result).unwrap_or(serde_json::Value::Null);
+                    match call_result.and_then(|r| map_call_tool_result(&server_name, r)) {
+                        Ok(value) => {
                             yield Ok(McpStreamPart::Final(McpResponse {
                                 request_id,
                                 result: value,
                             }));
-                        }
-                        Ok(other) => {
-                            yield Err(upstream(
-                                &server_name,
-                                format!("tools/call: unexpected server result {other:?}"),
-                            ));
                         }
                         Err(e) => yield Err(e),
                     }
@@ -569,6 +582,57 @@ fn stream_tools_call(
                 }
             }
         }
+    }
+}
+
+/// Map a `tools/call` response into the final result JSON, or a typed error.
+///
+/// Shared by the streaming and non-streaming paths so they agree exactly — at
+/// MCP `2026-07-28` a server may answer `tools/call` with something other than
+/// a `CallToolResult`, and the two paths would otherwise diverge (rmcp's
+/// high-level `call_tool` silently drives MRTR rounds, while the raw
+/// `send_cancellable_request` the streaming path needs for its progress token
+/// does not).
+///
+/// Neither non-final shape is one this gateway can carry:
+///
+/// - **MRTR `input_required` (SEP-2322)** asks the client to fulfil
+///   `sampling/createMessage`, `elicitation/create`, or `roots/list` and retry.
+///   Those are precisely the three server→client requests
+///   [`BitrouterMcpClient`] rejects with `-32601`, for the same reason: the
+///   inbound client connected statelessly, with no channel back. Driving the
+///   rounds would only produce a rejection per input request and then fail, so
+///   we say so directly instead.
+/// - **Tasks `resultType: "task"` (SEP-2663)** hands back a task id to poll.
+///   Polling is a lifecycle this executor does not implement yet — see
+///   `docs/MCP_2026_07_28_SPEC.md` (D1) — so we surface the task id rather
+///   than stranding the caller on an opaque failure.
+///
+/// Both follow the module's existing stance on server→client relaying: an
+/// explicit, diagnosable rejection beats a silent default.
+fn map_call_tool_result(server: &str, result: ServerResult) -> Result<serde_json::Value> {
+    match result {
+        ServerResult::CallToolResult(result) => serde_json::to_value(&result)
+            .map_err(|e| BitrouterError::internal(format!("mcp '{server}' tools/call: {e}"))),
+        ServerResult::InputRequiredResult(_) => Err(upstream(
+            server,
+            "tools/call returned an MRTR 'input_required' result (SEP-2322). The bitrouter \
+             gateway cannot fulfil server→client requests — the inbound client connected \
+             statelessly — so the round cannot be completed. Configure a direct MCP client \
+             connection if you need multi-round-trip tools.",
+        )),
+        ServerResult::CreateTaskResult(result) => Err(upstream(
+            server,
+            format!(
+                "tools/call was materialized as task '{}' (SEP-2663 Tasks extension). The \
+                 bitrouter gateway does not poll tasks; the call was not completed.",
+                result.task.task_id
+            ),
+        )),
+        other => Err(upstream(
+            server,
+            format!("tools/call: unexpected server result {other:?}"),
+        )),
     }
 }
 
@@ -589,13 +653,16 @@ async fn dispatch(
         "tools/call" => {
             let params: CallToolRequestParams = serde_json::from_value(request.params.clone())
                 .map_err(|e| bad_params(server, method, e))?;
+            // Deliberately *not* rmcp's high-level `call_tool`: that drives
+            // MRTR rounds through the local handler (which rejects every one)
+            // and reports a bare `UnexpectedResponse` for tasks. Sending the
+            // request directly lets `map_call_tool_result` give both this path
+            // and the streaming path the same explanation.
             let result = peer
-                .call_tool(params)
+                .send_request(ClientRequest::CallToolRequest(CallToolRequest::new(params)))
                 .await
                 .map_err(|e| map_service_error(server, method, e))?;
-            serde_json::to_value(&result).map_err(|e| {
-                BitrouterError::internal(format!("mcp '{server}' tools/call serialise: {e}"))
-            })
+            map_call_tool_result(server, result)
         }
         "resources/list" => {
             let resources = peer
@@ -666,6 +733,80 @@ mod tests {
     #[test]
     fn executor_constructs_with_empty_pool() {
         let _ = RmcpExecutor::new();
+    }
+
+    /// Build a `ServerResult` from JSON. The rmcp result types are
+    /// `#[non_exhaustive]` with custom `resultType`-discriminating
+    /// deserializers, so going through the wire shape is both the only
+    /// cross-crate route and a faithful match for what a real upstream sends.
+    fn server_result(json: serde_json::Value) -> ServerResult {
+        serde_json::from_value(json).expect("valid ServerResult")
+    }
+
+    #[test]
+    fn tools_call_maps_a_complete_result_to_its_json() {
+        let result = server_result(serde_json::json!({
+            "resultType": "complete",
+            "content": [{ "type": "text", "text": "hi" }],
+        }));
+        let value = map_call_tool_result("srv", result).expect("complete result maps to json");
+        assert_eq!(value["content"][0]["text"], "hi");
+    }
+
+    /// MRTR asks us to fulfil a server→client request and retry. This gateway
+    /// rejects all three such requests by design, so the round can never
+    /// complete — the caller deserves that explanation, not a bare
+    /// "unexpected server result".
+    #[test]
+    fn tools_call_maps_mrtr_input_required_to_an_explained_error() {
+        let result = server_result(serde_json::json!({
+            "resultType": "input_required",
+            "inputRequests": {
+                "confirm": {
+                    "method": "elicitation/create",
+                    // `properties` is required on an elicitation schema —
+                    // omit it and the whole result silently degrades to
+                    // `CustomResult` via the untagged union.
+                    "params": {
+                        "message": "ok?",
+                        "requestedSchema": { "type": "object", "properties": {} }
+                    }
+                }
+            },
+            "requestState": "opaque",
+        }));
+        let err = map_call_tool_result("srv", result).expect_err("input_required is an error");
+        let msg = err.to_string();
+        // Assert on text unique to the MRTR arm — the catch-all would also
+        // mention "input_required" via the result's `Debug`, so a looser
+        // assertion would pass even if the variant fell through.
+        assert!(msg.contains("SEP-2322"), "{msg}");
+        assert!(
+            msg.contains("cannot fulfil server→client requests"),
+            "{msg}"
+        );
+        assert!(msg.contains("srv"), "{msg}");
+    }
+
+    /// SEP-2663: the task id is the one thing that makes the failure
+    /// actionable, so it must survive into the error.
+    #[test]
+    fn tools_call_maps_a_task_result_to_an_error_naming_the_task() {
+        let result = server_result(serde_json::json!({
+            "resultType": "task",
+            "taskId": "task-42",
+            "status": "working",
+            "createdAt": "2026-07-28T00:00:00Z",
+            "lastUpdatedAt": "2026-07-28T00:00:00Z",
+            "ttlMs": 60000,
+        }));
+        let err = map_call_tool_result("srv", result).expect_err("task is an error");
+        let msg = err.to_string();
+        // As above: "task-42" alone would also appear in the catch-all's
+        // `Debug` output, so pin text only the Tasks arm produces.
+        assert!(msg.contains("SEP-2663"), "{msg}");
+        assert!(msg.contains("materialized as task 'task-42'"), "{msg}");
+        assert!(msg.contains("srv"), "{msg}");
     }
 
     #[tokio::test]

--- a/crates/bitrouter-sdk/src/mcp/rmcp_executor.rs
+++ b/crates/bitrouter-sdk/src/mcp/rmcp_executor.rs
@@ -709,10 +709,21 @@ fn merge_paginated_cache_hints(
             None => page_ttl_ms,
         });
     }
-    if matches!(page_cache_scope, Some(rmcp::model::CacheScope::Private)) {
-        *cache_scope = Some(rmcp::model::CacheScope::Private);
-    } else if cache_scope.is_none() {
-        *cache_scope = page_cache_scope;
+    // `CacheScope` is non-exhaustive. Keep private dominant, let public fill
+    // only an absent policy, and preserve any future non-public page scope as
+    // restrictive instead of silently treating it as public or ignoring it.
+    if !matches!(*cache_scope, Some(rmcp::model::CacheScope::Private)) {
+        match page_cache_scope {
+            None => {}
+            Some(rmcp::model::CacheScope::Private) => {
+                *cache_scope = Some(rmcp::model::CacheScope::Private);
+            }
+            Some(rmcp::model::CacheScope::Public) if cache_scope.is_none() => {
+                *cache_scope = Some(rmcp::model::CacheScope::Public);
+            }
+            Some(rmcp::model::CacheScope::Public) => {}
+            Some(restrictive) => *cache_scope = Some(restrictive),
+        }
     }
 }
 

--- a/crates/bitrouter-sdk/src/mcp/rmcp_executor.rs
+++ b/crates/bitrouter-sdk/src/mcp/rmcp_executor.rs
@@ -32,8 +32,8 @@ use rmcp::model::{
 )]
 use rmcp::model::{CreateMessageRequestParams, CreateMessageResult, ListRootsResult};
 use rmcp::service::{
-    ClientCacheConfig, NotificationContext, Peer, PeerRequestOptions, RequestContext, RoleClient,
-    RunningService,
+    ClientCacheConfig, ClientLifecycleMode, ClientServiceExt, NotificationContext, Peer,
+    PeerRequestOptions, RequestContext, RoleClient, RunningService,
 };
 use tokio::sync::{Mutex, broadcast};
 
@@ -343,11 +343,43 @@ impl RmcpExecutor {
     }
 }
 
+/// How to open a connection for the protocol version the executor is
+/// configured to request.
+///
+/// MCP `2026-07-28` removed the `initialize` handshake (SEP-2575): a client on
+/// that version opens with `server/discover` and then sends self-contained
+/// requests. Declaring `2026-07-28` inside an `initialize` — a method the
+/// version does not define — would be incoherent, and a conformant non-rmcp
+/// server would reject it outright.
+///
+/// So the opt-in switches lifecycle, not just the version string:
+///
+/// - `latest` keeps rmcp's plain `serve` (the `initialize` handshake), exactly
+///   as every release before this one.
+/// - `2026-07-28` uses [`ClientLifecycleMode::Auto`], which probes
+///   `server/discover` and falls back to `initialize` only when the peer
+///   answers `METHOD_NOT_FOUND` — so pointing the opt-in at a server that has
+///   not caught up still connects.
+///
+/// This is the reason to accept `Auto`'s one weakness (a server that rejects an
+/// unknown method with something other than `METHOD_NOT_FOUND` gets no
+/// fallback): on the `2026-07-28` path there is no correct alternative, and the
+/// default path never reaches this branch.
+fn lifecycle_for(version: &ProtocolVersion) -> Option<ClientLifecycleMode> {
+    (version.as_str() >= ProtocolVersion::V_2026_07_28.as_str()).then(|| {
+        ClientLifecycleMode::Auto {
+            preferred_versions: vec![version.clone()],
+            legacy_version: Some(ProtocolVersion::LATEST),
+        }
+    })
+}
+
 async fn connect(
     server_name: &str,
     transport: &McpTransport,
     client: BitrouterMcpClient,
 ) -> Result<RunningService<RoleClient, BitrouterMcpClient>> {
+    let lifecycle = lifecycle_for(&client.protocol_version);
     match transport {
         McpTransport::Http { url, headers } => {
             // Streamable HTTP transport per the MCP spec
@@ -378,10 +410,11 @@ async fn connect(
                 )
                 .custom_headers(header_map);
             let transport = rmcp::transport::StreamableHttpClientTransport::from_config(cfg);
-            client
-                .serve(transport)
-                .await
-                .map_err(|e| map_initialize_error(server_name, e))
+            match lifecycle {
+                Some(lifecycle) => client.serve_with_lifecycle(transport, lifecycle).await,
+                None => client.serve(transport).await,
+            }
+            .map_err(|e| map_initialize_error(server_name, e))
         }
         McpTransport::Stdio { command, args, env } => {
             // stdio child-process transport per the MCP spec
@@ -393,10 +426,11 @@ async fn connect(
             }
             let transport = rmcp::transport::TokioChildProcess::new(cmd)
                 .map_err(|e| upstream(server_name, format!("spawning '{command}': {e}")))?;
-            client
-                .serve(transport)
-                .await
-                .map_err(|e| map_initialize_error(server_name, e))
+            match lifecycle {
+                Some(lifecycle) => client.serve_with_lifecycle(transport, lifecycle).await,
+                None => client.serve(transport).await,
+            }
+            .map_err(|e| map_initialize_error(server_name, e))
         }
     }
 }
@@ -667,14 +701,46 @@ async fn dispatch(
     request: &McpRequest,
 ) -> Result<serde_json::Value> {
     let method = request.method.as_str();
-    match method {
-        "tools/list" => {
-            let tools = peer
-                .list_all_tools()
+
+    /// Aggregate every page of a paginated list method while **preserving the
+    /// rest of the result envelope**.
+    ///
+    /// rmcp's `list_all_*` helpers return only the item `Vec`, which meant we
+    /// used to rebuild the response as a bare `{"tools": [...]}` — silently
+    /// dropping the SEP-2549 `ttlMs` / `cacheScope` hints that `2026-07-28`
+    /// *requires* on exactly these methods, along with `resultType` and
+    /// `_meta`. `CachingExecutor` reads those hints, so the gateway was
+    /// discarding the upstream's cache policy before anything could honour it.
+    ///
+    /// Hints are taken from the first page and applied to the aggregate: the
+    /// pages compose into one logical result, so the freshness the server
+    /// stated for it governs the whole thing. `next_cursor` is cleared because
+    /// the aggregate has no further pages.
+    macro_rules! list_all_preserving {
+        ($call:ident, $items:ident) => {{
+            let mut result = peer
+                .$call(None)
                 .await
                 .map_err(|e| map_service_error(server, method, e))?;
-            Ok(serde_json::json!({ "tools": tools }))
-        }
+            let mut cursor = result.next_cursor.take();
+            while let Some(next) = cursor {
+                let mut page = peer
+                    .$call(Some(
+                        rmcp::model::PaginatedRequestParams::default().with_cursor(Some(next)),
+                    ))
+                    .await
+                    .map_err(|e| map_service_error(server, method, e))?;
+                result.$items.append(&mut page.$items);
+                cursor = page.next_cursor;
+            }
+            serde_json::to_value(&result).map_err(|e| {
+                BitrouterError::internal(format!("mcp '{server}' {method} serialise: {e}"))
+            })
+        }};
+    }
+
+    match method {
+        "tools/list" => list_all_preserving!(list_tools, tools),
         "tools/call" => {
             let params: CallToolRequestParams = serde_json::from_value(request.params.clone())
                 .map_err(|e| bad_params(server, method, e))?;
@@ -689,13 +755,7 @@ async fn dispatch(
                 .map_err(|e| map_service_error(server, method, e))?;
             map_call_tool_result(server, result)
         }
-        "resources/list" => {
-            let resources = peer
-                .list_all_resources()
-                .await
-                .map_err(|e| map_service_error(server, method, e))?;
-            Ok(serde_json::json!({ "resources": resources }))
-        }
+        "resources/list" => list_all_preserving!(list_resources, resources),
         "resources/read" => {
             let params: ReadResourceRequestParams = serde_json::from_value(request.params.clone())
                 .map_err(|e| bad_params(server, method, e))?;
@@ -708,19 +768,9 @@ async fn dispatch(
             })
         }
         "resources/templates/list" => {
-            let templates = peer
-                .list_all_resource_templates()
-                .await
-                .map_err(|e| map_service_error(server, method, e))?;
-            Ok(serde_json::json!({ "resourceTemplates": templates }))
+            list_all_preserving!(list_resource_templates, resource_templates)
         }
-        "prompts/list" => {
-            let prompts = peer
-                .list_all_prompts()
-                .await
-                .map_err(|e| map_service_error(server, method, e))?;
-            Ok(serde_json::json!({ "prompts": prompts }))
-        }
+        "prompts/list" => list_all_preserving!(list_prompts, prompts),
         "prompts/get" => {
             let params: GetPromptRequestParams = serde_json::from_value(request.params.clone())
                 .map_err(|e| bad_params(server, method, e))?;

--- a/crates/bitrouter-sdk/src/mcp/rmcp_executor.rs
+++ b/crates/bitrouter-sdk/src/mcp/rmcp_executor.rs
@@ -260,7 +260,7 @@ impl RmcpExecutor {
     /// raising it cannot strand a working upstream. What it *does* change is
     /// which response shapes an upstream is permitted to send — at
     /// `2026-07-28` a `tools/call` may come back as MRTR `input_required` or a
-    /// Tasks handle, which [`map_call_tool_result`] turns into explicit errors.
+    /// Tasks handle, which `map_call_tool_result` turns into explicit errors.
     ///
     /// Applies to connections opened after this call; pooled ones keep the
     /// version they negotiated.

--- a/dist/schema/bitrouter.config.schema.json
+++ b/dist/schema/bitrouter.config.schema.json
@@ -888,7 +888,7 @@
           "$ref": "#/$defs/McpCacheConfig"
         },
         "upstream_protocol": {
-          "description": "MCP protocol version to request when dialing upstream servers.",
+          "description": "MCP startup lifecycle and protocol version for upstream servers.",
           "$ref": "#/$defs/McpUpstreamProtocol"
         }
       }
@@ -956,15 +956,15 @@
       }
     },
     "McpUpstreamProtocol": {
-      "description": "`mcp.upstream_protocol` — the protocol version the gateway asks for in its\nupstream `initialize` handshake.\n\nA server that does not know the requested version answers with one it does\nsupport, and the connection proceeds on that; nothing here can strand a\nworking upstream. The setting only raises the *ceiling* of what may be\nnegotiated.",
+      "description": "`mcp.upstream_protocol` — the startup lifecycle and protocol version the\ngateway uses when dialing upstream MCP servers.\n\n`latest` keeps the legacy `initialize` path. `2026-07-28` starts with\n`server/discover` and falls back to `initialize` only when discovery returns\nJSON-RPC `METHOD_NOT_FOUND`. Any other discovery error fails the connection,\nso opt in only for upstreams expected to support the modern lifecycle.",
       "oneOf": [
         {
-          "description": "The latest version the MCP SDK treats as current — today `2025-11-25`.\nThe default, and what every release before the rmcp 3.0 upgrade used.",
+          "description": "Use the legacy `initialize` lifecycle with the latest version the MCP\nSDK treats as current — today `2025-11-25`. This is the default.",
           "type": "string",
           "const": "latest"
         },
         {
-          "description": "`2026-07-28`. Opting in lets upstreams answer `tools/call` with MRTR\n`input_required` or a Tasks `task` handle. Neither is a shape this\ngateway can carry — see `docs/MCP_2026_07_28_SPEC.md` (D1) — so both\nsurface as explicit errors rather than silent failures.",
+          "description": "Use `server/discover` and the modern `2026-07-28` lifecycle, falling\nback to legacy `initialize` only on `METHOD_NOT_FOUND`. Other discovery\nerrors fail the connection. Opting in also lets upstreams answer\n`tools/call` with MRTR `input_required` or a Tasks `task` handle;\nneither is a shape this gateway can carry, so both surface as explicit\nerrors (see `docs/MCP_2026_07_28_SPEC.md` D1).",
           "type": "string",
           "const": "2026-07-28"
         }

--- a/dist/schema/bitrouter.config.schema.json
+++ b/dist/schema/bitrouter.config.schema.json
@@ -886,6 +886,10 @@
         "cache": {
           "description": "List-call cache settings.",
           "$ref": "#/$defs/McpCacheConfig"
+        },
+        "upstream_protocol": {
+          "description": "MCP protocol version to request when dialing upstream servers.",
+          "$ref": "#/$defs/McpUpstreamProtocol"
         }
       }
     },
@@ -950,6 +954,21 @@
           "default": 64
         }
       }
+    },
+    "McpUpstreamProtocol": {
+      "description": "`mcp.upstream_protocol` — the protocol version the gateway asks for in its\nupstream `initialize` handshake.\n\nA server that does not know the requested version answers with one it does\nsupport, and the connection proceeds on that; nothing here can strand a\nworking upstream. The setting only raises the *ceiling* of what may be\nnegotiated.",
+      "oneOf": [
+        {
+          "description": "The latest version the MCP SDK treats as current — today `2025-11-25`.\nThe default, and what every release before the rmcp 3.0 upgrade used.",
+          "type": "string",
+          "const": "latest"
+        },
+        {
+          "description": "`2026-07-28`. Opting in lets upstreams answer `tools/call` with MRTR\n`input_required` or a Tasks `task` handle. Neither is a shape this\ngateway can carry — see `docs/MCP_2026_07_28_SPEC.md` (D1) — so both\nsurface as explicit errors rather than silent failures.",
+          "type": "string",
+          "const": "2026-07-28"
+        }
+      ]
     },
     "McpServerConfig": {
       "description": "One configured upstream MCP server, as written in `bitrouter.yaml`.\n\nThe same `name` becomes the URL segment in `POST /mcp/{name}` and the\nidentifier the [`super::RoutingTable`] resolves against. Restrictions\nchosen to match the v0 config schema for paste-compatibility:\n\n- non-empty\n- no `/` (collides with the URL path segment)\n- not literally `sse` (reserved by the spec's deprecated transport name)",

--- a/docs/MCP_2026_07_28_SPEC.md
+++ b/docs/MCP_2026_07_28_SPEC.md
@@ -8,9 +8,10 @@ Migrating BitRouter from `rmcp` 2.2.0 to the 3.x line so both of our MCP roles
 **Branch:** `claude/bitrouter-mcp-rust-sdk-36c540`.
 **Merge gate:** hold until `rmcp` 3.0 is stable (see [Merge gate](#merge-gate)).
 
-**Status:** phases 0, 1, 2, and 4 are implemented; phase 3 (the client-side
-opt-in) is deliberately deferred per [D3](#d3--client-opt-in-timing). All four
-open decisions are resolved — see [Open decisions](#open-decisions).
+**Status:** all five phases implemented. Phase 3 landed as a config-gated
+switch that is **off by default**, which is what [D3](#d3--client-opt-in-timing)
+asked for — the mechanism exists, the behavior change does not happen until
+someone opts in. All four open decisions are resolved.
 
 ## Contents
 
@@ -181,11 +182,31 @@ Only meaningful for the **client** half (the server already negotiates; see
 
 `ProtocolVersion::default()` is `LATEST` = `2025-11-25`, so a plain 3.0 bump
 leaves our upstream connections on the old version and Phase 2's failure modes
-stay dormant. To opt in, either set `protocol_version` on our `ClientInfo`, or
-adopt `ClientLifecycleMode::Auto { preferred_versions, legacy_version }`
-(`service/client.rs:546`), which probes `server/discover` and falls back only
-when the peer proves it is legacy. `Auto` is the better fit for a gateway
-dialing heterogeneous upstreams.
+stay dormant.
+
+**As built:** a new `mcp.upstream_protocol` config key (`latest` — the default —
+or `"2026-07-28"`) selects the version `RmcpExecutor` requests in its upstream
+`initialize` handshake, via `RmcpExecutor::with_protocol_version`.
+
+> **Correction to this plan as first written.** An earlier draft preferred
+> `ClientLifecycleMode::Auto { preferred_versions, legacy_version }` as "the
+> better fit for a gateway dialing heterogeneous upstreams". Reading
+> `legacy_startup` changed that: it accepts whatever version the server returns
+> and simply records it as peer info, with no client-side validation. So the
+> plain `ClientInfo` route already downgrades gracefully against any upstream,
+> and it is a *ceiling*, not a demand.
+>
+> `Auto` would add a `server/discover` probe that falls back only on
+> `METHOD_NOT_FOUND` — an upstream that rejects the unknown method with any
+> other error would break a connection that works today. For a gateway pointed
+> at arbitrary servers, that is a real regression risk in exchange for
+> discovery we have no use for yet. `Auto` stays available if server discovery
+> ever earns its keep.
+
+The setting deliberately raises only the ceiling, so flipping it cannot strand a
+working upstream — the worst case is that a draft-speaking server starts
+returning shapes Phase 2 turns into explicit errors, which is the informed
+trade the key exists to make.
 
 Also lands at this point, automatically via rmcp:
 
@@ -285,16 +306,16 @@ decision is applied once per connection at a single site.
 
 ### D3 — Client opt-in timing
 
-**Decided: defer the opt-in.** Opting in has no upside until an upstream
-supports it, and it activates every Phase 2 failure mode. Phases 0–2 landed;
-the switch did not.
+**Decided: ship the switch, leave it off.** Opting in has no upside until an
+upstream supports it, and it activates every Phase 2 failure mode — so the
+default must not change. But the mechanism is small and isolated, so there is
+no reason to withhold it.
 
-Concretely, this branch leaves upstream connections on `ProtocolVersion::LATEST`
-(`2025-11-25`) — rmcp's default and still the default in 3.0. Phase 2's handling
-is therefore *dormant but correct*: the shapes it maps cannot arrive until
-someone sets a preferred version or moves to
-`ClientLifecycleMode::Auto`. That is the whole of the remaining work for
-Phase 3, and it is now a small, isolated change.
+Built as `mcp.upstream_protocol`, defaulting to `latest`. Upstream connections
+therefore still negotiate `2025-11-25` on a stock config, and Phase 2's handling
+stays *dormant but correct*: the shapes it maps cannot arrive until someone
+flips the key. Two tests pin the default so a future refactor cannot opt
+everyone in by accident.
 
 ### D4 — Escalation capability granularity
 
@@ -313,13 +334,13 @@ pinned by test.
 
 ## Acceptance
 
-All met as of the phase 0/1/2/4 landing.
+All met.
 
-1. `cargo nextest run --workspace --all-features` — **2112 passed, 11 skipped**
+1. `cargo nextest run --workspace --all-features` — **2116 passed, 11 skipped**
    (up from 2104; no regressions).
 2. `cargo clippy --all-features --all-targets` clean; `cargo fmt -- --check`
    clean. No `#[allow]` added.
-3. New coverage — 10 tests:
+3. New coverage — 14 tests:
    - `extract_cache_hint` reads top-level `ttlMs`, falls back to `_meta.ttlMs`,
      prefers top level when both are present, clamps negatives to `0`, and
      declines `cacheScope: private`.
@@ -334,12 +355,20 @@ All met as of the phase 0/1/2/4 landing.
      the now-inert legacy `capabilities.tasks` field.
    - `tools/list` cache hints, end to end over a real stdio handshake, present
      for a `2026-07-28` peer and absent for a `2025-11-25` one.
-4. `cargo run -p dist-helper -- check` clean (no registry drift).
-5. No change to `skills/bitrouter/` or the plugin manifests — verified by
-   search: nothing under `skills/`, `.claude-plugin/`, `.codex-plugin/`, or
-   `.agents/` references the protocol version or any CLI surface touched here.
-   **If Phase 3 later adds a config key for the opt-in, that lockstep
-   obligation returns** per `CLAUDE.md`.
+   - The upstream handshake requests `LATEST` by default and the configured
+     version after `with_protocol_version`.
+   - `mcp.upstream_protocol` defaults to `latest` whether `mcp:` is absent or
+     present-but-silent, parses `"2026-07-28"`, and *rejects* an unknown
+     version rather than silently falling back to the default.
+4. `cargo run -p dist-helper -- check` clean (registry and schema). The new
+   config key changed the generated
+   `dist/schema/bitrouter.config.schema.json`, regenerated and committed.
+5. No change to `skills/bitrouter/` or the plugin manifests. Re-verified after
+   Phase 3 added a config key: the skill's contract is CLI flags, ports, env
+   vars, and harness wiring, none of which moved — `mcp.upstream_protocol` is
+   gateway YAML, a surface the skill does not document (neither `mcp.cache` nor
+   `mcp.aggregate` appears there either). The plugin manifests invoke
+   `bitrouter mcp serve`, unchanged.
 
 ## Merge gate
 
@@ -354,3 +383,17 @@ Hold the branch until `rmcp` 3.0 is stable, then before merging:
    (`map_call_tool_result`): both parse by wire shape, so a move there fails at
    runtime, not at compile time.
 3. Re-run acceptance.
+
+Leave `mcp.upstream_protocol` defaulting to `latest` at merge. Changing the
+default is a separate decision that should follow evidence — an upstream we
+actually talk to supporting `2026-07-28`, and a call on [D1](#d1--task-policy)
+(today a task-returning upstream becomes an error, which is the right failure
+but a poor default to hand everyone unannounced).
+
+One subtlety in that default: `latest` resolves to rmcp's
+`ProtocolVersion::LATEST`, so it starts meaning `2026-07-28` by itself once the
+SDK promotes it — and the test pinning the default asserts against `LATEST`, so
+it would not catch the change either. What keeps this from being a silent
+opt-in is the exact version pin: the promotion can only reach us through a
+deliberate rmcp bump, which this gate already requires reading the changelog
+for. Treat a `LATEST` move as a decision point, not a routine bump.

--- a/docs/MCP_2026_07_28_SPEC.md
+++ b/docs/MCP_2026_07_28_SPEC.md
@@ -310,8 +310,9 @@ rmcp's `list_all_*` helpers return only the item `Vec`, and `dispatch` rebuilt
 the response as a bare `{"tools": [...]}` — dropping `ttlMs`, `cacheScope`,
 `resultType`, and `_meta`. SEP-2549 *requires* those hints on exactly these
 methods, and `CachingExecutor` reads them, so the [Phase 1.1](#11-the-cache-hint-moved-and-we-read-the-old-location)
-fix could never have observed one. Now paginates while preserving the envelope,
-taking hints from the first page.
+fix could never have observed one. Now paginates while preserving the envelope
+and conservatively merges hints from every page: the shortest TTL wins,
+`private` dominates, and unknown future non-public scopes remain restrictive.
 
 This one is the argument for the round-trip test: three layers each looked
 correct in isolation, and the bug only appeared when a real client read a real

--- a/docs/MCP_2026_07_28_SPEC.md
+++ b/docs/MCP_2026_07_28_SPEC.md
@@ -191,29 +191,17 @@ Only meaningful for the **client** half (the server already negotiates; see
 leaves our upstream connections on the old version and Phase 2's failure modes
 stay dormant.
 
-**As built:** a new `mcp.upstream_protocol` config key (`latest` — the default —
-or `"2026-07-28"`) selects the version `RmcpExecutor` requests in its upstream
-`initialize` handshake, via `RmcpExecutor::with_protocol_version`.
+**As built:** `mcp.upstream_protocol` selects both version and lifecycle.
+`latest` (the default) keeps the legacy `initialize` path.
+`"2026-07-28"` uses `ClientLifecycleMode::Auto`: it opens with
+`server/discover`, sends self-contained metadata on later requests, and falls
+back to legacy `initialize` only when discovery returns `METHOD_NOT_FOUND`.
 
-> **Correction to this plan as first written.** An earlier draft preferred
-> `ClientLifecycleMode::Auto { preferred_versions, legacy_version }` as "the
-> better fit for a gateway dialing heterogeneous upstreams". Reading
-> `legacy_startup` changed that: it accepts whatever version the server returns
-> and simply records it as peer info, with no client-side validation. So the
-> plain `ClientInfo` route already downgrades gracefully against any upstream,
-> and it is a *ceiling*, not a demand.
->
-> `Auto` would add a `server/discover` probe that falls back only on
-> `METHOD_NOT_FOUND` — an upstream that rejects the unknown method with any
-> other error would break a connection that works today. For a gateway pointed
-> at arbitrary servers, that is a real regression risk in exchange for
-> discovery we have no use for yet. `Auto` stays available if server discovery
-> ever earns its keep.
-
-The setting deliberately raises only the ceiling, so flipping it cannot strand a
-working upstream — the worst case is that a draft-speaking server starts
-returning shapes Phase 2 turns into explicit errors, which is the informed
-trade the key exists to make.
+That fallback is intentionally narrow. An upstream that rejects discovery with
+any other error can fail to connect even if its legacy `initialize` path would
+work. The modern protocol removed `initialize`, so there is no correct modern
+alternative; keeping `latest` as the default contains that compatibility risk
+to explicit opt-ins.
 
 Also lands at this point, automatically via rmcp:
 
@@ -293,15 +281,14 @@ conformant client produces. Testing the real wire shapes found three bugs.
 
 ### 1. The stdio server rejected every conformant client
 
-`serve_stdio` used rmcp's `serve`, which waits for `initialize` and hard-errors
-otherwise. A real `2026-07-28` client opens with `server/discover`, so it got
-`expect initialized request` and the connection died. Switched to
-`serve_directly`, which skips the handshake; `initialize` is still dispatched as
-an ordinary request, so both lifecycles are served from one entry point.
-
-Consequence worth knowing: requests are no longer queued behind a handshake, so
-a client that pipelines without awaiting `initialize` may see responses out of
-order. Real clients await it — the tests now model that.
+The initial workaround used `serve_directly`, which accepted modern requests
+but bypassed rmcp's startup state. That left two connection-level bugs: legacy
+fallback responses did not update peer state to the negotiated version, and a
+modern opener did not require metadata on later requests. rmcp 3.1's stable
+server startup now accepts either a legacy `initialize` or a complete modern
+first request and records the corresponding state, so `serve_stdio` uses that
+entrypoint. A narrow preflight preserves the JSON-RPC `-32602` response for a
+malformed modern opener that rmcp otherwise rejects before dispatch.
 
 ### 2. The client opt-in spoke a version it could not speak
 
@@ -437,7 +424,7 @@ All met.
    clean; `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features
    --no-deps` clean (CI's `doc` job — worth running locally, it is the one gate
    that tests/clippy/fmt do not imply). No `#[allow]` added.
-3. New coverage — 20 tests:
+3. New coverage — 25 tests:
    - Both MCP lifecycles over real stdio: legacy `initialize` at `2025-11-25`
      and `2026-07-28`, plus `server/discover` and a handshake-free `tools/list`
      carrying `_meta`. A half-populated `_meta` is rejected `-32602`.
@@ -460,8 +447,8 @@ All met.
      the now-inert legacy `capabilities.tasks` field.
    - `tools/list` cache hints, end to end over a real stdio handshake, present
      for a `2026-07-28` peer and absent for a `2025-11-25` one.
-   - The upstream handshake requests `LATEST` by default and the configured
-     version after `with_protocol_version`.
+   - Upstream startup uses legacy `initialize` with `LATEST` by default, and
+     switches to `server/discover` for a configured `2026-07-28` version.
    - `mcp.upstream_protocol` defaults to `latest` whether `mcp:` is absent or
      present-but-silent, parses `"2026-07-28"`, and *rejects* an unknown
      version rather than silently falling back to the default.
@@ -487,7 +474,7 @@ gate: the stable SDK and its acceptance evidence were required.
 2. The beta.4-to-3.1 release notes were reviewed, including MRTR metadata
    decoding, protocol metadata validation, and version negotiation changes.
 3. Full acceptance passed on the stable dependency: `cargo nextest run
-   --all-features` → **2104 passed, 11 skipped**.
+   --all-features` → **2109 passed, 11 skipped**.
 
 Leave `mcp.upstream_protocol` defaulting to `latest` at merge. Changing the
 default is a separate decision that should follow evidence — an upstream we

--- a/docs/MCP_2026_07_28_SPEC.md
+++ b/docs/MCP_2026_07_28_SPEC.md
@@ -427,8 +427,11 @@ pinned by test.
 
 All met.
 
-1. `cargo nextest run --workspace --all-features` — **2122 passed, 11 skipped**
-   (up from 2104; no regressions).
+1. `cargo nextest run --workspace --all-features` — **2103 passed, 11 skipped**,
+   no regressions. (The absolute number moved down when this branch was rebased
+   onto the substrate refactor in #751, which deleted a batch of tests along
+   with the machinery they covered; the 20 tests below are what this branch
+   adds.)
 2. `cargo clippy --all-features --all-targets` clean; `cargo fmt -- --check`
    clean; `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features
    --no-deps` clean (CI's `doc` job — worth running locally, it is the one gate

--- a/docs/MCP_2026_07_28_SPEC.md
+++ b/docs/MCP_2026_07_28_SPEC.md
@@ -8,10 +8,15 @@ Migrating BitRouter from `rmcp` 2.2.0 to the 3.x line so both of our MCP roles
 **Branch:** `claude/bitrouter-mcp-rust-sdk-36c540`.
 **Merge gate:** hold until `rmcp` 3.0 is stable (see [Merge gate](#merge-gate)).
 
-**Status:** all five phases implemented. Phase 3 landed as a config-gated
-switch that is **off by default**, which is what [D3](#d3--client-opt-in-timing)
-asked for — the mechanism exists, the behavior change does not happen until
-someone opts in. All four open decisions are resolved.
+**Status:** all five phases implemented and validated against the **released**
+`2026-07-28` specification (it shipped 2026-07-28; this work began against the
+draft). Phase 3 landed as a config-gated switch that is **off by default**,
+which is what [D3](#d3--client-opt-in-timing) asked for. All four open decisions
+are resolved.
+
+See [Validation against the released spec](#validation-against-the-released-spec)
+for what changed between draft and release — it was more than a version-string
+bump, and it found three real bugs.
 
 ## Contents
 
@@ -22,6 +27,7 @@ someone opts in. All four open decisions are resolved.
 - [Phase 2 — client survives the new response shapes](#phase-2--client-survives-the-new-response-shapes)
 - [Phase 3 — deliberate opt-in](#phase-3--deliberate-opt-in)
 - [Phase 4 — server conformance](#phase-4--server-conformance)
+- [Validation against the released spec](#validation-against-the-released-spec)
 - [Open decisions](#open-decisions)
 - [Acceptance](#acceptance)
 - [Merge gate](#merge-gate)
@@ -270,6 +276,91 @@ stdio sessions stay long-lived. That existing decision is now load-bearing in a
 new way: **adding stateful tools to the HTTP profile would break under
 draft-version clients.** The comment at `server.rs:835` should say so.
 
+## Validation against the released spec
+
+`2026-07-28` was ratified on 2026-07-28, after phases 0–4 were written against
+the draft. Re-validating against the release found that the headline change is
+not any single SEP but the **lifecycle**: `initialize` /
+`notifications/initialized` are *gone* (SEP-2575), protocol-level sessions and
+`Mcp-Session-Id` are *gone* (SEP-2567), and `server/discover` is MUST-implement.
+Every request is self-contained, carrying its protocol version, client identity,
+and capabilities in `_meta`.
+
+That reframed the work: the draft-era tests exercised rmcp's *legacy bridge*
+(an `initialize` declaring version `2026-07-28`), which is not a shape any
+conformant client produces. Testing the real wire shapes found three bugs.
+
+### 1. The stdio server rejected every conformant client
+
+`serve_stdio` used rmcp's `serve`, which waits for `initialize` and hard-errors
+otherwise. A real `2026-07-28` client opens with `server/discover`, so it got
+`expect initialized request` and the connection died. Switched to
+`serve_directly`, which skips the handshake; `initialize` is still dispatched as
+an ordinary request, so both lifecycles are served from one entry point.
+
+Consequence worth knowing: requests are no longer queued behind a handshake, so
+a client that pipelines without awaiting `initialize` may see responses out of
+order. Real clients await it — the tests now model that.
+
+### 2. The client opt-in spoke a version it could not speak
+
+Phase 3 set `ClientInfo.protocol_version` and left rmcp's `serve` in place — so
+opting into `2026-07-28` sent an `initialize` *declaring* `2026-07-28`, using a
+method that version deletes. Against rmcp's bridge it worked; against a
+conformant non-rmcp server it would fail outright.
+
+**This reverses the reversal recorded in [Phase 3](#phase-3--deliberate-opt-in).**
+The opt-in now switches lifecycle, using `ClientLifecycleMode::Auto` —
+`server/discover` with an `initialize` fallback on `METHOD_NOT_FOUND`. The
+earlier objection to `Auto` (a server that rejects unknown methods with some
+other code gets no fallback) still stands, but on the `2026-07-28` path there is
+no correct alternative, and the default path never reaches that branch.
+
+### 3. The gateway discarded upstream cache hints
+
+rmcp's `list_all_*` helpers return only the item `Vec`, and `dispatch` rebuilt
+the response as a bare `{"tools": [...]}` — dropping `ttlMs`, `cacheScope`,
+`resultType`, and `_meta`. SEP-2549 *requires* those hints on exactly these
+methods, and `CachingExecutor` reads them, so the [Phase 1.1](#11-the-cache-hint-moved-and-we-read-the-old-location)
+fix could never have observed one. Now paginates while preserving the envelope,
+taking hints from the first page.
+
+This one is the argument for the round-trip test: three layers each looked
+correct in isolation, and the bug only appeared when a real client read a real
+server's response.
+
+### Also checked, no action needed
+
+- **Deterministic `tools/list` order** (SEP-2575 SHOULD) — rmcp's
+  `ToolRouter::list_all` sorts by name. Pinned by assertion.
+- **`resources/read`** already serialized the whole result, so it never had bug 3.
+- **Error-code renumbering** (`-32001`→`-32020` etc.) is internal to rmcp.
+- **`subscriptions/listen`** replaces `resources/subscribe`; we use neither.
+- **Server identity** — fixed, see below.
+
+### Server identity was reporting as "rmcp"
+
+`InitializeResult::new` defaults to `Implementation::from_build_env()`, which
+resolves against *rmcp's* build environment. Every client asking who we are —
+via `server/discover`, `initialize`, or the SEP-2575 `serverInfo` result
+metadata — was told "rmcp" / "3.0.0-beta.4". The client half of the gateway had
+always identified itself; the server half now does too.
+
+### Escalation is legacy-lifecycle only, by construction
+
+`2026-07-28` removed server-initiated requests in favour of MRTR, so there is no
+channel on which to issue `elicitation/create` to a modern client. The seam
+detects capability from `initialize` handshake info, which a stateless client
+never produces, so it stays inert and every gated permission takes the
+HumanBridge / deny fallback.
+
+That is correct, not a gap. Widening the capability read to
+`ctx.client_capabilities()` (which *would* see a modern client's `_meta`) would
+route permissions into a round-trip that cannot be answered, and the fail-safe
+would turn those into `Deny` — strictly worse than the HumanBridge prompt.
+Carrying escalation onto the modern lifecycle means returning an MRTR
+`InputRequiredResult` from the fleet tools, which is a separate design.
+
 ## Open decisions
 
 **All four resolved — each took the recommended option.** Kept here with their
@@ -336,11 +427,21 @@ pinned by test.
 
 All met.
 
-1. `cargo nextest run --workspace --all-features` — **2116 passed, 11 skipped**
+1. `cargo nextest run --workspace --all-features` — **2122 passed, 11 skipped**
    (up from 2104; no regressions).
 2. `cargo clippy --all-features --all-targets` clean; `cargo fmt -- --check`
-   clean. No `#[allow]` added.
-3. New coverage — 14 tests:
+   clean; `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features
+   --no-deps` clean (CI's `doc` job — worth running locally, it is the one gate
+   that tests/clippy/fmt do not imply). No `#[allow]` added.
+3. New coverage — 20 tests:
+   - Both MCP lifecycles over real stdio: legacy `initialize` at `2025-11-25`
+     and `2026-07-28`, plus `server/discover` and a handshake-free `tools/list`
+     carrying `_meta`. A half-populated `_meta` is rejected `-32602`.
+   - `server/discover` advertises `2026-07-28` and identifies as `bitrouter`.
+   - Per-caller bearer forwarding over the **stateless** HTTP path — the
+     multi-tenancy claim re-proved now that sessions are gone.
+   - The gateway's own client reaching our origin server on both lifecycles,
+     with SEP-2549 hints surviving the round trip.
    - `extract_cache_hint` reads top-level `ttlMs`, falls back to `_meta.ttlMs`,
      prefers top level when both are present, clamps negatives to `0`, and
      declines `cacheScope: private`.
@@ -372,9 +473,14 @@ All met.
 
 ## Merge gate
 
+**The gate is not met yet.** The `2026-07-28` *specification* is released, but
+`rmcp`'s latest stable is still **2.2.0** — the 3.0 line is on `3.0.0-beta.4`.
+A released spec does not imply a released SDK, and only the SDK version gates
+this branch.
+
 Hold the branch until `rmcp` 3.0 is stable, then before merging:
 
-1. Move `=3.0.0-beta.2` → `3.0` (caret) in `Cargo.toml`, and drop the pin
+1. Move `=3.0.0-beta.4` → `3.0` (caret) in `Cargo.toml`, and drop the pin
    rationale comment above it.
 2. Re-read the changelog for breaking changes between beta.2 and stable —
    `resultType`, cache hints, and the Tasks capability shape have all moved

--- a/docs/MCP_2026_07_28_SPEC.md
+++ b/docs/MCP_2026_07_28_SPEC.md
@@ -6,11 +6,12 @@ Migrating BitRouter from `rmcp` 2.2.0 to the 3.x line so both of our MCP roles
 `2026-07-28`.
 
 **Branch:** `claude/bitrouter-mcp-rust-sdk-36c540`.
-**Merge gate:** hold until `rmcp` 3.0 is stable (see [Merge gate](#merge-gate)).
+**Merge gate:** met on stable `rmcp` 3.1.0 (see [Merge gate](#merge-gate)).
 
 **Status:** all five phases implemented and validated against the **released**
 `2026-07-28` specification (it shipped 2026-07-28; this work began against the
-draft). Phase 3 landed as a config-gated switch that is **off by default**,
+draft). The SDK merge gate is met on stable `rmcp` 3.1.0. Phase 3 landed as a
+config-gated switch that is **off by default**,
 which is what [D3](#d3--client-opt-in-timing) asked for. All four open decisions
 are resolved.
 
@@ -34,14 +35,14 @@ bump, and it found three real bugs.
 
 ## Verified starting state
 
-Everything below was measured against `rmcp` 3.0.0-beta.2 in this worktree, not
-inferred from release notes.
+This historical starting state was measured against `rmcp` 3.0.0-beta.2 in this
+worktree, not inferred from release notes.
 
 | Fact | Evidence |
 |---|---|
-| We are on `rmcp` 2.2.0 | `Cargo.toml:90` |
-| Latest published is 3.0.0-beta.2 (2026-07-24) | crates.io |
-| `2026-07-28` is implemented **only** in 3.0.0-beta.x | `CHANGELOG.md` "update for 2026-07-28 version" (#1032), 3.0.0-beta.1 |
+| `rmcp` in use at the starting point is 2.2.0 | `Cargo.toml:90` |
+| Latest published then is 3.0.0-beta.2 (2026-07-24) | crates.io |
+| `2026-07-28` is implemented **only then** in 3.0.0-beta.x | `CHANGELOG.md` "update for 2026-07-28 version" (#1032), 3.0.0-beta.1 |
 | The mechanical port is **2 edits**, workspace-wide | trial bump: 1 compile error + 1 test assertion |
 | Full suite passes on 3.0.0-beta.2 | `cargo nextest run --workspace --all-features` → **2104 passed, 11 skipped** |
 | `ProtocolVersion::LATEST` is still `2025-11-25` in 3.0 | `model.rs:175` |
@@ -476,22 +477,17 @@ All met.
 
 ## Merge gate
 
-**The gate is not met yet.** The `2026-07-28` *specification* is released, but
-`rmcp`'s latest stable is still **2.2.0** — the 3.0 line is on `3.0.0-beta.4`.
-A released spec does not imply a released SDK, and only the SDK version gates
-this branch.
+**The gate is met.** Stable `rmcp` 3.0.0 shipped on 2026-07-28, followed by
+3.0.1 on 2026-07-29; the reviewed lockfile resolves 3.1.0, released on
+2026-07-31. A released specification alone was not sufficient to close this
+gate: the stable SDK and its acceptance evidence were required.
 
-Hold the branch until `rmcp` 3.0 is stable, then before merging:
-
-1. Move `=3.0.0-beta.4` → `3.0` (caret) in `Cargo.toml`, and drop the pin
-   rationale comment above it.
-2. Re-read the changelog for breaking changes between beta.2 and stable —
-   `resultType`, cache hints, and the Tasks capability shape have all moved
-   once already. Pay particular attention to anything touching the SEP-2549
-   field placement (`extract_cache_hint`) or the `ServerResult` union ordering
-   (`map_call_tool_result`): both parse by wire shape, so a move there fails at
-   runtime, not at compile time.
-3. Re-run acceptance.
+1. `Cargo.toml` now uses the stable `3.0` caret requirement and `Cargo.lock`
+   resolves 3.1.0.
+2. The beta.4-to-3.1 release notes were reviewed, including MRTR metadata
+   decoding, protocol metadata validation, and version negotiation changes.
+3. Full acceptance passed on the stable dependency: `cargo nextest run
+   --all-features` → **2104 passed, 11 skipped**.
 
 Leave `mcp.upstream_protocol` defaulting to `latest` at merge. Changing the
 default is a separate decision that should follow evidence — an upstream we
@@ -500,9 +496,7 @@ actually talk to supporting `2026-07-28`, and a call on [D1](#d1--task-policy)
 but a poor default to hand everyone unannounced).
 
 One subtlety in that default: `latest` resolves to rmcp's
-`ProtocolVersion::LATEST`, so it starts meaning `2026-07-28` by itself once the
-SDK promotes it — and the test pinning the default asserts against `LATEST`, so
-it would not catch the change either. What keeps this from being a silent
-opt-in is the exact version pin: the promotion can only reach us through a
-deliberate rmcp bump, which this gate already requires reading the changelog
-for. Treat a `LATEST` move as a decision point, not a routine bump.
+`ProtocolVersion::LATEST`, and the test pinning the default asserts against
+`LATEST` rather than a concrete protocol date. A future
+`ProtocolVersion::LATEST` change must therefore be treated as a deliberate
+decision point during an rmcp dependency update, not as a routine bump.

--- a/docs/MCP_2026_07_28_SPEC.md
+++ b/docs/MCP_2026_07_28_SPEC.md
@@ -1,0 +1,356 @@
+# MCP `2026-07-28` upgrade spec
+
+Migrating BitRouter from `rmcp` 2.2.0 to the 3.x line so both of our MCP roles
+— the **origin server** (`crates/bitrouter-mcp`) and the **gateway client**
+(`crates/bitrouter-sdk/src/mcp`) — are correct under MCP protocol version
+`2026-07-28`.
+
+**Branch:** `claude/bitrouter-mcp-rust-sdk-36c540`.
+**Merge gate:** hold until `rmcp` 3.0 is stable (see [Merge gate](#merge-gate)).
+
+**Status:** phases 0, 1, 2, and 4 are implemented; phase 3 (the client-side
+opt-in) is deliberately deferred per [D3](#d3--client-opt-in-timing). All four
+open decisions are resolved — see [Open decisions](#open-decisions).
+
+## Contents
+
+- [Verified starting state](#verified-starting-state)
+- [The central finding](#the-central-finding)
+- [Phase 0 — dependency bump](#phase-0--dependency-bump)
+- [Phase 1 — silent-semantics fixes](#phase-1--silent-semantics-fixes)
+- [Phase 2 — client survives the new response shapes](#phase-2--client-survives-the-new-response-shapes)
+- [Phase 3 — deliberate opt-in](#phase-3--deliberate-opt-in)
+- [Phase 4 — server conformance](#phase-4--server-conformance)
+- [Open decisions](#open-decisions)
+- [Acceptance](#acceptance)
+- [Merge gate](#merge-gate)
+
+## Verified starting state
+
+Everything below was measured against `rmcp` 3.0.0-beta.2 in this worktree, not
+inferred from release notes.
+
+| Fact | Evidence |
+|---|---|
+| We are on `rmcp` 2.2.0 | `Cargo.toml:90` |
+| Latest published is 3.0.0-beta.2 (2026-07-24) | crates.io |
+| `2026-07-28` is implemented **only** in 3.0.0-beta.x | `CHANGELOG.md` "update for 2026-07-28 version" (#1032), 3.0.0-beta.1 |
+| The mechanical port is **2 edits**, workspace-wide | trial bump: 1 compile error + 1 test assertion |
+| Full suite passes on 3.0.0-beta.2 | `cargo nextest run --workspace --all-features` → **2104 passed, 11 skipped** |
+| `ProtocolVersion::LATEST` is still `2025-11-25` in 3.0 | `model.rs:175` |
+
+The single compile error is `crates/bitrouter-mcp/src/capabilities/escalation.rs:40`.
+Everything else in the workspace builds untouched.
+
+## The central finding
+
+> Our server **already** negotiates `2026-07-28` today, and does so on a version
+> of `rmcp` that implements none of it.
+
+`negotiate_protocol_version` (`service/server.rs:478`) accepts any version in
+`ProtocolVersion::KNOWN_VERSIONS`, and `2026-07-28` has been in that list since
+2.2.0 — while `LATEST` stayed at `2025-11-25` and none of the draft SEPs were
+implemented. So a draft-era client that asks for `2026-07-28` gets an agreement
+our current build cannot honor.
+
+This inverts the usual framing of the upgrade:
+
+- **Server side is not an opt-in.** It is already happening. The bump is what
+  makes the agreement *truthful*; what we still control is conformance quality
+  (emitting cache hints), not acceptance.
+- **Client side is the opt-in**, and it is the risky half — because negotiating
+  `2026-07-28` upstream activates response shapes our executor currently treats
+  as hard errors (Phase 2).
+
+Phases 0–1 are therefore a correctness fix we want regardless. Phases 2–4 are
+the actual feature work.
+
+## Phase 0 — dependency bump
+
+Mechanical, already proven green.
+
+1. `Cargo.toml:90` — `rmcp = { version = "=3.0.0-beta.2", … }`.
+   **Exact-pinned on purpose**: beta.2 shipped a breaking change one day after
+   beta.1 (`omit resultType for legacy protocol sessions`, #1038). A caret range
+   would let a breaking beta.3 land silently in CI.
+2. `crates/bitrouter-mcp/src/capabilities/escalation.rs:36-42` — SEP-2663 moved
+   the Tasks capability off a dedicated `capabilities.tasks` field into the
+   SEP-1724 extensions map under `io.modelcontextprotocol/tasks`. Replace the
+   `tasks.requests.elicitation.create` probe with `caps.supports_tasks()`.
+3. Same file's test — assert the new wire shape
+   (`extensions: { "io.modelcontextprotocol/tasks": {} }`).
+
+Note the capability check gets **coarser**: `supports_tasks()` means "declares
+the extension", not "will answer an `elicitation/create`". See [D4](#d4--escalation-capability-granularity).
+
+No feature-name changes are needed — every feature we enable (`client`,
+`server`, `macros`, `transport-io`, `transport-child-process`,
+`transport-streamable-http-{client-reqwest,server}`, `reqwest`, `elicitation`)
+still exists in 3.0.
+
+## Phase 1 — silent-semantics fixes
+
+Behavior changes the compiler cannot catch. These are the reason this migration
+is not a one-line PR.
+
+### 1.1 The cache hint moved, and we read the old location
+
+`crates/bitrouter-sdk/src/mcp/caching_executor.rs:285` reads the SEP-2549 TTL
+hint from `_meta.ttlMs`. In the shipped SEP-2549 shape, `ttlMs` and `cacheScope`
+are **top-level fields on the result**, siblings of `_meta`
+(`model.rs:1505-1517`; `tests/test_cache_hints.rs:15` asserts `{"ttlMs": 5000}`
+at top level).
+
+Consequence: every upstream cache hint is ignored and we silently fall back to
+our configured default TTLs. Latent today (no `2025-11-25` server sends the
+field) and live the moment upstreams speak `2026-07-28`.
+
+- Read top-level `ttlMs`, keep `_meta.ttlMs` as a fallback for any server that
+  shipped the older draft shape.
+- Honor negative values as `0` per spec (rmcp's `deserialize_ttl_ms` does this;
+  our raw-JSON path must too).
+- Honor `cacheScope`: `private` responses must not be reused across callers.
+
+### 1.2 rmcp now has its own client cache, enabled by default
+
+3.0 allocates a `ClientCacheConfig` per client `Peer`, defaulting to
+`enabled: true` (`service/client/cache.rs:54`). Post-bump we would be running
+two cache layers, ours on top of rmcp's, with two defaults worth naming:
+
+- **`serve_stale_on_error: true`** — a failed re-fetch silently returns a stale
+  response instead of an error, underneath our executor, invisible to our tests.
+- **`private_partition: None`** — our pool is keyed by server name only
+  (`rmcp_executor.rs:209`), so one connection is shared by every downstream
+  caller. I checked `connect()` (`rmcp_executor.rs:301`): upstream credentials
+  come from static per-server config, so there is exactly one upstream principal
+  per connection and leaving this unset is correct **today**. It stops being
+  correct the moment we forward per-caller credentials upstream.
+
+Recommendation: call `peer.set_response_cache_config(ClientCacheConfig::disabled())`
+right after connect, in the pool-insert path. One cache — ours — with semantics
+we own and already test. Record the `private_partition` constraint as a comment
+next to the pool key so the next person to add credential forwarding trips over
+it. See [D2](#d2--whose-cache).
+
+## Phase 2 — client survives the new response shapes
+
+**As built.** Both paths now route through one `map_call_tool_result` helper
+(`rmcp_executor.rs`), and MRTR turned out to need no round-driving at all:
+
+> MRTR's `InputRequests` can only contain `sampling/createMessage`,
+> `elicitation/create`, or `roots/list` — which are exactly the three
+> server→client requests `BitrouterMcpClient` already rejects with `-32601`,
+> for the same architectural reason (the inbound client connected statelessly,
+> with no channel back).
+
+So driving the rounds would produce a rejection per input request and then fail
+anyway. Both non-final shapes therefore get the same treatment as Tasks: a
+typed, diagnosable error that explains *why*, matching the module's existing
+stance that an explicit rejection beats a silent default. `dispatch` moved off
+rmcp's high-level `call_tool` for the same reason — it would have driven those
+doomed rounds and reported a bare `UnexpectedResponse` for tasks.
+
+At `2026-07-28` a server may answer `tools/call` with something other than a
+`CallToolResult`: `InputRequired` (MRTR, SEP-2322) or `CreateTaskResult`
+(Tasks, SEP-2663). We have **two** tool-call paths and they fail differently:
+
+| Path | Location | Behavior at `2026-07-28` |
+|---|---|---|
+| Streaming | `rmcp_executor.rs:552` — matches `ServerResult::CallToolResult`, else `unexpected server result` | Hard error on **both** `InputRequired` and `Task` |
+| Non-streaming | `rmcp_executor.rs:593` — `peer.call_tool(params)` | Drives MRTR rounds transparently; `ServiceError::UnexpectedResponse` on `Task` (`service/client.rs:1815`) |
+
+Two problems: the streaming path errors on MRTR where the non-streaming path
+succeeds, so the same upstream call behaves differently depending on which
+BitRouter path invoked it; and neither handles Tasks.
+
+Work:
+
+1. Unify both paths on `call_tool_once` + an explicit `CallToolResponse` match,
+   so MRTR and Task handling live in one place.
+2. Drive MRTR rounds in the streaming path (bounded, mirroring rmcp's
+   `DEFAULT_MRTR_MAX_ROUNDS`) so both paths agree.
+3. Handle `CallToolResponse::Task` per [D1](#d1--task-policy).
+
+This phase is a prerequisite for Phase 3 — opting in without it converts
+working tool calls into errors.
+
+## Phase 3 — deliberate opt-in
+
+Only meaningful for the **client** half (the server already negotiates; see
+[The central finding](#the-central-finding)).
+
+`ProtocolVersion::default()` is `LATEST` = `2025-11-25`, so a plain 3.0 bump
+leaves our upstream connections on the old version and Phase 2's failure modes
+stay dormant. To opt in, either set `protocol_version` on our `ClientInfo`, or
+adopt `ClientLifecycleMode::Auto { preferred_versions, legacy_version }`
+(`service/client.rs:546`), which probes `server/discover` and falls back only
+when the peer proves it is legacy. `Auto` is the better fit for a gateway
+dialing heterogeneous upstreams.
+
+Also lands at this point, automatically via rmcp:
+
+- **SEP-2243 standard headers** (`Mcp-Method`, plus `Mcp-Name` for
+  `tools/call`, `prompts/get`, resource and task methods). rmcp emits and
+  validates these. Our `require_bearer` axum middleware runs ahead of rmcp and
+  does not inspect them, so no conflict — but any reverse proxy in front of
+  `/mcp-control` must pass them through.
+- **SEP-2260 request association** — at `2026-07-28`, server→client requests
+  (elicitation, sampling, roots) must correlate with an in-flight client
+  request. Our escalation fires *during* a fleet tool call, so it is associated;
+  worth an explicit test rather than an assumption.
+
+## Phase 4 — server conformance
+
+Our origin server accepts `2026-07-28` but does not yet speak it well.
+
+- **`resultType`** is handled for us: constructors default to
+  `Some(ResultType::COMPLETE)` and the handler clears it for older peers.
+- **`ttlMs` / `cacheScope`** are *required by the spec schema* on list and read
+  results at `2026-07-28` (rmcp keeps them optional for back-compat).
+
+> **Correction to this plan as first written.** An earlier draft said to emit
+> cache hints from the `list_models` and `status` *tools*. That was wrong:
+> those return `CallToolResult`, which carries no `ttlMs`/`cacheScope` at all —
+> SEP-2549 puts hints on **list and read** results. The real target is our
+> `tools/list` response.
+
+**As built.** `BitrouterMcp::list_tools` is now defined explicitly
+(`crates/bitrouter-mcp/src/server.rs`); `#[tool_handler]` skips generating a
+method the impl already defines, so this replaces the macro's version and adds
+version-gated hints on top of an otherwise identical body.
+
+Two things made the gating necessary rather than cosmetic:
+
+- rmcp strips only `resultType` for legacy peers
+  (`ServerResult::strip_result_type_for_legacy_peer`), **not** the cache hints.
+  Emitting them unconditionally would send draft-only fields to a `2025-11-25`
+  client, so `list_tools` checks the negotiated version first.
+- `cacheScope: public` is only accurate because the tool router is frozen at
+  `Builder::build` from the wired capabilities and never varies per caller. If
+  tool visibility ever becomes caller-dependent, that scope becomes wrong — the
+  code says so at the definition.
+
+`tests/stdio_smoke.rs` pins both halves against a real handshake: a
+`2025-11-25` peer sees no hints, a `2026-07-28` peer sees
+`ttlMs`/`cacheScope: public`. That draft test also demonstrates the central
+finding directly — the server echoes back `2026-07-28` with no opt-in on our
+side.
+
+**No action needed** on subscriptions: SEP-2575 deprecates `resources/subscribe`
+in favor of `subscriptions/listen`, and we use neither — our only notification
+consumers are `notifications/progress` and `notifications/*_list_changed`.
+
+**Stateless serving (SEP-2567)** costs us nothing, and it is worth recording
+why. `2026-07-28` sessions are always served statelessly, which would normally
+threaten connection-scoped state — and `EscalationState` is exactly that. We are
+safe because `build_http_router` (`server.rs:842`) deliberately carries only the
+`completion` backend; fleet, human-bridge, and escalation are stdio-only, and
+stdio sessions stay long-lived. That existing decision is now load-bearing in a
+new way: **adding stateful tools to the HTTP profile would break under
+draft-version clients.** The comment at `server.rs:835` should say so.
+
+## Open decisions
+
+**All four resolved — each took the recommended option.** Kept here with their
+reasoning because the merge gate and any future Tasks work depend on them.
+
+### D1 — Task policy
+
+When an upstream materializes a task for a `tools/call`, do we:
+
+- **(a) Reject cleanly** — map `CallToolResponse::Task` to a typed
+  `BitrouterError` naming the server and task id. Small, honest, no new state.
+- **(b) Poll to completion** — drive `tasks/get` behind our existing streaming
+  interface, emitting task status as progress notifications so downstream
+  harnesses see a long-running call rather than an error.
+
+**Decided: (a) now, (b) as its own change.** (b) is genuinely attractive for
+BitRouter — long-running `complete` calls and the fleet spawn surface both want
+it — but it introduces a polling lifecycle, TTL handling, and cancellation
+semantics that deserve their own design pass rather than riding along on a
+dependency bump. (a) is also strictly required as the fallback path for (b).
+
+Built as `map_call_tool_result`, which surfaces the task id so the failure is
+actionable. When (b) is picked up, this is the function it slots into.
+
+### D2 — Whose cache
+
+**Decided: keep ours, disable rmcp's.** Ours has notification-driven
+invalidation, LRU bounds, and aggregate-awareness rmcp's lacks; adopting rmcp's
+would mean losing invalidation-on-`list_changed` and rewriting the `mcp.cache:`
+config surface.
+
+Built as a `ClientCacheConfig::disabled()` call in the pool-insert path, so the
+decision is applied once per connection at a single site.
+
+### D3 — Client opt-in timing
+
+**Decided: defer the opt-in.** Opting in has no upside until an upstream
+supports it, and it activates every Phase 2 failure mode. Phases 0–2 landed;
+the switch did not.
+
+Concretely, this branch leaves upstream connections on `ProtocolVersion::LATEST`
+(`2025-11-25`) — rmcp's default and still the default in 3.0. Phase 2's handling
+is therefore *dormant but correct*: the shapes it maps cannot arrive until
+someone sets a preferred version or moves to
+`ClientLifecycleMode::Auto`. That is the whole of the remaining work for
+Phase 3, and it is now a small, isolated change.
+
+### D4 — Escalation capability granularity
+
+`supports_tasks()` is coarser than what we check today. A false positive routes
+a gated permission into a round-trip nobody answers. Our fail-safe maps failure
+to `Deny`, so this is a latency/UX problem, not a safety one — and the seam has
+never fired in production (no shipping harness declares the capability).
+**Decided: keep both** — `elicitation.is_some() || supports_tasks()` — since
+Deny is the fail-safe. The looseness and why it is tolerable are recorded on
+`client_supports_escalation` itself.
+
+One wire-level consequence worth knowing: a client still sending the
+pre-SEP-2663 `capabilities.tasks` field now reads as *no* capability and falls
+back to the HumanBridge / deny path. That is the safe direction, and it is
+pinned by test.
+
+## Acceptance
+
+All met as of the phase 0/1/2/4 landing.
+
+1. `cargo nextest run --workspace --all-features` — **2112 passed, 11 skipped**
+   (up from 2104; no regressions).
+2. `cargo clippy --all-features --all-targets` clean; `cargo fmt -- --check`
+   clean. No `#[allow]` added.
+3. New coverage — 10 tests:
+   - `extract_cache_hint` reads top-level `ttlMs`, falls back to `_meta.ttlMs`,
+     prefers top level when both are present, clamps negatives to `0`, and
+     declines `cacheScope: private`.
+   - A `private`-scoped list result is fetched upstream twice — never cached.
+   - `tools/call` maps `complete` / MRTR `input_required` / Tasks `task` to,
+     respectively, the result JSON and two explained errors. Both error tests
+     assert on text unique to their arm: the first drafts of these passed
+     *vacuously* through the catch-all, because an `inputRequests` fixture
+     missing the required `properties` key silently degrades to `CustomResult`
+     through the untagged `ServerResult` union.
+   - Escalation detection against the SEP-2663 extensions-map wire shape, plus
+     the now-inert legacy `capabilities.tasks` field.
+   - `tools/list` cache hints, end to end over a real stdio handshake, present
+     for a `2026-07-28` peer and absent for a `2025-11-25` one.
+4. `cargo run -p dist-helper -- check` clean (no registry drift).
+5. No change to `skills/bitrouter/` or the plugin manifests — verified by
+   search: nothing under `skills/`, `.claude-plugin/`, `.codex-plugin/`, or
+   `.agents/` references the protocol version or any CLI surface touched here.
+   **If Phase 3 later adds a config key for the opt-in, that lockstep
+   obligation returns** per `CLAUDE.md`.
+
+## Merge gate
+
+Hold the branch until `rmcp` 3.0 is stable, then before merging:
+
+1. Move `=3.0.0-beta.2` → `3.0` (caret) in `Cargo.toml`, and drop the pin
+   rationale comment above it.
+2. Re-read the changelog for breaking changes between beta.2 and stable —
+   `resultType`, cache hints, and the Tasks capability shape have all moved
+   once already. Pay particular attention to anything touching the SEP-2549
+   field placement (`extract_cache_hint`) or the `ServerResult` union ordering
+   (`map_call_tool_result`): both parse by wire shape, so a move there fails at
+   runtime, not at compile time.
+3. Re-run acceptance.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ workspace architecture guide, and design specs. It is *not* published anywhere.
 - [`CLI.md`](CLI.md) — full command reference, flags, and config resolution.
 - [`DEVELOPMENT.md`](DEVELOPMENT.md) — workspace architecture and SDK internals.
 - `*_SPEC.md` / `*_ACCEPTANCE.md` — design specs and acceptance criteria for
-  in-flight work (TUI, spawn/launch, onboarding).
+  in-flight work (TUI, spawn/launch, onboarding, the MCP `2026-07-28` upgrade).
 
 ## Where product docs live
 


### PR DESCRIPTION
Brings BitRouter onto `rmcp` 3.x so both MCP roles — the origin server
(`crates/bitrouter-mcp`) and the gateway client (`crates/bitrouter-sdk/src/mcp`)
— are correct under MCP protocol version `2026-07-28`.

## Why this is not just a version bump

`rmcp` 2.2.0 listed `2026-07-28` in `ProtocolVersion::KNOWN_VERSIONS` while
`LATEST` stayed at `2025-11-25` and none of the draft SEPs were implemented.
Since `negotiate_protocol_version` accepts any known version, **our origin
server already agreed to `2026-07-28` on a build that could not honor it.** A
draft-era client asking for it got an agreement we could not keep.

So the server side was never an opt-in — it was already happening. This makes
the agreement truthful. The *client* side is the real opt-in, and it ships off
by default.

The mechanical port was two lines. The work below is the part the compiler
could not point at.

## Silent-semantics fixes

**The SEP-2549 cache hint moved and we were reading the old location.**
`CachingExecutor` read `_meta.ttlMs`; the shipped shape puts `ttlMs` and
`cacheScope` at the *top level* of the result (rmcp's own
`tests/test_cache_hints.rs` asserts this). Every upstream hint was being
ignored in favour of configured defaults — latent today, live the moment an
upstream speaks the draft. Now reads top level with `_meta` as a legacy
fallback, clamps negatives to `0`, and declines to cache `private`-scoped
results, which a cache shared across callers must not retain.

**rmcp 3.x enables a per-`Peer` response cache by default**, including
`serve_stale_on_error` — a failed re-fetch silently returning stale data
underneath us. Explicitly disabled at the pool-insert site. We keep ours, which
rmcp's cannot replace: invalidation on `*_list_changed`, LRU bounds,
aggregate-member keying.

**SEP-2663 moved the Tasks capability** off `capabilities.tasks` into the
SEP-1724 extensions map. `client_supports_escalation` now uses
`supports_tasks()`, which is coarser — tolerable because the escalation
fail-safe is `Deny`, so a false positive costs latency, not safety.

## New `tools/call` response shapes

At `2026-07-28` a server may answer with MRTR `input_required` or a Tasks
handle. Both tool-call paths now share one `map_call_tool_result`, replacing a
hard `unexpected server result` on the streaming path and a bare
`UnexpectedResponse` on the other — which had also *diverged*, since rmcp's
high-level `call_tool` drives MRTR silently while the raw request the streaming
path needs for its progress token does not.

MRTR turned out to need no round-driving: its `InputRequests` can only hold
sampling, elicitation, or roots — exactly the three server→client requests this
gateway already rejects with `-32601`, for the same stateless-inbound reason.
Driving the rounds would produce a rejection each and fail anyway, so both
shapes get a typed error that explains why.

## Server conformance

`tools/list` now emits SEP-2549 hints, version-gated because rmcp strips only
`resultType` for legacy peers, not cache hints. `cacheScope: public` holds only
because the tool router is frozen at build time and never varies per caller —
noted at the definition, since caller-dependent tool visibility would make it
wrong.

Also documented: SEP-2567 always serves `2026-07-28` sessions statelessly, so
the existing "HTTP profile carries completion only" invariant is now
load-bearing for a second reason — adding a stateful tool there would break
under draft clients while working fine against `2025-11-25`.

## Client opt-in (off by default)

`mcp.upstream_protocol` — `latest` (default, today `2025-11-25`) or
`"2026-07-28"`. The setting selects both protocol version and lifecycle. `latest` keeps the
legacy `initialize` path. `"2026-07-28"` uses `ClientLifecycleMode::Auto`:
it opens with `server/discover`, sends self-contained metadata on subsequent
requests, and falls back to legacy `initialize` only when discovery returns
`METHOD_NOT_FOUND`. Other discovery errors fail the connection, so the
compatibility risk remains contained to explicit opt-ins.

Because the default does not move, the new response handling is dormant but
correct. Two tests pin that default.

## Verification

- `cargo nextest run --all-features` — **2111 passed, 11 skipped**
  (from 2104)
- `cargo clippy --all-features --all-targets` clean; `cargo fmt -- --check`
  clean; no `#[allow]` added
- `cargo run -p dist-helper -- check` clean; schema regenerated for the new
  config key
- No `skills/bitrouter/` or plugin-manifest change: no CLI flag, port, env var,
  or harness wiring step moved

## Reviewer notes

Two areas received independent fix review and focused regressions:

1. Stdio startup now delegates valid legacy `initialize` and pre-init `ping`
   requests to rmcp's stable lifecycle while preserving `-32602` for malformed
   modern openers. Tests cover unsupported-version fallback, discovery metadata
   enforcement, partial draft metadata on legacy openers, and continued use
   after initialization.
2. Paginated list aggregation now folds cache hints across every page: shortest
   TTL wins, `private` dominates, and future non-public scopes remain
   restrictive. Real two-page stdio fixtures cover private, zero-TTL, and
   shorter-TTL later pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
