### PR TITLE
feat: guide @auto workflow optimization

### DIFF
--- a/apps/bitrouter/src/assemble.rs
+++ b/apps/bitrouter/src/assemble.rs
@@ -1101,11 +1101,54 @@ pub(crate) fn build_pricing_table(config: &Config) -> PricingTable {
                         output_micro_usd_per_token: t.output_micro_usd_per_token,
                     })
                     .collect();
-                table.insert(provider_id.clone(), model.id.clone(), model_pricing);
+                table.insert(provider_id.clone(), model.id.clone(), model_pricing.clone());
+                if let Some(native_id) = model.provider_model_id.as_deref()
+                    && native_id != model.id
+                {
+                    table.insert(provider_id.clone(), native_id, model_pricing);
+                }
             }
         }
     }
     table
+}
+
+#[cfg(test)]
+mod pricing_assembly_tests {
+    use super::build_pricing_table;
+
+    #[test]
+    fn provider_native_model_id_reuses_registry_pricing() -> anyhow::Result<()> {
+        let config = bitrouter_sdk::config::parse_with(
+            r#"
+providers:
+  example:
+    api_base: https://example.test/v1
+    models:
+      - id: example/canonical-model
+        provider_model_id: native-model
+        pricing:
+          input_micro_usd_per_token: 1.25
+          output_micro_usd_per_token: 5.0
+"#,
+            |_| None,
+        )?;
+
+        let pricing = build_pricing_table(&config);
+        assert_eq!(
+            pricing
+                .resolve("example", "example/canonical-model")
+                .and_then(|entry| entry.input_micro_usd_per_token),
+            Some(1.25)
+        );
+        assert_eq!(
+            pricing
+                .resolve("example", "native-model")
+                .and_then(|entry| entry.input_micro_usd_per_token),
+            Some(1.25)
+        );
+        Ok(())
+    }
 }
 
 /// Load the `PolicyStore` from `plugins.bitrouter-policy.policy_dir`, if set.

--- a/apps/bitrouter/src/main.rs
+++ b/apps/bitrouter/src/main.rs
@@ -283,11 +283,11 @@ enum Command {
         #[arg(long)]
         optimize_success: Option<String>,
         /// Provider-qualified strong route for optimization onboarding.
-        #[arg(long, default_value = "openai-codex:gpt-5.6-sol")]
-        optimize_strong: String,
+        #[arg(long)]
+        optimize_strong: Option<String>,
         /// Provider-qualified economy route for optimization onboarding.
-        #[arg(long, default_value = "bitrouter:deepseek/deepseek-v4-flash-0731")]
-        optimize_economy: String,
+        #[arg(long)]
+        optimize_economy: Option<String>,
         /// Frozen normalized-showback price override. Repeat for unpriced
         /// subscription routes.
         #[arg(long = "optimize-normalized-price")]
@@ -1632,14 +1632,14 @@ async fn run(cli: Cli, output: &bitrouter::output::Output) -> Result<()> {
             optimize_normalized_prices,
             optimize_preference,
         } => {
-            let optimize_normalized_prices = if optimize_normalized_prices.is_empty()
-                && optimize_strong == "openai-codex:gpt-5.6-sol"
+            let optimization = if optimize
+                || optimize_workflow_command.is_some()
+                || optimize_strong.is_some()
+                || optimize_economy.is_some()
+                || optimize_success.is_some()
+                || !optimize_workflow_input.is_empty()
+                || !optimize_normalized_prices.is_empty()
             {
-                vec!["openai-codex:gpt-5.6-sol=5,0.5,6.25,30".into()]
-            } else {
-                optimize_normalized_prices
-            };
-            let optimization = if optimize || optimize_workflow_command.is_some() {
                 Some(bitrouter::onboarding::OnboardingOptimization {
                     workflow_command: optimize_workflow_command.map(|command| {
                         std::iter::once(command)
@@ -3824,28 +3824,6 @@ fn select_guided_workflow(
     }
 }
 
-async fn existing_optimization_routes(
-    source_config: &Path,
-    policy: &str,
-) -> Result<(Option<String>, Option<String>)> {
-    let raw = tokio::fs::read_to_string(source_config)
-        .await
-        .with_context(|| format!("reading source config {}", source_config.display()))?;
-    let parsed = config::parse(&raw).context("parsing source BitRouter config")?;
-    let Some(active) =
-        bitrouter::policy_lock::load_for_config(&parsed, Some(source_config)).await?
-    else {
-        return Ok((None, None));
-    };
-    let Some(definition) = active.document.policies.get(policy) else {
-        return Ok((None, None));
-    };
-    Ok((
-        definition.tiers.get("strong").cloned(),
-        definition.tiers.get("economy").cloned(),
-    ))
-}
-
 fn select_optimization_route(
     label: &str,
     requested: Option<String>,
@@ -3941,7 +3919,8 @@ async fn optimize(action: OptimizeAction, output: &Output) -> Result<()> {
             let workflow_command =
                 select_guided_workflow(project_root, workflow_command, workflow_arg)?;
             let (existing_strong, existing_economy) =
-                existing_optimization_routes(&source_config_path, &policy).await?;
+                bitrouter::optimization::setup::existing_tier_routes(&source_config_path, &policy)
+                    .await?;
             let strong = select_optimization_route("strong", strong, existing_strong)?;
             let economy = select_optimization_route("economy", economy, existing_economy)?;
             let operation_path = setup_paths.operation_lock_target();
@@ -6765,6 +6744,25 @@ mod tests {
             .is_ok()
         );
         assert!(Cli::try_parse_from(["bitrouter", "optimize", "rollback"]).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn init_optimization_routes_have_no_model_specific_defaults() -> anyhow::Result<()> {
+        use clap::Parser;
+
+        let parsed = Cli::try_parse_from(["bitrouter", "init", "--optimize"])?;
+        match parsed.command {
+            Some(Command::Init {
+                optimize_strong,
+                optimize_economy,
+                ..
+            }) => {
+                assert!(optimize_strong.is_none());
+                assert!(optimize_economy.is_none());
+            }
+            _ => anyhow::bail!("expected init command"),
+        }
         Ok(())
     }
 

--- a/apps/bitrouter/src/main.rs
+++ b/apps/bitrouter/src/main.rs
@@ -36,6 +36,9 @@ use bitrouter::output::reports::daemon::{
 use bitrouter::output::reports::eval::EvalReport;
 use bitrouter::output::reports::mcp::{McpAddReport, McpRegistryReport, McpRegistryRow};
 use bitrouter::output::reports::observe::ObserveStatusReport;
+use bitrouter::output::reports::optimization::{
+    OptimizationReviewReport, OptimizationSetupReport, OptimizationStatusReport,
+};
 use bitrouter::output::reports::policy::PolicyReport;
 use bitrouter::output::reports::routing::{ModelRow, ModelsReport, ProviderRow, ProvidersReport};
 use bitrouter::output::reports::tools::{
@@ -1138,9 +1141,9 @@ struct OptimizeSetupArgs {
     /// Source BitRouter config used by the workflow.
     #[arg(long, default_value = "bitrouter.yaml")]
     source_config: PathBuf,
-    /// Exact workflow executable (no shell parsing).
+    /// Exact workflow executable (no shell parsing). Omit for project discovery.
     #[arg(long)]
-    workflow_command: String,
+    workflow_command: Option<String>,
     /// One exact workflow argument; repeat to preserve argv boundaries.
     #[arg(long, allow_hyphen_values = true)]
     workflow_arg: Vec<String>,
@@ -1160,12 +1163,12 @@ struct OptimizeSetupArgs {
     /// Preset passed to the workflow as `@preset`.
     #[arg(long, default_value = "auto")]
     preset: String,
-    /// Provider-qualified strong route used by the baseline.
+    /// Provider-qualified strong route. Omit to reuse @auto or prompt.
     #[arg(long)]
-    strong: String,
-    /// Provider-qualified economy route tested as the one-variable candidate.
+    strong: Option<String>,
+    /// Provider-qualified economy route. Omit to reuse @auto or prompt.
     #[arg(long)]
-    economy: String,
+    economy: Option<String>,
     /// Frozen normalized-showback price as
     /// provider:model=uncached,cache_read,cache_write,output. Repeat for
     /// subscription or otherwise unpriced routes.
@@ -3737,6 +3740,154 @@ async fn policy(action: PolicyAction, output: &Output) -> Result<()> {
     Ok(())
 }
 
+fn read_optimization_prompt(prompt: &str) -> Result<String> {
+    use std::io::{BufRead, Write};
+
+    eprint!("{prompt}");
+    std::io::stderr().flush().ok();
+    let mut line = String::new();
+    let read = std::io::stdin()
+        .lock()
+        .read_line(&mut line)
+        .context("reading optimization setup input")?;
+    if read == 0 {
+        return Ok(String::new());
+    }
+    Ok(line.trim().to_string())
+}
+
+fn select_guided_workflow(
+    root: &Path,
+    executable: Option<String>,
+    arguments: Vec<String>,
+) -> Result<Vec<String>> {
+    use std::io::IsTerminal;
+
+    use bitrouter::optimization::discovery::GuidedWorkflow;
+
+    match bitrouter::optimization::discovery::resolve_guided_workflow(root, executable, arguments)?
+    {
+        GuidedWorkflow::Resolved { command, evidence } => {
+            eprintln!("  workflow: {evidence}");
+            Ok(command)
+        }
+        GuidedWorkflow::Choose(candidates) if std::io::stdin().is_terminal() => {
+            eprintln!("  Candidate agent workflows:");
+            for (index, candidate) in candidates.iter().enumerate() {
+                eprintln!(
+                    "    {}) {}  [{}]",
+                    index + 1,
+                    candidate.command.join(" "),
+                    candidate.evidence
+                );
+            }
+            let answer = read_optimization_prompt("  Select workflow [1]: ")?;
+            let selected = if answer.is_empty() {
+                1
+            } else {
+                answer
+                    .parse::<usize>()
+                    .context("workflow selection must be a candidate number")?
+            };
+            let candidate = candidates.get(selected.saturating_sub(1)).ok_or_else(|| {
+                anyhow::anyhow!("workflow selection {selected} is outside the candidate list")
+            })?;
+            Ok(candidate.command.clone())
+        }
+        GuidedWorkflow::Choose(candidates) => {
+            let choices = candidates
+                .iter()
+                .map(|candidate| format!("{} => {}", candidate.id, candidate.command.join(" ")))
+                .collect::<Vec<_>>()
+                .join("; ");
+            anyhow::bail!(
+                "multiple workflow candidates were discovered ({choices}); rerun with --workflow-command and repeated --workflow-arg values"
+            )
+        }
+        GuidedWorkflow::Missing if std::io::stdin().is_terminal() => {
+            let raw = read_optimization_prompt(
+                "  Workflow argv as JSON (example: [\"npm\",\"run\",\"eval\"]): ",
+            )?;
+            let command: Vec<String> = serde_json::from_str(&raw)
+                .context("workflow command must be a JSON string array")?;
+            bitrouter::optimization::WorkflowCommand {
+                command: command.clone(),
+                inputs: Vec::new(),
+                timeout_secs: 1,
+            }
+            .validate()?;
+            Ok(command)
+        }
+        GuidedWorkflow::Missing => anyhow::bail!(
+            "no agent eval or benchmark entrypoint was discovered; pass --workflow-command and repeat --workflow-arg for exact argv"
+        ),
+    }
+}
+
+async fn existing_optimization_routes(
+    source_config: &Path,
+    policy: &str,
+) -> Result<(Option<String>, Option<String>)> {
+    let raw = tokio::fs::read_to_string(source_config)
+        .await
+        .with_context(|| format!("reading source config {}", source_config.display()))?;
+    let parsed = config::parse(&raw).context("parsing source BitRouter config")?;
+    let Some(active) =
+        bitrouter::policy_lock::load_for_config(&parsed, Some(source_config)).await?
+    else {
+        return Ok((None, None));
+    };
+    let Some(definition) = active.document.policies.get(policy) else {
+        return Ok((None, None));
+    };
+    Ok((
+        definition.tiers.get("strong").cloned(),
+        definition.tiers.get("economy").cloned(),
+    ))
+}
+
+fn select_optimization_route(
+    label: &str,
+    requested: Option<String>,
+    existing: Option<String>,
+) -> Result<String> {
+    use std::io::IsTerminal;
+
+    if let Some(route) = requested.or(existing) {
+        return Ok(route);
+    }
+    if !std::io::stdin().is_terminal() {
+        anyhow::bail!(
+            "no {label} route exists in @auto; pass --{label} with a provider-qualified model"
+        );
+    }
+    let route = read_optimization_prompt(&format!("  {label} route (provider:model): "))?;
+    if route.trim().is_empty() {
+        anyhow::bail!("{label} route is required");
+    }
+    Ok(route)
+}
+
+fn resolve_adaptive_publication_consent(
+    explicit: bool,
+    interactive: bool,
+    answer: Option<&str>,
+) -> Result<bool> {
+    if explicit {
+        return Ok(true);
+    }
+    if !interactive {
+        anyhow::bail!(
+            "policy runtime mode is frozen; rerun this publication with --enable-adaptive"
+        );
+    }
+    if answer.is_some_and(|value| matches!(value.trim().to_ascii_lowercase().as_str(), "y" | "yes"))
+    {
+        return Ok(true);
+    }
+    anyhow::bail!("publication cancelled; @auto remains frozen and unchanged")
+}
+
 async fn optimize(action: OptimizeAction, output: &Output) -> Result<()> {
     match action {
         OptimizeAction::Setup(args) => {
@@ -3758,9 +3909,42 @@ async fn optimize(action: OptimizeAction, output: &Output) -> Result<()> {
                 evaluator_model,
                 evaluator_via_cloud,
             } = *args;
-            let operation_path =
-                bitrouter::optimization::OptimizationPaths::for_intent(config.clone())
-                    .operation_lock_target();
+            let setup_paths =
+                bitrouter::optimization::OptimizationPaths::for_intent(config.clone());
+            let project_root = setup_paths
+                .intent
+                .parent()
+                .unwrap_or_else(|| Path::new("."));
+            if setup_paths.intent.exists() {
+                anyhow::bail!(
+                    "{} already exists; use `bitrouter optimize resolve` after editing version-controlled inputs",
+                    setup_paths.intent.display()
+                );
+            }
+            if setup_paths.lock.exists() {
+                anyhow::bail!(
+                    "{} already exists; refusing to overwrite",
+                    setup_paths.lock.display()
+                );
+            }
+            let source_config_path = if source_config.is_absolute() {
+                source_config.clone()
+            } else {
+                project_root.join(&source_config)
+            };
+            if !source_config_path.is_file() {
+                anyhow::bail!(
+                    "source config '{}' does not exist; run `bitrouter init --write-config` first",
+                    source_config_path.display()
+                );
+            }
+            let workflow_command =
+                select_guided_workflow(project_root, workflow_command, workflow_arg)?;
+            let (existing_strong, existing_economy) =
+                existing_optimization_routes(&source_config_path, &policy).await?;
+            let strong = select_optimization_route("strong", strong, existing_strong)?;
+            let economy = select_optimization_route("economy", economy, existing_economy)?;
+            let operation_path = setup_paths.operation_lock_target();
             let _operation_lock =
                 bitrouter::policy_lock::try_acquire_publication_lock(&operation_path)?;
             let preference: bitrouter::optimization::OptimizationPreference = preference.into();
@@ -3773,9 +3957,7 @@ async fn optimize(action: OptimizeAction, output: &Output) -> Result<()> {
                 bitrouter::optimization::setup::SetupOptimizationRequest {
                     intent_path: config,
                     source_config,
-                    workflow_command: std::iter::once(workflow_command)
-                        .chain(workflow_arg)
-                        .collect(),
+                    workflow_command,
                     workflow_inputs: workflow_input,
                     timeout_secs,
                     contract,
@@ -3792,20 +3974,28 @@ async fn optimize(action: OptimizeAction, output: &Output) -> Result<()> {
                 },
             )
             .await?;
-            output.emit(&EvalReport {
-                action: "optimize.setup".into(),
-                data: serde_json::json!({
-                    "intent": outcome.paths.intent,
-                    "lock": outcome.paths.lock,
-                    "contract": outcome.contract_path,
-                    "active_policy_digest": outcome.lock.active_policy_digest,
-                    "evaluator": outcome.lock.evaluator,
-                    "strong": outcome.intent.strong,
-                    "economy": outcome.intent.economy,
-                    "normalized_price_overrides": outcome.intent.normalized_price_overrides,
-                    "preference": outcome.intent.preference,
-                    "latency": "observe_only",
-                }),
+            let evaluator_route = match outcome.lock.evaluator.route {
+                bitrouter::optimization::EvaluatorRoute::Cloud => "cloud",
+                bitrouter::optimization::EvaluatorRoute::Direct => "direct",
+            };
+            output.emit(&OptimizationSetupReport {
+                action: "optimize.setup",
+                model: "@auto",
+                intent: outcome.paths.intent.display().to_string(),
+                lock: outcome.paths.lock.display().to_string(),
+                contract: outcome.contract_path.display().to_string(),
+                workflow: outcome.intent.workflow.command.clone(),
+                strong: outcome.intent.strong,
+                economy: outcome.intent.economy,
+                evaluator: format!(
+                    "{} ({}, {evaluator_route})",
+                    outcome.lock.evaluator.agent, outcome.lock.evaluator.model
+                ),
+                evaluator_lock: Some(outcome.lock.evaluator),
+                normalized_price_overrides: outcome.intent.normalized_price_overrides,
+                preference: outcome.intent.preference,
+                active_policy_digest: outcome.lock.active_policy_digest,
+                latency: "observe_only",
             })?;
             Ok(())
         }
@@ -3980,10 +4170,10 @@ async fn optimize(action: OptimizeAction, output: &Output) -> Result<()> {
                 &outcome.updated_lock,
             )
             .await?;
-            output.emit(&EvalReport {
-                action: "optimize.run".into(),
-                data: serde_json::to_value(outcome.report)?,
-            })?;
+            output.emit(&OptimizationReviewReport::for_run(
+                outcome.report,
+                source_config.policy.mode == config::PolicyRuntimeMode::Frozen,
+            ))?;
             Ok(())
         }
         OptimizeAction::Review { config, run } => {
@@ -3996,15 +4186,21 @@ async fn optimize(action: OptimizeAction, output: &Output) -> Result<()> {
                 .latest_run
                 .as_ref()
                 .is_some_and(|latest| latest.published && !active);
-            let mut data = serde_json::to_value(report)?;
-            if let Some(object) = data.as_object_mut() {
-                object.insert("active".into(), serde_json::Value::Bool(active));
-                object.insert("rolled_back".into(), serde_json::Value::Bool(rolled_back));
-            }
-            output.emit(&EvalReport {
-                action: "optimize.review".into(),
-                data,
-            })?;
+            let source_raw = tokio::fs::read_to_string(&loaded.paths.source_config)
+                .await
+                .with_context(|| {
+                    format!(
+                        "reading source config {}",
+                        loaded.paths.source_config.display()
+                    )
+                })?;
+            let source_config = config::parse(&source_raw).context("parsing source config")?;
+            output.emit(&OptimizationReviewReport::new(
+                report,
+                active,
+                rolled_back,
+                source_config.policy.mode == config::PolicyRuntimeMode::Frozen,
+            ))?;
             Ok(())
         }
         OptimizeAction::Publish {
@@ -4091,13 +4287,27 @@ async fn optimize(action: OptimizeAction, output: &Output) -> Result<()> {
             } else {
                 source_raw.clone()
             };
-            let enable_adaptive =
-                cfg.policy.mode == config::PolicyRuntimeMode::Frozen && enable_adaptive;
-            if cfg.policy.mode == config::PolicyRuntimeMode::Frozen && !enable_adaptive {
-                anyhow::bail!(
-                    "policy runtime mode is frozen; rerun this explicit publication with --enable-adaptive"
-                );
-            }
+            let enable_adaptive = if cfg.policy.mode == config::PolicyRuntimeMode::Frozen {
+                use std::io::IsTerminal;
+
+                let interactive = std::io::stdin().is_terminal();
+                let answer = if !enable_adaptive && interactive {
+                    eprintln!("  Publish reviewed candidate {} to @auto?", latest.run_id);
+                    eprintln!(
+                        "  This enables adaptive policy publication; rollback remains available from policy history."
+                    );
+                    Some(read_optimization_prompt("  Continue [y/N]: ")?)
+                } else {
+                    None
+                };
+                resolve_adaptive_publication_consent(
+                    enable_adaptive,
+                    interactive,
+                    answer.as_deref(),
+                )?
+            } else {
+                false
+            };
             let policy_path = bitrouter::policy_lock::resolve_path(&cfg, Some(config_path))
                 .ok_or_else(|| anyhow::anyhow!("cannot resolve source policy lock"))?;
             let _policy_lock = bitrouter::policy_lock::acquire_publication_lock(&policy_path)?;
@@ -4437,23 +4647,34 @@ async fn optimize(action: OptimizeAction, output: &Output) -> Result<()> {
             } else {
                 None
             };
-            output.emit(&EvalReport {
-                action: "optimize.status".into(),
-                data: serde_json::json!({
-                    "intent": loaded.paths.intent,
-                    "intent_digest": loaded.digest,
-                    "lock_active_policy_digest": lock.document.active_policy_digest,
-                    "actual_active_policy_digest": active.digest,
-                    "policy_mode": source_config.policy.mode,
-                    "lineage_consistent": intent_matches && active_matches,
-                    "latest_candidate_active": latest_active,
-                    "rolled_back": rolled_back,
-                    "repair_hint": repair_hint,
-                    "preference": loaded.intent.preference,
-                    "evaluator": lock.document.evaluator,
-                    "latest_run": lock.document.latest_run,
-                    "latency": "observe_only",
-                }),
+            let evaluator_route = match lock.document.evaluator.route {
+                bitrouter::optimization::EvaluatorRoute::Cloud => "cloud",
+                bitrouter::optimization::EvaluatorRoute::Direct => "direct",
+            };
+            let policy_mode = match source_config.policy.mode {
+                config::PolicyRuntimeMode::Frozen => "frozen",
+                config::PolicyRuntimeMode::Adaptive => "adaptive",
+            };
+            output.emit(&OptimizationStatusReport {
+                action: "optimize.status",
+                model: "@auto",
+                intent: loaded.paths.intent.display().to_string(),
+                intent_digest: loaded.digest,
+                lock_active_policy_digest: lock.document.active_policy_digest,
+                actual_active_policy_digest: active.digest,
+                policy_mode: policy_mode.into(),
+                lineage_consistent: intent_matches && active_matches,
+                latest_candidate_active: latest_active,
+                rolled_back,
+                repair_hint: repair_hint.map(String::from),
+                preference: loaded.intent.preference,
+                evaluator: format!(
+                    "{} ({}, {evaluator_route})",
+                    lock.document.evaluator.agent, lock.document.evaluator.model
+                ),
+                evaluator_lock: Some(lock.document.evaluator),
+                latest_run: lock.document.latest_run,
+                latency: "observe_only",
             })?;
             Ok(())
         }
@@ -6488,6 +6709,8 @@ mod tests {
     fn workflow_optimization_commands_parse_with_direct_judge_default() -> anyhow::Result<()> {
         use clap::Parser;
 
+        assert!(Cli::try_parse_from(["bitrouter", "optimize", "setup"]).is_ok());
+
         let setup = Cli::try_parse_from([
             "bitrouter",
             "optimize",
@@ -6542,6 +6765,25 @@ mod tests {
             .is_ok()
         );
         assert!(Cli::try_parse_from(["bitrouter", "optimize", "rollback"]).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn adaptive_publication_requires_explicit_or_interactive_consent() -> anyhow::Result<()> {
+        assert!(resolve_adaptive_publication_consent(true, false, None)?);
+        assert!(resolve_adaptive_publication_consent(
+            false,
+            true,
+            Some("yes")
+        )?);
+        assert!(resolve_adaptive_publication_consent(false, true, Some("n")).is_err());
+        let error = resolve_adaptive_publication_consent(false, false, None);
+        assert!(
+            error
+                .err()
+                .map(|value| value.to_string())
+                .is_some_and(|message| message.contains("--enable-adaptive"))
+        );
         Ok(())
     }
 

--- a/apps/bitrouter/src/onboarding.rs
+++ b/apps/bitrouter/src/onboarding.rs
@@ -202,8 +202,8 @@ pub struct OnboardingOptimization {
     pub workflow_inputs: Vec<PathBuf>,
     /// Observable success criteria; interactive onboarding fills it in.
     pub success_contract: Option<String>,
-    pub strong: String,
-    pub economy: String,
+    pub strong: Option<String>,
+    pub economy: Option<String>,
     pub normalized_price_overrides: Vec<String>,
     pub preference: crate::optimization::OptimizationPreference,
 }
@@ -457,6 +457,9 @@ fn empty_report() -> OnboardingReport {
 // =====================================================================
 
 async fn run_headless(flags: OnboardingFlags, output: &Output) -> Result<()> {
+    if let Some(optimization) = flags.optimization.as_ref() {
+        preflight_headless_optimization_routes(&flags.config, optimization).await?;
+    }
     let signals = probe();
     // Already-present credentials always count (spec §4: "consume
     // already-present credentials + flag-supplied keys").
@@ -542,6 +545,25 @@ async fn run_headless(flags: OnboardingFlags, output: &Output) -> Result<()> {
         AfterAction::Serve => finish_serve(report, output).await,
         AfterAction::Exit => emit(output, &report),
     }
+}
+
+async fn preflight_headless_optimization_routes(
+    config: &Path,
+    requested: &OnboardingOptimization,
+) -> Result<()> {
+    let (existing_strong, existing_economy) = if config.is_file() {
+        crate::optimization::setup::existing_tier_routes(config, "auto").await?
+    } else {
+        (None, None)
+    };
+    resolve_onboarding_route("strong", requested.strong.clone(), existing_strong, false)?;
+    resolve_onboarding_route(
+        "economy",
+        requested.economy.clone(),
+        existing_economy,
+        false,
+    )?;
+    Ok(())
 }
 
 /// Apply the flag-supplied credentials shared by both the headless runner and
@@ -878,9 +900,9 @@ fn interactive_optimization(flags: &OnboardingFlags) -> Result<Option<Onboarding
             workflow_command: None,
             workflow_inputs: Vec::new(),
             success_contract: None,
-            strong: "openai-codex:gpt-5.6-sol".into(),
-            economy: "bitrouter:deepseek/deepseek-v4-flash-0731".into(),
-            normalized_price_overrides: vec!["openai-codex:gpt-5.6-sol=5,0.5,6.25,30".into()],
+            strong: None,
+            economy: None,
+            normalized_price_overrides: Vec::new(),
             preference: crate::optimization::OptimizationPreference::Balanced,
         },
     };
@@ -986,11 +1008,34 @@ fn interactive_workflow_command(config: &Path) -> Result<Vec<String>> {
     }
 }
 
+fn resolve_onboarding_route(
+    label: &str,
+    requested: Option<String>,
+    existing: Option<String>,
+    interactive: bool,
+) -> Result<String> {
+    if let Some(route) = requested.or(existing) {
+        return Ok(route);
+    }
+    if !interactive {
+        anyhow::bail!(
+            "no {label} route exists in @auto; pass --optimize-{label} with a provider-qualified model"
+        );
+    }
+    let route = prompt_line(&format!("  {label} route (provider:model): "))?;
+    if route.trim().is_empty() {
+        anyhow::bail!("{label} route is required");
+    }
+    Ok(route)
+}
+
 async fn configure_optimization(
     config: &std::path::Path,
     requested: OnboardingOptimization,
     installed: &[String],
 ) -> Result<OptimizationOnboardingReport> {
+    use std::io::IsTerminal;
+
     let workflow_command = match requested.workflow_command {
         Some(command) => command,
         None => {
@@ -1019,6 +1064,13 @@ async fn configure_optimization(
     let success_contract = requested.success_contract.ok_or_else(|| {
         anyhow::anyhow!("headless optimization onboarding requires --optimize-success")
     })?;
+    let (existing_strong, existing_economy) =
+        crate::optimization::setup::existing_tier_routes(config, "auto").await?;
+    let interactive = std::io::stdin().is_terminal();
+    let strong =
+        resolve_onboarding_route("strong", requested.strong, existing_strong, interactive)?;
+    let economy =
+        resolve_onboarding_route("economy", requested.economy, existing_economy, interactive)?;
     let evaluator_agent = if installed.iter().any(|agent| agent.contains("codex")) {
         "codex-acp"
     } else if installed.iter().any(|agent| agent.contains("claude")) {
@@ -1043,8 +1095,8 @@ async fn configure_optimization(
             )),
             policy: "auto".into(),
             preset: "auto".into(),
-            strong: requested.strong,
-            economy: requested.economy,
+            strong,
+            economy,
             normalized_price_overrides: requested.normalized_price_overrides,
             preference: requested.preference,
             evaluator_agent: evaluator_agent.into(),
@@ -1556,5 +1608,31 @@ mod tests {
         let v = serde_json::to_value(&report).unwrap();
         assert_eq!(v["action"], "status");
         assert_eq!(v["configured"], true);
+    }
+
+    #[test]
+    fn onboarding_route_resolution_is_explicit_or_reuses_auto() -> anyhow::Result<()> {
+        assert_eq!(
+            resolve_onboarding_route(
+                "strong",
+                Some("provider-a:model-a".into()),
+                Some("provider-b:model-b".into()),
+                false,
+            )?,
+            "provider-a:model-a"
+        );
+        assert_eq!(
+            resolve_onboarding_route("economy", None, Some("provider-b:model-b".into()), false,)?,
+            "provider-b:model-b"
+        );
+        let missing = resolve_onboarding_route("economy", None, None, false);
+        assert!(missing.is_err());
+        assert!(
+            missing
+                .err()
+                .map(|error| error.to_string())
+                .is_some_and(|message| message.contains("--optimize-economy"))
+        );
+        Ok(())
     }
 }

--- a/apps/bitrouter/src/onboarding.rs
+++ b/apps/bitrouter/src/onboarding.rs
@@ -21,7 +21,7 @@
 
 use std::collections::BTreeSet;
 use std::io::IsTerminal;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use bitrouter_cloud_sdk::auth::commands::{LoginInputs, login as cloud_login};
@@ -888,15 +888,7 @@ fn interactive_optimization(flags: &OnboardingFlags) -> Result<Option<Onboarding
     eprintln!("Workflow optimization — generic agentic evaluation");
     let workflow_command = match requested.workflow_command {
         Some(command) => command,
-        None => {
-            let raw = prompt_line("  Workflow argv as JSON (example: [\"npm\",\"test\"]): ")?;
-            let command: Vec<String> = serde_json::from_str(&raw)
-                .context("workflow command must be a JSON string array")?;
-            if command.is_empty() {
-                anyhow::bail!("workflow command must not be empty");
-            }
-            command
-        }
+        None => interactive_workflow_command(&flags.config)?,
     };
     let success_contract = match requested.success_contract {
         Some(contract) => contract,
@@ -944,14 +936,86 @@ fn interactive_optimization(flags: &OnboardingFlags) -> Result<Option<Onboarding
     }))
 }
 
+fn interactive_workflow_command(config: &Path) -> Result<Vec<String>> {
+    use crate::optimization::discovery::GuidedWorkflow;
+
+    let root = config.parent().unwrap_or_else(|| Path::new("."));
+    match crate::optimization::discovery::resolve_guided_workflow(root, None, Vec::new())? {
+        GuidedWorkflow::Resolved { command, evidence } => {
+            note(&format!("using discovered workflow: {evidence}"));
+            Ok(command)
+        }
+        GuidedWorkflow::Choose(candidates) => {
+            eprintln!("  Candidate agent workflows:");
+            for (index, candidate) in candidates.iter().enumerate() {
+                eprintln!(
+                    "    {}) {}  [{}]",
+                    index + 1,
+                    candidate.command.join(" "),
+                    candidate.evidence
+                );
+            }
+            let answer = prompt_line("  Select workflow [1]: ")?;
+            let selected = if answer.is_empty() {
+                1
+            } else {
+                answer
+                    .parse::<usize>()
+                    .context("workflow selection must be a candidate number")?
+            };
+            candidates
+                .get(selected.saturating_sub(1))
+                .map(|candidate| candidate.command.clone())
+                .ok_or_else(|| {
+                    anyhow::anyhow!("workflow selection {selected} is outside the candidate list")
+                })
+        }
+        GuidedWorkflow::Missing => {
+            let raw =
+                prompt_line("  Workflow argv as JSON (example: [\"npm\",\"run\",\"eval\"]): ")?;
+            let command: Vec<String> = serde_json::from_str(&raw)
+                .context("workflow command must be a JSON string array")?;
+            crate::optimization::WorkflowCommand {
+                command: command.clone(),
+                inputs: Vec::new(),
+                timeout_secs: 1,
+            }
+            .validate()?;
+            Ok(command)
+        }
+    }
+}
+
 async fn configure_optimization(
     config: &std::path::Path,
     requested: OnboardingOptimization,
     installed: &[String],
 ) -> Result<OptimizationOnboardingReport> {
-    let workflow_command = requested.workflow_command.ok_or_else(|| {
-        anyhow::anyhow!("headless optimization onboarding requires --optimize-workflow-command")
-    })?;
+    let workflow_command = match requested.workflow_command {
+        Some(command) => command,
+        None => {
+            let root = config.parent().unwrap_or_else(|| Path::new("."));
+            match crate::optimization::discovery::resolve_guided_workflow(root, None, Vec::new())? {
+                crate::optimization::discovery::GuidedWorkflow::Resolved { command, evidence } => {
+                    note(&format!("using discovered workflow: {evidence}"));
+                    command
+                }
+                crate::optimization::discovery::GuidedWorkflow::Choose(candidates) => {
+                    let choices = candidates
+                        .iter()
+                        .map(|candidate| candidate.command.join(" "))
+                        .collect::<Vec<_>>()
+                        .join("; ");
+                    anyhow::bail!(
+                        "multiple optimization workflows were discovered ({choices}); pass --optimize-workflow-command and repeated --optimize-workflow-arg values"
+                    );
+                }
+                crate::optimization::discovery::GuidedWorkflow::Missing => anyhow::bail!(
+                    "no optimization workflow was discovered; pass --optimize-workflow-command and repeated --optimize-workflow-arg values"
+                ),
+            }
+        }
+    };
     let success_contract = requested.success_contract.ok_or_else(|| {
         anyhow::anyhow!("headless optimization onboarding requires --optimize-success")
     })?;

--- a/apps/bitrouter/src/optimization/discovery.rs
+++ b/apps/bitrouter/src/optimization/discovery.rs
@@ -1,0 +1,224 @@
+//! Deterministic discovery of project-owned agent workflow entrypoints.
+//!
+//! Discovery proposes commands from repository facts. It never executes a
+//! candidate, guesses a model/provider, or turns an ordinary unit-test target
+//! into an optimization quality contract.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+const EXECUTABLE_SEARCH_DIRS: &[&str] = &["", "scripts", "bin", "eval", "evals", "benchmarks"];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkflowCandidateSource {
+    PackageScript,
+    Executable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkflowCandidate {
+    pub id: String,
+    pub label: String,
+    pub command: Vec<String>,
+    pub source: WorkflowCandidateSource,
+    pub evidence: String,
+    pub required_inputs: Vec<PathBuf>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GuidedWorkflow {
+    Resolved {
+        command: Vec<String>,
+        evidence: String,
+    },
+    Choose(Vec<WorkflowCandidate>),
+    Missing,
+}
+
+/// Resolve an exact command when supplied; otherwise adopt a unique project
+/// candidate and leave ambiguous/empty cases to the interactive CLI boundary.
+pub fn resolve_guided_workflow(
+    root: &Path,
+    executable: Option<String>,
+    arguments: Vec<String>,
+) -> Result<GuidedWorkflow> {
+    if let Some(executable) = executable {
+        if executable.trim().is_empty() || executable.chars().any(char::is_control) {
+            anyhow::bail!("--workflow-command must be a non-empty bounded executable");
+        }
+        let mut command = Vec::with_capacity(arguments.len() + 1);
+        command.push(executable);
+        command.extend(arguments);
+        return Ok(GuidedWorkflow::Resolved {
+            command,
+            evidence: "explicit --workflow-command argv".into(),
+        });
+    }
+    if !arguments.is_empty() {
+        anyhow::bail!("--workflow-arg requires --workflow-command");
+    }
+    let candidates = discover_workflow_candidates(root)?;
+    match candidates.as_slice() {
+        [] => Ok(GuidedWorkflow::Missing),
+        [candidate] => Ok(GuidedWorkflow::Resolved {
+            command: candidate.command.clone(),
+            evidence: candidate.evidence.clone(),
+        }),
+        _ => Ok(GuidedWorkflow::Choose(candidates)),
+    }
+}
+
+/// Return bounded, deterministic workflow suggestions derived from `root`.
+pub fn discover_workflow_candidates(root: &Path) -> Result<Vec<WorkflowCandidate>> {
+    let root = fs::canonicalize(root)
+        .with_context(|| format!("resolving workflow project root {}", root.display()))?;
+    if !root.is_dir() {
+        anyhow::bail!("workflow project root must be a directory");
+    }
+
+    let mut candidates = discover_package_scripts(&root)?;
+    candidates.extend(discover_executables(&root)?);
+    candidates.sort_by(|left, right| left.id.cmp(&right.id));
+    candidates.dedup_by(|left, right| left.id == right.id);
+    Ok(candidates)
+}
+
+fn discover_package_scripts(root: &Path) -> Result<Vec<WorkflowCandidate>> {
+    let package_path = root.join("package.json");
+    let bytes = match fs::read(&package_path) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("reading workflow metadata {}", package_path.display()));
+        }
+    };
+    if bytes.len() > 4 * 1024 * 1024 {
+        anyhow::bail!("package.json exceeds the workflow discovery size limit");
+    }
+    let document: serde_json::Value =
+        serde_json::from_slice(&bytes).context("parsing package.json for workflow discovery")?;
+    let Some(scripts) = document
+        .get("scripts")
+        .and_then(serde_json::Value::as_object)
+    else {
+        return Ok(Vec::new());
+    };
+    let manager = package_manager(root);
+    let mut candidates = Vec::new();
+    for (name, body) in scripts {
+        if !semantic_workflow_name(name) || body.as_str().is_none_or(str::is_empty) {
+            continue;
+        }
+        candidates.push(WorkflowCandidate {
+            id: format!("package:{name}"),
+            label: format!("package.json script `{name}`"),
+            command: vec![manager.into(), "run".into(), name.clone()],
+            source: WorkflowCandidateSource::PackageScript,
+            evidence: format!("package.json declares the `{name}` script"),
+            required_inputs: Vec::new(),
+        });
+    }
+    Ok(candidates)
+}
+
+fn package_manager(root: &Path) -> &'static str {
+    if root.join("pnpm-lock.yaml").is_file() {
+        "pnpm"
+    } else if root.join("yarn.lock").is_file() {
+        "yarn"
+    } else if root.join("bun.lock").is_file() || root.join("bun.lockb").is_file() {
+        "bun"
+    } else {
+        "npm"
+    }
+}
+
+fn discover_executables(root: &Path) -> Result<Vec<WorkflowCandidate>> {
+    let mut candidates = Vec::new();
+    for relative_dir in EXECUTABLE_SEARCH_DIRS {
+        let directory = if relative_dir.is_empty() {
+            root.to_path_buf()
+        } else {
+            root.join(relative_dir)
+        };
+        let directory_metadata = match fs::symlink_metadata(&directory) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!(
+                        "reading workflow directory metadata {}",
+                        directory.display()
+                    )
+                });
+            }
+        };
+        if !directory_metadata.file_type().is_dir() {
+            continue;
+        }
+        let entries = match fs::read_dir(&directory) {
+            Ok(entries) => entries,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!("reading workflow directory {}", directory.display())
+                });
+            }
+        };
+        for entry in entries {
+            let entry = entry.with_context(|| {
+                format!("enumerating workflow directory {}", directory.display())
+            })?;
+            let metadata = fs::symlink_metadata(entry.path())?;
+            if !metadata.file_type().is_file() || !is_executable(&metadata) {
+                continue;
+            }
+            let name = entry.file_name().to_string_lossy().into_owned();
+            if !semantic_workflow_name(&name) {
+                continue;
+            }
+            let relative = entry
+                .path()
+                .strip_prefix(root)
+                .context("workflow entrypoint escaped the project root")?
+                .to_path_buf();
+            let normalized = relative.to_string_lossy().replace('\\', "/");
+            candidates.push(WorkflowCandidate {
+                id: format!("executable:{normalized}"),
+                label: format!("project executable `{normalized}`"),
+                command: vec![format!("./{normalized}")],
+                source: WorkflowCandidateSource::Executable,
+                evidence: format!("{normalized} is an executable project file"),
+                required_inputs: Vec::new(),
+            });
+        }
+    }
+    Ok(candidates)
+}
+
+#[cfg(unix)]
+fn is_executable(metadata: &fs::Metadata) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    metadata.permissions().mode() & 0o111 != 0
+}
+
+#[cfg(windows)]
+fn is_executable(metadata: &fs::Metadata) -> bool {
+    metadata.is_file()
+}
+
+fn semantic_workflow_name(name: &str) -> bool {
+    name.split(|character: char| !character.is_ascii_alphanumeric())
+        .filter(|part| !part.is_empty())
+        .any(|part| {
+            matches!(
+                part.to_ascii_lowercase().as_str(),
+                "eval" | "evaluation" | "benchmark" | "bench" | "quality" | "acceptance"
+            )
+        })
+}

--- a/apps/bitrouter/src/optimization/mod.rs
+++ b/apps/bitrouter/src/optimization/mod.rs
@@ -4,6 +4,7 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
+pub mod discovery;
 pub mod evaluator;
 pub mod orchestrator;
 pub mod runner;

--- a/apps/bitrouter/src/optimization/runner.rs
+++ b/apps/bitrouter/src/optimization/runner.rs
@@ -863,6 +863,12 @@ pub fn collect_variant_evidence(
     if !matches!(variant, "baseline" | "candidate") {
         anyhow::bail!("variant must be baseline or candidate");
     }
+    if !usage.is_empty() && usage.iter().all(|record| record.error_code.is_some()) {
+        anyhow::bail!(
+            "{variant} produced no successful model request ({} failed); verify provider login and route health before optimizing",
+            usage.len()
+        );
+    }
     let mut by_request = BTreeMap::new();
     for record in usage {
         let request_id = record
@@ -1664,10 +1670,33 @@ mod tests {
                 execution,
                 &[decision(&policy_digest)],
                 &[subject(&policy_digest)?],
-                &[missing_price],
+                &[missing_price.clone()],
             )
             .is_err()
         );
+
+        let mut failed_request = missing_price;
+        failed_request.error_code = Some("upstream_bad_gateway".into());
+        let error = collect_variant_evidence(
+            "baseline",
+            &policy_digest,
+            WorkflowExecution {
+                exit_code: Some(1),
+                timed_out: false,
+                elapsed: Duration::from_millis(500),
+                stdout: String::new(),
+                stderr: String::new(),
+                launches: 1,
+                cwd: "/tmp/project".into(),
+            },
+            &[decision(&policy_digest)],
+            &[subject(&policy_digest)?],
+            &[failed_request],
+        )
+        .err()
+        .ok_or_else(|| anyhow::anyhow!("all-failed evidence unexpectedly succeeded"))?;
+        assert!(error.to_string().contains("no successful model request"));
+        assert!(!error.to_string().contains("normalized showback"));
         Ok(())
     }
 

--- a/apps/bitrouter/src/optimization/runner.rs
+++ b/apps/bitrouter/src/optimization/runner.rs
@@ -624,7 +624,7 @@ async fn run_workflow_command_isolated(
     let (exit_code, timed_out) = match tokio::time::timeout(deadline, child.wait()).await {
         Ok(status) => {
             let exit_code = status.context("waiting for workflow program")?.code();
-            if workflow_process_group_has_live_members(child_pid).await? {
+            if !wait_for_workflow_process_group_exit(child_pid, Duration::from_secs(2)).await? {
                 terminate_workflow_tree(&mut child, child_pid)
                     .await
                     .context("terminating workflow background descendants")?;
@@ -781,6 +781,24 @@ impl Drop for WorkflowProcessGroupGuard {
                 .stderr(Stdio::null())
                 .status();
         }
+    }
+}
+
+#[cfg(not(windows))]
+async fn wait_for_workflow_process_group_exit(
+    child_pid: Option<u32>,
+    grace: Duration,
+) -> Result<bool> {
+    let deadline = Instant::now() + grace;
+    loop {
+        if !workflow_process_group_has_live_members(child_pid).await? {
+            return Ok(true);
+        }
+        let now = Instant::now();
+        if now >= deadline {
+            return Ok(false);
+        }
+        tokio::time::sleep((deadline - now).min(Duration::from_millis(25))).await;
     }
 }
 
@@ -1554,6 +1572,28 @@ mod tests {
             assert!(routed.stdout.contains("model=\"@auto\""));
             assert!(routed.stdout.contains("exec\nrun the eval"));
         }
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn workflow_runner_allows_short_lived_descendants_to_drain() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let execution = run_workflow_command(WorkflowRunRequest {
+            workflow: &WorkflowCommand {
+                command: vec!["/bin/sh".into(), "-c".into(), "(sleep 0.05) &".into()],
+                inputs: Vec::new(),
+                timeout_secs: 2,
+            },
+            cwd: dir.path(),
+            env: &BTreeMap::new(),
+            maximum_output_bytes: 1024,
+        })
+        .await?;
+
+        assert_eq!(execution.exit_code, Some(0));
+        assert!(!execution.timed_out);
+        assert!(execution.elapsed >= Duration::from_millis(40));
         Ok(())
     }
 

--- a/apps/bitrouter/src/optimization/setup.rs
+++ b/apps/bitrouter/src/optimization/setup.rs
@@ -189,7 +189,7 @@ pub async fn setup_optimization(
                 &source_raw,
                 &source_with_providers,
             )?;
-            rollback.record_source_policy_owned()?;
+            rollback.record_source_owned()?;
         }
         let source_raw = tokio::fs::read_to_string(&source_config).await?;
         let source_parsed = bitrouter_sdk::config::parse(&source_raw)
@@ -385,8 +385,13 @@ impl SetupRollback {
         self.committed = true;
     }
 
-    fn record_source_policy_owned(&mut self) -> Result<()> {
+    fn record_source_owned(&mut self) -> Result<()> {
         self.source_owned = Some(std::fs::read(&self.source_config)?);
+        Ok(())
+    }
+
+    fn record_source_policy_owned(&mut self) -> Result<()> {
+        self.record_source_owned()?;
         self.policy_owned = Some(std::fs::read(&self.policy_path)?);
         Ok(())
     }
@@ -686,10 +691,31 @@ fn claude_model_from_settings(raw: &str) -> Result<String> {
 #[cfg(all(test, not(windows)))]
 mod tests {
     use super::{
-        claude_model_from_settings, codex_model_from_config,
+        SetupRollback, claude_model_from_settings, codex_model_from_config,
         ensure_workflow_optimization_compatible, validate_cloud_catalog_model,
         validate_routable_model,
     };
+
+    #[test]
+    fn setup_can_record_a_source_edit_before_the_policy_exists() -> anyhow::Result<()> {
+        let directory = tempfile::tempdir()?;
+        let source = directory.path().join("bitrouter.yaml");
+        let policy = directory.path().join("policy-lock.yaml");
+        std::fs::write(&source, b"inherit_defaults: true\n")?;
+        let mut rollback = SetupRollback::new(
+            source.clone(),
+            Vec::new(),
+            policy,
+            None,
+            directory.path().join("bitrouter.eval.md"),
+            directory.path().join("bitrouter.optimize.yaml"),
+            directory.path().join("bitrouter.optimize.lock.yaml"),
+        );
+
+        rollback.record_source_owned()?;
+        rollback.commit();
+        Ok(())
+    }
 
     #[test]
     fn detects_exact_local_codex_model_without_importing_agent_settings() -> anyhow::Result<()> {

--- a/apps/bitrouter/src/optimization/setup.rs
+++ b/apps/bitrouter/src/optimization/setup.rs
@@ -157,8 +157,9 @@ pub async fn setup_optimization(
     let policy_path = crate::policy_lock::resolve_path(&source_parsed, Some(&source_config))
         .ok_or_else(|| anyhow::anyhow!("cannot resolve source policy lock"))?;
     let _policy_lock = crate::policy_lock::acquire_publication_lock(&policy_path)?;
-    if let Some(active) =
-        crate::policy_lock::load_for_config(&source_parsed, Some(&source_config)).await?
+    if policy_path.is_file()
+        && let Some(active) =
+            crate::policy_lock::load_for_config(&source_parsed, Some(&source_config)).await?
     {
         ensure_workflow_optimization_compatible(&active.document)?;
     }

--- a/apps/bitrouter/src/optimization/setup.rs
+++ b/apps/bitrouter/src/optimization/setup.rs
@@ -37,6 +37,24 @@ pub struct SetupOptimizationOutcome {
     pub lock: OptimizationLock,
 }
 
+pub fn ensure_workflow_optimization_compatible(
+    policy_lock: &crate::policy_lock::PolicyLock,
+) -> Result<()> {
+    let guarded = policy_lock
+        .policies
+        .iter()
+        .filter_map(|(name, definition)| definition.progress_guard.is_some().then_some(name))
+        .cloned()
+        .collect::<Vec<_>>();
+    if !guarded.is_empty() {
+        anyhow::bail!(
+            "workflow optimization cannot preserve the active progress guard for policies [{}] in its exact two-tier experiment; use an unguarded @auto policy for this optimization lineage",
+            guarded.join(", ")
+        );
+    }
+    Ok(())
+}
+
 #[cfg(windows)]
 pub async fn setup_optimization(
     _request: SetupOptimizationRequest,
@@ -139,6 +157,11 @@ pub async fn setup_optimization(
     let policy_path = crate::policy_lock::resolve_path(&source_parsed, Some(&source_config))
         .ok_or_else(|| anyhow::anyhow!("cannot resolve source policy lock"))?;
     let _policy_lock = crate::policy_lock::acquire_publication_lock(&policy_path)?;
+    if let Some(active) =
+        crate::policy_lock::load_for_config(&source_parsed, Some(&source_config)).await?
+    {
+        ensure_workflow_optimization_compatible(&active.document)?;
+    }
     let policy_original = if policy_path.is_file() {
         Some(
             std::fs::read(&policy_path)
@@ -662,7 +685,8 @@ fn claude_model_from_settings(raw: &str) -> Result<String> {
 #[cfg(all(test, not(windows)))]
 mod tests {
     use super::{
-        claude_model_from_settings, codex_model_from_config, validate_cloud_catalog_model,
+        claude_model_from_settings, codex_model_from_config,
+        ensure_workflow_optimization_compatible, validate_cloud_catalog_model,
         validate_routable_model,
     };
 
@@ -719,5 +743,34 @@ inherit_defaults: false
         );
         assert_eq!(claude_model_from_settings("{}")?, "claude-sonnet-4-6");
         Ok(())
+    }
+
+    #[test]
+    fn progress_guard_is_rejected_by_setup_preflight() {
+        let mut document = crate::policy_lock::PolicyLock::default();
+        let mut definition = crate::policy_lock::PolicyDefinition::default();
+        definition.progress_guard = Some(crate::trajectory::guard::ProgressGuardPolicy {
+            escalation_tier: "strong".into(),
+            protected_tiers: std::collections::BTreeSet::from(["strong".into()]),
+            max_consecutive_unprotected: Some(3),
+            max_same_projection_unprotected: None,
+            max_recovery_count: None,
+            max_episode_requests: None,
+            max_episode_elapsed_ms: None,
+            max_episode_cost_micro_usd: None,
+            hold_for_requests: 2,
+            incomplete_history: crate::trajectory::guard::IncompleteHistoryAction::Escalate,
+        });
+        document.policies.insert("auto".into(), definition);
+
+        let error = ensure_workflow_optimization_compatible(&document);
+
+        assert!(error.is_err());
+        assert!(
+            error
+                .err()
+                .map(|value| value.to_string())
+                .is_some_and(|message| message.contains("progress guard"))
+        );
     }
 }

--- a/apps/bitrouter/src/optimization/setup.rs
+++ b/apps/bitrouter/src/optimization/setup.rs
@@ -775,19 +775,21 @@ inherit_defaults: false
     #[test]
     fn progress_guard_is_rejected_by_setup_preflight() {
         let mut document = crate::policy_lock::PolicyLock::default();
-        let mut definition = crate::policy_lock::PolicyDefinition::default();
-        definition.progress_guard = Some(crate::trajectory::guard::ProgressGuardPolicy {
-            escalation_tier: "strong".into(),
-            protected_tiers: std::collections::BTreeSet::from(["strong".into()]),
-            max_consecutive_unprotected: Some(3),
-            max_same_projection_unprotected: None,
-            max_recovery_count: None,
-            max_episode_requests: None,
-            max_episode_elapsed_ms: None,
-            max_episode_cost_micro_usd: None,
-            hold_for_requests: 2,
-            incomplete_history: crate::trajectory::guard::IncompleteHistoryAction::Escalate,
-        });
+        let definition = crate::policy_lock::PolicyDefinition {
+            progress_guard: Some(crate::trajectory::guard::ProgressGuardPolicy {
+                escalation_tier: "strong".into(),
+                protected_tiers: std::collections::BTreeSet::from(["strong".into()]),
+                max_consecutive_unprotected: Some(3),
+                max_same_projection_unprotected: None,
+                max_recovery_count: None,
+                max_episode_requests: None,
+                max_episode_elapsed_ms: None,
+                max_episode_cost_micro_usd: None,
+                hold_for_requests: 2,
+                incomplete_history: crate::trajectory::guard::IncompleteHistoryAction::Escalate,
+            }),
+            ..Default::default()
+        };
         document.policies.insert("auto".into(), definition);
 
         let error = ensure_workflow_optimization_compatible(&document);

--- a/apps/bitrouter/src/optimization/setup.rs
+++ b/apps/bitrouter/src/optimization/setup.rs
@@ -37,6 +37,28 @@ pub struct SetupOptimizationOutcome {
     pub lock: OptimizationLock,
 }
 
+/// Resolve the current strong/economy routes for a named policy, when one is active.
+pub async fn existing_tier_routes(
+    source_config: &std::path::Path,
+    policy: &str,
+) -> Result<(Option<String>, Option<String>)> {
+    let raw = tokio::fs::read_to_string(source_config)
+        .await
+        .with_context(|| format!("reading source config {}", source_config.display()))?;
+    let parsed = bitrouter_sdk::config::parse(&raw).context("parsing source BitRouter config")?;
+    let Some(active) = crate::policy_lock::load_for_config(&parsed, Some(source_config)).await?
+    else {
+        return Ok((None, None));
+    };
+    let Some(definition) = active.document.policies.get(policy) else {
+        return Ok((None, None));
+    };
+    Ok((
+        definition.tiers.get("strong").cloned(),
+        definition.tiers.get("economy").cloned(),
+    ))
+}
+
 pub fn ensure_workflow_optimization_compatible(
     policy_lock: &crate::policy_lock::PolicyLock,
 ) -> Result<()> {

--- a/apps/bitrouter/src/output/reports/mod.rs
+++ b/apps/bitrouter/src/output/reports/mod.rs
@@ -11,6 +11,7 @@ pub mod daemon;
 pub mod eval;
 pub mod mcp;
 pub mod observe;
+pub mod optimization;
 pub mod policy;
 pub mod routing;
 pub mod skills;

--- a/apps/bitrouter/src/output/reports/optimization.rs
+++ b/apps/bitrouter/src/output/reports/optimization.rs
@@ -1,0 +1,243 @@
+use serde::Serialize;
+
+use crate::optimization::OptimizationVerdict;
+use crate::optimization::orchestrator::OptimizationReport;
+use crate::optimization::{EvaluatorLock, OptimizationPreference, OptimizationRunLock};
+use crate::output::CliReport;
+use crate::output::human::{Health, Human};
+
+#[derive(Debug, Clone, Serialize)]
+pub struct OptimizationSetupReport {
+    pub action: &'static str,
+    pub model: &'static str,
+    pub intent: String,
+    pub lock: String,
+    pub contract: String,
+    pub workflow: Vec<String>,
+    pub strong: String,
+    pub economy: String,
+    pub evaluator: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub evaluator_lock: Option<EvaluatorLock>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub normalized_price_overrides: Vec<String>,
+    pub preference: OptimizationPreference,
+    pub active_policy_digest: String,
+    pub latency: &'static str,
+}
+
+impl CliReport for OptimizationSetupReport {
+    fn render(&self, human: &mut Human<'_>) -> std::io::Result<()> {
+        human.status_block(Health::Up, "@auto optimization is configured")?;
+        human.field("workflow", self.workflow.join(" "))?;
+        human.field("routes", format!("{} → {}", self.strong, self.economy))?;
+        human.field("judge", &self.evaluator)?;
+        human.field("intent", &self.intent)?;
+        human.field("lock", &self.lock)?;
+        human.field("contract", &self.contract)?;
+        human.blank()?;
+        human.note(&format!(
+            "next: edit {} if needed, then run `bitrouter optimize run --human`",
+            self.contract
+        ))
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct OptimizationStatusReport {
+    pub action: &'static str,
+    pub model: &'static str,
+    pub intent: String,
+    pub intent_digest: String,
+    pub lock_active_policy_digest: String,
+    pub actual_active_policy_digest: String,
+    pub policy_mode: String,
+    pub lineage_consistent: bool,
+    pub latest_candidate_active: bool,
+    pub rolled_back: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repair_hint: Option<String>,
+    pub preference: OptimizationPreference,
+    pub evaluator: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub evaluator_lock: Option<EvaluatorLock>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub latest_run: Option<OptimizationRunLock>,
+    pub latency: &'static str,
+}
+
+impl CliReport for OptimizationStatusReport {
+    fn render(&self, human: &mut Human<'_>) -> std::io::Result<()> {
+        let (health, headline) = if !self.lineage_consistent {
+            (Health::Down, "@auto optimization lineage needs repair")
+        } else if self.latest_candidate_active {
+            (Health::Up, "@auto optimized candidate is active")
+        } else if self.rolled_back {
+            (Health::Unknown, "@auto is active after rollback")
+        } else if self.latest_run.as_ref().is_some_and(|run| run.publishable) {
+            (Health::Up, "@auto candidate is ready for review")
+        } else if self.latest_run.is_some() {
+            (Health::Down, "@auto latest candidate is not publishable")
+        } else {
+            (Health::Up, "@auto is ready to measure")
+        };
+        human.status_block(health, headline)?;
+        human.field(
+            "lineage",
+            if self.lineage_consistent {
+                "consistent"
+            } else {
+                "diverged"
+            },
+        )?;
+        human.field("mode", &self.policy_mode)?;
+        human.field("judge", &self.evaluator)?;
+        human.field("intent", &self.intent)?;
+        if let Some(latest) = &self.latest_run {
+            human.field("run", &latest.run_id)?;
+        }
+        human.blank()?;
+        if let Some(hint) = &self.repair_hint {
+            human.note(&format!("repair: {hint}"))?;
+        } else if let Some(latest) = &self.latest_run {
+            if self.latest_candidate_active || self.rolled_back {
+                human.note("next: bitrouter optimize run --human")?;
+            } else {
+                human.note(&format!(
+                    "next: bitrouter optimize review --run {} --human",
+                    latest.run_id
+                ))?;
+            }
+        } else {
+            human.note("next: bitrouter optimize run --human")?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct OptimizationReviewReport {
+    pub action: &'static str,
+    pub model: &'static str,
+    #[serde(flatten)]
+    pub report: OptimizationReport,
+    pub active: bool,
+    pub rolled_back: bool,
+    pub publication_requires_enable_adaptive: bool,
+}
+
+impl OptimizationReviewReport {
+    pub fn for_run(report: OptimizationReport, publication_requires_enable_adaptive: bool) -> Self {
+        Self {
+            action: "optimize.run",
+            model: "@auto",
+            report,
+            active: false,
+            rolled_back: false,
+            publication_requires_enable_adaptive,
+        }
+    }
+
+    pub fn new(
+        report: OptimizationReport,
+        active: bool,
+        rolled_back: bool,
+        publication_requires_enable_adaptive: bool,
+    ) -> Self {
+        Self {
+            action: "optimize.review",
+            model: "@auto",
+            report,
+            active,
+            rolled_back,
+            publication_requires_enable_adaptive,
+        }
+    }
+}
+
+impl CliReport for OptimizationReviewReport {
+    fn render(&self, human: &mut Human<'_>) -> std::io::Result<()> {
+        let (health, headline) = if self.active {
+            (Health::Up, "@auto candidate is active")
+        } else if self.rolled_back {
+            (Health::Unknown, "@auto candidate was rolled back")
+        } else if self.report.publishable {
+            (Health::Up, "@auto candidate is ready for review")
+        } else {
+            (Health::Down, "@auto candidate is not publishable")
+        };
+        human.status_block(health, headline)?;
+        human.field("run", &self.report.run_id)?;
+        human.field("route", &self.report.target_request_key)?;
+        human.field(
+            "quality",
+            format!(
+                "{} → {}",
+                verdict(self.report.baseline.verdict),
+                verdict(self.report.candidate.verdict)
+            ),
+        )?;
+        human.field(
+            "cost",
+            format!(
+                "{} → {}{}",
+                dollars(self.report.baseline.normalized_cost_micro_usd),
+                dollars(self.report.candidate.normalized_cost_micro_usd),
+                savings(self.report.normalized_cost_delta_ppm)
+            ),
+        )?;
+        human.field(
+            "latency",
+            format!(
+                "{} ms → {} ms (latency is observe-only)",
+                self.report.baseline.observed_latency_ms, self.report.candidate.observed_latency_ms
+            ),
+        )?;
+        human.field("candidate", &self.report.candidate_digest)?;
+        for caveat in &self.report.caveats {
+            human.note(caveat)?;
+        }
+        if self.action == "optimize.run" {
+            human.blank()?;
+            human.note(&format!(
+                "next: bitrouter optimize review --run {} --human",
+                self.report.run_id
+            ))?;
+        } else if !self.active && self.report.publishable {
+            human.blank()?;
+            let adaptive = if self.publication_requires_enable_adaptive {
+                " --enable-adaptive"
+            } else {
+                ""
+            };
+            human.note(&format!(
+                "next: bitrouter optimize publish --run {}{adaptive}",
+                self.report.run_id
+            ))?;
+        }
+        Ok(())
+    }
+}
+
+fn verdict(value: OptimizationVerdict) -> &'static str {
+    match value {
+        OptimizationVerdict::Pass => "pass",
+        OptimizationVerdict::Fail => "fail",
+        OptimizationVerdict::Inconclusive => "inconclusive",
+    }
+}
+
+fn dollars(micro_usd: u64) -> String {
+    format!("${}.{:06}", micro_usd / 1_000_000, micro_usd % 1_000_000)
+}
+
+fn savings(delta_ppm: Option<i64>) -> String {
+    match delta_ppm {
+        Some(delta) if delta < 0 => {
+            format!(" ({:.1}% lower)", (delta.unsigned_abs() as f64) / 10_000.0)
+        }
+        Some(delta) if delta > 0 => format!(" ({:.1}% higher)", (delta as f64) / 10_000.0),
+        Some(_) => " (unchanged)".into(),
+        None => " (baseline cost was zero)".into(),
+    }
+}

--- a/apps/bitrouter/src/policy_lock.rs
+++ b/apps/bitrouter/src/policy_lock.rs
@@ -1547,8 +1547,53 @@ fn route_supports_capability(
         return false;
     };
     config.providers.get(provider_id).is_some_and(|provider| {
-        provider.active && provider.model_supports_capability(model_id, capability)
+        provider.active
+            && (provider.model_supports_capability(model_id, capability)
+                || embedded_catalog_supports_capability(provider_id, model_id, capability))
     })
+}
+
+fn embedded_catalog_supports_capability(
+    provider_id: &str,
+    model_id: &str,
+    capability: bitrouter_sdk::language_model::types::Capability,
+) -> bool {
+    let Ok(catalog) = serde_json::from_str::<serde_json::Value>(include_str!(
+        "../../../dist/registry/models.json"
+    )) else {
+        return false;
+    };
+    catalog
+        .get("data")
+        .and_then(serde_json::Value::as_array)
+        .is_some_and(|models| {
+            models.iter().any(|model| {
+                let canonical_match =
+                    model.get("id").and_then(serde_json::Value::as_str) == Some(model_id);
+                model
+                    .get("providers")
+                    .and_then(serde_json::Value::as_array)
+                    .is_some_and(|providers| {
+                        providers.iter().any(|provider| {
+                            provider.get("provider").and_then(serde_json::Value::as_str)
+                                == Some(provider_id)
+                                && (canonical_match
+                                    || provider
+                                        .get("provider_model_id")
+                                        .and_then(serde_json::Value::as_str)
+                                        == Some(model_id))
+                                && provider
+                                    .get("capabilities")
+                                    .and_then(serde_json::Value::as_array)
+                                    .is_some_and(|capabilities| {
+                                        capabilities
+                                            .iter()
+                                            .any(|item| item.as_str() == Some(capability.as_str()))
+                                    })
+                        })
+                    })
+            })
+        })
 }
 
 /// Compile a candidate from a caller-frozen database snapshot time.
@@ -3946,6 +3991,46 @@ presets:
             "auto",
             None,
             "economy-provider:economy-model",
+        )
+        .await?;
+        let loaded = load(&update.path).await?;
+
+        assert_eq!(
+            loaded.document.policies["auto"].tool_safe_tiers,
+            ["strong", "economy"]
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn initialize_uses_embedded_cloud_capabilities_for_tool_safety() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let config_path = dir.path().join("bitrouter.yaml");
+        tokio::fs::write(
+            &config_path,
+            r#"registry:
+  enabled: false
+providers:
+  openai-codex:
+    api_base: https://chatgpt.example/backend-api/codex
+    models:
+      - id: gpt-5.6-sol
+        capabilities: [reasoning, tools]
+  bitrouter:
+    api_base: https://api.bitrouter.example/v1
+presets:
+  auto:
+    model: openai-codex:gpt-5.6-sol
+"#,
+        )
+        .await?;
+
+        let update = initialize_files(
+            &config_path,
+            "auto",
+            "auto",
+            None,
+            "bitrouter:deepseek/deepseek-v4-flash-0731",
         )
         .await?;
         let loaded = load(&update.path).await?;

--- a/apps/bitrouter/src/policy_lock.rs
+++ b/apps/bitrouter/src/policy_lock.rs
@@ -1442,6 +1442,18 @@ pub async fn initialize_files_unlocked(
         anyhow::bail!("strong and economy tiers must use different models");
     }
 
+    let mut capability_config = config.clone();
+    crate::merge_registry_into(&mut capability_config).await;
+    bitrouter_providers::apply_builtin_defaults(&mut capability_config);
+    let mut tool_safe_tiers = vec!["strong".to_string()];
+    if route_supports_capability(
+        &capability_config,
+        economy_model,
+        bitrouter_sdk::language_model::types::Capability::Tools,
+    ) {
+        tool_safe_tiers.push("economy".to_string());
+    }
+
     let lock_path = resolve_path(&config, Some(config_path))
         .ok_or_else(|| anyhow::anyhow!("cannot resolve policy lock path"))?;
     if lock_path == config_path {
@@ -1476,7 +1488,7 @@ pub async fn initialize_files_unlocked(
             ]),
             default_tier: Some("strong".into()),
             tool_use_tier: Some("strong".into()),
-            tool_safe_tiers: vec!["strong".into()],
+            tool_safe_tiers,
             adequacy,
             ..PolicyDefinition::default()
         },
@@ -1523,6 +1535,19 @@ pub async fn initialize_files_unlocked(
             format!("bound preset '@{preset_name}'"),
         ],
         conflicts: Vec::new(),
+    })
+}
+
+fn route_supports_capability(
+    config: &bitrouter_sdk::config::Config,
+    route: &str,
+    capability: bitrouter_sdk::language_model::types::Capability,
+) -> bool {
+    let Some((provider_id, model_id)) = route.split_once(':') else {
+        return false;
+    };
+    config.providers.get(provider_id).is_some_and(|provider| {
+        provider.active && provider.model_supports_capability(model_id, capability)
     })
 }
 
@@ -3886,6 +3911,50 @@ presets:
         assert_eq!(policy.tiers["economy"], "moonshotai/kimi-k2.7-code");
         assert_eq!(policy.default_tier.as_deref(), Some("strong"));
         assert_eq!(policy.adequacy.explore_tier.as_deref(), Some("economy"));
+    }
+
+    #[tokio::test]
+    async fn initialize_marks_only_declared_tool_capable_tiers_safe() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let config_path = dir.path().join("bitrouter.yaml");
+        tokio::fs::write(
+            &config_path,
+            r#"inherit_defaults: false
+providers:
+  strong-provider:
+    api_base: https://strong.example/v1
+    api_key: strong
+    models:
+      - id: strong-model
+        capabilities: [reasoning, tools]
+  economy-provider:
+    api_base: https://economy.example/v1
+    api_key: economy
+    models:
+      - id: economy-model
+        capabilities: [tools]
+presets:
+  auto:
+    model: strong-provider:strong-model
+"#,
+        )
+        .await?;
+
+        let update = initialize_files(
+            &config_path,
+            "auto",
+            "auto",
+            None,
+            "economy-provider:economy-model",
+        )
+        .await?;
+        let loaded = load(&update.path).await?;
+
+        assert_eq!(
+            loaded.document.policies["auto"].tool_safe_tiers,
+            ["strong", "economy"]
+        );
+        Ok(())
     }
 
     #[tokio::test]

--- a/apps/bitrouter/tests/onboarding.rs
+++ b/apps/bitrouter/tests/onboarding.rs
@@ -169,6 +169,46 @@ fn init_yes_cloud_login_without_key_is_reported_and_skipped() {
 }
 
 #[test]
+fn init_yes_optimization_requires_routes_before_scaffolding() -> anyhow::Result<()> {
+    let home = TempDir::new()?;
+    let data = TempDir::new()?;
+    let cfg = home.path().join("bitrouter.yaml");
+    let cfg_arg = cfg
+        .to_str()
+        .ok_or_else(|| anyhow::anyhow!("temporary config path is not UTF-8"))?;
+    let out = run_cli(
+        home.path(),
+        data.path(),
+        &[
+            "init",
+            "--yes",
+            "--optimize",
+            "--optimize-workflow-command",
+            "/usr/bin/true",
+            "--optimize-success",
+            "the workflow exits",
+            "--after",
+            "exit",
+            "-c",
+            cfg_arg,
+        ],
+        &[],
+    );
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stderr.contains("--optimize-strong") || stdout.contains("--optimize-strong"),
+        "unexpected optimization preflight error: stdout={stdout}; stderr={stderr}"
+    );
+    assert!(
+        !cfg.exists(),
+        "route preflight must fail before creating the source config"
+    );
+    Ok(())
+}
+
+#[test]
 fn init_yes_refuses_overwrite_without_force() {
     let home = TempDir::new().unwrap();
     let data = TempDir::new().unwrap();

--- a/apps/bitrouter/tests/optimization_discovery.rs
+++ b/apps/bitrouter/tests/optimization_discovery.rs
@@ -1,0 +1,161 @@
+use std::fs;
+
+use anyhow::Result;
+use bitrouter::optimization::discovery::{
+    GuidedWorkflow, WorkflowCandidateSource, discover_workflow_candidates, resolve_guided_workflow,
+};
+
+#[test]
+fn discovers_semantic_package_scripts_with_the_project_package_manager() -> Result<()> {
+    let project = tempfile::tempdir()?;
+    fs::write(
+        project.path().join("package.json"),
+        r#"{"scripts":{"test":"vitest","eval:agent":"node eval.mjs","benchmark":"node bench.mjs"}}"#,
+    )?;
+    fs::write(
+        project.path().join("pnpm-lock.yaml"),
+        "lockfileVersion: '9.0'\n",
+    )?;
+
+    let candidates = discover_workflow_candidates(project.path())?;
+
+    assert_eq!(candidates.len(), 2);
+    assert_eq!(candidates[0].id, "package:benchmark");
+    assert_eq!(
+        candidates[0].command,
+        ["pnpm", "run", "benchmark"].map(String::from)
+    );
+    assert_eq!(candidates[1].id, "package:eval:agent");
+    assert_eq!(candidates[1].source, WorkflowCandidateSource::PackageScript);
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn discovers_executable_eval_entrypoints_but_not_generic_test_helpers() -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let project = tempfile::tempdir()?;
+    fs::create_dir(project.path().join("scripts"))?;
+    for name in ["run-agent-eval", "test-helper"] {
+        let path = project.path().join("scripts").join(name);
+        fs::write(&path, "#!/bin/sh\nexit 0\n")?;
+        let mut permissions = fs::metadata(&path)?.permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(path, permissions)?;
+    }
+
+    let candidates = discover_workflow_candidates(project.path())?;
+
+    assert_eq!(candidates.len(), 1);
+    assert_eq!(candidates[0].id, "executable:scripts/run-agent-eval");
+    assert_eq!(
+        candidates[0].command,
+        ["./scripts/run-agent-eval"].map(String::from)
+    );
+    assert_eq!(candidates[0].source, WorkflowCandidateSource::Executable);
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn skips_symlinked_entrypoints_and_sorts_results_deterministically() -> Result<()> {
+    use std::os::unix::fs::{PermissionsExt, symlink};
+
+    let project = tempfile::tempdir()?;
+    let outside = tempfile::tempdir()?;
+    let outside_eval = outside.path().join("agent-eval");
+    fs::write(&outside_eval, "#!/bin/sh\nexit 0\n")?;
+    let mut permissions = fs::metadata(&outside_eval)?.permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&outside_eval, permissions)?;
+    symlink(&outside_eval, project.path().join("agent-eval"))?;
+
+    fs::write(
+        project.path().join("package.json"),
+        r#"{"scripts":{"z-eval":"true","a-bench":"true"}}"#,
+    )?;
+
+    let first = discover_workflow_candidates(project.path())?;
+    let second = discover_workflow_candidates(project.path())?;
+
+    assert_eq!(first, second);
+    assert_eq!(
+        first
+            .iter()
+            .map(|candidate| candidate.id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["package:a-bench", "package:z-eval"]
+    );
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn skips_entrypoints_reached_through_a_symlinked_search_directory() -> Result<()> {
+    use std::os::unix::fs::{PermissionsExt, symlink};
+
+    let project = tempfile::tempdir()?;
+    let outside = tempfile::tempdir()?;
+    let outside_eval = outside.path().join("agent-eval");
+    fs::write(&outside_eval, "#!/bin/sh\nexit 0\n")?;
+    let mut permissions = fs::metadata(&outside_eval)?.permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&outside_eval, permissions)?;
+    symlink(outside.path(), project.path().join("scripts"))?;
+
+    let candidates = discover_workflow_candidates(project.path())?;
+
+    assert!(candidates.is_empty());
+    Ok(())
+}
+
+#[test]
+fn guided_workflow_uses_the_only_discovered_candidate() -> Result<()> {
+    let project = tempfile::tempdir()?;
+    fs::write(
+        project.path().join("package.json"),
+        r#"{"scripts":{"eval":"node eval.mjs"}}"#,
+    )?;
+
+    let guided = resolve_guided_workflow(project.path(), None, Vec::new())?;
+
+    assert_eq!(
+        guided,
+        GuidedWorkflow::Resolved {
+            command: ["npm", "run", "eval"].map(String::from).to_vec(),
+            evidence: "package.json declares the `eval` script".into(),
+        }
+    );
+    Ok(())
+}
+
+#[test]
+fn guided_workflow_preserves_explicit_argv_and_reports_ambiguity() -> Result<()> {
+    let project = tempfile::tempdir()?;
+    fs::write(
+        project.path().join("package.json"),
+        r#"{"scripts":{"eval":"true","bench":"true"}}"#,
+    )?;
+
+    let explicit = resolve_guided_workflow(
+        project.path(),
+        Some("./quality-gate".into()),
+        vec!["--case".into(), "agent flow".into()],
+    )?;
+    assert_eq!(
+        explicit,
+        GuidedWorkflow::Resolved {
+            command: vec![
+                "./quality-gate".into(),
+                "--case".into(),
+                "agent flow".into()
+            ],
+            evidence: "explicit --workflow-command argv".into(),
+        }
+    );
+
+    let ambiguous = resolve_guided_workflow(project.path(), None, Vec::new())?;
+    assert!(matches!(ambiguous, GuidedWorkflow::Choose(candidates) if candidates.len() == 2));
+    Ok(())
+}

--- a/apps/bitrouter/tests/optimization_output.rs
+++ b/apps/bitrouter/tests/optimization_output.rs
@@ -1,0 +1,134 @@
+use std::collections::BTreeMap;
+
+use anyhow::Result;
+use bitrouter::optimization::orchestrator::{
+    OptimizationReport, VariantReport, WorkflowFingerprint,
+};
+use bitrouter::optimization::{OptimizationPreference, OptimizationVerdict};
+use bitrouter::output::reports::optimization::{
+    OptimizationReviewReport, OptimizationSetupReport, OptimizationStatusReport,
+};
+use bitrouter::output::{Format, Output};
+
+fn variant(cost: u64, latency: u64) -> VariantReport {
+    VariantReport {
+        verdict: OptimizationVerdict::Pass,
+        confidence: "high".into(),
+        reason: "observable contract passed".into(),
+        evidence_digest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            .into(),
+        policy_digest: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+            .into(),
+        request_count: 4,
+        normalized_cost_micro_usd: cost,
+        observed_latency_ms: latency,
+        elapsed_ms: 2_000,
+    }
+}
+
+#[test]
+fn human_review_leads_with_quality_and_cost_tradeoff_for_auto() -> Result<()> {
+    let report = OptimizationReport {
+        run_id: "run-20260808".into(),
+        created_at: "2026-08-08T00:00:00Z".into(),
+        source_policy_digest:
+            "sha256:1111111111111111111111111111111111111111111111111111111111111111".into(),
+        source_config_digest:
+            "sha256:2222222222222222222222222222222222222222222222222222222222222222".into(),
+        workflow_fingerprint: WorkflowFingerprint {
+            argv_digest: "sha256:3333333333333333333333333333333333333333333333333333333333333333"
+                .into(),
+            referenced_files: BTreeMap::new(),
+            workspace_digest:
+                "sha256:4444444444444444444444444444444444444444444444444444444444444444".into(),
+        },
+        target_request_key: "agent_trace/v2|edit|normal".into(),
+        preference: OptimizationPreference::Balanced,
+        baseline: variant(10_000, 1_000),
+        candidate: variant(6_000, 1_100),
+        normalized_cost_delta_micro_usd: -4_000,
+        normalized_cost_delta_ppm: Some(-400_000),
+        latency_observe_only: true,
+        eval_snapshot_digest:
+            "sha256:5555555555555555555555555555555555555555555555555555555555555555".into(),
+        candidate_digest: "sha256:6666666666666666666666666666666666666666666666666666666666666666"
+            .into(),
+        candidate_path: "candidate.yaml".into(),
+        publishable: true,
+        caveats: Vec::new(),
+    };
+    let view = OptimizationReviewReport::new(report, false, false, true);
+
+    let rendered = String::from_utf8(Output::new(Format::Human).render_to_vec(&view))?;
+
+    assert!(rendered.contains("@auto candidate is ready for review"));
+    assert!(rendered.contains("pass → pass"));
+    assert!(rendered.contains("$0.010000 → $0.006000"));
+    assert!(rendered.contains("40.0% lower"));
+    assert!(rendered.contains("latency is observe-only"));
+    assert!(rendered.contains("bitrouter optimize publish --run run-20260808"));
+    Ok(())
+}
+
+#[test]
+fn human_setup_explains_auto_workflow_and_next_step() -> Result<()> {
+    let view = OptimizationSetupReport {
+        action: "optimize.setup",
+        model: "@auto",
+        intent: "bitrouter.optimize.yaml".into(),
+        lock: "bitrouter.optimize.lock.yaml".into(),
+        contract: "bitrouter.eval.md".into(),
+        workflow: ["npm", "run", "eval"].map(String::from).to_vec(),
+        strong: "openai-codex:gpt-5.6-sol".into(),
+        economy: "bitrouter:deepseek/deepseek-v4-flash-0731".into(),
+        evaluator: "codex-acp (gpt-5.6-sol, direct)".into(),
+        evaluator_lock: None,
+        normalized_price_overrides: Vec::new(),
+        preference: OptimizationPreference::Balanced,
+        active_policy_digest:
+            "sha256:7777777777777777777777777777777777777777777777777777777777777777".into(),
+        latency: "observe_only",
+    };
+
+    let rendered = String::from_utf8(Output::new(Format::Human).render_to_vec(&view))?;
+
+    assert!(rendered.contains("@auto optimization is configured"));
+    assert!(rendered.contains("npm run eval"));
+    assert!(rendered.contains("openai-codex:gpt-5.6-sol → bitrouter:deepseek"));
+    assert!(rendered.contains("edit bitrouter.eval.md"));
+    assert!(rendered.contains("bitrouter optimize run"));
+    Ok(())
+}
+
+#[test]
+fn human_status_explains_ready_state_and_repair_before_running() -> Result<()> {
+    let view = OptimizationStatusReport {
+        action: "optimize.status",
+        model: "@auto",
+        intent: "bitrouter.optimize.yaml".into(),
+        intent_digest: "sha256:8888888888888888888888888888888888888888888888888888888888888888"
+            .into(),
+        lock_active_policy_digest:
+            "sha256:9999999999999999999999999999999999999999999999999999999999999999".into(),
+        actual_active_policy_digest:
+            "sha256:9999999999999999999999999999999999999999999999999999999999999999".into(),
+        policy_mode: "frozen".into(),
+        lineage_consistent: true,
+        latest_candidate_active: false,
+        rolled_back: false,
+        repair_hint: None,
+        preference: OptimizationPreference::Balanced,
+        evaluator: "codex-acp (gpt-5.6-sol, direct)".into(),
+        evaluator_lock: None,
+        latest_run: None,
+        latency: "observe_only",
+    };
+
+    let rendered = String::from_utf8(Output::new(Format::Human).render_to_vec(&view))?;
+
+    assert!(rendered.contains("@auto is ready to measure"));
+    assert!(rendered.contains("lineage"));
+    assert!(rendered.contains("consistent"));
+    assert!(rendered.contains("bitrouter optimize run --human"));
+    Ok(())
+}

--- a/crates/bitrouter-cloud-sdk/src/provider/applier.rs
+++ b/crates/bitrouter-cloud-sdk/src/provider/applier.rs
@@ -107,10 +107,10 @@ struct ResolvedCloudAuth {
 }
 
 fn oauth_continuation_authority(credentials: &Credentials) -> Result<Option<CredentialAuthority>> {
-    let Some(subject) = credentials
-        .subject
+    let Some(namespace_id) = credentials
+        .namespace_id
         .as_deref()
-        .filter(|subject| !subject.is_empty())
+        .filter(|namespace_id| !namespace_id.is_empty())
     else {
         return Ok(None);
     };
@@ -123,9 +123,9 @@ fn oauth_continuation_authority(credentials: &Credentials) -> Result<Option<Cred
     )?;
     let normalized_issuer = issuer.as_str().trim_end_matches('/');
     Ok(Some(CredentialAuthority::derive_scoped(
-        "bitrouter-cloud/oauth-subject",
+        "bitrouter-cloud/oauth-namespace",
         normalized_issuer,
-        subject,
+        namespace_id,
     )))
 }
 
@@ -210,8 +210,9 @@ impl BitrouterCloudAuthApplier {
         let Some(credential) = store.current() else {
             return Ok(None);
         };
-        // A subject is stable across OAuth access/refresh-token rotation. A
-        // legacy OAuth file without one cannot safely publish a resumable
+        // The namespace baked into a CLI OAuth credential is stable across
+        // access/refresh-token rotation and is the Cloud inference authority.
+        // A legacy OAuth file without one cannot safely publish a resumable
         // Responses root. Static stored keys use the key itself only as input
         // to the one-way proof and never retain or log it.
         let oauth_authority = match credential.oauth() {
@@ -387,7 +388,7 @@ mod tests {
     }
 
     #[test]
-    fn oauth_authority_survives_token_rotation_for_same_issuer_and_subject() {
+    fn oauth_authority_survives_token_rotation_for_same_issuer_and_namespace() {
         let before = oauth_credentials(
             "HTTPS://AS.EXAMPLE:443/oauth/",
             "user-42",
@@ -405,6 +406,43 @@ mod tests {
             oauth_continuation_authority(&before).unwrap(),
             oauth_continuation_authority(&after).unwrap()
         );
+    }
+
+    #[test]
+    fn oauth_authority_uses_namespace_when_subject_is_unavailable() -> Result<()> {
+        let mut credentials = oauth_credentials(
+            "https://as.example/oauth",
+            "display-only-subject",
+            "access-token",
+            "refresh-token",
+        );
+        credentials.subject = None;
+
+        assert!(oauth_continuation_authority(&credentials)?.is_some());
+        Ok(())
+    }
+
+    #[test]
+    fn oauth_authority_changes_when_namespace_changes() -> Result<()> {
+        let original = oauth_credentials(
+            "https://as.example/oauth",
+            "shared-subject",
+            "access-a",
+            "refresh-a",
+        );
+        let mut rebound = oauth_credentials(
+            "https://as.example/oauth",
+            "shared-subject",
+            "access-b",
+            "refresh-b",
+        );
+        rebound.namespace_id = Some("ns-2".to_owned());
+
+        assert_ne!(
+            oauth_continuation_authority(&original)?,
+            oauth_continuation_authority(&rebound)?
+        );
+        Ok(())
     }
 
     #[test]

--- a/crates/bitrouter-providers/src/codex/headers.rs
+++ b/crates/bitrouter-providers/src/codex/headers.rs
@@ -3,9 +3,8 @@
 //! Codex's backend at `chatgpt.com/backend-api/codex` rejects requests that
 //! don't carry the integration headers an official CLI client would send.
 //! We mirror what OpenAI's Codex CLI ships with — `chatgpt-account-id`
-//! sourced from the OAuth access-token's JWT claims, `OpenAI-Beta` to opt
-//! into the streamed-Responses path, and an `originator` tag identifying
-//! the client.
+//! sourced from the OAuth access-token's JWT claims, the current Codex HTTP
+//! Responses contract marker, and an `originator` tag identifying the client.
 //!
 //! Header values cribbed from the OpenCode reference at
 //! `packages/opencode/src/plugin/codex.ts` (line 108: `originator: "opencode"`)
@@ -19,9 +18,8 @@
 /// other Codex clients.
 pub const ORIGINATOR: &str = "bitrouter";
 
-/// `OpenAI-Beta` value to opt into the experimental Responses API surface
-/// that Codex's backend speaks.
-pub const OPENAI_BETA: &str = "responses=experimental";
+/// Header value used by the current Codex CLI for HTTP Responses requests.
+pub const RESPONSES_LITE: &str = "true";
 
 /// `user-agent` bitrouter sends on Codex requests. The backend is lenient
 /// about the value (the OpenClaw reference sends its own name), so we send

--- a/crates/bitrouter-providers/src/codex/mod.rs
+++ b/crates/bitrouter-providers/src/codex/mod.rs
@@ -397,8 +397,11 @@ impl AuthApplier for OpenAiCodexAuthApplier {
 /// their encrypted reasoning for multi-turn continuity. The Responses-Lite
 /// transport marker also requires `reasoning.context: "all_turns"` and
 /// `parallel_tool_calls: false`; preserve any caller effort while pinning that
-/// provider contract. The caller's system prompt rides in `instructions` (set
-/// by the Responses adapter); when the
+/// provider contract. Codex clients using a custom gateway emit their local
+/// tools at the public top-level `tools` field, while the subscription backend
+/// accepts the same definitions as a developer `additional_tools` input item;
+/// normalize to that official wire shape. The caller's system prompt rides in
+/// `instructions` (set by the Responses adapter); when the
 /// caller sent none, default it to the Codex CLI's own fallback so the backend
 /// always sees instructions. Mirrors OpenClaw
 /// `src/llm/providers/openai-chatgpt-responses.ts`.
@@ -484,6 +487,7 @@ fn shape_codex_responses_body(body: &mut serde_json::Value) {
     }
     ensure_tool_names(obj);
     ensure_tool_descriptions(obj);
+    move_tools_to_additional_input(obj);
 }
 
 fn strip_codex_unsupported_fields(value: &mut serde_json::Value) {
@@ -574,6 +578,40 @@ fn ensure_tool_descriptions(obj: &mut serde_json::Map<String, serde_json::Value>
             .entry("parameters".to_string())
             .or_insert_with(|| serde_json::json!({}));
     }
+}
+
+fn move_tools_to_additional_input(obj: &mut serde_json::Map<String, serde_json::Value>) {
+    let Some(tools) = obj.remove("tools") else {
+        return;
+    };
+    let serde_json::Value::Array(tools) = tools else {
+        obj.insert("tools".to_string(), tools);
+        return;
+    };
+    if tools.is_empty() {
+        return;
+    }
+    let Some(serde_json::Value::Array(input)) = obj.get_mut("input") else {
+        obj.insert("tools".to_string(), serde_json::Value::Array(tools));
+        return;
+    };
+    if let Some(existing) = input.iter_mut().find(|item| {
+        item.get("type").and_then(serde_json::Value::as_str) == Some("additional_tools")
+    }) && let Some(existing_tools) = existing
+        .get_mut("tools")
+        .and_then(serde_json::Value::as_array_mut)
+    {
+        existing_tools.extend(tools);
+        return;
+    }
+    input.insert(
+        0,
+        serde_json::json!({
+            "type": "additional_tools",
+            "role": "developer",
+            "tools": tools,
+        }),
+    );
 }
 
 fn is_instruction_message(item: &serde_json::Value) -> bool {
@@ -948,6 +986,11 @@ mod tests {
         let mut body = serde_json::json!({
             "model": "gpt-5-codex",
             "input": [],
+            "tools": [
+                {"type": "function", "name": "shell", "parameters": {}},
+                {"type": "namespace", "name": "workspace", "tools": []},
+                {"type": "web_search"}
+            ],
             "reasoning": {"effort": "high", "context": "legacy"},
             "max_output_tokens": 16,
             "stream_options": {"include_usage": true}
@@ -966,6 +1009,19 @@ mod tests {
         assert_eq!(body["reasoning"]["context"], serde_json::json!("all_turns"));
         assert_eq!(body["reasoning"]["effort"], serde_json::json!("high"));
         assert_eq!(body["parallel_tool_calls"], serde_json::json!(false));
+        assert!(body.get("tools").is_none());
+        assert_eq!(
+            body["input"][0]["type"],
+            serde_json::json!("additional_tools")
+        );
+        assert_eq!(body["input"][0]["role"], serde_json::json!("developer"));
+        assert_eq!(
+            body["input"][0]["tools"].as_array().map(|tools| tools
+                .iter()
+                .filter_map(|tool| tool.get("type").and_then(serde_json::Value::as_str))
+                .collect::<Vec<_>>()),
+            Some(vec!["function", "namespace", "web_search"])
+        );
         // include already present → reasoning item appended without duplication.
         let mut body2 = serde_json::json!({ "include": ["foo"] });
         applier
@@ -1059,13 +1115,14 @@ mod tests {
             .prepare_body(&mut body5, &codex_target(None))
             .await
             .unwrap();
-        assert_eq!(body5["tools"][0]["name"], serde_json::json!("custom"));
+        let moved_tools = &body5["input"][0]["tools"];
+        assert_eq!(moved_tools[0]["name"], serde_json::json!("custom"));
         assert_eq!(
-            body5["tools"][1]["description"],
+            moved_tools[1]["description"],
             serde_json::json!("Search for available tools.")
         );
-        assert_eq!(body5["tools"][1]["parameters"], serde_json::json!({}));
-        assert!(body5["tools"][1].get("name").is_none());
-        assert_eq!(body5["tools"][2]["name"], serde_json::json!("read_file"));
+        assert_eq!(moved_tools[1]["parameters"], serde_json::json!({}));
+        assert!(moved_tools[1].get("name").is_none());
+        assert_eq!(moved_tools[2]["name"], serde_json::json!("read_file"));
     }
 }

--- a/crates/bitrouter-providers/src/codex/mod.rs
+++ b/crates/bitrouter-providers/src/codex/mod.rs
@@ -14,7 +14,7 @@
 //!    [`crate::oauth::refresh::REFRESH_WINDOW`] of expiry.
 //! 3. Decode the access token JWT to extract `chatgpt_account_id` and
 //!    forward it on the `chatgpt-account-id` header alongside the Bearer.
-//! 4. Set `OpenAI-Beta: responses=experimental` and `originator: bitrouter`
+//! 4. Set the current Codex HTTP Responses marker and `originator: bitrouter`
 //!    so the upstream admits the request through the Codex pipeline.
 //!
 //! ## Body shape
@@ -342,8 +342,8 @@ impl AuthApplier for OpenAiCodexAuthApplier {
             headers_mut.insert(HeaderName::from_static("chatgpt-account-id"), value);
         }
         headers_mut.insert(
-            HeaderName::from_static("openai-beta"),
-            HeaderValue::from_static(headers::OPENAI_BETA),
+            HeaderName::from_static("x-openai-internal-codex-responses-lite"),
+            HeaderValue::from_static(headers::RESPONSES_LITE),
         );
         headers_mut.insert(
             HeaderName::from_static("originator"),
@@ -394,8 +394,11 @@ impl AuthApplier for OpenAiCodexAuthApplier {
 ///
 /// The backend requires `store: false` (it does not persist Codex responses)
 /// and `include: ["reasoning.encrypted_content"]` so reasoning models return
-/// their encrypted reasoning for multi-turn continuity. The caller's system
-/// prompt rides in `instructions` (set by the Responses adapter); when the
+/// their encrypted reasoning for multi-turn continuity. The Responses-Lite
+/// transport marker also requires `reasoning.context: "all_turns"` and
+/// `parallel_tool_calls: false`; preserve any caller effort while pinning that
+/// provider contract. The caller's system prompt rides in `instructions` (set
+/// by the Responses adapter); when the
 /// caller sent none, default it to the Codex CLI's own fallback so the backend
 /// always sees instructions. Mirrors OpenClaw
 /// `src/llm/providers/openai-chatgpt-responses.ts`.
@@ -426,6 +429,19 @@ fn shape_codex_responses_body(body: &mut serde_json::Value) {
         strip_codex_unsupported_fields(value);
     }
     obj.insert("store".to_string(), Value::Bool(false));
+    obj.insert("parallel_tool_calls".to_string(), Value::Bool(false));
+    let reasoning = obj
+        .entry("reasoning".to_string())
+        .or_insert_with(|| Value::Object(serde_json::Map::new()));
+    if !reasoning.is_object() {
+        *reasoning = Value::Object(serde_json::Map::new());
+    }
+    if let Some(reasoning) = reasoning.as_object_mut() {
+        reasoning.insert(
+            "context".to_string(),
+            Value::String("all_turns".to_string()),
+        );
+    }
     match obj.get_mut("include") {
         Some(Value::Array(items)) => {
             if !items.iter().any(|v| v.as_str() == Some(REASONING_INCLUDE)) {
@@ -713,9 +729,11 @@ mod tests {
             h.get("chatgpt-account-id").and_then(|v| v.to_str().ok()),
             Some("acct-bitrouter")
         );
+        assert!(h.get("openai-beta").is_none());
         assert_eq!(
-            h.get("openai-beta").and_then(|v| v.to_str().ok()),
-            Some(headers::OPENAI_BETA)
+            h.get("x-openai-internal-codex-responses-lite")
+                .and_then(|v| v.to_str().ok()),
+            Some("true")
         );
         assert_eq!(
             h.get("originator").and_then(|v| v.to_str().ok()),
@@ -930,6 +948,7 @@ mod tests {
         let mut body = serde_json::json!({
             "model": "gpt-5-codex",
             "input": [],
+            "reasoning": {"effort": "high", "context": "legacy"},
             "max_output_tokens": 16,
             "stream_options": {"include_usage": true}
         });
@@ -944,6 +963,9 @@ mod tests {
             body["include"],
             serde_json::json!(["reasoning.encrypted_content"])
         );
+        assert_eq!(body["reasoning"]["context"], serde_json::json!("all_turns"));
+        assert_eq!(body["reasoning"]["effort"], serde_json::json!("high"));
+        assert_eq!(body["parallel_tool_calls"], serde_json::json!(false));
         // include already present → reasoning item appended without duplication.
         let mut body2 = serde_json::json!({ "include": ["foo"] });
         applier

--- a/crates/bitrouter-providers/src/registry/apply.rs
+++ b/crates/bitrouter-providers/src/registry/apply.rs
@@ -284,6 +284,7 @@ fn build_models(provider: &RegistryProvider) -> Vec<ProviderModel> {
             api_protocol: Some(m.api_protocol.to_protocol_list()),
             rate_limits: m.rate_limits.as_ref().map(map_rate_limits),
             pricing: m.pricing.as_ref().and_then(map_pricing),
+            capabilities: m.capabilities.clone(),
             compatibility: m.compatibility.clone(),
         })
         .collect()
@@ -361,6 +362,7 @@ mod tests {
                     context_tiers: Vec::new(),
                 }),
                 rate_limits: None,
+                capabilities: Vec::new(),
                 compatibility: Default::default(),
             }],
             status: "active".to_string(),
@@ -376,8 +378,12 @@ mod tests {
     }
 
     #[test]
-    fn model_compatibility_reaches_provider_model() {
+    fn model_capabilities_and_compatibility_reach_provider_model() {
         let mut registry_provider = provider("regtestprov");
+        registry_provider.models[0].capabilities = vec![
+            bitrouter_sdk::language_model::types::Capability::Reasoning,
+            bitrouter_sdk::language_model::types::Capability::Tools,
+        ];
         registry_provider.models[0]
             .compatibility
             .chat_completions
@@ -387,6 +393,13 @@ mod tests {
         assert_eq!(
             models[0].compatibility.chat_completions.token_limit_field,
             Some(ChatTokenLimitField::MaxCompletionTokens)
+        );
+        assert_eq!(
+            models[0].capabilities,
+            [
+                bitrouter_sdk::language_model::types::Capability::Reasoning,
+                bitrouter_sdk::language_model::types::Capability::Tools,
+            ]
         );
     }
 
@@ -767,6 +780,7 @@ mod tests {
             api_protocol: None,
             rate_limits: None,
             pricing: None,
+            capabilities: Vec::new(),
             compatibility: Default::default(),
         }];
         config.providers.insert("regtestprov".to_string(), user);

--- a/crates/bitrouter-providers/src/registry/types.rs
+++ b/crates/bitrouter-providers/src/registry/types.rs
@@ -21,7 +21,7 @@ use std::collections::BTreeMap;
 use serde::Deserialize;
 
 use bitrouter_sdk::language_model::types::ModelCompatibility;
-use bitrouter_sdk::language_model::types::{ApiProtocol, ProtocolList};
+use bitrouter_sdk::language_model::types::{ApiProtocol, Capability, ProtocolList};
 
 /// The distribution envelope shared by both dist files: `{ "data": [ … ] }`.
 #[derive(Debug, Clone, Deserialize)]
@@ -342,6 +342,9 @@ pub struct RegistryModel {
     /// Resolved rate limits for this (provider, model) pair, if any.
     #[serde(default)]
     pub rate_limits: Option<RegistryRateLimits>,
+    /// Positively verified model features from the public registry.
+    #[serde(default)]
+    pub capabilities: Vec<Capability>,
     /// Provider/model request-shape compatibility settings.
     #[serde(default)]
     pub compatibility: ModelCompatibility,
@@ -509,6 +512,7 @@ mod tests {
         let m = &anthropic.models[0];
         assert_eq!(m.id, "anthropic/claude-sonnet-4.6");
         assert_eq!(m.provider_model_id, "claude-sonnet-4-6");
+        assert_eq!(m.capabilities, [Capability::Reasoning, Capability::Tools]);
         // Resolved per-model protocol + rate limits (no glob to resolve here).
         assert_eq!(
             m.api_protocol,

--- a/crates/bitrouter-sdk/src/config/mod.rs
+++ b/crates/bitrouter-sdk/src/config/mod.rs
@@ -1112,6 +1112,21 @@ impl ProviderConfig {
         })
     }
 
+    /// Whether a concrete model positively advertises `capability`.
+    ///
+    /// This intentionally distinguishes an explicit declaration from legacy
+    /// model entries whose capability list is empty/unknown. Callers that
+    /// grant a policy exception (for example, a tool-safe economy tier) must
+    /// use positive evidence rather than treating unknown as supported.
+    pub fn model_supports_capability(
+        &self,
+        model_id: &str,
+        capability: crate::language_model::types::Capability,
+    ) -> bool {
+        self.model_config(model_id)
+            .is_some_and(|model| model.capabilities.contains(&capability))
+    }
+
     /// The API key for provider-level operations that aren't tied to a
     /// specific routed request — currently model discovery's `/models`
     /// probe. Returns the top-level [`api_key`](Self::api_key), or the
@@ -1208,6 +1223,12 @@ pub struct ProviderModel {
     /// Per-model pricing.
     #[serde(default)]
     pub pricing: Option<PricingConfig>,
+    /// Features this concrete provider/model route explicitly advertises.
+    /// An empty list means unknown, not unsupported. Runtime routing preserves
+    /// legacy unknown entries; policy code that grants a capability-specific
+    /// exception requires a positive declaration.
+    #[serde(default)]
+    pub capabilities: Vec<crate::language_model::types::Capability>,
     /// Provider/model request-shape quirks that do not change model semantics.
     #[serde(default)]
     pub compatibility: ModelCompatibility,
@@ -1794,6 +1815,7 @@ pub async fn discover_models(config: &mut Config) {
                         api_protocol: None,
                         rate_limits: None,
                         pricing: None,
+                        capabilities: Vec::new(),
                         compatibility: ModelCompatibility::default(),
                     })
                     .collect();

--- a/crates/bitrouter-sdk/src/config/mod.rs
+++ b/crates/bitrouter-sdk/src/config/mod.rs
@@ -1102,6 +1102,16 @@ impl Default for ProviderConfig {
 }
 
 impl ProviderConfig {
+    /// Resolve either the registry's canonical model id or its provider-native
+    /// dispatch id to the same metadata entry. Explicit `provider:model`
+    /// routes commonly use the native id, but must retain the registry's
+    /// protocol, pricing, and compatibility contract.
+    pub(crate) fn model_config(&self, model_id: &str) -> Option<&ProviderModel> {
+        self.models.iter().find(|model| {
+            model.id == model_id || model.provider_model_id.as_deref() == Some(model_id)
+        })
+    }
+
     /// The API key for provider-level operations that aren't tied to a
     /// specific routed request — currently model discovery's `/models`
     /// probe. Returns the top-level [`api_key`](Self::api_key), or the
@@ -1126,7 +1136,7 @@ impl ProviderConfig {
     /// router prefers whichever member matches the inbound request (native
     /// routing) and otherwise falls back to the head.
     pub fn protocols_for(&self, model_id: &str) -> Vec<ApiProtocol> {
-        if let Some(m) = self.models.iter().find(|m| m.id == model_id)
+        if let Some(m) = self.model_config(model_id)
             && let Some(list) = &m.api_protocol
             && !list.is_empty()
         {

--- a/crates/bitrouter-sdk/src/config/routing_table.rs
+++ b/crates/bitrouter-sdk/src/config/routing_table.rs
@@ -244,25 +244,6 @@ fn provider_matches_tags(provider: &crate::config::ProviderConfig, require: &[St
     require.iter().all(|t| provider.tags.contains(t))
 }
 
-/// Whether a concrete provider/model pair positively advertises every
-/// capability required by this request. Empty requirements preserve legacy
-/// routing. A legacy empty capability list remains permissive for backwards
-/// compatibility, while a non-empty declaration is authoritative and filters
-/// requests that need a capability it omits.
-fn model_matches_capabilities(
-    provider: &crate::config::ProviderConfig,
-    model_id: &str,
-    require: &[crate::language_model::types::Capability],
-) -> bool {
-    require.is_empty()
-        || provider.model_config(model_id).is_none_or(|model| {
-            model.capabilities.is_empty()
-                || require
-                    .iter()
-                    .all(|capability| model.capabilities.contains(capability))
-        })
-}
-
 /// Build the fallback chain for an explicit virtual model (Strategy 2),
 /// honouring its [`VirtualModelStrategy`].
 ///
@@ -310,10 +291,6 @@ fn resolve_virtual_model(
             if !provider_matches_tags(provider, &prefs.require_tags) {
                 continue;
             }
-        }
-        if !model_matches_capabilities(provider, &endpoint.service_id, &prefs.require_capabilities)
-        {
-            continue;
         }
         endpoints.push((
             endpoint.provider.clone(),
@@ -376,11 +353,6 @@ fn resolve_clean_route_chain(
         && let Some(provider) = config.providers.get(provider_id)
         && provider.active
     {
-        if !model_matches_capabilities(provider, model_id, &prefs.require_capabilities) {
-            return Err(BitrouterError::NotFound(format!(
-                "provider model '{clean}' does not advertise the required capabilities"
-            )));
-        }
         return Ok(build_targets(
             provider_id,
             provider,
@@ -411,9 +383,6 @@ fn resolve_clean_route_chain(
             continue;
         }
         if !provider_matches_tags(provider, &prefs.require_tags) {
-            continue;
-        }
-        if !model_matches_capabilities(provider, clean, &prefs.require_capabilities) {
             continue;
         }
         // Subscription providers (a caller's own plan, reached by a local OAuth
@@ -664,7 +633,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn required_capabilities_filter_direct_and_cascade_routes()
+    async fn capability_metadata_is_positive_not_an_exhaustive_denylist()
     -> std::result::Result<(), Box<dyn std::error::Error>> {
         let table = table(
             r#"
@@ -691,14 +660,13 @@ providers:
         let cascade = table
             .route_chain("shared", &prefs, &CallerContext::local())
             .await?;
-        assert_eq!(cascade.len(), 1);
+        assert_eq!(cascade.len(), 2);
         assert_eq!(cascade[0].provider_name, "alpha");
-        assert!(
-            table
-                .route_chain("beta:shared", &prefs, &CallerContext::local())
-                .await
-                .is_err()
-        );
+        assert_eq!(cascade[1].provider_name, "beta");
+        let direct = table
+            .route_chain("beta:shared", &prefs, &CallerContext::local())
+            .await?;
+        assert_eq!(direct[0].provider_name, "beta");
         Ok(())
     }
 

--- a/crates/bitrouter-sdk/src/config/routing_table.rs
+++ b/crates/bitrouter-sdk/src/config/routing_table.rs
@@ -119,15 +119,11 @@ fn build_targets(
     // `provider:upstream-id` route that matches no declared model also passes
     // through unchanged.
     let service_id = provider
-        .models
-        .iter()
-        .find(|m| m.id == model_id)
+        .model_config(model_id)
         .and_then(|m| m.provider_model_id.as_deref())
         .unwrap_or(model_id);
     let chat_compatibility = provider
-        .models
-        .iter()
-        .find(|m| m.id == model_id)
+        .model_config(model_id)
         .map(|m| &m.compatibility.chat_completions);
     let chat_token_limit_field =
         chat_compatibility.and_then(|compatibility| compatibility.token_limit_field);
@@ -1581,6 +1577,32 @@ providers:
         assert_eq!(chain[0].provider_name, "anthropic");
         // Dispatched against the upstream id, not the canonical match key.
         assert_eq!(chain[0].service_id, "claude-sonnet-4-6");
+    }
+
+    #[tokio::test]
+    async fn explicit_upstream_id_reuses_registry_model_protocol() -> crate::Result<()> {
+        let yaml = r#"
+providers:
+  openai-codex:
+    api_base: https://chatgpt.com/backend-api/codex
+    models:
+      - id: openai/gpt-5.6-sol
+        provider_model_id: gpt-5.6-sol
+        api_protocol: responses
+"#;
+
+        let chain = table(yaml)
+            .route_chain(
+                "openai-codex:gpt-5.6-sol",
+                &RoutingPrefs::default(),
+                &CallerContext::local(),
+            )
+            .await?;
+
+        assert_eq!(chain.len(), 1);
+        assert_eq!(chain[0].service_id, "gpt-5.6-sol");
+        assert_eq!(chain[0].api_protocol, ApiProtocol::Responses);
+        Ok(())
     }
 
     #[tokio::test]

--- a/crates/bitrouter-sdk/src/config/routing_table.rs
+++ b/crates/bitrouter-sdk/src/config/routing_table.rs
@@ -244,6 +244,25 @@ fn provider_matches_tags(provider: &crate::config::ProviderConfig, require: &[St
     require.iter().all(|t| provider.tags.contains(t))
 }
 
+/// Whether a concrete provider/model pair positively advertises every
+/// capability required by this request. Empty requirements preserve legacy
+/// routing. A legacy empty capability list remains permissive for backwards
+/// compatibility, while a non-empty declaration is authoritative and filters
+/// requests that need a capability it omits.
+fn model_matches_capabilities(
+    provider: &crate::config::ProviderConfig,
+    model_id: &str,
+    require: &[crate::language_model::types::Capability],
+) -> bool {
+    require.is_empty()
+        || provider.model_config(model_id).is_none_or(|model| {
+            model.capabilities.is_empty()
+                || require
+                    .iter()
+                    .all(|capability| model.capabilities.contains(capability))
+        })
+}
+
 /// Build the fallback chain for an explicit virtual model (Strategy 2),
 /// honouring its [`VirtualModelStrategy`].
 ///
@@ -291,6 +310,10 @@ fn resolve_virtual_model(
             if !provider_matches_tags(provider, &prefs.require_tags) {
                 continue;
             }
+        }
+        if !model_matches_capabilities(provider, &endpoint.service_id, &prefs.require_capabilities)
+        {
+            continue;
         }
         endpoints.push((
             endpoint.provider.clone(),
@@ -353,6 +376,11 @@ fn resolve_clean_route_chain(
         && let Some(provider) = config.providers.get(provider_id)
         && provider.active
     {
+        if !model_matches_capabilities(provider, model_id, &prefs.require_capabilities) {
+            return Err(BitrouterError::NotFound(format!(
+                "provider model '{clean}' does not advertise the required capabilities"
+            )));
+        }
         return Ok(build_targets(
             provider_id,
             provider,
@@ -383,6 +411,9 @@ fn resolve_clean_route_chain(
             continue;
         }
         if !provider_matches_tags(provider, &prefs.require_tags) {
+            continue;
+        }
+        if !model_matches_capabilities(provider, clean, &prefs.require_capabilities) {
             continue;
         }
         // Subscription providers (a caller's own plan, reached by a local OAuth
@@ -610,6 +641,11 @@ fn merge_prefs(base: &mut RoutingPrefs, extra: &RoutingPrefs) {
             base.ignore.push(p.clone());
         }
     }
+    for capability in &extra.require_capabilities {
+        if !base.require_capabilities.contains(capability) {
+            base.require_capabilities.push(*capability);
+        }
+    }
     // The inbound protocol is a per-request fact set by the pipeline (not a
     // preset knob); carry it so target construction can route natively.
     if extra.inbound_protocol.is_some() {
@@ -621,9 +657,49 @@ fn merge_prefs(base: &mut RoutingPrefs, extra: &RoutingPrefs) {
 mod tests {
     use super::*;
     use crate::config::parse;
+    use crate::language_model::types::Capability;
 
     fn table(yaml: &str) -> ConfigRoutingTable {
         ConfigRoutingTable::from_config(parse(yaml).unwrap())
+    }
+
+    #[tokio::test]
+    async fn required_capabilities_filter_direct_and_cascade_routes()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let table = table(
+            r#"
+providers:
+  alpha:
+    api_base: https://alpha.example/v1
+    api_key: alpha
+    models:
+      - id: shared
+        capabilities: [tools]
+  beta:
+    api_base: https://beta.example/v1
+    api_key: beta
+    models:
+      - id: shared
+        capabilities: [reasoning]
+"#,
+        );
+        let prefs = RoutingPrefs {
+            require_capabilities: vec![Capability::Tools],
+            ..RoutingPrefs::default()
+        };
+
+        let cascade = table
+            .route_chain("shared", &prefs, &CallerContext::local())
+            .await?;
+        assert_eq!(cascade.len(), 1);
+        assert_eq!(cascade[0].provider_name, "alpha");
+        assert!(
+            table
+                .route_chain("beta:shared", &prefs, &CallerContext::local())
+                .await
+                .is_err()
+        );
+        Ok(())
     }
 
     const PROVIDERS: &str = r#"

--- a/crates/bitrouter-sdk/src/language_model/types.rs
+++ b/crates/bitrouter-sdk/src/language_model/types.rs
@@ -1062,7 +1062,7 @@ pub enum ToolChoice {
 /// A capability-aware [`RoutingTable`](crate::language_model::routing::RoutingTable)
 /// can read the set a request requires ([`Prompt::required_capabilities`]) and
 /// restrict the chain to providers advertising all of them.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum Capability {
     /// JSON-Schema-constrained output — [`ResponseFormat::JsonSchema`].

--- a/dist/registry/models.json
+++ b/dist/registry/models.json
@@ -1781,6 +1781,10 @@
         },
         {
           "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
           "pricing": {
             "input_tokens": {
               "cache_read": 0.028,

--- a/dist/registry/providers.json
+++ b/dist/registry/providers.json
@@ -2960,6 +2960,10 @@
         },
         {
           "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
           "id": "deepseek/deepseek-v4-flash-0731",
           "pricing": {
             "input_tokens": {

--- a/dist/schema/bitrouter.config.schema.json
+++ b/dist/schema/bitrouter.config.schema.json
@@ -614,6 +614,14 @@
             }
           ]
         },
+        "capabilities": {
+          "description": "Features this concrete provider/model route explicitly advertises.\nAn empty list means unknown, not unsupported; capability-constrained\nrouting admits only positive declarations.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Capability"
+          },
+          "default": []
+        },
         "compatibility": {
           "description": "Provider/model request-shape quirks that do not change model semantics.",
           "$ref": "#/$defs/ModelCompatibility",
@@ -728,6 +736,66 @@
       },
       "required": [
         "above_input_tokens"
+      ]
+    },
+    "Capability": {
+      "description": "An optional inference feature a request may require and a provider may\nadvertise. Capabilities are API-agnostic: the same capability maps to a\ndifferent wire parameter in each protocol (structured outputs is Chat\nCompletions' `response_format`, Messages' `output_config.format`, Generate\nContent's `responseSchema`, Responses' `text.format`). The serde\nrepresentation (e.g. `structured_outputs`) is the stable token used to match\na request's needs against a provider's advertised capabilities.\n\nA capability-aware [`RoutingTable`](crate::language_model::routing::RoutingTable)\ncan read the set a request requires ([`Prompt::required_capabilities`]) and\nrestrict the chain to providers advertising all of them.",
+      "oneOf": [
+        {
+          "description": "JSON-Schema-constrained output — [`ResponseFormat::JsonSchema`].",
+          "type": "string",
+          "const": "structured_outputs"
+        },
+        {
+          "description": "Tool / function calling — the request supplies a non-empty tool list.",
+          "type": "string",
+          "const": "tools"
+        },
+        {
+          "description": "Extended reasoning / thinking — the request sets a reasoning-effort hint.",
+          "type": "string",
+          "const": "reasoning"
+        },
+        {
+          "description": "Provider-side web search / browsing.",
+          "type": "string",
+          "const": "web_search"
+        },
+        {
+          "description": "Token log-probabilities in the response.",
+          "type": "string",
+          "const": "logprobs"
+        },
+        {
+          "description": "Image input (vision) — a message carries an `image/*` file part.",
+          "type": "string",
+          "const": "image_input"
+        },
+        {
+          "description": "Audio input — a message carries an `audio/*` file part.",
+          "type": "string",
+          "const": "audio_input"
+        },
+        {
+          "description": "Video input — a message carries a `video/*` file part.",
+          "type": "string",
+          "const": "video_input"
+        },
+        {
+          "description": "Document / file input — a message carries a non-image/audio/video file\npart (e.g. `application/pdf`).",
+          "type": "string",
+          "const": "file_input"
+        },
+        {
+          "description": "Image output (generation) — the request asks for an `image` output\nmodality.",
+          "type": "string",
+          "const": "image_output"
+        },
+        {
+          "description": "Audio output (speech) — the request asks for an `audio` output modality.",
+          "type": "string",
+          "const": "audio_output"
+        }
       ]
     },
     "ModelCompatibility": {

--- a/dist/schema/bitrouter.config.schema.json
+++ b/dist/schema/bitrouter.config.schema.json
@@ -615,7 +615,7 @@
           ]
         },
         "capabilities": {
-          "description": "Features this concrete provider/model route explicitly advertises.\nAn empty list means unknown, not unsupported; capability-constrained\nrouting admits only positive declarations.",
+          "description": "Features this concrete provider/model route explicitly advertises.\nAn empty list means unknown, not unsupported. Runtime routing preserves\nlegacy unknown entries; policy code that grants a capability-specific\nexception requires a positive declaration.",
           "type": "array",
           "items": {
             "$ref": "#/$defs/Capability"

--- a/docs/AGENTIC_OPTIMIZATION_SPEC.md
+++ b/docs/AGENTIC_OPTIMIZATION_SPEC.md
@@ -20,18 +20,19 @@ The primary flow is:
 
 ```text
 bitrouter init
-bitrouter optimize run
-bitrouter optimize review
-bitrouter optimize publish --enable-adaptive
+bitrouter optimize run --human
+bitrouter optimize review --human
+bitrouter optimize publish
 ```
 
-`bitrouter init` can create two version-controlled files after the user opts
+`bitrouter init` can create three version-controlled files after the user opts
 into workflow optimization:
 
 - `bitrouter.optimize.yaml`: human-authored intent, workflow command, success
   contract, route ladder, evaluator choice, and qualitative trade-off.
 - `bitrouter.optimize.lock.yaml`: resolved evaluator/runtime identities,
   content digests, active policy lineage, and latest candidate state.
+- `bitrouter.eval.md`: observable, user-editable workflow success contract.
 
 Private workflow output and model replies are stored under the BitRouter home,
 not in the source repository. The lock contains only identities, digests, and
@@ -205,11 +206,12 @@ inconclusive.
 `optimize publish` revalidates the candidate parent digest, optimization lock,
 Eval snapshot, and source config. It then delegates to the existing atomic
 policy/config publication and daemon reload path. A frozen project requires
-the explicit first-publication consent `--enable-adaptive`; setup never changes
-that safety mode. The transition is idempotently
+explicit first-publication consent: an attached TTY shows the reviewed run and
+asks for confirmation, while headless/CI use requires `--enable-adaptive`.
+Setup never changes that safety mode. The transition is idempotently
 recoverable if the process exits after the policy write but before the
-optimization-lock compare-and-swap. No interactive prompt is required, but
-publication is always a distinct command. `optimize rollback` restores an
+optimization-lock compare-and-swap. Publication is always a distinct command.
+`optimize rollback` restores an
 archived policy and changes the optimization lock's active digest in the same
 recoverable workflow, keeping the next experiment's parent lineage usable.
 
@@ -224,6 +226,13 @@ bitrouter optimize publish [--run ID] [--enable-adaptive] [--config FILE]
 bitrouter optimize rollback DIGEST [--config FILE] [--socket PATH]
 bitrouter optimize status [--config FILE]
 ```
+
+Interactive `setup` may omit workflow and route flags. It deterministically
+discovers repository-owned eval/benchmark package scripts and executable
+entrypoints, adopts a unique candidate, prompts on ambiguity, and reuses an
+existing `@auto` strong/economy ladder when present. If repository facts are
+insufficient it asks for exact argv/model ids; non-interactive execution fails
+before mutation and prints the required explicit flags.
 
 Headless setup accepts exact argv rather than a shell program:
 
@@ -246,6 +255,9 @@ which starts a fresh lineage.
 
 Controlled execution is Unix-only in this version. Windows setup fails before
 creating files until Job Object process-tree cleanup is implemented.
+An active progress guard is also rejected before mutation: the current exact
+two-tier experiment cannot preserve guard runtime semantics and never clears or
+reinterprets the guard as a convenience.
 
 ## Failure behavior
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -369,9 +369,9 @@ The lock contains deterministic routes, tiers, and learning thresholds, but no a
 ### `bitrouter optimize`
 
 ```text
-bitrouter optimize setup --workflow-command CMD [--workflow-arg ARG ...] \
+bitrouter optimize setup [--workflow-command CMD] [--workflow-arg ARG ...] \
   [--workflow-input PATH ...] \
-  --strong PROVIDER:MODEL --economy PROVIDER:MODEL \
+  [--strong PROVIDER:MODEL] [--economy PROVIDER:MODEL] \
   [--normalized-price PROVIDER:MODEL=INPUT,CACHE_READ,CACHE_WRITE,OUTPUT] \
   [--preference PROFILE]
 bitrouter optimize resolve [--config bitrouter.optimize.yaml]
@@ -385,7 +385,12 @@ bitrouter optimize status [--config bitrouter.optimize.yaml]
 `optimize` is the version-controlled quality/cost loop for an arbitrary agent
 workflow. `setup` creates `bitrouter.optimize.yaml`,
 `bitrouter.optimize.lock.yaml`, and a success-contract starter without
-overwriting existing files. The workflow is launched without shell parsing;
+overwriting existing files. With omitted workflow flags, interactive setup
+discovers project-owned eval/benchmark package scripts and executable
+entrypoints, selects a unique candidate automatically, and prompts when more
+than one is plausible. It reuses an existing `@auto` strong/economy ladder;
+otherwise a TTY asks for both routes. Non-interactive ambiguity fails before
+any file mutation and reports the exact flags to supply. The workflow is launched without shell parsing;
 user argv boundaries are preserved after any catalog-owned routing prefix for
 a recognized agent. Common OpenAI, Anthropic, Gemini, and BitRouter client
 variables are pointed at a fresh private daemon using the configured preset.
@@ -435,8 +440,9 @@ the exact report, snapshot, candidate, parent policy, and lock lineage before
 using the atomic policy publication and daemon-reload path. Publication is
 idempotent: if the policy write succeeded before an interrupted lock update,
 rerunning the command completes that lock transition. The first publication
-from the default frozen mode requires explicit `--enable-adaptive`; setup does
-not silently widen policy permissions. `optimize rollback`
+from the default frozen mode asks for explicit confirmation on a TTY;
+headless/CI publication requires `--enable-adaptive`. Setup does not silently
+widen policy permissions. `optimize rollback`
 restores an archived policy digest and updates the optimization lock so the
 next cycle starts from the restored parent; it can also reconcile a matching
 rollback previously made through `bitrouter policy rollback`.
@@ -446,6 +452,8 @@ automation supplies `--optimize-workflow-command`, repeated
 `--optimize-workflow-arg`/`--optimize-workflow-input`, and
 `--optimize-success`; model and preference flags remain optional. Optimization
 setup is currently Unix-only.
+Setup also rejects an active progress guard before mutation because the exact
+two-tier experiment cannot preserve guard semantics yet.
 
 ### `bitrouter trajectory`
 

--- a/registry/providers/bitrouter.yaml
+++ b/registry/providers/bitrouter.yaml
@@ -420,6 +420,7 @@ models:
         text: 25
   - id: deepseek/deepseek-v4-flash-0731
     provider_model_id: deepseek/deepseek-v4-flash-0731
+    capabilities: [reasoning, tools]
     pricing:
       input_tokens:
         no_cache: 0.14

--- a/skills/bitrouter/references/workflow-optimization.md
+++ b/skills/bitrouter/references/workflow-optimization.md
@@ -14,8 +14,12 @@ Interactive:
 bitrouter init
 ```
 
-Choose workflow optimization, provide the exact workflow argv and an
-observable success contract, then choose a qualitative preference. Do not
+Choose workflow optimization, confirm a discovered workflow (or provide exact
+argv), provide an observable success contract, then choose a qualitative
+preference. Setup proposes repository-owned eval/benchmark package scripts and
+executable entrypoints; it adopts one unambiguous candidate automatically and
+offers a numbered choice when several are plausible. Ordinary unit-test
+scripts and symlink escapes are not guessed. Do not
 promise fixed quality-loss or latency percentages: latency is observe-only in
 this release and the user's eval data determines the actual trade-off.
 
@@ -55,9 +59,10 @@ a claim of marginal cash spend.
 ## Evolve one route at a time
 
 ```bash
-bitrouter optimize run
-bitrouter optimize review
-bitrouter optimize publish --enable-adaptive # first publication from frozen mode
+bitrouter optimize run --human
+bitrouter optimize review --human
+bitrouter optimize publish # confirms the first frozen -> adaptive publication on a TTY
+# Headless/CI first publication: bitrouter optimize publish --enable-adaptive
 # Optional: restore a prior policy while keeping the optimization lock aligned.
 bitrouter optimize rollback sha256:<digest>
 ```
@@ -73,6 +78,9 @@ observed latency, the route-key change, and content digests. `run` never changes
 active policy. `publish` is a separate explicit action and rejects stale or
 mismatched lineage. Run the loop again after publication to optimize another
 eligible route key.
+
+The stable public model is `@auto`. Internal policy and preset keys remain
+`auto`; do not document or send `bitrouter/auto` as an alias.
 
 Profiles:
 
@@ -90,6 +98,11 @@ If the workflow uses ignored/generated inputs (for example `node_modules`,
 setup or `--optimize-workflow-input` during onboarding. BitRouter freezes the
 same manifest into two detached Git worktrees. Controlled execution is
 currently Unix-only.
+
+The controlled two-tier experiment does not yet preserve a signed
+`progress_guard`. Setup checks every active policy before writing any
+optimization file and asks the user to use an unguarded `@auto` lineage rather
+than silently changing guard semantics.
 
 ## Failure interpretation
 


### PR DESCRIPTION
## Outcome

Make `@auto` the single public model for the workflow-optimization loop and turn the merged #777 control plane into a guided, auditable first-run experience.

This PR deliberately keeps routing generic: the online daemon sees canonical request traces and provider-qualified routes, never benchmark labels, task answers, framework names, or workflow-specific routing keys. Every baseline and candidate tier continues to execute through the private BitRouter daemon. The ACP agent is an independent quality judge only; it is not a tier backend.

## Product decisions

- Public model: `@auto`. `bitrouter/auto` is not introduced as an alias.
- Setup may discover project-owned eval/benchmark entrypoints, but it never invents a task or silently adopts an ordinary unit-test command.
- Exact argv flags remain the deterministic automation contract.
- Existing `@auto` strong/economy tiers are reused; otherwise a TTY asks for provider-qualified routes and headless execution fails before mutation with exact remediation flags.
- Quality profiles remain qualitative search-order preferences. This release requires an agentic pass plus lower normalized showback cost; latency is observe-only.
- First publication from frozen mode requires affirmative TTY consent or `--enable-adaptive` in headless/CI execution.
- Signed progress-guard semantics are not approximated. Setup rejects an active guard before writing any optimization artifact.

## Changes

### Guided workflow setup

- Discover semantic `package.json` scripts using the repository's package manager.
- Discover bounded project executables from conventional project entrypoint directories.
- Skip generic test helpers, direct symlinks, symlinked search roots, and path escapes.
- Deterministically sort candidates; auto-adopt exactly one and present numbered choices on a TTY.
- Share the discovery path with `bitrouter init --optimize`.
- Preserve `--workflow-command` plus repeated `--workflow-arg` as exact, shell-free argv.

### `@auto` review loop

- Add typed human/JSON reports for setup, run/review, and status.
- Lead review with the two coupled outcomes users care about: agentic quality and normalized cost delta.
- Show latency explicitly as observe-only, plus route key, candidate digest, lineage state, and the exact next command.
- Preserve evaluator/runtime lock details in structured output.

### Safety

- Keep setup and publication separate; setup never enables adaptive mode.
- Add interactive frozen-to-adaptive publication consent while retaining a non-interactive explicit flag.
- Reject active progress guards before any setup mutation.
- Keep workflow discovery provider/model/task neutral.

### Shippable contract

- Update the in-repo CLI reference, implementation contract, and bundled BitRouter skill.
- Document `@auto` consistently and distinguish workflow tiers (daemon routes) from the direct/cloud evaluator authority.

## Relationship to bitrouter-docs#65

This implements the proposal's useful product arc—`@auto` → measure → review → publish—while correcting the speculative parts:

- `@auto`, not `bitrouter/auto`;
- real guided setup rather than a fictional zero-input command;
- real captured review output rather than invented terminal text;
- local daemon routing for every tier, not hosted-bypass semantics;
- separate direct/cloud judge authority;
- explicit normalized-showback and latency limitations.

A stacked docs PR will update #65's branch after the installed binary passes the clean-host walkthrough.

## Verification completed

- `cargo clippy --workspace --all-features --tests -- -D warnings`
- `cargo run -p dist-helper -- check`
- `cargo fmt --all -- --check`
- `cargo nextest run --workspace --all-features`
  - 2,678 passed
  - 11 existing conditional skips
- `git diff --check`

## Merge-readiness gates still running

- Install this branch into an isolated prefix and invoke only the resulting `bitrouter` from `PATH`.
- Back up the host BitRouter state, start from default directories, and restore only an authorized OAuth credential copy.
- Run setup → status → baseline/candidate → review → publish/rollback on a fresh real agent workflow.
- Prove real daemon decisions, normalized metering, evaluator evidence, exact cleanup, and host-state restoration.
- Capture the verified terminal output for the stacked docs PR.
- Complete CI and final review; remove draft status only after these gates pass.