### PR TITLE
fix(policy): make runtime mode authoritative

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ BitRouter wraps your agentic loop in a second loop. Each loop gets its own **pol
 
 ```yaml
 # bitrouter.yaml — context-aware routing as code, keyed on the loop's step
+policy:
+  mode: adaptive                  # the running process may learn and publish
 policy_table:
   tiers:                         # a tier name → the model it routes to
     cheap:    moonshotai/kimi-k2.6
@@ -45,7 +47,6 @@ policy_table:
   tool_use_tier:   flagship      # guardrail: a tool call is never
   tool_safe_tiers: [flagship]    #   stranded on a tool-blind model
   adequacy:
-    enabled: true                # a downgrade that starts failing…
     escalation_tier: flagship    #   …escalates itself back up
 ```
 

--- a/apps/bitrouter/src/assemble.rs
+++ b/apps/bitrouter/src/assemble.rs
@@ -458,12 +458,22 @@ pub async fn build_app_with_path(
     // table is read by the ingress router (below) and, when online adequacy
     // learning is enabled, by the adequacy observe hook. The ledger persists its
     // escalation pins in the local db and warms its in-memory cache from it.
-    let policy_table = crate::policy_table_router::PolicyTable::from_config(&config.policy_table);
+    let mut effective_policy_table_config = config.policy_table.clone();
+    effective_policy_table_config.adequacy = config
+        .policy
+        .mode
+        .apply_to_adequacy(&config.policy_table.adequacy);
+    let policy_table =
+        crate::policy_table_router::PolicyTable::from_config(&effective_policy_table_config);
     let adequacy_ledger = match &policy_table {
-        Some(_) if config.policy_table.adequacy.enabled => {
+        Some(_) if effective_policy_table_config.adequacy.enabled => {
             let store = crate::adequacy::store::AdequacyStore::new(db.clone());
             Some(Arc::new(
-                crate::adequacy::AdequacyLedger::load(&config.policy_table.adequacy, store).await?,
+                crate::adequacy::AdequacyLedger::load(
+                    &effective_policy_table_config.adequacy,
+                    store,
+                )
+                .await?,
             ))
         }
         _ => None,

--- a/apps/bitrouter/src/main.rs
+++ b/apps/bitrouter/src/main.rs
@@ -857,7 +857,7 @@ enum PolicyAction {
         #[arg(short, long)]
         config: Option<PathBuf>,
     },
-    /// Show policy path, digest, writeback mode, and preset bindings.
+    /// Show policy path, digest, runtime mode, and preset bindings.
     Status {
         #[arg(short, long)]
         config: Option<PathBuf>,
@@ -883,19 +883,6 @@ enum PolicyAction {
         /// Export the candidate without changing the active policy lock.
         #[arg(long, value_name = "FILE", conflicts_with = "apply")]
         output: Option<PathBuf>,
-        /// Disable future exploration in the exported candidate.
-        #[arg(long, requires = "output")]
-        freeze: bool,
-        #[arg(short, long)]
-        config: Option<PathBuf>,
-    },
-    /// Forbid optimizer writes to `policy-lock.yaml`.
-    Lock {
-        #[arg(short, long)]
-        config: Option<PathBuf>,
-    },
-    /// Permit `policy evolve --apply` to publish `policy-lock.yaml`.
-    Unlock {
         #[arg(short, long)]
         config: Option<PathBuf>,
     },
@@ -2930,7 +2917,6 @@ async fn policy(action: PolicyAction, output: &Output) -> Result<()> {
         PolicyAction::Evolve {
             apply,
             output: candidate_output,
-            freeze,
             config,
         } => {
             let source = bitrouter::paths::resolve_config(config.as_deref())?;
@@ -2947,44 +2933,16 @@ async fn policy(action: PolicyAction, output: &Output) -> Result<()> {
             let mut report =
                 routing_policy_report(config_path, action, published, update.changes, None).await?;
             if let Some(candidate_path) = candidate_output {
-                let document = if freeze {
-                    bitrouter::policy_lock::freeze_document(update.document)
-                } else {
-                    update.document
-                };
                 report.digest = Some(bitrouter::policy_lock::export_candidate_file(
                     &update.path,
                     &candidate_path,
-                    &document,
+                    &update.document,
                 )?);
                 report.candidate_path = Some(candidate_path.display().to_string());
             } else {
                 report.digest = Some(update.digest);
             }
             output.emit(&report)?;
-        }
-        PolicyAction::Lock { config } => {
-            let source = bitrouter::paths::resolve_config(config.as_deref())?;
-            let config_path = require_policy_config_path(&source)?;
-            bitrouter::policy_lock::set_writeback_file(
-                config_path,
-                config::PolicyWriteback::Locked,
-            )
-            .await?;
-            output
-                .emit(&routing_policy_report(config_path, "lock", true, Vec::new(), None).await?)?;
-        }
-        PolicyAction::Unlock { config } => {
-            let source = bitrouter::paths::resolve_config(config.as_deref())?;
-            let config_path = require_policy_config_path(&source)?;
-            bitrouter::policy_lock::set_writeback_file(
-                config_path,
-                config::PolicyWriteback::Evolve,
-            )
-            .await?;
-            output.emit(
-                &routing_policy_report(config_path, "unlock", true, Vec::new(), None).await?,
-            )?;
         }
     }
     Ok(())
@@ -3048,9 +3006,9 @@ async fn routing_policy_report(
         path: path.map(|path| path.display().to_string()),
         candidate_path: None,
         digest: loaded.as_ref().map(|lock| lock.digest.clone()),
-        writeback: match cfg.policy.writeback {
-            config::PolicyWriteback::Locked => "locked",
-            config::PolicyWriteback::Evolve => "evolve",
+        mode: match cfg.policy.mode {
+            config::PolicyRuntimeMode::Frozen => "frozen",
+            config::PolicyRuntimeMode::Adaptive => "adaptive",
         }
         .to_string(),
         policies,
@@ -3856,22 +3814,22 @@ mod tests {
             "evolve",
             "--output",
             "candidate.yaml",
-            "--freeze",
         ])
-        .expect("parse frozen export");
+        .expect("parse candidate export");
         assert!(matches!(
             export.command,
             Some(Command::Policy {
                 action: PolicyAction::Evolve {
                     apply: false,
                     output: Some(path),
-                    freeze: true,
                     ..
                 }
             }) if path == Path::new("candidate.yaml")
         ));
 
         assert!(Cli::try_parse_from(["bitrouter", "policy", "evolve", "--freeze"]).is_err());
+        assert!(Cli::try_parse_from(["bitrouter", "policy", "lock"]).is_err());
+        assert!(Cli::try_parse_from(["bitrouter", "policy", "unlock"]).is_err());
         assert!(
             Cli::try_parse_from([
                 "bitrouter",

--- a/apps/bitrouter/src/output/reports/policy.rs
+++ b/apps/bitrouter/src/output/reports/policy.rs
@@ -15,7 +15,7 @@ pub struct PolicyReport {
     pub candidate_path: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub digest: Option<String>,
-    pub writeback: String,
+    pub mode: String,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub policies: Vec<String>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
@@ -39,7 +39,7 @@ impl CliReport for PolicyReport {
         if let Some(digest) = &self.digest {
             h.line(&format!("  digest: {digest}"))?;
         }
-        h.line(&format!("  writeback: {}", self.writeback))?;
+        h.line(&format!("  mode: {}", self.mode))?;
         if !self.policies.is_empty() {
             h.line(&format!("  policies: {}", self.policies.join(", ")))?;
         }

--- a/apps/bitrouter/src/policy_lock.rs
+++ b/apps/bitrouter/src/policy_lock.rs
@@ -12,7 +12,7 @@ use std::sync::{Arc, PoisonError, RwLock};
 
 use anyhow::{Context, Result};
 use bitrouter_sdk::config::{
-    AdequacyConfig, Config, PolicyKeyStrategy, PolicyTableConfig, PolicyWriteback,
+    AdequacyConfig, Config, PolicyKeyStrategy, PolicyRuntimeMode, PolicyTableConfig,
     validate_policy_table_config,
 };
 use bitrouter_sdk::language_model::{ModelSelector, PipelineContext};
@@ -82,7 +82,7 @@ impl Default for PolicyDefinition {
 }
 
 impl PolicyDefinition {
-    pub fn as_table_config(&self) -> PolicyTableConfig {
+    pub fn as_table_config(&self, mode: PolicyRuntimeMode) -> PolicyTableConfig {
         PolicyTableConfig {
             key_strategy: self.key_strategy,
             tiers: self
@@ -98,7 +98,7 @@ impl PolicyDefinition {
             default_tier: self.default_tier.clone(),
             tool_use_tier: self.tool_use_tier.clone(),
             tool_safe_tiers: self.tool_safe_tiers.clone(),
-            adequacy: self.adequacy.clone(),
+            adequacy: mode.apply_to_adequacy(&self.adequacy),
         }
     }
 }
@@ -186,7 +186,7 @@ pub fn validate_document(document: &PolicyLock) -> Result<()> {
     }
     for (name, policy) in &document.policies {
         validate_name(name)?;
-        let config = policy.as_table_config();
+        let config = policy.as_table_config(PolicyRuntimeMode::Frozen);
         validate_policy_table_config(&config)
             .map_err(anyhow::Error::from)
             .with_context(|| format!("validating policy '{name}'"))?;
@@ -215,6 +215,16 @@ pub fn validate_document(document: &PolicyLock) -> Result<()> {
 
 pub fn validate_for_config(config: &Config, document: &PolicyLock) -> Result<()> {
     validate_document(document)?;
+    for (name, policy) in &document.policies {
+        validate_policy_table_config(&policy.as_table_config(config.policy.mode))
+            .map_err(anyhow::Error::from)
+            .with_context(|| {
+                format!(
+                    "validating policy '{name}' for {:?} mode",
+                    config.policy.mode
+                )
+            })?;
+    }
     for (preset_name, preset) in &config.presets {
         let Some(policy_name) = &preset.policy else {
             continue;
@@ -304,9 +314,6 @@ pub fn evolve_document(
         let Some(policy) = document.policies.get_mut(policy_name) else {
             continue;
         };
-        if !policy.adequacy.enabled || !policy.adequacy.explore_enabled {
-            continue;
-        }
         let Some(explore_tier) = policy.adequacy.explore_tier.clone() else {
             continue;
         };
@@ -341,17 +348,6 @@ pub fn evolve_document(
 
     validate_document(&document)?;
     Ok(EvolutionResult { document, changes })
-}
-
-/// Turn an evolved candidate into a deployment artifact. Learned routes and
-/// routing-only session budgets remain active, while the adequacy learner and
-/// future exploration are disabled so holdout routing cannot mutate itself.
-pub fn freeze_document(mut document: PolicyLock) -> PolicyLock {
-    for policy in document.policies.values_mut() {
-        policy.adequacy.enabled = false;
-        policy.adequacy.explore_enabled = false;
-    }
-    document
 }
 
 /// Atomically publish a candidate without permitting it to replace the lock
@@ -405,23 +401,23 @@ fn resolved_file_location(path: &Path) -> Result<PathBuf> {
     Ok(resolved)
 }
 
-/// Bind an existing preset to a routing policy and set the optimizer's
-/// publication permission without reserializing the rest of `bitrouter.yaml`.
+/// Bind an existing preset to a routing policy and set the process mode
+/// without reserializing the rest of `bitrouter.yaml`.
 /// This keeps comments and operator formatting intact.
 pub fn edit_config_policy(
     raw: &str,
     preset: &str,
     policy: &str,
-    writeback: PolicyWriteback,
+    mode: PolicyRuntimeMode,
 ) -> Result<String> {
-    edit_config_policy_with_model(raw, preset, policy, None, writeback)
+    edit_config_policy_with_model(raw, preset, policy, None, mode)
 }
 
-/// Change only the optimizer publication mode in `bitrouter.yaml`.
-pub fn edit_config_writeback(raw: &str, writeback: PolicyWriteback) -> Result<String> {
+/// Change only the policy runtime mode in `bitrouter.yaml`.
+pub fn edit_config_mode(raw: &str, mode: PolicyRuntimeMode) -> Result<String> {
     bitrouter_sdk::config::parse(raw).context("parsing bitrouter.yaml")?;
     let mut lines = source_lines(raw);
-    set_policy_writeback(&mut lines, writeback)?;
+    set_policy_mode(&mut lines, mode)?;
     let edited = render_source_lines(lines, raw.ends_with('\n'));
     bitrouter_sdk::config::parse(&edited).context("validating edited bitrouter.yaml")?;
     Ok(edited)
@@ -434,7 +430,7 @@ pub fn edit_config_policy_with_model(
     preset: &str,
     policy: &str,
     model: Option<&str>,
-    writeback: PolicyWriteback,
+    mode: PolicyRuntimeMode,
 ) -> Result<String> {
     validate_name(preset).context("validating preset name")?;
     validate_name(policy)?;
@@ -452,7 +448,7 @@ pub fn edit_config_policy_with_model(
     }
 
     let mut lines = source_lines(raw);
-    set_policy_writeback(&mut lines, writeback)?;
+    set_policy_mode(&mut lines, mode)?;
     bind_preset(&mut lines, preset, policy, model)?;
     let edited = render_source_lines(lines, raw.ends_with('\n'));
     let checked =
@@ -480,24 +476,26 @@ fn render_source_lines(lines: Vec<String>, had_trailing_newline: bool) -> String
     rendered
 }
 
-fn set_policy_writeback(lines: &mut Vec<String>, writeback: PolicyWriteback) -> Result<()> {
-    let value = match writeback {
-        PolicyWriteback::Locked => "locked",
-        PolicyWriteback::Evolve => "evolve",
+fn set_policy_mode(lines: &mut Vec<String>, mode: PolicyRuntimeMode) -> Result<()> {
+    let value = match mode {
+        PolicyRuntimeMode::Frozen => "frozen",
+        PolicyRuntimeMode::Adaptive => "adaptive",
     };
     if let Some((start, end)) = block_range(lines, "policy", 0) {
         require_block_header(&lines[start], "policy")?;
-        if let Some(index) = child_key(lines, start + 1, end, "writeback", 2) {
-            lines[index] = format!("  writeback: {value}");
+        if let Some(index) = child_key(lines, start + 1, end, "mode", 2)
+            .or_else(|| child_key(lines, start + 1, end, "writeback", 2))
+        {
+            lines[index] = format!("  mode: {value}");
         } else {
-            lines.insert(end, format!("  writeback: {value}"));
+            lines.insert(end, format!("  mode: {value}"));
         }
     } else {
         if !lines.is_empty() && !lines.last().is_some_and(|line| line.is_empty()) {
             lines.push(String::new());
         }
         lines.push("policy:".into());
-        lines.push(format!("  writeback: {value}"));
+        lines.push(format!("  mode: {value}"));
     }
     Ok(())
 }
@@ -605,7 +603,7 @@ pub struct PolicyFileUpdate {
 
 /// Create one named adaptive policy and bind it to a preset. The candidate
 /// main config and lock are fully cross-validated before either file is
-/// published. Optimizer writeback starts locked.
+/// published. The BitRouter process starts in frozen mode.
 pub async fn initialize_files(
     config_path: &Path,
     policy_name: &str,
@@ -657,9 +655,7 @@ pub async fn initialize_files(
     }
 
     let adequacy = AdequacyConfig {
-        enabled: true,
         escalation_tier: Some("strong".into()),
-        explore_enabled: true,
         explore_tier: Some("economy".into()),
         min_semantic_successes_for_lock: 1,
         ..AdequacyConfig::default()
@@ -684,7 +680,7 @@ pub async fn initialize_files(
         preset_name,
         policy_name,
         preset_model,
-        PolicyWriteback::Locked,
+        PolicyRuntimeMode::Frozen,
     )?;
     let candidate_config =
         bitrouter_sdk::config::parse(&edited_config).context("validating candidate config")?;
@@ -704,15 +700,15 @@ pub async fn initialize_files(
 }
 
 /// Read adequacy evidence and project it into a candidate policy lock. Dry-run
-/// is the default. Applying is permitted only while `policy.writeback: evolve`.
+/// is the default. Applying is permitted only in adaptive process mode.
 pub async fn evolve_files(config_path: &Path, apply: bool) -> Result<PolicyFileUpdate> {
     let raw = tokio::fs::read_to_string(config_path)
         .await
         .with_context(|| format!("reading {}", config_path.display()))?;
     let config = bitrouter_sdk::config::parse(&raw).context("parsing bitrouter.yaml")?;
-    if apply && config.policy.writeback == PolicyWriteback::Locked {
+    if apply && config.policy.mode == PolicyRuntimeMode::Frozen {
         anyhow::bail!(
-            "policy writeback is locked; run `bitrouter policy unlock` before `policy evolve --apply`"
+            "policy runtime mode is frozen; set `policy.mode: adaptive` before `policy evolve --apply`"
         );
     }
     let loaded = load_for_config(&config, Some(config_path))
@@ -754,13 +750,12 @@ pub async fn evolve_files(config_path: &Path, apply: bool) -> Result<PolicyFileU
     })
 }
 
-/// Explicit operator command for changing optimizer publication permission.
-/// `locked` governs programmatic writes to the lock, not this main-config edit.
-pub async fn set_writeback_file(config_path: &Path, writeback: PolicyWriteback) -> Result<()> {
+/// Explicit helper for changing process-owned policy mode in the main config.
+pub async fn set_mode_file(config_path: &Path, mode: PolicyRuntimeMode) -> Result<()> {
     let raw = tokio::fs::read_to_string(config_path)
         .await
         .with_context(|| format!("reading {}", config_path.display()))?;
-    let edited = edit_config_writeback(&raw, writeback)?;
+    let edited = edit_config_mode(&raw, mode)?;
     write_text_atomic(config_path, &raw, &edited)
 }
 
@@ -987,7 +982,7 @@ impl PolicyRuntime {
         let mut routers = BTreeMap::new();
         if let Some(loaded) = &loaded {
             for (name, definition) in &loaded.document.policies {
-                let table_config = definition.as_table_config();
+                let table_config = definition.as_table_config(config.policy.mode);
                 let table = PolicyTable::from_config(&table_config)
                     .ok_or_else(|| anyhow::anyhow!("policy '{name}' is inert"))?;
                 let ledger = if table_config.adequacy.enabled {
@@ -1026,7 +1021,7 @@ impl PolicyRuntime {
             .unwrap_or_else(PoisonError::into_inner) = prepared.0;
     }
 
-    pub fn status(&self, writeback: PolicyWriteback) -> PolicyRuntimeStatus {
+    pub fn status(&self, mode: PolicyRuntimeMode) -> PolicyRuntimeStatus {
         let snapshot = self
             .snapshot
             .read()
@@ -1036,7 +1031,7 @@ impl PolicyRuntime {
             path: snapshot.path.clone(),
             digest: snapshot.digest.clone(),
             policies: snapshot.routers.keys().cloned().collect(),
-            writeback,
+            mode,
         }
     }
 }
@@ -1067,7 +1062,7 @@ pub struct PolicyRuntimeStatus {
     pub path: Option<PathBuf>,
     pub digest: Option<String>,
     pub policies: Vec<String>,
-    pub writeback: PolicyWriteback,
+    pub mode: PolicyRuntimeMode,
 }
 
 #[cfg(test)]
@@ -1107,28 +1102,107 @@ mod tests {
     }
 
     #[test]
-    fn freezing_disables_all_learning() {
+    fn process_mode_is_authoritative_for_learning_activation() {
         let mut policy = definition();
-        policy.adequacy.enabled = true;
-        policy.adequacy.explore_enabled = true;
+        policy.adequacy.enabled = false;
+        policy.adequacy.explore_enabled = false;
         policy.adequacy.explore_tier = Some("economy".into());
+
+        let frozen = policy.as_table_config(PolicyRuntimeMode::Frozen);
+        assert!(!frozen.adequacy.enabled);
+        assert!(!frozen.adequacy.explore_enabled);
+
+        let adaptive = policy.as_table_config(PolicyRuntimeMode::Adaptive);
+        assert!(adaptive.adequacy.enabled);
+        assert!(adaptive.adequacy.explore_enabled);
+        assert_eq!(adaptive.adequacy.explore_tier.as_deref(), Some("economy"));
+    }
+
+    #[tokio::test]
+    async fn frozen_runtime_ignores_learned_db_routes_until_reloaded_as_adaptive()
+    -> anyhow::Result<()> {
+        use bitrouter_sdk::caller::CallerContext;
+        use bitrouter_sdk::language_model::{
+            GenerationParams, Message, PipelineRequest, Prompt, Role,
+        };
+
+        fn context() -> PipelineContext {
+            let prompt = Prompt {
+                model: "vendor:strong".into(),
+                system: None,
+                system_provider_metadata: Default::default(),
+                messages: vec![Message::text(Role::User, "solve this")],
+                tools: Vec::new(),
+                params: GenerationParams::default(),
+                response_format: None,
+                tool_choice: None,
+                stream: false,
+            };
+            PipelineContext::new(PipelineRequest::new(
+                "vendor:strong",
+                CallerContext::local(),
+                prompt,
+            ))
+        }
+
+        let dir = tempfile::tempdir()?;
+        let config_path = dir.path().join("bitrouter.yaml");
+        tokio::fs::write(
+            &config_path,
+            r#"policy:
+  mode: frozen
+presets:
+  coding:
+    model: vendor:strong
+    policy: coding
+"#,
+        )
+        .await?;
+        let mut policy = definition();
+        policy.adequacy.escalation_tier = Some("strong".into());
+        policy.adequacy.explore_tier = Some("economy".into());
+        policy.adequacy.explore_opening = true;
+        policy.adequacy.min_semantic_successes_for_lock = 1;
         let lock = PolicyLock {
             lockfile_version: 1,
             policies: BTreeMap::from([("coding".into(), policy)]),
         };
+        write_atomic(&dir.path().join("policy-lock.yaml"), None, &lock)?;
 
-        let frozen = freeze_document(lock);
+        let mut config = bitrouter_sdk::config::load(&config_path).await?;
+        let db = crate::db::connect("sqlite::memory:").await?;
+        crate::db::run_migrations(&db).await?;
+        let store = AdequacyStore::new(db.clone());
+        let ledger_key = "coding\0agent_trace/v1|opening|normal";
+        store.upsert_exploration(ledger_key, 3, 3, true).await?;
+        store
+            .record_semantic_success(ledger_key, "terminal-bench/task-a")
+            .await?;
 
-        assert!(!frozen.policies["coding"].adequacy.enabled);
-        assert!(!frozen.policies["coding"].adequacy.explore_enabled);
-        assert_eq!(
-            frozen.policies["coding"].adequacy.explore_tier.as_deref(),
-            Some("economy")
-        );
+        let runtime = PolicyRuntime::new(
+            &config,
+            Some(&config_path),
+            db,
+            Arc::new(PendingAdequacyStore::default()),
+            None,
+        )
+        .await?;
+        let mut frozen = context();
+        runtime.select("coding", &mut frozen)?;
+        assert_eq!(frozen.model(), "vendor:strong");
+
+        config.policy.mode = PolicyRuntimeMode::Adaptive;
+        runtime
+            .reload_for_config(&config, Some(&config_path))
+            .await?;
+        let mut adaptive = context();
+        runtime.select("coding", &mut adaptive)?;
+        assert_eq!(adaptive.model(), "vendor:economy");
+        Ok(())
     }
 
     #[test]
-    fn legacy_workflow_state_locks_deserialize_as_agent_trace_and_freeze_canonically() {
+    fn legacy_workflow_state_locks_deserialize_as_agent_trace_canonically() {
         let lock: PolicyLock = serde_saphyr::from_str(
             r#"
 lockfileVersion: 1
@@ -1147,8 +1221,7 @@ policies:
             PolicyKeyStrategy::AgentTrace
         );
 
-        let frozen = freeze_document(lock);
-        let rendered = deterministic_yaml(&frozen).unwrap();
+        let rendered = deterministic_yaml(&lock).unwrap();
         assert!(rendered.contains("key_strategy: agent_trace"));
         assert!(!rendered.contains("key_strategy: workflow_state"));
     }
@@ -1158,16 +1231,16 @@ policies:
         let template_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("../..")
             .join("templates/auto-router");
-        let config = bitrouter_sdk::config::parse(
-            &std::fs::read_to_string(template_dir.join("bitrouter.yaml")).unwrap(),
-        )
-        .unwrap();
-        let lock: PolicyLock = serde_saphyr::from_str(
-            &std::fs::read_to_string(template_dir.join("policy-lock.yaml")).unwrap(),
-        )
-        .unwrap();
+        let config_raw = std::fs::read_to_string(template_dir.join("bitrouter.yaml")).unwrap();
+        let lock_raw = std::fs::read_to_string(template_dir.join("policy-lock.yaml")).unwrap();
+        let config = bitrouter_sdk::config::parse(&config_raw).unwrap();
+        let lock: PolicyLock = serde_saphyr::from_str(&lock_raw).unwrap();
 
         validate_for_config(&config, &lock).unwrap();
+        assert_eq!(config.policy.mode, PolicyRuntimeMode::Frozen);
+        assert!(!config_raw.contains("writeback:"));
+        assert!(!lock_raw.contains("enabled:"));
+        assert!(!lock_raw.contains("explore_enabled:"));
         let policy = &lock.policies["auto"];
         assert_eq!(policy.key_strategy, PolicyKeyStrategy::AgentTrace);
         assert_eq!(policy.routes["agent_trace/v1|edit|normal"], "economy");
@@ -1336,18 +1409,18 @@ presets:
 "#;
 
         let edited =
-            edit_config_policy(raw, "coding", "terminal-bench", PolicyWriteback::Locked).unwrap();
+            edit_config_policy(raw, "coding", "terminal-bench", PolicyRuntimeMode::Frozen).unwrap();
 
         assert!(edited.contains("# team routing"));
         assert!(edited.contains("# keep this operator note"));
         assert!(edited.contains("    policy: terminal-bench"));
-        assert!(edited.contains("policy:\n  writeback: locked"));
+        assert!(edited.contains("policy:\n  mode: frozen"));
         let parsed = bitrouter_sdk::config::parse(&edited).unwrap();
         assert_eq!(
             parsed.presets["coding"].policy.as_deref(),
             Some("terminal-bench")
         );
-        assert_eq!(parsed.policy.writeback, PolicyWriteback::Locked);
+        assert_eq!(parsed.policy.mode, PolicyRuntimeMode::Frozen);
     }
 
     #[test]
@@ -1359,7 +1432,7 @@ presets:
 "#;
 
         let error =
-            edit_config_policy(raw, "coding", "experiment", PolicyWriteback::Locked).unwrap_err();
+            edit_config_policy(raw, "coding", "experiment", PolicyRuntimeMode::Frozen).unwrap_err();
 
         assert!(
             error
@@ -1373,8 +1446,10 @@ presets:
         use crate::adequacy::store::PersistedExplorationState;
 
         let mut policy = definition();
-        policy.adequacy.enabled = true;
-        policy.adequacy.explore_enabled = true;
+        // Artifact booleans are legacy input only. Candidate generation uses
+        // accumulated evidence and configured tier/threshold parameters.
+        policy.adequacy.enabled = false;
+        policy.adequacy.explore_enabled = false;
         policy.adequacy.explore_tier = Some("economy".into());
         policy.adequacy.min_semantic_successes_for_lock = 2;
         let lock = PolicyLock {
@@ -1501,7 +1576,7 @@ presets:
     }
 
     #[tokio::test]
-    async fn initialize_writes_a_locked_policy_and_preserves_the_config() {
+    async fn initialize_writes_a_frozen_policy_and_preserves_the_config() {
         let dir = tempfile::tempdir().unwrap();
         let config_path = dir.path().join("bitrouter.yaml");
         tokio::fs::write(
@@ -1529,7 +1604,7 @@ presets:
         let config_raw = tokio::fs::read_to_string(&config_path).await.unwrap();
         assert!(config_raw.contains("# owned by the routing team"));
         let config = bitrouter_sdk::config::parse(&config_raw).unwrap();
-        assert_eq!(config.policy.writeback, PolicyWriteback::Locked);
+        assert_eq!(config.policy.mode, PolicyRuntimeMode::Frozen);
         assert_eq!(
             config.presets["coding"].policy.as_deref(),
             Some("terminal-bench")
@@ -1543,7 +1618,7 @@ presets:
     }
 
     #[tokio::test]
-    async fn locked_config_refuses_evolution_apply() {
+    async fn frozen_config_refuses_evolution_apply() {
         let dir = tempfile::tempdir().unwrap();
         let config_path = dir.path().join("bitrouter.yaml");
         tokio::fs::write(
@@ -1569,12 +1644,12 @@ presets:
 
         let error = evolve_files(&config_path, true).await.unwrap_err();
 
-        assert!(error.to_string().contains("writeback is locked"));
+        assert!(error.to_string().contains("runtime mode is frozen"));
         assert!(!dir.path().join("bitrouter.db").exists());
     }
 
     #[tokio::test]
-    async fn locked_config_can_export_without_mutating_active_files() {
+    async fn frozen_config_can_export_without_mutating_active_files() {
         let dir = tempfile::tempdir().unwrap();
         let config_path = dir.path().join("bitrouter.yaml");
         tokio::fs::write(
@@ -1608,8 +1683,7 @@ presets:
         let candidate_path = dir.path().join("candidate.yaml");
 
         let update = evolve_files(&config_path, false).await.unwrap();
-        let frozen = freeze_document(update.document);
-        export_candidate_file(&update.path, &candidate_path, &frozen).unwrap();
+        export_candidate_file(&update.path, &candidate_path, &update.document).unwrap();
 
         assert_eq!(tokio::fs::read(&config_path).await.unwrap(), before_config);
         assert_eq!(
@@ -1617,16 +1691,7 @@ presets:
             before_lock
         );
         let candidate = load(&candidate_path).await.unwrap();
-        assert!(
-            !candidate.document.policies["terminal-bench"]
-                .adequacy
-                .enabled
-        );
-        assert!(
-            !candidate.document.policies["terminal-bench"]
-                .adequacy
-                .explore_enabled
-        );
+        assert_eq!(candidate.document, update.document);
     }
 
     #[tokio::test]
@@ -1740,7 +1805,7 @@ presets:
         )
         .await
         .unwrap();
-        set_writeback_file(&config_path, PolicyWriteback::Evolve)
+        set_mode_file(&config_path, PolicyRuntimeMode::Adaptive)
             .await
             .unwrap();
         let db_path = dir.path().join("bitrouter.db");

--- a/apps/bitrouter/src/reload.rs
+++ b/apps/bitrouter/src/reload.rs
@@ -350,7 +350,7 @@ providers:
     async fn invalid_policy_candidate_does_not_swap_routing_or_policy() {
         use crate::adequacy::settlement::PendingAdequacyStore;
         use crate::policy_lock::PolicyRuntime;
-        use bitrouter_sdk::config::PolicyWriteback;
+        use bitrouter_sdk::config::PolicyRuntimeMode;
 
         let (path, dir) = temp_config_path();
         let config_yaml = |model: &str| {
@@ -394,7 +394,7 @@ policies:
         .await
         .expect("build policy runtime");
         let initial_digest = runtime
-            .status(PolicyWriteback::Locked)
+            .status(PolicyRuntimeMode::Frozen)
             .digest
             .expect("initial digest");
         let executor = Arc::new(HttpExecutor::new(HttpTimeouts::default()).expect("executor"));
@@ -418,7 +418,7 @@ policies:
             Some("vendor:old")
         );
         assert_eq!(
-            runtime.status(PolicyWriteback::Locked).digest.as_deref(),
+            runtime.status(PolicyRuntimeMode::Frozen).digest.as_deref(),
             Some(initial_digest.as_str())
         );
         std::fs::remove_dir_all(dir).ok();

--- a/apps/bitrouter/tests/smithers_reward_loop.rs
+++ b/apps/bitrouter/tests/smithers_reward_loop.rs
@@ -5,8 +5,7 @@ use bitrouter::metering::{
     ChargeEvidence, ChargeStatus, EffectivePricingRates, PricingSource, ReconciliationStatus,
 };
 use bitrouter::policy_lock::{
-    PolicyDefinition, PolicyLock, deterministic_yaml, evolve_document, freeze_document,
-    semantic_digest,
+    PolicyDefinition, PolicyLock, deterministic_yaml, evolve_document, semantic_digest,
 };
 use bitrouter::workflow_state::archive::{CloudUsageRecord, WorkflowRunArtifact};
 use bitrouter::workflow_state::decision::PolicyDecisionRecord;
@@ -179,29 +178,23 @@ async fn smithers_terminal_reward_materializes_only_the_credited_route() {
     };
     let exploration = store.load_exploration_all().await.unwrap();
     let semantic = store.load_semantic_success_counts().await.unwrap();
-    let frozen = freeze_document(
-        evolve_document(&lock, &exploration, &semantic)
-            .unwrap()
-            .document,
-    );
-    assert_eq!(frozen.policies["smithers"].routes[target_key], "economy");
-    assert!(!frozen.policies["smithers"].routes.contains_key(other_key));
-    assert!(!frozen.policies["smithers"].adequacy.enabled);
-    assert!(!frozen.policies["smithers"].adequacy.explore_enabled);
+    let evolved = evolve_document(&lock, &exploration, &semantic)
+        .unwrap()
+        .document;
+    assert_eq!(evolved.policies["smithers"].routes[target_key], "economy");
+    assert!(!evolved.policies["smithers"].routes.contains_key(other_key));
 
-    let independently_frozen = freeze_document(
-        evolve_document(&lock, &exploration, &semantic)
-            .unwrap()
-            .document,
-    );
+    let independently_evolved = evolve_document(&lock, &exploration, &semantic)
+        .unwrap()
+        .document;
     assert_eq!(
-        deterministic_yaml(&frozen).unwrap().as_bytes(),
-        deterministic_yaml(&independently_frozen)
+        deterministic_yaml(&evolved).unwrap().as_bytes(),
+        deterministic_yaml(&independently_evolved)
             .unwrap()
             .as_bytes()
     );
     assert_eq!(
-        semantic_digest(&frozen).unwrap(),
-        semantic_digest(&independently_frozen).unwrap()
+        semantic_digest(&evolved).unwrap(),
+        semantic_digest(&independently_evolved).unwrap()
     );
 }

--- a/apps/bitrouter/tests/workflow_state_replay.rs
+++ b/apps/bitrouter/tests/workflow_state_replay.rs
@@ -2013,7 +2013,9 @@ policies:
         .expect("legacy bound lock loads");
     let definition = loaded.document.policies.get("legacy").unwrap();
     assert_eq!(
-        definition.as_table_config().key_strategy,
+        definition
+            .as_table_config(bitrouter_sdk::config::PolicyRuntimeMode::Frozen)
+            .key_strategy,
         bitrouter_sdk::config::PolicyKeyStrategy::AgentTrace
     );
     assert!(

--- a/crates/bitrouter-sdk/src/config/mod.rs
+++ b/crates/bitrouter-sdk/src/config/mod.rs
@@ -185,22 +185,38 @@ pub struct PolicyConfig {
     /// directory containing the parsed `bitrouter.yaml`. `None` means the
     /// sibling `policy-lock.yaml` default.
     pub path: Option<PathBuf>,
-    /// Whether the optimizer may publish an evolved policy lock. Loading an
-    /// operator or Git-authored update is allowed in both modes.
-    pub writeback: PolicyWriteback,
+    /// Runtime authority for adaptive routing and active policy publication.
+    /// `writeback` is accepted as a migration alias for older configuration.
+    #[serde(alias = "writeback")]
+    pub mode: PolicyRuntimeMode,
 }
 
-/// Permission for programmatic policy-lock publication.
+/// Process-owned routing-policy behavior.
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize, Serialize, schemars::JsonSchema,
 )]
 #[serde(rename_all = "snake_case")]
-pub enum PolicyWriteback {
-    /// Observe and propose, but never write `policy-lock.yaml`.
+pub enum PolicyRuntimeMode {
+    /// Route from the static lock while continuing to record evidence. Learned
+    /// database state cannot affect live routing or replace the active lock.
     #[default]
-    Locked,
-    /// Permit validated evolution output to atomically replace the lock file.
-    Evolve,
+    #[serde(alias = "locked")]
+    Frozen,
+    /// Permit adequacy state to affect routing and validated evolution output
+    /// to atomically replace the active lock.
+    #[serde(alias = "evolve")]
+    Adaptive,
+}
+
+impl PolicyRuntimeMode {
+    /// Derive the effective learner switches from process mode. The lock keeps
+    /// thresholds and tier names, but cannot activate or freeze the learner.
+    pub fn apply_to_adequacy(self, configured: &AdequacyConfig) -> AdequacyConfig {
+        let mut effective = configured.clone();
+        effective.enabled = self == Self::Adaptive;
+        effective.explore_enabled = effective.enabled && effective.explore_tier.is_some();
+        effective
+    }
 }
 
 /// Default base URL for the public registry distribution artifacts — the raw
@@ -344,7 +360,7 @@ impl schemars::JsonSchema for PolicyKeyStrategy {
 
 /// Online adequacy-learning settings — the `policy_table.adequacy` block.
 ///
-/// When [`enabled`](Self::enabled), the daemon watches every request a downgrade
+/// In adaptive process mode, the daemon watches every request a downgrade
 /// produced and counts the ones that hard-fail (an upstream error or a stream
 /// error). Once a fingerprint accumulates
 /// [`escalation_threshold`](Self::escalation_threshold) such failures it is
@@ -357,9 +373,10 @@ impl schemars::JsonSchema for PolicyKeyStrategy {
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, schemars::JsonSchema)]
 #[serde(default)]
 pub struct AdequacyConfig {
-    /// Whether online adequacy learning is active. Off by default, so a
-    /// `policy_table:` with no `adequacy:` block behaves exactly as the static
-    /// table.
+    /// Legacy input compatibility only. Effective activation is derived from
+    /// [`PolicyConfig::mode`] and this field is omitted from new output.
+    #[serde(skip_serializing)]
+    #[schemars(skip)]
     pub enabled: bool,
     /// Tier a pinned fingerprint escalates to. When unset, falls back to
     /// [`PolicyTableConfig::default_tier`]. Must resolve to a defined tier when
@@ -386,16 +403,19 @@ pub struct AdequacyConfig {
     /// Seconds an open provider circuit waits before admitting exactly one
     /// half-open probe. Default `300`.
     pub reliability_cooldown_secs: u64,
-    /// Aggressive downgrade *discovery*: when [`explore_enabled`](Self::explore_enabled)
-    /// is on, the daemon periodically trials [`explore_tier`](Self::explore_tier)
+    /// Aggressive downgrade *discovery*: in adaptive process mode, the daemon
+    /// periodically trials [`explore_tier`](Self::explore_tier)
     /// on fingerprints the static table routes to the escalation tier (i.e. ones
     /// the operator did *not* downgrade), and locks a fingerprint to the cheap
     /// tier once it survives [`explore_threshold`](Self::explore_threshold)
     /// trials — so safe downgrades are found automatically rather than only
     /// hand-configured. A trial that fails escalates and stops (the same pin as
-    /// the safety path). Off by default; requires `enabled`. This is the
-    /// *aggressive* half — it routes traffic the operator left at the capable
-    /// tier to a cheaper one on a fraction of requests.
+    /// the safety path). This is the *aggressive* half — it routes traffic the
+    /// operator left at the capable tier to a cheaper one on a fraction of
+    /// requests. Legacy input is accepted, but process mode is authoritative
+    /// and this field is omitted from new output.
+    #[serde(skip_serializing)]
+    #[schemars(skip)]
     pub explore_enabled: bool,
     /// The cheap tier exploration trials toward. Must resolve to a defined tier
     /// when [`explore_enabled`](Self::explore_enabled). Required to explore.
@@ -1330,7 +1350,13 @@ where
 /// a configuration error rather than a silent fall-through to the caller's
 /// model. A section with no tiers is inert and validates trivially.
 fn validate_policy_table(config: &Config) -> Result<()> {
-    validate_policy_table_config(&config.policy_table)
+    // Legacy activation fields remain accepted as input during migration, so
+    // reject contradictory declarations before process mode overrides them.
+    // Then validate the configuration BitRouter will actually run.
+    validate_policy_table_config(&config.policy_table)?;
+    let mut effective = config.policy_table.clone();
+    effective.adequacy = config.policy.mode.apply_to_adequacy(&effective.adequacy);
+    validate_policy_table_config(&effective)
 }
 
 /// Validate one policy-table definition independently of the top-level config.

--- a/crates/bitrouter-sdk/src/config/tests.rs
+++ b/crates/bitrouter-sdk/src/config/tests.rs
@@ -527,6 +527,76 @@ fn auto_router_template_resolves_auto_and_cost_variant() {
 }
 
 #[test]
+fn policy_runtime_mode_defaults_to_frozen() -> crate::Result<()> {
+    let config = parse("")?;
+    let policy = serde_json::to_value(&config.policy)
+        .map_err(|error| crate::BitrouterError::internal(error.to_string()))?;
+
+    assert_eq!(policy["mode"], "frozen");
+    assert!(policy.get("writeback").is_none());
+    Ok(())
+}
+
+#[test]
+fn policy_runtime_mode_accepts_adaptive_and_legacy_writeback_values() -> crate::Result<()> {
+    for (yaml, expected) in [
+        ("policy:\n  mode: adaptive\n", "adaptive"),
+        ("policy:\n  writeback: locked\n", "frozen"),
+        ("policy:\n  writeback: evolve\n", "adaptive"),
+    ] {
+        let config = parse(yaml)?;
+        let policy = serde_json::to_value(&config.policy)
+            .map_err(|error| crate::BitrouterError::internal(error.to_string()))?;
+        assert_eq!(policy["mode"], expected, "yaml: {yaml}");
+        assert!(policy.get("writeback").is_none(), "yaml: {yaml}");
+    }
+    Ok(())
+}
+
+#[test]
+fn policy_runtime_mode_controls_effective_adequacy_flags() -> crate::Result<()> {
+    let config = AdequacyConfig {
+        enabled: false,
+        explore_enabled: false,
+        explore_tier: Some("economy".to_string()),
+        ..AdequacyConfig::default()
+    };
+
+    let frozen = PolicyRuntimeMode::Frozen.apply_to_adequacy(&config);
+    assert!(!frozen.enabled);
+    assert!(!frozen.explore_enabled);
+
+    let adaptive = PolicyRuntimeMode::Adaptive.apply_to_adequacy(&config);
+    assert!(adaptive.enabled);
+    assert!(adaptive.explore_enabled);
+
+    let without_explore_tier =
+        PolicyRuntimeMode::Adaptive.apply_to_adequacy(&AdequacyConfig::default());
+    assert!(without_explore_tier.enabled);
+    assert!(!without_explore_tier.explore_enabled);
+    Ok(())
+}
+
+#[test]
+fn adaptive_runtime_mode_validates_effective_legacy_policy_table() {
+    let error = parse(
+        r#"
+policy:
+  mode: adaptive
+policy_table:
+  tiers:
+    economy: vendor:economy
+  default_tier: null
+  adequacy:
+    enabled: false
+"#,
+    )
+    .unwrap_err();
+
+    assert!(error.to_string().contains("no escalation target"));
+}
+
+#[test]
 fn parses_multi_account_provider() {
     let yaml = r#"
 providers:

--- a/dist/schema/bitrouter.config.schema.json
+++ b/dist/schema/bitrouter.config.schema.json
@@ -96,7 +96,7 @@
       "$ref": "#/$defs/PolicyConfig",
       "default": {
         "path": null,
-        "writeback": "locked"
+        "mode": "frozen"
       }
     },
     "policy_table": {
@@ -110,7 +110,6 @@
         "tool_use_tier": null,
         "tool_safe_tiers": [],
         "adequacy": {
-          "enabled": false,
           "escalation_tier": null,
           "escalation_threshold": 1,
           "pin_cooldown_secs": 1800,
@@ -118,7 +117,6 @@
           "reliability_consecutive_failures": 2,
           "reliability_error_rate_percent": 35,
           "reliability_cooldown_secs": 300,
-          "explore_enabled": false,
           "explore_tier": null,
           "explore_interval": 5,
           "explore_threshold": 3,
@@ -1609,25 +1607,25 @@
           ],
           "default": null
         },
-        "writeback": {
-          "description": "Whether the optimizer may publish an evolved policy lock. Loading an\noperator or Git-authored update is allowed in both modes.",
-          "$ref": "#/$defs/PolicyWriteback",
-          "default": "locked"
+        "mode": {
+          "description": "Runtime authority for adaptive routing and active policy publication.\n`writeback` is accepted as a migration alias for older configuration.",
+          "$ref": "#/$defs/PolicyRuntimeMode",
+          "default": "frozen"
         }
       }
     },
-    "PolicyWriteback": {
-      "description": "Permission for programmatic policy-lock publication.",
+    "PolicyRuntimeMode": {
+      "description": "Process-owned routing-policy behavior.",
       "oneOf": [
         {
-          "description": "Observe and propose, but never write `policy-lock.yaml`.",
+          "description": "Route from the static lock while continuing to record evidence. Learned\ndatabase state cannot affect live routing or replace the active lock.",
           "type": "string",
-          "const": "locked"
+          "const": "frozen"
         },
         {
-          "description": "Permit validated evolution output to atomically replace the lock file.",
+          "description": "Permit adequacy state to affect routing and validated evolution output\nto atomically replace the active lock.",
           "type": "string",
-          "const": "evolve"
+          "const": "adaptive"
         }
       ]
     },
@@ -1684,7 +1682,6 @@
           "description": "Online adequacy learning. When enabled, the daemon observes each\ndowngraded request's outcome and, after repeated failures, escalates the\noffending fingerprint to a more capable tier — so an operator's downgrade\nthat proves inadequate is self-correcting. Off by default.",
           "$ref": "#/$defs/AdequacyConfig",
           "default": {
-            "enabled": false,
             "escalation_tier": null,
             "escalation_threshold": 1,
             "pin_cooldown_secs": 1800,
@@ -1692,7 +1689,6 @@
             "reliability_consecutive_failures": 2,
             "reliability_error_rate_percent": 35,
             "reliability_cooldown_secs": 300,
-            "explore_enabled": false,
             "explore_tier": null,
             "explore_interval": 5,
             "explore_threshold": 3,
@@ -1711,14 +1707,9 @@
       ]
     },
     "AdequacyConfig": {
-      "description": "Online adequacy-learning settings — the `policy_table.adequacy` block.\n\nWhen [`enabled`](Self::enabled), the daemon watches every request a downgrade\nproduced and counts the ones that hard-fail (an upstream error or a stream\nerror). Once a fingerprint accumulates\n[`escalation_threshold`](Self::escalation_threshold) such failures it is\n*pinned*: subsequent requests with that fingerprint route to\n[`escalation_tier`](Self::escalation_tier) instead of the cheap tier the\nstatic table would pick. A pin decays after\n[`pin_cooldown_secs`](Self::pin_cooldown_secs) so the downgrade is re-tried\nlater. This is a safety net layered on the static table — it never downgrades\non its own, only escalates a downgrade that is failing.",
+      "description": "Online adequacy-learning settings — the `policy_table.adequacy` block.\n\nIn adaptive process mode, the daemon watches every request a downgrade\nproduced and counts the ones that hard-fail (an upstream error or a stream\nerror). Once a fingerprint accumulates\n[`escalation_threshold`](Self::escalation_threshold) such failures it is\n*pinned*: subsequent requests with that fingerprint route to\n[`escalation_tier`](Self::escalation_tier) instead of the cheap tier the\nstatic table would pick. A pin decays after\n[`pin_cooldown_secs`](Self::pin_cooldown_secs) so the downgrade is re-tried\nlater. This is a safety net layered on the static table — it never downgrades\non its own, only escalates a downgrade that is failing.",
       "type": "object",
       "properties": {
-        "enabled": {
-          "description": "Whether online adequacy learning is active. Off by default, so a\n`policy_table:` with no `adequacy:` block behaves exactly as the static\ntable.",
-          "type": "boolean",
-          "default": false
-        },
         "escalation_tier": {
           "description": "Tier a pinned fingerprint escalates to. When unset, falls back to\n[`PolicyTableConfig::default_tier`]. Must resolve to a defined tier when\n[`enabled`](Self::enabled).",
           "type": [
@@ -1768,11 +1759,6 @@
           "format": "uint64",
           "minimum": 0,
           "default": 300
-        },
-        "explore_enabled": {
-          "description": "Aggressive downgrade *discovery*: when [`explore_enabled`](Self::explore_enabled)\nis on, the daemon periodically trials [`explore_tier`](Self::explore_tier)\non fingerprints the static table routes to the escalation tier (i.e. ones\nthe operator did *not* downgrade), and locks a fingerprint to the cheap\ntier once it survives [`explore_threshold`](Self::explore_threshold)\ntrials — so safe downgrades are found automatically rather than only\nhand-configured. A trial that fails escalates and stops (the same pin as\nthe safety path). Off by default; requires `enabled`. This is the\n*aggressive* half — it routes traffic the operator left at the capable\ntier to a cheaper one on a fraction of requests.",
-          "type": "boolean",
-          "default": false
         },
         "explore_tier": {
           "description": "The cheap tier exploration trials toward. Must resolve to a defined tier\nwhen [`explore_enabled`](Self::explore_enabled). Required to explore.",

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -320,6 +320,27 @@ Routed sub-agents authenticate with `BITROUTER_API_KEY` when set, else a local p
 
 In `-p` mode the **first** NDJSON line is a `session` correlation line — `{"type":"session","record_id":"…","agent":"…","via":"http://127.0.0.1:4356"}` (`via` is `null` when `--direct`) — followed by the normal update stream and a terminal `result` line.
 
+### `bitrouter policy`
+
+```text
+bitrouter policy init NAME --preset PRESET --economy MODEL [--strong MODEL]
+bitrouter policy check|status|show [--config PATH]
+bitrouter policy evolve [--config PATH] [--apply | --output FILE]
+bitrouter policy reload [--config PATH] [--socket PATH]
+```
+
+The BitRouter process, not the policy lock, owns adaptive behavior:
+
+```yaml
+policy:
+  path: ./policy-lock.yaml
+  mode: frozen # or adaptive
+```
+
+`frozen` is the safe default. Live routes use the static lock while BitRouter continues to record observations and rewards; database-learned routes cannot affect requests or replace the lock. Dry-run evolution and candidate export remain available. `adaptive` enables configured exploration and learned pins, and permits validated `policy evolve --apply` publication.
+
+The lock contains deterministic routes, tiers, and learning thresholds, but no activation or freeze switch. Older `policy.writeback: locked|evolve` input remains readable as `frozen|adaptive`; newly written configuration uses `policy.mode`. The old `policy lock`, `policy unlock`, and `policy evolve --freeze` surfaces have been removed.
+
 ### `bitrouter key sign`
 
 ```

--- a/skills/bitrouter/references/adaptive-routing.md
+++ b/skills/bitrouter/references/adaptive-routing.md
@@ -17,6 +17,12 @@ bitrouter config validate --config bitrouter.yaml
 bitrouter serve --config bitrouter.yaml
 ```
 
+The starter runs with `policy.mode: frozen`. That process mode keeps routing
+deterministic and forbids active lock replacement while telemetry and reward
+evidence continue to accumulate. Change the main config to
+`policy.mode: adaptive` for an evolution run. The lock itself never selects the
+runtime mode.
+
 ## Route inputs and safety
 
 The lock uses `key_strategy: agent_trace`. It routes the generic normal
@@ -38,9 +44,9 @@ diagnostic-only and the parser rejects that setting.
 ## Evaluation and publication
 
 Treat the starter as a baseline. Evaluate it against representative traffic,
-then review generated candidates before publication. A frozen lock is
-deterministic and can be checked or reloaded without permitting programmatic
-replacement:
+then review generated candidates before publication. A process running in
+frozen mode is deterministic and can check, export, or reload a lock without
+permitting programmatic replacement:
 
 ```bash
 bitrouter policy check --config bitrouter.yaml

--- a/skills/bitrouter/references/cli.md
+++ b/skills/bitrouter/references/cli.md
@@ -71,11 +71,10 @@ See `references/sessions.md` for the full per-session model (identity, turn queu
 | `bitrouter init [flags]` | Guided onboarding wizard: **credentials** → **harness** → **finish** (launch / serve+snippet / exit). Interactive by default; `--yes` runs it headlessly — process the flags below, never block on a human, emit the JSON result envelope (`action: onboarding`, `providers_configured`, `providers_skipped_interactive`, `harnesses_installed`, `after`, `snippet`), and scaffold the starter `bitrouter.yaml` (`skip_auth: true`, `listen: 127.0.0.1:4356`, common providers stubbed `{}`). The scaffold refuses to overwrite unless `--force`; `--reset` clears stored credentials first (cloud session always, provider creds after a confirm / unconditionally under `--yes`). Flags mirror every prompt: `--cloud-login`, `--api-key <brk_…>` (cloud), `--provider <id>` + `--provider-api-key <k>` (repeatable), `--use-detected`, `--harness claude\|codex` (repeatable), `--no-install`, `--after launch\|serve\|exit`, `--model <id>`, `--write-config`, `-c/--config PATH`. Under `--yes`, anything needing interactive OAuth (bare `--cloud-login`, a `--provider` with no key) is reported in `providers_skipped_interactive`, not attempted. |
 | `bitrouter config validate [--config PATH]` | Validate a config file by running the real parse path: structure (deserialization), `derives` resolution, the upstream-URL (SSRF) gate, and any referenced `policy-lock.yaml`. Exits non-zero on an invalid config — **CI-safe**. Does *not* load the JSON Schema (that artifact, at `dist/schema/bitrouter.config.schema.json` / regenerated with `cargo run -p dist-helper -- generate-schema`, is for IDE autocomplete + the drift check). Unset `${VAR}` references are substituted with a `.invalid` placeholder and reported as warnings, so secrets need not be present; a value that embeds one mid-string is not authoritatively checked. |
 | `bitrouter policy create <id> [--dir DIR]` | Write a starter access-control policy file under `--dir` (default `./policies`). Bind to a key with `bitrouter key sign --user <id> --policy <id>`. |
-| `bitrouter policy init <name> --preset <preset> --economy <model> [--strong <model>] [--config PATH]` | Create or extend the deterministic `policy-lock.yaml`, bind the named policy to a preset, and leave programmatic writeback locked. The strong model is inferred from an existing preset when omitted. Presets use `@preset[:variant]`; `templates/auto-router` provides `@auto` and `@auto:cost`. |
-| `bitrouter policy check|status [--config PATH]` | Cross-validate the main config and lock, or report the resolved path, semantic digest, writeback mode, policies, and preset bindings. |
+| `bitrouter policy init <name> --preset <preset> --economy <model> [--strong <model>] [--config PATH]` | Create or extend deterministic `policy-lock.yaml`, bind the named policy to a preset, and set the process configuration to `policy.mode: frozen`. The strong model is inferred from an existing preset when omitted. Presets use `@preset[:variant]`; `templates/auto-router` provides `@auto` and `@auto:cost`. |
+| `bitrouter policy check|status [--config PATH]` | Cross-validate the main config and lock, or report the resolved path, semantic digest, runtime mode, policies, and preset bindings. |
 | `bitrouter policy show <name> [--config PATH]` | Print one validated effective policy. |
-| `bitrouter policy evolve [--apply \| --output FILE [--freeze]] [--config PATH]` | Project policy-namespaced adequacy evidence into a deterministic candidate. Dry-run by default; `--apply` requires writeback to be unlocked. `--output` writes a separate atomic candidate while locked and refuses the active lock path; `--freeze` disables the adequacy learner and future exploration after materializing qualified routes. Existing routes are never overwritten or removed. |
-| `bitrouter policy lock|unlock [--config PATH]` | Forbid or permit programmatic replacement of `policy-lock.yaml`. Manual/Git edits and reload remain allowed while locked. |
+| `bitrouter policy evolve [--apply \| --output FILE] [--config PATH]` | Project policy-namespaced adequacy evidence into a deterministic candidate. Dry-run and separate candidate export work in both modes; `--apply` requires `policy.mode: adaptive`. Candidate export refuses the active lock path. Existing routes are never overwritten or removed. |
 | `bitrouter policy reload [--config PATH] [--socket PATH]` | Hot-reload main config and policy lock through the existing daemon control socket. Invalid locks preserve the last-known-good runtime snapshot. |
 | `bitrouter key sign --user <id> [--db URL] [--policy ID]` | Mint a `brvk_…` virtual key in the auth DB. Plaintext is shown once; only its SHA-256 hash is stored. Default DB is `sqlite://./bitrouter.db`. |
 
@@ -89,6 +88,13 @@ uses `agent_trace`. `adequacy.explore_opening: true` enables exploration for
 source-neutral opening projections. The removed
 `adequacy.max_downgraded_requests_per_session` setting is rejected because
 session identity is diagnostic-only.
+
+`policy.mode` belongs to the running process and defaults to `frozen`. Frozen
+mode ignores adequacy DB pins and locks for live routing and forbids active
+lock replacement while continuing to record evidence. `adaptive` activates
+the configured adequacy thresholds and permits validated writeback. Legacy
+`writeback: locked|evolve` input parses as `frozen|adaptive`, but new config and
+status output use only `mode`.
 
 ## Per-provider OAuth
 

--- a/templates/auto-router/README.md
+++ b/templates/auto-router/README.md
@@ -11,11 +11,19 @@ Start BitRouter from this directory:
 bitrouter serve --config bitrouter.yaml
 ```
 
+The template starts in `policy.mode: frozen`: routes are deterministic, learned
+database state cannot change live decisions, and BitRouter will not replace the
+active lock. Traces, metering, decisions, reward feedback, dry-runs, and
+separate candidate exports remain available. Set `policy.mode: adaptive` in
+`bitrouter.yaml` for an evolution run; the process mode, not the lock artifact,
+then enables exploration, pins, learned routes, and `policy evolve --apply`.
+
 Use `@auto` for the strong base policy, or `@auto:cost` to add the top-level
 cost routing variant. Physical model ids remain passthrough, so an explicit
 `openai-codex:gpt-5.6-sol` request is not converted to a preset.
 
-The lock uses the generic `agent_trace` key strategy. Runtime adapters can
+The lock uses the generic `agent_trace` key strategy. It contains routing and
+learner thresholds, but no activation/freeze switch. Runtime adapters can
 enrich diagnostics from native request shapes, but do not supply policy keys.
 No private BitRouter headers are required. The strong/economy tool capability
 guardrails remain in the lock, so a request only uses economy when its route

--- a/templates/auto-router/bitrouter.yaml
+++ b/templates/auto-router/bitrouter.yaml
@@ -14,7 +14,7 @@ providers:
 inherit_defaults: true
 policy:
   path: "./policy-lock.yaml"
-  writeback: locked
+  mode: frozen
 presets:
   auto:
     model: "openai-codex:gpt-5.6-sol"

--- a/templates/auto-router/policy-lock.yaml
+++ b/templates/auto-router/policy-lock.yaml
@@ -15,11 +15,9 @@ policies:
       - strong
       - economy
     adequacy:
-      enabled: false
       escalation_tier: strong
       escalation_threshold: 1
       pin_cooldown_secs: 0
-      explore_enabled: false
       explore_tier: economy
       explore_interval: 1
       explore_threshold: 1


### PR DESCRIPTION
## Summary

- make `policy.mode: frozen|adaptive` the process-owned authority for live policy behavior
- keep policy locks limited to deterministic routes, tiers, and learning thresholds
- make frozen mode ignore learned DB routes and reject active writeback while retaining observation, reward, dry-run, and candidate-export paths
- migrate the policy CLI, starter template, docs, skill references, and generated schema
- accept legacy `policy.writeback: locked|evolve` input while emitting only the new mode vocabulary

## CLI migration

- remove `bitrouter policy lock|unlock`
- remove `bitrouter policy evolve --freeze`
- switch modes by editing `policy.mode` in `bitrouter.yaml`; reload or restart BitRouter to apply it

## Verification

- `cargo test --all-features`
- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo fmt -- --check`
- `cargo run -p dist-helper -- check`
