### PR TITLE
fix(launch): say `launch:` not `spawn:` in console output

### DIFF
--- a/apps/bitrouter/src/acp_cli.rs
+++ b/apps/bitrouter/src/acp_cli.rs
@@ -543,7 +543,7 @@ pub async fn serve(ctx: SpawnContext<'_>) -> Result<()> {
     // opted out. Fail fast to stderr — before speaking any ACP — so a manager
     // handles "child failed to start" rather than a mid-session provider error.
     if let Err(e) = apply_routing(source, &mut config, agent_id, &routing).await {
-        eprintln!("spawn: {}\n  hint: {}", e.message(), e.hint());
+        eprintln!("error: {}\n  hint: {}", e.message(), e.hint());
         std::process::exit(1);
     }
     let catalog = catalog_from_config(&config)?;

--- a/apps/bitrouter/src/spawn.rs
+++ b/apps/bitrouter/src/spawn.rs
@@ -215,7 +215,7 @@ impl SpawnCheckReport {
 impl CliReport for SpawnCheckReport {
     fn render(&self, h: &mut Human<'_>) -> std::io::Result<()> {
         h.line(&format!(
-            "spawn check for {} via {}",
+            "preflight for {} via {}",
             self.agent, self.base_url
         ))?;
         if let Some(model) = &self.model {
@@ -334,7 +334,7 @@ pub async fn run(
         // daemon itself borrows as providers — routing them through BitRouter
         // would loop back to the same backend on the same credential.
         eprintln!(
-            "{cyan}{bold}spawn:{reset} launching {bold}{agent_id}{reset} with its own \
+            "{cyan}{bold}launch:{reset} launching {bold}{agent_id}{reset} with its own \
              subscription auth — not routed through BitRouter",
             cyan = p.cyan,
             bold = p.bold,
@@ -342,7 +342,7 @@ pub async fn run(
         );
     } else {
         eprintln!(
-            "{cyan}{bold}spawn:{reset} launching {bold}{agent_id}{reset} via BitRouter ({})",
+            "{cyan}{bold}launch:{reset} launching {bold}{agent_id}{reset} via BitRouter ({})",
             base_url,
             cyan = p.cyan,
             bold = p.bold,
@@ -408,7 +408,7 @@ async fn print_exit_summary(
         return;
     }
     eprintln!(
-        "{cyan}{bold}spawn:{reset} session spend {bold}{}{reset} ({} requests) · today {}",
+        "{cyan}{bold}launch:{reset} session spend {bold}{}{reset} ({} requests) · today {}",
         crate::metering::fmt_usd(session.spend_micro_usd),
         session.requests,
         crate::metering::fmt_usd(today.spend_micro_usd),
@@ -1214,9 +1214,10 @@ impl InstallCommand {
     async fn run(&self) -> Result<()> {
         let p = Palette::for_stderr();
         eprintln!(
-            "{cyan}spawn:{reset} installing — {}",
+            "{cyan}{bold}info:{reset} installing — {}",
             self.human,
             cyan = p.cyan,
+            bold = p.bold,
             reset = p.reset,
         );
         let status = tokio::process::Command::new(self.program)


### PR DESCRIPTION
Fixes item 1 of #794, plus the identical-class defects a sweep turned up. Deliberately scoped — the other ten items in #794 are untouched.

## The reported bug

`bitrouter launch` prefixed its output with `spawn:`, which is now a **different command** (`spawn` runs a headless ACP sub-agent; `spawn --agent` survives only as a hidden deprecated alias). It printed on every launch of all eight harnesses.

## The actual bug underneath

`<command>:` was never the convention here. The house style on stderr is **severity heads** — `error:`, `note:`, `info:`, `hint:`, `warning:` (39 uses across `apps/` and `crates/`). `spawn.rs` was the only place using a command name as a head.

So renaming everything to `launch:` would have entrenched the mistake. Three of the five sites were shared across commands and became severity heads instead:

| Site | Was | Now | Why |
|---|---|---|---|
| `spawn.rs:337,345,411` | `spawn:` | `launch:` | The launcher's own identity line — the one place a command name belongs |
| `spawn.rs:1217` | `spawn: installing` | `info:` | Reached from `launch`, the `init` wizard, **and** `providers login claude-code` — named the wrong command in *every* caller. Matches the sibling `info: agent \`x\` is not installed` a few lines earlier in the same flow |
| `acp_cli.rs:546` | `spawn: {msg}` | `error:` | Reached from both `spawn --serve` and `acp serve`. Its own `hint:` continuation already pairs with `error:` |
| `spawn.rs:218` | `spawn check for <agent>` | `preflight for <agent>` | This is what `launch --check` printed. "Preflight" is already the codebase's word for it (clap help at `main.rs:1770`, and the report's own doc comments) |

## Shared `launch` / deprecated-`spawn` path

`spawn.rs` backs both, so the banner sites are shared. Resolved as a static `launch:` — it names the command users should be running, which is the point of the fix. The deprecated alias already prints its own notice first, verified live, so the sequence reads coherently:

```
note: `bitrouter spawn --agent` is deprecated — use `bitrouter launch --agent claude` (this alias will be removed).
launch: launching claude via BitRouter (http://127.0.0.1:4356)
```

No extra notice was needed.

## Deliberately not changed

- `main.rs:1719`, `main.rs:1769` — `bail!("spawn: …")`. Both sit in the `Command::Spawn` arm *after* the legacy-alias early return, so `spawn` is the correct verb there.
- `acp_cli.rs:580` — `anyhow!("acp serve: {e}")` is error context, not a console head; it names the loop that failed, accurately, and renders under `error:` upstream.
- `spawn.rs:244` — doc comment still says *"Run `bitrouter spawn`"*. That is #794 item 5, out of scope here; whoever takes that item should fold it in.

## Before / after

```
# before
launch -a claude          spawn: launching claude via BitRouter (http://127.0.0.1:4356)
launch -a grok            spawn: launching grok with its own subscription auth — not routed
launch -a grok --check    spawn check for grok via http://127.0.0.1:4356

# after
launch -a claude          launch: launching claude via BitRouter (http://127.0.0.1:4356)
launch -a grok            launch: launching grok with its own subscription auth — not routed
launch -a grok --check    preflight for grok via http://127.0.0.1:4356
```

Driven through the real banner path (`--no-start -- --version`), not just `--check`.

## Verification

```
cargo nextest run --all-features --no-fail-fast  →  2424 passed, 11 skipped
cargo clippy --all-features --workspace --all-targets  →  clean
cargo fmt --all -- --check  →  clean
RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --workspace  →  clean
cargo run -p dist-helper -- check  →  up to date
```

No test asserted on any changed string. Grepped `skills/`, `docs/`, `README.md`, and the three plugin manifests for quoted output — no lockstep updates needed.

**One caveat:** the exit-summary line (`spawn.rs:411`) is reviewed but not executed — `print_exit_summary` returns early when the metering DB recorded zero requests in the session window. It is a literal swap in the same format string as the two banners that were verified live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
