### PR TITLE
fix(protocol): preserve Anthropic tool extension fields

### DIFF
--- a/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
@@ -36,6 +36,21 @@ use crate::language_model::types::{
 /// SDK's `providerOptions.anthropic.cacheControl` naming.
 /// <https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching>
 const ANTHROPIC_CACHE_CONTROL: &str = "cacheControl";
+/// The metadata key, within the `anthropic` namespace, under which a **client
+/// function tool's** unmodelled wire fields ride as a JSON object.
+///
+/// A [`Tool::Function`] models only `{name, description, input_schema}`, but the
+/// Messages wire keeps adding optional tool properties — `defer_loading` (tool
+/// search), `input_examples`, and whatever ships next. Without this slot the
+/// typeless-tool parse drops every one of them, which silently disables the
+/// feature they turn on: a request carrying a `tool_search_tool_*` entry plus
+/// `defer_loading: true` tools reaches the upstream with the search tool intact
+/// and nothing deferred, so every definition loads into the prefix anyway.
+///
+/// [`Tool::ProviderDefined`] needs no equivalent — its `args` already round-trip
+/// the whole residual object.
+/// <https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-search-tool>
+const ANTHROPIC_TOOL_EXTRA: &str = "toolExtra";
 /// The metadata key carrying an Anthropic thinking block's `signature` — the
 /// opaque token that lets a thinking block be replayed on a follow-up turn.
 /// <https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking>
@@ -105,6 +120,42 @@ fn apply_cache_control(target: &mut serde_json::Value, meta: &ProviderMetadata) 
         && let Some(obj) = target.as_object_mut()
     {
         obj.insert("cache_control".to_string(), cc);
+    }
+}
+
+/// Stash a client function tool's residual wire fields under
+/// `anthropic.toolExtra` so [`apply_tool_extra`] can restore them on render. A
+/// no-op when `extra` is empty, so tools that carry nothing extra produce
+/// byte-identical metadata to before.
+fn set_tool_extra(meta: &mut ProviderMetadata, extra: HashMap<String, serde_json::Value>) {
+    if extra.is_empty() {
+        return;
+    }
+    set_provider_metadata(
+        meta,
+        PROVIDER_ID_ANTHROPIC,
+        ANTHROPIC_TOOL_EXTRA,
+        serde_json::Value::Object(extra.into_iter().collect()),
+    );
+}
+
+/// Splat a client function tool's residual wire fields from `meta` back onto a
+/// rendered tool object — the inverse of [`set_tool_extra`]. Existing keys win,
+/// so the typed `{name, description, input_schema}` this adapter just wrote can
+/// never be overwritten by a stale residual field.
+fn apply_tool_extra(target: &mut serde_json::Value, meta: &ProviderMetadata) {
+    let Some(extra) = provider_namespace(meta, PROVIDER_ID_ANTHROPIC)
+        .and_then(|o| o.get(ANTHROPIC_TOOL_EXTRA))
+        .and_then(|v| v.as_object())
+    else {
+        return;
+    };
+    if let Some(obj) = target.as_object_mut() {
+        for (key, value) in extra {
+            if !obj.contains_key(key) {
+                obj.insert(key.clone(), value.clone());
+            }
+        }
     }
 }
 
@@ -419,8 +470,15 @@ fn parse_messages_tool(mut t: MessagesTool) -> Option<Tool> {
             provider_metadata,
         });
     }
+    // Client function tool. `extra` holds every wire field this adapter does
+    // not model — `defer_loading`, `input_examples`, … — which the canonical
+    // `Tool::Function` has no slot for. Preserve them under the `anthropic`
+    // namespace so a same-protocol round-trip is lossless; dropping them
+    // silently disables the upstream feature they enable.
+    let name = t.name?;
+    set_tool_extra(&mut provider_metadata, t.extra);
     Some(Tool::Function {
-        name: t.name?,
+        name,
         description: t.description,
         parameters: t.input_schema,
         // Anthropic client tools carry no `strict` slot.
@@ -431,10 +489,12 @@ fn parse_messages_tool(mut t: MessagesTool) -> Option<Tool> {
 
 /// Render one canonical [`Tool`] into an Anthropic `tools` entry.
 ///
-/// A [`Tool::Function`] becomes `{name, description?, input_schema}`. Anthropic
-/// has **no** `strict` slot, so [`Tool::Function::strict`] is intentionally
-/// dropped here (documented; the same drop applies to structured-output
-/// `strict`). A [`Tool::ProviderDefined`] renders to its source-native shape via
+/// A [`Tool::Function`] becomes `{name, description?, input_schema}` plus any
+/// residual wire fields carried under [`ANTHROPIC_TOOL_EXTRA`] (`defer_loading`,
+/// `input_examples`, …). Anthropic has **no** `strict` slot, so
+/// [`Tool::Function::strict`] is intentionally dropped here (documented; the
+/// same drop applies to structured-output `strict`). A [`Tool::ProviderDefined`]
+/// renders to its source-native shape via
 /// [`provider_defined_native`]: an `anthropic.*` id reproduces the exact server
 /// tool (`{type:<version>, name, …args}`) for a lossless same-protocol
 /// round-trip; a foreign-provider id is preserved verbatim (faithful
@@ -454,7 +514,9 @@ fn render_messages_tool(tool: &Tool) -> serde_json::Value {
                 "description": description,
                 "input_schema": parameters,
             });
-            // Restore a tool-level `cache_control` breakpoint when it round-tripped.
+            // Restore the unmodelled wire fields (`defer_loading`, …) this
+            // adapter lifted on parse, then the `cache_control` breakpoint.
+            apply_tool_extra(&mut obj, provider_metadata);
             apply_cache_control(&mut obj, provider_metadata);
             obj
         }

--- a/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
@@ -8550,6 +8550,144 @@ fn messages_cache_control_on_tool_round_trips() {
     );
 }
 
+/// A client function tool's unmodelled wire fields survive a same-protocol
+/// round-trip. `defer_loading` is the expensive instance: a request pairing a
+/// `tool_search_tool_*` entry with deferred tools reaches the upstream with the
+/// search tool intact, so dropping the flags leaves every definition eagerly
+/// loaded — the caller silently loses the whole saving the feature exists for.
+/// <https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-search-tool>
+#[test]
+fn messages_defer_loading_on_tool_round_trips() {
+    let adapter = messages::MessagesAdapter;
+    let body = serde_json::json!({
+        "model": "claude-3-5-sonnet",
+        "max_tokens": 64,
+        "messages": [{ "role": "user", "content": "hi" }],
+        "tools": [
+            {
+                "type": "tool_search_tool_regex_20251119",
+                "name": "tool_search_tool_regex",
+            },
+            {
+                "name": "get_weather",
+                "description": "weather",
+                "input_schema": { "type": "object" },
+                "defer_loading": true,
+                "input_examples": [{ "location": "SF" }],
+            },
+        ],
+    });
+    let prompt = adapter.parse_request(body).unwrap();
+    let rendered = adapter.render_request(&prompt).unwrap();
+
+    // The server tool is untouched — it is the one tool that must NOT defer.
+    assert_eq!(
+        rendered["tools"][0]["type"],
+        "tool_search_tool_regex_20251119"
+    );
+    // And the deferred client tool kept both optional properties.
+    let deferred = &rendered["tools"][1];
+    assert_eq!(deferred["name"], "get_weather");
+    assert_eq!(deferred["defer_loading"], serde_json::json!(true));
+    assert_eq!(
+        deferred["input_examples"],
+        serde_json::json!([{ "location": "SF" }])
+    );
+    // The residual fields did not leak into the schema.
+    assert!(deferred["input_schema"].get("defer_loading").is_none());
+}
+
+/// The residual-field slot composes with a tool-level cache breakpoint: both
+/// ride the same `anthropic` namespace and both render back onto the tool.
+#[test]
+fn messages_tool_extra_and_cache_control_compose() {
+    let adapter = messages::MessagesAdapter;
+    let body = serde_json::json!({
+        "model": "claude-3-5-sonnet",
+        "max_tokens": 64,
+        "messages": [{ "role": "user", "content": "hi" }],
+        "tools": [{
+            "name": "always_loaded",
+            "description": "stays in context",
+            "input_schema": { "type": "object" },
+            "cache_control": { "type": "ephemeral" },
+            "input_examples": [{ "q": "x" }],
+        }],
+    });
+    let prompt = adapter.parse_request(body).unwrap();
+    let rendered = adapter.render_request(&prompt).unwrap();
+    assert_eq!(rendered["tools"][0]["cache_control"], ephemeral());
+    assert_eq!(
+        rendered["tools"][0]["input_examples"],
+        serde_json::json!([{ "q": "x" }])
+    );
+}
+
+/// A tool carrying no extension fields renders exactly as before — the residual
+/// slot must not introduce keys (or an empty `anthropic` namespace) on the
+/// overwhelmingly common path.
+#[test]
+fn messages_tool_without_extras_is_unchanged() {
+    let adapter = messages::MessagesAdapter;
+    let body = serde_json::json!({
+        "model": "claude-3-5-sonnet",
+        "max_tokens": 64,
+        "messages": [{ "role": "user", "content": "hi" }],
+        "tools": [{
+            "name": "plain",
+            "description": "no extras",
+            "input_schema": { "type": "object" },
+        }],
+    });
+    let prompt = adapter.parse_request(body).unwrap();
+    match &prompt.tools[0] {
+        Tool::Function {
+            provider_metadata, ..
+        } => assert!(
+            provider_metadata.is_empty(),
+            "a plain tool must carry no provider metadata, got {provider_metadata:?}"
+        ),
+        other => panic!("expected function tool, got {other:?}"),
+    }
+    let rendered = adapter.render_request(&prompt).unwrap();
+    assert_eq!(
+        rendered["tools"][0],
+        serde_json::json!({
+            "name": "plain",
+            "description": "no extras",
+            "input_schema": { "type": "object" },
+        })
+    );
+}
+
+/// Cross-protocol: `defer_loading` is an Anthropic-namespaced hint, so routing a
+/// Messages request to a Chat Completions upstream must NOT leak it onto the
+/// OpenAI tool shape — the field is meaningless there and OpenAI rejects
+/// unknown properties on some endpoints.
+#[test]
+fn messages_defer_loading_does_not_leak_cross_protocol() {
+    let inbound = messages::MessagesAdapter;
+    let body = serde_json::json!({
+        "model": "claude-3-5-sonnet",
+        "max_tokens": 64,
+        "messages": [{ "role": "user", "content": "hi" }],
+        "tools": [{
+            "name": "get_weather",
+            "description": "weather",
+            "input_schema": { "type": "object" },
+            "defer_loading": true,
+        }],
+    });
+    let prompt = inbound.parse_request(body).unwrap();
+    let rendered = chat_completions::ChatCompletionsAdapter
+        .render_request(&prompt)
+        .unwrap();
+    let tool = &rendered["tools"][0];
+    assert_eq!(tool["function"]["name"], "get_weather");
+    assert!(tool.get("defer_loading").is_none());
+    assert!(tool["function"].get("defer_loading").is_none());
+}
+
 /// Anthropic `cache_control` on a `tool_result` block round-trips: a long tool
 /// output can mark a cache boundary, and the breakpoint must survive.
 #[test]


### PR DESCRIPTION
Anthropic client function tools lose every optional wire property except `cache_control` on a same-protocol round-trip through BitRouter.

`parse_messages_tool` (`crates/bitrouter-sdk/src/language_model/protocol/messages.rs`) collects unmodelled fields into `MessagesTool::extra`, lifts `cache_control` out, then drops the rest — `Tool::Function` has no slot for them. `render_messages_tool` emits only `{name, description, input_schema}` + `cache_control`.

## Why it is expensive

`defer_loading` is the instance that costs money. A `tool_search_tool_*` entry carries a `type`, so it parses to `Tool::ProviderDefined` and round-trips intact — while the `defer_loading: true` flags on the tools it exists to defer did not.

The upstream therefore receives **a tool search tool plus a fully eager tool array**. That is not a 400 (the API only rejects when *all* tools are deferred), so it fails silently: every definition loads into the prefix, the caller pays the tool search tool overhead on top, and the model may spend turns searching for tools already in its context. Anthropic reports [>85% tool-definition token reduction](https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-search-tool) from this feature, and Claude Code has shipped MCP tool search on by default since v2.1.7 — so this affects a large slice of real traffic today.

`input_examples` was dropped the same way. The root cause is general: the parse is lossy for every extension field the wire grows.

## The fix

Stash the residual object under `anthropic.toolExtra` and splat it back on render, mirroring the existing `cache_control` lift/apply pair rather than inventing a new mechanism.

- Existing keys win on restore, so the typed `{name, description, input_schema}` can never be clobbered.
- Empty extras write no metadata — the common path is byte-identical to before.
- Namespaced under `anthropic`, so the fields stay off non-Anthropic upstreams.
- `Tool::ProviderDefined` needs no equivalent; its `args` already round-trip the whole residual object.

## Verification

Live, through `bitrouter serve` against a capture upstream — not just unit tests.

Before:

```
tool                     sent by client                       forwarded upstream
tool_search_tool_regex   []                                   []
get_weather              [defer_loading]                      []
search_files             [defer_loading, input_examples]      []
always_loaded            [cache_control]                      [cache_control]
```

After:

```
tool                     sent by client                       forwarded upstream
tool_search_tool_regex   []                                   []
get_weather              [defer_loading]                      [defer_loading]
search_files             [defer_loading, input_examples]      [defer_loading, input_examples]
always_loaded            [cache_control]                      [cache_control]
```

Cross-protocol (Messages inbound → Chat Completions outbound) confirmed to carry no `defer_loading` leakage.

Four regression tests added: same-protocol round-trip, composition with `cache_control`, the no-extras path staying unchanged, and no cross-protocol leak.

`cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, and `cargo nextest run --workspace --all-features` (2208 passed) all clean.

## Follow-ups, not in this PR

- **Cross-protocol normalization.** A Messages request routed to Chat Completions silently discards the `tool_search_tool_*` entry entirely (4 tools in, 3 out). OpenAI Responses has its own `tool_search` + deferred-tool dialect; translating between them is squarely BitRouter's job and is not attempted here.
- **`cache_control` is dropped cross-protocol too**, so an OpenAI-shaped client routed to an Anthropic upstream gets zero cache breakpoints. Separate issue, likely larger in dollar terms than this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)