### PR TITLE
feat(registry): add Opus 5 and refresh providers

### DIFF
--- a/dist/registry/models.json
+++ b/dist/registry/models.json
@@ -703,6 +703,144 @@
       "release_date": "2026-05-28"
     },
     {
+      "description": "Anthropic's Claude Opus 5.",
+      "family": "claude-opus",
+      "id": "anthropic/claude-opus-5",
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "knowledge_cutoff": "2026-05-31",
+      "max_input_tokens": 1000000,
+      "max_output_tokens": 128000,
+      "name": "Anthropic: Claude Opus 5",
+      "open_weights": false,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": "anthropic",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider": "anthropic",
+          "provider_model_id": "claude-opus-5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider": "atlascloud",
+          "provider_model_id": "anthropic/claude-opus-5-ccmax"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider": "aws-bedrock",
+          "provider_model_id": "anthropic.claude-opus-5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider": "azure",
+          "provider_model_id": "claude-opus-5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "anthropic",
+          "provider": "claude-code",
+          "provider_model_id": "claude-opus-5"
+        },
+        {
+          "api_protocol": "openai",
+          "provider": "github-copilot",
+          "provider_model_id": "claude-opus-5"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider": "opencode-zen",
+          "provider_model_id": "claude-opus-5"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "anthropic/claude-opus-5"
+        }
+      ],
+      "release_date": "2026-07-24"
+    },
+    {
       "description": "Anthropic's Claude Sonnet 4.6.",
       "family": "claude-sonnet",
       "id": "anthropic/claude-sonnet-4.6",
@@ -1108,11 +1246,11 @@
           ],
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.14,
-              "no_cache": 0.28
+              "cache_read": 0.5,
+              "no_cache": 1.0
             },
             "output_tokens": {
-              "text": 0.42
+              "text": 1.0
             }
           },
           "provider": "chutes",
@@ -1143,10 +1281,11 @@
           ],
           "pricing": {
             "input_tokens": {
-              "no_cache": 0.2288
+              "cache_read": 0.1345,
+              "no_cache": 0.269
             },
             "output_tokens": {
-              "text": 0.3432
+              "text": 0.4
             }
           },
           "provider": "openrouter",
@@ -1381,7 +1520,7 @@
           ],
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.028,
+              "cache_read": 0.0028,
               "no_cache": 0.14
             },
             "output_tokens": {
@@ -1449,11 +1588,11 @@
           ],
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.02,
-              "no_cache": 0.09
+              "cache_read": 0.028,
+              "no_cache": 0.14
             },
             "output_tokens": {
-              "text": 0.18
+              "text": 0.28
             }
           },
           "provider": "openrouter",
@@ -1480,11 +1619,11 @@
           "api_protocol": "openai",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.0197,
-              "no_cache": 0.0983
+              "cache_read": 0.028,
+              "no_cache": 0.14
             },
             "output_tokens": {
-              "text": 0.1966
+              "text": 0.28
             }
           },
           "provider": "qianfan",
@@ -1693,11 +1832,11 @@
           ],
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.145,
-              "no_cache": 1.74
+              "cache_read": 0.003625,
+              "no_cache": 0.435
             },
             "output_tokens": {
-              "text": 3.48
+              "text": 0.87
             }
           },
           "provider": "deepseek",
@@ -2936,11 +3075,11 @@
           ],
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.12,
-              "no_cache": 0.6
+              "cache_read": 0.06,
+              "no_cache": 0.3
             },
             "output_tokens": {
-              "text": 2.4
+              "text": 1.2
             }
           },
           "provider": "minimax",
@@ -2956,11 +3095,11 @@
           ],
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.12,
-              "no_cache": 0.6
+              "cache_read": 0.06,
+              "no_cache": 0.3
             },
             "output_tokens": {
-              "text": 2.4
+              "text": 1.2
             }
           },
           "provider": "minimax_cn",
@@ -3279,10 +3418,11 @@
           ],
           "pricing": {
             "input_tokens": {
-              "no_cache": 0.375
+              "cache_read": 0.095,
+              "no_cache": 0.57
             },
             "output_tokens": {
-              "text": 2.025
+              "text": 2.85
             }
           },
           "provider": "openrouter",
@@ -3487,11 +3627,11 @@
           ],
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.475,
-              "no_cache": 0.95
+              "cache_read": 0.33,
+              "no_cache": 0.66
             },
             "output_tokens": {
-              "text": 4.0
+              "text": 3.5
             }
           },
           "provider": "chutes",
@@ -3580,11 +3720,11 @@
           ],
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.144,
-              "no_cache": 0.66
+              "cache_read": 0.0992,
+              "no_cache": 0.589
             },
             "output_tokens": {
-              "text": 3.41
+              "text": 2.48
             }
           },
           "provider": "openrouter",
@@ -3612,11 +3752,11 @@
           "api_protocol": "openai",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.144,
-              "no_cache": 0.684
+              "cache_read": 0.16,
+              "no_cache": 0.95
             },
             "output_tokens": {
-              "text": 3.42
+              "text": 4.0
             }
           },
           "provider": "qianfan",
@@ -3765,10 +3905,11 @@
           ],
           "pricing": {
             "input_tokens": {
-              "no_cache": 0.84
+              "cache_read": 0.15,
+              "no_cache": 0.73
             },
             "output_tokens": {
-              "text": 3.99
+              "text": 3.5
             }
           },
           "provider": "ambient",
@@ -3885,11 +4026,11 @@
           ],
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.1296,
-              "no_cache": 0.612
+              "cache_read": 0.15,
+              "no_cache": 0.73
             },
             "output_tokens": {
-              "text": 3.069
+              "text": 3.5
             }
           },
           "provider": "openrouter",
@@ -4013,6 +4154,46 @@
             }
           },
           "provider": "openrouter",
+          "provider_model_id": "moonshotai/kimi-k3"
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools",
+            "image_input"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 1.5,
+              "no_cache": 3.0
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider": "phala",
+          "provider_model_id": "moonshotai/kimi-k3"
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools",
+            "image_input"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 1.5,
+              "no_cache": 3.0
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider": "redpill",
           "provider_model_id": "moonshotai/kimi-k3"
         }
       ],
@@ -4487,12 +4668,12 @@
           ],
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.1,
-              "cache_write": 1.25,
-              "no_cache": 1.0
+              "cache_read": 0.022,
+              "cache_write": 0.275,
+              "no_cache": 0.22
             },
             "output_tokens": {
-              "text": 6.0
+              "text": 1.32
             }
           },
           "provider": "aws-bedrock",
@@ -4508,11 +4689,11 @@
           ],
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.1,
-              "no_cache": 1.0
+              "cache_read": 0.02,
+              "no_cache": 0.2
             },
             "output_tokens": {
-              "text": 6.0
+              "text": 1.2
             }
           },
           "provider": "azure",
@@ -4571,12 +4752,12 @@
               }
             ],
             "input_tokens": {
-              "cache_read": 0.1,
-              "cache_write": 1.25,
-              "no_cache": 1.0
+              "cache_read": 0.02,
+              "cache_write": 0.25,
+              "no_cache": 0.2
             },
             "output_tokens": {
-              "text": 6.0
+              "text": 1.2
             }
           },
           "provider": "openai",
@@ -4596,14 +4777,19 @@
         },
         {
           "api_protocol": "openai",
+          "provider": "opencode-go",
+          "provider_model_id": "gpt-5.6-luna"
+        },
+        {
+          "api_protocol": "openai",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.1,
-              "cache_write": 1.25,
-              "no_cache": 1.0
+              "cache_read": 0.02,
+              "cache_write": 0.25,
+              "no_cache": 0.2
             },
             "output_tokens": {
-              "text": 6.0
+              "text": 1.2
             }
           },
           "provider": "opencode-zen",
@@ -4617,12 +4803,12 @@
           ],
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.1,
-              "cache_write": 1.25,
-              "no_cache": 1.0
+              "cache_read": 0.01,
+              "cache_write": 0.125,
+              "no_cache": 0.1
             },
             "output_tokens": {
-              "text": 6.0
+              "text": 0.6
             }
           },
           "provider": "openrouter",
@@ -4654,12 +4840,12 @@
           ],
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.5,
-              "cache_write": 6.25,
-              "no_cache": 5.0
+              "cache_read": 0.55,
+              "cache_write": 6.88,
+              "no_cache": 5.5
             },
             "output_tokens": {
-              "text": 30.0
+              "text": 33.0
             }
           },
           "provider": "aws-bedrock",
@@ -4821,12 +5007,12 @@
           ],
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.25,
-              "cache_write": 3.125,
-              "no_cache": 2.5
+              "cache_read": 0.22,
+              "cache_write": 2.75,
+              "no_cache": 2.2
             },
             "output_tokens": {
-              "text": 15.0
+              "text": 13.2
             }
           },
           "provider": "aws-bedrock",
@@ -4842,11 +5028,11 @@
           ],
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.25,
-              "no_cache": 2.5
+              "cache_read": 0.2,
+              "no_cache": 2.0
             },
             "output_tokens": {
-              "text": 15.0
+              "text": 12.0
             }
           },
           "provider": "azure",
@@ -4905,12 +5091,12 @@
               }
             ],
             "input_tokens": {
-              "cache_read": 0.25,
-              "cache_write": 3.125,
-              "no_cache": 2.5
+              "cache_read": 0.2,
+              "cache_write": 2.5,
+              "no_cache": 2.0
             },
             "output_tokens": {
-              "text": 15.0
+              "text": 12.0
             }
           },
           "provider": "openai",
@@ -4951,12 +5137,12 @@
           ],
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.25,
-              "cache_write": 3.125,
-              "no_cache": 2.5
+              "cache_read": 0.1,
+              "cache_write": 1.25,
+              "no_cache": 1.0
             },
             "output_tokens": {
-              "text": 15.0
+              "text": 6.0
             }
           },
           "provider": "openrouter",
@@ -5239,10 +5425,10 @@
           "pricing": {
             "input_tokens": {
               "cache_read": 0.15,
-              "no_cache": 0.285
+              "no_cache": 0.3
             },
             "output_tokens": {
-              "text": 2.4
+              "text": 2.0
             }
           },
           "provider": "openrouter",
@@ -5394,10 +5580,11 @@
               }
             ],
             "input_tokens": {
-              "no_cache": 0.25
+              "cache_write": 0.234375,
+              "no_cache": 0.1875
             },
             "output_tokens": {
-              "text": 1.5
+              "text": 1.125
             }
           },
           "provider": "alibaba",
@@ -5425,10 +5612,11 @@
               }
             ],
             "input_tokens": {
-              "no_cache": 0.165
+              "cache_write": 0.234375,
+              "no_cache": 0.1875
             },
             "output_tokens": {
-              "text": 0.99
+              "text": 1.125
             }
           },
           "provider": "alibaba_cn",
@@ -5501,6 +5689,8 @@
           ],
           "pricing": {
             "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 3.125,
               "no_cache": 2.5
             },
             "output_tokens": {
@@ -5521,10 +5711,12 @@
           ],
           "pricing": {
             "input_tokens": {
-              "no_cache": 1.65
+              "cache_read": 0.5,
+              "cache_write": 3.125,
+              "no_cache": 2.5
             },
             "output_tokens": {
-              "text": 4.951
+              "text": 7.5
             }
           },
           "provider": "alibaba_cn",
@@ -5575,6 +5767,7 @@
           "pricing": {
             "input_tokens": {
               "cache_read": 0.25,
+              "cache_write": 3.125,
               "no_cache": 2.5
             },
             "output_tokens": {
@@ -5589,6 +5782,7 @@
           "pricing": {
             "input_tokens": {
               "cache_read": 0.25,
+              "cache_write": 1.5625,
               "no_cache": 1.25
             },
             "output_tokens": {
@@ -5611,12 +5805,12 @@
           ],
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.25,
-              "cache_write": 1.5625,
-              "no_cache": 1.25
+              "cache_read": 0.295,
+              "cache_write": 1.84375,
+              "no_cache": 1.475
             },
             "output_tokens": {
-              "text": 3.75
+              "text": 4.425
             }
           },
           "provider": "openrouter",
@@ -5660,10 +5854,12 @@
               }
             ],
             "input_tokens": {
-              "no_cache": 0.4
+              "cache_read": 0.05,
+              "cache_write": 0.625,
+              "no_cache": 0.5
             },
             "output_tokens": {
-              "text": 1.6
+              "text": 3.0
             }
           },
           "provider": "alibaba",
@@ -5691,10 +5887,12 @@
               }
             ],
             "input_tokens": {
-              "no_cache": 0.276
+              "cache_read": 0.05,
+              "cache_write": 0.625,
+              "no_cache": 0.5
             },
             "output_tokens": {
-              "text": 1.101
+              "text": 3.0
             }
           },
           "provider": "alibaba_cn",
@@ -5813,8 +6011,7 @@
           ],
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.02,
-              "no_cache": 0.09
+              "no_cache": 0.1
             },
             "output_tokens": {
               "text": 0.3
@@ -5860,11 +6057,11 @@
           ],
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.019,
-              "no_cache": 0.096
+              "cache_read": 0.02,
+              "no_cache": 0.1
             },
             "output_tokens": {
-              "text": 0.288
+              "text": 0.3
             }
           },
           "provider": "stepfun",
@@ -5884,11 +6081,11 @@
           ],
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.019,
-              "no_cache": 0.096
+              "cache_read": 0.02,
+              "no_cache": 0.1
             },
             "output_tokens": {
-              "text": 0.288
+              "text": 0.3
             }
           },
           "provider": "stepfun_cn",
@@ -5948,12 +6145,12 @@
           "api_protocol": "openai",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.04,
+              "cache_read": 0.03,
               "cache_write": 0.0,
-              "no_cache": 0.2
+              "no_cache": 0.19
             },
             "output_tokens": {
-              "text": 1.15
+              "text": 1.14
             }
           },
           "provider": "ambient",
@@ -6004,11 +6201,11 @@
           ],
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.04,
-              "no_cache": 0.2
+              "cache_read": 0.037,
+              "no_cache": 0.185
             },
             "output_tokens": {
-              "text": 1.15
+              "text": 1.11
             }
           },
           "provider": "stepfun",
@@ -6027,11 +6224,11 @@
           ],
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.04,
-              "no_cache": 0.2
+              "cache_read": 0.037,
+              "no_cache": 0.185
             },
             "output_tokens": {
-              "text": 1.15
+              "text": 1.11
             }
           },
           "provider": "stepfun_cn",
@@ -6111,11 +6308,11 @@
           ],
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.5,
-              "no_cache": 0.2
+              "cache_read": 0.033,
+              "no_cache": 0.132
             },
             "output_tokens": {
-              "text": 0.8
+              "text": 0.528
             }
           },
           "provider": "openrouter",
@@ -6529,7 +6726,7 @@
           ],
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.5,
+              "cache_read": 0.3,
               "no_cache": 2.0
             },
             "output_tokens": {
@@ -6562,7 +6759,7 @@
           ],
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.5,
+              "cache_read": 0.3,
               "no_cache": 2.0
             },
             "output_tokens": {
@@ -6756,11 +6953,11 @@
           ],
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.08,
-              "no_cache": 0.4
+              "cache_read": 0.0028,
+              "no_cache": 0.14
             },
             "output_tokens": {
-              "text": 2.0
+              "text": 0.28
             }
           },
           "provider": "xiaomi",
@@ -6885,11 +7082,11 @@
           ],
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.2,
-              "no_cache": 1.0
+              "cache_read": 0.0036,
+              "no_cache": 0.435
             },
             "output_tokens": {
-              "text": 3.0
+              "text": 0.87
             }
           },
           "provider": "xiaomi",
@@ -7008,7 +7205,7 @@
           "api_protocol": "openai",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.0,
+              "cache_read": 2.25,
               "cache_write": 0.0,
               "no_cache": 2.25
             },
@@ -7254,11 +7451,11 @@
           ],
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.12,
-              "no_cache": 0.6
+              "cache_read": 0.2,
+              "no_cache": 0.95
             },
             "output_tokens": {
-              "text": 1.92
+              "text": 2.55
             }
           },
           "provider": "openrouter",
@@ -7468,11 +7665,11 @@
           ],
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.525,
-              "no_cache": 1.05
+              "cache_read": 0.49,
+              "no_cache": 0.98
             },
             "output_tokens": {
-              "text": 3.5
+              "text": 3.08
             }
           },
           "provider": "chutes",
@@ -7536,11 +7733,11 @@
           ],
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.182,
-              "no_cache": 0.98
+              "cache_read": 0.1794,
+              "no_cache": 0.966
             },
             "output_tokens": {
-              "text": 3.08
+              "text": 3.036
             }
           },
           "provider": "openrouter",
@@ -7568,11 +7765,11 @@
           "api_protocol": "openai",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.182,
-              "no_cache": 0.98
+              "cache_read": 0.26,
+              "no_cache": 1.4
             },
             "output_tokens": {
-              "text": 3.08
+              "text": 4.4
             }
           },
           "provider": "qianfan",
@@ -7776,9 +7973,9 @@
           "api_protocol": "openai",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.26,
+              "cache_read": 0.2,
               "cache_write": 0.0,
-              "no_cache": 1.4
+              "no_cache": 1.05
             },
             "output_tokens": {
               "text": 4.4
@@ -7873,11 +8070,11 @@
           ],
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.18,
-              "no_cache": 1.0
+              "cache_read": 0.208,
+              "no_cache": 1.12
             },
             "output_tokens": {
-              "text": 4.0
+              "text": 3.52
             }
           },
           "provider": "openrouter",
@@ -7891,7 +8088,7 @@
           ],
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.7,
+              "cache_read": 0.26,
               "no_cache": 1.4
             },
             "output_tokens": {
@@ -7905,11 +8102,11 @@
           "api_protocol": "openai",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.181,
-              "no_cache": 0.97
+              "cache_read": 0.26,
+              "no_cache": 1.4
             },
             "output_tokens": {
-              "text": 3.07
+              "text": 4.4
             }
           },
           "provider": "qianfan",
@@ -7923,7 +8120,7 @@
           ],
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.7,
+              "cache_read": 0.26,
               "no_cache": 1.4
             },
             "output_tokens": {
@@ -8011,6 +8208,7 @@
           "api_protocol": "openai",
           "pricing": {
             "input_tokens": {
+              "cache_read": 0.375,
               "no_cache": 1.5
             },
             "output_tokens": {

--- a/dist/registry/providers.json
+++ b/dist/registry/providers.json
@@ -30,6 +30,8 @@
           "id": "qwen/qwen3.7-max",
           "pricing": {
             "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 3.125,
               "no_cache": 2.5
             },
             "output_tokens": {
@@ -61,10 +63,12 @@
               }
             ],
             "input_tokens": {
-              "no_cache": 0.4
+              "cache_read": 0.05,
+              "cache_write": 0.625,
+              "no_cache": 0.5
             },
             "output_tokens": {
-              "text": 1.6
+              "text": 3.0
             }
           },
           "provider_model_id": "qwen3.7-plus",
@@ -92,6 +96,8 @@
               }
             ],
             "input_tokens": {
+              "cache_read": 0.05,
+              "cache_write": 0.625,
               "no_cache": 0.5
             },
             "output_tokens": {
@@ -123,10 +129,11 @@
               }
             ],
             "input_tokens": {
-              "no_cache": 0.25
+              "cache_write": 0.234375,
+              "no_cache": 0.1875
             },
             "output_tokens": {
-              "text": 1.5
+              "text": 1.125
             }
           },
           "provider_model_id": "qwen3.6-flash",
@@ -256,10 +263,12 @@
           "id": "qwen/qwen3.7-max",
           "pricing": {
             "input_tokens": {
-              "no_cache": 1.65
+              "cache_read": 0.5,
+              "cache_write": 3.125,
+              "no_cache": 2.5
             },
             "output_tokens": {
-              "text": 4.951
+              "text": 7.5
             }
           },
           "provider_model_id": "qwen3.7-max",
@@ -287,10 +296,12 @@
               }
             ],
             "input_tokens": {
-              "no_cache": 0.276
+              "cache_read": 0.05,
+              "cache_write": 0.625,
+              "no_cache": 0.5
             },
             "output_tokens": {
-              "text": 1.101
+              "text": 3.0
             }
           },
           "provider_model_id": "qwen3.7-plus",
@@ -318,10 +329,12 @@
               }
             ],
             "input_tokens": {
-              "no_cache": 0.276
+              "cache_read": 0.05,
+              "cache_write": 0.625,
+              "no_cache": 0.5
             },
             "output_tokens": {
-              "text": 1.651
+              "text": 3.0
             }
           },
           "provider_model_id": "qwen3.6-plus",
@@ -349,10 +362,11 @@
               }
             ],
             "input_tokens": {
-              "no_cache": 0.165
+              "cache_write": 0.234375,
+              "no_cache": 0.1875
             },
             "output_tokens": {
-              "text": 0.99
+              "text": 1.125
             }
           },
           "provider_model_id": "qwen3.6-flash",
@@ -685,10 +699,11 @@
           "id": "moonshotai/kimi-k2.7-code",
           "pricing": {
             "input_tokens": {
-              "no_cache": 0.84
+              "cache_read": 0.15,
+              "no_cache": 0.73
             },
             "output_tokens": {
-              "text": 3.99
+              "text": 3.5
             }
           },
           "provider_model_id": "moonshotai/kimi-k2.7-code",
@@ -719,9 +734,9 @@
           "id": "z-ai/glm-5.2",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.26,
+              "cache_read": 0.2,
               "cache_write": 0.0,
-              "no_cache": 1.4
+              "no_cache": 1.05
             },
             "output_tokens": {
               "text": 4.4
@@ -737,12 +752,12 @@
           "id": "stepfun/step-3.7-flash",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.04,
+              "cache_read": 0.03,
               "cache_write": 0.0,
-              "no_cache": 0.2
+              "no_cache": 0.19
             },
             "output_tokens": {
-              "text": 1.15
+              "text": 1.14
             }
           },
           "provider_model_id": "stepfun/step-3.7-flash",
@@ -998,6 +1013,24 @@
           "rate_limits": {
             "requests_per_minute": 60
           }
+        },
+        {
+          "api_protocol": "anthropic",
+          "id": "anthropic/claude-opus-5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider_model_id": "claude-opus-5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
         }
       ],
       "name": "anthropic",
@@ -1246,6 +1279,20 @@
             }
           },
           "provider_model_id": "xai/grok-4.3"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "anthropic/claude-opus-5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider_model_id": "anthropic/claude-opus-5-ccmax"
         }
       ],
       "name": "atlascloud",
@@ -1567,12 +1614,12 @@
           "id": "openai/gpt-5.6-luna",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.1,
-              "cache_write": 1.25,
-              "no_cache": 1.0
+              "cache_read": 0.022,
+              "cache_write": 0.275,
+              "no_cache": 0.22
             },
             "output_tokens": {
-              "text": 6.0
+              "text": 1.32
             }
           },
           "provider_model_id": "openai.gpt-5.6-luna",
@@ -1588,12 +1635,12 @@
           "id": "openai/gpt-5.6-sol",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.5,
-              "cache_write": 6.25,
-              "no_cache": 5.0
+              "cache_read": 0.55,
+              "cache_write": 6.88,
+              "no_cache": 5.5
             },
             "output_tokens": {
-              "text": 30.0
+              "text": 33.0
             }
           },
           "provider_model_id": "openai.gpt-5.6-sol",
@@ -1609,15 +1656,36 @@
           "id": "openai/gpt-5.6-terra",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.25,
-              "cache_write": 3.125,
-              "no_cache": 2.5
+              "cache_read": 0.22,
+              "cache_write": 2.75,
+              "no_cache": 2.2
             },
             "output_tokens": {
-              "text": 15.0
+              "text": 13.2
             }
           },
           "provider_model_id": "openai.gpt-5.6-terra",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "id": "anthropic/claude-opus-5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider_model_id": "anthropic.claude-opus-5",
           "rate_limits": {
             "requests_per_minute": 60
           }
@@ -1965,11 +2033,11 @@
           "id": "openai/gpt-5.6-luna",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.1,
-              "no_cache": 1.0
+              "cache_read": 0.02,
+              "no_cache": 0.2
             },
             "output_tokens": {
-              "text": 6.0
+              "text": 1.2
             }
           },
           "provider_model_id": "gpt-5.6-luna",
@@ -2005,14 +2073,35 @@
           "id": "openai/gpt-5.6-terra",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.25,
-              "no_cache": 2.5
+              "cache_read": 0.2,
+              "no_cache": 2.0
             },
             "output_tokens": {
-              "text": 15.0
+              "text": 12.0
             }
           },
           "provider_model_id": "gpt-5.6-terra",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "id": "anthropic/claude-opus-5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider_model_id": "claude-opus-5",
           "rate_limits": {
             "requests_per_minute": 60
           }
@@ -2814,10 +2903,10 @@
           "id": "openai/gpt-oss-120b",
           "pricing": {
             "input_tokens": {
-              "no_cache": 0.25
+              "no_cache": 0.35
             },
             "output_tokens": {
-              "text": 0.69
+              "text": 0.75
             }
           },
           "provider_model_id": "gpt-oss-120b",
@@ -2846,7 +2935,7 @@
           "id": "z-ai/glm-4.7",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.0,
+              "cache_read": 2.25,
               "cache_write": 0.0,
               "no_cache": 2.25
             },
@@ -2915,11 +3004,11 @@
           "id": "moonshotai/kimi-k2.6",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.475,
-              "no_cache": 0.95
+              "cache_read": 0.33,
+              "no_cache": 0.66
             },
             "output_tokens": {
-              "text": 4.0
+              "text": 3.5
             }
           },
           "provider_model_id": "moonshotai/Kimi-K2.6-TEE",
@@ -2936,11 +3025,11 @@
           "id": "z-ai/glm-5.1",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.525,
-              "no_cache": 1.05
+              "cache_read": 0.49,
+              "no_cache": 0.98
             },
             "output_tokens": {
-              "text": 3.5
+              "text": 3.08
             }
           },
           "provider_model_id": "zai-org/GLM-5.1-TEE",
@@ -2978,11 +3067,11 @@
           "id": "deepseek/deepseek-v3.2",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.14,
-              "no_cache": 0.28
+              "cache_read": 0.5,
+              "no_cache": 1.0
             },
             "output_tokens": {
-              "text": 0.42
+              "text": 1.0
             }
           },
           "provider_model_id": "deepseek-ai/DeepSeek-V3.2-TEE",
@@ -3129,6 +3218,11 @@
           "api_protocol": "anthropic",
           "id": "anthropic/claude-fable-5",
           "provider_model_id": "claude-fable-5"
+        },
+        {
+          "api_protocol": "anthropic",
+          "id": "anthropic/claude-opus-5",
+          "provider_model_id": "claude-opus-5"
         }
       ],
       "name": "claude-code",
@@ -3169,11 +3263,11 @@
           "id": "deepseek/deepseek-v4-pro",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.145,
-              "no_cache": 1.74
+              "cache_read": 0.003625,
+              "no_cache": 0.435
             },
             "output_tokens": {
-              "text": 3.48
+              "text": 0.87
             }
           },
           "provider_model_id": "deepseek-v4-pro",
@@ -3193,7 +3287,7 @@
           "id": "deepseek/deepseek-v4-flash",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.028,
+              "cache_read": 0.0028,
               "no_cache": 0.14
             },
             "output_tokens": {
@@ -3331,6 +3425,11 @@
           "api_protocol": "openai",
           "id": "openai/gpt-5.6-terra",
           "provider_model_id": "gpt-5.6-terra"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "anthropic/claude-opus-5",
+          "provider_model_id": "claude-opus-5"
         }
       ],
       "name": "github-copilot",
@@ -3363,6 +3462,7 @@
           "pricing": {
             "input_tokens": {
               "cache_read": 0.25,
+              "cache_write": 3.125,
               "no_cache": 2.5
             },
             "output_tokens": {
@@ -3822,11 +3922,11 @@
           "id": "minimax/minimax-m3",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.12,
-              "no_cache": 0.6
+              "cache_read": 0.06,
+              "no_cache": 0.3
             },
             "output_tokens": {
-              "text": 2.4
+              "text": 1.2
             }
           },
           "provider_model_id": "MiniMax-M3",
@@ -3924,11 +4024,11 @@
           "id": "minimax/minimax-m3",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.12,
-              "no_cache": 0.6
+              "cache_read": 0.06,
+              "no_cache": 0.3
             },
             "output_tokens": {
-              "text": 2.4
+              "text": 1.2
             }
           },
           "provider_model_id": "MiniMax-M3",
@@ -4178,6 +4278,7 @@
           "pricing": {
             "input_tokens": {
               "cache_read": 0.25,
+              "cache_write": 1.5625,
               "no_cache": 1.25
             },
             "output_tokens": {
@@ -4473,12 +4574,12 @@
               }
             ],
             "input_tokens": {
-              "cache_read": 0.25,
-              "cache_write": 3.125,
-              "no_cache": 2.5
+              "cache_read": 0.2,
+              "cache_write": 2.5,
+              "no_cache": 2.0
             },
             "output_tokens": {
-              "text": 15.0
+              "text": 12.0
             }
           },
           "provider_model_id": "gpt-5.6-terra",
@@ -4517,12 +4618,12 @@
               }
             ],
             "input_tokens": {
-              "cache_read": 0.1,
-              "cache_write": 1.25,
-              "no_cache": 1.0
+              "cache_read": 0.02,
+              "cache_write": 0.25,
+              "no_cache": 0.2
             },
             "output_tokens": {
-              "text": 6.0
+              "text": 1.2
             }
           },
           "provider_model_id": "gpt-5.6-luna",
@@ -4849,6 +4950,11 @@
           "api_protocol": "openai",
           "id": "tencent/hy3",
           "provider_model_id": "hy3"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "openai/gpt-5.6-luna",
+          "provider_model_id": "gpt-5.6-luna"
         }
       ],
       "name": "opencode-go",
@@ -5273,12 +5379,12 @@
           "id": "openai/gpt-5.6-luna",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.1,
-              "cache_write": 1.25,
-              "no_cache": 1.0
+              "cache_read": 0.02,
+              "cache_write": 0.25,
+              "no_cache": 0.2
             },
             "output_tokens": {
-              "text": 6.0
+              "text": 1.2
             }
           },
           "provider_model_id": "gpt-5.6-luna"
@@ -5326,6 +5432,21 @@
             }
           },
           "provider_model_id": "kimi-k3"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "anthropic/claude-opus-5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider_model_id": "claude-opus-5"
         }
       ],
       "name": "opencode-zen",
@@ -5368,11 +5489,11 @@
           "id": "moonshotai/kimi-k2.7-code",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.1296,
-              "no_cache": 0.612
+              "cache_read": 0.15,
+              "no_cache": 0.73
             },
             "output_tokens": {
-              "text": 3.069
+              "text": 3.5
             }
           },
           "provider_model_id": "moonshotai/kimi-k2.7-code"
@@ -5386,10 +5507,11 @@
           "id": "moonshotai/kimi-k2.5",
           "pricing": {
             "input_tokens": {
-              "no_cache": 0.375
+              "cache_read": 0.095,
+              "no_cache": 0.57
             },
             "output_tokens": {
-              "text": 2.025
+              "text": 2.85
             }
           },
           "provider_model_id": "moonshotai/kimi-k2.5"
@@ -5403,11 +5525,11 @@
           "id": "moonshotai/kimi-k2.6",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.144,
-              "no_cache": 0.66
+              "cache_read": 0.0992,
+              "no_cache": 0.589
             },
             "output_tokens": {
-              "text": 3.41
+              "text": 2.48
             }
           },
           "provider_model_id": "moonshotai/kimi-k2.6"
@@ -5533,11 +5655,11 @@
           "id": "z-ai/glm-5.1",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.182,
-              "no_cache": 0.98
+              "cache_read": 0.1794,
+              "no_cache": 0.966
             },
             "output_tokens": {
-              "text": 3.08
+              "text": 3.036
             }
           },
           "provider_model_id": "z-ai/glm-5.1"
@@ -5551,11 +5673,11 @@
           "id": "z-ai/glm-5.2",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.18,
-              "no_cache": 1.0
+              "cache_read": 0.208,
+              "no_cache": 1.12
             },
             "output_tokens": {
-              "text": 4.0
+              "text": 3.52
             }
           },
           "provider_model_id": "z-ai/glm-5.2"
@@ -5569,11 +5691,11 @@
           "id": "z-ai/glm-5",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.12,
-              "no_cache": 0.6
+              "cache_read": 0.2,
+              "no_cache": 0.95
             },
             "output_tokens": {
-              "text": 1.92
+              "text": 2.55
             }
           },
           "provider_model_id": "z-ai/glm-5"
@@ -5587,10 +5709,10 @@
           "id": "openai/gpt-oss-120b",
           "pricing": {
             "input_tokens": {
-              "no_cache": 0.039
+              "no_cache": 0.037
             },
             "output_tokens": {
-              "text": 0.18
+              "text": 0.17
             }
           },
           "provider_model_id": "openai/gpt-oss-120b"
@@ -5826,8 +5948,7 @@
           "id": "stepfun/step-3.5-flash",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.02,
-              "no_cache": 0.09
+              "no_cache": 0.1
             },
             "output_tokens": {
               "text": 0.3
@@ -5863,12 +5984,12 @@
           "id": "qwen/qwen3.7-max",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.25,
-              "cache_write": 1.5625,
-              "no_cache": 1.25
+              "cache_read": 0.295,
+              "cache_write": 1.84375,
+              "no_cache": 1.475
             },
             "output_tokens": {
-              "text": 3.75
+              "text": 4.425
             }
           },
           "provider_model_id": "qwen/qwen3.7-max"
@@ -5918,11 +6039,11 @@
           "id": "deepseek/deepseek-v4-flash",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.02,
-              "no_cache": 0.09
+              "cache_read": 0.028,
+              "no_cache": 0.14
             },
             "output_tokens": {
-              "text": 0.18
+              "text": 0.28
             }
           },
           "provider_model_id": "deepseek/deepseek-v4-flash"
@@ -5954,10 +6075,11 @@
           "id": "deepseek/deepseek-v3.2",
           "pricing": {
             "input_tokens": {
-              "no_cache": 0.2288
+              "cache_read": 0.1345,
+              "no_cache": 0.269
             },
             "output_tokens": {
-              "text": 0.3432
+              "text": 0.4
             }
           },
           "provider_model_id": "deepseek/deepseek-v3.2"
@@ -6134,10 +6256,10 @@
           "pricing": {
             "input_tokens": {
               "cache_read": 0.15,
-              "no_cache": 0.285
+              "no_cache": 0.3
             },
             "output_tokens": {
-              "text": 2.4
+              "text": 2.0
             }
           },
           "provider_model_id": "qwen/qwen3.6-27b"
@@ -6168,11 +6290,11 @@
           "id": "tencent/hy3",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.5,
-              "no_cache": 0.2
+              "cache_read": 0.033,
+              "no_cache": 0.132
             },
             "output_tokens": {
-              "text": 0.8
+              "text": 0.528
             }
           },
           "provider_model_id": "tencent/hy3"
@@ -6204,12 +6326,12 @@
           "id": "openai/gpt-5.6-luna",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.1,
-              "cache_write": 1.25,
-              "no_cache": 1.0
+              "cache_read": 0.01,
+              "cache_write": 0.125,
+              "no_cache": 0.1
             },
             "output_tokens": {
-              "text": 6.0
+              "text": 0.6
             }
           },
           "provider_model_id": "openai/gpt-5.6-luna"
@@ -6242,12 +6364,12 @@
           "id": "openai/gpt-5.6-terra",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.25,
-              "cache_write": 3.125,
-              "no_cache": 2.5
+              "cache_read": 0.1,
+              "cache_write": 1.25,
+              "no_cache": 1.0
             },
             "output_tokens": {
-              "text": 15.0
+              "text": 6.0
             }
           },
           "provider_model_id": "openai/gpt-5.6-terra"
@@ -6261,7 +6383,7 @@
           "id": "x-ai/grok-4.5",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.5,
+              "cache_read": 0.3,
               "no_cache": 2.0
             },
             "output_tokens": {
@@ -6305,6 +6427,25 @@
             }
           },
           "provider_model_id": "meituan/longcat-2.0"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "anthropic/claude-opus-5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider_model_id": "anthropic/claude-opus-5"
         }
       ],
       "name": "openrouter",
@@ -6392,6 +6533,26 @@
           "api_protocol": "openai",
           "capabilities": [
             "reasoning",
+            "structured_outputs",
+            "tools",
+            "image_input"
+          ],
+          "id": "moonshotai/kimi-k3",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 1.5,
+              "no_cache": 3.0
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider_model_id": "moonshotai/kimi-k3"
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
             "tools"
           ],
           "id": "z-ai/glm-5.1",
@@ -6415,7 +6576,7 @@
           "id": "z-ai/glm-5.2",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.7,
+              "cache_read": 0.26,
               "no_cache": 1.4
             },
             "output_tokens": {
@@ -6484,11 +6645,11 @@
           "id": "deepseek/deepseek-v4-flash",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.0197,
-              "no_cache": 0.0983
+              "cache_read": 0.028,
+              "no_cache": 0.14
             },
             "output_tokens": {
-              "text": 0.1966
+              "text": 0.28
             }
           },
           "provider_model_id": "deepseek-v4-flash"
@@ -6498,11 +6659,11 @@
           "id": "moonshotai/kimi-k2.6",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.144,
-              "no_cache": 0.684
+              "cache_read": 0.16,
+              "no_cache": 0.95
             },
             "output_tokens": {
-              "text": 3.42
+              "text": 4.0
             }
           },
           "provider_model_id": "kimi-k2.6"
@@ -6526,11 +6687,11 @@
           "id": "z-ai/glm-5.1",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.182,
-              "no_cache": 0.98
+              "cache_read": 0.26,
+              "no_cache": 1.4
             },
             "output_tokens": {
-              "text": 3.08
+              "text": 4.4
             }
           },
           "provider_model_id": "glm-5.1"
@@ -6540,11 +6701,11 @@
           "id": "z-ai/glm-5.2",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.181,
-              "no_cache": 0.97
+              "cache_read": 0.26,
+              "no_cache": 1.4
             },
             "output_tokens": {
-              "text": 3.07
+              "text": 4.4
             }
           },
           "provider_model_id": "glm-5.2"
@@ -6778,6 +6939,26 @@
           "api_protocol": "openai",
           "capabilities": [
             "reasoning",
+            "structured_outputs",
+            "tools",
+            "image_input"
+          ],
+          "id": "moonshotai/kimi-k3",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 1.5,
+              "no_cache": 3.0
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider_model_id": "moonshotai/kimi-k3"
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
             "tools"
           ],
           "id": "z-ai/glm-5.1",
@@ -6801,7 +6982,7 @@
           "id": "z-ai/glm-5.2",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.7,
+              "cache_read": 0.26,
               "no_cache": 1.4
             },
             "output_tokens": {
@@ -7312,11 +7493,11 @@
           "id": "stepfun/step-3.7-flash",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.04,
-              "no_cache": 0.2
+              "cache_read": 0.037,
+              "no_cache": 0.185
             },
             "output_tokens": {
-              "text": 1.15
+              "text": 1.11
             }
           },
           "provider_model_id": "step-3.7-flash",
@@ -7336,11 +7517,11 @@
           "id": "stepfun/step-3.5-flash",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.019,
-              "no_cache": 0.096
+              "cache_read": 0.02,
+              "no_cache": 0.1
             },
             "output_tokens": {
-              "text": 0.288
+              "text": 0.3
             }
           },
           "provider_model_id": "step-3.5-flash",
@@ -7387,11 +7568,11 @@
           "id": "stepfun/step-3.7-flash",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.04,
-              "no_cache": 0.2
+              "cache_read": 0.037,
+              "no_cache": 0.185
             },
             "output_tokens": {
-              "text": 1.15
+              "text": 1.11
             }
           },
           "provider_model_id": "step-3.7-flash",
@@ -7411,11 +7592,11 @@
           "id": "stepfun/step-3.5-flash",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.019,
-              "no_cache": 0.096
+              "cache_read": 0.02,
+              "no_cache": 0.1
             },
             "output_tokens": {
-              "text": 0.288
+              "text": 0.3
             }
           },
           "provider_model_id": "step-3.5-flash",
@@ -8364,6 +8545,7 @@
           "id": "z-ai/glm-5.2",
           "pricing": {
             "input_tokens": {
+              "cache_read": 0.375,
               "no_cache": 1.5
             },
             "output_tokens": {
@@ -8498,7 +8680,7 @@
           "id": "x-ai/grok-4.5",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.5,
+              "cache_read": 0.3,
               "no_cache": 2.0
             },
             "output_tokens": {
@@ -8642,11 +8824,11 @@
           "id": "xiaomi/mimo-v2.5-pro",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.2,
-              "no_cache": 1.0
+              "cache_read": 0.0036,
+              "no_cache": 0.435
             },
             "output_tokens": {
-              "text": 3.0
+              "text": 0.87
             }
           },
           "provider_model_id": "mimo-v2.5-pro",
@@ -8667,11 +8849,11 @@
           "id": "xiaomi/mimo-v2.5",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.08,
-              "no_cache": 0.4
+              "cache_read": 0.0028,
+              "no_cache": 0.14
             },
             "output_tokens": {
-              "text": 2.0
+              "text": 0.28
             }
           },
           "provider_model_id": "mimo-v2.5",
@@ -8693,11 +8875,11 @@
           "id": "xiaomi/mimo-v2-pro",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.2,
-              "no_cache": 1.0
+              "cache_read": 0.0036,
+              "no_cache": 0.435
             },
             "output_tokens": {
-              "text": 3.0
+              "text": 0.87
             }
           },
           "provider_model_id": "mimo-v2-pro",
@@ -8719,11 +8901,11 @@
           "id": "xiaomi/mimo-v2-omni",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.08,
-              "no_cache": 0.4
+              "cache_read": 0.0028,
+              "no_cache": 0.14
             },
             "output_tokens": {
-              "text": 2.0
+              "text": 0.28
             }
           },
           "provider_model_id": "mimo-v2-omni",
@@ -8745,11 +8927,11 @@
           "id": "xiaomi/mimo-v2-flash",
           "pricing": {
             "input_tokens": {
-              "cache_read": 0.01,
-              "no_cache": 0.1
+              "cache_read": 0.0028,
+              "no_cache": 0.14
             },
             "output_tokens": {
-              "text": 0.3
+              "text": 0.28
             }
           },
           "provider_model_id": "mimo-v2-flash",

--- a/helpers/dist-helper/src/registry.rs
+++ b/helpers/dist-helper/src/registry.rs
@@ -3104,7 +3104,7 @@ api_base: https://api.acme.test/v1
             "qwen/qwen3.7-max",
             "Qwen/Qwen3.7-Max",
             2.5,
-            (Some(0.25), None),
+            (Some(0.25), Some(3.125)),
             7.5,
         );
 
@@ -3150,9 +3150,9 @@ api_base: https://api.acme.test/v1
             "Qianfan International",
             "z-ai/glm-5.2",
             "glm-5.2",
-            0.97,
-            (Some(0.181), None),
-            3.07,
+            1.4,
+            (Some(0.26), None),
+            4.4,
         );
     }
 

--- a/registry/models/anthropic.yaml
+++ b/registry/models/anthropic.yaml
@@ -62,6 +62,20 @@
   release_date: 2026-05-28
   open_weights: false
   family: claude-opus
+- id: anthropic/claude-opus-5
+  name: 'Anthropic: Claude Opus 5'
+  description: Anthropic's Claude Opus 5.
+  input_modalities:
+  - text
+  - image
+  output_modalities:
+  - text
+  max_input_tokens: 1000000
+  max_output_tokens: 128000
+  release_date: 2026-07-24
+  knowledge_cutoff: 2026-05-31
+  open_weights: false
+  family: claude-opus
 - id: anthropic/claude-sonnet-5
   name: 'Anthropic: Claude Sonnet 5'
   description: Anthropic's Claude Sonnet 5.

--- a/registry/providers/alibaba.yaml
+++ b/registry/providers/alibaba.yaml
@@ -25,15 +25,19 @@ models:
     pricing:
       input_tokens:
         no_cache: 2.5
+        cache_read: 0.5
+        cache_write: 3.125
       output_tokens:
         text: 7.5
   - id: qwen/qwen3.7-plus
     provider_model_id: qwen3.7-plus
     pricing:
       input_tokens:
-        no_cache: 0.4
+        no_cache: 0.5
+        cache_read: 0.05
+        cache_write: 0.625
       output_tokens:
-        text: 1.6
+        text: 3
       context_tiers:
         - above_input_tokens: 256000
           input_tokens:
@@ -45,6 +49,8 @@ models:
     pricing:
       input_tokens:
         no_cache: 0.5
+        cache_read: 0.05
+        cache_write: 0.625
       output_tokens:
         text: 3
       context_tiers:
@@ -57,9 +63,10 @@ models:
     provider_model_id: qwen3.6-flash
     pricing:
       input_tokens:
-        no_cache: 0.25
+        no_cache: 0.1875
+        cache_write: 0.234375
       output_tokens:
-        text: 1.5
+        text: 1.125
       context_tiers:
         - above_input_tokens: 256000
           input_tokens:

--- a/registry/providers/alibaba_cn.yaml
+++ b/registry/providers/alibaba_cn.yaml
@@ -22,16 +22,20 @@ models:
     provider_model_id: qwen3.7-max
     pricing:
       input_tokens:
-        no_cache: 1.65
+        no_cache: 2.5
+        cache_read: 0.5
+        cache_write: 3.125
       output_tokens:
-        text: 4.951
+        text: 7.5
   - id: qwen/qwen3.7-plus
     provider_model_id: qwen3.7-plus
     pricing:
       input_tokens:
-        no_cache: 0.276
+        no_cache: 0.5
+        cache_read: 0.05
+        cache_write: 0.625
       output_tokens:
-        text: 1.101
+        text: 3
       context_tiers:
         - above_input_tokens: 256000
           input_tokens:
@@ -42,9 +46,11 @@ models:
     provider_model_id: qwen3.6-plus
     pricing:
       input_tokens:
-        no_cache: 0.276
+        no_cache: 0.5
+        cache_read: 0.05
+        cache_write: 0.625
       output_tokens:
-        text: 1.651
+        text: 3
       context_tiers:
         - above_input_tokens: 256000
           input_tokens:
@@ -55,9 +61,10 @@ models:
     provider_model_id: qwen3.6-flash
     pricing:
       input_tokens:
-        no_cache: 0.165
+        no_cache: 0.1875
+        cache_write: 0.234375
       output_tokens:
-        text: 0.99
+        text: 1.125
       context_tiers:
         - above_input_tokens: 256000
           input_tokens:

--- a/registry/providers/ambient.yaml
+++ b/registry/providers/ambient.yaml
@@ -38,9 +38,10 @@ models:
     provider_model_id: moonshotai/kimi-k2.7-code
     pricing:
       input_tokens:
-        no_cache: 0.84
+        no_cache: 0.73
+        cache_read: 0.15
       output_tokens:
-        text: 3.99
+        text: 3.5
     capabilities:
       - reasoning
       - tools
@@ -58,8 +59,8 @@ models:
     provider_model_id: z-ai/glm-5.2
     pricing:
       input_tokens:
-        no_cache: 1.4
-        cache_read: 0.26
+        no_cache: 1.05
+        cache_read: 0.2
         cache_write: 0
       output_tokens:
         text: 4.4
@@ -67,11 +68,11 @@ models:
     provider_model_id: stepfun/step-3.7-flash
     pricing:
       input_tokens:
-        no_cache: 0.2
-        cache_read: 0.04
+        no_cache: 0.19
+        cache_read: 0.03
         cache_write: 0
       output_tokens:
-        text: 1.15
+        text: 1.14
   - id: deepseek/deepseek-v4-flash
     provider_model_id: deepseek/deepseek-v4-flash
     pricing:

--- a/registry/providers/anthropic.yaml
+++ b/registry/providers/anthropic.yaml
@@ -113,6 +113,15 @@ models:
         cache_write: 1.25
       output_tokens:
         text: 5
+  - id: anthropic/claude-opus-5
+    provider_model_id: claude-opus-5
+    pricing:
+      input_tokens:
+        no_cache: 5
+        cache_read: 0.5
+        cache_write: 6.25
+      output_tokens:
+        text: 25
 status: active
 weight: 1
 submitted_at: 2026-05-25

--- a/registry/providers/atlascloud.yaml
+++ b/registry/providers/atlascloud.yaml
@@ -1,4 +1,4 @@
-# Verified 2026-07-08 against the public
+# Verified 2026-08-01 against the public
 # `GET https://api.atlascloud.ai/v1/models` catalog and Atlas Cloud docs.
 # Atlas exposes an OpenAI-compatible LLM endpoint; catalog pricing is per token,
 # converted below to USD per 1M tokens. `openai/gpt-oss-120b` was removed because
@@ -144,6 +144,14 @@ models:
             cache_read: 0.4
           output_tokens:
             text: 5
+  - id: anthropic/claude-opus-5
+    provider_model_id: anthropic/claude-opus-5-ccmax
+    pricing:
+      input_tokens:
+        no_cache: 5
+        cache_read: 0.5
+      output_tokens:
+        text: 25
 status: active
 weight: 1
 submitted_at: 2026-07-07

--- a/registry/providers/aws-bedrock.yaml
+++ b/registry/providers/aws-bedrock.yaml
@@ -146,29 +146,38 @@ models:
     provider_model_id: openai.gpt-5.6-luna
     pricing:
       input_tokens:
-        no_cache: 1
-        cache_read: 0.1
-        cache_write: 1.25
+        no_cache: 0.22
+        cache_read: 0.022
+        cache_write: 0.275
       output_tokens:
-        text: 6
+        text: 1.32
   - id: openai/gpt-5.6-sol
     provider_model_id: openai.gpt-5.6-sol
+    pricing:
+      input_tokens:
+        no_cache: 5.5
+        cache_read: 0.55
+        cache_write: 6.88
+      output_tokens:
+        text: 33
+  - id: openai/gpt-5.6-terra
+    provider_model_id: openai.gpt-5.6-terra
+    pricing:
+      input_tokens:
+        no_cache: 2.2
+        cache_read: 0.22
+        cache_write: 2.75
+      output_tokens:
+        text: 13.2
+  - id: anthropic/claude-opus-5
+    provider_model_id: anthropic.claude-opus-5
     pricing:
       input_tokens:
         no_cache: 5
         cache_read: 0.5
         cache_write: 6.25
       output_tokens:
-        text: 30
-  - id: openai/gpt-5.6-terra
-    provider_model_id: openai.gpt-5.6-terra
-    pricing:
-      input_tokens:
-        no_cache: 2.5
-        cache_read: 0.25
-        cache_write: 3.125
-      output_tokens:
-        text: 15
+        text: 25
 auto_sync:
   feed: models_dev
   key: amazon-bedrock

--- a/registry/providers/azure.yaml
+++ b/registry/providers/azure.yaml
@@ -155,10 +155,10 @@ models:
     provider_model_id: gpt-5.6-luna
     pricing:
       input_tokens:
-        no_cache: 1
-        cache_read: 0.1
+        no_cache: 0.2
+        cache_read: 0.02
       output_tokens:
-        text: 6
+        text: 1.2
   - id: openai/gpt-5.6-sol
     provider_model_id: gpt-5.6-sol
     pricing:
@@ -171,10 +171,19 @@ models:
     provider_model_id: gpt-5.6-terra
     pricing:
       input_tokens:
-        no_cache: 2.5
-        cache_read: 0.25
+        no_cache: 2
+        cache_read: 0.2
       output_tokens:
-        text: 15
+        text: 12
+  - id: anthropic/claude-opus-5
+    provider_model_id: claude-opus-5
+    pricing:
+      input_tokens:
+        no_cache: 5
+        cache_read: 0.5
+        cache_write: 6.25
+      output_tokens:
+        text: 25
 auto_sync:
   feed: models_dev
   key: azure

--- a/registry/providers/cerebras.yaml
+++ b/registry/providers/cerebras.yaml
@@ -17,9 +17,9 @@ models:
     provider_model_id: gpt-oss-120b
     pricing:
       input_tokens:
-        no_cache: 0.25
+        no_cache: 0.35
       output_tokens:
-        text: 0.69
+        text: 0.75
     capabilities:
       - reasoning
       - structured_outputs
@@ -36,7 +36,7 @@ models:
     pricing:
       input_tokens:
         no_cache: 2.25
-        cache_read: 0
+        cache_read: 2.25
         cache_write: 0
       output_tokens:
         text: 2.75

--- a/registry/providers/chutes.yaml
+++ b/registry/providers/chutes.yaml
@@ -28,10 +28,10 @@ models:
     provider_model_id: moonshotai/Kimi-K2.6-TEE
     pricing:
       input_tokens:
-        no_cache: 0.95
-        cache_read: 0.475
+        no_cache: 0.66
+        cache_read: 0.33
       output_tokens:
-        text: 4
+        text: 3.5
     capabilities:
       - reasoning
       - tools
@@ -39,10 +39,10 @@ models:
     provider_model_id: zai-org/GLM-5.1-TEE
     pricing:
       input_tokens:
-        no_cache: 1.05
-        cache_read: 0.525
+        no_cache: 0.98
+        cache_read: 0.49
       output_tokens:
-        text: 3.5
+        text: 3.08
     capabilities:
       - reasoning
       - tools
@@ -61,10 +61,10 @@ models:
     provider_model_id: deepseek-ai/DeepSeek-V3.2-TEE
     pricing:
       input_tokens:
-        no_cache: 0.28
-        cache_read: 0.14
+        no_cache: 1
+        cache_read: 0.5
       output_tokens:
-        text: 0.42
+        text: 1
     capabilities:
       - reasoning
       - tools

--- a/registry/providers/claude-code.yaml
+++ b/registry/providers/claude-code.yaml
@@ -56,6 +56,8 @@ models:
   - id: anthropic/claude-fable-5
     provider_model_id: claude-fable-5
     capabilities: []
+  - id: anthropic/claude-opus-5
+    provider_model_id: claude-opus-5
 status: active
 weight: 1
 community: false

--- a/registry/providers/deepseek.yaml
+++ b/registry/providers/deepseek.yaml
@@ -22,10 +22,10 @@ models:
     provider_model_id: deepseek-v4-pro
     pricing:
       input_tokens:
-        no_cache: 1.74
-        cache_read: 0.145
+        no_cache: 0.435
+        cache_read: 0.003625
       output_tokens:
-        text: 3.48
+        text: 0.87
     capabilities:
       - reasoning
       - tools
@@ -34,7 +34,7 @@ models:
     pricing:
       input_tokens:
         no_cache: 0.14
-        cache_read: 0.028
+        cache_read: 0.0028
       output_tokens:
         text: 0.28
     capabilities:

--- a/registry/providers/github-copilot.yaml
+++ b/registry/providers/github-copilot.yaml
@@ -57,6 +57,8 @@ models:
     provider_model_id: gpt-5.6-sol
   - id: openai/gpt-5.6-terra
     provider_model_id: gpt-5.6-terra
+  - id: anthropic/claude-opus-5
+    provider_model_id: claude-opus-5
 status: active
 weight: 1
 community: false

--- a/registry/providers/gmicloud.yaml
+++ b/registry/providers/gmicloud.yaml
@@ -19,6 +19,7 @@ models:
       input_tokens:
         no_cache: 2.5
         cache_read: 0.25
+        cache_write: 3.125
       output_tokens:
         text: 7.5
   - id: deepseek/deepseek-v4-pro

--- a/registry/providers/minimax.yaml
+++ b/registry/providers/minimax.yaml
@@ -44,10 +44,10 @@ models:
     provider_model_id: MiniMax-M3
     pricing:
       input_tokens:
-        no_cache: 0.6
-        cache_read: 0.12
+        no_cache: 0.3
+        cache_read: 0.06
       output_tokens:
-        text: 2.4
+        text: 1.2
 status: active
 weight: 1
 submitted_at: 2026-05-25

--- a/registry/providers/minimax_cn.yaml
+++ b/registry/providers/minimax_cn.yaml
@@ -44,10 +44,10 @@ models:
     provider_model_id: MiniMax-M3
     pricing:
       input_tokens:
-        no_cache: 0.6
-        cache_read: 0.12
+        no_cache: 0.3
+        cache_read: 0.06
       output_tokens:
-        text: 2.4
+        text: 1.2
 status: active
 weight: 1
 submitted_at: 2026-05-25

--- a/registry/providers/novita.yaml
+++ b/registry/providers/novita.yaml
@@ -42,6 +42,7 @@ models:
       input_tokens:
         no_cache: 1.25
         cache_read: 0.25
+        cache_write: 1.5625
       output_tokens:
         text: 3.75
   - id: qwen/qwen3.5-122b-a10b

--- a/registry/providers/openai.yaml
+++ b/registry/providers/openai.yaml
@@ -47,11 +47,11 @@ models:
     compatibility: *modern_openai_chat
     pricing:
       input_tokens:
-        no_cache: 2.5
-        cache_read: 0.25
-        cache_write: 3.125
+        no_cache: 2
+        cache_read: 0.2
+        cache_write: 2.5
       output_tokens:
-        text: 15
+        text: 12
       context_tiers:
         - above_input_tokens: 272000
           input_tokens:
@@ -69,11 +69,11 @@ models:
     compatibility: *modern_openai_chat
     pricing:
       input_tokens:
-        no_cache: 1
-        cache_read: 0.1
-        cache_write: 1.25
+        no_cache: 0.2
+        cache_read: 0.02
+        cache_write: 0.25
       output_tokens:
-        text: 6
+        text: 1.2
       context_tiers:
         - above_input_tokens: 272000
           input_tokens:

--- a/registry/providers/opencode-go.yaml
+++ b/registry/providers/opencode-go.yaml
@@ -71,6 +71,8 @@ models:
     provider_model_id: kimi-k3
   - id: tencent/hy3
     provider_model_id: hy3
+  - id: openai/gpt-5.6-luna
+    provider_model_id: gpt-5.6-luna
 status: active
 auto_sync:
   feed: models_dev

--- a/registry/providers/opencode-zen.yaml
+++ b/registry/providers/opencode-zen.yaml
@@ -245,11 +245,11 @@ models:
     provider_model_id: gpt-5.6-luna
     pricing:
       input_tokens:
-        no_cache: 1
-        cache_read: 0.1
-        cache_write: 1.25
+        no_cache: 0.2
+        cache_read: 0.02
+        cache_write: 0.25
       output_tokens:
-        text: 6
+        text: 1.2
   - id: openai/gpt-5.6-sol
     provider_model_id: gpt-5.6-sol
     pricing:
@@ -276,6 +276,15 @@ models:
         cache_read: 0.3
       output_tokens:
         text: 15
+  - id: anthropic/claude-opus-5
+    provider_model_id: claude-opus-5
+    pricing:
+      input_tokens:
+        no_cache: 5
+        cache_read: 0.5
+        cache_write: 6.25
+      output_tokens:
+        text: 25
 status: active
 weight: 1
 community: false

--- a/registry/providers/openrouter.yaml
+++ b/registry/providers/openrouter.yaml
@@ -20,25 +20,26 @@ models:
     provider_model_id: moonshotai/kimi-k2.7-code
     pricing:
       input_tokens:
-        no_cache: 0.612
-        cache_read: 0.1296
+        no_cache: 0.73
+        cache_read: 0.15
       output_tokens:
-        text: 3.069
+        text: 3.5
   - id: moonshotai/kimi-k2.5
     provider_model_id: moonshotai/kimi-k2.5
     pricing:
       input_tokens:
-        no_cache: 0.375
+        no_cache: 0.57
+        cache_read: 0.095
       output_tokens:
-        text: 2.025
+        text: 2.85
   - id: moonshotai/kimi-k2.6
     provider_model_id: moonshotai/kimi-k2.6
     pricing:
       input_tokens:
-        no_cache: 0.66
-        cache_read: 0.144
+        no_cache: 0.589
+        cache_read: 0.0992
       output_tokens:
-        text: 3.41
+        text: 2.48
   - id: google/gemini-3.5-flash
     provider_model_id: google/gemini-3.5-flash
     pricing:
@@ -95,33 +96,33 @@ models:
     provider_model_id: z-ai/glm-5.1
     pricing:
       input_tokens:
-        no_cache: 0.98
-        cache_read: 0.182
+        no_cache: 0.966
+        cache_read: 0.1794
       output_tokens:
-        text: 3.08
+        text: 3.036
   - id: z-ai/glm-5.2
     provider_model_id: z-ai/glm-5.2
     pricing:
       input_tokens:
-        no_cache: 1
-        cache_read: 0.18
+        no_cache: 1.12
+        cache_read: 0.208
       output_tokens:
-        text: 4
+        text: 3.52
   - id: z-ai/glm-5
     provider_model_id: z-ai/glm-5
     pricing:
       input_tokens:
-        no_cache: 0.6
-        cache_read: 0.12
+        no_cache: 0.95
+        cache_read: 0.2
       output_tokens:
-        text: 1.92
+        text: 2.55
   - id: openai/gpt-oss-120b
     provider_model_id: openai/gpt-oss-120b
     pricing:
       input_tokens:
-        no_cache: 0.039
+        no_cache: 0.037
       output_tokens:
-        text: 0.18
+        text: 0.17
   - id: openai/gpt-5.4
     provider_model_id: openai/gpt-5.4
     pricing:
@@ -228,8 +229,7 @@ models:
     provider_model_id: stepfun/step-3.5-flash
     pricing:
       input_tokens:
-        no_cache: 0.09
-        cache_read: 0.02
+        no_cache: 0.1
       output_tokens:
         text: 0.3
   - id: qwen/qwen3.7-plus
@@ -245,11 +245,11 @@ models:
     provider_model_id: qwen/qwen3.7-max
     pricing:
       input_tokens:
-        no_cache: 1.25
-        cache_read: 0.25
-        cache_write: 1.5625
+        no_cache: 1.475
+        cache_read: 0.295
+        cache_write: 1.84375
       output_tokens:
-        text: 3.75
+        text: 4.425
   - id: qwen/qwen3.6-flash
     provider_model_id: qwen/qwen3.6-flash
     pricing:
@@ -270,10 +270,10 @@ models:
     provider_model_id: deepseek/deepseek-v4-flash
     pricing:
       input_tokens:
-        no_cache: 0.09
-        cache_read: 0.02
+        no_cache: 0.14
+        cache_read: 0.028
       output_tokens:
-        text: 0.18
+        text: 0.28
   - id: deepseek/deepseek-v4-pro
     provider_model_id: deepseek/deepseek-v4-pro
     pricing:
@@ -286,9 +286,10 @@ models:
     provider_model_id: deepseek/deepseek-v3.2
     pricing:
       input_tokens:
-        no_cache: 0.2288
+        no_cache: 0.269
+        cache_read: 0.1345
       output_tokens:
-        text: 0.3432
+        text: 0.4
   - id: minimax/minimax-m2.5
     provider_model_id: minimax/minimax-m2.5
     pricing:
@@ -365,10 +366,10 @@ models:
     provider_model_id: qwen/qwen3.6-27b
     pricing:
       input_tokens:
-        no_cache: 0.285
+        no_cache: 0.3
         cache_read: 0.15
       output_tokens:
-        text: 2.4
+        text: 2
   - id: qwen/qwen3.6-35b-a3b
     provider_model_id: qwen/qwen3.6-35b-a3b
     pricing:
@@ -380,10 +381,10 @@ models:
     provider_model_id: tencent/hy3
     pricing:
       input_tokens:
-        no_cache: 0.2
-        cache_read: 0.5
+        no_cache: 0.132
+        cache_read: 0.033
       output_tokens:
-        text: 0.8
+        text: 0.528
   - id: z-ai/glm-4.7
     provider_model_id: z-ai/glm-4.7
     pricing:
@@ -396,11 +397,11 @@ models:
     provider_model_id: openai/gpt-5.6-luna
     pricing:
       input_tokens:
-        no_cache: 1
-        cache_read: 0.1
-        cache_write: 1.25
+        no_cache: 0.1
+        cache_read: 0.01
+        cache_write: 0.125
       output_tokens:
-        text: 6
+        text: 0.6
   - id: openai/gpt-5.6-sol
     provider_model_id: openai/gpt-5.6-sol
     pricing:
@@ -414,17 +415,17 @@ models:
     provider_model_id: openai/gpt-5.6-terra
     pricing:
       input_tokens:
-        no_cache: 2.5
-        cache_read: 0.25
-        cache_write: 3.125
+        no_cache: 1
+        cache_read: 0.1
+        cache_write: 1.25
       output_tokens:
-        text: 15
+        text: 6
   - id: x-ai/grok-4.5
     provider_model_id: x-ai/grok-4.5
     pricing:
       input_tokens:
         no_cache: 2
-        cache_read: 0.5
+        cache_read: 0.3
       output_tokens:
         text: 6
   - id: moonshotai/kimi-k3
@@ -443,6 +444,15 @@ models:
         cache_read: 0.006
       output_tokens:
         text: 1.2
+  - id: anthropic/claude-opus-5
+    provider_model_id: anthropic/claude-opus-5
+    pricing:
+      input_tokens:
+        no_cache: 5
+        cache_read: 0.5
+        cache_write: 6.25
+      output_tokens:
+        text: 25
 status: active
 weight: 1
 community: false

--- a/registry/providers/phala.yaml
+++ b/registry/providers/phala.yaml
@@ -12,7 +12,7 @@ api_protocol:
   - "*": openai
 auth_scheme: bearer
 kind: gateway
-# Phala Cloud confidential (GPU-TEE) inference gateway. Verified 2026-07-08
+# Phala Cloud confidential (GPU-TEE) inference gateway. Verified 2026-08-01
 # against the public `GET https://inference.phala.com/v1/models` catalog.
 # Distinct from the `redpill` provider, which uses `https://api.redpill.ai/v1`.
 # Prices below are the live catalog's per-token prices converted to USD per 1M.
@@ -48,6 +48,19 @@ models:
     capabilities:
       - reasoning
       - tools
+  - id: moonshotai/kimi-k3
+    provider_model_id: moonshotai/kimi-k3
+    pricing:
+      input_tokens:
+        no_cache: 3
+        cache_read: 1.5
+      output_tokens:
+        text: 15
+    capabilities:
+      - reasoning
+      - structured_outputs
+      - tools
+      - image_input
   - id: z-ai/glm-5.1
     provider_model_id: z-ai/glm-5.1
     pricing:
@@ -64,7 +77,7 @@ models:
     pricing:
       input_tokens:
         no_cache: 1.4
-        cache_read: 0.7
+        cache_read: 0.26
       output_tokens:
         text: 4.4
     capabilities:

--- a/registry/providers/qianfan.yaml
+++ b/registry/providers/qianfan.yaml
@@ -1,4 +1,4 @@
-# Verified 2026-07-11 against Baidu Qianfan international docs and the public
+# Verified 2026-08-01 against Baidu Qianfan international docs and the public
 # `GET https://api.baiduqianfan.ai/v1/models` catalog. The endpoint is
 # OpenAI-compatible and uses Bearer API keys (`bce-v3/ALTAK-...`). Prices below
 # are the live catalog's per-token prices converted to USD per 1M tokens.
@@ -36,18 +36,18 @@ models:
     provider_model_id: deepseek-v4-flash
     pricing:
       input_tokens:
-        no_cache: 0.0983
-        cache_read: 0.0197
+        no_cache: 0.14
+        cache_read: 0.028
       output_tokens:
-        text: 0.1966
+        text: 0.28
   - id: moonshotai/kimi-k2.6
     provider_model_id: kimi-k2.6
     pricing:
       input_tokens:
-        no_cache: 0.684
-        cache_read: 0.144
+        no_cache: 0.95
+        cache_read: 0.16
       output_tokens:
-        text: 3.42
+        text: 4
   - id: z-ai/glm-5
     provider_model_id: glm-5
     pricing:
@@ -60,18 +60,18 @@ models:
     provider_model_id: glm-5.1
     pricing:
       input_tokens:
-        no_cache: 0.98
-        cache_read: 0.182
+        no_cache: 1.4
+        cache_read: 0.26
       output_tokens:
-        text: 3.08
+        text: 4.4
   - id: z-ai/glm-5.2
     provider_model_id: glm-5.2
     pricing:
       input_tokens:
-        no_cache: 0.97
-        cache_read: 0.181
+        no_cache: 1.4
+        cache_read: 0.26
       output_tokens:
-        text: 3.07
+        text: 4.4
   - id: tencent/hy3
     provider_model_id: hy3-preview
     pricing:

--- a/registry/providers/redpill.yaml
+++ b/registry/providers/redpill.yaml
@@ -12,7 +12,7 @@ api_protocol:
 auth_scheme: bearer
 kind: gateway
 doc_url: https://docs.redpill.ai/get-started/introduction
-# RedPill is Phala Network's confidential AI gateway. Verified 2026-07-08
+# RedPill is Phala Network's confidential AI gateway. Verified 2026-08-01
 # against public `GET https://api.redpill.ai/v1/models`; the response currently
 # matches Phala's inference catalog for these models. Prices below are converted
 # from per-token catalog values to USD per 1M tokens.
@@ -48,6 +48,19 @@ models:
     capabilities:
       - reasoning
       - tools
+  - id: moonshotai/kimi-k3
+    provider_model_id: moonshotai/kimi-k3
+    pricing:
+      input_tokens:
+        no_cache: 3
+        cache_read: 1.5
+      output_tokens:
+        text: 15
+    capabilities:
+      - reasoning
+      - structured_outputs
+      - tools
+      - image_input
   - id: z-ai/glm-5.1
     provider_model_id: z-ai/glm-5.1
     pricing:
@@ -64,7 +77,7 @@ models:
     pricing:
       input_tokens:
         no_cache: 1.4
-        cache_read: 0.7
+        cache_read: 0.26
       output_tokens:
         text: 4.4
     capabilities:

--- a/registry/providers/stepfun.yaml
+++ b/registry/providers/stepfun.yaml
@@ -22,20 +22,20 @@ models:
     provider_model_id: step-3.7-flash
     pricing:
       input_tokens:
-        no_cache: 0.2
-        cache_read: 0.04
+        no_cache: 0.185
+        cache_read: 0.037
       output_tokens:
-        text: 1.15
+        text: 1.11
     capabilities:
       - structured_outputs
   - id: stepfun/step-3.5-flash
     provider_model_id: step-3.5-flash
     pricing:
       input_tokens:
-        no_cache: 0.096
-        cache_read: 0.019
+        no_cache: 0.1
+        cache_read: 0.02
       output_tokens:
-        text: 0.288
+        text: 0.3
     capabilities:
       - reasoning
       - tools

--- a/registry/providers/stepfun_cn.yaml
+++ b/registry/providers/stepfun_cn.yaml
@@ -22,20 +22,20 @@ models:
     provider_model_id: step-3.7-flash
     pricing:
       input_tokens:
-        no_cache: 0.2
-        cache_read: 0.04
+        no_cache: 0.185
+        cache_read: 0.037
       output_tokens:
-        text: 1.15
+        text: 1.11
     capabilities:
       - structured_outputs
   - id: stepfun/step-3.5-flash
     provider_model_id: step-3.5-flash
     pricing:
       input_tokens:
-        no_cache: 0.096
-        cache_read: 0.019
+        no_cache: 0.1
+        cache_read: 0.02
       output_tokens:
-        text: 0.288
+        text: 0.3
     capabilities:
       - reasoning
       - tools

--- a/registry/providers/tinfoil.yaml
+++ b/registry/providers/tinfoil.yaml
@@ -47,6 +47,7 @@ models:
     pricing:
       input_tokens:
         no_cache: 1.5
+        cache_read: 0.375
       output_tokens:
         text: 5.25
 status: active

--- a/registry/providers/xai.yaml
+++ b/registry/providers/xai.yaml
@@ -22,7 +22,7 @@ models:
     pricing:
       input_tokens:
         no_cache: 2
-        cache_read: 0.5
+        cache_read: 0.3
       output_tokens:
         text: 6
     capabilities:

--- a/registry/providers/xiaomi.yaml
+++ b/registry/providers/xiaomi.yaml
@@ -20,10 +20,10 @@ models:
     provider_model_id: mimo-v2.5-pro
     pricing:
       input_tokens:
-        no_cache: 1
-        cache_read: 0.2
+        no_cache: 0.435
+        cache_read: 0.0036
       output_tokens:
-        text: 3
+        text: 0.87
     capabilities:
       - reasoning
       - tools
@@ -31,10 +31,10 @@ models:
     provider_model_id: mimo-v2.5
     pricing:
       input_tokens:
-        no_cache: 0.4
-        cache_read: 0.08
+        no_cache: 0.14
+        cache_read: 0.0028
       output_tokens:
-        text: 2
+        text: 0.28
     capabilities:
       - reasoning
       - tools
@@ -43,10 +43,10 @@ models:
     deprecation_date: 2026-06-30
     pricing:
       input_tokens:
-        no_cache: 1
-        cache_read: 0.2
+        no_cache: 0.435
+        cache_read: 0.0036
       output_tokens:
-        text: 3
+        text: 0.87
     capabilities:
       - reasoning
       - tools
@@ -55,10 +55,10 @@ models:
     deprecation_date: 2026-06-30
     pricing:
       input_tokens:
-        no_cache: 0.4
-        cache_read: 0.08
+        no_cache: 0.14
+        cache_read: 0.0028
       output_tokens:
-        text: 2
+        text: 0.28
     capabilities:
       - reasoning
       - tools
@@ -67,10 +67,10 @@ models:
     deprecation_date: 2026-06-30
     pricing:
       input_tokens:
-        no_cache: 0.1
-        cache_read: 0.01
+        no_cache: 0.14
+        cache_read: 0.0028
       output_tokens:
-        text: 0.3
+        text: 0.28
     capabilities:
       - reasoning
       - tools


### PR DESCRIPTION
## What changed

- add the canonical `anthropic/claude-opus-5` model with the official 1M context, 128K output, release metadata, and $5/$25 token pricing
- expose Claude Opus 5 through Anthropic, AWS Bedrock, Azure, Claude Code, GitHub Copilot, OpenCode Zen, OpenRouter, and AtlasCloud
- add `moonshotai/kimi-k3` to the live Phala and RedPill catalogs, bringing its registry coverage to 9 providers
- refresh all 42 configured auto-sync provider catalogs and update changed prices from the preferred models.dev feed
- verify all 8 manually maintained providers; refresh AtlasCloud, Phala, Qianfan International, and RedPill from public catalogs while preserving providers whose catalogs require credentials
- rebuild the checked-in registry artifacts and update price-sensitive contract assertions

## Scope notes

- MiniMax H3 is intentionally not registered because no official, verifiable model ID/catalog entry is currently available. Existing MiniMax M3 pricing was refreshed from $0.60/$2.40 to $0.30/$1.20 per 1M input/output tokens.
- AtlasCloud advertises Kimi K3 but marks it not ready, so it is not exposed there yet.
- BytePlus, Google AI, Qianfan CN, and Tencent do not expose an unauthenticated public catalog; their existing entries are preserved.
- All prices in registry source files are USD per 1M tokens.

Sources: [Anthropic Opus 5](https://www.anthropic.com/news/claude-opus-5), [Anthropic model overview](https://platform.claude.com/docs/en/about-claude/models/overview), [Kimi K3 quickstart](https://platform.kimi.ai/docs/guide/kimi-k3-quickstart), [Kimi K3 pricing](https://platform.kimi.ai/docs/pricing/chat-k3), and provider public model catalogs/models.dev.

## Validation

- `cargo test --all-features`
- `cargo clippy --all-features`
- `cargo fmt -- --check`
- `cargo run -p dist-helper -- registry validate` (`50 canonical models, 50 providers`)
- `cargo run -p dist-helper -- check`
- `git diff --check origin/main...HEAD`
