### PR TITLE
feat(policy): harden cost-aware workflow routing

### DIFF
--- a/apps/bitrouter/src/assemble.rs
+++ b/apps/bitrouter/src/assemble.rs
@@ -498,6 +498,14 @@ pub async fn build_app_with_path(
         .metrics_renderer(metrics_renderer)
         .language_model(move |lm| {
             lm.routing_table(routing_table).executor(executor);
+            lm.fallback_backoff(
+                config
+                    .upstream
+                    .fallback_backoff_ms
+                    .iter()
+                    .copied()
+                    .map(std::time::Duration::from_millis),
+            );
             lm.model_selector(policy_runtime_for_selector);
             // Server-tool declaration capture runs first and is pure
             // observation: it parses any advisor / sub-agent / fusion

--- a/apps/bitrouter/src/commands.rs
+++ b/apps/bitrouter/src/commands.rs
@@ -37,6 +37,12 @@ server:
   # sign` for a multi-tenant deployment.
   skip_auth: true
 
+# Retryable fallback is immediate by default. For providers that can return a
+# short overload burst, opt into a bounded delay schedule. Values apply before
+# the 2nd, 3rd, ... route candidate; the final value repeats for longer chains.
+# upstream:
+#   fallback_backoff_ms: [1000, 2000, 4000, 8000, 16000, 30000]
+
 database:
   # Relative paths are interpreted against the bitrouter home (the
   # directory containing this file) — the daemon chdirs there on

--- a/apps/bitrouter/src/main.rs
+++ b/apps/bitrouter/src/main.rs
@@ -491,6 +491,36 @@ enum ConfigAction {
     },
 }
 
+fn parse_unit_interval_ppm(value: &str) -> std::result::Result<u32, String> {
+    let value = value.trim();
+    let (whole, fractional) = value.split_once('.').unwrap_or((value, ""));
+    if !matches!(whole, "0" | "1")
+        || fractional.len() > 6
+        || !fractional.bytes().all(|byte| byte.is_ascii_digit())
+        || (whole == "1" && fractional.bytes().any(|byte| byte != b'0'))
+    {
+        return Err(format!(
+            "expected a decimal between 0 and 1 with at most six fractional digits, got {value}"
+        ));
+    }
+    let fractional_value = if fractional.is_empty() {
+        0
+    } else {
+        fractional
+            .parse::<u32>()
+            .map_err(|error| format!("expected a decimal between 0 and 1, got {value}: {error}"))?
+    };
+    let scale = 10_u32.pow(
+        u32::try_from(6_usize.saturating_sub(fractional.len()))
+            .map_err(|error| format!("could not scale unit interval {value}: {error}"))?,
+    );
+    Ok(if whole == "1" {
+        1_000_000
+    } else {
+        fractional_value.saturating_mul(scale)
+    })
+}
+
 #[derive(Subcommand)]
 enum WorkflowStateAction {
     /// Convert a Harbor run directory into benchmark outcome JSONL.
@@ -551,6 +581,31 @@ enum WorkflowStateAction {
         /// Frozen BitRouter config that defines the reliability thresholds.
         #[arg(long)]
         config: PathBuf,
+        /// Output JSON report path.
+        #[arg(long)]
+        output: PathBuf,
+    },
+    /// Estimate policy cost coverage and savings without changing live routing.
+    PolicyOracle {
+        /// Protocol-native daemon workflow trace JSONL from the baseline run.
+        #[arg(long)]
+        traces: PathBuf,
+        /// Request-settled usage JSONL for the same baseline run.
+        #[arg(long)]
+        cloud_usage: PathBuf,
+        /// Policy lock containing the candidate routes to replay.
+        #[arg(long)]
+        policy_lock: PathBuf,
+        /// Named policy within the lock.
+        #[arg(long)]
+        policy: String,
+        /// Candidate effective cost divided by baseline cost, including any
+        /// expected token, retry, or turn inflation (for example 0.24).
+        #[arg(long = "effective-cost-factor", value_parser = parse_unit_interval_ppm)]
+        effective_cost_factor_ppm: u32,
+        /// Desired end-to-end savings fraction. Repeat for multiple targets.
+        #[arg(long = "target-savings", required = true, value_parser = parse_unit_interval_ppm)]
+        target_savings_ppm: Vec<u32>,
         /// Output JSON report path.
         #[arg(long)]
         output: PathBuf,
@@ -1685,6 +1740,52 @@ async fn workflow_state_cmd(action: WorkflowStateAction) -> Result<()> {
             println!(
                 "✓ wrote {} reliability events to {}",
                 report.event_count,
+                output.display()
+            );
+            Ok(())
+        }
+        WorkflowStateAction::PolicyOracle {
+            traces,
+            cloud_usage,
+            policy_lock,
+            policy,
+            effective_cost_factor_ppm,
+            target_savings_ppm,
+            output,
+        } => {
+            use bitrouter::workflow_state::archive::{CloudUsageRecord, TraceArchive};
+            use bitrouter::workflow_state::counterfactual::analyze_policy_counterfactual;
+
+            let traces = TraceArchive::read_jsonl(&traces)
+                .with_context(|| format!("read workflow traces {}", traces.display()))?;
+            let usage = CloudUsageRecord::load_snapshot_jsonl(&cloud_usage)
+                .with_context(|| format!("read cloud usage {}", cloud_usage.display()))?;
+            let lock = bitrouter::policy_lock::load(&policy_lock)
+                .await
+                .with_context(|| format!("load policy lock {}", policy_lock.display()))?;
+            let definition = lock.document.policies.get(&policy).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "policy {policy} does not exist in {}",
+                    policy_lock.display()
+                )
+            })?;
+            let report = analyze_policy_counterfactual(
+                &traces,
+                &usage,
+                definition,
+                effective_cost_factor_ppm,
+                &target_savings_ppm,
+            )
+            .context("analyze policy counterfactual")?;
+            let encoded = serde_json::to_vec_pretty(&report)
+                .context("serialize policy counterfactual report")?;
+            std::fs::write(&output, encoded)
+                .with_context(|| format!("write policy oracle report {}", output.display()))?;
+            println!(
+                "✓ analyzed {} requests: {:.1}% cost coverage, {:.1}% projected savings -> {}",
+                report.trace_count,
+                f64::from(report.cost_weighted_coverage_ppm) / 10_000.0,
+                f64::from(report.projected_savings_ppm) / 10_000.0,
                 output.display()
             );
             Ok(())
@@ -4069,6 +4170,45 @@ mod tests {
             Some(Command::WorkflowState {
                 action: WorkflowStateAction::Bundle { outcomes: None, .. }
             })
+        ));
+    }
+
+    #[test]
+    fn policy_oracle_accepts_human_readable_cost_assumptions() {
+        use clap::Parser;
+
+        let cli = Cli::try_parse_from([
+            "bitrouter",
+            "workflow-state",
+            "policy-oracle",
+            "--traces",
+            "traces.jsonl",
+            "--cloud-usage",
+            "usage.jsonl",
+            "--policy-lock",
+            "policy-lock.yaml",
+            "--policy",
+            "auto",
+            "--effective-cost-factor",
+            "0.24",
+            "--target-savings",
+            "0.30",
+            "--target-savings",
+            "0.40",
+            "--output",
+            "oracle.json",
+        ])
+        .expect("parse policy counterfactual oracle");
+
+        assert!(matches!(
+            cli.command,
+            Some(Command::WorkflowState {
+                action: WorkflowStateAction::PolicyOracle {
+                    effective_cost_factor_ppm: 240_000,
+                    target_savings_ppm,
+                    ..
+                }
+            }) if target_savings_ppm == vec![300_000, 400_000]
         ));
     }
 

--- a/apps/bitrouter/src/main.rs
+++ b/apps/bitrouter/src/main.rs
@@ -630,6 +630,8 @@ enum WorkflowStateAction {
         #[arg(long = "request-id", required = true)]
         request_ids: Vec<String>,
         /// Frozen price as provider:model=uncached,cache_read,cache_write,output.
+        /// Repeat a provider/model pair for alternative schedules; settlement
+        /// accepts only one distinct candidate that reconstructs the receipt.
         #[arg(long = "price")]
         prices: Vec<String>,
         /// Maximum durable receipt fetches per request.

--- a/apps/bitrouter/src/main.rs
+++ b/apps/bitrouter/src/main.rs
@@ -1218,8 +1218,31 @@ enum AcpCmd {
     Sessions,
 }
 
+const CLI_MAIN_STACK_SIZE: usize = 8 * 1024 * 1024;
+
+fn main() {
+    let worker = std::thread::Builder::new()
+        .name("bitrouter-main".to_owned())
+        .stack_size(CLI_MAIN_STACK_SIZE)
+        .spawn(async_main);
+
+    match worker {
+        Ok(handle) => {
+            if handle.join().is_err() {
+                // The panic hook already rendered the original failure. Match
+                // Rust's normal main-thread panic exit status without hiding it.
+                std::process::exit(101);
+            }
+        }
+        Err(error) => {
+            eprintln!("error: failed to start BitRouter CLI runtime: {error}");
+            std::process::exit(1);
+        }
+    }
+}
+
 #[tokio::main]
-async fn main() {
+async fn async_main() {
     // Parse once here so the global `--json` / `--human` flags are available to
     // render the *result* — a success report or the error envelope — through the
     // single `Output` driver. Diagnostics during execution go to stderr; the
@@ -1235,11 +1258,10 @@ async fn main() {
     let output = bitrouter::output::Output::from_flags(cli.json, cli.human || cli.human_short);
     // Box the dispatch future onto the heap. `run` is a large `async fn` whose
     // state machine inlines the biggest per-command futures (the onboarding
-    // wizard, `spawn`, …), and `#[tokio::main]` polls it on the main thread —
-    // whose stack is only ~1 MiB on Windows. Keeping that state off the stack
-    // leaves headroom for the deep synchronous call chains (rustls/reqwest on
-    // the `cloud` path) that would otherwise overflow the main-thread stack on
-    // Windows (macOS/Linux's 8 MiB default hides it).
+    // wizard, `spawn`, …). Before `async_main` moved to its dedicated stack,
+    // `#[tokio::main]` polled that state on Windows' ~1 MiB native main thread.
+    // Keeping it off the dedicated stack still leaves more headroom for deep
+    // synchronous call chains such as rustls/reqwest on the `cloud` path.
     match Box::pin(run(cli, &output)).await {
         Ok(()) => {}
         Err(e) => {

--- a/apps/bitrouter/src/metering/store.rs
+++ b/apps/bitrouter/src/metering/store.rs
@@ -590,8 +590,10 @@ impl MeteringStore {
     }
 
     /// Apply one content-free authoritative receipt to a pending local row.
-    /// Computed receipts are accepted only when frozen pricing reconstructs
-    /// the exact final micro-USD charge.
+    /// Computed receipts are accepted only when exactly one distinct frozen
+    /// pricing candidate reconstructs the final micro-USD charge. Repeated
+    /// identical candidates are harmless; distinct candidates that collide
+    /// after provider rounding fail closed as ambiguous.
     pub async fn apply_authoritative_receipt(
         &self,
         receipt: &SettlementReceipt,
@@ -676,10 +678,10 @@ impl MeteringStore {
                         )
                         .await;
                 };
-                let Some(price) = prices
+                let candidates = prices
                     .iter()
-                    .find(|price| price.provider_id == provider_id && price.model_id == model_id)
-                else {
+                    .filter(|price| price.provider_id == provider_id && price.model_id == model_id);
+                if candidates.clone().next().is_none() {
                     return self
                         .persist_unknown_reconciliation(
                             row,
@@ -688,23 +690,38 @@ impl MeteringStore {
                             "authoritative_pricing_not_found",
                         )
                         .await;
-                };
-                let pricing = ModelPricing::cache_aware(
-                    Some(price.input_micro_usd_per_token),
-                    price.cache_read_micro_usd_per_token,
-                    price.cache_write_micro_usd_per_token,
-                    Some(price.output_micro_usd_per_token),
-                );
-                let evidence = calculate_charge_evidence(&usage, &pricing, PricingSource::Override);
-                if evidence.status != ChargeStatus::Computed
-                    || evidence.charge_micro_usd != receipt.final_charge_micro_usd
-                {
+                }
+                let mut matching = candidates
+                    .map(|price| {
+                        let pricing = ModelPricing::cache_aware(
+                            Some(price.input_micro_usd_per_token),
+                            price.cache_read_micro_usd_per_token,
+                            price.cache_write_micro_usd_per_token,
+                            Some(price.output_micro_usd_per_token),
+                        );
+                        calculate_charge_evidence(&usage, &pricing, PricingSource::Override)
+                    })
+                    .filter(|evidence| {
+                        evidence.status == ChargeStatus::Computed
+                            && evidence.charge_micro_usd == receipt.final_charge_micro_usd
+                    });
+                let Some(evidence) = matching.next() else {
                     return self
                         .persist_unknown_reconciliation(
                             row,
                             &usage,
                             receipt_json,
                             "authoritative_charge_mismatch",
+                        )
+                        .await;
+                };
+                if matching.any(|candidate| candidate.pricing_version != evidence.pricing_version) {
+                    return self
+                        .persist_unknown_reconciliation(
+                            row,
+                            &usage,
+                            receipt_json,
+                            "authoritative_pricing_ambiguous",
                         )
                         .await;
                 }

--- a/apps/bitrouter/src/metering/tests.rs
+++ b/apps/bitrouter/src/metering/tests.rs
@@ -211,6 +211,94 @@ async fn computed_receipt_replaces_local_usage_only_when_charge_matches() -> Res
 }
 
 #[tokio::test]
+async fn computed_receipt_selects_the_unique_exact_price_candidate() -> Result<()> {
+    let pool = pool().await;
+    let store = MeteringStore::new(pool.clone());
+    let recorder =
+        MeteringRecorder::new(store.clone(), pricing()).with_reconciliation_provider("bitrouter");
+    let mut settlement = ctx("candidate-price", 1, 1);
+    settlement.provider_id = "bitrouter".to_string();
+    recorder.record(&mut settlement).await?;
+    let receipt = SettlementReceipt {
+        request_id: settlement.request_id.clone(),
+        state: SettlementState::Computed,
+        model_id: Some("model-a".to_string()),
+        provider_id: Some("provider-a".to_string()),
+        usage: SettlementUsage {
+            uncached_input_tokens: 10,
+            cache_read_tokens: 0,
+            cache_write_tokens: 0,
+            output_tokens: 5,
+            reasoning_tokens: 0,
+        },
+        final_charge_micro_usd: Some(25),
+    };
+    let prices = [
+        super::UsagePriceOverride::parse("provider-a:model-a=2,0,0,10")?,
+        super::UsagePriceOverride::parse("provider-a:model-a=1,0,0,3")?,
+    ];
+
+    let status = store.apply_authoritative_receipt(&receipt, &prices).await?;
+    let records = store.export_usage(TimeWindow::ThisMonth).await?;
+    let record = &records[0];
+
+    assert_eq!(status, super::ReconciliationStatus::Computed);
+    assert_eq!(record.final_charge_micro_usd, Some(25));
+    let rates = &record
+        .charge_evidence
+        .as_ref()
+        .expect("selected price evidence")
+        .effective_rates;
+    assert_eq!(rates.uncached_input_micro_usd_per_token, Some(1.0));
+    assert_eq!(rates.output_micro_usd_per_token, Some(3.0));
+    Ok(())
+}
+
+#[tokio::test]
+async fn computed_receipt_rejects_ambiguous_exact_price_candidates() -> Result<()> {
+    let pool = pool().await;
+    let store = MeteringStore::new(pool.clone());
+    let recorder =
+        MeteringRecorder::new(store.clone(), pricing()).with_reconciliation_provider("bitrouter");
+    let mut settlement = ctx("ambiguous-price", 1, 0);
+    settlement.provider_id = "bitrouter".to_string();
+    recorder.record(&mut settlement).await?;
+    let receipt = SettlementReceipt {
+        request_id: settlement.request_id.clone(),
+        state: SettlementState::Computed,
+        model_id: Some("model-a".to_string()),
+        provider_id: Some("provider-a".to_string()),
+        usage: SettlementUsage {
+            uncached_input_tokens: 1,
+            cache_read_tokens: 0,
+            cache_write_tokens: 0,
+            output_tokens: 0,
+            reasoning_tokens: 0,
+        },
+        final_charge_micro_usd: Some(1),
+    };
+    let prices = [
+        super::UsagePriceOverride::parse("provider-a:model-a=1.1,0,0,3")?,
+        super::UsagePriceOverride::parse("provider-a:model-a=1.4,0,0,5")?,
+    ];
+
+    let status = store.apply_authoritative_receipt(&receipt, &prices).await?;
+    let records = store.export_usage(TimeWindow::ThisMonth).await?;
+    let record = &records[0];
+
+    assert_eq!(status, super::ReconciliationStatus::Unknown);
+    assert_eq!(record.final_charge_micro_usd, None);
+    assert_eq!(
+        record
+            .charge_evidence
+            .as_ref()
+            .and_then(|evidence| evidence.unknown_reason.as_deref()),
+        Some("authoritative_pricing_ambiguous")
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn authoritative_half_micro_charge_matches_provider_rounding() -> Result<()> {
     let pool = pool().await;
     let store = MeteringStore::new(pool.clone());

--- a/apps/bitrouter/src/policy_compile.rs
+++ b/apps/bitrouter/src/policy_compile.rs
@@ -511,9 +511,20 @@ fn eval_recommendation(
                     .is_none_or(|baseline_rate| evidence.pass_rate_ppm() >= baseline_rate)
         })
         .max_by(|(left_tier, left), (right_tier, right)| {
-            left.independent_tasks
-                .len()
-                .cmp(&right.independent_tasks.len())
+            let cost_order = if left.independent_tasks == right.independent_tasks {
+                match (left.cost_micro_usd.mean(), right.cost_micro_usd.mean()) {
+                    (Some(left_cost), Some(right_cost)) => right_cost.cmp(&left_cost),
+                    _ => std::cmp::Ordering::Equal,
+                }
+            } else {
+                std::cmp::Ordering::Equal
+            };
+            cost_order
+                .then_with(|| {
+                    left.independent_tasks
+                        .len()
+                        .cmp(&right.independent_tasks.len())
+                })
                 .then_with(|| left.pass_rate_ppm().cmp(&right.pass_rate_ppm()))
                 .then_with(|| right_tier.cmp(left_tier))
         })
@@ -702,14 +713,14 @@ mod tests {
     use crate::eval::compiler::{EvalEvidenceRecord, EvalEvidenceSnapshot};
     use crate::eval::types::{
         EvalDecisionRef, EvalScope, EvalSubject, EvalVerdict, EvaluationResult, EvaluatorIdentity,
-        EvaluatorKind, evidence_digest,
+        EvaluatorKind, MetricUnit, MetricValue, evidence_digest,
     };
     use crate::policy_lock::{
         CertificateSource, PolicyDefinition, PolicyLock, PromotionVerdict, RouteOwner,
         deterministic_yaml,
     };
 
-    const EDIT_KEY: &str = "agent_trace/v1|edit|normal";
+    const EDIT_KEY: &str = "agent_trace/v2|edit|normal";
 
     fn policy(route: Option<&str>) -> PolicyDefinition {
         PolicyDefinition {
@@ -1108,6 +1119,97 @@ mod tests {
                 .as_ref()
                 .map(|q| q.candidate_pass_rate_ppm),
             Some(1_000_000)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn qualified_eval_candidates_prefer_lower_observed_cost() -> anyhow::Result<()> {
+        let mut current = v1(None);
+        current
+            .policies
+            .get_mut("auto")
+            .ok_or_else(|| anyhow::anyhow!("test fixture is missing policy auto"))?
+            .tiers
+            .insert("balanced".into(), "vendor:balanced".into());
+        let records = [("balanced", "task-shared", 600), ("economy", "task-shared", 300)]
+            .into_iter()
+            .map(|(tier, task, cost)| -> anyhow::Result<EvalEvidenceRecord> {
+                let evidence = Vec::new();
+                let evidence_digest = evidence_digest(&evidence)?;
+                let subject = EvalSubject {
+                    schema_version: 1,
+                    eval_id: format!("eval-{tier}"),
+                    scope: EvalScope::Task,
+                    subject_id: task.into(),
+                    policy_digest: "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".into(),
+                    preset: Some("auto".into()),
+                    cohort: None,
+                    holdout: false,
+                    decisions: vec![EvalDecisionRef {
+                        decision_id: format!("decision-{tier}"),
+                        policy: "auto".into(),
+                        request_key: EDIT_KEY.into(),
+                        selected_tier: tier.into(),
+                        baseline_tier: Some("strong".into()),
+                        policy_digest: "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".into(),
+                    }],
+                    requested_dimensions: BTreeSet::from([
+                        "quality.pass".into(),
+                        "cost.usd_micros".into(),
+                    ]),
+                    evidence,
+                    evidence_digest: evidence_digest.clone(),
+                    observed_at: "2026-07-30T00:00:00Z".into(),
+                };
+                let result = EvaluationResult {
+                    schema_version: 1,
+                    eval_id: subject.eval_id.clone(),
+                    evidence_digest,
+                    evaluator: EvaluatorIdentity {
+                        authority_id: "task-native".into(),
+                        evaluator_id: "suite".into(),
+                        kind: EvaluatorKind::TaskNative,
+                        version: "1".into(),
+                        config_digest: "sha256:1123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".into(),
+                    },
+                    verdict: EvalVerdict::Pass,
+                    metrics: BTreeMap::from([(
+                        "cost.usd_micros".into(),
+                        MetricValue::new(cost, MetricUnit::MicroUsd),
+                    )]),
+                    hard_violations: Vec::new(),
+                    confidence_ppm: Some(1_000_000),
+                    evidence_refs: Vec::new(),
+                    decision_credit: BTreeMap::new(),
+                    idempotency_key: format!("result-{tier}"),
+                    submitted_at: "2026-07-30T00:01:00Z".into(),
+                };
+                Ok(EvalEvidenceRecord {
+                    result_id: format!("result-{tier}"),
+                    content_digest: format!("content-{tier}"),
+                    subject,
+                    result,
+                })
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        let eval = EvalEvidenceSnapshot {
+            evidence_root:
+                "sha256:2123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".into(),
+            frozen_at: "2026-07-30T00:02:00Z".into(),
+            records,
+        };
+
+        let compiled = super::compile_candidate(super::CompileInput {
+            current: &current,
+            parent_digest: None,
+            legacy: &snapshot(false, None),
+            eval: Some(&eval),
+        })?;
+
+        assert_eq!(
+            compiled.document.policies["auto"].routes[EDIT_KEY],
+            "economy"
         );
         Ok(())
     }

--- a/apps/bitrouter/src/policy_lock.rs
+++ b/apps/bitrouter/src/policy_lock.rs
@@ -2194,7 +2194,7 @@ policies:
         assert!(!lock_raw.contains("explore_enabled:"));
         let policy = &lock.policies["auto"];
         assert_eq!(policy.key_strategy, PolicyKeyStrategy::AgentTrace);
-        assert_eq!(policy.tiers["balanced"], "bitrouter:z-ai/glm-5.2");
+        assert_eq!(policy.tiers["balanced"], "bitrouter:moonshotai/kimi-k3");
         assert_eq!(policy.routes["agent_trace/v2|edit|normal"], "economy");
         assert_eq!(policy.routes["agent_trace/v2|test|normal"], "economy");
         assert_eq!(

--- a/apps/bitrouter/src/policy_lock.rs
+++ b/apps/bitrouter/src/policy_lock.rs
@@ -2194,15 +2194,25 @@ policies:
         assert!(!lock_raw.contains("explore_enabled:"));
         let policy = &lock.policies["auto"];
         assert_eq!(policy.key_strategy, PolicyKeyStrategy::AgentTrace);
-        assert_eq!(policy.routes["agent_trace/v1|edit|normal"], "economy");
-        assert_eq!(policy.routes["agent_trace/v1|test|normal"], "economy");
+        assert_eq!(policy.tiers["balanced"], "bitrouter:z-ai/glm-5.2");
+        assert_eq!(policy.routes["agent_trace/v2|edit|normal"], "economy");
+        assert_eq!(policy.routes["agent_trace/v2|test|normal"], "economy");
         assert_eq!(
-            policy.routes["agent_trace/v1|tool_followup|normal"],
+            policy.routes["agent_trace/v2|tool_followup|normal"],
             "economy"
         );
+        for key in [
+            "agent_trace/v2|review|normal",
+            "agent_trace/v2|review|context",
+            "agent_trace/v2|edit|context",
+            "agent_trace/v2|test|context",
+            "agent_trace/v2|tool_followup|context",
+        ] {
+            assert_eq!(policy.routes[key], "balanced", "{key}");
+        }
         assert_eq!(policy.default_tier.as_deref(), Some("strong"));
         assert_eq!(policy.tool_use_tier.as_deref(), Some("strong"));
-        assert_eq!(policy.tool_safe_tiers, ["strong", "economy"]);
+        assert_eq!(policy.tool_safe_tiers, ["strong", "balanced", "economy"]);
 
         let rendered = deterministic_yaml(&lock).unwrap();
         assert!(rendered.contains("key_strategy: agent_trace"));
@@ -2210,7 +2220,7 @@ policies:
     }
 
     #[test]
-    fn auto_router_template_migrated_routes_are_compiler_owned() -> anyhow::Result<()> {
+    fn auto_router_template_experiments_are_compiler_owned() -> anyhow::Result<()> {
         let template_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("../..")
             .join("templates/auto-router");
@@ -2222,10 +2232,11 @@ policies:
             .certificates
             .get("auto")
             .ok_or_else(|| anyhow::anyhow!("auto template is missing route certificates"))?;
-        assert_eq!(certificates.len(), 3);
+        assert_eq!(certificates.len(), 8);
         for certificate in certificates.values() {
             assert_eq!(certificate.owner, RouteOwner::Compiler);
-            assert_eq!(certificate.source, CertificateSource::LegacyAdequacyV1);
+            assert_eq!(certificate.source, CertificateSource::Mixed);
+            assert_eq!(certificate.verdict, PromotionVerdict::Experiment);
         }
         Ok(())
     }

--- a/apps/bitrouter/src/policy_table_router.rs
+++ b/apps/bitrouter/src/policy_table_router.rs
@@ -127,13 +127,21 @@ impl PolicyTable {
         }))
     }
 
-    /// The tier a fingerprint maps to (or `default_tier`), before any guardrail
-    /// or escalation. `None` when unmapped and no default tier is set.
-    fn tier_for_fingerprint(&self, fingerprint: &str) -> Option<&str> {
-        self.fingerprints
-            .get(fingerprint)
-            .or(self.default_tier.as_ref())
-            .map(String::as_str)
+    /// Resolve a v2 workflow key, then its exact v1 compatibility projection,
+    /// then the default. The returned key is the key that actually selected
+    /// the tier, except that defaults deliberately retain the v2 learning key.
+    fn tier_for_workflow<'table, 'key>(
+        &'table self,
+        primary: &'key str,
+        compatibility_v1: &'key str,
+    ) -> Option<(&'table str, &'key str)> {
+        if let Some(tier) = self.fingerprints.get(primary) {
+            return Some((tier.as_str(), primary));
+        }
+        if let Some(tier) = self.fingerprints.get(compatibility_v1) {
+            return Some((tier.as_str(), compatibility_v1));
+        }
+        self.default_tier.as_deref().map(|tier| (tier, primary))
     }
 
     fn guardrail_with_status<'a>(&'a self, tier: &'a str, prompt: &Prompt) -> (&'a str, bool) {
@@ -306,10 +314,10 @@ impl PolicyTableRouter {
         let online =
             OnlineWorkflowState::from_headers_with_tracker(headers, prompt, &self.identity_tracker);
         let legacy_fingerprint = online.legacy_fingerprint().to_string();
-        let request_key = online.routing_key().to_string();
+        let primary_request_key = online.routing_key().to_string();
         let mut decision = PolicyDecision {
             key_strategy: PolicyKeyStrategy::AgentTrace,
-            request_key,
+            request_key: primary_request_key.clone(),
             legacy_fingerprint,
             workflow_state_kind: online.ir.state_kind.to_string(),
             harness_id: online.ir.harness_id.clone(),
@@ -333,9 +341,13 @@ impl PolicyTableRouter {
             return decision;
         }
 
-        let Some(raw_static_tier) = self.table.tier_for_fingerprint(&decision.request_key) else {
+        let Some((raw_static_tier, matched_request_key)) = self
+            .table
+            .tier_for_workflow(&primary_request_key, online.compatibility_routing_key_v1())
+        else {
             return decision;
         };
+        decision.request_key = matched_request_key.to_string();
         decision.static_tier = Some(raw_static_tier.to_string());
         decision.static_model = self
             .table
@@ -1111,6 +1123,48 @@ mod tests {
             ),
             "vendor/cheap"
         );
+    }
+
+    #[test]
+    fn v1_policy_routes_remain_active_as_compatibility_fallbacks() {
+        let router = router();
+        let mut prompt = prompt("inbound");
+        prompt.messages = read_step();
+
+        let decision = router.decision_for(&prompt, &HeaderMap::new());
+
+        assert_eq!(decision.request_key, "agent_trace/v1|tool_followup|normal");
+        assert_eq!(decision.selected_tier.as_deref(), Some("cheap"));
+    }
+
+    #[test]
+    fn v2_policy_route_wins_over_a_v1_compatibility_route() {
+        let mut cfg = config();
+        cfg.fingerprints.insert(
+            "agent_trace/v2|tool_followup|normal".to_string(),
+            "flagship".to_string(),
+        );
+        let router = PolicyTableRouter::from_config(&cfg).expect("configured");
+        let mut prompt = prompt("inbound");
+        prompt.messages = read_step();
+
+        let decision = router.decision_for(&prompt, &HeaderMap::new());
+
+        assert_eq!(decision.request_key, "agent_trace/v2|tool_followup|normal");
+        assert_eq!(decision.selected_tier.as_deref(), Some("flagship"));
+    }
+
+    #[test]
+    fn default_policy_route_records_the_v2_learning_key() {
+        let mut cfg = config();
+        cfg.fingerprints.clear();
+        let router = PolicyTableRouter::from_config(&cfg).expect("configured");
+        let prompt = prompt("inbound");
+
+        let decision = router.decision_for(&prompt, &HeaderMap::new());
+
+        assert_eq!(decision.request_key, "agent_trace/v2|opening|normal");
+        assert_eq!(decision.selected_tier.as_deref(), Some("flagship"));
     }
 
     #[test]

--- a/apps/bitrouter/src/workflow_state/counterfactual.rs
+++ b/apps/bitrouter/src/workflow_state/counterfactual.rs
@@ -1,0 +1,485 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::Serialize;
+
+use crate::policy_lock::PolicyDefinition;
+use crate::workflow_state::archive::CloudUsageRecord;
+use crate::workflow_state::fixture::WorkflowTraceFixture;
+use crate::workflow_state::real_trace::{CapturedIngressTrace, TraceSanitizer};
+use crate::workflow_state::replay::extract_fixture_ir;
+use bitrouter_sdk::{BitrouterError, Result};
+
+const PPM: u64 = 1_000_000;
+
+/// Cost-only replay of one immutable policy over a settled baseline trace.
+///
+/// The factor is the candidate's effective cost divided by baseline cost and
+/// may already include expected token, retry, and turn inflation. This is an
+/// upper-bound prioritization tool: it never claims that replacing a request
+/// leaves the remainder of the live trajectory unchanged.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PolicyCounterfactualReport {
+    pub effective_cost_factor_ppm: u32,
+    pub trace_count: usize,
+    pub known_cost_request_count: usize,
+    pub unknown_cost_request_count: usize,
+    pub eligible_request_count: usize,
+    pub baseline_cost_micro_usd: u64,
+    pub eligible_cost_micro_usd: u64,
+    pub cost_weighted_coverage_ppm: u32,
+    pub projected_savings_micro_usd: u64,
+    pub projected_savings_ppm: u32,
+    pub complete_cost_evidence: bool,
+    pub routes: Vec<CounterfactualRouteSummary>,
+    pub uncovered_routes: Vec<CounterfactualRouteSummary>,
+    pub ranked_requests: Vec<CounterfactualRequest>,
+    pub ranked_uncovered_requests: Vec<CounterfactualRequest>,
+    pub targets: Vec<CounterfactualTarget>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CounterfactualRouteSummary {
+    pub request_key: String,
+    pub selected_tier: String,
+    pub request_count: usize,
+    pub baseline_cost_micro_usd: u64,
+    pub cost_share_ppm: u32,
+    pub projected_savings_micro_usd: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CounterfactualRequest {
+    pub trace_id: String,
+    pub request_id: String,
+    pub request_key: String,
+    pub selected_tier: String,
+    pub baseline_cost_micro_usd: u64,
+    pub projected_savings_micro_usd: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CounterfactualTarget {
+    pub target_savings_ppm: u32,
+    pub required_coverage_ppm: u32,
+    pub attainable: bool,
+    pub minimum_request_count: Option<usize>,
+}
+
+#[derive(Default)]
+struct RouteAccumulator {
+    request_count: usize,
+    baseline_cost_micro_usd: u64,
+    projected_savings_micro_usd: u64,
+}
+
+/// Replay `policy` over protocol-native baseline traces and exact request
+/// settlement. Route eligibility is derived from the lock rather than from a
+/// benchmark- or agent-specific label.
+pub fn analyze_policy_counterfactual(
+    traces: &[CapturedIngressTrace],
+    usage: &[CloudUsageRecord],
+    policy: &PolicyDefinition,
+    effective_cost_factor_ppm: u32,
+    target_savings_ppm: &[u32],
+) -> Result<PolicyCounterfactualReport> {
+    if effective_cost_factor_ppm > PPM as u32 {
+        return Err(BitrouterError::bad_request(
+            "counterfactual effective cost factor must be between 0 and 1000000 ppm",
+        ));
+    }
+    if target_savings_ppm.iter().any(|target| *target > PPM as u32) {
+        return Err(BitrouterError::bad_request(
+            "counterfactual savings targets must be between 0 and 1000000 ppm",
+        ));
+    }
+    let default_tier = policy.default_tier.as_deref().ok_or_else(|| {
+        BitrouterError::bad_request("counterfactual policy requires a default_tier")
+    })?;
+    let usage_by_request = strict_usage_join(traces, usage)?;
+    let mut baseline_cost_micro_usd = 0_u64;
+    let mut eligible_cost_micro_usd = 0_u64;
+    let mut projected_savings_micro_usd = 0_u64;
+    let mut known_cost_request_count = 0_usize;
+    let mut unknown_cost_request_count = 0_usize;
+    let mut routes = BTreeMap::<(String, String), RouteAccumulator>::new();
+    let mut uncovered_routes = BTreeMap::<(String, String), RouteAccumulator>::new();
+    let mut ranked_requests = Vec::new();
+    let mut ranked_uncovered_requests = Vec::new();
+
+    for trace in traces {
+        let fixture = WorkflowTraceFixture::from_value(
+            trace.to_replay_fixture_json(&TraceSanitizer::default())?,
+        )?;
+        let ir = extract_fixture_ir(&fixture);
+        let projection = ir.route_projection();
+        let primary_request_key = projection.key();
+        let compatibility_request_key = ir.compatibility_route_projection_v1().key();
+        let (selected_tier, request_key) = resolve_tier(
+            policy,
+            &primary_request_key,
+            &compatibility_request_key,
+            !fixture.prompt.tools.is_empty(),
+        )
+        .ok_or_else(|| {
+            BitrouterError::bad_request("counterfactual policy has no resolvable tier")
+        })?;
+        let Some(cost) = usage_by_request
+            .get(trace.id.as_str())
+            .and_then(|record| record.final_charge_micro_usd)
+        else {
+            unknown_cost_request_count = unknown_cost_request_count.saturating_add(1);
+            continue;
+        };
+        known_cost_request_count = known_cost_request_count.saturating_add(1);
+        baseline_cost_micro_usd = baseline_cost_micro_usd.saturating_add(cost);
+        if selected_tier == default_tier {
+            let route = uncovered_routes
+                .entry((request_key.to_string(), selected_tier.to_string()))
+                .or_default();
+            route.request_count = route.request_count.saturating_add(1);
+            route.baseline_cost_micro_usd = route.baseline_cost_micro_usd.saturating_add(cost);
+            ranked_uncovered_requests.push(CounterfactualRequest {
+                trace_id: trace.id.clone(),
+                request_id: trace.id.clone(),
+                request_key: request_key.to_string(),
+                selected_tier: selected_tier.to_string(),
+                baseline_cost_micro_usd: cost,
+                projected_savings_micro_usd: 0,
+            });
+            continue;
+        }
+        let savings = scaled_savings(cost, effective_cost_factor_ppm);
+        eligible_cost_micro_usd = eligible_cost_micro_usd.saturating_add(cost);
+        projected_savings_micro_usd = projected_savings_micro_usd.saturating_add(savings);
+        let route = routes
+            .entry((request_key.to_string(), selected_tier.to_string()))
+            .or_default();
+        route.request_count = route.request_count.saturating_add(1);
+        route.baseline_cost_micro_usd = route.baseline_cost_micro_usd.saturating_add(cost);
+        route.projected_savings_micro_usd =
+            route.projected_savings_micro_usd.saturating_add(savings);
+        ranked_requests.push(CounterfactualRequest {
+            trace_id: trace.id.clone(),
+            request_id: trace.id.clone(),
+            request_key: request_key.to_string(),
+            selected_tier: selected_tier.to_string(),
+            baseline_cost_micro_usd: cost,
+            projected_savings_micro_usd: savings,
+        });
+    }
+
+    ranked_requests.sort_by(|left, right| {
+        right
+            .baseline_cost_micro_usd
+            .cmp(&left.baseline_cost_micro_usd)
+            .then_with(|| left.request_id.cmp(&right.request_id))
+    });
+    ranked_uncovered_requests.sort_by(|left, right| {
+        right
+            .baseline_cost_micro_usd
+            .cmp(&left.baseline_cost_micro_usd)
+            .then_with(|| left.request_id.cmp(&right.request_id))
+    });
+    let complete_cost_evidence = unknown_cost_request_count == 0;
+    let routes = route_summaries(routes, baseline_cost_micro_usd);
+    let uncovered_routes = route_summaries(uncovered_routes, baseline_cost_micro_usd);
+    let projected_savings_ppm = ratio_ppm(projected_savings_micro_usd, baseline_cost_micro_usd);
+    let targets = target_savings_ppm
+        .iter()
+        .map(|target| {
+            target_report(
+                *target,
+                effective_cost_factor_ppm,
+                baseline_cost_micro_usd,
+                projected_savings_ppm,
+                complete_cost_evidence,
+                &ranked_requests,
+            )
+        })
+        .collect();
+
+    Ok(PolicyCounterfactualReport {
+        effective_cost_factor_ppm,
+        trace_count: traces.len(),
+        known_cost_request_count,
+        unknown_cost_request_count,
+        eligible_request_count: ranked_requests.len(),
+        baseline_cost_micro_usd,
+        eligible_cost_micro_usd,
+        cost_weighted_coverage_ppm: ratio_ppm(eligible_cost_micro_usd, baseline_cost_micro_usd),
+        projected_savings_micro_usd,
+        projected_savings_ppm,
+        complete_cost_evidence,
+        routes,
+        uncovered_routes,
+        ranked_requests,
+        ranked_uncovered_requests,
+        targets,
+    })
+}
+
+fn route_summaries(
+    routes: BTreeMap<(String, String), RouteAccumulator>,
+    baseline_cost_micro_usd: u64,
+) -> Vec<CounterfactualRouteSummary> {
+    routes
+        .into_iter()
+        .map(
+            |((request_key, selected_tier), route)| CounterfactualRouteSummary {
+                request_key,
+                selected_tier,
+                request_count: route.request_count,
+                baseline_cost_micro_usd: route.baseline_cost_micro_usd,
+                cost_share_ppm: ratio_ppm(route.baseline_cost_micro_usd, baseline_cost_micro_usd),
+                projected_savings_micro_usd: route.projected_savings_micro_usd,
+            },
+        )
+        .collect()
+}
+
+fn strict_usage_join<'a>(
+    traces: &[CapturedIngressTrace],
+    usage: &'a [CloudUsageRecord],
+) -> Result<BTreeMap<&'a str, &'a CloudUsageRecord>> {
+    let mut trace_ids = BTreeSet::new();
+    for trace in traces {
+        if trace.id.trim().is_empty() || !trace_ids.insert(trace.id.as_str()) {
+            return Err(BitrouterError::bad_request(
+                "counterfactual traces contain an empty or duplicate request id",
+            ));
+        }
+    }
+    let mut usage_by_request = BTreeMap::new();
+    for record in usage {
+        let Some(request_id) = record.request_id.as_deref() else {
+            return Err(BitrouterError::bad_request(
+                "counterfactual usage row has no request id",
+            ));
+        };
+        if usage_by_request.insert(request_id, record).is_some() {
+            return Err(BitrouterError::bad_request(format!(
+                "counterfactual usage contains duplicate request id {request_id}"
+            )));
+        }
+    }
+    let usage_ids = usage_by_request.keys().copied().collect::<BTreeSet<_>>();
+    if trace_ids != usage_ids {
+        return Err(BitrouterError::bad_request(
+            "counterfactual trace/usage request ids differ",
+        ));
+    }
+    Ok(usage_by_request)
+}
+
+fn resolve_tier<'policy, 'key>(
+    policy: &'policy PolicyDefinition,
+    primary_request_key: &'key str,
+    compatibility_request_key: &'key str,
+    carries_tools: bool,
+) -> Option<(&'policy str, &'key str)> {
+    let (raw, matched_request_key) = if let Some(tier) = policy.routes.get(primary_request_key) {
+        (tier.as_str(), primary_request_key)
+    } else if let Some(tier) = policy.routes.get(compatibility_request_key) {
+        (tier.as_str(), compatibility_request_key)
+    } else {
+        (policy.default_tier.as_deref()?, primary_request_key)
+    };
+    if carries_tools
+        && !policy.tool_safe_tiers.iter().any(|tier| tier == raw)
+        && let Some(floor) = policy.tool_use_tier.as_deref()
+    {
+        return Some((floor, matched_request_key));
+    }
+    Some((raw, matched_request_key))
+}
+
+fn scaled_savings(cost: u64, effective_cost_factor_ppm: u32) -> u64 {
+    let savings_factor = PPM.saturating_sub(u64::from(effective_cost_factor_ppm));
+    mul_div_floor(cost, savings_factor, PPM)
+}
+
+fn ratio_ppm(numerator: u64, denominator: u64) -> u32 {
+    if denominator == 0 {
+        return 0;
+    }
+    let ratio = mul_div_floor(numerator, PPM, denominator);
+    u32::try_from(ratio.min(PPM)).unwrap_or(PPM as u32)
+}
+
+fn target_report(
+    target_savings_ppm: u32,
+    effective_cost_factor_ppm: u32,
+    baseline_cost_micro_usd: u64,
+    projected_savings_ppm: u32,
+    complete_cost_evidence: bool,
+    ranked_requests: &[CounterfactualRequest],
+) -> CounterfactualTarget {
+    let savings_factor = PPM.saturating_sub(u64::from(effective_cost_factor_ppm));
+    let required_coverage_ppm = if target_savings_ppm == 0 {
+        0
+    } else if savings_factor == 0 {
+        u32::MAX
+    } else {
+        let required = mul_div_ceil(u64::from(target_savings_ppm), PPM, savings_factor);
+        u32::try_from(required).unwrap_or(u32::MAX)
+    };
+    let target_cost = mul_div_ceil(baseline_cost_micro_usd, u64::from(target_savings_ppm), PPM);
+    let mut accumulated = 0_u64;
+    let mut minimum_request_count = None;
+    if target_cost == 0 {
+        minimum_request_count = Some(0);
+    } else {
+        for (index, request) in ranked_requests.iter().enumerate() {
+            accumulated = accumulated.saturating_add(request.projected_savings_micro_usd);
+            if accumulated >= target_cost {
+                minimum_request_count = Some(index.saturating_add(1));
+                break;
+            }
+        }
+    }
+    CounterfactualTarget {
+        target_savings_ppm,
+        required_coverage_ppm,
+        attainable: complete_cost_evidence && projected_savings_ppm >= target_savings_ppm,
+        minimum_request_count,
+    }
+}
+
+fn mul_div_floor(value: u64, multiplier: u64, divisor: u64) -> u64 {
+    if divisor == 0 {
+        return u64::MAX;
+    }
+    let result = u128::from(value).saturating_mul(u128::from(multiplier)) / u128::from(divisor);
+    u64::try_from(result).unwrap_or(u64::MAX)
+}
+
+fn mul_div_ceil(value: u64, multiplier: u64, divisor: u64) -> u64 {
+    if divisor == 0 {
+        return u64::MAX;
+    }
+    let numerator = u128::from(value).saturating_mul(u128::from(multiplier));
+    let result =
+        numerator.saturating_add(u128::from(divisor).saturating_sub(1)) / u128::from(divisor);
+    u64::try_from(result).unwrap_or(u64::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use crate::metering::{ChargeStatus, ReconciliationStatus};
+    use crate::policy_lock::PolicyDefinition;
+    use crate::workflow_state::archive::CloudUsageRecord;
+    use crate::workflow_state::ir::{HarnessId, ProtocolKind};
+    use crate::workflow_state::real_trace::{CapturedIngressTrace, RealTraceOutcome};
+
+    use super::analyze_policy_counterfactual;
+
+    fn trace(id: &str, assistant_action: Option<&str>) -> CapturedIngressTrace {
+        let mut messages = vec![
+            serde_json::json!({
+                "role": "system",
+                "content": "You are an AI assistant tasked with solving command-line tasks in a Linux environment. Format your response as JSON with commands and task_complete."
+            }),
+            serde_json::json!({"role": "user", "content": "continue"}),
+        ];
+        if let Some(action) = assistant_action {
+            messages.push(serde_json::json!({"role": "assistant", "content": action}));
+            messages.push(serde_json::json!({"role": "user", "content": "command output"}));
+        }
+        CapturedIngressTrace {
+            id: id.to_string(),
+            captured_at: Some("2026-07-31T00:00:00Z".to_string()),
+            harness: HarnessId::Terminus2,
+            protocol: ProtocolKind::ChatCompletions,
+            method: "POST".to_string(),
+            path: "/v1/chat/completions".to_string(),
+            headers: BTreeMap::new(),
+            raw_body: serde_json::json!({
+                "model": "@auto",
+                "messages": messages
+            }),
+            outcome: RealTraceOutcome {
+                http_status: 200,
+                status: "completed".to_string(),
+            },
+        }
+    }
+
+    fn usage(id: &str, cost: u64) -> CloudUsageRecord {
+        CloudUsageRecord {
+            request_id: Some(id.to_string()),
+            provider_id: "openai-codex".to_string(),
+            model_id: "gpt-5.6-sol".to_string(),
+            final_charge_micro_usd: Some(cost),
+            charge_status: ChargeStatus::Computed,
+            reconciliation_status: ReconciliationStatus::NotApplicable,
+            ..CloudUsageRecord::default()
+        }
+    }
+
+    fn policy() -> PolicyDefinition {
+        PolicyDefinition {
+            tiers: BTreeMap::from([
+                ("economy".to_string(), "vendor:economy".to_string()),
+                ("strong".to_string(), "vendor:strong".to_string()),
+            ]),
+            routes: BTreeMap::from([(
+                "agent_trace/v1|edit|normal".to_string(),
+                "economy".to_string(),
+            )]),
+            default_tier: Some("strong".to_string()),
+            tool_use_tier: Some("strong".to_string()),
+            tool_safe_tiers: vec!["strong".to_string(), "economy".to_string()],
+            ..PolicyDefinition::default()
+        }
+    }
+
+    #[test]
+    fn oracle_reports_cost_weighted_coverage_and_target_steps() {
+        let traces = vec![
+            trace("opening", None),
+            trace(
+                "edit",
+                Some(r#"{"commands":[{"keystrokes":"sed -i s/a/b/ file"}],"task_complete":false}"#),
+            ),
+        ];
+        let usage = vec![usage("opening", 1_000), usage("edit", 3_000)];
+
+        let report = analyze_policy_counterfactual(&traces, &usage, &policy(), 250_000, &[500_000])
+            .expect("counterfactual report");
+
+        assert_eq!(report.baseline_cost_micro_usd, 4_000);
+        assert_eq!(report.eligible_request_count, 1);
+        assert_eq!(report.eligible_cost_micro_usd, 3_000);
+        assert_eq!(report.cost_weighted_coverage_ppm, 750_000);
+        assert_eq!(report.projected_savings_micro_usd, 2_250);
+        assert_eq!(report.projected_savings_ppm, 562_500);
+        assert_eq!(report.targets[0].required_coverage_ppm, 666_667);
+        assert!(report.targets[0].attainable);
+        assert_eq!(report.targets[0].minimum_request_count, Some(1));
+        assert_eq!(report.ranked_requests[0].request_id, "edit");
+        assert_eq!(report.ranked_requests[0].baseline_cost_micro_usd, 3_000);
+        assert_eq!(report.uncovered_routes.len(), 1);
+        assert_eq!(
+            report.uncovered_routes[0].request_key,
+            "agent_trace/v2|opening|normal"
+        );
+        assert_eq!(report.uncovered_routes[0].baseline_cost_micro_usd, 1_000);
+        assert_eq!(report.ranked_uncovered_requests[0].request_id, "opening");
+    }
+
+    #[test]
+    fn oracle_rejects_an_incomplete_trace_usage_join() {
+        let error = analyze_policy_counterfactual(
+            &[trace("opening", None)],
+            &[],
+            &policy(),
+            250_000,
+            &[300_000],
+        )
+        .expect_err("missing usage must fail closed");
+
+        assert!(error.to_string().contains("trace/usage request ids differ"));
+    }
+}

--- a/apps/bitrouter/src/workflow_state/extractors/generic.rs
+++ b/apps/bitrouter/src/workflow_state/extractors/generic.rs
@@ -11,6 +11,8 @@ use crate::workflow_state::session::resolve_session_signal;
 
 pub struct GenericPromptExtractor;
 
+const GUARDED_TOOL_TRAJECTORY_ASSISTANT_TURNS: usize = 8;
+
 impl WorkflowStateExtractor for GenericPromptExtractor {
     fn extract(&self, input: &ExtractorInput<'_>) -> WorkflowStateIR {
         let prompt = input.prompt;
@@ -77,7 +79,7 @@ impl WorkflowStateExtractor for GenericPromptExtractor {
             });
         }
 
-        WorkflowStateIR {
+        let mut ir = WorkflowStateIR {
             harness_id: input.harness_hint.clone().unwrap_or(HarnessId::Generic),
             protocol: input.protocol_hint.clone(),
             state_kind,
@@ -92,7 +94,50 @@ impl WorkflowStateExtractor for GenericPromptExtractor {
             identity: Default::default(),
             confidence: 0.7,
             evidence,
-        }
+        };
+        apply_trajectory_pressure(prompt, &mut ir);
+        ir
+    }
+}
+
+pub(crate) fn apply_trajectory_pressure(prompt: &Prompt, ir: &mut WorkflowStateIR) {
+    let observed_structured_action = prompt
+        .messages
+        .iter()
+        .flat_map(|message| &message.content)
+        .any(|content| {
+            matches!(
+                content,
+                Content::ToolCall { .. } | Content::ToolResult { .. }
+            )
+        });
+    let observed_native_action = ir
+        .evidence
+        .iter()
+        .any(|evidence| evidence.kind == "terminus_2_action_format");
+    if !observed_structured_action && !observed_native_action {
+        return;
+    }
+    let assistant_turns = prompt
+        .messages
+        .iter()
+        .filter(|message| message.role == Role::Assistant)
+        .count();
+    if assistant_turns < GUARDED_TOOL_TRAJECTORY_ASSISTANT_TURNS {
+        return;
+    }
+    ir.capability_constraints.expected_redo_penalty = RequirementLevel::High;
+    if !ir
+        .evidence
+        .iter()
+        .any(|evidence| evidence.kind == "trajectory_pressure")
+    {
+        ir.evidence.push(Evidence {
+            kind: "trajectory_pressure".to_string(),
+            value: format!("assistant_turns:{assistant_turns}"),
+            confidence: 0.9,
+            level: EvidenceLevel::Observed,
+        });
     }
 }
 
@@ -281,18 +326,21 @@ fn content_size(content: &Content) -> usize {
 }
 
 fn recovery_signal(prompt: &Prompt) -> RecoverySignal {
+    const RECOVERY_OBSERVATION_WINDOW: usize = 3;
     let structured_failure = prompt
         .messages
         .iter()
         .rev()
-        .take(4)
         .flat_map(|message| &message.content)
-        .any(|content| match content {
-            Content::ToolResult { output, .. } => tool_result_reports_failure(output),
-            _ => false,
-        });
-    let transcript_failure =
-        latest_terminal_output(prompt).is_some_and(plain_output_reports_failure);
+        .filter_map(|content| match content {
+            Content::ToolResult { output, .. } => Some(output),
+            _ => None,
+        })
+        .take(RECOVERY_OBSERVATION_WINDOW)
+        .any(tool_result_reports_failure);
+    let transcript_failure = recent_terminal_outputs(prompt, RECOVERY_OBSERVATION_WINDOW)
+        .into_iter()
+        .any(plain_output_reports_failure);
     if structured_failure || transcript_failure {
         RecoverySignal::LikelyRecovery
     } else {
@@ -314,9 +362,12 @@ fn tool_result_reports_failure(output: &ToolResultOutput) -> bool {
     }
 }
 
-fn latest_terminal_output(prompt: &Prompt) -> Option<&str> {
-    const MARKER: &str = "New Terminal Output:";
+fn recent_terminal_outputs(prompt: &Prompt, maximum: usize) -> Vec<&str> {
+    let mut outputs = Vec::new();
     for (index, message) in prompt.messages.iter().enumerate().rev() {
+        if outputs.len() >= maximum {
+            break;
+        }
         if message.role != Role::User
             || !prompt.messages[..index]
                 .iter()
@@ -324,19 +375,26 @@ fn latest_terminal_output(prompt: &Prompt) -> Option<&str> {
         {
             continue;
         }
-        let mut plain_result = None;
-        for content in message.content.iter().rev() {
-            let Content::Text { text, .. } = content else {
-                continue;
-            };
-            if let Some((_, output)) = text.rsplit_once(MARKER) {
-                return Some(output);
-            }
-            plain_result.get_or_insert(text.as_str());
+        if let Some(output) = terminal_output(message) {
+            outputs.push(output);
         }
-        return plain_result;
     }
-    None
+    outputs
+}
+
+fn terminal_output(message: &bitrouter_sdk::language_model::types::Message) -> Option<&str> {
+    const MARKER: &str = "New Terminal Output:";
+    let mut plain_result = None;
+    for content in message.content.iter().rev() {
+        let Content::Text { text, .. } = content else {
+            continue;
+        };
+        if let Some((_, output)) = text.rsplit_once(MARKER) {
+            return Some(output);
+        }
+        plain_result.get_or_insert(text.as_str());
+    }
+    plain_result
 }
 
 fn plain_output_reports_failure(text: &str) -> bool {
@@ -420,7 +478,8 @@ mod tests {
     };
 
     use crate::workflow_state::ir::{
-        ContextSizeBucket, ProtocolKind, RecoverySignal, ToolDensity, WorkflowStateKind,
+        ContextSizeBucket, ProtocolKind, RecoverySignal, RequirementLevel, ToolDensity,
+        WorkflowStateKind,
     };
 
     fn prompt(messages: Vec<Message>, tools: Vec<Tool>) -> Prompt {
@@ -607,6 +666,98 @@ mod tests {
     }
 
     #[test]
+    fn generic_keeps_recovery_guard_through_two_successful_tool_observations() {
+        let prompt = prompt(
+            vec![
+                user("run tests"),
+                assistant_calls("bash"),
+                tool_error_result("operation could not complete"),
+                assistant_calls("bash"),
+                tool_result("first repair command completed"),
+                assistant_calls("bash"),
+                tool_result("second repair command completed"),
+                assistant_calls("bash"),
+            ],
+            Vec::new(),
+        );
+
+        let ir = extract(&prompt);
+
+        assert_eq!(ir.recovery_signal, RecoverySignal::LikelyRecovery);
+        assert_eq!(ir.state_kind, WorkflowStateKind::Recovery);
+    }
+
+    #[test]
+    fn generic_keeps_recovery_guard_through_two_successful_terminal_observations() {
+        let prompt = prompt(
+            vec![
+                user("run tests"),
+                assistant_calls("bash"),
+                user("New Terminal Output:\nerror: test command failed"),
+                assistant_calls("bash"),
+                user("New Terminal Output:\nfirst repair command completed"),
+                assistant_calls("bash"),
+                user("New Terminal Output:\nsecond repair command completed"),
+                assistant_calls("bash"),
+            ],
+            Vec::new(),
+        );
+
+        let ir = extract(&prompt);
+
+        assert_eq!(ir.recovery_signal, RecoverySignal::LikelyRecovery);
+        assert_eq!(ir.state_kind, WorkflowStateKind::Recovery);
+    }
+
+    #[test]
+    fn generic_releases_structured_recovery_after_three_successful_observations() {
+        let prompt = prompt(
+            vec![
+                user("run tests"),
+                assistant_calls("bash"),
+                tool_error_result("operation could not complete"),
+                assistant_calls("bash"),
+                tool_result("first repair command completed"),
+                assistant_calls("bash"),
+                tool_result("second repair command completed"),
+                assistant_calls("bash"),
+                tool_result("third repair command completed"),
+                assistant_calls("bash"),
+            ],
+            Vec::new(),
+        );
+
+        let ir = extract(&prompt);
+
+        assert_eq!(ir.recovery_signal, RecoverySignal::None);
+        assert_eq!(ir.state_kind, WorkflowStateKind::ToolFollowup);
+    }
+
+    #[test]
+    fn generic_releases_terminal_recovery_after_three_successful_observations() {
+        let prompt = prompt(
+            vec![
+                user("run tests"),
+                assistant_calls("bash"),
+                user("New Terminal Output:\nerror: test command failed"),
+                assistant_calls("bash"),
+                user("New Terminal Output:\nfirst repair command completed"),
+                assistant_calls("bash"),
+                user("New Terminal Output:\nsecond repair command completed"),
+                assistant_calls("bash"),
+                user("New Terminal Output:\nthird repair command completed"),
+                assistant_calls("bash"),
+            ],
+            Vec::new(),
+        );
+
+        let ir = extract(&prompt);
+
+        assert_eq!(ir.recovery_signal, RecoverySignal::None);
+        assert_eq!(ir.state_kind, WorkflowStateKind::ToolFollowup);
+    }
+
+    #[test]
     fn generic_splits_command_not_found_tool_followup_into_recovery_state() {
         let prompt = prompt(
             vec![
@@ -687,5 +838,83 @@ root@box:/app#",
         let prompt = prompt(vec![user(&large)], Vec::new());
         let ir = extract(&prompt);
         assert_eq!(ir.context_size, ContextSizeBucket::Large);
+    }
+
+    #[test]
+    fn generic_guards_a_long_tool_trajectory_as_high_redo_risk() {
+        let mut messages = vec![user("finish the task")];
+        for turn in 0..8 {
+            messages.push(assistant_calls("bash"));
+            messages.push(tool_result(&format!("step {turn} completed")));
+        }
+        let prompt = prompt(messages, Vec::new());
+
+        let ir = extract(&prompt);
+
+        assert_eq!(
+            ir.capability_constraints.expected_redo_penalty,
+            RequirementLevel::High
+        );
+        assert_eq!(
+            ir.route_projection().key(),
+            "agent_trace/v2|tool_followup|guarded"
+        );
+        assert!(ir.evidence.iter().any(|evidence| {
+            evidence.kind == "trajectory_pressure" && evidence.value == "assistant_turns:8"
+        }));
+    }
+
+    #[test]
+    fn generic_does_not_guard_a_long_conversation_without_agent_actions() {
+        let mut messages = vec![user("talk through the design")];
+        for turn in 0..8 {
+            messages.push(Message::text(Role::Assistant, format!("answer {turn}")));
+            messages.push(user(&format!("follow-up {turn}")));
+        }
+        let prompt = prompt(messages, Vec::new());
+
+        let ir = extract(&prompt);
+
+        assert_eq!(
+            ir.capability_constraints.expected_redo_penalty,
+            RequirementLevel::Medium
+        );
+        assert_eq!(
+            ir.route_projection().key(),
+            "agent_trace/v2|planning|normal"
+        );
+        assert!(
+            ir.evidence
+                .iter()
+                .all(|evidence| evidence.kind != "trajectory_pressure")
+        );
+    }
+
+    #[test]
+    fn generic_does_not_treat_a_declared_but_unused_tool_as_an_agent_trajectory() {
+        let mut messages = vec![user("talk through the design")];
+        for turn in 0..8 {
+            messages.push(Message::text(Role::Assistant, format!("answer {turn}")));
+            messages.push(user(&format!("follow-up {turn}")));
+        }
+        let declared_tool = Tool::Function {
+            name: "search".to_string(),
+            description: None,
+            parameters: serde_json::json!({"type": "object"}),
+            strict: None,
+            provider_metadata: ProviderMetadata::new(),
+        };
+        let prompt = prompt(messages, vec![declared_tool]);
+
+        let ir = extract(&prompt);
+
+        assert_eq!(
+            ir.capability_constraints.expected_redo_penalty,
+            RequirementLevel::Medium
+        );
+        assert_eq!(
+            ir.route_projection().key(),
+            "agent_trace/v2|planning|normal"
+        );
     }
 }

--- a/apps/bitrouter/src/workflow_state/extractors/generic.rs
+++ b/apps/bitrouter/src/workflow_state/extractors/generic.rs
@@ -1,5 +1,5 @@
 use bitrouter_sdk::language_model::types::{
-    Content, Message, Prompt, Role, ToolResultContentPart, ToolResultOutput,
+    Content, Prompt, Role, ToolResultContentPart, ToolResultOutput,
 };
 
 use crate::workflow_state::extractors::{ExtractorInput, WorkflowStateExtractor};
@@ -71,9 +71,9 @@ impl WorkflowStateExtractor for GenericPromptExtractor {
         if recovery_signal == RecoverySignal::LikelyRecovery {
             evidence.push(Evidence {
                 kind: "recovery_marker".to_string(),
-                value: "recent content contains error marker".to_string(),
-                confidence: 0.75,
-                level: EvidenceLevel::Inferred,
+                value: "recent observation reports execution failure".to_string(),
+                confidence: 0.9,
+                level: EvidenceLevel::Observed,
             });
         }
 
@@ -281,46 +281,111 @@ fn content_size(content: &Content) -> usize {
 }
 
 fn recovery_signal(prompt: &Prompt) -> RecoverySignal {
-    let recent_text = prompt
+    let structured_failure = prompt
         .messages
         .iter()
         .rev()
         .take(4)
-        .flat_map(message_text)
-        .collect::<Vec<_>>()
-        .join("\n")
-        .to_ascii_lowercase();
-    let markers = [
-        "error:",
-        "failed",
-        "traceback",
-        "exit code 1",
-        "command not found",
-        "no such file or directory",
-        "nonzero",
-        "panic",
-        "exception",
-    ];
-    if markers.iter().any(|marker| recent_text.contains(marker)) {
+        .flat_map(|message| &message.content)
+        .any(|content| match content {
+            Content::ToolResult { output, .. } => tool_result_reports_failure(output),
+            _ => false,
+        });
+    let transcript_failure =
+        latest_terminal_output(prompt).is_some_and(plain_output_reports_failure);
+    if structured_failure || transcript_failure {
         RecoverySignal::LikelyRecovery
     } else {
         RecoverySignal::None
     }
 }
 
-fn message_text(message: &Message) -> Vec<String> {
-    message.content.iter().filter_map(content_text).collect()
+fn tool_result_reports_failure(output: &ToolResultOutput) -> bool {
+    match output {
+        ToolResultOutput::ErrorText { .. }
+        | ToolResultOutput::ErrorJson { .. }
+        | ToolResultOutput::ExecutionDenied { .. } => true,
+        ToolResultOutput::Text { value } => plain_output_reports_failure(value),
+        ToolResultOutput::Json { value } => plain_output_reports_failure(&value.to_string()),
+        ToolResultOutput::Content { value } => value
+            .iter()
+            .filter_map(tool_part_text)
+            .any(|text| plain_output_reports_failure(&text)),
+    }
 }
 
-fn content_text(content: &Content) -> Option<String> {
-    match content {
-        Content::Text { text, .. } | Content::Reasoning { text, .. } => Some(text.clone()),
-        Content::ToolCall {
-            name, arguments, ..
-        } => Some(format!("{name} {arguments}")),
-        Content::ToolResult { output, .. } => Some(tool_result_text(output)),
-        _ => None,
+fn latest_terminal_output(prompt: &Prompt) -> Option<&str> {
+    const MARKER: &str = "New Terminal Output:";
+    for (index, message) in prompt.messages.iter().enumerate().rev() {
+        if message.role != Role::User
+            || !prompt.messages[..index]
+                .iter()
+                .any(|prior| prior.role == Role::Assistant)
+        {
+            continue;
+        }
+        let mut plain_result = None;
+        for content in message.content.iter().rev() {
+            let Content::Text { text, .. } = content else {
+                continue;
+            };
+            if let Some((_, output)) = text.rsplit_once(MARKER) {
+                return Some(output);
+            }
+            plain_result.get_or_insert(text.as_str());
+        }
+        return plain_result;
     }
+    None
+}
+
+fn plain_output_reports_failure(text: &str) -> bool {
+    text.lines().any(|line| {
+        let line = line.trim();
+        if line.is_empty() || is_shell_echo_line(line) {
+            return false;
+        }
+        let lower = line.to_ascii_lowercase();
+        explicit_nonzero_exit(&lower)
+            || lower.starts_with("error:")
+            || lower.starts_with("traceback (most recent call last):")
+            || (lower.starts_with("thread '") && lower.contains(" panicked at "))
+            || lower.ends_with(": command not found")
+            || lower.ends_with(": no such file or directory")
+            || lower.starts_with("failed ")
+            || lower.starts_with("failed:")
+    })
+}
+
+fn explicit_nonzero_exit(line: &str) -> bool {
+    [
+        "process exited with code",
+        "command exited with code",
+        "exit code",
+        "exit_code",
+    ]
+    .into_iter()
+    .filter_map(|marker| line.find(marker).map(|index| &line[index + marker.len()..]))
+    .any(|suffix| {
+        let suffix = suffix.trim_start_matches([' ', '\t', ':', '=', '"', '\'']);
+        let number = suffix
+            .chars()
+            .take_while(|character| character.is_ascii_digit() || *character == '-')
+            .collect::<String>();
+        number.parse::<i64>().is_ok_and(|code| code != 0)
+    })
+}
+
+fn is_shell_echo_line(line: &str) -> bool {
+    if line.starts_with('>') {
+        return true;
+    }
+    ["# ", "$ "].into_iter().any(|delimiter| {
+        line.find(delimiter).is_some_and(|index| {
+            let prefix = &line[..index];
+            prefix.contains('@') && prefix.contains(':')
+        })
+    })
 }
 
 fn tool_result_text(output: &ToolResultOutput) -> String {
@@ -401,6 +466,21 @@ mod tests {
                 call_id: "call_bash".to_string(),
                 tool_name: Some("bash".to_string()),
                 output: ToolResultOutput::Text {
+                    value: text.to_string(),
+                },
+                dynamic: false,
+                provider_metadata: ProviderMetadata::new(),
+            }],
+        }
+    }
+
+    fn tool_error_result(text: &str) -> Message {
+        Message {
+            role: Role::Tool,
+            content: vec![Content::ToolResult {
+                call_id: "call_bash".to_string(),
+                tool_name: Some("bash".to_string()),
+                output: ToolResultOutput::ErrorText {
                     value: text.to_string(),
                 },
                 dynamic: false,
@@ -540,6 +620,65 @@ mod tests {
         assert_eq!(ir.recovery_signal, RecoverySignal::LikelyRecovery);
         assert_eq!(ir.state_kind, WorkflowStateKind::Recovery);
         assert_eq!(ir.last_tool_name.as_deref(), Some("bash"));
+    }
+
+    #[test]
+    fn generic_does_not_treat_task_or_echoed_source_words_as_recovery() {
+        let prompt = prompt(
+            vec![
+                user("fix the failed certificate verification"),
+                assistant_calls("bash"),
+                user(
+                    "New Terminal Output:\n\
+root@box:/app# cat > check.py <<'PY'\n\
+> print(\"Certificate verification failed\")\n\
+> PY\n\
+root@box:/app# python check.py\n\
+Certificate verification successful\n\
+root@box:/app#",
+                ),
+            ],
+            Vec::new(),
+        );
+
+        let ir = extract(&prompt);
+
+        assert_eq!(ir.recovery_signal, RecoverySignal::None);
+        assert_eq!(ir.state_kind, WorkflowStateKind::ToolFollowup);
+    }
+
+    #[test]
+    fn generic_trusts_typed_tool_error_without_keyword_guessing() {
+        let prompt = prompt(
+            vec![
+                user("run the command"),
+                assistant_calls("bash"),
+                tool_error_result("operation could not complete"),
+            ],
+            Vec::new(),
+        );
+
+        let ir = extract(&prompt);
+
+        assert_eq!(ir.recovery_signal, RecoverySignal::LikelyRecovery);
+        assert_eq!(ir.state_kind, WorkflowStateKind::Recovery);
+    }
+
+    #[test]
+    fn generic_uses_explicit_nonzero_exit_status_from_plain_tool_output() {
+        let prompt = prompt(
+            vec![
+                user("run the command"),
+                assistant_calls("bash"),
+                tool_result("Process exited with code 2\nFinal output:\ninvalid input"),
+            ],
+            Vec::new(),
+        );
+
+        let ir = extract(&prompt);
+
+        assert_eq!(ir.recovery_signal, RecoverySignal::LikelyRecovery);
+        assert_eq!(ir.state_kind, WorkflowStateKind::Recovery);
     }
 
     #[test]

--- a/apps/bitrouter/src/workflow_state/extractors/terminus_2.rs
+++ b/apps/bitrouter/src/workflow_state/extractors/terminus_2.rs
@@ -8,7 +8,9 @@
 
 use bitrouter_sdk::language_model::types::{Content, Prompt, Role};
 
-use crate::workflow_state::extractors::generic::GenericPromptExtractor;
+use crate::workflow_state::extractors::generic::{
+    GenericPromptExtractor, apply_trajectory_pressure,
+};
 use crate::workflow_state::extractors::{ExtractorInput, WorkflowStateExtractor};
 use crate::workflow_state::ir::{
     Evidence, EvidenceLevel, HarnessId, RecoverySignal, RequirementLevel, ToolDensity,
@@ -94,6 +96,7 @@ impl WorkflowStateExtractor for Terminus2Extractor {
             confidence: 0.9,
             level: EvidenceLevel::Inferred,
         });
+        apply_trajectory_pressure(input.prompt, &mut ir);
         ir
     }
 }

--- a/apps/bitrouter/src/workflow_state/ir.rs
+++ b/apps/bitrouter/src/workflow_state/ir.rs
@@ -52,6 +52,7 @@ impl fmt::Display for WorkflowStateKind {
 #[serde(rename_all = "snake_case")]
 pub enum RouteRisk {
     Normal,
+    Context,
     Guarded,
 }
 
@@ -147,13 +148,19 @@ impl RouteProjection {
         ) else {
             return None;
         };
-        if namespace_version != "agent_trace/v1" {
+        let schema_version = match namespace_version {
+            "agent_trace/v1" => 1,
+            "agent_trace/v2" => 2,
+            _ => return None,
+        };
+        let risk = parse_route_risk(risk)?;
+        if schema_version == 1 && risk == RouteRisk::Context {
             return None;
         }
         Some(Self {
-            schema_version: 1,
+            schema_version,
             state_kind: parse_workflow_state_kind(state)?,
-            risk: parse_route_risk(risk)?,
+            risk,
         })
     }
 
@@ -192,6 +199,7 @@ fn parse_workflow_state_kind(value: &str) -> Option<WorkflowStateKind> {
 fn parse_route_risk(value: &str) -> Option<RouteRisk> {
     match value {
         "normal" => Some(RouteRisk::Normal),
+        "context" => Some(RouteRisk::Context),
         "guarded" => Some(RouteRisk::Guarded),
         _ => None,
     }
@@ -361,6 +369,44 @@ impl WorkflowStateIR {
     }
 
     pub fn route_projection(&self) -> RouteProjection {
+        let hard_guarded_state = matches!(
+            self.state_kind,
+            WorkflowStateKind::Unknown
+                | WorkflowStateKind::Debug
+                | WorkflowStateKind::Recovery
+                | WorkflowStateKind::Finalization
+        );
+        let hard_guarded_constraint = matches!(
+            self.capability_constraints.expected_redo_penalty,
+            RequirementLevel::High
+        ) || matches!(
+            self.capability_constraints.output_precision,
+            RequirementLevel::High
+        );
+        let risk = if self.recovery_signal == RecoverySignal::LikelyRecovery
+            || hard_guarded_state
+            || hard_guarded_constraint
+        {
+            RouteRisk::Guarded
+        } else if matches!(
+            self.capability_constraints.context_pressure,
+            RequirementLevel::High
+        ) {
+            RouteRisk::Context
+        } else {
+            RouteRisk::Normal
+        };
+
+        RouteProjection {
+            schema_version: 2,
+            state_kind: self.state_kind.clone(),
+            risk,
+        }
+    }
+
+    /// Exact v1 projection used only to keep published v1 locks routable while
+    /// their routes are migrated to v2.
+    pub fn compatibility_route_projection_v1(&self) -> RouteProjection {
         let guarded_state = matches!(
             self.state_kind,
             WorkflowStateKind::Unknown
@@ -514,12 +560,12 @@ mod tests {
             ir.recovery_signal = RecoverySignal::None;
             ir.capability_constraints = CapabilityConstraints::default();
 
-            assert_eq!(ir.route_projection().key(), "agent_trace/v1|edit|normal");
+            assert_eq!(ir.route_projection().key(), "agent_trace/v2|edit|normal");
         }
     }
 
     #[test]
-    fn route_projection_parser_accepts_only_canonical_v1_keys() {
+    fn route_projection_parser_accepts_canonical_v1_and_v2_keys() {
         let projection = RouteProjection::parse_key("agent_trace/v1|tool_followup|normal")
             .expect("canonical agent trace projection");
         assert_eq!(projection.key(), "agent_trace/v1|tool_followup|normal");
@@ -529,7 +575,8 @@ mod tests {
 
         for key in [
             "codex|responses|tool_followup|-|-|exec_command",
-            "agent_trace/v2|tool_followup|normal",
+            "agent_trace/v3|tool_followup|normal",
+            "agent_trace/v1|tool_followup|context",
             "agent_trace/v1|not_a_state|normal",
             "agent_trace/v1|tool_followup|not_a_risk",
             "agent_trace/v1|tool_followup|normal|extra",
@@ -546,7 +593,7 @@ mod tests {
         baseline.state_kind = WorkflowStateKind::Edit;
         baseline.recovery_signal = RecoverySignal::None;
         baseline.capability_constraints = CapabilityConstraints::default();
-        let expected = "agent_trace/v1|edit|normal";
+        let expected = "agent_trace/v2|edit|normal";
 
         let mut changed = baseline.clone();
         changed.harness_id = HarnessId::ClaudeCode;
@@ -572,22 +619,22 @@ mod tests {
     #[test]
     fn route_projection_keys_normal_and_guarded_risk() {
         let cases = [
-            (WorkflowStateKind::Edit, "agent_trace/v1|edit|normal"),
-            (WorkflowStateKind::Test, "agent_trace/v1|test|normal"),
+            (WorkflowStateKind::Edit, "agent_trace/v2|edit|normal"),
+            (WorkflowStateKind::Test, "agent_trace/v2|test|normal"),
             (
                 WorkflowStateKind::ToolFollowup,
-                "agent_trace/v1|tool_followup|normal",
+                "agent_trace/v2|tool_followup|normal",
             ),
-            (WorkflowStateKind::Unknown, "agent_trace/v1|unknown|guarded"),
-            (WorkflowStateKind::Debug, "agent_trace/v1|debug|guarded"),
-            (WorkflowStateKind::Review, "agent_trace/v1|review|guarded"),
+            (WorkflowStateKind::Unknown, "agent_trace/v2|unknown|guarded"),
+            (WorkflowStateKind::Debug, "agent_trace/v2|debug|guarded"),
+            (WorkflowStateKind::Review, "agent_trace/v2|review|normal"),
             (
                 WorkflowStateKind::Recovery,
-                "agent_trace/v1|recovery|guarded",
+                "agent_trace/v2|recovery|guarded",
             ),
             (
                 WorkflowStateKind::Finalization,
-                "agent_trace/v1|finalization|guarded",
+                "agent_trace/v2|finalization|guarded",
             ),
         ];
 
@@ -606,6 +653,7 @@ mod tests {
             (
                 RecoverySignal::LikelyRecovery,
                 CapabilityConstraints::default(),
+                "agent_trace/v2|edit|guarded",
             ),
             (
                 RecoverySignal::None,
@@ -613,6 +661,7 @@ mod tests {
                     context_pressure: RequirementLevel::High,
                     ..CapabilityConstraints::default()
                 },
+                "agent_trace/v2|edit|context",
             ),
             (
                 RecoverySignal::None,
@@ -620,6 +669,7 @@ mod tests {
                     expected_redo_penalty: RequirementLevel::High,
                     ..CapabilityConstraints::default()
                 },
+                "agent_trace/v2|edit|guarded",
             ),
             (
                 RecoverySignal::None,
@@ -627,15 +677,61 @@ mod tests {
                     output_precision: RequirementLevel::High,
                     ..CapabilityConstraints::default()
                 },
+                "agent_trace/v2|edit|guarded",
             ),
         ];
 
-        for (recovery_signal, capability_constraints) in cases {
+        for (recovery_signal, capability_constraints, expected) in cases {
             let mut ir = sample_ir();
             ir.state_kind = WorkflowStateKind::Edit;
             ir.recovery_signal = recovery_signal;
             ir.capability_constraints = capability_constraints;
-            assert_eq!(ir.route_projection().key(), "agent_trace/v1|edit|guarded");
+            assert_eq!(ir.route_projection().key(), expected);
         }
+    }
+
+    #[test]
+    fn route_projection_v2_splits_context_from_hard_guardrails() {
+        let mut review = sample_ir();
+        review.state_kind = WorkflowStateKind::Review;
+        review.recovery_signal = RecoverySignal::None;
+        review.capability_constraints = CapabilityConstraints::default();
+        assert_eq!(
+            review.route_projection().key(),
+            "agent_trace/v2|review|normal"
+        );
+
+        let mut long_context_edit = review.clone();
+        long_context_edit.state_kind = WorkflowStateKind::Edit;
+        long_context_edit.capability_constraints.context_pressure = RequirementLevel::High;
+        assert_eq!(
+            long_context_edit.route_projection().key(),
+            "agent_trace/v2|edit|context"
+        );
+
+        long_context_edit
+            .capability_constraints
+            .expected_redo_penalty = RequirementLevel::High;
+        assert_eq!(
+            long_context_edit.route_projection().key(),
+            "agent_trace/v2|edit|guarded"
+        );
+    }
+
+    #[test]
+    fn route_projection_keeps_an_exact_v1_compatibility_key() {
+        let mut review = sample_ir();
+        review.state_kind = WorkflowStateKind::Review;
+        review.recovery_signal = RecoverySignal::None;
+        review.capability_constraints = CapabilityConstraints::default();
+        assert_eq!(
+            review.compatibility_route_projection_v1().key(),
+            "agent_trace/v1|review|guarded"
+        );
+
+        let parsed = RouteProjection::parse_key("agent_trace/v2|edit|context")
+            .expect("canonical v2 context projection");
+        assert_eq!(parsed.risk, RouteRisk::Context);
+        assert!(RouteProjection::parse_key("agent_trace/v1|edit|context").is_none());
     }
 }

--- a/apps/bitrouter/src/workflow_state/mod.rs
+++ b/apps/bitrouter/src/workflow_state/mod.rs
@@ -1,6 +1,7 @@
 //! Experimental workflow-state extraction for cross-harness cost optimization.
 
 pub mod archive;
+pub mod counterfactual;
 pub mod decision;
 pub mod extractors;
 pub mod fixture;

--- a/apps/bitrouter/src/workflow_state/online.rs
+++ b/apps/bitrouter/src/workflow_state/online.rs
@@ -12,6 +12,7 @@ pub struct OnlineWorkflowState {
     pub ir: WorkflowStateIR,
     legacy_fingerprint: String,
     routing_key: String,
+    compatibility_routing_key_v1: String,
     legacy_routing_key: String,
 }
 
@@ -66,17 +67,23 @@ impl OnlineWorkflowState {
         ir.identity = resolve_workflow_identity(&input, tracker);
         let legacy_fingerprint = PolicyTable::fingerprint(prompt);
         let routing_key = ir.route_projection().key();
+        let compatibility_routing_key_v1 = ir.compatibility_route_projection_v1().key();
         let legacy_routing_key = ir.legacy_routing_key();
         Self {
             ir,
             legacy_fingerprint,
             routing_key,
+            compatibility_routing_key_v1,
             legacy_routing_key,
         }
     }
 
     pub fn routing_key(&self) -> &str {
         &self.routing_key
+    }
+
+    pub fn compatibility_routing_key_v1(&self) -> &str {
+        &self.compatibility_routing_key_v1
     }
 
     pub fn legacy_routing_key(&self) -> &str {
@@ -185,7 +192,11 @@ mod tests {
         );
 
         assert_eq!(state.legacy_fingerprint(), "after_Bash");
-        assert_eq!(state.routing_key(), "agent_trace/v1|tool_followup|normal");
+        assert_eq!(state.routing_key(), "agent_trace/v2|tool_followup|normal");
+        assert_eq!(
+            state.compatibility_routing_key_v1(),
+            "agent_trace/v1|tool_followup|normal"
+        );
         assert_eq!(state.ir.last_tool_name.as_deref(), Some("Bash"));
     }
 
@@ -200,7 +211,7 @@ mod tests {
 
         assert_eq!(state.ir.harness_id, HarnessId::Generic);
         assert_eq!(state.ir.protocol, ProtocolKind::Responses);
-        assert_eq!(state.routing_key(), "agent_trace/v1|tool_followup|normal");
+        assert_eq!(state.routing_key(), "agent_trace/v2|tool_followup|normal");
         assert!(state.ir.evidence.iter().any(|e| {
             e.kind == "trace_adapter" && e.value == "compatibility_harness_hint:Codex"
         }));
@@ -221,7 +232,7 @@ mod tests {
         assert_eq!(state.ir.harness_id, HarnessId::Smithers);
         assert_eq!(state.ir.active_workflow.as_deref(), Some("release-review"));
         assert_eq!(state.ir.subagent_role.as_deref(), Some("analyze-risk"));
-        assert_eq!(state.routing_key(), "agent_trace/v1|tool_followup|normal");
+        assert_eq!(state.routing_key(), "agent_trace/v2|tool_followup|normal");
         assert!(
             state.legacy_routing_key().starts_with(
                 "smithers|chat_completions|tool_followup|release-review|analyze-risk|"

--- a/apps/bitrouter/tests/agent_trace_generalization.rs
+++ b/apps/bitrouter/tests/agent_trace_generalization.rs
@@ -23,6 +23,7 @@ const PRIVATE_IDENTITY_HEADERS: &[&str] = &[
 static DECISION_RECORDER_ENV_LOCK: Mutex<()> = Mutex::const_new(());
 
 const MOCK_STRONG_MODEL: &str = "mock-strong:gpt-5.6-sol";
+const MOCK_BALANCED_MODEL: &str = "mock-economy:z-ai/glm-5.2";
 const MOCK_ECONOMY_MODEL: &str = "mock-economy:deepseek/deepseek-v4-pro";
 
 struct NativeCase {
@@ -71,7 +72,7 @@ async fn native_http_matrix_routes_without_private_workflow_headers() {
     assert_eq!(decisions.len(), 7, "each HTTP request emits one decision");
     for decision in &decisions {
         assert_eq!(decision.key_strategy, "agent_trace");
-        assert_eq!(decision.request_key, "agent_trace/v1|opening|normal");
+        assert_eq!(decision.request_key, "agent_trace/v2|opening|normal");
         assert_eq!(
             decision.selected_tier.as_deref(),
             Some("strong"),
@@ -178,6 +179,19 @@ async fn auto_template_keeps_normal_traces_shared_and_guarded_traces_strong() {
         .json(&json!({
             "model": "@auto",
             "messages": [
+                {"role": "system", "content": "You are an AI assistant tasked with solving command-line tasks in a Linux environment. Format your response as JSON with commands and task_complete."},
+                {"role": "user", "content": "continue"},
+                {"role": "assistant", "content": "{\"commands\":[{\"keystrokes\":\"git diff\"}],\"task_complete\":false}"}
+            ]
+        }))
+        .await
+        .assert_status_ok();
+
+    server
+        .post("/v1/chat/completions")
+        .json(&json!({
+            "model": "@auto",
+            "messages": [
                 {"role": "user", "content": "continue"},
                 {"role": "assistant", "tool_calls": [{
                     "id": "call_failed", "type": "function",
@@ -191,21 +205,27 @@ async fn auto_template_keeps_normal_traces_shared_and_guarded_traces_strong() {
 
     let decisions = PolicyDecisionRecord::load_jsonl(&decisions_path)
         .expect("HTTP traffic emits readable policy decisions");
-    assert_eq!(decisions.len(), 6);
+    assert_eq!(decisions.len(), 7);
     for (decision, key) in decisions[..5].iter().zip([
-        "agent_trace/v1|edit|normal",
-        "agent_trace/v1|test|normal",
-        "agent_trace/v1|tool_followup|normal",
-        "agent_trace/v1|tool_followup|normal",
-        "agent_trace/v1|tool_followup|normal",
+        "agent_trace/v2|edit|normal",
+        "agent_trace/v2|test|normal",
+        "agent_trace/v2|tool_followup|normal",
+        "agent_trace/v2|tool_followup|normal",
+        "agent_trace/v2|tool_followup|normal",
     ]) {
         assert_eq!(decision.request_key, key);
         assert_eq!(decision.selected_tier.as_deref(), Some("economy"));
     }
-    assert_eq!(decisions[5].request_key, "agent_trace/v1|recovery|guarded");
-    assert_eq!(decisions[5].selected_tier.as_deref(), Some("strong"));
+    assert_eq!(decisions[5].request_key, "agent_trace/v2|review|normal");
+    assert_eq!(decisions[5].selected_tier.as_deref(), Some("balanced"));
     assert_eq!(
         decisions[5].selected_model.as_deref(),
+        Some(MOCK_BALANCED_MODEL)
+    );
+    assert_eq!(decisions[6].request_key, "agent_trace/v2|recovery|guarded");
+    assert_eq!(decisions[6].selected_tier.as_deref(), Some("strong"));
+    assert_eq!(
+        decisions[6].selected_model.as_deref(),
         Some(MOCK_STRONG_MODEL)
     );
 }
@@ -222,7 +242,7 @@ async fn native_sources_share_template_projection_keys_and_tiers() {
     let scenarios = [
         (
             "edit",
-            "agent_trace/v1|edit|normal",
+            "agent_trace/v2|edit|normal",
             terminus_action_case("@auto", "apply_patch <<'PATCH'\nPATCH"),
             claude_fixture_case("@auto:cost", ClaudeFixture::Edit, None),
             "economy",
@@ -230,7 +250,7 @@ async fn native_sources_share_template_projection_keys_and_tiers() {
         ),
         (
             "test",
-            "agent_trace/v1|test|normal",
+            "agent_trace/v2|test|normal",
             terminus_action_case("@auto", "cargo test -p bitrouter"),
             claude_fixture_case("@auto:cost", ClaudeFixture::Test, None),
             "economy",
@@ -238,7 +258,7 @@ async fn native_sources_share_template_projection_keys_and_tiers() {
         ),
         (
             "tool followup",
-            "agent_trace/v1|tool_followup|normal",
+            "agent_trace/v2|tool_followup|normal",
             terminus_tool_case("@auto", None),
             claude_fixture_case("@auto:cost", ClaudeFixture::ToolFollowup, None),
             "economy",
@@ -246,7 +266,7 @@ async fn native_sources_share_template_projection_keys_and_tiers() {
         ),
         (
             "recovery",
-            "agent_trace/v1|recovery|guarded",
+            "agent_trace/v2|recovery|guarded",
             terminus_tool_case("@auto", Some("error: cargo test failed")),
             claude_fixture_case(
                 "@auto:cost",
@@ -540,6 +560,8 @@ fn template_config_with_mock(upstream: &str) -> (config::Config, PathBuf, TempDi
         .expect("template auto policy exists");
     auto.tiers
         .insert("strong".to_string(), MOCK_STRONG_MODEL.to_string());
+    auto.tiers
+        .insert("balanced".to_string(), MOCK_BALANCED_MODEL.to_string());
     auto.tiers
         .insert("economy".to_string(), MOCK_ECONOMY_MODEL.to_string());
     let mock_lock_path = config_dir.path().join("policy-lock.yaml");

--- a/apps/bitrouter/tests/terminus_2_workflow_state.rs
+++ b/apps/bitrouter/tests/terminus_2_workflow_state.rs
@@ -193,6 +193,25 @@ fn terminus_xml_action_and_command_density_are_recognized() {
 }
 
 #[test]
+fn terminus_text_actions_share_the_generic_long_trajectory_guard() {
+    let mut messages = vec![user(TERMINUS_OPENING)];
+    for turn in 0..8 {
+        messages.push(assistant(&json_action(&["git diff --check\n"], false)));
+        messages.push(user(&format!("step {turn} clean")));
+    }
+    let prompt = prompt(messages);
+
+    let ir = extract(&prompt);
+
+    assert_eq!(ir.state_kind, WorkflowStateKind::Review);
+    assert_eq!(
+        ir.capability_constraints.expected_redo_penalty,
+        RequirementLevel::High
+    );
+    assert_eq!(ir.route_projection().key(), "agent_trace/v2|review|guarded");
+}
+
+#[test]
 fn oversized_or_malformed_action_fails_open_to_planning() {
     let oversized = format!(
         "{{\"commands\":[{{\"keystrokes\":\"{}\"}}]}}",

--- a/apps/bitrouter/tests/workflow_state_replay.rs
+++ b/apps/bitrouter/tests/workflow_state_replay.rs
@@ -925,7 +925,7 @@ fn evaluators_merge_equivalent_generic_and_native_terminus_projections() {
             .iter()
             .map(|decision| decision.ir_key.as_str())
             .collect::<Vec<_>>(),
-        vec!["agent_trace/v1|opening|normal"; 2]
+        vec!["agent_trace/v2|opening|normal"; 2]
     );
     assert_ne!(
         shadow.decisions[0].legacy_evidence_key, shadow.decisions[1].legacy_evidence_key,

--- a/crates/bitrouter-sdk/src/config/mod.rs
+++ b/crates/bitrouter-sdk/src/config/mod.rs
@@ -668,6 +668,12 @@ pub struct UpstreamConfig {
     /// Global upstream timeout defaults. A provider may override any field
     /// under `providers.<id>.timeouts:`.
     pub timeouts: TimeoutConfig,
+    /// Optional delay schedule before advancing through a retryable fallback
+    /// chain, in milliseconds. The first value applies before the second
+    /// candidate, the second before the third, and the last value repeats when
+    /// the chain is longer than the schedule. Empty (the default) preserves
+    /// immediate fallback.
+    pub fallback_backoff_ms: Vec<u64>,
 }
 
 /// Upstream HTTP timeout knobs, in seconds. Every field is optional; an unset

--- a/crates/bitrouter-sdk/src/config/mod.rs
+++ b/crates/bitrouter-sdk/src/config/mod.rs
@@ -1412,7 +1412,7 @@ fn validate_policy_table(config: &Config) -> Result<()> {
 pub fn validate_policy_table_config(policy: &PolicyTableConfig) -> Result<()> {
     if policy.key_strategy == PolicyKeyStrategy::LegacyFingerprint {
         return Err(BitrouterError::bad_request(
-            "policy_table.key_strategy: 'legacy_fingerprint' is no longer supported; use 'agent_trace' with agent_trace/v1 projection routes"
+            "policy_table.key_strategy: 'legacy_fingerprint' is no longer supported; use 'agent_trace' projection routes"
                 .to_string(),
         ));
     }

--- a/crates/bitrouter-sdk/src/config/tests.rs
+++ b/crates/bitrouter-sdk/src/config/tests.rs
@@ -1194,3 +1194,23 @@ providers:
         "unset provider field stays None"
     );
 }
+
+#[test]
+fn parses_opt_in_fallback_backoff_schedule() {
+    let cfg = parse(
+        r#"
+upstream:
+  fallback_backoff_ms: [1000, 2000, 4000, 8000]
+"#,
+    )
+    .expect("parse");
+
+    assert_eq!(
+        cfg.upstream.fallback_backoff_ms,
+        vec![1000, 2000, 4000, 8000]
+    );
+    assert!(
+        Config::default().upstream.fallback_backoff_ms.is_empty(),
+        "existing deployments must retain immediate fallback by default"
+    );
+}

--- a/crates/bitrouter-sdk/src/language_model/builder.rs
+++ b/crates/bitrouter-sdk/src/language_model/builder.rs
@@ -32,6 +32,7 @@ pub struct PipelineBuilder {
     executor: Option<Arc<dyn Executor>>,
     server_tool_loop: Option<Arc<ServerToolLoop>>,
     keepalive_interval: Duration,
+    fallback_backoff: Vec<Duration>,
 }
 
 impl PipelineBuilder {
@@ -50,6 +51,7 @@ impl PipelineBuilder {
             executor: None,
             server_tool_loop: None,
             keepalive_interval: DEFAULT_KEEPALIVE,
+            fallback_backoff: Vec::new(),
         }
     }
 
@@ -82,6 +84,14 @@ impl PipelineBuilder {
     /// Set the SSE keepalive interval.
     pub fn keepalive_interval(&mut self, interval: Duration) -> &mut Self {
         self.keepalive_interval = interval;
+        self
+    }
+
+    /// Set the delay schedule used before advancing after retryable upstream
+    /// failures. The last delay repeats when the fallback chain is longer than
+    /// the schedule. Empty (the default) keeps fallback immediate.
+    pub fn fallback_backoff(&mut self, schedule: impl IntoIterator<Item = Duration>) -> &mut Self {
+        self.fallback_backoff = schedule.into_iter().collect();
         self
     }
 
@@ -164,6 +174,7 @@ impl PipelineBuilder {
             executor,
             server_tool_loop: self.server_tool_loop,
             keepalive_interval: self.keepalive_interval,
+            fallback_backoff: self.fallback_backoff,
             pending_settlements: Arc::new(std::sync::Mutex::new(tokio::task::JoinSet::new())),
             detached_executions: tokio_util::task::TaskTracker::new(),
         })

--- a/crates/bitrouter-sdk/src/language_model/pipeline.rs
+++ b/crates/bitrouter-sdk/src/language_model/pipeline.rs
@@ -119,6 +119,9 @@ pub struct Pipeline {
     /// pipeline strictly single-shot.
     pub(crate) server_tool_loop: Option<Arc<ServerToolLoop>>,
     pub(crate) keepalive_interval: Duration,
+    /// Opt-in bounded delay schedule between retryable fallback candidates.
+    /// The final entry repeats for longer chains.
+    pub(crate) fallback_backoff: Vec<Duration>,
     /// Detached stream-finalization tasks. Every terminal stream moves its
     /// settlement here before awaiting it, so a client disconnect cannot cancel
     /// recorders after the terminal SSE frame has already been delivered.
@@ -614,7 +617,8 @@ impl Pipeline {
         ctx: &PipelineContext,
     ) -> Result<ExecutionResult> {
         let mut errors = Vec::new();
-        for target in chain {
+        for (attempt_index, target) in chain.iter().enumerate() {
+            self.wait_before_fallback(attempt_index).await;
             self.observe_hop_start(ctx, target).await;
             let outcome = self.executor.execute(target, prompt, ctx).await;
             match &outcome {
@@ -658,7 +662,8 @@ impl Pipeline {
         ctx: &PipelineContext,
     ) -> Result<StreamingExecution> {
         let mut errors = Vec::new();
-        for target in chain {
+        for (attempt_index, target) in chain.iter().enumerate() {
+            self.wait_before_fallback(attempt_index).await;
             let provider_started_at = Instant::now();
             self.observe_hop_start(ctx, target).await;
             let outcome = self
@@ -709,6 +714,23 @@ impl Pipeline {
             }
         }
         Err(aggregate_fallback_errors(errors))
+    }
+
+    async fn wait_before_fallback(&self, attempt_index: usize) {
+        if attempt_index == 0 || self.fallback_backoff.is_empty() {
+            return;
+        }
+        let schedule_index = (attempt_index - 1).min(self.fallback_backoff.len() - 1);
+        let delay = self.fallback_backoff[schedule_index];
+        if delay.is_zero() {
+            return;
+        }
+        tracing::debug!(
+            attempt = attempt_index + 1,
+            delay_ms = delay.as_millis(),
+            "waiting before retryable fallback candidate"
+        );
+        tokio::time::sleep(delay).await;
     }
 
     /// Decide fallback after an upstream failure. Any registered execution hook

--- a/crates/bitrouter-sdk/src/language_model/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/tests.rs
@@ -2,6 +2,7 @@
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
 
 use async_trait::async_trait;
 use futures::StreamExt;
@@ -952,6 +953,84 @@ async fn mixed_retryable_upstream_failures_become_service_unavailable() {
         pipeline.execute(request()).await.unwrap_err(),
         BitrouterError::UpstreamUnavailable
     ));
+}
+
+#[tokio::test(start_paused = true)]
+async fn fallback_backoff_waits_before_each_retryable_next_candidate() {
+    let pipeline = pipeline_with(
+        routing_table(&["a-provider", "b-provider", "c-provider"]),
+        Arc::new(MockExecutor::new(vec![
+            MockResponse::Error(BitrouterError::Upstream {
+                status: 502,
+                message: "overloaded once".into(),
+            }),
+            MockResponse::Error(BitrouterError::Upstream {
+                status: 502,
+                message: "overloaded twice".into(),
+            }),
+            MockResponse::Generate(GenerateResult {
+                content: vec![],
+                usage: None,
+                finish_reason: None,
+                response_id: None,
+                stop_details: None,
+                provider_metadata: Default::default(),
+            }),
+        ])),
+        |builder| {
+            builder.fallback_backoff([Duration::from_secs(2), Duration::from_secs(4)]);
+        },
+    );
+
+    let request = tokio::spawn(async move { pipeline.execute(request()).await });
+    tokio::task::yield_now().await;
+    assert!(
+        !request.is_finished(),
+        "first fallback must wait two seconds"
+    );
+
+    tokio::time::advance(Duration::from_secs(2)).await;
+    tokio::task::yield_now().await;
+    assert!(
+        !request.is_finished(),
+        "second fallback must wait four seconds"
+    );
+
+    tokio::time::advance(Duration::from_secs(4)).await;
+    assert!(request.await.expect("task joins").is_ok());
+}
+
+#[tokio::test(start_paused = true)]
+async fn fallback_backoff_repeats_last_delay_when_chain_is_longer() {
+    let pipeline = pipeline_with(
+        routing_table(&["a-provider", "b-provider", "c-provider"]),
+        Arc::new(MockExecutor::new(vec![
+            MockResponse::Error(BitrouterError::UpstreamTimeout),
+            MockResponse::Error(BitrouterError::UpstreamTimeout),
+            MockResponse::Generate(GenerateResult {
+                content: vec![],
+                usage: None,
+                finish_reason: None,
+                response_id: None,
+                stop_details: None,
+                provider_metadata: Default::default(),
+            }),
+        ])),
+        |builder| {
+            builder.fallback_backoff([Duration::from_secs(3)]);
+        },
+    );
+
+    let request = tokio::spawn(async move { pipeline.execute(request()).await });
+    tokio::task::yield_now().await;
+    tokio::time::advance(Duration::from_secs(3)).await;
+    tokio::task::yield_now().await;
+    assert!(
+        !request.is_finished(),
+        "the capped delay repeats on later hops"
+    );
+    tokio::time::advance(Duration::from_secs(3)).await;
+    assert!(request.await.expect("task joins").is_ok());
 }
 
 #[tokio::test]

--- a/dist/schema/bitrouter.config.schema.json
+++ b/dist/schema/bitrouter.config.schema.json
@@ -168,6 +168,16 @@
         "timeouts": {
           "description": "Global upstream timeout defaults. A provider may override any field\nunder `providers.<id>.timeouts:`.",
           "$ref": "#/$defs/TimeoutConfig"
+        },
+        "fallback_backoff_ms": {
+          "description": "Optional delay schedule before advancing through a retryable fallback\nchain, in milliseconds. The first value applies before the second\ncandidate, the second before the third, and the last value repeats when\nthe chain is longer than the schedule. Empty (the default) preserves\nimmediate fallback.",
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "default": []
         }
       }
     },

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -484,6 +484,10 @@ bitrouter workflow-state apply-reward-feedback --database-url <URL> --traces <JS
 credential file. The latter resolves static keys and refreshable OAuth without
 putting a bearer in the environment. Price specs use
 `provider:model=uncached,cache_read,cache_write,output` in micro-USD per token.
+Repeat the same provider/model pair when a gateway may have applied one of
+several frozen schedules. A computed receipt is accepted only when exactly one
+distinct candidate reconstructs its final micro-USD charge; no match or an
+ambiguous rounding collision remains `unknown`.
 
 `policy-oracle` performs an immutable cost-only replay of a candidate lock over
 baseline traces and exact request settlement. `--effective-cost-factor` is the

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -460,6 +460,7 @@ bitrouter workflow-state harbor-outcomes --harbor-run-dir <DIR> --output <JSONL>
 bitrouter workflow-state metering-usage --database-url <URL> --output <JSONL> [--since <RFC3339>] [--until <RFC3339>] [--impute-price <SPEC> ...]
 bitrouter workflow-state reconcile-metering --database-url <URL> [--api-base <URL>] [--api-key-env <NAME> | --credentials-file <PATH>] --request-id <ID> ... [--price <SPEC> ...] [--max-attempts <N>] [--poll-interval-ms <MS>]
 bitrouter workflow-state reliability-report --database-url <URL> --config <PATH> --output <JSON>
+bitrouter workflow-state policy-oracle --traces <JSONL> --cloud-usage <JSONL> --policy-lock <YAML> --policy <NAME> --effective-cost-factor <0..1> --target-savings <0..1> ... --output <JSON>
 bitrouter workflow-state bundle --run-label <LABEL> --traces <JSONL> --cloud-usage <JSONL> [--outcomes <JSONL>] [--policy-decisions <JSONL>] --output-dir <DIR>
 bitrouter workflow-state apply-reward-feedback --database-url <URL> --traces <JSONL> --cloud-usage <JSONL> --outcomes <JSONL> --policy-decisions <JSONL>
 ```
@@ -469,6 +470,15 @@ bitrouter workflow-state apply-reward-feedback --database-url <URL> --traces <JS
 credential file. The latter resolves static keys and refreshable OAuth without
 putting a bearer in the environment. Price specs use
 `provider:model=uncached,cache_read,cache_write,output` in micro-USD per token.
+
+`policy-oracle` performs an immutable cost-only replay of a candidate lock over
+baseline traces and exact request settlement. `--effective-cost-factor` is the
+candidate-to-baseline cost ratio after expected token, retry, and turn
+inflation. The report includes cost-weighted route coverage, projected savings,
+ranked eligible requests, the highest-cost routes still left on the default
+tier, and the minimum covered requests needed for each repeated
+`--target-savings`. It is an upper-bound prioritization report, not a quality
+claim or a claim that the live trajectory will remain unchanged.
 
 `bundle` is fail-closed: every non-empty trace set needs an exact request-ID
 usage join and computed auditable charge; supplied policy decisions and outcomes

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -148,6 +148,20 @@ The result envelope:
 }
 ```
 
+Retryable route candidates advance immediately unless an operator opts into an
+upstream fallback delay schedule:
+
+```yaml
+upstream:
+  fallback_backoff_ms: [1000, 2000, 4000, 8000, 16000, 30000]
+```
+
+The first value applies before the second candidate, the second before the
+third, and the final value repeats if the configured chain is longer. The
+schedule applies only after an error the fallback policy classifies as
+retryable; it does not retry non-retryable 4xx responses and does not change
+route selection. An empty or omitted schedule preserves the existing behavior.
+
 ---
 
 ## Routing / introspection

--- a/skills/bitrouter/references/adaptive-routing.md
+++ b/skills/bitrouter/references/adaptive-routing.md
@@ -36,7 +36,9 @@ are required for routing. Existing `workflow_state` lock configuration remains
 readable as a compatibility alias, but deterministic lock output is canonical
 `agent_trace`. `agent_trace` is the only active strategy:
 `key_strategy: legacy_fingerprint` is rejected, so migrate its routes to
-`agent_trace/v1|<state>|<risk>`. `adequacy.explore_opening: true` opts
+`agent_trace/v2|<state>|<risk>`, where risk is `normal`, `context`, or
+`guarded`. Published v1 routes remain compatible through exact fallback.
+`adequacy.explore_opening: true` opts
 source-neutral opening projections into exploration. Do not configure the
 removed `adequacy.max_downgraded_requests_per_session`; session identity is
 diagnostic-only and the parser rejects that setting.

--- a/skills/bitrouter/references/cli.md
+++ b/skills/bitrouter/references/cli.md
@@ -110,7 +110,8 @@ Adaptive routing uses generic `agent_trace` projections. Native runtime adapters
 add diagnostics only, not policy keys, and private BitRouter headers are not
 needed. `agent_trace` is the active and default strategy;
 `key_strategy: legacy_fingerprint` is rejected and must be migrated to
-canonical `agent_trace/v1|<state>|<risk>` routes. Existing `workflow_state`
+canonical `agent_trace/v2|<state>|<risk>` routes. Existing v1 locks remain
+compatible through exact projection fallback. Existing `workflow_state`
 lock configuration is readable for compatibility, while canonical lock output
 uses `agent_trace`. `adequacy.explore_opening: true` enables exploration for
 source-neutral opening projections. The removed

--- a/skills/bitrouter/references/metering.md
+++ b/skills/bitrouter/references/metering.md
@@ -147,3 +147,24 @@ not participate in learning.
 The in-memory analytical `build*` APIs may omit usage and decisions for
 extractor development. The `workflow-state bundle` command is benchmark-grade
 and fails closed when traces exist without usage evidence.
+
+## Rank a candidate policy by settled baseline cost
+
+```bash
+bitrouter workflow-state policy-oracle \
+  --traces artifacts/traces.jsonl \
+  --cloud-usage artifacts/cloud-usage.jsonl \
+  --policy-lock policy-lock.yaml \
+  --policy auto \
+  --effective-cost-factor 0.24 \
+  --target-savings 0.30 \
+  --target-savings 0.40 \
+  --output artifacts/policy-oracle.json
+```
+
+The oracle requires an exact trace/usage request-ID set. Its effective cost
+factor must include expected token, retry, and turn inflation. The JSON output
+ranks eligible requests by baseline charge, identifies the highest-cost routes
+still left on the default tier, and reports whether each savings target is
+attainable under the candidate lock. Treat it as a cost-only upper bound;
+quality and trajectory effects still require live eval evidence.

--- a/templates/auto-router/README.md
+++ b/templates/auto-router/README.md
@@ -29,6 +29,14 @@ keys. No private BitRouter headers are required. Published `agent_trace/v1`
 locks remain routable through an exact compatibility fallback; new default
 decisions and learning evidence use v2.
 
+The v2 request projection also bounds model-induced loops without keeping a
+source-specific session budget. A visible agent trajectory with eight prior
+assistant action turns raises expected redo risk to `guarded`, and an observed
+execution failure remains guarded through the next two execution observations.
+Both signals are reconstructed from inbound message history. Ordinary long
+conversations without agent actions are unaffected; protocols that hide prior
+turns retain explicit visibility-gap evidence instead of inventing state.
+
 The eight starter routes are compiler-owned experiments informed by settled
 trace analysis, model protocol canaries, and synthetic long-context action
 qualification. Cross-agent quality has not been validated; evaluate the policy

--- a/templates/auto-router/README.md
+++ b/templates/auto-router/README.md
@@ -1,9 +1,10 @@
 # Adaptive `@auto` routing
 
-This starter policy uses GPT-5.6 as the strong route and DeepSeek V4 Pro as
-the economy route. It is agent- and workflow-independent: ordinary `edit`,
-`test`, and `tool_followup` projections use economy; guarded and unmatched
-projections use strong.
+This starter policy uses GPT-5.6 as the strong route, GLM-5.2 as the balanced
+route, and DeepSeek V4 Pro as the economy route. It is agent- and
+workflow-independent: ordinary `edit`, `test`, and `tool_followup` projections
+use economy; read-only `review` and long-context execution projections use
+balanced; guarded and unmatched projections use strong.
 
 Start BitRouter from this directory:
 
@@ -21,20 +22,40 @@ Use `@auto` for the strong base policy, or `@auto:cost` to add the top-level
 cost routing variant. Physical model ids remain passthrough, so an explicit
 `openai-codex:gpt-5.6-sol` request is not converted to a preset.
 
-The v2 lock uses the generic `agent_trace` key strategy. It contains effective
-routing plus a certificate for every explicit route, but no activation/freeze switch. Runtime adapters can
-enrich diagnostics from native request shapes, but do not supply policy keys.
-No private BitRouter headers are required. The strong/economy tool capability
-guardrails remain in the lock, so a request only uses economy when its route
-and capability constraints permit it.
+The v2 lock uses generic `agent_trace/v2|<state>|<risk>` keys. The `context`
+risk band is separate from hard `guarded` recovery/redo/precision risk. Runtime
+adapters enrich diagnostics from native request shapes but do not supply policy
+keys. No private BitRouter headers are required. Published `agent_trace/v1`
+locks remain routable through an exact compatibility fallback; new default
+decisions and learning evidence use v2.
 
-This policy was migrated from a same-scenario evaluation. Cross-agent quality
-has not been validated; evaluate it against your own traffic before broadening
-the economy routes. The three starter routes are migrated learned routes, so
-their certificates are compiler-owned with `legacy_adequacy_v1` source metadata
-and admitted evidence can promote or demote them. Routes explicitly authored as
-operator-owned remain pinned: conflicting evidence is reported rather than
-overriding the operator's route.
+The eight starter routes are compiler-owned experiments informed by settled
+trace analysis and model protocol canaries. Cross-agent quality has not been
+validated; evaluate the policy against your own traffic before broad rollout.
+Admitted evidence can promote or demote compiler-owned routes. Routes explicitly
+authored as operator-owned remain pinned: conflicting evidence is reported
+rather than overriding the operator's route.
+
+Before a live experiment, estimate the maximum useful surface from settled
+baseline traffic. The effective cost factor includes expected token, retry, and
+turn inflation, not just provider list price:
+
+```bash
+bitrouter workflow-state policy-oracle \
+  --traces traces.jsonl \
+  --cloud-usage usage.jsonl \
+  --policy-lock policy-lock.yaml \
+  --policy auto \
+  --effective-cost-factor 0.24 \
+  --target-savings 0.30 \
+  --target-savings 0.40 \
+  --output oracle.json
+```
+
+The oracle is a cost-only upper-bound replay. It ranks eligible requests and
+routes by baseline cost, and separately surfaces the costly routes still left
+on the default tier. It does not assume the remainder of a live agent trajectory
+will stay unchanged.
 
 The daemon creates redacted request subjects automatically. External evaluators
 submit results through `bitrouter eval result submit` or `POST /v1/evals/results`.

--- a/templates/auto-router/README.md
+++ b/templates/auto-router/README.md
@@ -1,6 +1,6 @@
 # Adaptive `@auto` routing
 
-This starter policy uses GPT-5.6 as the strong route, GLM-5.2 as the balanced
+This starter policy uses GPT-5.6 as the strong route, Kimi K3 as the balanced
 route, and DeepSeek V4 Pro as the economy route. It is agent- and
 workflow-independent: ordinary `edit`, `test`, and `tool_followup` projections
 use economy; read-only `review` and long-context execution projections use
@@ -30,8 +30,9 @@ locks remain routable through an exact compatibility fallback; new default
 decisions and learning evidence use v2.
 
 The eight starter routes are compiler-owned experiments informed by settled
-trace analysis and model protocol canaries. Cross-agent quality has not been
-validated; evaluate the policy against your own traffic before broad rollout.
+trace analysis, model protocol canaries, and synthetic long-context action
+qualification. Cross-agent quality has not been validated; evaluate the policy
+against your own traffic before broad rollout.
 Admitted evidence can promote or demote compiler-owned routes. Routes explicitly
 authored as operator-owned remain pinned: conflicting evidence is reported
 rather than overriding the operator's route.

--- a/templates/auto-router/bitrouter.yaml
+++ b/templates/auto-router/bitrouter.yaml
@@ -11,8 +11,8 @@ providers:
     models:
       - id: deepseek/deepseek-v4-pro
         provider_model_id: deepseek/deepseek-v4-pro
-      - id: z-ai/glm-5.2
-        provider_model_id: z-ai/glm-5.2
+      - id: moonshotai/kimi-k3
+        provider_model_id: moonshotai/kimi-k3
 inherit_defaults: true
 policy:
   path: "./policy-lock.yaml"

--- a/templates/auto-router/bitrouter.yaml
+++ b/templates/auto-router/bitrouter.yaml
@@ -11,6 +11,8 @@ providers:
     models:
       - id: deepseek/deepseek-v4-pro
         provider_model_id: deepseek/deepseek-v4-pro
+      - id: z-ai/glm-5.2
+        provider_model_id: z-ai/glm-5.2
 inherit_defaults: true
 policy:
   path: "./policy-lock.yaml"

--- a/templates/auto-router/policy-lock.yaml
+++ b/templates/auto-router/policy-lock.yaml
@@ -10,7 +10,7 @@ policies:
   auto:
     key_strategy: agent_trace
     tiers:
-      balanced: "bitrouter:z-ai/glm-5.2"
+      balanced: "bitrouter:moonshotai/kimi-k3"
       economy: "bitrouter:deepseek/deepseek-v4-pro"
       strong: "openai-codex:gpt-5.6-sol"
     routes:

--- a/templates/auto-router/policy-lock.yaml
+++ b/templates/auto-router/policy-lock.yaml
@@ -1,25 +1,32 @@
 lockfileVersion: 2
 artifact:
-  evidence_root: "sha256:418cffc3ef87521257683679e326cc6d638d536daaf388351867c5bad88758cd"
+  evidence_root: "sha256:fe8319381e94b97d2213d6ed21cfe0c42bb302f23c04ea8799a2a3143adcb01b"
   source_snapshot_time_unix_ms: 0
   compiler:
     id: bitrouter-template-compiler
-    version: 1
-    config_digest: "sha256:f5770ed5849566ff315715ee70f7c7e6310f8e631f1ed3cac7b91b25f6007396"
+    version: 2
+    config_digest: "sha256:7121d39ca7774be6f3411566fabd0aab163cd1ca21d2c42e8424d59bfdf21fb1"
 policies:
   auto:
     key_strategy: agent_trace
     tiers:
+      balanced: "bitrouter:z-ai/glm-5.2"
       economy: "bitrouter:deepseek/deepseek-v4-pro"
       strong: "openai-codex:gpt-5.6-sol"
     routes:
-      "agent_trace/v1|edit|normal": economy
-      "agent_trace/v1|test|normal": economy
-      "agent_trace/v1|tool_followup|normal": economy
+      "agent_trace/v2|edit|normal": economy
+      "agent_trace/v2|test|normal": economy
+      "agent_trace/v2|tool_followup|normal": economy
+      "agent_trace/v2|review|normal": balanced
+      "agent_trace/v2|review|context": balanced
+      "agent_trace/v2|edit|context": balanced
+      "agent_trace/v2|test|context": balanced
+      "agent_trace/v2|tool_followup|context": balanced
     default_tier: strong
     tool_use_tier: strong
     tool_safe_tiers:
       - strong
+      - balanced
       - economy
     adequacy:
       escalation_tier: strong
@@ -33,36 +40,91 @@ policies:
       min_semantic_successes_for_opening: 1
 certificates:
   auto:
-    "agent_trace/v1|edit|normal":
+    "agent_trace/v2|edit|normal":
       owner: compiler
       selected_tier: economy
       baseline_tier: strong
-      source: legacy_adequacy_v1
+      source: mixed
       eligible_episodes: 0
       independent_tasks: 0
       critical_violations: 0
-      verdict: retain
-      compiler_config_digest: "sha256:f5770ed5849566ff315715ee70f7c7e6310f8e631f1ed3cac7b91b25f6007396"
-      evidence_digest: "sha256:474fe9afab41feb204ddc1e96dab88ef76fc5320d7670384558a61d719f8e0a9"
-    "agent_trace/v1|test|normal":
+      verdict: experiment
+      compiler_config_digest: "sha256:7121d39ca7774be6f3411566fabd0aab163cd1ca21d2c42e8424d59bfdf21fb1"
+      evidence_digest: "sha256:f89eb6856c550a1ce8e0d8f134294a7a43f50c58b367bd335a932ae9ad73e0fa"
+    "agent_trace/v2|test|normal":
       owner: compiler
       selected_tier: economy
       baseline_tier: strong
-      source: legacy_adequacy_v1
+      source: mixed
       eligible_episodes: 0
       independent_tasks: 0
       critical_violations: 0
-      verdict: retain
-      compiler_config_digest: "sha256:f5770ed5849566ff315715ee70f7c7e6310f8e631f1ed3cac7b91b25f6007396"
-      evidence_digest: "sha256:7540cf9b82402f66cec51f2b47313cfdaa5ace99a69d0bc068a96d7670208a4a"
-    "agent_trace/v1|tool_followup|normal":
+      verdict: experiment
+      compiler_config_digest: "sha256:7121d39ca7774be6f3411566fabd0aab163cd1ca21d2c42e8424d59bfdf21fb1"
+      evidence_digest: "sha256:2a066520e701d6775705340773ba097c1f29af0b8572994e3860addf2377937d"
+    "agent_trace/v2|tool_followup|normal":
       owner: compiler
       selected_tier: economy
       baseline_tier: strong
-      source: legacy_adequacy_v1
+      source: mixed
       eligible_episodes: 0
       independent_tasks: 0
       critical_violations: 0
-      verdict: retain
-      compiler_config_digest: "sha256:f5770ed5849566ff315715ee70f7c7e6310f8e631f1ed3cac7b91b25f6007396"
-      evidence_digest: "sha256:3f0e5fb7cdd81edc005158d7640eff58fd970a683f60400e9762c9aae049cf87"
+      verdict: experiment
+      compiler_config_digest: "sha256:7121d39ca7774be6f3411566fabd0aab163cd1ca21d2c42e8424d59bfdf21fb1"
+      evidence_digest: "sha256:b13fb4a76830d26a888d8609761ecacdca2c4c552c10f0fac48af36284b3481b"
+    "agent_trace/v2|review|normal":
+      owner: compiler
+      selected_tier: balanced
+      baseline_tier: strong
+      source: mixed
+      eligible_episodes: 0
+      independent_tasks: 0
+      critical_violations: 0
+      verdict: experiment
+      compiler_config_digest: "sha256:7121d39ca7774be6f3411566fabd0aab163cd1ca21d2c42e8424d59bfdf21fb1"
+      evidence_digest: "sha256:f1f20f5a669ba271f2e69f64ac3133d4af96e720419a0facfe808a4604575c91"
+    "agent_trace/v2|review|context":
+      owner: compiler
+      selected_tier: balanced
+      baseline_tier: strong
+      source: mixed
+      eligible_episodes: 0
+      independent_tasks: 0
+      critical_violations: 0
+      verdict: experiment
+      compiler_config_digest: "sha256:7121d39ca7774be6f3411566fabd0aab163cd1ca21d2c42e8424d59bfdf21fb1"
+      evidence_digest: "sha256:7e0f3df21c1d89a76d8cf46401a507d5292d3e2f06bd2440702eb6c3126f4910"
+    "agent_trace/v2|edit|context":
+      owner: compiler
+      selected_tier: balanced
+      baseline_tier: strong
+      source: mixed
+      eligible_episodes: 0
+      independent_tasks: 0
+      critical_violations: 0
+      verdict: experiment
+      compiler_config_digest: "sha256:7121d39ca7774be6f3411566fabd0aab163cd1ca21d2c42e8424d59bfdf21fb1"
+      evidence_digest: "sha256:df61766c3a5534bcfe78b839b9776a15b6c20dc4bb6014a513442b6b67cda564"
+    "agent_trace/v2|test|context":
+      owner: compiler
+      selected_tier: balanced
+      baseline_tier: strong
+      source: mixed
+      eligible_episodes: 0
+      independent_tasks: 0
+      critical_violations: 0
+      verdict: experiment
+      compiler_config_digest: "sha256:7121d39ca7774be6f3411566fabd0aab163cd1ca21d2c42e8424d59bfdf21fb1"
+      evidence_digest: "sha256:57dab48bbdb7204119fcf8d44b55422e1c9faf2e12fb4520c86b26e478be945d"
+    "agent_trace/v2|tool_followup|context":
+      owner: compiler
+      selected_tier: balanced
+      baseline_tier: strong
+      source: mixed
+      eligible_episodes: 0
+      independent_tasks: 0
+      critical_violations: 0
+      verdict: experiment
+      compiler_config_digest: "sha256:7121d39ca7774be6f3411566fabd0aab163cd1ca21d2c42e8424d59bfdf21fb1"
+      evidence_digest: "sha256:02031c9aedbfa83119b9db14d22699ce5c8635a5a1f9a71e63e771200082581e"

--- a/templates/auto-router/policy-metadata.json
+++ b/templates/auto-router/policy-metadata.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
-  "migration": "This v2 policy adds a context band and a canary-validated balanced tier.",
+  "migration": "This v2 policy adds a context band and a long-context-qualified balanced tier.",
   "crossAgentQuality": "unvalidated",
   "strongModel": "openai-codex:gpt-5.6-sol",
-  "balancedModel": "bitrouter:z-ai/glm-5.2",
+  "balancedModel": "bitrouter:moonshotai/kimi-k3",
   "economyModel": "bitrouter:deepseek/deepseek-v4-pro"
 }

--- a/templates/auto-router/policy-metadata.json
+++ b/templates/auto-router/policy-metadata.json
@@ -1,7 +1,8 @@
 {
   "schemaVersion": 1,
-  "migration": "This policy was migrated from a same-scenario evaluation.",
+  "migration": "This v2 policy adds a context band and a canary-validated balanced tier.",
   "crossAgentQuality": "unvalidated",
   "strongModel": "openai-codex:gpt-5.6-sol",
+  "balancedModel": "bitrouter:z-ai/glm-5.2",
   "economyModel": "bitrouter:deepseek/deepseek-v4-pro"
 }

--- a/templates/auto-router/policy-metadata.json
+++ b/templates/auto-router/policy-metadata.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "migration": "This v2 policy adds a context band and a long-context-qualified balanced tier.",
+  "migration": "This v2 policy adds context and guarded trajectory bands, a bounded recovery window, and a long-context-qualified balanced tier.",
   "crossAgentQuality": "unvalidated",
   "strongModel": "openai-codex:gpt-5.6-sol",
   "balancedModel": "bitrouter:moonshotai/kimi-k3",


### PR DESCRIPTION
## Summary

- harden `@auto:cost` with a long-context-qualified balanced tier and opt-in fallback backoff
- derive a bounded recovery guard and long-trajectory redo pressure from inbound message history only
- keep generic routing model- and harness-agnostic; ordinary long conversations remain unaffected
- make authoritative settlement deterministic when multiple frozen price schedules target one provider/model, failing closed on rounding ambiguity
- document the new workflow-state and settlement contracts and cover them with unit/integration tests

## Why

The previous policy could release recovery protection too quickly, repeatedly use a weaker model after a long tool trajectory, and fail to reconcile a valid receipt when the frozen benchmark needed multiple historical price schedules. These changes preserve the generic `request -> workflow state IR -> route` product boundary while improving quality-adjusted cost and exact benchmark settlement.

No task IDs, benchmark-specific route branches, or private routing headers were added. The new signals are reconstructed from messages and native action formats already visible to the router.

## Frozen short13 evidence

Two independent, fully accepted `control -> R1 -> R2 -> R3` lineages used the same frozen source and runner:

| Lineage | Control | Final R3 | Paired cost change |
| --- | --- | --- | --- |
| 1 | 10/13, 78 requests, $5.070774 | 11/13, 81 requests, $4.102794 | -19.09% |
| 2 | 11/13, 92 requests, $6.105430 | 11/13, 90 requests, $5.233069 | -14.29% |

Mean paired saving was 16.69% ($0.920171 per short13) while final R3 quality was 11/13 in both accepted lineages. Population SD across the two paired percentages was 2.40 percentage points (sample SD 3.39 pp). R3 used 169 GPT-5.6-sol requests and only 2 Kimi K3 requests across both runs, so the measured saving is primarily trajectory/token efficiency rather than aggressive weak-model substitution.

A third independent attempt was intentionally retained as rejected diagnostic evidence and excluded from effect statistics. Its control was accepted, but R1 ended `terminal_invalid` (`exit=1`) after Kimi K3 returned 9x503 + 16x504 + 2x429 in case 7 and 23x503 + 4x429 in case 9. R2/R3 were not started and the lineage was not retried. This exposes a separate follow-up requirement for model/provider health state across requests.

## Validation

- `git diff --check`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `env GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false cargo test --workspace --all-features`
- two exact accepted frozen short13 lineages with `exit=0`, complete request/eval joins, exact settlement, and zero sandbox cleanup

Benchmark cleanup is complete: all three temporary security-group rules were revoked, the controller was stopped, and final sandbox instance/volume/ENI queries returned empty arrays.
