### PR TITLE
fix(config): make server.log_level set the log filter

### DIFF
--- a/apps/bitrouter/src/main.rs
+++ b/apps/bitrouter/src/main.rs
@@ -2450,33 +2450,119 @@ async fn resolve_client_socket(config: Option<&Path>, socket: Option<&Path>) -> 
 
 // ===== tracing subscriber init =====
 
+/// The filter used when neither `RUST_LOG` nor `server.log_level` supplies a
+/// usable one.
+const DEFAULT_LOG_FILTER: &str = "info";
+
+/// Resolve the tracing filter. Precedence, highest first:
+///
+/// 1. **`RUST_LOG`** — the Rust convention, and the escape hatch an operator
+///    reaches for during an incident without editing (and reloading) config.
+/// 2. **`server.log_level`** from `bitrouter.yaml`. Only `serve` has a config
+///    loaded this early; every other command passes `None`, because its
+///    subscriber is installed before any config is read.
+/// 3. **`info`**.
+///
+/// Returns the filter plus an optional warning. Nothing can be logged before
+/// the subscriber this feeds is installed, so an unparseable filter string is
+/// handed back for the caller to emit *after* `init()` rather than silently
+/// swallowed — the same deferred-diagnostic shape `serve` already uses for
+/// OTel init errors.
+fn resolve_env_filter(
+    config_log_level: Option<&str>,
+) -> (tracing_subscriber::EnvFilter, Option<String>) {
+    // `EnvFilter::try_from_default_env` collapses "unset" and "set but
+    // invalid" into one `Err`, which is exactly the distinction that decides
+    // whether the config value gets a turn — so read the variable directly.
+    let rust_log = std::env::var(tracing_subscriber::EnvFilter::DEFAULT_ENV).ok();
+    resolve_env_filter_from(rust_log.as_deref(), config_log_level)
+}
+
+/// The precedence logic behind [`resolve_env_filter`], with the environment
+/// passed in so it is testable without mutating process-global state.
+fn resolve_env_filter_from(
+    rust_log: Option<&str>,
+    config_log_level: Option<&str>,
+) -> (tracing_subscriber::EnvFilter, Option<String>) {
+    let non_blank = |s: &&str| !s.trim().is_empty();
+    let (source, raw) = match (
+        rust_log.filter(non_blank),
+        config_log_level.filter(non_blank),
+    ) {
+        (Some(raw), _) => (tracing_subscriber::EnvFilter::DEFAULT_ENV, raw),
+        (None, Some(level)) => ("server.log_level", level),
+        (None, None) => return (tracing_subscriber::EnvFilter::new(DEFAULT_LOG_FILTER), None),
+    };
+    match parse_log_filter(raw) {
+        Ok(filter) => (filter, None),
+        Err(reason) => (
+            tracing_subscriber::EnvFilter::new(DEFAULT_LOG_FILTER),
+            Some(format!(
+                "invalid {source} value {raw:?}: {reason} — falling back to `{DEFAULT_LOG_FILTER}`"
+            )),
+        ),
+    }
+}
+
+/// Parse one filter string, rejecting the failure mode `EnvFilter` itself
+/// won't.
+///
+/// `EnvFilter::try_new("dbug")` **succeeds**: with no directive syntax present
+/// it reads the word as a *target* named `dbug` at trace level. The resulting
+/// filter matches nothing, so a one-character typo in `log_level` silently
+/// mutes the daemon instead of erroring — the worst possible outcome for a
+/// logging setting. So a bare word (no `=`, no `,`) must parse as a level;
+/// anything carrying directive syntax is handed to `EnvFilter` as-is.
+fn parse_log_filter(raw: &str) -> std::result::Result<tracing_subscriber::EnvFilter, String> {
+    let raw = raw.trim();
+    if !raw.contains('=')
+        && !raw.contains(',')
+        && raw
+            .parse::<tracing_subscriber::filter::LevelFilter>()
+            .is_err()
+    {
+        return Err(
+            "expected a level (`trace`, `debug`, `info`, `warn`, `error`, `off`) or an \
+             `EnvFilter` directive list such as `info,bitrouter=debug`"
+                .to_string(),
+        );
+    }
+    tracing_subscriber::EnvFilter::try_new(raw).map_err(|e| e.to_string())
+}
+
 /// Install a basic fmt-only tracing subscriber. Used for every command
 /// except `serve` and the `acp` subcommands — see
 /// [`init_serve_tracing_subscriber`] and [`init_stderr_tracing_subscriber`].
+///
+/// Runs before any config is read, so `RUST_LOG` is the only input.
 fn init_basic_tracing_subscriber() {
+    let (env_filter, warning) = resolve_env_filter(None);
     tracing_subscriber::fmt()
         // Diagnostics MUST go to stderr so stdout stays a pure JSON result
         // surface (`tracing_subscriber::fmt()` otherwise defaults to stdout).
         .with_writer(std::io::stderr)
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
-        )
+        .with_env_filter(env_filter)
         .init();
+    if let Some(warning) = warning {
+        tracing::warn!("{warning}");
+    }
 }
 
 /// Install a tracing subscriber that writes to **stderr**. Used for the `acp`
 /// subcommands, which keep stdout exclusively for their machine-readable
 /// protocol stream (JSON-RPC for `acp serve`, NDJSON for `acp prompt`) —
 /// logging on stdout would corrupt the stream the caller parses.
+///
+/// Runs before any config is read, so `RUST_LOG` is the only input.
 fn init_stderr_tracing_subscriber() {
+    let (env_filter, warning) = resolve_env_filter(None);
     tracing_subscriber::fmt()
         .with_writer(std::io::stderr)
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
-        )
+        .with_env_filter(env_filter)
         .init();
+    if let Some(warning) = warning {
+        tracing::warn!("{warning}");
+    }
 }
 
 /// Install the full tracing subscriber for the `serve` command: fmt plus
@@ -2487,11 +2573,18 @@ fn init_stderr_tracing_subscriber() {
 /// so this MUST be called after [`bitrouter_observe::otel::OtelExporter::new`]
 /// has built the real exporter; passing `None` (OTel disabled in config)
 /// installs the fmt-only registry.
-fn init_serve_tracing_subscriber(exporter: Option<&bitrouter_observe::otel::OtelExporter>) {
+///
+/// This is the one path with a config in hand, so it is where
+/// `server.log_level` takes effect. Resolution happens once here — a later
+/// `bitrouter reload` re-reads the config but cannot re-install the
+/// subscriber, so a changed `log_level` needs a restart.
+fn init_serve_tracing_subscriber(
+    exporter: Option<&bitrouter_observe::otel::OtelExporter>,
+    config_log_level: &str,
+) {
     use tracing_subscriber::layer::SubscriberExt;
     use tracing_subscriber::util::SubscriberInitExt;
-    let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
-        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
+    let (env_filter, warning) = resolve_env_filter(Some(config_log_level));
     let registry = tracing_subscriber::registry()
         .with(env_filter)
         .with(tracing_subscriber::fmt::layer());
@@ -2500,6 +2593,9 @@ fn init_serve_tracing_subscriber(exporter: Option<&bitrouter_observe::otel::Otel
             .with(bitrouter_observe::otel::http_layer::tracing_subscriber_layer(exp))
             .init(),
         None => registry.init(),
+    }
+    if let Some(warning) = warning {
+        tracing::warn!("{warning}");
     }
 }
 
@@ -2581,7 +2677,7 @@ async fn serve(source: &bitrouter::paths::ConfigSource) -> Result<()> {
     // Hand its SDK tracer to the `tracing-opentelemetry` bridge layer now
     // — the bridge captures its tracer at construction, so this can only
     // happen after the exporter exists.
-    init_serve_tracing_subscriber(assembled.otel_exporter.as_deref());
+    init_serve_tracing_subscriber(assembled.otel_exporter.as_deref(), &cfg.server.log_level);
     // Surface any deferred OTel-init failure now that the subscriber is up.
     if let Some(msg) = &assembled.otel_init_error {
         tracing::error!("{msg}");
@@ -5264,6 +5360,109 @@ fn process_is_alive(pid: u32) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ===== tracing filter resolution =====
+
+    #[test]
+    fn config_log_level_is_used_when_rust_log_is_unset() {
+        let (filter, warning) = resolve_env_filter_from(None, Some("debug"));
+        assert_eq!(filter.to_string(), "debug");
+        assert!(warning.is_none());
+    }
+
+    #[test]
+    fn config_log_level_accepts_per_target_filter_syntax() {
+        let (filter, warning) = resolve_env_filter_from(None, Some("warn,bitrouter=trace"));
+        // `EnvFilter`'s `Display` does not preserve directive order.
+        let rendered = filter.to_string();
+        assert!(rendered.contains("warn"), "{rendered}");
+        assert!(rendered.contains("bitrouter=trace"), "{rendered}");
+        assert!(warning.is_none());
+    }
+
+    #[test]
+    fn rust_log_wins_over_config_log_level() {
+        let (filter, warning) = resolve_env_filter_from(Some("trace"), Some("error"));
+        assert_eq!(filter.to_string(), "trace");
+        assert!(warning.is_none());
+    }
+
+    #[test]
+    fn defaults_to_info_when_neither_source_is_set() {
+        let (filter, warning) = resolve_env_filter_from(None, None);
+        assert_eq!(filter.to_string(), DEFAULT_LOG_FILTER);
+        assert!(warning.is_none());
+    }
+
+    #[test]
+    fn blank_sources_fall_through_rather_than_erroring() {
+        // An empty `RUST_LOG=` must not shadow a real config value, and a
+        // blank `log_level: ""` must not be treated as a filter.
+        let (filter, warning) = resolve_env_filter_from(Some("  "), Some("debug"));
+        assert_eq!(filter.to_string(), "debug");
+        assert!(warning.is_none());
+
+        let (filter, warning) = resolve_env_filter_from(None, Some(""));
+        assert_eq!(filter.to_string(), DEFAULT_LOG_FILTER);
+        assert!(warning.is_none());
+    }
+
+    #[test]
+    fn invalid_config_log_level_warns_and_falls_back() {
+        let (filter, warning) = resolve_env_filter_from(None, Some("not-a-level"));
+        assert_eq!(filter.to_string(), DEFAULT_LOG_FILTER);
+        let warning = warning.expect("an unparseable log_level must be reported");
+        assert!(warning.contains("server.log_level"), "{warning}");
+        assert!(warning.contains("not-a-level"), "{warning}");
+    }
+
+    #[test]
+    fn typo_level_does_not_silently_mute_the_daemon() {
+        // Regression guard: `EnvFilter::try_new("dbug")` succeeds, reading the
+        // word as a *target* at trace level — a filter that matches nothing.
+        // Left unchecked, `log_level: dbug` would silence the daemon with no
+        // diagnostic at all.
+        assert_eq!(
+            tracing_subscriber::EnvFilter::try_new("dbug")
+                .expect("EnvFilter accepts a bare word as a target")
+                .to_string(),
+            "dbug=trace",
+        );
+
+        let (filter, warning) = resolve_env_filter_from(None, Some("dbug"));
+        assert_eq!(filter.to_string(), DEFAULT_LOG_FILTER);
+        assert!(warning.is_some(), "a typo'd level must warn, not mute");
+    }
+
+    #[test]
+    fn every_level_name_is_accepted() {
+        for level in ["trace", "debug", "info", "warn", "error", "off"] {
+            let (filter, warning) = resolve_env_filter_from(None, Some(level));
+            assert!(warning.is_none(), "{level} should be valid: {warning:?}");
+            assert_eq!(filter.to_string(), level);
+        }
+    }
+
+    #[test]
+    fn invalid_rust_log_warns_and_does_not_fall_back_to_config() {
+        // `RUST_LOG` is an explicit operator override; a typo in it should be
+        // reported rather than silently resolved from config behind the
+        // operator's back.
+        let (filter, warning) = resolve_env_filter_from(Some("not-a-level"), Some("debug"));
+        assert_eq!(filter.to_string(), DEFAULT_LOG_FILTER);
+        let warning = warning.expect("an unparseable RUST_LOG must be reported");
+        assert!(warning.contains("RUST_LOG"), "{warning}");
+    }
+
+    #[test]
+    fn server_config_default_log_level_is_a_valid_filter() {
+        // The default that ships in `ServerConfig` (and the JSON Schema) must
+        // survive the same parse path a user-supplied value takes.
+        let default_level = config::ServerConfig::default().log_level;
+        let (filter, warning) = resolve_env_filter_from(None, Some(&default_level));
+        assert_eq!(filter.to_string(), DEFAULT_LOG_FILTER);
+        assert!(warning.is_none());
+    }
 
     enum RestartCommandKind {
         Status,

--- a/crates/bitrouter-sdk/src/config/mod.rs
+++ b/crates/bitrouter-sdk/src/config/mod.rs
@@ -699,7 +699,14 @@ pub struct ServerConfig {
     pub listen: String,
     /// Unix control socket path.
     pub control_socket: String,
-    /// Log level.
+    /// Log filter for the daemon, in `tracing-subscriber` `EnvFilter` syntax —
+    /// a bare level (`debug`) or a per-target list (`info,bitrouter=debug`).
+    ///
+    /// `RUST_LOG` overrides this when set, following the Rust convention. The
+    /// filter is resolved once at startup, so changing it needs a restart —
+    /// `bitrouter reload` will not pick it up. Applies to `bitrouter serve`
+    /// (and therefore `start`); other subcommands install their subscriber
+    /// before any config is read and honour `RUST_LOG` only.
     pub log_level: String,
     /// SDK-level flag: when `true`, credential-less requests are admitted with
     /// a synthesised local caller. Code default is **`false`** — only the

--- a/dist/schema/bitrouter.config.schema.json
+++ b/dist/schema/bitrouter.config.schema.json
@@ -159,7 +159,7 @@
           "default": "./bitrouter.sock"
         },
         "log_level": {
-          "description": "Log level.",
+          "description": "Log filter for the daemon, in `tracing-subscriber` `EnvFilter` syntax —\na bare level (`debug`) or a per-target list (`info,bitrouter=debug`).\n\n`RUST_LOG` overrides this when set, following the Rust convention. The\nfilter is resolved once at startup, so changing it needs a restart —\n`bitrouter reload` will not pick it up. Applies to `bitrouter serve`\n(and therefore `start`); other subcommands install their subscriber\nbefore any config is read and honour `RUST_LOG` only.",
           "type": "string",
           "default": "info"
         },


### PR DESCRIPTION
## The bug

`server.log_level` was declared on `ServerConfig` and published in `dist/schema/bitrouter.config.schema.json`, but **nothing read it**. Grepping the workspace returned only the two definition sites.

Verbosity came exclusively from `RUST_LOG` — all three subscriber initializers build their filter with `EnvFilter::try_from_default_env()` and fall back to `info`. So `log_level: debug` in `bitrouter.yaml` changed nothing, produced no warning, and passed `bitrouter config validate`.

## The fix

Wired into the `serve` path, the only one holding a loaded config when its subscriber is installed. Precedence:

1. `RUST_LOG` — kept authoritative per Rust convention, so an operator can override without editing and reloading config
2. `server.log_level`
3. `info`

Other subcommands install their subscriber before any config is read and are unchanged.

## A worse bug found while fixing it

`EnvFilter::try_new("dbug")` **succeeds** — with no directive syntax present it reads the bare word as a *target* named `dbug` at trace level, producing a filter that matches nothing.

Wiring the field up naively would therefore have turned a one-character typo into a **silently muted daemon** — strictly worse than the field being ignored. So a bare value must parse as a level; anything carrying `=` or `,` still goes to `EnvFilter` untouched. There's a regression test asserting the raw `EnvFilter` behavior directly, so the reason for the guard can't be refactored away by accident.

Nothing can be logged before the subscriber exists, so an unusable filter is returned to the caller and warned about right after `init()` — the deferred-diagnostic shape `serve` already uses for OTel init errors:

```
WARN bitrouter: invalid server.log_level value "dbug": expected a level
(`trace`, `debug`, `info`, `warn`, `error`, `off`) or an `EnvFilter`
directive list such as `info,bitrouter=debug` — falling back to `info`
```

## Verification

9 new unit tests (45 pass in the bin), `clippy` clean on both crates, `cargo fmt --check` clean, `dist-helper check` reports both artifacts up to date.

End-to-end against a real daemon:

| `log_level` | `RUST_LOG` | Result |
|---|---|---|
| `info` / `trace` | unset | 3 / 6 tracing lines — identical to `RUST_LOG=trace` |
| `off` | unset | total silence — proves the config value is applied |
| `info,sea_orm=debug` | unset | directive list accepted |
| `debug` | `error` | silent — `RUST_LOG` wins |
| `dbug` | unset | falls back to `info` + the warning above |

## Notes

- **Startup-only.** `bitrouter reload` re-reads the config but cannot reinstall the subscriber, so a changed `log_level` needs a restart. Documented on the field (and therefore in the schema).
- **`config validate` left alone.** Its `warnings` field is typed `Vec<UnsetVar>`, so a filter warning needs a report reshape, and promoting it to `errors` would newly fail CI for anyone carrying a bogus value. Happy to add it in a follow-up.
- **Docs follow-up:** the bitrouter-docs Self-hosting section currently documents `RUST_LOG` as the only knob and carries an explicit callout that `server.log_level` is inert. That page should be updated when this ships — not before, since docs track released binaries.
- **Unrelated, pre-existing:** `cargo test -p bitrouter-sdk --lib` fails to compile on clean `main` (`error[E0432]: unresolved import` for `PromptOverrides` in `language_model/server_tools`). Confirmed via `git stash`; not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)