### PR TITLE
feat(registry): add DeepSeek V4 Flash 0731

### DIFF
--- a/dist/registry/models.json
+++ b/dist/registry/models.json
@@ -1525,30 +1525,6 @@
           "provider_model_id": "deepseek/deepseek-v4-flash"
         },
         {
-          "api_protocol": [
-            "openai",
-            "anthropic"
-          ],
-          "capabilities": [
-            "reasoning",
-            "tools"
-          ],
-          "pricing": {
-            "input_tokens": {
-              "cache_read": 0.0028,
-              "no_cache": 0.14
-            },
-            "output_tokens": {
-              "text": 0.28
-            }
-          },
-          "provider": "deepseek",
-          "provider_model_id": "deepseek-v4-flash",
-          "rate_limits": {
-            "requests_per_minute": 60
-          }
-        },
-        {
           "api_protocol": "openai",
           "pricing": {
             "input_tokens": {
@@ -1575,25 +1551,6 @@
           },
           "provider": "novita",
           "provider_model_id": "deepseek/deepseek-v4-flash"
-        },
-        {
-          "api_protocol": "openai",
-          "provider": "opencode-go",
-          "provider_model_id": "deepseek-v4-flash"
-        },
-        {
-          "api_protocol": "openai",
-          "pricing": {
-            "input_tokens": {
-              "cache_read": 0.028,
-              "no_cache": 0.14
-            },
-            "output_tokens": {
-              "text": 0.28
-            }
-          },
-          "provider": "opencode-zen",
-          "provider_model_id": "deepseek-v4-flash"
         },
         {
           "api_protocol": [
@@ -1752,6 +1709,172 @@
         }
       ],
       "release_date": "2026-04-24"
+    },
+    {
+      "description": "Official DeepSeek V4 Flash release with enhanced agentic capabilities.",
+      "family": "deepseek-flash",
+      "id": "deepseek/deepseek-v4-flash-0731",
+      "input_modalities": [
+        "text"
+      ],
+      "knowledge_cutoff": "2025-05",
+      "max_input_tokens": 1000000,
+      "max_output_tokens": 384000,
+      "name": "DeepSeek: DeepSeek V4 Flash 0731",
+      "open_weights": true,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.028,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider": "alibaba_cn",
+          "provider_model_id": "deepseek-v4-flash-0731",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.028,
+              "cache_write": 0.0,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider": "ambient",
+          "provider_model_id": "deepseek/deepseek-v4-flash-0731",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.028,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider": "atlascloud",
+          "provider_model_id": "deepseek-ai/deepseek-v4-flash-0731"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.0028,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider": "deepseek",
+          "provider_model_id": "deepseek-v4-flash",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.028,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider": "novita",
+          "provider_model_id": "deepseek/deepseek-v4-flash-0731"
+        },
+        {
+          "api_protocol": "openai",
+          "provider": "opencode-go",
+          "provider_model_id": "deepseek-v4-flash"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.028,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider": "opencode-zen",
+          "provider_model_id": "deepseek-v4-flash"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.018,
+              "no_cache": 0.09
+            },
+            "output_tokens": {
+              "text": 0.18
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "deepseek/deepseek-v4-flash-0731"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.028,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider": "qianfan",
+          "provider_model_id": "deepseek-v4-flash-0731"
+        }
+      ],
+      "release_date": "2026-07-31"
     },
     {
       "family": "deepseek-thinking",

--- a/dist/registry/providers.json
+++ b/dist/registry/providers.json
@@ -443,6 +443,27 @@
             "responses",
             "anthropic"
           ],
+          "id": "deepseek/deepseek-v4-flash-0731",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.028,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider_model_id": "deepseek-v4-flash-0731",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
           "id": "deepseek/deepseek-v4-pro",
           "pricing": {
             "input_tokens": {
@@ -779,6 +800,24 @@
             }
           },
           "provider_model_id": "deepseek/deepseek-v4-flash",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "id": "deepseek/deepseek-v4-flash-0731",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.028,
+              "cache_write": 0.0,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider_model_id": "deepseek/deepseek-v4-flash-0731",
           "rate_limits": {
             "requests_per_minute": 60
           }
@@ -1129,6 +1168,20 @@
             }
           },
           "provider_model_id": "deepseek-ai/deepseek-v4-flash"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "deepseek/deepseek-v4-flash-0731",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.028,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider_model_id": "deepseek-ai/deepseek-v4-flash-0731"
         },
         {
           "api_protocol": "openai",
@@ -3293,13 +3346,14 @@
         {
           "api_protocol": [
             "openai",
+            "responses",
             "anthropic"
           ],
           "capabilities": [
             "reasoning",
             "tools"
           ],
-          "id": "deepseek/deepseek-v4-flash",
+          "id": "deepseek/deepseek-v4-flash-0731",
           "pricing": {
             "input_tokens": {
               "cache_read": 0.0028,
@@ -4274,6 +4328,24 @@
           "provider_model_id": "deepseek/deepseek-v4-flash"
         },
         {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "deepseek/deepseek-v4-flash-0731",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.028,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider_model_id": "deepseek/deepseek-v4-flash-0731"
+        },
+        {
           "api_protocol": "openai",
           "id": "deepseek/deepseek-v3.2",
           "pricing": {
@@ -4863,7 +4935,7 @@
       "models": [
         {
           "api_protocol": "openai",
-          "id": "deepseek/deepseek-v4-flash",
+          "id": "deepseek/deepseek-v4-flash-0731",
           "provider_model_id": "deepseek-v4-flash"
         },
         {
@@ -5004,7 +5076,7 @@
       "models": [
         {
           "api_protocol": "openai",
-          "id": "deepseek/deepseek-v4-flash",
+          "id": "deepseek/deepseek-v4-flash-0731",
           "pricing": {
             "input_tokens": {
               "cache_read": 0.028,
@@ -6069,6 +6141,24 @@
             "responses",
             "anthropic"
           ],
+          "id": "deepseek/deepseek-v4-flash-0731",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.018,
+              "no_cache": 0.09
+            },
+            "output_tokens": {
+              "text": 0.18
+            }
+          },
+          "provider_model_id": "deepseek/deepseek-v4-flash-0731"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
           "id": "deepseek/deepseek-v4-pro",
           "pricing": {
             "input_tokens": {
@@ -6668,6 +6758,20 @@
             }
           },
           "provider_model_id": "deepseek-v4-flash"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "deepseek/deepseek-v4-flash-0731",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.028,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider_model_id": "deepseek-v4-flash-0731"
         },
         {
           "api_protocol": "openai",

--- a/docs/DEEPSEEK_V4_FLASH_0731_SPEC.md
+++ b/docs/DEEPSEEK_V4_FLASH_0731_SPEC.md
@@ -68,4 +68,3 @@ models.
 - Do not infer 0731 availability for providers without explicit evidence.
 - Do not repoint the preview canonical ID to the official release.
 - Do not change DeepSeek V4 Pro or unrelated provider catalogs.
-

--- a/docs/DEEPSEEK_V4_FLASH_0731_SPEC.md
+++ b/docs/DEEPSEEK_V4_FLASH_0731_SPEC.md
@@ -1,0 +1,71 @@
+# DeepSeek V4 Flash 0731 Registry Design
+
+## Goal
+
+Publish DeepSeek V4 Flash 0731 as a distinct canonical model while preserving
+the existing unversioned DeepSeek V4 Flash entry as the preview release.
+Routing must never mix the preview and 0731 revisions under one canonical ID.
+
+## Canonical models
+
+- Keep `deepseek/deepseek-v4-flash` unchanged as the preview revision.
+- Add `deepseek/deepseek-v4-flash-0731` for the 2026-07-31 official release.
+- Record the official release's text-only modalities, 1,000,000-token input
+  limit, 384,000-token output limit, May 2025 knowledge cutoff, open weights,
+  and `deepseek-flash` family.
+
+## Provider mappings
+
+Only providers whose current public catalog identifies the 0731 revision are
+eligible for the new canonical model.
+
+| Provider | Preview mapping | 0731 mapping |
+| --- | --- | --- |
+| DeepSeek | remove (upstream alias moved) | `deepseek-v4-flash` |
+| opencode zen | remove (upstream alias moved) | `deepseek-v4-flash` |
+| opencode go | remove (upstream alias moved) | `deepseek-v4-flash` |
+| Alibaba Cloud Model Studio (China) | keep `deepseek-v4-flash` | `deepseek-v4-flash-0731` |
+| Ambient | keep `deepseek/deepseek-v4-flash` | `deepseek/deepseek-v4-flash-0731` |
+| Atlas Cloud | keep `deepseek-ai/deepseek-v4-flash` | `deepseek-ai/deepseek-v4-flash-0731` |
+| Novita AI | keep `deepseek/deepseek-v4-flash` | `deepseek/deepseek-v4-flash-0731` |
+| OpenRouter | keep `deepseek/deepseek-v4-flash` | `deepseek/deepseek-v4-flash-0731` |
+| Baidu Qianfan International | keep `deepseek-v4-flash` | `deepseek-v4-flash-0731` |
+
+All other provider mappings remain on the preview canonical model until their
+upstream catalog explicitly confirms the 0731 revision.
+
+Provider pricing and protocol support come from each provider's current public
+catalog. In particular, the first-party DeepSeek mapping advertises its native
+Responses API support, and OpenRouter uses the price published for its explicit
+0731 model rather than copying the preview price.
+
+## Sync durability
+
+DeepSeek and the two opencode providers reuse an unversioned upstream model ID
+for the 0731 revision. The additive registry sync currently deduplicates only by
+canonical ID, so it would reattach that same upstream ID to the preview
+canonical model after the source mapping is moved.
+
+The sync planner will also deduplicate by `provider_model_id`. A provider model
+already mapped to any canonical ID cannot be automatically attached a second
+time under another canonical ID. Validation will reject duplicate upstream IDs
+inside a provider file. This preserves explicit maintainer mappings and prevents
+one upstream endpoint from representing two supposedly different canonical
+models.
+
+## Generated artifacts and verification
+
+- Rebuild `dist/registry/models.json` and `dist/registry/providers.json`.
+- Add regression coverage for canonical metadata, exact provider mappings, and
+  the preview/0731 separation.
+- Add sync-planner and validation coverage for duplicate upstream IDs.
+- Run registry validation, catalog build/check, targeted dist-helper tests,
+  formatting, linting, and the repository test suite required for Rust source
+  changes.
+
+## Non-goals
+
+- Do not infer 0731 availability for providers without explicit evidence.
+- Do not repoint the preview canonical ID to the official release.
+- Do not change DeepSeek V4 Pro or unrelated provider catalogs.
+

--- a/helpers/dist-helper/src/registry.rs
+++ b/helpers/dist-helper/src/registry.rs
@@ -124,9 +124,18 @@ async fn sync_models_dev_loaded(_root: &Path, loaded: &LoadedRegistry, write: bo
             continue;
         };
         let have: HashSet<&str> = provider.data.models.iter().map(|m| m.id.as_str()).collect();
+        let have_provider_model_ids: HashSet<&str> = provider
+            .data
+            .models
+            .iter()
+            .map(|model| model.provider_model_id.as_str())
+            .collect();
         let mut staged = HashSet::new();
         let subscription = provider.data.billing == Billing::Subscription;
         for (model_id, model) in &models.models {
+            if have_provider_model_ids.contains(model_id.as_str()) {
+                continue;
+            }
             let Some(canonical_id) = resolve(model_id) else {
                 continue;
             };
@@ -285,12 +294,20 @@ fn v1_models_plan_for_provider(
     let catalog: V1ModelsResponse =
         serde_json::from_str(body).context("parsing OpenAI-compatible /models response")?;
     let have: HashSet<&str> = provider.models.iter().map(|m| m.id.as_str()).collect();
+    let have_provider_model_ids: HashSet<&str> = provider
+        .models
+        .iter()
+        .map(|model| model.provider_model_id.as_str())
+        .collect();
     let mut staged = HashSet::new();
     let mut unresolved_seen = HashSet::new();
     let mut adds = Vec::new();
     let mut unresolved = Vec::new();
 
     for model in catalog.data {
+        if have_provider_model_ids.contains(model.id.as_str()) {
+            continue;
+        }
         let Some(canonical_id) = resolve(&model.id) else {
             if unresolved_seen.insert(model.id.clone()) {
                 unresolved.push(model.id);
@@ -1172,11 +1189,18 @@ fn validate_provider<'a>(
     }
 
     let mut seen_models = HashSet::new();
+    let mut seen_provider_model_ids = HashSet::new();
     for model in &data.models {
         if !seen_models.insert(model.id.as_str()) {
             issues.push(format!(
                 "{file}: provider '{}' declares model '{}' twice",
                 data.name, model.id
+            ));
+        }
+        if !seen_provider_model_ids.insert(model.provider_model_id.as_str()) {
+            issues.push(format!(
+                "{file}: provider '{}' declares provider_model_id '{}' twice",
+                data.name, model.provider_model_id
             ));
         }
         // A provider may serve models beyond the curated `registry/models`
@@ -2619,6 +2643,38 @@ auto_sync:
     }
 
     #[test]
+    fn v1_models_catalog_preserves_existing_provider_model_mapping() {
+        let provider: ProviderFile = serde_saphyr::from_str(
+            r#"
+name: deepseek
+api_protocol:
+  - "*": openai
+models:
+  - id: deepseek/deepseek-v4-flash-0731
+    provider_model_id: deepseek-v4-flash
+status: active
+billing: subscription
+api_base: https://api.deepseek.test/v1
+auto_sync:
+  feed: v1_models
+"#,
+        )
+        .unwrap();
+        let resolve = canonical_resolver([
+            "deepseek/deepseek-v4-flash",
+            "deepseek/deepseek-v4-flash-0731",
+        ]);
+        let body = r#"{"data":[{"id":"deepseek-v4-flash"}]}"#;
+
+        let plan = v1_models_plan_for_provider(&provider, body, &resolve).unwrap();
+
+        assert!(
+            plan.adds.is_empty(),
+            "an explicitly mapped upstream model must not be attached to a second canonical ID"
+        );
+    }
+
+    #[test]
     fn v1_models_catalog_copies_pricing_when_present() {
         let provider: ProviderFile = serde_saphyr::from_str(
             r#"
@@ -3028,6 +3084,54 @@ api_base: https://api.acme.test/v1
         assert!(
             advisories.iter().any(|a| a.contains("acme/byok-extra")),
             "expected an advisory for acme/byok-extra, got: {advisories:?}"
+        );
+    }
+
+    #[test]
+    fn provider_rejects_duplicate_provider_model_ids() {
+        let root = test_root("duplicate-provider-model-id");
+        write(
+            &root,
+            "registry/models/acme.yaml",
+            r#"
+- id: acme/preview
+  name: "Acme: Preview"
+  input_modalities: [text]
+  output_modalities: [text]
+- id: acme/release
+  name: "Acme: Release"
+  input_modalities: [text]
+  output_modalities: [text]
+"#,
+        );
+        write(
+            &root,
+            "registry/providers/acme.yaml",
+            r#"
+name: acme
+metadata:
+  headquarters: US
+  name: Acme
+  slug: acme
+api_protocol:
+  - "*": openai
+models:
+  - id: acme/preview
+    provider_model_id: flash
+  - id: acme/release
+    provider_model_id: flash
+status: active
+billing: subscription
+api_base: https://api.acme.test/v1
+"#,
+        );
+
+        let loaded = load_registry(&root).expect("loads");
+        let err = validate_loaded(&loaded).expect_err("duplicate upstream IDs must fail");
+
+        assert!(
+            err.to_string().contains("provider_model_id 'flash' twice"),
+            "unexpected error: {err}"
         );
     }
 

--- a/helpers/dist-helper/src/registry.rs
+++ b/helpers/dist-helper/src/registry.rs
@@ -3228,6 +3228,105 @@ api_base: https://api.acme.test/v1
     }
 
     #[test]
+    fn built_registry_separates_deepseek_v4_flash_revisions() {
+        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+        let artifacts = build_artifacts(&root).expect("builds repository registry");
+        let models: Value = serde_json::from_str(&artifacts.models).expect("valid models JSON");
+        let providers: Value =
+            serde_json::from_str(&artifacts.providers).expect("valid providers JSON");
+
+        let dated = models["data"].as_array().and_then(|models| {
+            models
+                .iter()
+                .find(|model| model["id"] == "deepseek/deepseek-v4-flash-0731")
+        });
+        assert!(dated.is_some(), "dated canonical model");
+        let Some(dated) = dated else {
+            return;
+        };
+        assert_eq!(dated["release_date"], "2026-07-31");
+        assert_eq!(dated["max_input_tokens"], 1_000_000);
+        assert_eq!(dated["max_output_tokens"], 384_000);
+
+        let provider_data = providers["data"].as_array();
+        assert!(provider_data.is_some(), "provider data array");
+        let Some(provider_data) = provider_data else {
+            return;
+        };
+        let find_mapping = |provider_name: &str, canonical_id: &str| {
+            provider_data
+                .iter()
+                .find(|provider| provider["name"] == provider_name)
+                .and_then(|provider| provider["models"].as_array())
+                .and_then(|models| models.iter().find(|model| model["id"] == canonical_id))
+        };
+
+        let expected = [
+            ("deepseek", "deepseek-v4-flash"),
+            ("opencode-zen", "deepseek-v4-flash"),
+            ("opencode-go", "deepseek-v4-flash"),
+            ("alibaba_cn", "deepseek-v4-flash-0731"),
+            ("ambient", "deepseek/deepseek-v4-flash-0731"),
+            ("atlascloud", "deepseek-ai/deepseek-v4-flash-0731"),
+            ("novita", "deepseek/deepseek-v4-flash-0731"),
+            ("openrouter", "deepseek/deepseek-v4-flash-0731"),
+            ("qianfan", "deepseek-v4-flash-0731"),
+        ];
+        for (provider_name, provider_model_id) in expected {
+            let mapping = find_mapping(provider_name, "deepseek/deepseek-v4-flash-0731");
+            assert!(
+                mapping.is_some(),
+                "{provider_name} should serve the dated canonical model"
+            );
+            assert_eq!(
+                mapping.and_then(|model| model["provider_model_id"].as_str()),
+                Some(provider_model_id),
+                "{provider_name} upstream model ID"
+            );
+        }
+
+        for provider_name in ["deepseek", "opencode-zen", "opencode-go"] {
+            assert!(
+                find_mapping(provider_name, "deepseek/deepseek-v4-flash").is_none(),
+                "{provider_name} no longer serves the preview alias"
+            );
+        }
+        for provider_name in [
+            "alibaba_cn",
+            "ambient",
+            "atlascloud",
+            "novita",
+            "openrouter",
+            "qianfan",
+        ] {
+            assert!(
+                find_mapping(provider_name, "deepseek/deepseek-v4-flash").is_some(),
+                "{provider_name} keeps its distinct preview model"
+            );
+        }
+
+        let deepseek = find_mapping("deepseek", "deepseek/deepseek-v4-flash-0731");
+        assert_eq!(
+            deepseek.map(|model| model["api_protocol"].clone()),
+            Some(serde_json::json!(["openai", "responses", "anthropic"]))
+        );
+
+        let openrouter = find_mapping("openrouter", "deepseek/deepseek-v4-flash-0731");
+        assert_eq!(
+            openrouter.and_then(|model| model["pricing"]["input_tokens"]["no_cache"].as_f64()),
+            Some(0.09)
+        );
+        assert_eq!(
+            openrouter.and_then(|model| model["pricing"]["input_tokens"]["cache_read"].as_f64()),
+            Some(0.018)
+        );
+        assert_eq!(
+            openrouter.and_then(|model| model["pricing"]["output_tokens"]["text"].as_f64()),
+            Some(0.18)
+        );
+    }
+
+    #[test]
     fn built_registry_refreshes_qianfan_international_catalog() {
         let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
         let artifacts = build_artifacts(&root).expect("builds repository registry");

--- a/helpers/dist-helper/src/registry.rs
+++ b/helpers/dist-helper/src/registry.rs
@@ -123,43 +123,12 @@ async fn sync_models_dev_loaded(_root: &Path, loaded: &LoadedRegistry, write: bo
             );
             continue;
         };
-        let have: HashSet<&str> = provider.data.models.iter().map(|m| m.id.as_str()).collect();
-        let have_provider_model_ids: HashSet<&str> = provider
-            .data
-            .models
-            .iter()
-            .map(|model| model.provider_model_id.as_str())
-            .collect();
-        let mut staged = HashSet::new();
-        let subscription = provider.data.billing == Billing::Subscription;
-        for (model_id, model) in &models.models {
-            if have_provider_model_ids.contains(model_id.as_str()) {
-                continue;
-            }
-            let Some(canonical_id) = resolve(model_id) else {
-                continue;
-            };
-            if have.contains(canonical_id.as_str()) || !staged.insert(canonical_id.clone()) {
-                continue;
-            }
-            let pricing = if subscription {
-                None
-            } else {
-                pricing_from_cost(model.cost.as_ref())
-            };
+        let adds = models_dev_plan_for_provider(&provider.data, models, &resolve);
+        if !adds.is_empty() {
             attaches
                 .entry(provider.data.name.clone())
                 .or_default()
-                .push(ProviderModel {
-                    id: canonical_id,
-                    provider_model_id: model_id.clone(),
-                    api_protocol: None,
-                    pricing,
-                    rate_limits: None,
-                    compatibility: None,
-                    capabilities: Vec::new(),
-                    deprecation_date: None,
-                });
+                .extend(adds);
         }
     }
 
@@ -284,6 +253,55 @@ async fn sync_v1_models_loaded(root: &Path, loaded: &LoadedRegistry, write: bool
 struct V1ModelsPlan {
     adds: Vec<ProviderModel>,
     unresolved: Vec<String>,
+}
+
+fn models_dev_plan_for_provider(
+    provider: &ProviderFile,
+    catalog: &ModelsDevProvider,
+    resolve: &impl Fn(&str) -> Option<String>,
+) -> Vec<ProviderModel> {
+    let have: HashSet<&str> = provider
+        .models
+        .iter()
+        .map(|model| model.id.as_str())
+        .collect();
+    let have_provider_model_ids: HashSet<&str> = provider
+        .models
+        .iter()
+        .map(|model| model.provider_model_id.as_str())
+        .collect();
+    let mut staged = HashSet::new();
+    let subscription = provider.billing == Billing::Subscription;
+    let mut adds = Vec::new();
+
+    for (model_id, model) in &catalog.models {
+        if have_provider_model_ids.contains(model_id.as_str()) {
+            continue;
+        }
+        let Some(canonical_id) = resolve(model_id) else {
+            continue;
+        };
+        if have.contains(canonical_id.as_str()) || !staged.insert(canonical_id.clone()) {
+            continue;
+        }
+        let pricing = if subscription {
+            None
+        } else {
+            pricing_from_cost(model.cost.as_ref())
+        };
+        adds.push(ProviderModel {
+            id: canonical_id,
+            provider_model_id: model_id.clone(),
+            api_protocol: None,
+            pricing,
+            rate_limits: None,
+            compatibility: None,
+            capabilities: Vec::new(),
+            deprecation_date: None,
+        });
+    }
+
+    adds
 }
 
 fn v1_models_plan_for_provider(
@@ -2604,6 +2622,41 @@ auto_sync:
     }
 
     #[test]
+    fn models_dev_catalog_preserves_existing_provider_model_mapping() {
+        let provider: ProviderFile = serde_saphyr::from_str(
+            r#"
+name: deepseek
+api_protocol:
+  - "*": openai
+models:
+  - id: deepseek/deepseek-v4-flash-0731
+    provider_model_id: deepseek-v4-flash
+status: active
+billing: usage_token
+api_base: https://api.deepseek.test/v1
+auto_sync:
+  feed: models_dev
+"#,
+        )
+        .unwrap();
+        let catalog: ModelsDevProvider = serde_json::from_str(
+            r#"{"models":{"deepseek-v4-flash":{"cost":{"input":0.14,"output":0.28}}}}"#,
+        )
+        .unwrap();
+        let resolve = canonical_resolver([
+            "deepseek/deepseek-v4-flash",
+            "deepseek/deepseek-v4-flash-0731",
+        ]);
+
+        let adds = models_dev_plan_for_provider(&provider, &catalog, &resolve);
+
+        assert!(
+            adds.is_empty(),
+            "an explicitly mapped upstream model must not be attached to a second canonical ID"
+        );
+    }
+
+    #[test]
     fn v1_models_catalog_attaches_known_canonical_models_only() {
         let provider: ProviderFile = serde_saphyr::from_str(
             r#"
@@ -3244,9 +3297,39 @@ api_base: https://api.acme.test/v1
         let Some(dated) = dated else {
             return;
         };
+        assert_eq!(dated["name"], "DeepSeek: DeepSeek V4 Flash 0731");
+        assert_eq!(
+            dated["description"],
+            "Official DeepSeek V4 Flash release with enhanced agentic capabilities."
+        );
+        assert_eq!(dated["input_modalities"], serde_json::json!(["text"]));
+        assert_eq!(dated["output_modalities"], serde_json::json!(["text"]));
         assert_eq!(dated["release_date"], "2026-07-31");
         assert_eq!(dated["max_input_tokens"], 1_000_000);
         assert_eq!(dated["max_output_tokens"], 384_000);
+        assert_eq!(dated["knowledge_cutoff"], "2025-05");
+        assert_eq!(dated["open_weights"], true);
+        assert_eq!(dated["family"], "deepseek-flash");
+
+        let preview = models["data"].as_array().and_then(|models| {
+            models
+                .iter()
+                .find(|model| model["id"] == "deepseek/deepseek-v4-flash")
+        });
+        assert!(preview.is_some(), "preview canonical model");
+        let Some(preview) = preview else {
+            return;
+        };
+        assert_eq!(preview["name"], "DeepSeek: DeepSeek V4 Flash");
+        assert!(preview.get("description").is_none());
+        assert_eq!(preview["input_modalities"], serde_json::json!(["text"]));
+        assert_eq!(preview["output_modalities"], serde_json::json!(["text"]));
+        assert_eq!(preview["release_date"], "2026-04-24");
+        assert_eq!(preview["max_input_tokens"], 262_144);
+        assert_eq!(preview["max_output_tokens"], 262_144);
+        assert_eq!(preview["knowledge_cutoff"], "2025-05");
+        assert_eq!(preview["open_weights"], true);
+        assert_eq!(preview["family"], "deepseek-flash");
 
         let provider_data = providers["data"].as_array();
         assert!(provider_data.is_some(), "provider data array");

--- a/registry/models/deepseek.yaml
+++ b/registry/models/deepseek.yaml
@@ -23,6 +23,21 @@
   knowledge_cutoff: 2025-05
   open_weights: true
   family: deepseek-flash
+# Official release: https://api-docs.deepseek.com/updates/#date-2026-07-31
+# Limits: https://api-docs.deepseek.com/quick_start/pricing
+- id: deepseek/deepseek-v4-flash-0731
+  name: 'DeepSeek: DeepSeek V4 Flash 0731'
+  description: Official DeepSeek V4 Flash release with enhanced agentic capabilities.
+  input_modalities:
+  - text
+  output_modalities:
+  - text
+  max_input_tokens: 1000000
+  max_output_tokens: 384000
+  release_date: 2026-07-31
+  knowledge_cutoff: 2025-05
+  open_weights: true
+  family: deepseek-flash
 - id: deepseek/deepseek-v4-pro
   name: 'DeepSeek: DeepSeek V4 Pro'
   input_modalities:

--- a/registry/providers/alibaba_cn.yaml
+++ b/registry/providers/alibaba_cn.yaml
@@ -95,6 +95,16 @@ models:
         cache_read: 0.0028
       output_tokens:
         text: 0.28
+  # Official dated revision: https://help.aliyun.com/zh/model-studio/deepseek-v4-flash
+  # CNY 1.0 / 0.2 / 2.0 per 1M tokens converted at ~7.2 CNY/USD.
+  - id: deepseek/deepseek-v4-flash-0731
+    provider_model_id: deepseek-v4-flash-0731
+    pricing:
+      input_tokens:
+        no_cache: 0.14
+        cache_read: 0.028
+      output_tokens:
+        text: 0.28
   - id: deepseek/deepseek-v4-pro
     provider_model_id: deepseek-v4-pro
     pricing:

--- a/registry/providers/ambient.yaml
+++ b/registry/providers/ambient.yaml
@@ -82,6 +82,16 @@ models:
         cache_write: 0
       output_tokens:
         text: 0.28
+  # Dated revision in the live catalog: https://api.ambient.xyz/v1/models
+  - id: deepseek/deepseek-v4-flash-0731
+    provider_model_id: deepseek/deepseek-v4-flash-0731
+    pricing:
+      input_tokens:
+        no_cache: 0.14
+        cache_read: 0.028
+        cache_write: 0
+      output_tokens:
+        text: 0.28
   - id: xiaomi/mimo-v2.5
     provider_model_id: xiaomi/mimo-v2.5
     pricing:

--- a/registry/providers/atlascloud.yaml
+++ b/registry/providers/atlascloud.yaml
@@ -58,6 +58,15 @@ models:
         cache_read: 0.028
       output_tokens:
         text: 0.28
+  # Dated revision in the live catalog: https://api.atlascloud.ai/v1/models
+  - id: deepseek/deepseek-v4-flash-0731
+    provider_model_id: deepseek-ai/deepseek-v4-flash-0731
+    pricing:
+      input_tokens:
+        no_cache: 0.14
+        cache_read: 0.028
+      output_tokens:
+        text: 0.28
   - id: deepseek/deepseek-v3.2
     provider_model_id: deepseek-ai/deepseek-v3.2
     pricing:

--- a/registry/providers/deepseek.yaml
+++ b/registry/providers/deepseek.yaml
@@ -29,8 +29,11 @@ models:
     capabilities:
       - reasoning
       - tools
-  - id: deepseek/deepseek-v4-flash
+  # `deepseek-v4-flash` moved in place to 0731:
+  # https://api-docs.deepseek.com/updates/#date-2026-07-31
+  - id: deepseek/deepseek-v4-flash-0731
     provider_model_id: deepseek-v4-flash
+    api_protocol: [openai, responses, anthropic]
     pricing:
       input_tokens:
         no_cache: 0.14

--- a/registry/providers/novita.yaml
+++ b/registry/providers/novita.yaml
@@ -28,6 +28,16 @@ models:
         cache_read: 0.028
       output_tokens:
         text: 0.28
+  # Dated revision in the live catalog: https://api.novita.ai/openai/models
+  - id: deepseek/deepseek-v4-flash-0731
+    provider_model_id: deepseek/deepseek-v4-flash-0731
+    api_protocol: [openai, responses, anthropic]
+    pricing:
+      input_tokens:
+        no_cache: 0.14
+        cache_read: 0.028
+      output_tokens:
+        text: 0.28
   - id: deepseek/deepseek-v3.2
     provider_model_id: deepseek/deepseek-v3.2
     pricing:

--- a/registry/providers/opencode-go.yaml
+++ b/registry/providers/opencode-go.yaml
@@ -29,7 +29,8 @@ auth:
   kind: bearer
   env: OPENCODE_ZEN_API_KEY
 models:
-  - id: deepseek/deepseek-v4-flash
+  # Live catalog moved this alias to 0731: https://opencode.ai/zen/go/v1/models
+  - id: deepseek/deepseek-v4-flash-0731
     provider_model_id: deepseek-v4-flash
   - id: minimax/minimax-m2.5
     provider_model_id: minimax-m2.5

--- a/registry/providers/opencode-zen.yaml
+++ b/registry/providers/opencode-zen.yaml
@@ -16,7 +16,8 @@ api_protocol:
   - "*": openai
 rate_limits: []
 models:
-  - id: deepseek/deepseek-v4-flash
+  # Live catalog moved this alias to 0731: https://opencode.ai/zen/v1/models
+  - id: deepseek/deepseek-v4-flash-0731
     provider_model_id: deepseek-v4-flash
     pricing:
       input_tokens:

--- a/registry/providers/openrouter.yaml
+++ b/registry/providers/openrouter.yaml
@@ -274,6 +274,15 @@ models:
         cache_read: 0.028
       output_tokens:
         text: 0.28
+  # Dated revision in the live catalog: https://openrouter.ai/api/v1/models
+  - id: deepseek/deepseek-v4-flash-0731
+    provider_model_id: deepseek/deepseek-v4-flash-0731
+    pricing:
+      input_tokens:
+        no_cache: 0.09
+        cache_read: 0.018
+      output_tokens:
+        text: 0.18
   - id: deepseek/deepseek-v4-pro
     provider_model_id: deepseek/deepseek-v4-pro
     pricing:

--- a/registry/providers/qianfan.yaml
+++ b/registry/providers/qianfan.yaml
@@ -40,6 +40,15 @@ models:
         cache_read: 0.028
       output_tokens:
         text: 0.28
+  # Dated revision in the live catalog: https://api.baiduqianfan.ai/v1/models
+  - id: deepseek/deepseek-v4-flash-0731
+    provider_model_id: deepseek-v4-flash-0731
+    pricing:
+      input_tokens:
+        no_cache: 0.14
+        cache_read: 0.028
+      output_tokens:
+        text: 0.28
   - id: moonshotai/kimi-k2.6
     provider_model_id: kimi-k2.6
     pricing:


### PR DESCRIPTION
## Summary

- add `deepseek/deepseek-v4-flash-0731` as the formal 2026-07-31 release while retaining the unversioned canonical model as the older Preview
- map the dated release to the nine providers whose public catalogs identify it, moving the in-place alias only for DeepSeek and opencode zen/go
- preserve explicit upstream model ownership during registry sync and reject duplicate `provider_model_id` mappings
- regenerate the published registry artifacts and add regression coverage for revision separation, metadata, provider mappings, and both sync paths

## Why

DeepSeek updated its unversioned upstream alias in place, while other enabled providers either retain the older model or expose a separate dated ID. Treating every unversioned provider ID as the new release can therefore route requests to the wrong revision. The registry now models the two revisions separately and prevents automated sync from attaching one upstream endpoint to both canonical IDs.

## Validation

- `cargo run -p dist-helper -- registry validate`
- `cargo run -p dist-helper -- check`
- `cargo fmt -- --check`
- `cargo clippy --all-features`
- `cargo test -p dist-helper` (33 passed)
- `cargo nextest run --all-features` (2,178 passed; 11 skipped)
- independent code review completed with no remaining findings
