### PR TITLE
fix(registry): advertise tool-capable routes

### DIFF
--- a/dist/registry/models.json
+++ b/dist/registry/models.json
@@ -156,6 +156,9 @@
       "providers": [
         {
           "api_protocol": "anthropic",
+          "capabilities": [
+            "tools"
+          ],
           "pricing": {
             "input_tokens": {
               "cache_read": 0.1,
@@ -195,6 +198,9 @@
         },
         {
           "api_protocol": "openai",
+          "capabilities": [
+            "tools"
+          ],
           "pricing": {
             "input_tokens": {
               "cache_read": 0.1,
@@ -243,6 +249,9 @@
             "openai",
             "responses",
             "anthropic"
+          ],
+          "capabilities": [
+            "tools"
           ],
           "pricing": {
             "input_tokens": {
@@ -6179,6 +6188,9 @@
             "responses",
             "anthropic"
           ],
+          "capabilities": [
+            "tools"
+          ],
           "pricing": {
             "input_tokens": {
               "cache_read": 0.25,
@@ -6201,6 +6213,9 @@
             "responses",
             "anthropic"
           ],
+          "capabilities": [
+            "tools"
+          ],
           "pricing": {
             "input_tokens": {
               "cache_read": 0.167,
@@ -6219,6 +6234,9 @@
         },
         {
           "api_protocol": "openai",
+          "capabilities": [
+            "tools"
+          ],
           "pricing": {
             "input_tokens": {
               "cache_read": 0.25,
@@ -6242,6 +6260,9 @@
             "openai",
             "responses",
             "anthropic"
+          ],
+          "capabilities": [
+            "tools"
           ],
           "pricing": {
             "input_tokens": {

--- a/dist/registry/providers.json
+++ b/dist/registry/providers.json
@@ -27,6 +27,9 @@
             "responses",
             "anthropic"
           ],
+          "capabilities": [
+            "tools"
+          ],
           "id": "qwen/qwen3.8-max",
           "pricing": {
             "input_tokens": {
@@ -281,6 +284,9 @@
             "openai",
             "responses",
             "anthropic"
+          ],
+          "capabilities": [
+            "tools"
           ],
           "id": "qwen/qwen3.8-max",
           "pricing": {
@@ -1081,6 +1087,9 @@
         },
         {
           "api_protocol": "anthropic",
+          "capabilities": [
+            "tools"
+          ],
           "id": "anthropic/claude-haiku-4.5",
           "pricing": {
             "input_tokens": {
@@ -2272,6 +2281,9 @@
         },
         {
           "api_protocol": "openai",
+          "capabilities": [
+            "tools"
+          ],
           "id": "anthropic/claude-haiku-4.5",
           "pricing": {
             "input_tokens": {
@@ -2978,6 +2990,9 @@
         },
         {
           "api_protocol": "openai",
+          "capabilities": [
+            "tools"
+          ],
           "id": "qwen/qwen3.8-max",
           "pricing": {
             "input_tokens": {
@@ -6031,6 +6046,9 @@
             "responses",
             "anthropic"
           ],
+          "capabilities": [
+            "tools"
+          ],
           "id": "anthropic/claude-haiku-4.5",
           "pricing": {
             "input_tokens": {
@@ -6198,6 +6216,9 @@
             "openai",
             "responses",
             "anthropic"
+          ],
+          "capabilities": [
+            "tools"
           ],
           "id": "qwen/qwen3.8-max",
           "pricing": {

--- a/registry/providers/alibaba.yaml
+++ b/registry/providers/alibaba.yaml
@@ -21,6 +21,7 @@ rate_limits:
       requests_per_minute: 60
 models:
   # Official pricing: https://www.qwencloud.com/models/qwen3.8-max
+  # Official function-calling docs: https://docs.qwencloud.com/developer-guides/text-generation/function-calling
   - id: qwen/qwen3.8-max
     provider_model_id: qwen3.8-max
     pricing:
@@ -30,6 +31,7 @@ models:
         cache_write: 2.5
       output_tokens:
         text: 6
+    capabilities: [tools]
   - id: qwen/qwen3.7-max
     provider_model_id: qwen3.7-max
     pricing:

--- a/registry/providers/alibaba_cn.yaml
+++ b/registry/providers/alibaba_cn.yaml
@@ -21,6 +21,7 @@ models:
   # CNY 12/1.2/15/36 converted at ~7.2 CNY/USD.
   # Sources: https://help.aliyun.com/zh/model-studio/model-pricing
   # and https://help.aliyun.com/zh/model-studio/context-cache
+  # Official function-calling docs: https://docs.qwencloud.com/developer-guides/text-generation/function-calling
   - id: qwen/qwen3.8-max
     provider_model_id: qwen3.8-max
     pricing:
@@ -30,6 +31,7 @@ models:
         cache_write: 2.083
       output_tokens:
         text: 5
+    capabilities: [tools]
   - id: qwen/qwen3.7-max
     provider_model_id: qwen3.7-max
     pricing:

--- a/registry/providers/anthropic.yaml
+++ b/registry/providers/anthropic.yaml
@@ -104,6 +104,7 @@ models:
         cache_write: 12.5
       output_tokens:
         text: 50
+  # Official tool-use docs: https://platform.claude.com/docs/en/agents-and-tools/tool-use/overview
   - id: anthropic/claude-haiku-4.5
     provider_model_id: claude-haiku-4-5
     pricing:
@@ -113,6 +114,7 @@ models:
         cache_write: 1.25
       output_tokens:
         text: 5
+    capabilities: [tools]
   - id: anthropic/claude-opus-5
     provider_model_id: claude-opus-5
     pricing:

--- a/registry/providers/bitrouter.yaml
+++ b/registry/providers/bitrouter.yaml
@@ -24,6 +24,7 @@ models:
         cache_write: 12.5
       output_tokens:
         text: 50
+  # Official tool-use docs: https://platform.claude.com/docs/en/agents-and-tools/tool-use/overview
   - id: anthropic/claude-haiku-4.5
     provider_model_id: anthropic/claude-haiku-4.5
     pricing:
@@ -33,6 +34,7 @@ models:
         cache_write: 1.25
       output_tokens:
         text: 5
+    capabilities: [tools]
   - id: anthropic/claude-opus-4.6
     provider_model_id: anthropic/claude-opus-4.6
     pricing:
@@ -427,6 +429,7 @@ models:
         cache_read: 0.028
       output_tokens:
         text: 0.28
+  # Official function-calling docs: https://docs.qwencloud.com/developer-guides/text-generation/function-calling
   - id: qwen/qwen3.8-max
     provider_model_id: qwen/qwen3.8-max
     pricing:
@@ -436,6 +439,7 @@ models:
         cache_write: 2.5
       output_tokens:
         text: 6
+    capabilities: [tools]
 status: active
 weight: 1
 community: false

--- a/registry/providers/openrouter.yaml
+++ b/registry/providers/openrouter.yaml
@@ -172,6 +172,7 @@ models:
         cache_write: 3.75
       output_tokens:
         text: 15
+  # OpenRouter catalog: https://openrouter.ai/api/v1/models
   - id: anthropic/claude-haiku-4.5
     provider_model_id: anthropic/claude-haiku-4.5
     pricing:
@@ -181,6 +182,7 @@ models:
         cache_write: 1.25
       output_tokens:
         text: 5
+    capabilities: [tools]
   - id: anthropic/claude-opus-4.7
     provider_model_id: anthropic/claude-opus-4.7
     pricing:
@@ -250,7 +252,7 @@ models:
         cache_write: 1.84375
       output_tokens:
         text: 4.425
-  # Live catalog: https://openrouter.ai/api/v1/models
+  # OpenRouter tool support catalog: https://openrouter.ai/api/v1/models
   - id: qwen/qwen3.8-max
     provider_model_id: qwen/qwen3.8-max
     pricing:
@@ -260,6 +262,7 @@ models:
         cache_write: 2.5
       output_tokens:
         text: 6
+    capabilities: [tools]
   - id: qwen/qwen3.6-flash
     provider_model_id: qwen/qwen3.6-flash
     pricing:


### PR DESCRIPTION
## Summary

- advertise verified tool support for Claude Haiku 4.5 and Qwen3.8 Max routes
- rebuild the public registry artifacts so routing and `/v1/models` see the capability
- preserve fail-closed capability routing

## Root cause

The affected provider-model entries omitted `capabilities: [tools]`, so tool-bearing requests had no eligible provider even though the upstreams support tool calling.

## Validation

- `cargo run -p dist-helper -- registry validate`
- `cargo run -p dist-helper -- registry build`
- `cargo run -p dist-helper -- check`
- generated provider/model catalog `jq -e` assertions
- `git diff --check`

Closes #783