### PR TITLE
feat(registry): add Qwen3.8 Max

### DIFF
--- a/dist/registry/models.json
+++ b/dist/registry/models.json
@@ -6128,6 +6128,94 @@
       "release_date": "2026-06-01"
     },
     {
+      "description": "2.4T-parameter multimodal MoE flagship for coding, professional work, and long-horizon agentic workflows.",
+      "family": "qwen3.8",
+      "id": "qwen/qwen3.8-max",
+      "input_modalities": [
+        "text",
+        "image",
+        "video"
+      ],
+      "max_input_tokens": 1000000,
+      "max_output_tokens": 131072,
+      "name": "Qwen: Qwen3.8 Max",
+      "open_weights": false,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.25,
+              "cache_write": 2.5,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 6.0
+            }
+          },
+          "provider": "alibaba",
+          "provider_model_id": "qwen3.8-max",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.167,
+              "cache_write": 2.083,
+              "no_cache": 1.667
+            },
+            "output_tokens": {
+              "text": 5.0
+            }
+          },
+          "provider": "alibaba_cn",
+          "provider_model_id": "qwen3.8-max",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "provider": "opencode-go",
+          "provider_model_id": "qwen3.8-max"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.25,
+              "cache_write": 2.5,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 6.0
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "qwen/qwen3.8-max"
+        }
+      ],
+      "release_date": "2026-08-03"
+    },
+    {
       "id": "stepfun/step-3.5-flash",
       "input_modalities": [
         "text"

--- a/dist/registry/providers.json
+++ b/dist/registry/providers.json
@@ -27,6 +27,28 @@
             "responses",
             "anthropic"
           ],
+          "id": "qwen/qwen3.8-max",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.25,
+              "cache_write": 2.5,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 6.0
+            }
+          },
+          "provider_model_id": "qwen3.8-max",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
           "id": "qwen/qwen3.7-max",
           "pricing": {
             "input_tokens": {
@@ -254,6 +276,28 @@
         "terms_of_service_url": "https://help.aliyun.com/zh/model-studio/related-agreements"
       },
       "models": [
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "qwen/qwen3.8-max",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.167,
+              "cache_write": 2.083,
+              "no_cache": 1.667
+            },
+            "output_tokens": {
+              "text": 5.0
+            }
+          },
+          "provider_model_id": "qwen3.8-max",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
         {
           "api_protocol": [
             "openai",
@@ -4974,6 +5018,11 @@
         },
         {
           "api_protocol": "openai",
+          "id": "qwen/qwen3.8-max",
+          "provider_model_id": "qwen3.8-max"
+        },
+        {
+          "api_protocol": "openai",
           "id": "moonshotai/kimi-k2.7-code",
           "provider_model_id": "kimi-k2.7-code"
         },
@@ -6099,6 +6148,25 @@
             }
           },
           "provider_model_id": "qwen/qwen3.7-max"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "qwen/qwen3.8-max",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.25,
+              "cache_write": 2.5,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 6.0
+            }
+          },
+          "provider_model_id": "qwen/qwen3.8-max"
         },
         {
           "api_protocol": [

--- a/docs/QWEN3_8_MAX_SPEC.md
+++ b/docs/QWEN3_8_MAX_SPEC.md
@@ -1,0 +1,75 @@
+# Qwen3.8 Max Registry Design
+
+## Goal
+
+Publish the generally available Qwen3.8 Max model in the BitRouter OSS
+registry. The canonical model must represent the formal `qwen3.8-max`
+release, not the earlier Token Plan-only `qwen3.8-max-preview` alias.
+
+## Upstream evidence
+
+The official QwenCloud model page now exposes `qwen3.8-max` as a
+2.4-trillion-parameter multimodal MoE flagship. It accepts text, image, and
+video input, produces text, has a 1,000,000-token context window, and supports
+up to 131,072 output tokens. Its published international price is USD 2.00 per
+million uncached input tokens and USD 6.00 per million output tokens, with USD
+0.25 cache reads and USD 2.50 cache writes.
+
+Alibaba Cloud's China pricing and cache documentation also lists
+`qwen3.8-max`. The base CNY 12 input / CNY 36 output prices are converted at
+approximately 7.2 CNY/USD. Explicit cache reads are billed at 10% of standard
+input and cache creation at 125%.
+
+The live OpenRouter and opencode go catalogs expose the formal model as
+`qwen/qwen3.8-max` and `qwen3.8-max`, respectively. No Qwen3.8 entry exists in
+the current BitRouter registry.
+
+## Canonical model
+
+Add `qwen/qwen3.8-max` with:
+
+- name `Qwen: Qwen3.8 Max`;
+- text, image, and video input with text output;
+- 1,000,000 maximum input tokens and 131,072 maximum output tokens;
+- release date `2026-08-03`;
+- proprietary weights and family `qwen3.8`;
+- a concise description of the 2.4T MoE, multimodal, long-horizon agent model.
+
+Do not add `qwen/qwen3.8-max-preview`. The preview is a temporary Token Plan
+model and is explicitly outside this change.
+
+## Provider mappings
+
+Add only providers with current public evidence for the formal model:
+
+| Provider | Upstream model ID | Pricing (USD / 1M tokens) |
+| --- | --- | --- |
+| Alibaba Cloud Model Studio (International) | `qwen3.8-max` | input 2.00, cache read 0.25, cache write 2.50, output 6.00 |
+| Alibaba Cloud Model Studio (China) | `qwen3.8-max` | input 1.667, cache read 0.167, cache write 2.083, output 5.00 |
+| OpenRouter | `qwen/qwen3.8-max` | input 2.00, cache read 0.25, cache write 2.50, output 6.00 |
+| opencode go | `qwen3.8-max` | subscription; no token price |
+
+Alibaba and OpenRouter inherit their existing OpenAI, Responses, and
+Anthropic protocol declarations. opencode go inherits its OpenAI protocol.
+
+Do not add the model to Alibaba Coding Plan: official documentation excludes
+Qwen3.8 from Coding Plan and its live catalog does not list the model. Do not
+introduce new Alibaba Token Plan providers in this model-scoped change.
+
+## Generated artifacts and regression coverage
+
+- Rebuild `dist/registry/models.json` and `dist/registry/providers.json`.
+- Add a repository-registry regression test that asserts the complete canonical
+  metadata, absence of a preview canonical, and the exact four provider
+  mappings and prices.
+- Run registry validation and generated-artifact checks.
+- Because the regression test changes Rust source, run formatting, Clippy, and
+  the full all-features test suite required by the repository.
+
+## Non-goals
+
+- Do not add or repoint `qwen3.8-max-preview`.
+- Do not create Alibaba Token Plan provider definitions.
+- Do not infer availability for providers whose public catalogs omit the
+  formal model.
+- Do not modify Qwen3.7 or unrelated model/provider entries.

--- a/helpers/dist-helper/src/registry.rs
+++ b/helpers/dist-helper/src/registry.rs
@@ -1072,7 +1072,7 @@ fn validate_loaded(registry: &LoadedRegistry) -> Result<Vec<String>> {
 
 fn validate_canonical_model(model: &CanonicalModel, issues: &mut Vec<String>) {
     for modality in &model.input_modalities {
-        if !matches!(modality.as_str(), "text" | "image" | "audio") {
+        if !matches!(modality.as_str(), "text" | "image" | "audio" | "video") {
             issues.push(format!(
                 "registry/models: model '{}' has invalid input modality '{}'",
                 model.id, modality
@@ -3407,6 +3407,81 @@ api_base: https://api.acme.test/v1
             openrouter.and_then(|model| model["pricing"]["output_tokens"]["text"].as_f64()),
             Some(0.18)
         );
+    }
+
+    #[test]
+    fn built_registry_includes_qwen3_8_max() {
+        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+        let artifacts = build_artifacts(&root).expect("builds repository registry");
+        let models: Value = serde_json::from_str(&artifacts.models).expect("valid models JSON");
+        let model_data = models["data"].as_array();
+        assert!(model_data.is_some(), "model data array");
+        let Some(model_data) = model_data else {
+            return;
+        };
+        assert!(
+            model_data
+                .iter()
+                .all(|model| model["id"] != "qwen/qwen3.8-max-preview")
+        );
+        let qwen = model_data
+            .iter()
+            .find(|model| model["id"] == "qwen/qwen3.8-max");
+        assert!(qwen.is_some(), "Qwen3.8 Max canonical model");
+        let Some(qwen) = qwen else {
+            return;
+        };
+        assert_eq!(qwen["name"], "Qwen: Qwen3.8 Max");
+        assert_eq!(
+            qwen["input_modalities"],
+            serde_json::json!(["text", "image", "video"])
+        );
+        assert_eq!(qwen["output_modalities"], serde_json::json!(["text"]));
+        assert_eq!(qwen["max_input_tokens"], 1_000_000);
+        assert_eq!(qwen["max_output_tokens"], 131_072);
+        assert_eq!(qwen["release_date"], "2026-08-03");
+        assert_eq!(qwen["open_weights"], false);
+        assert_eq!(qwen["family"], "qwen3.8");
+
+        let mappings = qwen["providers"].as_array();
+        assert!(mappings.is_some(), "provider mappings");
+        let Some(mappings) = mappings else {
+            return;
+        };
+        let expected = [
+            ("alibaba", "qwen3.8-max", Some((2.0, 0.25, 2.5, 6.0))),
+            (
+                "alibaba_cn",
+                "qwen3.8-max",
+                Some((1.667, 0.167, 2.083, 5.0)),
+            ),
+            (
+                "openrouter",
+                "qwen/qwen3.8-max",
+                Some((2.0, 0.25, 2.5, 6.0)),
+            ),
+            ("opencode-go", "qwen3.8-max", None),
+        ];
+        assert_eq!(mappings.len(), expected.len());
+        for (provider, provider_model_id, pricing) in expected {
+            let mapping = mappings.iter().find(|item| item["provider"] == provider);
+            assert!(mapping.is_some(), "{provider} mapping");
+            let Some(mapping) = mapping else {
+                continue;
+            };
+            assert_eq!(mapping["provider_model_id"], provider_model_id);
+            if let Some((input, cache_read, cache_write, output)) = pricing {
+                assert_eq!(mapping["pricing"]["input_tokens"]["no_cache"], input);
+                assert_eq!(mapping["pricing"]["input_tokens"]["cache_read"], cache_read);
+                assert_eq!(
+                    mapping["pricing"]["input_tokens"]["cache_write"],
+                    cache_write
+                );
+                assert_eq!(mapping["pricing"]["output_tokens"]["text"], output);
+            } else {
+                assert!(mapping.get("pricing").is_none());
+            }
+        }
     }
 
     #[test]

--- a/helpers/dist-helper/src/registry.rs
+++ b/helpers/dist-helper/src/registry.rs
@@ -3412,8 +3412,16 @@ api_base: https://api.acme.test/v1
     #[test]
     fn built_registry_includes_qwen3_8_max() {
         let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
-        let artifacts = build_artifacts(&root).expect("builds repository registry");
-        let models: Value = serde_json::from_str(&artifacts.models).expect("valid models JSON");
+        let artifacts = build_artifacts(&root);
+        assert!(artifacts.is_ok(), "builds repository registry");
+        let Ok(artifacts) = artifacts else {
+            return;
+        };
+        let models = serde_json::from_str::<Value>(&artifacts.models);
+        assert!(models.is_ok(), "valid models JSON");
+        let Ok(models) = models else {
+            return;
+        };
         let model_data = models["data"].as_array();
         assert!(model_data.is_some(), "model data array");
         let Some(model_data) = model_data else {
@@ -3433,6 +3441,10 @@ api_base: https://api.acme.test/v1
         };
         assert_eq!(qwen["name"], "Qwen: Qwen3.8 Max");
         assert_eq!(
+            qwen["description"],
+            "2.4T-parameter multimodal MoE flagship for coding, professional work, and long-horizon agentic workflows."
+        );
+        assert_eq!(
             qwen["input_modalities"],
             serde_json::json!(["text", "image", "video"])
         );
@@ -3449,27 +3461,40 @@ api_base: https://api.acme.test/v1
             return;
         };
         let expected = [
-            ("alibaba", "qwen3.8-max", Some((2.0, 0.25, 2.5, 6.0))),
+            (
+                "alibaba",
+                "qwen3.8-max",
+                Some((2.0, 0.25, 2.5, 6.0)),
+                serde_json::json!(["openai", "responses", "anthropic"]),
+            ),
             (
                 "alibaba_cn",
                 "qwen3.8-max",
                 Some((1.667, 0.167, 2.083, 5.0)),
+                serde_json::json!(["openai", "responses", "anthropic"]),
             ),
             (
                 "openrouter",
                 "qwen/qwen3.8-max",
                 Some((2.0, 0.25, 2.5, 6.0)),
+                serde_json::json!(["openai", "responses", "anthropic"]),
             ),
-            ("opencode-go", "qwen3.8-max", None),
+            (
+                "opencode-go",
+                "qwen3.8-max",
+                None,
+                serde_json::json!("openai"),
+            ),
         ];
         assert_eq!(mappings.len(), expected.len());
-        for (provider, provider_model_id, pricing) in expected {
+        for (provider, provider_model_id, pricing, api_protocol) in expected {
             let mapping = mappings.iter().find(|item| item["provider"] == provider);
             assert!(mapping.is_some(), "{provider} mapping");
             let Some(mapping) = mapping else {
                 continue;
             };
             assert_eq!(mapping["provider_model_id"], provider_model_id);
+            assert_eq!(mapping["api_protocol"], api_protocol);
             if let Some((input, cache_read, cache_write, output)) = pricing {
                 assert_eq!(mapping["pricing"]["input_tokens"]["no_cache"], input);
                 assert_eq!(mapping["pricing"]["input_tokens"]["cache_read"], cache_read);

--- a/registry/models/qwen.yaml
+++ b/registry/models/qwen.yaml
@@ -74,6 +74,21 @@
   release_date: 2026-06-10
   open_weights: false
   family: qwen3.7
+# Official model: https://www.qwencloud.com/models/qwen3.8-max
+- id: qwen/qwen3.8-max
+  name: 'Qwen: Qwen3.8 Max'
+  description: 2.4T-parameter multimodal MoE flagship for coding, professional work, and long-horizon agentic workflows.
+  input_modalities:
+  - text
+  - image
+  - video
+  output_modalities:
+  - text
+  max_input_tokens: 1000000
+  max_output_tokens: 131072
+  release_date: 2026-08-03
+  open_weights: false
+  family: qwen3.8
 - id: qwen/qwen3.6-flash
   name: 'Qwen: Qwen3.6 Flash'
   input_modalities:

--- a/registry/providers/alibaba.yaml
+++ b/registry/providers/alibaba.yaml
@@ -20,6 +20,16 @@ rate_limits:
   - "*":
       requests_per_minute: 60
 models:
+  # Official pricing: https://www.qwencloud.com/models/qwen3.8-max
+  - id: qwen/qwen3.8-max
+    provider_model_id: qwen3.8-max
+    pricing:
+      input_tokens:
+        no_cache: 2
+        cache_read: 0.25
+        cache_write: 2.5
+      output_tokens:
+        text: 6
   - id: qwen/qwen3.7-max
     provider_model_id: qwen3.7-max
     pricing:

--- a/registry/providers/alibaba_cn.yaml
+++ b/registry/providers/alibaba_cn.yaml
@@ -18,6 +18,18 @@ rate_limits:
   - "*":
       requests_per_minute: 60
 models:
+  # CNY 12/1.2/15/36 converted at ~7.2 CNY/USD.
+  # Sources: https://help.aliyun.com/zh/model-studio/model-pricing
+  # and https://help.aliyun.com/zh/model-studio/context-cache
+  - id: qwen/qwen3.8-max
+    provider_model_id: qwen3.8-max
+    pricing:
+      input_tokens:
+        no_cache: 1.667
+        cache_read: 0.167
+        cache_write: 2.083
+      output_tokens:
+        text: 5
   - id: qwen/qwen3.7-max
     provider_model_id: qwen3.7-max
     pricing:

--- a/registry/providers/opencode-go.yaml
+++ b/registry/providers/opencode-go.yaml
@@ -38,6 +38,9 @@ models:
     provider_model_id: qwen3.7-plus
   - id: qwen/qwen3.7-max
     provider_model_id: qwen3.7-max
+  # Live catalog: https://opencode.ai/zen/go/v1/models
+  - id: qwen/qwen3.8-max
+    provider_model_id: qwen3.8-max
   - id: moonshotai/kimi-k2.7-code
     provider_model_id: kimi-k2.7-code
   - id: z-ai/glm-5.1

--- a/registry/providers/openrouter.yaml
+++ b/registry/providers/openrouter.yaml
@@ -250,6 +250,16 @@ models:
         cache_write: 1.84375
       output_tokens:
         text: 4.425
+  # Live catalog: https://openrouter.ai/api/v1/models
+  - id: qwen/qwen3.8-max
+    provider_model_id: qwen/qwen3.8-max
+    pricing:
+      input_tokens:
+        no_cache: 2
+        cache_read: 0.25
+        cache_write: 2.5
+      output_tokens:
+        text: 6
   - id: qwen/qwen3.6-flash
     provider_model_id: qwen/qwen3.6-flash
     pricing:


### PR DESCRIPTION
## Summary

- add the formal `qwen/qwen3.8-max` canonical model with text, image, and video input metadata
- map the verified Alibaba International, Alibaba China, OpenRouter, and opencode go upstream IDs
- publish usage pricing for the three pay-as-you-go providers while keeping opencode go subscription-only
- allow `video` in canonical input modality validation and add a real registry artifact regression test
- rebuild `dist/registry/models.json` and `dist/registry/providers.json`

## Scope

This intentionally excludes `qwen3.8-max-preview`, Alibaba Coding Plan, Token Plan provider definitions, and unrelated catalog updates. The regression test requires the provider set to remain exactly these four mappings.

## Sources

- QwenCloud model card and international pricing: https://www.qwencloud.com/models/qwen3.8-max
- Alibaba Model Studio pricing: https://help.aliyun.com/zh/model-studio/model-pricing
- Alibaba context cache pricing: https://help.aliyun.com/zh/model-studio/context-cache
- OpenRouter live catalog: https://openrouter.ai/api/v1/models
- opencode go live catalog: https://opencode.ai/zen/go/v1/models

## Validation

- `cargo run -p dist-helper -- registry validate`
- `cargo run -p dist-helper -- check`
- `cargo fmt -- --check`
- `cargo clippy --all-features`
- `cargo nextest run --all-features -j 4` — 2204 passed, 11 skipped
- independent read-only review and follow-up review: no remaining findings