### PR TITLE
ci(sdk): gate the SDK public API against OTel leaks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,131 @@ jobs:
           printf '%s\n' "$out" | grep -qF 'the OpenTelemetry stack needs a transport' || {
             echo "::error::failed, but not with the transport compile_error"; printf '%s\n' "$out"; exit 1; }
 
+  sdk-public-api:
+    name: sdk-public-api
+    runs-on: ubuntu-latest
+    # The SDK exports OTLP without making the OpenTelemetry version part of its
+    # own semver contract. That only holds while the hard constraint holds:
+    #
+    #   No `opentelemetry*` or `tracing_opentelemetry` type may appear in any
+    #   public `bitrouter-sdk` signature.
+    #
+    # "Signature" is broader than function returns — public struct fields, enum
+    # variant payloads, trait method signatures, generic bounds, associated
+    # types, type aliases, and re-exports all count. `cargo public-api` prints
+    # one fully-qualified line per public item with rustdoc's own resolution
+    # already applied, so all of those collapse into the same grep.
+    #
+    # `--simplified` omits blanket impls. That is load-bearing, not cosmetic:
+    # `opentelemetry` has `impl<T> FutureExt for T`, which rustdoc attaches to
+    # every documented type in the crate. Without the flag the listing carries
+    # hundreds of `impl<T> opentelemetry::context::future_ext::FutureExt for
+    # <every SDK type>` lines that this crate never authored, and the gate
+    # below would be permanently red. The flag drops them structurally — no
+    # allow-list, so a real `opentelemetry` leak still cannot hide behind one.
+    #
+    # The same listing doubles as a committed baseline. A guard that only
+    # greps cannot see *unintended* public API growth, which is how a public
+    # foreign type gets added in the first place; the baseline makes every
+    # public-surface change show up in review as a diff.
+    #
+    # Linux-only on purpose: the SDK has `#[cfg(unix)]` items, so a Windows
+    # runner would produce a different (correct, but non-matching) listing.
+    # This is not folded into `feature-isolation` — that job is stable-only,
+    # and rustdoc JSON needs nightly.
+    steps:
+      - uses: actions/checkout@v6
+      - name: read the pins
+        id: pin
+        shell: bash
+        run: |
+          # Single source of truth: the pins live beside the baseline they
+          # describe, so a human regenerating locally uses the same versions
+          # this job runs on. Both are load-bearing — rustdoc's JSON format and
+          # `cargo public-api`'s rendering each change across releases, and
+          # either would rewrite the whole baseline.
+          pins=crates/bitrouter-sdk/public-api.pins
+          for key in toolchain tool; do
+            value="$(sed -n "s/^$key=//p" "$pins" | tr -d '[:space:]')"
+            if [[ -z "$value" ]]; then
+              echo "::error::$pins has no '$key=' line"; exit 1
+            fi
+            echo "$key=$value" >> "$GITHUB_OUTPUT"
+          done
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+          # This step exists only to build the helper binary below; the nightly
+          # step is the one whose cache is worth keeping.
+          cache: false
+      # Built on stable. It shells out to `cargo rustdoc` itself and picks the
+      # toolchain up from the `+<pin>` on the invocation further down.
+      - name: install the pinned cargo-public-api
+        run: cargo install --locked "${{ steps.pin.outputs.tool }}"
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: ${{ steps.pin.outputs.toolchain }}
+      - name: render the SDK's public API
+        shell: bash
+        run: |
+          cargo "+${{ steps.pin.outputs.toolchain }}" public-api \
+            -p bitrouter-sdk --all-features --simplified > "$RUNNER_TEMP/public-api.txt"
+      - name: the listing is real
+        shell: bash
+        run: |
+          # The gates below are negative assertions over this one file, and an
+          # empty or otel-less listing would satisfy every one of them
+          # vacuously — exactly the silent pass this job exists to prevent.
+          # Prove the surface under test is in the listing before trusting
+          # anything the listing does not say.
+          for sentinel in \
+            'pub mod bitrouter_sdk::otel' \
+            'pub fn bitrouter_sdk::otel::subscriber::tracing_subscriber_layer'; do
+            if ! grep -qF "$sentinel" "$RUNNER_TEMP/public-api.txt"; then
+              echo "::error::'$sentinel' is missing — did --all-features stop enabling otel?"
+              exit 1
+            fi
+          done
+      - name: no opentelemetry type in the SDK's public API
+        shell: bash
+        run: |
+          # Case-insensitive so it catches both the module paths
+          # (`opentelemetry_sdk::…`, `tracing_opentelemetry::…`) and the type
+          # names (`OpenTelemetryLayer`). `tracing_opentelemetry` contains
+          # `opentelemetry`, so one pattern covers both crates.
+          if hits="$(grep -niE 'opentelemetry' "$RUNNER_TEMP/public-api.txt")"; then
+            echo "::error::opentelemetry types leaked into bitrouter-sdk's public API — see docs/OTEL_SDK_MIGRATION_SPEC.md 'Hard constraint'"
+            printf '%s\n' "$hits"
+            exit 1
+          fi
+      - name: no re-export of an OTel type out of the SDK
+        shell: bash
+        run: |
+          # The one thing the listing grep above cannot see. `cargo public-api`
+          # renders a bare re-export under its *local* path — re-exporting
+          # `opentelemetry_sdk::trace::SdkTracer` from `otel` prints
+          # `pub use bitrouter_sdk::otel::SdkTracer`, with the origin crate
+          # nowhere in the line. Types whose *name* carries "OpenTelemetry"
+          # (e.g. `OpenTelemetrySpanExt`) do trip the grep; neutrally-named
+          # ones do not. The baseline gate still catches the added line, but it
+          # would not say why the line matters — so pin it at the source.
+          #
+          # Verbatim `pub use` only: `pub(crate) use` is not public API, and a
+          # re-export laundered through a local alias is out of reach of any
+          # lexical check. That residual is the baseline gate's job.
+          if hits="$(grep -rnE '^[[:space:]]*pub use[[:space:]]+(::)?(opentelemetry|tracing_opentelemetry)' crates/bitrouter-sdk/src/)"; then
+            echo "::error::bitrouter-sdk re-exports an OpenTelemetry type — see docs/OTEL_SDK_MIGRATION_SPEC.md 'Hard constraint'"
+            printf '%s\n' "$hits"
+            exit 1
+          fi
+      - name: the committed public API baseline is up to date
+        shell: bash
+        run: |
+          if ! diff -u crates/bitrouter-sdk/public-api.txt "$RUNNER_TEMP/public-api.txt"; then
+            echo "::error::bitrouter-sdk's public API changed. Review the diff above; if every line is intended, regenerate the baseline with: cargo +${{ steps.pin.outputs.toolchain }} public-api -p bitrouter-sdk --all-features --simplified > crates/bitrouter-sdk/public-api.txt"
+            exit 1
+          fi
+
   dist:
     name: dist
     runs-on: ubuntu-latest

--- a/crates/bitrouter-sdk/Cargo.toml
+++ b/crates/bitrouter-sdk/Cargo.toml
@@ -7,6 +7,10 @@ license.workspace = true
 authors.workspace = true
 repository.workspace = true
 rust-version.workspace = true
+# CI artifacts for the `sdk-public-api` job, not crate content. The baseline is
+# ~1 MB of rendered public-API lines; consumers who download the crate have no
+# use for it.
+exclude = ["public-api.txt", "public-api.pins"]
 
 [dependencies]
 async-trait.workspace = true

--- a/crates/bitrouter-sdk/public-api.pins
+++ b/crates/bitrouter-sdk/public-api.pins
@@ -1,0 +1,25 @@
+# Pins for `public-api.txt`, the committed public-API baseline next to this
+# file. The `sdk-public-api` CI job reads both values out of here, so this is
+# the single source of truth — the workflow does not repeat them.
+#
+# Both pins matter, and for the same reason: the baseline is a byte-for-byte
+# diff, so anything that changes the *rendering* rewrites the whole file and
+# buries the real signal.
+#
+#   toolchain  — rustdoc's JSON format changes shape across nightlies.
+#   tool       — `cargo public-api`'s own rendering changes across releases.
+#
+# Regenerate the baseline with exactly these:
+#
+#   rustup toolchain install nightly-2026-05-05
+#   cargo install cargo-public-api --locked --version 0.52.0
+#   cargo +nightly-2026-05-05 public-api -p bitrouter-sdk --all-features --simplified \
+#     > crates/bitrouter-sdk/public-api.txt
+#
+# Run it on Linux or macOS. `bitrouter-sdk` has `#[cfg(unix)]` items, so a
+# Windows-generated baseline will not match; the CI job runs on Linux.
+#
+# Moving either pin is a deliberate act: regenerate, and expect a large diff
+# that is rendering churn rather than an API change.
+toolchain=nightly-2026-05-05
+tool=cargo-public-api@0.52.0

--- a/crates/bitrouter-sdk/public-api.txt
+++ b/crates/bitrouter-sdk/public-api.txt
@@ -1,0 +1,8539 @@
+pub mod bitrouter_sdk
+pub use bitrouter_sdk::HeaderMap
+pub mod bitrouter_sdk::acp
+pub mod bitrouter_sdk::acp::config_routing
+pub struct bitrouter_sdk::acp::config_routing::ConfigAcpRoutingTable
+impl bitrouter_sdk::acp::config_routing::ConfigAcpRoutingTable
+pub fn bitrouter_sdk::acp::config_routing::ConfigAcpRoutingTable::from_configs<I>(I) -> bitrouter_sdk::error::Result<Self> where I: core::iter::traits::collect::IntoIterator<Item = (alloc::string::String, bitrouter_sdk::acp::transport::AcpAgentConfig)>
+pub fn bitrouter_sdk::acp::config_routing::ConfigAcpRoutingTable::is_empty(&self) -> bool
+pub fn bitrouter_sdk::acp::config_routing::ConfigAcpRoutingTable::lookup(&self, &str) -> core::option::Option<&bitrouter_sdk::acp::transport::AcpTransport>
+impl bitrouter_sdk::acp::RoutingTable for bitrouter_sdk::acp::config_routing::ConfigAcpRoutingTable
+pub fn bitrouter_sdk::acp::config_routing::ConfigAcpRoutingTable::resolve<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 str, &'life2 bitrouter_sdk::caller::CallerContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::acp::AcpTarget>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+impl core::clone::Clone for bitrouter_sdk::acp::config_routing::ConfigAcpRoutingTable
+pub fn bitrouter_sdk::acp::config_routing::ConfigAcpRoutingTable::clone(&self) -> bitrouter_sdk::acp::config_routing::ConfigAcpRoutingTable
+impl core::default::Default for bitrouter_sdk::acp::config_routing::ConfigAcpRoutingTable
+pub fn bitrouter_sdk::acp::config_routing::ConfigAcpRoutingTable::default() -> bitrouter_sdk::acp::config_routing::ConfigAcpRoutingTable
+impl core::fmt::Debug for bitrouter_sdk::acp::config_routing::ConfigAcpRoutingTable
+pub fn bitrouter_sdk::acp::config_routing::ConfigAcpRoutingTable::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::acp::config_routing::ConfigAcpRoutingTable
+impl core::marker::Send for bitrouter_sdk::acp::config_routing::ConfigAcpRoutingTable
+impl core::marker::Sync for bitrouter_sdk::acp::config_routing::ConfigAcpRoutingTable
+impl core::marker::Unpin for bitrouter_sdk::acp::config_routing::ConfigAcpRoutingTable
+impl core::marker::UnsafeUnpin for bitrouter_sdk::acp::config_routing::ConfigAcpRoutingTable
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::acp::config_routing::ConfigAcpRoutingTable
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::acp::config_routing::ConfigAcpRoutingTable
+pub mod bitrouter_sdk::acp::down
+pub fn bitrouter_sdk::acp::down::serve(alloc::sync::Arc<bitrouter_sdk::acp::engine::Session>) -> impl core::future::future::Future<Output = agent_client_protocol_schema::v1::error::Result<()>>
+pub mod bitrouter_sdk::acp::engine
+pub struct bitrouter_sdk::acp::engine::LaunchOptions
+pub bitrouter_sdk::acp::engine::LaunchOptions::mcp_servers: alloc::vec::Vec<agent_client_protocol_schema::v1::agent::McpServer>
+pub bitrouter_sdk::acp::engine::LaunchOptions::settlement_recorders: alloc::vec::Vec<alloc::sync::Arc<dyn bitrouter_sdk::acp::settlement::AcpSettlementRecorder>>
+pub bitrouter_sdk::acp::engine::LaunchOptions::strip_inherited_env: alloc::vec::Vec<alloc::string::String>
+pub bitrouter_sdk::acp::engine::LaunchOptions::turn_timeout: core::option::Option<core::time::Duration>
+impl core::clone::Clone for bitrouter_sdk::acp::engine::LaunchOptions
+pub fn bitrouter_sdk::acp::engine::LaunchOptions::clone(&self) -> bitrouter_sdk::acp::engine::LaunchOptions
+impl core::default::Default for bitrouter_sdk::acp::engine::LaunchOptions
+pub fn bitrouter_sdk::acp::engine::LaunchOptions::default() -> bitrouter_sdk::acp::engine::LaunchOptions
+impl core::fmt::Debug for bitrouter_sdk::acp::engine::LaunchOptions
+pub fn bitrouter_sdk::acp::engine::LaunchOptions::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::acp::engine::LaunchOptions
+impl core::marker::Send for bitrouter_sdk::acp::engine::LaunchOptions
+impl core::marker::Sync for bitrouter_sdk::acp::engine::LaunchOptions
+impl core::marker::Unpin for bitrouter_sdk::acp::engine::LaunchOptions
+impl core::marker::UnsafeUnpin for bitrouter_sdk::acp::engine::LaunchOptions
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::acp::engine::LaunchOptions
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::acp::engine::LaunchOptions
+pub struct bitrouter_sdk::acp::engine::Session
+pub bitrouter_sdk::acp::engine::Session::state: bitrouter_sdk::acp::session::SessionState
+impl bitrouter_sdk::acp::engine::Session
+pub async fn bitrouter_sdk::acp::engine::Session::cancel(&self) -> anyhow::Result<()>
+pub async fn bitrouter_sdk::acp::engine::Session::launch(&bitrouter_sdk::acp::config_routing::ConfigAcpRoutingTable, &str, std::path::PathBuf, bitrouter_sdk::acp::engine::LaunchOptions) -> anyhow::Result<Self>
+pub async fn bitrouter_sdk::acp::engine::Session::launch_deferred(&bitrouter_sdk::acp::config_routing::ConfigAcpRoutingTable, &str, std::path::PathBuf, bitrouter_sdk::acp::engine::LaunchOptions) -> anyhow::Result<Self>
+pub async fn bitrouter_sdk::acp::engine::Session::open(&self, core::option::Option<std::path::PathBuf>, alloc::vec::Vec<agent_client_protocol_schema::v1::agent::McpServer>) -> anyhow::Result<()>
+pub fn bitrouter_sdk::acp::engine::Session::permissions(&self) -> core::pin::Pin<alloc::boxed::Box<(dyn futures_core::stream::Stream<Item = bitrouter_sdk::acp::up::PendingPermission> + core::marker::Send)>>
+pub async fn bitrouter_sdk::acp::engine::Session::prompt(&self, &str) -> anyhow::Result<agent_client_protocol_schema::v1::agent::PromptResponse>
+pub async fn bitrouter_sdk::acp::engine::Session::prompt_blocks(&self, alloc::vec::Vec<agent_client_protocol_schema::v1::content::ContentBlock>) -> anyhow::Result<agent_client_protocol_schema::v1::agent::PromptResponse>
+pub fn bitrouter_sdk::acp::engine::Session::raw_updates(&self) -> core::pin::Pin<alloc::boxed::Box<(dyn futures_core::stream::Stream<Item = agent_client_protocol_schema::v1::client::SessionUpdate> + core::marker::Send)>>
+pub async fn bitrouter_sdk::acp::engine::Session::shutdown(self) -> anyhow::Result<()>
+pub fn bitrouter_sdk::acp::engine::Session::state(&self) -> &bitrouter_sdk::acp::session::SessionState
+pub fn bitrouter_sdk::acp::engine::Session::telemetry(&self) -> core::option::Option<tokio::sync::mpsc::unbounded::UnboundedReceiver<bitrouter_sdk::acp::telemetry::RequestCompleted>>
+pub fn bitrouter_sdk::acp::engine::Session::updates(&self) -> core::pin::Pin<alloc::boxed::Box<(dyn futures_core::stream::Stream<Item = bitrouter_sdk::acp::translate::SessionUpdateKind> + core::marker::Send)>>
+pub fn bitrouter_sdk::acp::engine::Session::upstream_init(&self) -> &agent_client_protocol_schema::v1::agent::InitializeResponse
+impl !core::marker::Freeze for bitrouter_sdk::acp::engine::Session
+impl core::marker::Send for bitrouter_sdk::acp::engine::Session
+impl core::marker::Sync for bitrouter_sdk::acp::engine::Session
+impl core::marker::Unpin for bitrouter_sdk::acp::engine::Session
+impl core::marker::UnsafeUnpin for bitrouter_sdk::acp::engine::Session
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::acp::engine::Session
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::acp::engine::Session
+pub mod bitrouter_sdk::acp::executor
+pub struct bitrouter_sdk::acp::executor::SessionExecutor
+impl bitrouter_sdk::acp::executor::SessionExecutor
+pub fn bitrouter_sdk::acp::executor::SessionExecutor::new(alloc::sync::Arc<bitrouter_sdk::acp::up::UpstreamConnection>) -> Self
+impl bitrouter_sdk::acp::Executor for bitrouter_sdk::acp::executor::SessionExecutor
+pub fn bitrouter_sdk::acp::executor::SessionExecutor::execute<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::acp::AcpTarget, &'life2 bitrouter_sdk::acp::AcpRequest) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::acp::AcpResponse>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+impl core::marker::Freeze for bitrouter_sdk::acp::executor::SessionExecutor
+impl core::marker::Send for bitrouter_sdk::acp::executor::SessionExecutor
+impl core::marker::Sync for bitrouter_sdk::acp::executor::SessionExecutor
+impl core::marker::Unpin for bitrouter_sdk::acp::executor::SessionExecutor
+impl core::marker::UnsafeUnpin for bitrouter_sdk::acp::executor::SessionExecutor
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::acp::executor::SessionExecutor
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::acp::executor::SessionExecutor
+pub mod bitrouter_sdk::acp::permissions
+pub struct bitrouter_sdk::acp::permissions::PermissionRegistry
+impl bitrouter_sdk::acp::permissions::PermissionRegistry
+pub fn bitrouter_sdk::acp::permissions::PermissionRegistry::insert(&self, bitrouter_sdk::acp::up::PendingPermission)
+pub fn bitrouter_sdk::acp::permissions::PermissionRegistry::new() -> Self
+pub fn bitrouter_sdk::acp::permissions::PermissionRegistry::subscribe(&alloc::sync::Arc<Self>) -> core::pin::Pin<alloc::boxed::Box<(dyn futures_core::stream::Stream<Item = bitrouter_sdk::acp::up::PendingPermission> + core::marker::Send)>>
+impl core::default::Default for bitrouter_sdk::acp::permissions::PermissionRegistry
+pub fn bitrouter_sdk::acp::permissions::PermissionRegistry::default() -> Self
+impl !core::marker::Freeze for bitrouter_sdk::acp::permissions::PermissionRegistry
+impl core::marker::Send for bitrouter_sdk::acp::permissions::PermissionRegistry
+impl core::marker::Sync for bitrouter_sdk::acp::permissions::PermissionRegistry
+impl core::marker::Unpin for bitrouter_sdk::acp::permissions::PermissionRegistry
+impl core::marker::UnsafeUnpin for bitrouter_sdk::acp::permissions::PermissionRegistry
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::acp::permissions::PermissionRegistry
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::acp::permissions::PermissionRegistry
+pub mod bitrouter_sdk::acp::session
+pub struct bitrouter_sdk::acp::session::SessionState
+pub bitrouter_sdk::acp::session::SessionState::acp_session_id: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::acp::session::SessionState::agent_id: alloc::string::String
+pub bitrouter_sdk::acp::session::SessionState::agent_session_id: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::acp::session::SessionState::record_id: alloc::string::String
+impl bitrouter_sdk::acp::session::SessionState
+pub fn bitrouter_sdk::acp::session::SessionState::new(alloc::string::String, alloc::string::String) -> Self
+pub fn bitrouter_sdk::acp::session::SessionState::set_acp_session_id(&mut self, alloc::string::String)
+pub fn bitrouter_sdk::acp::session::SessionState::set_agent_session_id(&mut self, alloc::string::String)
+impl core::clone::Clone for bitrouter_sdk::acp::session::SessionState
+pub fn bitrouter_sdk::acp::session::SessionState::clone(&self) -> bitrouter_sdk::acp::session::SessionState
+impl core::fmt::Debug for bitrouter_sdk::acp::session::SessionState
+pub fn bitrouter_sdk::acp::session::SessionState::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::acp::session::SessionState
+impl core::marker::Send for bitrouter_sdk::acp::session::SessionState
+impl core::marker::Sync for bitrouter_sdk::acp::session::SessionState
+impl core::marker::Unpin for bitrouter_sdk::acp::session::SessionState
+impl core::marker::UnsafeUnpin for bitrouter_sdk::acp::session::SessionState
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::acp::session::SessionState
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::acp::session::SessionState
+pub mod bitrouter_sdk::acp::settlement
+pub struct bitrouter_sdk::acp::settlement::AcpCostFacts
+pub bitrouter_sdk::acp::settlement::AcpCostFacts::context_size: u64
+pub bitrouter_sdk::acp::settlement::AcpCostFacts::context_used: u64
+impl core::clone::Clone for bitrouter_sdk::acp::settlement::AcpCostFacts
+pub fn bitrouter_sdk::acp::settlement::AcpCostFacts::clone(&self) -> bitrouter_sdk::acp::settlement::AcpCostFacts
+impl core::cmp::Eq for bitrouter_sdk::acp::settlement::AcpCostFacts
+impl core::cmp::PartialEq for bitrouter_sdk::acp::settlement::AcpCostFacts
+pub fn bitrouter_sdk::acp::settlement::AcpCostFacts::eq(&self, &bitrouter_sdk::acp::settlement::AcpCostFacts) -> bool
+impl core::fmt::Debug for bitrouter_sdk::acp::settlement::AcpCostFacts
+pub fn bitrouter_sdk::acp::settlement::AcpCostFacts::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for bitrouter_sdk::acp::settlement::AcpCostFacts
+impl core::marker::StructuralPartialEq for bitrouter_sdk::acp::settlement::AcpCostFacts
+impl core::marker::Freeze for bitrouter_sdk::acp::settlement::AcpCostFacts
+impl core::marker::Send for bitrouter_sdk::acp::settlement::AcpCostFacts
+impl core::marker::Sync for bitrouter_sdk::acp::settlement::AcpCostFacts
+impl core::marker::Unpin for bitrouter_sdk::acp::settlement::AcpCostFacts
+impl core::marker::UnsafeUnpin for bitrouter_sdk::acp::settlement::AcpCostFacts
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::acp::settlement::AcpCostFacts
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::acp::settlement::AcpCostFacts
+pub struct bitrouter_sdk::acp::settlement::AcpSettlementContext
+pub bitrouter_sdk::acp::settlement::AcpSettlementContext::agent: alloc::string::String
+pub bitrouter_sdk::acp::settlement::AcpSettlementContext::cost_facts: core::option::Option<bitrouter_sdk::acp::settlement::AcpCostFacts>
+pub bitrouter_sdk::acp::settlement::AcpSettlementContext::latency_ms: u64
+pub bitrouter_sdk::acp::settlement::AcpSettlementContext::stop_reason: alloc::string::String
+pub bitrouter_sdk::acp::settlement::AcpSettlementContext::turn_id: alloc::string::String
+impl core::clone::Clone for bitrouter_sdk::acp::settlement::AcpSettlementContext
+pub fn bitrouter_sdk::acp::settlement::AcpSettlementContext::clone(&self) -> bitrouter_sdk::acp::settlement::AcpSettlementContext
+impl core::fmt::Debug for bitrouter_sdk::acp::settlement::AcpSettlementContext
+pub fn bitrouter_sdk::acp::settlement::AcpSettlementContext::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::acp::settlement::AcpSettlementContext
+impl core::marker::Send for bitrouter_sdk::acp::settlement::AcpSettlementContext
+impl core::marker::Sync for bitrouter_sdk::acp::settlement::AcpSettlementContext
+impl core::marker::Unpin for bitrouter_sdk::acp::settlement::AcpSettlementContext
+impl core::marker::UnsafeUnpin for bitrouter_sdk::acp::settlement::AcpSettlementContext
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::acp::settlement::AcpSettlementContext
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::acp::settlement::AcpSettlementContext
+pub trait bitrouter_sdk::acp::settlement::AcpSettlementRecorder: core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::acp::settlement::AcpSettlementRecorder::record<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::acp::settlement::AcpSettlementContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<()>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub mod bitrouter_sdk::acp::telemetry
+pub struct bitrouter_sdk::acp::telemetry::ContextUsage
+pub bitrouter_sdk::acp::telemetry::ContextUsage::size: u64
+pub bitrouter_sdk::acp::telemetry::ContextUsage::used: u64
+impl core::clone::Clone for bitrouter_sdk::acp::telemetry::ContextUsage
+pub fn bitrouter_sdk::acp::telemetry::ContextUsage::clone(&self) -> bitrouter_sdk::acp::telemetry::ContextUsage
+impl core::cmp::Eq for bitrouter_sdk::acp::telemetry::ContextUsage
+impl core::cmp::PartialEq for bitrouter_sdk::acp::telemetry::ContextUsage
+pub fn bitrouter_sdk::acp::telemetry::ContextUsage::eq(&self, &bitrouter_sdk::acp::telemetry::ContextUsage) -> bool
+impl core::fmt::Debug for bitrouter_sdk::acp::telemetry::ContextUsage
+pub fn bitrouter_sdk::acp::telemetry::ContextUsage::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for bitrouter_sdk::acp::telemetry::ContextUsage
+impl core::marker::StructuralPartialEq for bitrouter_sdk::acp::telemetry::ContextUsage
+impl core::marker::Freeze for bitrouter_sdk::acp::telemetry::ContextUsage
+impl core::marker::Send for bitrouter_sdk::acp::telemetry::ContextUsage
+impl core::marker::Sync for bitrouter_sdk::acp::telemetry::ContextUsage
+impl core::marker::Unpin for bitrouter_sdk::acp::telemetry::ContextUsage
+impl core::marker::UnsafeUnpin for bitrouter_sdk::acp::telemetry::ContextUsage
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::acp::telemetry::ContextUsage
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::acp::telemetry::ContextUsage
+pub struct bitrouter_sdk::acp::telemetry::RequestCompleted
+pub bitrouter_sdk::acp::telemetry::RequestCompleted::agent: alloc::string::String
+pub bitrouter_sdk::acp::telemetry::RequestCompleted::context: core::option::Option<bitrouter_sdk::acp::telemetry::ContextUsage>
+pub bitrouter_sdk::acp::telemetry::RequestCompleted::latency_ms: u64
+pub bitrouter_sdk::acp::telemetry::RequestCompleted::stop_reason: alloc::string::String
+impl core::clone::Clone for bitrouter_sdk::acp::telemetry::RequestCompleted
+pub fn bitrouter_sdk::acp::telemetry::RequestCompleted::clone(&self) -> bitrouter_sdk::acp::telemetry::RequestCompleted
+impl core::fmt::Debug for bitrouter_sdk::acp::telemetry::RequestCompleted
+pub fn bitrouter_sdk::acp::telemetry::RequestCompleted::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::acp::telemetry::RequestCompleted
+impl core::marker::Send for bitrouter_sdk::acp::telemetry::RequestCompleted
+impl core::marker::Sync for bitrouter_sdk::acp::telemetry::RequestCompleted
+impl core::marker::Unpin for bitrouter_sdk::acp::telemetry::RequestCompleted
+impl core::marker::UnsafeUnpin for bitrouter_sdk::acp::telemetry::RequestCompleted
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::acp::telemetry::RequestCompleted
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::acp::telemetry::RequestCompleted
+pub struct bitrouter_sdk::acp::telemetry::TelemetryHook
+impl bitrouter_sdk::acp::telemetry::TelemetryHook
+pub fn bitrouter_sdk::acp::telemetry::TelemetryHook::new(tokio::sync::mpsc::unbounded::UnboundedSender<bitrouter_sdk::acp::telemetry::RequestCompleted>, bitrouter_sdk::acp::telemetry::SharedContextUsage) -> Self
+impl bitrouter_sdk::acp::ExecutionHook for bitrouter_sdk::acp::telemetry::TelemetryHook
+pub fn bitrouter_sdk::acp::telemetry::TelemetryHook::on_success<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::acp::AcpContext, &'life2 bitrouter_sdk::acp::AcpResponse) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<()>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+impl core::marker::Freeze for bitrouter_sdk::acp::telemetry::TelemetryHook
+impl core::marker::Send for bitrouter_sdk::acp::telemetry::TelemetryHook
+impl core::marker::Sync for bitrouter_sdk::acp::telemetry::TelemetryHook
+impl core::marker::Unpin for bitrouter_sdk::acp::telemetry::TelemetryHook
+impl core::marker::UnsafeUnpin for bitrouter_sdk::acp::telemetry::TelemetryHook
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::acp::telemetry::TelemetryHook
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::acp::telemetry::TelemetryHook
+pub type bitrouter_sdk::acp::telemetry::SharedContextUsage = alloc::sync::Arc<std::sync::poison::mutex::Mutex<core::option::Option<bitrouter_sdk::acp::telemetry::ContextUsage>>>
+pub mod bitrouter_sdk::acp::translate
+pub enum bitrouter_sdk::acp::translate::PermissionOutcome
+pub bitrouter_sdk::acp::translate::PermissionOutcome::AllowAlways
+pub bitrouter_sdk::acp::translate::PermissionOutcome::AllowOnce
+pub bitrouter_sdk::acp::translate::PermissionOutcome::Deny
+impl core::clone::Clone for bitrouter_sdk::acp::translate::PermissionOutcome
+pub fn bitrouter_sdk::acp::translate::PermissionOutcome::clone(&self) -> bitrouter_sdk::acp::translate::PermissionOutcome
+impl core::cmp::Eq for bitrouter_sdk::acp::translate::PermissionOutcome
+impl core::cmp::PartialEq for bitrouter_sdk::acp::translate::PermissionOutcome
+pub fn bitrouter_sdk::acp::translate::PermissionOutcome::eq(&self, &bitrouter_sdk::acp::translate::PermissionOutcome) -> bool
+impl core::fmt::Debug for bitrouter_sdk::acp::translate::PermissionOutcome
+pub fn bitrouter_sdk::acp::translate::PermissionOutcome::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for bitrouter_sdk::acp::translate::PermissionOutcome
+impl core::marker::StructuralPartialEq for bitrouter_sdk::acp::translate::PermissionOutcome
+impl core::marker::Freeze for bitrouter_sdk::acp::translate::PermissionOutcome
+impl core::marker::Send for bitrouter_sdk::acp::translate::PermissionOutcome
+impl core::marker::Sync for bitrouter_sdk::acp::translate::PermissionOutcome
+impl core::marker::Unpin for bitrouter_sdk::acp::translate::PermissionOutcome
+impl core::marker::UnsafeUnpin for bitrouter_sdk::acp::translate::PermissionOutcome
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::acp::translate::PermissionOutcome
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::acp::translate::PermissionOutcome
+pub enum bitrouter_sdk::acp::translate::SessionUpdateKind
+pub bitrouter_sdk::acp::translate::SessionUpdateKind::MessageChunk
+pub bitrouter_sdk::acp::translate::SessionUpdateKind::MessageChunk::message_id: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::acp::translate::SessionUpdateKind::MessageChunk::text: alloc::string::String
+pub bitrouter_sdk::acp::translate::SessionUpdateKind::ThoughtChunk
+pub bitrouter_sdk::acp::translate::SessionUpdateKind::ThoughtChunk::message_id: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::acp::translate::SessionUpdateKind::ThoughtChunk::text: alloc::string::String
+pub bitrouter_sdk::acp::translate::SessionUpdateKind::ToolCall
+pub bitrouter_sdk::acp::translate::SessionUpdateKind::ToolCall::diff: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::acp::translate::SessionUpdateKind::ToolCall::id: alloc::string::String
+pub bitrouter_sdk::acp::translate::SessionUpdateKind::ToolCall::status: bitrouter_sdk::acp::translate::ToolStatus
+pub bitrouter_sdk::acp::translate::SessionUpdateKind::ToolCall::title: alloc::string::String
+pub bitrouter_sdk::acp::translate::SessionUpdateKind::ToolCallUpdate
+pub bitrouter_sdk::acp::translate::SessionUpdateKind::ToolCallUpdate::diff: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::acp::translate::SessionUpdateKind::ToolCallUpdate::id: alloc::string::String
+pub bitrouter_sdk::acp::translate::SessionUpdateKind::ToolCallUpdate::status: core::option::Option<bitrouter_sdk::acp::translate::ToolStatus>
+pub bitrouter_sdk::acp::translate::SessionUpdateKind::ToolCallUpdate::title: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::acp::translate::SessionUpdateKind::Usage
+pub bitrouter_sdk::acp::translate::SessionUpdateKind::Usage::cost: core::option::Option<bitrouter_sdk::acp::translate::UsageCost>
+pub bitrouter_sdk::acp::translate::SessionUpdateKind::Usage::size: u64
+pub bitrouter_sdk::acp::translate::SessionUpdateKind::Usage::used: u64
+impl core::clone::Clone for bitrouter_sdk::acp::translate::SessionUpdateKind
+pub fn bitrouter_sdk::acp::translate::SessionUpdateKind::clone(&self) -> bitrouter_sdk::acp::translate::SessionUpdateKind
+impl core::cmp::PartialEq for bitrouter_sdk::acp::translate::SessionUpdateKind
+pub fn bitrouter_sdk::acp::translate::SessionUpdateKind::eq(&self, &bitrouter_sdk::acp::translate::SessionUpdateKind) -> bool
+impl core::fmt::Debug for bitrouter_sdk::acp::translate::SessionUpdateKind
+pub fn bitrouter_sdk::acp::translate::SessionUpdateKind::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::acp::translate::SessionUpdateKind
+impl serde_core::ser::Serialize for bitrouter_sdk::acp::translate::SessionUpdateKind
+pub fn bitrouter_sdk::acp::translate::SessionUpdateKind::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl core::marker::Freeze for bitrouter_sdk::acp::translate::SessionUpdateKind
+impl core::marker::Send for bitrouter_sdk::acp::translate::SessionUpdateKind
+impl core::marker::Sync for bitrouter_sdk::acp::translate::SessionUpdateKind
+impl core::marker::Unpin for bitrouter_sdk::acp::translate::SessionUpdateKind
+impl core::marker::UnsafeUnpin for bitrouter_sdk::acp::translate::SessionUpdateKind
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::acp::translate::SessionUpdateKind
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::acp::translate::SessionUpdateKind
+pub enum bitrouter_sdk::acp::translate::ToolStatus
+pub bitrouter_sdk::acp::translate::ToolStatus::Failed
+pub bitrouter_sdk::acp::translate::ToolStatus::Ok
+pub bitrouter_sdk::acp::translate::ToolStatus::Pending
+pub bitrouter_sdk::acp::translate::ToolStatus::Running
+impl core::clone::Clone for bitrouter_sdk::acp::translate::ToolStatus
+pub fn bitrouter_sdk::acp::translate::ToolStatus::clone(&self) -> bitrouter_sdk::acp::translate::ToolStatus
+impl core::cmp::Eq for bitrouter_sdk::acp::translate::ToolStatus
+impl core::cmp::PartialEq for bitrouter_sdk::acp::translate::ToolStatus
+pub fn bitrouter_sdk::acp::translate::ToolStatus::eq(&self, &bitrouter_sdk::acp::translate::ToolStatus) -> bool
+impl core::fmt::Debug for bitrouter_sdk::acp::translate::ToolStatus
+pub fn bitrouter_sdk::acp::translate::ToolStatus::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::acp::translate::ToolStatus
+impl serde_core::ser::Serialize for bitrouter_sdk::acp::translate::ToolStatus
+pub fn bitrouter_sdk::acp::translate::ToolStatus::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl core::marker::Freeze for bitrouter_sdk::acp::translate::ToolStatus
+impl core::marker::Send for bitrouter_sdk::acp::translate::ToolStatus
+impl core::marker::Sync for bitrouter_sdk::acp::translate::ToolStatus
+impl core::marker::Unpin for bitrouter_sdk::acp::translate::ToolStatus
+impl core::marker::UnsafeUnpin for bitrouter_sdk::acp::translate::ToolStatus
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::acp::translate::ToolStatus
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::acp::translate::ToolStatus
+pub struct bitrouter_sdk::acp::translate::UsageCost
+pub bitrouter_sdk::acp::translate::UsageCost::amount: f64
+pub bitrouter_sdk::acp::translate::UsageCost::currency: alloc::string::String
+impl core::clone::Clone for bitrouter_sdk::acp::translate::UsageCost
+pub fn bitrouter_sdk::acp::translate::UsageCost::clone(&self) -> bitrouter_sdk::acp::translate::UsageCost
+impl core::cmp::PartialEq for bitrouter_sdk::acp::translate::UsageCost
+pub fn bitrouter_sdk::acp::translate::UsageCost::eq(&self, &bitrouter_sdk::acp::translate::UsageCost) -> bool
+impl core::fmt::Debug for bitrouter_sdk::acp::translate::UsageCost
+pub fn bitrouter_sdk::acp::translate::UsageCost::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::acp::translate::UsageCost
+impl serde_core::ser::Serialize for bitrouter_sdk::acp::translate::UsageCost
+pub fn bitrouter_sdk::acp::translate::UsageCost::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl core::marker::Freeze for bitrouter_sdk::acp::translate::UsageCost
+impl core::marker::Send for bitrouter_sdk::acp::translate::UsageCost
+impl core::marker::Sync for bitrouter_sdk::acp::translate::UsageCost
+impl core::marker::Unpin for bitrouter_sdk::acp::translate::UsageCost
+impl core::marker::UnsafeUnpin for bitrouter_sdk::acp::translate::UsageCost
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::acp::translate::UsageCost
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::acp::translate::UsageCost
+pub fn bitrouter_sdk::acp::translate::map_status(agent_client_protocol_schema::v1::tool_call::ToolCallStatus) -> bitrouter_sdk::acp::translate::ToolStatus
+pub fn bitrouter_sdk::acp::translate::render_diff(&[agent_client_protocol_schema::v1::tool_call::ToolCallContent]) -> core::option::Option<alloc::string::String>
+pub fn bitrouter_sdk::acp::translate::sanitize_selection(agent_client_protocol_schema::v1::client::RequestPermissionOutcome, &[agent_client_protocol_schema::v1::client::PermissionOption]) -> agent_client_protocol_schema::v1::client::RequestPermissionOutcome
+pub fn bitrouter_sdk::acp::translate::select_option(bitrouter_sdk::acp::translate::PermissionOutcome, &[agent_client_protocol_schema::v1::client::PermissionOption]) -> agent_client_protocol_schema::v1::client::RequestPermissionOutcome
+pub fn bitrouter_sdk::acp::translate::translate(agent_client_protocol_schema::v1::client::SessionUpdate) -> core::option::Option<bitrouter_sdk::acp::translate::SessionUpdateKind>
+pub mod bitrouter_sdk::acp::transport
+pub enum bitrouter_sdk::acp::transport::AcpConfigError
+pub bitrouter_sdk::acp::transport::AcpConfigError::EmptyStdioCommand
+pub bitrouter_sdk::acp::transport::AcpConfigError::EmptyStdioCommand::name: alloc::string::String
+pub bitrouter_sdk::acp::transport::AcpConfigError::InvalidName
+pub bitrouter_sdk::acp::transport::AcpConfigError::InvalidName::name: alloc::string::String
+pub bitrouter_sdk::acp::transport::AcpConfigError::InvalidName::reason: alloc::string::String
+impl core::cmp::Eq for bitrouter_sdk::acp::transport::AcpConfigError
+impl core::cmp::PartialEq for bitrouter_sdk::acp::transport::AcpConfigError
+pub fn bitrouter_sdk::acp::transport::AcpConfigError::eq(&self, &bitrouter_sdk::acp::transport::AcpConfigError) -> bool
+impl core::error::Error for bitrouter_sdk::acp::transport::AcpConfigError
+impl core::fmt::Debug for bitrouter_sdk::acp::transport::AcpConfigError
+pub fn bitrouter_sdk::acp::transport::AcpConfigError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitrouter_sdk::acp::transport::AcpConfigError
+pub fn bitrouter_sdk::acp::transport::AcpConfigError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::acp::transport::AcpConfigError
+impl core::marker::Freeze for bitrouter_sdk::acp::transport::AcpConfigError
+impl core::marker::Send for bitrouter_sdk::acp::transport::AcpConfigError
+impl core::marker::Sync for bitrouter_sdk::acp::transport::AcpConfigError
+impl core::marker::Unpin for bitrouter_sdk::acp::transport::AcpConfigError
+impl core::marker::UnsafeUnpin for bitrouter_sdk::acp::transport::AcpConfigError
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::acp::transport::AcpConfigError
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::acp::transport::AcpConfigError
+pub enum bitrouter_sdk::acp::transport::AcpTransport
+pub bitrouter_sdk::acp::transport::AcpTransport::Stdio
+pub bitrouter_sdk::acp::transport::AcpTransport::Stdio::args: alloc::vec::Vec<alloc::string::String>
+pub bitrouter_sdk::acp::transport::AcpTransport::Stdio::command: alloc::string::String
+pub bitrouter_sdk::acp::transport::AcpTransport::Stdio::env: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+impl core::clone::Clone for bitrouter_sdk::acp::transport::AcpTransport
+pub fn bitrouter_sdk::acp::transport::AcpTransport::clone(&self) -> bitrouter_sdk::acp::transport::AcpTransport
+impl core::cmp::Eq for bitrouter_sdk::acp::transport::AcpTransport
+impl core::cmp::PartialEq for bitrouter_sdk::acp::transport::AcpTransport
+pub fn bitrouter_sdk::acp::transport::AcpTransport::eq(&self, &bitrouter_sdk::acp::transport::AcpTransport) -> bool
+impl core::fmt::Debug for bitrouter_sdk::acp::transport::AcpTransport
+pub fn bitrouter_sdk::acp::transport::AcpTransport::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::acp::transport::AcpTransport
+impl schemars::JsonSchema for bitrouter_sdk::acp::transport::AcpTransport
+pub fn bitrouter_sdk::acp::transport::AcpTransport::inline_schema() -> bool
+pub fn bitrouter_sdk::acp::transport::AcpTransport::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::acp::transport::AcpTransport::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::acp::transport::AcpTransport::schema_name() -> alloc::borrow::Cow<'static, str>
+impl serde_core::ser::Serialize for bitrouter_sdk::acp::transport::AcpTransport
+pub fn bitrouter_sdk::acp::transport::AcpTransport::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::acp::transport::AcpTransport
+pub fn bitrouter_sdk::acp::transport::AcpTransport::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::acp::transport::AcpTransport
+impl core::marker::Send for bitrouter_sdk::acp::transport::AcpTransport
+impl core::marker::Sync for bitrouter_sdk::acp::transport::AcpTransport
+impl core::marker::Unpin for bitrouter_sdk::acp::transport::AcpTransport
+impl core::marker::UnsafeUnpin for bitrouter_sdk::acp::transport::AcpTransport
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::acp::transport::AcpTransport
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::acp::transport::AcpTransport
+pub struct bitrouter_sdk::acp::transport::AcpAgentConfig
+pub bitrouter_sdk::acp::transport::AcpAgentConfig::name: alloc::string::String
+pub bitrouter_sdk::acp::transport::AcpAgentConfig::transport: bitrouter_sdk::acp::transport::AcpTransport
+impl bitrouter_sdk::acp::transport::AcpAgentConfig
+pub fn bitrouter_sdk::acp::transport::AcpAgentConfig::validate(&self) -> core::result::Result<(), bitrouter_sdk::acp::transport::AcpConfigError>
+impl core::clone::Clone for bitrouter_sdk::acp::transport::AcpAgentConfig
+pub fn bitrouter_sdk::acp::transport::AcpAgentConfig::clone(&self) -> bitrouter_sdk::acp::transport::AcpAgentConfig
+impl core::fmt::Debug for bitrouter_sdk::acp::transport::AcpAgentConfig
+pub fn bitrouter_sdk::acp::transport::AcpAgentConfig::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::acp::transport::AcpAgentConfig
+pub fn bitrouter_sdk::acp::transport::AcpAgentConfig::inline_schema() -> bool
+pub fn bitrouter_sdk::acp::transport::AcpAgentConfig::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::acp::transport::AcpAgentConfig::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::acp::transport::AcpAgentConfig::schema_name() -> alloc::borrow::Cow<'static, str>
+impl serde_core::ser::Serialize for bitrouter_sdk::acp::transport::AcpAgentConfig
+pub fn bitrouter_sdk::acp::transport::AcpAgentConfig::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::acp::transport::AcpAgentConfig
+pub fn bitrouter_sdk::acp::transport::AcpAgentConfig::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::acp::transport::AcpAgentConfig
+impl core::marker::Send for bitrouter_sdk::acp::transport::AcpAgentConfig
+impl core::marker::Sync for bitrouter_sdk::acp::transport::AcpAgentConfig
+impl core::marker::Unpin for bitrouter_sdk::acp::transport::AcpAgentConfig
+impl core::marker::UnsafeUnpin for bitrouter_sdk::acp::transport::AcpAgentConfig
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::acp::transport::AcpAgentConfig
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::acp::transport::AcpAgentConfig
+pub mod bitrouter_sdk::acp::turn
+pub struct bitrouter_sdk::acp::turn::TurnController<I, T>
+impl<I: core::marker::Send + 'static, T: core::marker::Send + 'static> bitrouter_sdk::acp::turn::TurnController<I, T>
+pub fn bitrouter_sdk::acp::turn::TurnController<I, T>::flush(&self)
+pub fn bitrouter_sdk::acp::turn::TurnController<I, T>::new<F, Fut, G>(usize, F, G) -> Self where F: core::ops::function::Fn(I) -> Fut + core::marker::Send + 'static, Fut: core::future::future::Future<Output = anyhow::Result<T>> + core::marker::Send + 'static, G: core::ops::function::Fn() -> anyhow::Result<T> + core::marker::Send + 'static
+pub fn bitrouter_sdk::acp::turn::TurnController<I, T>::submit(&self, I) -> tokio::sync::oneshot::Receiver<anyhow::Result<T>>
+pub fn bitrouter_sdk::acp::turn::TurnController<I, T>::try_submit(&self, I) -> anyhow::Result<tokio::sync::oneshot::Receiver<anyhow::Result<T>>>
+impl<I, T> core::marker::Freeze for bitrouter_sdk::acp::turn::TurnController<I, T>
+impl<I, T> core::marker::Send for bitrouter_sdk::acp::turn::TurnController<I, T> where I: core::marker::Send, T: core::marker::Send
+impl<I, T> core::marker::Sync for bitrouter_sdk::acp::turn::TurnController<I, T> where I: core::marker::Send, T: core::marker::Send
+impl<I, T> core::marker::Unpin for bitrouter_sdk::acp::turn::TurnController<I, T>
+impl<I, T> core::marker::UnsafeUnpin for bitrouter_sdk::acp::turn::TurnController<I, T>
+impl<I, T> core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::acp::turn::TurnController<I, T>
+impl<I, T> core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::acp::turn::TurnController<I, T>
+pub mod bitrouter_sdk::acp::up
+pub struct bitrouter_sdk::acp::up::PendingPermission
+pub bitrouter_sdk::acp::up::PendingPermission::options: alloc::vec::Vec<agent_client_protocol_schema::v1::client::PermissionOption>
+pub bitrouter_sdk::acp::up::PendingPermission::request_id: alloc::string::String
+pub bitrouter_sdk::acp::up::PendingPermission::tool_call: agent_client_protocol_schema::v1::tool_call::ToolCallUpdate
+impl bitrouter_sdk::acp::up::PendingPermission
+pub fn bitrouter_sdk::acp::up::PendingPermission::deny(&self)
+pub fn bitrouter_sdk::acp::up::PendingPermission::is_resolved(&self) -> bool
+pub fn bitrouter_sdk::acp::up::PendingPermission::resolve(&self, agent_client_protocol_schema::v1::client::RequestPermissionOutcome)
+impl core::clone::Clone for bitrouter_sdk::acp::up::PendingPermission
+pub fn bitrouter_sdk::acp::up::PendingPermission::clone(&self) -> bitrouter_sdk::acp::up::PendingPermission
+impl core::fmt::Debug for bitrouter_sdk::acp::up::PendingPermission
+pub fn bitrouter_sdk::acp::up::PendingPermission::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::acp::up::PendingPermission
+impl core::marker::Send for bitrouter_sdk::acp::up::PendingPermission
+impl core::marker::Sync for bitrouter_sdk::acp::up::PendingPermission
+impl core::marker::Unpin for bitrouter_sdk::acp::up::PendingPermission
+impl core::marker::UnsafeUnpin for bitrouter_sdk::acp::up::PendingPermission
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::acp::up::PendingPermission
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::acp::up::PendingPermission
+pub struct bitrouter_sdk::acp::up::UpstreamConnection
+impl bitrouter_sdk::acp::up::UpstreamConnection
+pub async fn bitrouter_sdk::acp::up::UpstreamConnection::cancel(&self, &str) -> anyhow::Result<()>
+pub fn bitrouter_sdk::acp::up::UpstreamConnection::context_usage(&self) -> bitrouter_sdk::acp::telemetry::SharedContextUsage
+pub async fn bitrouter_sdk::acp::up::UpstreamConnection::new_session(&self, std::path::PathBuf, alloc::vec::Vec<agent_client_protocol_schema::v1::agent::McpServer>) -> anyhow::Result<bitrouter_sdk::acp::up::UpstreamSessionIds>
+pub async fn bitrouter_sdk::acp::up::UpstreamConnection::prompt(&self, &str, &str) -> anyhow::Result<agent_client_protocol_schema::v1::agent::PromptResponse>
+pub async fn bitrouter_sdk::acp::up::UpstreamConnection::prompt_typed(&self, agent_client_protocol_schema::v1::agent::PromptRequest) -> anyhow::Result<agent_client_protocol_schema::v1::agent::PromptResponse>
+pub async fn bitrouter_sdk::acp::up::UpstreamConnection::shutdown(&self) -> anyhow::Result<()>
+pub async fn bitrouter_sdk::acp::up::UpstreamConnection::spawn(&str, &[alloc::string::String], &std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>) -> anyhow::Result<Self>
+pub async fn bitrouter_sdk::acp::up::UpstreamConnection::spawn_with_stripped_env(&str, &[alloc::string::String], &std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>, &[alloc::string::String]) -> anyhow::Result<Self>
+pub fn bitrouter_sdk::acp::up::UpstreamConnection::subscribe_permissions(&self) -> core::pin::Pin<alloc::boxed::Box<(dyn futures_core::stream::Stream<Item = bitrouter_sdk::acp::up::PendingPermission> + core::marker::Send)>>
+pub fn bitrouter_sdk::acp::up::UpstreamConnection::subscribe_raw_updates(&self) -> core::pin::Pin<alloc::boxed::Box<(dyn futures_core::stream::Stream<Item = agent_client_protocol_schema::v1::client::SessionUpdate> + core::marker::Send)>>
+pub fn bitrouter_sdk::acp::up::UpstreamConnection::subscribe_updates(&self) -> core::pin::Pin<alloc::boxed::Box<(dyn futures_core::stream::Stream<Item = bitrouter_sdk::acp::translate::SessionUpdateKind> + core::marker::Send)>>
+pub fn bitrouter_sdk::acp::up::UpstreamConnection::upstream_init(&self) -> &agent_client_protocol_schema::v1::agent::InitializeResponse
+impl !core::marker::Freeze for bitrouter_sdk::acp::up::UpstreamConnection
+impl core::marker::Send for bitrouter_sdk::acp::up::UpstreamConnection
+impl core::marker::Sync for bitrouter_sdk::acp::up::UpstreamConnection
+impl core::marker::Unpin for bitrouter_sdk::acp::up::UpstreamConnection
+impl core::marker::UnsafeUnpin for bitrouter_sdk::acp::up::UpstreamConnection
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::acp::up::UpstreamConnection
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::acp::up::UpstreamConnection
+pub struct bitrouter_sdk::acp::up::UpstreamSessionIds
+pub bitrouter_sdk::acp::up::UpstreamSessionIds::acp_session_id: alloc::string::String
+pub bitrouter_sdk::acp::up::UpstreamSessionIds::agent_session_id: core::option::Option<alloc::string::String>
+impl core::clone::Clone for bitrouter_sdk::acp::up::UpstreamSessionIds
+pub fn bitrouter_sdk::acp::up::UpstreamSessionIds::clone(&self) -> bitrouter_sdk::acp::up::UpstreamSessionIds
+impl core::fmt::Debug for bitrouter_sdk::acp::up::UpstreamSessionIds
+pub fn bitrouter_sdk::acp::up::UpstreamSessionIds::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::acp::up::UpstreamSessionIds
+impl core::marker::Send for bitrouter_sdk::acp::up::UpstreamSessionIds
+impl core::marker::Sync for bitrouter_sdk::acp::up::UpstreamSessionIds
+impl core::marker::Unpin for bitrouter_sdk::acp::up::UpstreamSessionIds
+impl core::marker::UnsafeUnpin for bitrouter_sdk::acp::up::UpstreamSessionIds
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::acp::up::UpstreamSessionIds
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::acp::up::UpstreamSessionIds
+pub async fn bitrouter_sdk::acp::up::health_check(&str, &[alloc::string::String], &std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>) -> core::result::Result<core::time::Duration, alloc::string::String>
+pub enum bitrouter_sdk::acp::AcpRequestPayload
+pub bitrouter_sdk::acp::AcpRequestPayload::Cancel
+pub bitrouter_sdk::acp::AcpRequestPayload::Cancel::session_id: alloc::string::String
+pub bitrouter_sdk::acp::AcpRequestPayload::Prompt(agent_client_protocol_schema::v1::agent::PromptRequest)
+impl core::clone::Clone for bitrouter_sdk::acp::AcpRequestPayload
+pub fn bitrouter_sdk::acp::AcpRequestPayload::clone(&self) -> bitrouter_sdk::acp::AcpRequestPayload
+impl core::fmt::Debug for bitrouter_sdk::acp::AcpRequestPayload
+pub fn bitrouter_sdk::acp::AcpRequestPayload::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::acp::AcpRequestPayload
+impl core::marker::Send for bitrouter_sdk::acp::AcpRequestPayload
+impl core::marker::Sync for bitrouter_sdk::acp::AcpRequestPayload
+impl core::marker::Unpin for bitrouter_sdk::acp::AcpRequestPayload
+impl core::marker::UnsafeUnpin for bitrouter_sdk::acp::AcpRequestPayload
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::acp::AcpRequestPayload
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::acp::AcpRequestPayload
+pub enum bitrouter_sdk::acp::AcpTransport
+pub bitrouter_sdk::acp::AcpTransport::Stdio
+pub bitrouter_sdk::acp::AcpTransport::Stdio::args: alloc::vec::Vec<alloc::string::String>
+pub bitrouter_sdk::acp::AcpTransport::Stdio::command: alloc::string::String
+pub bitrouter_sdk::acp::AcpTransport::Stdio::env: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+impl core::clone::Clone for bitrouter_sdk::acp::transport::AcpTransport
+pub fn bitrouter_sdk::acp::transport::AcpTransport::clone(&self) -> bitrouter_sdk::acp::transport::AcpTransport
+impl core::cmp::Eq for bitrouter_sdk::acp::transport::AcpTransport
+impl core::cmp::PartialEq for bitrouter_sdk::acp::transport::AcpTransport
+pub fn bitrouter_sdk::acp::transport::AcpTransport::eq(&self, &bitrouter_sdk::acp::transport::AcpTransport) -> bool
+impl core::fmt::Debug for bitrouter_sdk::acp::transport::AcpTransport
+pub fn bitrouter_sdk::acp::transport::AcpTransport::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::acp::transport::AcpTransport
+impl schemars::JsonSchema for bitrouter_sdk::acp::transport::AcpTransport
+pub fn bitrouter_sdk::acp::transport::AcpTransport::inline_schema() -> bool
+pub fn bitrouter_sdk::acp::transport::AcpTransport::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::acp::transport::AcpTransport::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::acp::transport::AcpTransport::schema_name() -> alloc::borrow::Cow<'static, str>
+impl serde_core::ser::Serialize for bitrouter_sdk::acp::transport::AcpTransport
+pub fn bitrouter_sdk::acp::transport::AcpTransport::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::acp::transport::AcpTransport
+pub fn bitrouter_sdk::acp::transport::AcpTransport::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::acp::transport::AcpTransport
+impl core::marker::Send for bitrouter_sdk::acp::transport::AcpTransport
+impl core::marker::Sync for bitrouter_sdk::acp::transport::AcpTransport
+impl core::marker::Unpin for bitrouter_sdk::acp::transport::AcpTransport
+impl core::marker::UnsafeUnpin for bitrouter_sdk::acp::transport::AcpTransport
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::acp::transport::AcpTransport
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::acp::transport::AcpTransport
+pub struct bitrouter_sdk::acp::AcpAgentConfig
+pub bitrouter_sdk::acp::AcpAgentConfig::name: alloc::string::String
+pub bitrouter_sdk::acp::AcpAgentConfig::transport: bitrouter_sdk::acp::transport::AcpTransport
+impl bitrouter_sdk::acp::transport::AcpAgentConfig
+pub fn bitrouter_sdk::acp::transport::AcpAgentConfig::validate(&self) -> core::result::Result<(), bitrouter_sdk::acp::transport::AcpConfigError>
+impl core::clone::Clone for bitrouter_sdk::acp::transport::AcpAgentConfig
+pub fn bitrouter_sdk::acp::transport::AcpAgentConfig::clone(&self) -> bitrouter_sdk::acp::transport::AcpAgentConfig
+impl core::fmt::Debug for bitrouter_sdk::acp::transport::AcpAgentConfig
+pub fn bitrouter_sdk::acp::transport::AcpAgentConfig::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::acp::transport::AcpAgentConfig
+pub fn bitrouter_sdk::acp::transport::AcpAgentConfig::inline_schema() -> bool
+pub fn bitrouter_sdk::acp::transport::AcpAgentConfig::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::acp::transport::AcpAgentConfig::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::acp::transport::AcpAgentConfig::schema_name() -> alloc::borrow::Cow<'static, str>
+impl serde_core::ser::Serialize for bitrouter_sdk::acp::transport::AcpAgentConfig
+pub fn bitrouter_sdk::acp::transport::AcpAgentConfig::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::acp::transport::AcpAgentConfig
+pub fn bitrouter_sdk::acp::transport::AcpAgentConfig::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::acp::transport::AcpAgentConfig
+impl core::marker::Send for bitrouter_sdk::acp::transport::AcpAgentConfig
+impl core::marker::Sync for bitrouter_sdk::acp::transport::AcpAgentConfig
+impl core::marker::Unpin for bitrouter_sdk::acp::transport::AcpAgentConfig
+impl core::marker::UnsafeUnpin for bitrouter_sdk::acp::transport::AcpAgentConfig
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::acp::transport::AcpAgentConfig
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::acp::transport::AcpAgentConfig
+pub struct bitrouter_sdk::acp::AcpContext
+pub bitrouter_sdk::acp::AcpContext::target: core::option::Option<bitrouter_sdk::acp::AcpTarget>
+impl bitrouter_sdk::acp::AcpContext
+pub fn bitrouter_sdk::acp::AcpContext::caller(&self) -> &bitrouter_sdk::caller::CallerContext
+pub fn bitrouter_sdk::acp::AcpContext::emit<E: bitrouter_sdk::event::PipelineEvent>(&mut self, E)
+pub fn bitrouter_sdk::acp::AcpContext::has_event<E: bitrouter_sdk::event::PipelineEvent>(&self) -> bool
+pub fn bitrouter_sdk::acp::AcpContext::new(bitrouter_sdk::acp::AcpRequest) -> Self
+pub fn bitrouter_sdk::acp::AcpContext::request(&self) -> &bitrouter_sdk::acp::AcpRequest
+pub fn bitrouter_sdk::acp::AcpContext::started_at(&self) -> std::time::Instant
+impl core::marker::Freeze for bitrouter_sdk::acp::AcpContext
+impl core::marker::Send for bitrouter_sdk::acp::AcpContext
+impl core::marker::Sync for bitrouter_sdk::acp::AcpContext
+impl core::marker::Unpin for bitrouter_sdk::acp::AcpContext
+impl core::marker::UnsafeUnpin for bitrouter_sdk::acp::AcpContext
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::acp::AcpContext
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::acp::AcpContext
+pub struct bitrouter_sdk::acp::AcpRequest
+pub bitrouter_sdk::acp::AcpRequest::agent: alloc::string::String
+pub bitrouter_sdk::acp::AcpRequest::caller: bitrouter_sdk::caller::CallerContext
+pub bitrouter_sdk::acp::AcpRequest::payload: bitrouter_sdk::acp::AcpRequestPayload
+pub bitrouter_sdk::acp::AcpRequest::request_id: alloc::string::String
+impl bitrouter_sdk::acp::AcpRequest
+pub fn bitrouter_sdk::acp::AcpRequest::new(impl core::convert::Into<alloc::string::String>, bitrouter_sdk::acp::AcpRequestPayload, bitrouter_sdk::caller::CallerContext) -> Self
+impl core::clone::Clone for bitrouter_sdk::acp::AcpRequest
+pub fn bitrouter_sdk::acp::AcpRequest::clone(&self) -> bitrouter_sdk::acp::AcpRequest
+impl core::fmt::Debug for bitrouter_sdk::acp::AcpRequest
+pub fn bitrouter_sdk::acp::AcpRequest::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::acp::AcpRequest
+impl core::marker::Send for bitrouter_sdk::acp::AcpRequest
+impl core::marker::Sync for bitrouter_sdk::acp::AcpRequest
+impl core::marker::Unpin for bitrouter_sdk::acp::AcpRequest
+impl core::marker::UnsafeUnpin for bitrouter_sdk::acp::AcpRequest
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::acp::AcpRequest
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::acp::AcpRequest
+pub struct bitrouter_sdk::acp::AcpResponse
+pub bitrouter_sdk::acp::AcpResponse::request_id: alloc::string::String
+pub bitrouter_sdk::acp::AcpResponse::result: agent_client_protocol_schema::v1::agent::PromptResponse
+impl core::clone::Clone for bitrouter_sdk::acp::AcpResponse
+pub fn bitrouter_sdk::acp::AcpResponse::clone(&self) -> bitrouter_sdk::acp::AcpResponse
+impl core::fmt::Debug for bitrouter_sdk::acp::AcpResponse
+pub fn bitrouter_sdk::acp::AcpResponse::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::acp::AcpResponse
+impl core::marker::Send for bitrouter_sdk::acp::AcpResponse
+impl core::marker::Sync for bitrouter_sdk::acp::AcpResponse
+impl core::marker::Unpin for bitrouter_sdk::acp::AcpResponse
+impl core::marker::UnsafeUnpin for bitrouter_sdk::acp::AcpResponse
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::acp::AcpResponse
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::acp::AcpResponse
+pub struct bitrouter_sdk::acp::AcpTarget
+pub bitrouter_sdk::acp::AcpTarget::agent_name: alloc::string::String
+pub bitrouter_sdk::acp::AcpTarget::transport: bitrouter_sdk::acp::transport::AcpTransport
+impl core::clone::Clone for bitrouter_sdk::acp::AcpTarget
+pub fn bitrouter_sdk::acp::AcpTarget::clone(&self) -> bitrouter_sdk::acp::AcpTarget
+impl core::fmt::Debug for bitrouter_sdk::acp::AcpTarget
+pub fn bitrouter_sdk::acp::AcpTarget::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::acp::AcpTarget
+impl core::marker::Send for bitrouter_sdk::acp::AcpTarget
+impl core::marker::Sync for bitrouter_sdk::acp::AcpTarget
+impl core::marker::Unpin for bitrouter_sdk::acp::AcpTarget
+impl core::marker::UnsafeUnpin for bitrouter_sdk::acp::AcpTarget
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::acp::AcpTarget
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::acp::AcpTarget
+pub struct bitrouter_sdk::acp::ConfigAcpRoutingTable
+impl bitrouter_sdk::acp::config_routing::ConfigAcpRoutingTable
+pub fn bitrouter_sdk::acp::config_routing::ConfigAcpRoutingTable::from_configs<I>(I) -> bitrouter_sdk::error::Result<Self> where I: core::iter::traits::collect::IntoIterator<Item = (alloc::string::String, bitrouter_sdk::acp::transport::AcpAgentConfig)>
+pub fn bitrouter_sdk::acp::config_routing::ConfigAcpRoutingTable::is_empty(&self) -> bool
+pub fn bitrouter_sdk::acp::config_routing::ConfigAcpRoutingTable::lookup(&self, &str) -> core::option::Option<&bitrouter_sdk::acp::transport::AcpTransport>
+impl bitrouter_sdk::acp::RoutingTable for bitrouter_sdk::acp::config_routing::ConfigAcpRoutingTable
+pub fn bitrouter_sdk::acp::config_routing::ConfigAcpRoutingTable::resolve<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 str, &'life2 bitrouter_sdk::caller::CallerContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::acp::AcpTarget>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+impl core::clone::Clone for bitrouter_sdk::acp::config_routing::ConfigAcpRoutingTable
+pub fn bitrouter_sdk::acp::config_routing::ConfigAcpRoutingTable::clone(&self) -> bitrouter_sdk::acp::config_routing::ConfigAcpRoutingTable
+impl core::default::Default for bitrouter_sdk::acp::config_routing::ConfigAcpRoutingTable
+pub fn bitrouter_sdk::acp::config_routing::ConfigAcpRoutingTable::default() -> bitrouter_sdk::acp::config_routing::ConfigAcpRoutingTable
+impl core::fmt::Debug for bitrouter_sdk::acp::config_routing::ConfigAcpRoutingTable
+pub fn bitrouter_sdk::acp::config_routing::ConfigAcpRoutingTable::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::acp::config_routing::ConfigAcpRoutingTable
+impl core::marker::Send for bitrouter_sdk::acp::config_routing::ConfigAcpRoutingTable
+impl core::marker::Sync for bitrouter_sdk::acp::config_routing::ConfigAcpRoutingTable
+impl core::marker::Unpin for bitrouter_sdk::acp::config_routing::ConfigAcpRoutingTable
+impl core::marker::UnsafeUnpin for bitrouter_sdk::acp::config_routing::ConfigAcpRoutingTable
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::acp::config_routing::ConfigAcpRoutingTable
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::acp::config_routing::ConfigAcpRoutingTable
+pub struct bitrouter_sdk::acp::Pipeline
+impl bitrouter_sdk::acp::Pipeline
+pub async fn bitrouter_sdk::acp::Pipeline::execute(&self, bitrouter_sdk::acp::AcpRequest) -> bitrouter_sdk::error::Result<bitrouter_sdk::acp::AcpResponse>
+impl core::marker::Freeze for bitrouter_sdk::acp::Pipeline
+impl core::marker::Send for bitrouter_sdk::acp::Pipeline
+impl core::marker::Sync for bitrouter_sdk::acp::Pipeline
+impl core::marker::Unpin for bitrouter_sdk::acp::Pipeline
+impl core::marker::UnsafeUnpin for bitrouter_sdk::acp::Pipeline
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::acp::Pipeline
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::acp::Pipeline
+pub struct bitrouter_sdk::acp::PipelineBuilder
+impl bitrouter_sdk::acp::PipelineBuilder
+pub fn bitrouter_sdk::acp::PipelineBuilder::build(self) -> bitrouter_sdk::error::Result<bitrouter_sdk::acp::Pipeline>
+pub fn bitrouter_sdk::acp::PipelineBuilder::context_usage(&mut self, bitrouter_sdk::acp::telemetry::SharedContextUsage) -> &mut Self
+pub fn bitrouter_sdk::acp::PipelineBuilder::execution_hook(&mut self, impl bitrouter_sdk::acp::ExecutionHook + 'static) -> &mut Self
+pub fn bitrouter_sdk::acp::PipelineBuilder::executor(&mut self, alloc::sync::Arc<dyn bitrouter_sdk::acp::Executor>) -> &mut Self
+pub fn bitrouter_sdk::acp::PipelineBuilder::is_configured(&self) -> bool
+pub fn bitrouter_sdk::acp::PipelineBuilder::new() -> Self
+pub fn bitrouter_sdk::acp::PipelineBuilder::pre_request_hook(&mut self, impl bitrouter_sdk::acp::PreRequestHook + 'static) -> &mut Self
+pub fn bitrouter_sdk::acp::PipelineBuilder::route_hook(&mut self, impl bitrouter_sdk::acp::RouteHook + 'static) -> &mut Self
+pub fn bitrouter_sdk::acp::PipelineBuilder::routing_table(&mut self, alloc::sync::Arc<dyn bitrouter_sdk::acp::RoutingTable>) -> &mut Self
+pub fn bitrouter_sdk::acp::PipelineBuilder::settlement_recorder(&mut self, alloc::sync::Arc<dyn bitrouter_sdk::acp::settlement::AcpSettlementRecorder>) -> &mut Self
+impl core::default::Default for bitrouter_sdk::acp::PipelineBuilder
+pub fn bitrouter_sdk::acp::PipelineBuilder::default() -> bitrouter_sdk::acp::PipelineBuilder
+impl core::marker::Freeze for bitrouter_sdk::acp::PipelineBuilder
+impl core::marker::Send for bitrouter_sdk::acp::PipelineBuilder
+impl core::marker::Sync for bitrouter_sdk::acp::PipelineBuilder
+impl core::marker::Unpin for bitrouter_sdk::acp::PipelineBuilder
+impl core::marker::UnsafeUnpin for bitrouter_sdk::acp::PipelineBuilder
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::acp::PipelineBuilder
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::acp::PipelineBuilder
+pub trait bitrouter_sdk::acp::ExecutionHook: core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::acp::ExecutionHook::on_success<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::acp::AcpContext, &'life2 bitrouter_sdk::acp::AcpResponse) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<()>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+impl bitrouter_sdk::acp::ExecutionHook for bitrouter_sdk::acp::telemetry::TelemetryHook
+pub fn bitrouter_sdk::acp::telemetry::TelemetryHook::on_success<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::acp::AcpContext, &'life2 bitrouter_sdk::acp::AcpResponse) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<()>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub trait bitrouter_sdk::acp::Executor: core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::acp::Executor::execute<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::acp::AcpTarget, &'life2 bitrouter_sdk::acp::AcpRequest) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::acp::AcpResponse>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+impl bitrouter_sdk::acp::Executor for bitrouter_sdk::acp::executor::SessionExecutor
+pub fn bitrouter_sdk::acp::executor::SessionExecutor::execute<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::acp::AcpTarget, &'life2 bitrouter_sdk::acp::AcpRequest) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::acp::AcpResponse>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub trait bitrouter_sdk::acp::PreRequestHook: core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::acp::PreRequestHook::check<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 mut bitrouter_sdk::acp::AcpContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::hooks::HookDecision>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub trait bitrouter_sdk::acp::RouteHook: core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::acp::RouteHook::resolve<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 mut bitrouter_sdk::acp::AcpTarget, &'life2 mut bitrouter_sdk::acp::AcpContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<()>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub trait bitrouter_sdk::acp::RoutingTable: core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::acp::RoutingTable::resolve<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 str, &'life2 bitrouter_sdk::caller::CallerContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::acp::AcpTarget>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+impl bitrouter_sdk::acp::RoutingTable for bitrouter_sdk::acp::config_routing::ConfigAcpRoutingTable
+pub fn bitrouter_sdk::acp::config_routing::ConfigAcpRoutingTable::resolve<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 str, &'life2 bitrouter_sdk::caller::CallerContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::acp::AcpTarget>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub mod bitrouter_sdk::app
+pub struct bitrouter_sdk::app::App
+impl bitrouter_sdk::app::App
+pub fn bitrouter_sdk::app::App::builder() -> bitrouter_sdk::app::AppBuilder
+pub fn bitrouter_sdk::app::App::language_model(&self) -> core::option::Option<&alloc::sync::Arc<bitrouter_sdk::language_model::pipeline::Pipeline>>
+pub fn bitrouter_sdk::app::App::mcp(&self) -> core::option::Option<&alloc::sync::Arc<bitrouter_sdk::mcp::Pipeline>>
+pub fn bitrouter_sdk::app::App::mcp_aggregate_route(&self) -> core::option::Option<&str>
+pub fn bitrouter_sdk::app::App::metrics_renderer(&self) -> core::option::Option<&alloc::sync::Arc<dyn bitrouter_sdk::metrics::MetricsRenderer>>
+pub fn bitrouter_sdk::app::App::migrations(&self) -> &[bitrouter_sdk::plugin::MigrationItem]
+pub fn bitrouter_sdk::app::App::prompt_transforms(&self) -> &[alloc::sync::Arc<dyn bitrouter_sdk::app::PromptTransform>]
+pub fn bitrouter_sdk::app::App::skip_auth(&self) -> bool
+impl bitrouter_sdk::app::App
+pub async fn bitrouter_sdk::app::App::serve(&self, &str) -> bitrouter_sdk::error::Result<()>
+pub async fn bitrouter_sdk::app::App::serve_with_router_wrapper<F>(&self, &str, F) -> bitrouter_sdk::error::Result<()> where F: core::ops::function::Fn(axum::routing::Router) -> axum::routing::Router + core::marker::Send + core::marker::Sync + 'static
+pub async fn bitrouter_sdk::app::App::serve_with_router_wrapper_and_shutdown<F, S>(&self, &str, F, S) -> bitrouter_sdk::error::Result<()> where F: core::ops::function::Fn(axum::routing::Router) -> axum::routing::Router + core::marker::Send + core::marker::Sync + 'static, S: core::future::future::Future<Output = ()> + core::marker::Send + 'static
+pub async fn bitrouter_sdk::app::App::serve_with_shutdown<S>(&self, &str, S) -> bitrouter_sdk::error::Result<()> where S: core::future::future::Future<Output = ()> + core::marker::Send + 'static
+impl core::marker::Freeze for bitrouter_sdk::app::App
+impl core::marker::Send for bitrouter_sdk::app::App
+impl core::marker::Sync for bitrouter_sdk::app::App
+impl core::marker::Unpin for bitrouter_sdk::app::App
+impl core::marker::UnsafeUnpin for bitrouter_sdk::app::App
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::app::App
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::app::App
+pub struct bitrouter_sdk::app::AppBuilder
+impl bitrouter_sdk::app::AppBuilder
+pub fn bitrouter_sdk::app::AppBuilder::add_migrations(&mut self, impl core::iter::traits::collect::IntoIterator<Item = bitrouter_sdk::plugin::MigrationItem>)
+pub fn bitrouter_sdk::app::AppBuilder::build(self) -> bitrouter_sdk::error::Result<bitrouter_sdk::app::App>
+pub fn bitrouter_sdk::app::AppBuilder::language_model<F>(self, F) -> Self where F: core::ops::function::FnOnce(&mut bitrouter_sdk::language_model::builder::PipelineBuilder)
+pub fn bitrouter_sdk::app::AppBuilder::language_model_builder(&mut self) -> &mut bitrouter_sdk::language_model::builder::PipelineBuilder
+pub fn bitrouter_sdk::app::AppBuilder::mcp<F>(self, F) -> Self where F: core::ops::function::FnOnce(&mut bitrouter_sdk::mcp::PipelineBuilder)
+pub fn bitrouter_sdk::app::AppBuilder::mcp_aggregate_route(self, impl core::convert::Into<alloc::string::String>) -> Self
+pub fn bitrouter_sdk::app::AppBuilder::metrics_renderer(self, alloc::sync::Arc<dyn bitrouter_sdk::metrics::MetricsRenderer>) -> Self
+pub fn bitrouter_sdk::app::AppBuilder::new() -> Self
+pub fn bitrouter_sdk::app::AppBuilder::plugin(self, impl bitrouter_sdk::app::Plugin) -> Self
+pub fn bitrouter_sdk::app::AppBuilder::prompt_transform(self, alloc::sync::Arc<dyn bitrouter_sdk::app::PromptTransform>) -> Self
+pub fn bitrouter_sdk::app::AppBuilder::skip_auth(self, bool) -> Self
+impl core::default::Default for bitrouter_sdk::app::AppBuilder
+pub fn bitrouter_sdk::app::AppBuilder::default() -> Self
+impl core::marker::Freeze for bitrouter_sdk::app::AppBuilder
+impl core::marker::Send for bitrouter_sdk::app::AppBuilder
+impl core::marker::Sync for bitrouter_sdk::app::AppBuilder
+impl core::marker::Unpin for bitrouter_sdk::app::AppBuilder
+impl core::marker::UnsafeUnpin for bitrouter_sdk::app::AppBuilder
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::app::AppBuilder
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::app::AppBuilder
+pub trait bitrouter_sdk::app::Plugin
+pub fn bitrouter_sdk::app::Plugin::id(&self) -> &bitrouter_sdk::plugin::PluginId
+pub fn bitrouter_sdk::app::Plugin::install(&self, &mut bitrouter_sdk::app::AppBuilder)
+pub fn bitrouter_sdk::app::Plugin::migrations(&self) -> alloc::vec::Vec<bitrouter_sdk::plugin::MigrationItem>
+pub trait bitrouter_sdk::app::PromptTransform: core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::app::PromptTransform::apply(&self, &mut bitrouter_sdk::language_model::types::Prompt)
+pub fn bitrouter_sdk::app::PromptTransform::apply_with_headers(&self, &mut bitrouter_sdk::language_model::types::Prompt, &http::header::map::HeaderMap)
+impl bitrouter_sdk::app::PromptTransform for bitrouter_sdk::language_model::server_tools::fusion::alias::FusionAliasConfig
+pub fn bitrouter_sdk::language_model::server_tools::fusion::alias::FusionAliasConfig::apply(&self, &mut bitrouter_sdk::language_model::types::Prompt)
+pub fn bitrouter_sdk::language_model::server_tools::fusion::alias::FusionAliasConfig::apply_with_headers(&self, &mut bitrouter_sdk::language_model::types::Prompt, &http::header::map::HeaderMap)
+pub mod bitrouter_sdk::caller
+pub struct bitrouter_sdk::caller::CallerContext
+impl bitrouter_sdk::caller::CallerContext
+pub fn bitrouter_sdk::caller::CallerContext::anonymous() -> Self
+pub fn bitrouter_sdk::caller::CallerContext::api_key_id(&self) -> &str
+pub fn bitrouter_sdk::caller::CallerContext::is_anonymous(&self) -> bool
+pub fn bitrouter_sdk::caller::CallerContext::is_local(&self) -> bool
+pub fn bitrouter_sdk::caller::CallerContext::launch_id(&self) -> core::option::Option<&str>
+pub fn bitrouter_sdk::caller::CallerContext::local() -> Self
+pub fn bitrouter_sdk::caller::CallerContext::local_launch(impl core::convert::Into<alloc::string::String>) -> Self
+pub fn bitrouter_sdk::caller::CallerContext::new(impl core::convert::Into<alloc::string::String>, impl core::convert::Into<alloc::string::String>) -> Self
+pub fn bitrouter_sdk::caller::CallerContext::user_id(&self) -> &str
+impl core::clone::Clone for bitrouter_sdk::caller::CallerContext
+pub fn bitrouter_sdk::caller::CallerContext::clone(&self) -> bitrouter_sdk::caller::CallerContext
+impl core::fmt::Debug for bitrouter_sdk::caller::CallerContext
+pub fn bitrouter_sdk::caller::CallerContext::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl serde_core::ser::Serialize for bitrouter_sdk::caller::CallerContext
+pub fn bitrouter_sdk::caller::CallerContext::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::caller::CallerContext
+pub fn bitrouter_sdk::caller::CallerContext::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::caller::CallerContext
+impl core::marker::Send for bitrouter_sdk::caller::CallerContext
+impl core::marker::Sync for bitrouter_sdk::caller::CallerContext
+impl core::marker::Unpin for bitrouter_sdk::caller::CallerContext
+impl core::marker::UnsafeUnpin for bitrouter_sdk::caller::CallerContext
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::caller::CallerContext
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::caller::CallerContext
+pub const bitrouter_sdk::caller::LAUNCH_TOKEN_PREFIX: &str
+pub fn bitrouter_sdk::caller::launch_tag(core::option::Option<&str>) -> core::option::Option<alloc::string::String>
+pub mod bitrouter_sdk::config
+pub mod bitrouter_sdk::config::pattern
+pub enum bitrouter_sdk::config::pattern::Pattern
+pub bitrouter_sdk::config::pattern::Pattern::Exact(alloc::string::String)
+pub bitrouter_sdk::config::pattern::Pattern::Prefix(alloc::string::String)
+pub bitrouter_sdk::config::pattern::Pattern::Wildcard
+impl bitrouter_sdk::config::pattern::Pattern
+pub fn bitrouter_sdk::config::pattern::Pattern::matches(&self, &str) -> bool
+pub fn bitrouter_sdk::config::pattern::Pattern::parse(&str) -> Self
+pub fn bitrouter_sdk::config::pattern::Pattern::specificity(&self) -> usize
+impl core::clone::Clone for bitrouter_sdk::config::pattern::Pattern
+pub fn bitrouter_sdk::config::pattern::Pattern::clone(&self) -> bitrouter_sdk::config::pattern::Pattern
+impl core::cmp::Eq for bitrouter_sdk::config::pattern::Pattern
+impl core::cmp::PartialEq for bitrouter_sdk::config::pattern::Pattern
+pub fn bitrouter_sdk::config::pattern::Pattern::eq(&self, &bitrouter_sdk::config::pattern::Pattern) -> bool
+impl core::fmt::Debug for bitrouter_sdk::config::pattern::Pattern
+pub fn bitrouter_sdk::config::pattern::Pattern::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::config::pattern::Pattern
+impl core::marker::Freeze for bitrouter_sdk::config::pattern::Pattern
+impl core::marker::Send for bitrouter_sdk::config::pattern::Pattern
+impl core::marker::Sync for bitrouter_sdk::config::pattern::Pattern
+impl core::marker::Unpin for bitrouter_sdk::config::pattern::Pattern
+impl core::marker::UnsafeUnpin for bitrouter_sdk::config::pattern::Pattern
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::config::pattern::Pattern
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::config::pattern::Pattern
+pub struct bitrouter_sdk::config::pattern::PatternMap<T>
+impl<T> bitrouter_sdk::config::pattern::PatternMap<T>
+pub fn bitrouter_sdk::config::pattern::PatternMap<T>::is_empty(&self) -> bool
+pub fn bitrouter_sdk::config::pattern::PatternMap<T>::new() -> Self
+pub fn bitrouter_sdk::config::pattern::PatternMap<T>::push(&mut self, bitrouter_sdk::config::pattern::Pattern, T)
+pub fn bitrouter_sdk::config::pattern::PatternMap<T>::resolve(&self, &str) -> core::option::Option<&T>
+impl<'de, T> serde_core::de::Deserialize<'de> for bitrouter_sdk::config::pattern::PatternMap<T> where T: serde_core::de::Deserialize<'de>
+pub fn bitrouter_sdk::config::pattern::PatternMap<T>::deserialize<D>(D) -> core::result::Result<Self, <D as serde_core::de::Deserializer>::Error> where D: serde_core::de::Deserializer<'de>
+impl<T: core::clone::Clone> core::clone::Clone for bitrouter_sdk::config::pattern::PatternMap<T>
+pub fn bitrouter_sdk::config::pattern::PatternMap<T>::clone(&self) -> bitrouter_sdk::config::pattern::PatternMap<T>
+impl<T: core::default::Default> core::default::Default for bitrouter_sdk::config::pattern::PatternMap<T>
+pub fn bitrouter_sdk::config::pattern::PatternMap<T>::default() -> bitrouter_sdk::config::pattern::PatternMap<T>
+impl<T: core::fmt::Debug> core::fmt::Debug for bitrouter_sdk::config::pattern::PatternMap<T>
+pub fn bitrouter_sdk::config::pattern::PatternMap<T>::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<T: schemars::JsonSchema> schemars::JsonSchema for bitrouter_sdk::config::pattern::PatternMap<T>
+pub fn bitrouter_sdk::config::pattern::PatternMap<T>::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::config::pattern::PatternMap<T>::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::config::pattern::PatternMap<T>::schema_name() -> alloc::borrow::Cow<'static, str>
+impl<T> core::marker::Freeze for bitrouter_sdk::config::pattern::PatternMap<T>
+impl<T> core::marker::Send for bitrouter_sdk::config::pattern::PatternMap<T> where T: core::marker::Send
+impl<T> core::marker::Sync for bitrouter_sdk::config::pattern::PatternMap<T> where T: core::marker::Sync
+impl<T> core::marker::Unpin for bitrouter_sdk::config::pattern::PatternMap<T> where T: core::marker::Unpin
+impl<T> core::marker::UnsafeUnpin for bitrouter_sdk::config::pattern::PatternMap<T>
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::config::pattern::PatternMap<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::config::pattern::PatternMap<T> where T: core::panic::unwind_safe::UnwindSafe
+pub mod bitrouter_sdk::config::presets
+pub struct bitrouter_sdk::config::presets::PresetResolution
+pub bitrouter_sdk::config::presets::PresetResolution::clean_model: alloc::string::String
+pub bitrouter_sdk::config::presets::PresetResolution::overrides: bitrouter_sdk::language_model::routing::PromptOverrides
+pub bitrouter_sdk::config::presets::PresetResolution::policy: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::config::presets::PresetResolution::prefs: bitrouter_sdk::language_model::routing::RoutingPrefs
+pub bitrouter_sdk::config::presets::PresetResolution::variant: core::option::Option<alloc::string::String>
+impl core::clone::Clone for bitrouter_sdk::config::presets::PresetResolution
+pub fn bitrouter_sdk::config::presets::PresetResolution::clone(&self) -> bitrouter_sdk::config::presets::PresetResolution
+impl core::fmt::Debug for bitrouter_sdk::config::presets::PresetResolution
+pub fn bitrouter_sdk::config::presets::PresetResolution::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::config::presets::PresetResolution
+impl core::marker::Send for bitrouter_sdk::config::presets::PresetResolution
+impl core::marker::Sync for bitrouter_sdk::config::presets::PresetResolution
+impl core::marker::Unpin for bitrouter_sdk::config::presets::PresetResolution
+impl core::marker::UnsafeUnpin for bitrouter_sdk::config::presets::PresetResolution
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::config::presets::PresetResolution
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::config::presets::PresetResolution
+pub struct bitrouter_sdk::config::presets::PromptOverrides
+pub bitrouter_sdk::config::presets::PromptOverrides::params: serde_json::map::Map<alloc::string::String, serde_json::value::Value>
+pub bitrouter_sdk::config::presets::PromptOverrides::system_prompt: core::option::Option<alloc::string::String>
+impl bitrouter_sdk::language_model::routing::PromptOverrides
+pub fn bitrouter_sdk::language_model::routing::PromptOverrides::is_empty(&self) -> bool
+impl core::clone::Clone for bitrouter_sdk::language_model::routing::PromptOverrides
+pub fn bitrouter_sdk::language_model::routing::PromptOverrides::clone(&self) -> bitrouter_sdk::language_model::routing::PromptOverrides
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::routing::PromptOverrides
+pub fn bitrouter_sdk::language_model::routing::PromptOverrides::eq(&self, &bitrouter_sdk::language_model::routing::PromptOverrides) -> bool
+impl core::default::Default for bitrouter_sdk::language_model::routing::PromptOverrides
+pub fn bitrouter_sdk::language_model::routing::PromptOverrides::default() -> bitrouter_sdk::language_model::routing::PromptOverrides
+impl core::fmt::Debug for bitrouter_sdk::language_model::routing::PromptOverrides
+pub fn bitrouter_sdk::language_model::routing::PromptOverrides::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::routing::PromptOverrides
+impl core::marker::Freeze for bitrouter_sdk::language_model::routing::PromptOverrides
+impl core::marker::Send for bitrouter_sdk::language_model::routing::PromptOverrides
+impl core::marker::Sync for bitrouter_sdk::language_model::routing::PromptOverrides
+impl core::marker::Unpin for bitrouter_sdk::language_model::routing::PromptOverrides
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::routing::PromptOverrides
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::routing::PromptOverrides
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::routing::PromptOverrides
+pub fn bitrouter_sdk::config::presets::resolve_presets(&str, &std::collections::hash::map::HashMap<alloc::string::String, bitrouter_sdk::config::PresetConfig>, &std::collections::hash::map::HashMap<alloc::string::String, bitrouter_sdk::config::VariantConfig>) -> bitrouter_sdk::error::Result<bitrouter_sdk::config::presets::PresetResolution>
+pub mod bitrouter_sdk::config::routing_table
+pub struct bitrouter_sdk::config::routing_table::ConfigRoutingTable
+impl bitrouter_sdk::config::routing_table::ConfigRoutingTable
+pub fn bitrouter_sdk::config::routing_table::ConfigRoutingTable::from_config(bitrouter_sdk::config::Config) -> Self
+pub fn bitrouter_sdk::config::routing_table::ConfigRoutingTable::from_config_with_path(bitrouter_sdk::config::Config, impl core::convert::Into<std::path::PathBuf>) -> Self
+pub async fn bitrouter_sdk::config::routing_table::ConfigRoutingTable::load(impl core::convert::Into<std::path::PathBuf>) -> bitrouter_sdk::error::Result<Self>
+pub async fn bitrouter_sdk::config::routing_table::ConfigRoutingTable::replace_config(&self, bitrouter_sdk::config::Config) -> bitrouter_sdk::error::Result<()>
+pub fn bitrouter_sdk::config::routing_table::ConfigRoutingTable::snapshot_config(&self) -> bitrouter_sdk::config::Config
+impl bitrouter_sdk::language_model::routing::RoutingTable for bitrouter_sdk::config::routing_table::ConfigRoutingTable
+pub fn bitrouter_sdk::config::routing_table::ConfigRoutingTable::list_models(&self) -> alloc::vec::Vec<bitrouter_sdk::language_model::routing::ModelInfo>
+pub fn bitrouter_sdk::config::routing_table::ConfigRoutingTable::model_info(&self, &str) -> core::option::Option<bitrouter_sdk::language_model::routing::ModelInfo>
+pub fn bitrouter_sdk::config::routing_table::ConfigRoutingTable::preset_overrides<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 str) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::routing::PromptOverrides>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::config::routing_table::ConfigRoutingTable::reload<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<()>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn bitrouter_sdk::config::routing_table::ConfigRoutingTable::resolve_model<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 str) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::routing::ModelResolution>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::config::routing_table::ConfigRoutingTable::route_chain<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 str, &'life2 bitrouter_sdk::language_model::routing::RoutingPrefs, &'life3 bitrouter_sdk::caller::CallerContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<alloc::vec::Vec<bitrouter_sdk::language_model::types::RoutingTarget>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub fn bitrouter_sdk::config::routing_table::ConfigRoutingTable::route_resolved<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 str, &'life2 bitrouter_sdk::language_model::routing::RoutingPrefs, &'life3 bitrouter_sdk::caller::CallerContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<alloc::vec::Vec<bitrouter_sdk::language_model::types::RoutingTarget>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+impl !core::marker::Freeze for bitrouter_sdk::config::routing_table::ConfigRoutingTable
+impl core::marker::Send for bitrouter_sdk::config::routing_table::ConfigRoutingTable
+impl core::marker::Sync for bitrouter_sdk::config::routing_table::ConfigRoutingTable
+impl core::marker::Unpin for bitrouter_sdk::config::routing_table::ConfigRoutingTable
+impl core::marker::UnsafeUnpin for bitrouter_sdk::config::routing_table::ConfigRoutingTable
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::config::routing_table::ConfigRoutingTable
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::config::routing_table::ConfigRoutingTable
+pub fn bitrouter_sdk::config::routing_table::list_models_for(&bitrouter_sdk::config::Config) -> alloc::vec::Vec<bitrouter_sdk::language_model::routing::ModelInfo>
+pub fn bitrouter_sdk::config::routing_table::resolve_route_chain(&bitrouter_sdk::config::Config, &str, &bitrouter_sdk::language_model::routing::RoutingPrefs) -> bitrouter_sdk::error::Result<alloc::vec::Vec<bitrouter_sdk::language_model::types::RoutingTarget>>
+pub enum bitrouter_sdk::config::AccountStrategy
+pub bitrouter_sdk::config::AccountStrategy::Balance
+pub bitrouter_sdk::config::AccountStrategy::Failover
+impl core::clone::Clone for bitrouter_sdk::config::AccountStrategy
+pub fn bitrouter_sdk::config::AccountStrategy::clone(&self) -> bitrouter_sdk::config::AccountStrategy
+impl core::cmp::Eq for bitrouter_sdk::config::AccountStrategy
+impl core::cmp::PartialEq for bitrouter_sdk::config::AccountStrategy
+pub fn bitrouter_sdk::config::AccountStrategy::eq(&self, &bitrouter_sdk::config::AccountStrategy) -> bool
+impl core::default::Default for bitrouter_sdk::config::AccountStrategy
+pub fn bitrouter_sdk::config::AccountStrategy::default() -> bitrouter_sdk::config::AccountStrategy
+impl core::fmt::Debug for bitrouter_sdk::config::AccountStrategy
+pub fn bitrouter_sdk::config::AccountStrategy::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for bitrouter_sdk::config::AccountStrategy
+impl core::marker::StructuralPartialEq for bitrouter_sdk::config::AccountStrategy
+impl schemars::JsonSchema for bitrouter_sdk::config::AccountStrategy
+pub fn bitrouter_sdk::config::AccountStrategy::inline_schema() -> bool
+pub fn bitrouter_sdk::config::AccountStrategy::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::config::AccountStrategy::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::config::AccountStrategy::schema_name() -> alloc::borrow::Cow<'static, str>
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::config::AccountStrategy
+pub fn bitrouter_sdk::config::AccountStrategy::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::config::AccountStrategy
+impl core::marker::Send for bitrouter_sdk::config::AccountStrategy
+impl core::marker::Sync for bitrouter_sdk::config::AccountStrategy
+impl core::marker::Unpin for bitrouter_sdk::config::AccountStrategy
+impl core::marker::UnsafeUnpin for bitrouter_sdk::config::AccountStrategy
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::config::AccountStrategy
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::config::AccountStrategy
+pub enum bitrouter_sdk::config::EvalAuthorityKind
+pub bitrouter_sdk::config::EvalAuthorityKind::Agentic
+pub bitrouter_sdk::config::EvalAuthorityKind::Enterprise
+pub bitrouter_sdk::config::EvalAuthorityKind::Generic
+pub bitrouter_sdk::config::EvalAuthorityKind::Human
+pub bitrouter_sdk::config::EvalAuthorityKind::TaskNative
+impl core::clone::Clone for bitrouter_sdk::config::EvalAuthorityKind
+pub fn bitrouter_sdk::config::EvalAuthorityKind::clone(&self) -> bitrouter_sdk::config::EvalAuthorityKind
+impl core::cmp::Eq for bitrouter_sdk::config::EvalAuthorityKind
+impl core::cmp::PartialEq for bitrouter_sdk::config::EvalAuthorityKind
+pub fn bitrouter_sdk::config::EvalAuthorityKind::eq(&self, &bitrouter_sdk::config::EvalAuthorityKind) -> bool
+impl core::default::Default for bitrouter_sdk::config::EvalAuthorityKind
+pub fn bitrouter_sdk::config::EvalAuthorityKind::default() -> bitrouter_sdk::config::EvalAuthorityKind
+impl core::fmt::Debug for bitrouter_sdk::config::EvalAuthorityKind
+pub fn bitrouter_sdk::config::EvalAuthorityKind::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for bitrouter_sdk::config::EvalAuthorityKind
+impl core::marker::StructuralPartialEq for bitrouter_sdk::config::EvalAuthorityKind
+impl schemars::JsonSchema for bitrouter_sdk::config::EvalAuthorityKind
+pub fn bitrouter_sdk::config::EvalAuthorityKind::inline_schema() -> bool
+pub fn bitrouter_sdk::config::EvalAuthorityKind::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::config::EvalAuthorityKind::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::config::EvalAuthorityKind::schema_name() -> alloc::borrow::Cow<'static, str>
+impl serde_core::ser::Serialize for bitrouter_sdk::config::EvalAuthorityKind
+pub fn bitrouter_sdk::config::EvalAuthorityKind::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::config::EvalAuthorityKind
+pub fn bitrouter_sdk::config::EvalAuthorityKind::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::config::EvalAuthorityKind
+impl core::marker::Send for bitrouter_sdk::config::EvalAuthorityKind
+impl core::marker::Sync for bitrouter_sdk::config::EvalAuthorityKind
+impl core::marker::Unpin for bitrouter_sdk::config::EvalAuthorityKind
+impl core::marker::UnsafeUnpin for bitrouter_sdk::config::EvalAuthorityKind
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::config::EvalAuthorityKind
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::config::EvalAuthorityKind
+pub enum bitrouter_sdk::config::McpUpstreamProtocol
+pub bitrouter_sdk::config::McpUpstreamProtocol::Latest
+pub bitrouter_sdk::config::McpUpstreamProtocol::V2026_07_28
+impl core::clone::Clone for bitrouter_sdk::config::McpUpstreamProtocol
+pub fn bitrouter_sdk::config::McpUpstreamProtocol::clone(&self) -> bitrouter_sdk::config::McpUpstreamProtocol
+impl core::cmp::Eq for bitrouter_sdk::config::McpUpstreamProtocol
+impl core::cmp::PartialEq for bitrouter_sdk::config::McpUpstreamProtocol
+pub fn bitrouter_sdk::config::McpUpstreamProtocol::eq(&self, &bitrouter_sdk::config::McpUpstreamProtocol) -> bool
+impl core::default::Default for bitrouter_sdk::config::McpUpstreamProtocol
+pub fn bitrouter_sdk::config::McpUpstreamProtocol::default() -> bitrouter_sdk::config::McpUpstreamProtocol
+impl core::fmt::Debug for bitrouter_sdk::config::McpUpstreamProtocol
+pub fn bitrouter_sdk::config::McpUpstreamProtocol::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for bitrouter_sdk::config::McpUpstreamProtocol
+impl core::marker::StructuralPartialEq for bitrouter_sdk::config::McpUpstreamProtocol
+impl schemars::JsonSchema for bitrouter_sdk::config::McpUpstreamProtocol
+pub fn bitrouter_sdk::config::McpUpstreamProtocol::inline_schema() -> bool
+pub fn bitrouter_sdk::config::McpUpstreamProtocol::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::config::McpUpstreamProtocol::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::config::McpUpstreamProtocol::schema_name() -> alloc::borrow::Cow<'static, str>
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::config::McpUpstreamProtocol
+pub fn bitrouter_sdk::config::McpUpstreamProtocol::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::config::McpUpstreamProtocol
+impl core::marker::Send for bitrouter_sdk::config::McpUpstreamProtocol
+impl core::marker::Sync for bitrouter_sdk::config::McpUpstreamProtocol
+impl core::marker::Unpin for bitrouter_sdk::config::McpUpstreamProtocol
+impl core::marker::UnsafeUnpin for bitrouter_sdk::config::McpUpstreamProtocol
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::config::McpUpstreamProtocol
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::config::McpUpstreamProtocol
+pub enum bitrouter_sdk::config::Pattern
+pub bitrouter_sdk::config::Pattern::Exact(alloc::string::String)
+pub bitrouter_sdk::config::Pattern::Prefix(alloc::string::String)
+pub bitrouter_sdk::config::Pattern::Wildcard
+impl bitrouter_sdk::config::pattern::Pattern
+pub fn bitrouter_sdk::config::pattern::Pattern::matches(&self, &str) -> bool
+pub fn bitrouter_sdk::config::pattern::Pattern::parse(&str) -> Self
+pub fn bitrouter_sdk::config::pattern::Pattern::specificity(&self) -> usize
+impl core::clone::Clone for bitrouter_sdk::config::pattern::Pattern
+pub fn bitrouter_sdk::config::pattern::Pattern::clone(&self) -> bitrouter_sdk::config::pattern::Pattern
+impl core::cmp::Eq for bitrouter_sdk::config::pattern::Pattern
+impl core::cmp::PartialEq for bitrouter_sdk::config::pattern::Pattern
+pub fn bitrouter_sdk::config::pattern::Pattern::eq(&self, &bitrouter_sdk::config::pattern::Pattern) -> bool
+impl core::fmt::Debug for bitrouter_sdk::config::pattern::Pattern
+pub fn bitrouter_sdk::config::pattern::Pattern::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::config::pattern::Pattern
+impl core::marker::Freeze for bitrouter_sdk::config::pattern::Pattern
+impl core::marker::Send for bitrouter_sdk::config::pattern::Pattern
+impl core::marker::Sync for bitrouter_sdk::config::pattern::Pattern
+impl core::marker::Unpin for bitrouter_sdk::config::pattern::Pattern
+impl core::marker::UnsafeUnpin for bitrouter_sdk::config::pattern::Pattern
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::config::pattern::Pattern
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::config::pattern::Pattern
+pub enum bitrouter_sdk::config::PolicyKeyStrategy
+pub bitrouter_sdk::config::PolicyKeyStrategy::AgentTrace
+pub bitrouter_sdk::config::PolicyKeyStrategy::LegacyFingerprint
+pub bitrouter_sdk::config::PolicyKeyStrategy::WorkflowState
+impl core::clone::Clone for bitrouter_sdk::config::PolicyKeyStrategy
+pub fn bitrouter_sdk::config::PolicyKeyStrategy::clone(&self) -> bitrouter_sdk::config::PolicyKeyStrategy
+impl core::cmp::Eq for bitrouter_sdk::config::PolicyKeyStrategy
+impl core::cmp::PartialEq for bitrouter_sdk::config::PolicyKeyStrategy
+pub fn bitrouter_sdk::config::PolicyKeyStrategy::eq(&self, &bitrouter_sdk::config::PolicyKeyStrategy) -> bool
+impl core::default::Default for bitrouter_sdk::config::PolicyKeyStrategy
+pub fn bitrouter_sdk::config::PolicyKeyStrategy::default() -> bitrouter_sdk::config::PolicyKeyStrategy
+impl core::fmt::Debug for bitrouter_sdk::config::PolicyKeyStrategy
+pub fn bitrouter_sdk::config::PolicyKeyStrategy::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for bitrouter_sdk::config::PolicyKeyStrategy
+impl core::marker::StructuralPartialEq for bitrouter_sdk::config::PolicyKeyStrategy
+impl schemars::JsonSchema for bitrouter_sdk::config::PolicyKeyStrategy
+pub fn bitrouter_sdk::config::PolicyKeyStrategy::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::config::PolicyKeyStrategy::schema_name() -> alloc::borrow::Cow<'static, str>
+impl serde_core::ser::Serialize for bitrouter_sdk::config::PolicyKeyStrategy
+pub fn bitrouter_sdk::config::PolicyKeyStrategy::serialize<S>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error> where S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::config::PolicyKeyStrategy
+pub fn bitrouter_sdk::config::PolicyKeyStrategy::deserialize<D>(D) -> core::result::Result<Self, <D as serde_core::de::Deserializer>::Error> where D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::config::PolicyKeyStrategy
+impl core::marker::Send for bitrouter_sdk::config::PolicyKeyStrategy
+impl core::marker::Sync for bitrouter_sdk::config::PolicyKeyStrategy
+impl core::marker::Unpin for bitrouter_sdk::config::PolicyKeyStrategy
+impl core::marker::UnsafeUnpin for bitrouter_sdk::config::PolicyKeyStrategy
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::config::PolicyKeyStrategy
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::config::PolicyKeyStrategy
+pub enum bitrouter_sdk::config::PolicyRuntimeMode
+pub bitrouter_sdk::config::PolicyRuntimeMode::Adaptive
+pub bitrouter_sdk::config::PolicyRuntimeMode::Frozen
+impl bitrouter_sdk::config::PolicyRuntimeMode
+pub fn bitrouter_sdk::config::PolicyRuntimeMode::apply_to_adequacy(self, &bitrouter_sdk::config::AdequacyConfig) -> bitrouter_sdk::config::AdequacyConfig
+impl core::clone::Clone for bitrouter_sdk::config::PolicyRuntimeMode
+pub fn bitrouter_sdk::config::PolicyRuntimeMode::clone(&self) -> bitrouter_sdk::config::PolicyRuntimeMode
+impl core::cmp::Eq for bitrouter_sdk::config::PolicyRuntimeMode
+impl core::cmp::PartialEq for bitrouter_sdk::config::PolicyRuntimeMode
+pub fn bitrouter_sdk::config::PolicyRuntimeMode::eq(&self, &bitrouter_sdk::config::PolicyRuntimeMode) -> bool
+impl core::default::Default for bitrouter_sdk::config::PolicyRuntimeMode
+pub fn bitrouter_sdk::config::PolicyRuntimeMode::default() -> bitrouter_sdk::config::PolicyRuntimeMode
+impl core::fmt::Debug for bitrouter_sdk::config::PolicyRuntimeMode
+pub fn bitrouter_sdk::config::PolicyRuntimeMode::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for bitrouter_sdk::config::PolicyRuntimeMode
+impl core::marker::StructuralPartialEq for bitrouter_sdk::config::PolicyRuntimeMode
+impl schemars::JsonSchema for bitrouter_sdk::config::PolicyRuntimeMode
+pub fn bitrouter_sdk::config::PolicyRuntimeMode::inline_schema() -> bool
+pub fn bitrouter_sdk::config::PolicyRuntimeMode::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::config::PolicyRuntimeMode::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::config::PolicyRuntimeMode::schema_name() -> alloc::borrow::Cow<'static, str>
+impl serde_core::ser::Serialize for bitrouter_sdk::config::PolicyRuntimeMode
+pub fn bitrouter_sdk::config::PolicyRuntimeMode::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::config::PolicyRuntimeMode
+pub fn bitrouter_sdk::config::PolicyRuntimeMode::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::config::PolicyRuntimeMode
+impl core::marker::Send for bitrouter_sdk::config::PolicyRuntimeMode
+impl core::marker::Sync for bitrouter_sdk::config::PolicyRuntimeMode
+impl core::marker::Unpin for bitrouter_sdk::config::PolicyRuntimeMode
+impl core::marker::UnsafeUnpin for bitrouter_sdk::config::PolicyRuntimeMode
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::config::PolicyRuntimeMode
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::config::PolicyRuntimeMode
+pub enum bitrouter_sdk::config::ProviderClass
+pub bitrouter_sdk::config::ProviderClass::BitrouterCloud
+pub bitrouter_sdk::config::ProviderClass::FirstPartyApi
+pub bitrouter_sdk::config::ProviderClass::FirstPartySubscription
+pub bitrouter_sdk::config::ProviderClass::GatewaySubscription
+pub bitrouter_sdk::config::ProviderClass::ThirdPartyApi
+impl bitrouter_sdk::config::ProviderClass
+pub fn bitrouter_sdk::config::ProviderClass::default_priority() -> alloc::vec::Vec<bitrouter_sdk::config::ProviderClass>
+impl core::clone::Clone for bitrouter_sdk::config::ProviderClass
+pub fn bitrouter_sdk::config::ProviderClass::clone(&self) -> bitrouter_sdk::config::ProviderClass
+impl core::cmp::Eq for bitrouter_sdk::config::ProviderClass
+impl core::cmp::PartialEq for bitrouter_sdk::config::ProviderClass
+pub fn bitrouter_sdk::config::ProviderClass::eq(&self, &bitrouter_sdk::config::ProviderClass) -> bool
+impl core::fmt::Debug for bitrouter_sdk::config::ProviderClass
+pub fn bitrouter_sdk::config::ProviderClass::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for bitrouter_sdk::config::ProviderClass
+pub fn bitrouter_sdk::config::ProviderClass::hash<__H: core::hash::Hasher>(&self, &mut __H)
+impl core::marker::Copy for bitrouter_sdk::config::ProviderClass
+impl core::marker::StructuralPartialEq for bitrouter_sdk::config::ProviderClass
+impl schemars::JsonSchema for bitrouter_sdk::config::ProviderClass
+pub fn bitrouter_sdk::config::ProviderClass::inline_schema() -> bool
+pub fn bitrouter_sdk::config::ProviderClass::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::config::ProviderClass::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::config::ProviderClass::schema_name() -> alloc::borrow::Cow<'static, str>
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::config::ProviderClass
+pub fn bitrouter_sdk::config::ProviderClass::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::config::ProviderClass
+impl core::marker::Send for bitrouter_sdk::config::ProviderClass
+impl core::marker::Sync for bitrouter_sdk::config::ProviderClass
+impl core::marker::Unpin for bitrouter_sdk::config::ProviderClass
+impl core::marker::UnsafeUnpin for bitrouter_sdk::config::ProviderClass
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::config::ProviderClass
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::config::ProviderClass
+pub enum bitrouter_sdk::config::VirtualModelStrategy
+pub bitrouter_sdk::config::VirtualModelStrategy::Cascade
+pub bitrouter_sdk::config::VirtualModelStrategy::Priority
+impl core::clone::Clone for bitrouter_sdk::config::VirtualModelStrategy
+pub fn bitrouter_sdk::config::VirtualModelStrategy::clone(&self) -> bitrouter_sdk::config::VirtualModelStrategy
+impl core::cmp::Eq for bitrouter_sdk::config::VirtualModelStrategy
+impl core::cmp::PartialEq for bitrouter_sdk::config::VirtualModelStrategy
+pub fn bitrouter_sdk::config::VirtualModelStrategy::eq(&self, &bitrouter_sdk::config::VirtualModelStrategy) -> bool
+impl core::default::Default for bitrouter_sdk::config::VirtualModelStrategy
+pub fn bitrouter_sdk::config::VirtualModelStrategy::default() -> bitrouter_sdk::config::VirtualModelStrategy
+impl core::fmt::Debug for bitrouter_sdk::config::VirtualModelStrategy
+pub fn bitrouter_sdk::config::VirtualModelStrategy::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for bitrouter_sdk::config::VirtualModelStrategy
+impl core::marker::StructuralPartialEq for bitrouter_sdk::config::VirtualModelStrategy
+impl schemars::JsonSchema for bitrouter_sdk::config::VirtualModelStrategy
+pub fn bitrouter_sdk::config::VirtualModelStrategy::inline_schema() -> bool
+pub fn bitrouter_sdk::config::VirtualModelStrategy::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::config::VirtualModelStrategy::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::config::VirtualModelStrategy::schema_name() -> alloc::borrow::Cow<'static, str>
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::config::VirtualModelStrategy
+pub fn bitrouter_sdk::config::VirtualModelStrategy::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::config::VirtualModelStrategy
+impl core::marker::Send for bitrouter_sdk::config::VirtualModelStrategy
+impl core::marker::Sync for bitrouter_sdk::config::VirtualModelStrategy
+impl core::marker::Unpin for bitrouter_sdk::config::VirtualModelStrategy
+impl core::marker::UnsafeUnpin for bitrouter_sdk::config::VirtualModelStrategy
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::config::VirtualModelStrategy
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::config::VirtualModelStrategy
+pub struct bitrouter_sdk::config::AdequacyConfig
+pub bitrouter_sdk::config::AdequacyConfig::enabled: bool
+pub bitrouter_sdk::config::AdequacyConfig::escalation_threshold: u32
+pub bitrouter_sdk::config::AdequacyConfig::escalation_tier: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::config::AdequacyConfig::explore_enabled: bool
+pub bitrouter_sdk::config::AdequacyConfig::explore_interval: u32
+pub bitrouter_sdk::config::AdequacyConfig::explore_opening: bool
+pub bitrouter_sdk::config::AdequacyConfig::explore_threshold: u32
+pub bitrouter_sdk::config::AdequacyConfig::explore_tier: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::config::AdequacyConfig::max_downgraded_requests_per_session: u32
+pub bitrouter_sdk::config::AdequacyConfig::min_semantic_successes_for_lock: u32
+pub bitrouter_sdk::config::AdequacyConfig::min_semantic_successes_for_opening: u32
+pub bitrouter_sdk::config::AdequacyConfig::pin_cooldown_secs: u64
+pub bitrouter_sdk::config::AdequacyConfig::reliability_consecutive_failures: u32
+pub bitrouter_sdk::config::AdequacyConfig::reliability_cooldown_secs: u64
+pub bitrouter_sdk::config::AdequacyConfig::reliability_error_rate_percent: u32
+pub bitrouter_sdk::config::AdequacyConfig::reliability_window_size: u32
+impl core::clone::Clone for bitrouter_sdk::config::AdequacyConfig
+pub fn bitrouter_sdk::config::AdequacyConfig::clone(&self) -> bitrouter_sdk::config::AdequacyConfig
+impl core::cmp::Eq for bitrouter_sdk::config::AdequacyConfig
+impl core::cmp::PartialEq for bitrouter_sdk::config::AdequacyConfig
+pub fn bitrouter_sdk::config::AdequacyConfig::eq(&self, &bitrouter_sdk::config::AdequacyConfig) -> bool
+impl core::default::Default for bitrouter_sdk::config::AdequacyConfig
+pub fn bitrouter_sdk::config::AdequacyConfig::default() -> Self
+impl core::fmt::Debug for bitrouter_sdk::config::AdequacyConfig
+pub fn bitrouter_sdk::config::AdequacyConfig::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::config::AdequacyConfig
+impl schemars::JsonSchema for bitrouter_sdk::config::AdequacyConfig
+pub fn bitrouter_sdk::config::AdequacyConfig::inline_schema() -> bool
+pub fn bitrouter_sdk::config::AdequacyConfig::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::config::AdequacyConfig::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::config::AdequacyConfig::schema_name() -> alloc::borrow::Cow<'static, str>
+impl serde_core::ser::Serialize for bitrouter_sdk::config::AdequacyConfig
+pub fn bitrouter_sdk::config::AdequacyConfig::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::config::AdequacyConfig where bitrouter_sdk::config::AdequacyConfig: core::default::Default
+pub fn bitrouter_sdk::config::AdequacyConfig::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::config::AdequacyConfig
+impl core::marker::Send for bitrouter_sdk::config::AdequacyConfig
+impl core::marker::Sync for bitrouter_sdk::config::AdequacyConfig
+impl core::marker::Unpin for bitrouter_sdk::config::AdequacyConfig
+impl core::marker::UnsafeUnpin for bitrouter_sdk::config::AdequacyConfig
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::config::AdequacyConfig
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::config::AdequacyConfig
+pub struct bitrouter_sdk::config::Config
+pub bitrouter_sdk::config::Config::agents: std::collections::hash::map::HashMap<alloc::string::String, bitrouter_sdk::acp::transport::AcpAgentConfig>
+pub bitrouter_sdk::config::Config::continuation: bitrouter_sdk::config::ContinuationConfig
+pub bitrouter_sdk::config::Config::database: bitrouter_sdk::config::DatabaseConfig
+pub bitrouter_sdk::config::Config::eval: bitrouter_sdk::config::EvalConfig
+pub bitrouter_sdk::config::Config::inherit_defaults: bool
+pub bitrouter_sdk::config::Config::mcp: bitrouter_sdk::config::McpConfig
+pub bitrouter_sdk::config::Config::mcp_servers: std::collections::hash::map::HashMap<alloc::string::String, bitrouter_sdk::mcp::transport::McpServerConfig>
+pub bitrouter_sdk::config::Config::models: std::collections::hash::map::HashMap<alloc::string::String, bitrouter_sdk::config::VirtualModel>
+pub bitrouter_sdk::config::Config::plugins: std::collections::hash::map::HashMap<alloc::string::String, serde_json::value::Value>
+pub bitrouter_sdk::config::Config::policy: bitrouter_sdk::config::PolicyConfig
+pub bitrouter_sdk::config::Config::policy_table: bitrouter_sdk::config::PolicyTableConfig
+pub bitrouter_sdk::config::Config::presets: std::collections::hash::map::HashMap<alloc::string::String, bitrouter_sdk::config::PresetConfig>
+pub bitrouter_sdk::config::Config::providers: std::collections::hash::map::HashMap<alloc::string::String, bitrouter_sdk::config::ProviderConfig>
+pub bitrouter_sdk::config::Config::registry: bitrouter_sdk::config::RegistryConfig
+pub bitrouter_sdk::config::Config::server: bitrouter_sdk::config::ServerConfig
+pub bitrouter_sdk::config::Config::server_tools: bitrouter_sdk::language_model::server_tools::config::ServerToolsConfig
+pub bitrouter_sdk::config::Config::trajectory: bitrouter_sdk::config::TrajectoryConfig
+pub bitrouter_sdk::config::Config::upstream: bitrouter_sdk::config::UpstreamConfig
+pub bitrouter_sdk::config::Config::variants: std::collections::hash::map::HashMap<alloc::string::String, bitrouter_sdk::config::VariantConfig>
+impl core::clone::Clone for bitrouter_sdk::config::Config
+pub fn bitrouter_sdk::config::Config::clone(&self) -> bitrouter_sdk::config::Config
+impl core::default::Default for bitrouter_sdk::config::Config
+pub fn bitrouter_sdk::config::Config::default() -> Self
+impl core::fmt::Debug for bitrouter_sdk::config::Config
+pub fn bitrouter_sdk::config::Config::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::config::Config
+pub fn bitrouter_sdk::config::Config::inline_schema() -> bool
+pub fn bitrouter_sdk::config::Config::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::config::Config::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::config::Config::schema_name() -> alloc::borrow::Cow<'static, str>
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::config::Config where bitrouter_sdk::config::Config: core::default::Default
+pub fn bitrouter_sdk::config::Config::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::config::Config
+impl core::marker::Send for bitrouter_sdk::config::Config
+impl core::marker::Sync for bitrouter_sdk::config::Config
+impl core::marker::Unpin for bitrouter_sdk::config::Config
+impl core::marker::UnsafeUnpin for bitrouter_sdk::config::Config
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::config::Config
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::config::Config
+pub struct bitrouter_sdk::config::ConfigRoutingTable
+impl bitrouter_sdk::config::routing_table::ConfigRoutingTable
+pub fn bitrouter_sdk::config::routing_table::ConfigRoutingTable::from_config(bitrouter_sdk::config::Config) -> Self
+pub fn bitrouter_sdk::config::routing_table::ConfigRoutingTable::from_config_with_path(bitrouter_sdk::config::Config, impl core::convert::Into<std::path::PathBuf>) -> Self
+pub async fn bitrouter_sdk::config::routing_table::ConfigRoutingTable::load(impl core::convert::Into<std::path::PathBuf>) -> bitrouter_sdk::error::Result<Self>
+pub async fn bitrouter_sdk::config::routing_table::ConfigRoutingTable::replace_config(&self, bitrouter_sdk::config::Config) -> bitrouter_sdk::error::Result<()>
+pub fn bitrouter_sdk::config::routing_table::ConfigRoutingTable::snapshot_config(&self) -> bitrouter_sdk::config::Config
+impl bitrouter_sdk::language_model::routing::RoutingTable for bitrouter_sdk::config::routing_table::ConfigRoutingTable
+pub fn bitrouter_sdk::config::routing_table::ConfigRoutingTable::list_models(&self) -> alloc::vec::Vec<bitrouter_sdk::language_model::routing::ModelInfo>
+pub fn bitrouter_sdk::config::routing_table::ConfigRoutingTable::model_info(&self, &str) -> core::option::Option<bitrouter_sdk::language_model::routing::ModelInfo>
+pub fn bitrouter_sdk::config::routing_table::ConfigRoutingTable::preset_overrides<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 str) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::routing::PromptOverrides>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::config::routing_table::ConfigRoutingTable::reload<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<()>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn bitrouter_sdk::config::routing_table::ConfigRoutingTable::resolve_model<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 str) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::routing::ModelResolution>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::config::routing_table::ConfigRoutingTable::route_chain<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 str, &'life2 bitrouter_sdk::language_model::routing::RoutingPrefs, &'life3 bitrouter_sdk::caller::CallerContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<alloc::vec::Vec<bitrouter_sdk::language_model::types::RoutingTarget>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub fn bitrouter_sdk::config::routing_table::ConfigRoutingTable::route_resolved<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 str, &'life2 bitrouter_sdk::language_model::routing::RoutingPrefs, &'life3 bitrouter_sdk::caller::CallerContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<alloc::vec::Vec<bitrouter_sdk::language_model::types::RoutingTarget>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+impl !core::marker::Freeze for bitrouter_sdk::config::routing_table::ConfigRoutingTable
+impl core::marker::Send for bitrouter_sdk::config::routing_table::ConfigRoutingTable
+impl core::marker::Sync for bitrouter_sdk::config::routing_table::ConfigRoutingTable
+impl core::marker::Unpin for bitrouter_sdk::config::routing_table::ConfigRoutingTable
+impl core::marker::UnsafeUnpin for bitrouter_sdk::config::routing_table::ConfigRoutingTable
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::config::routing_table::ConfigRoutingTable
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::config::routing_table::ConfigRoutingTable
+pub struct bitrouter_sdk::config::ContinuationConfig
+pub bitrouter_sdk::config::ContinuationConfig::prune_batch_size: usize
+pub bitrouter_sdk::config::ContinuationConfig::retention_days: u32
+impl core::clone::Clone for bitrouter_sdk::config::ContinuationConfig
+pub fn bitrouter_sdk::config::ContinuationConfig::clone(&self) -> bitrouter_sdk::config::ContinuationConfig
+impl core::cmp::Eq for bitrouter_sdk::config::ContinuationConfig
+impl core::cmp::PartialEq for bitrouter_sdk::config::ContinuationConfig
+pub fn bitrouter_sdk::config::ContinuationConfig::eq(&self, &bitrouter_sdk::config::ContinuationConfig) -> bool
+impl core::default::Default for bitrouter_sdk::config::ContinuationConfig
+pub fn bitrouter_sdk::config::ContinuationConfig::default() -> Self
+impl core::fmt::Debug for bitrouter_sdk::config::ContinuationConfig
+pub fn bitrouter_sdk::config::ContinuationConfig::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::config::ContinuationConfig
+impl schemars::JsonSchema for bitrouter_sdk::config::ContinuationConfig
+pub fn bitrouter_sdk::config::ContinuationConfig::inline_schema() -> bool
+pub fn bitrouter_sdk::config::ContinuationConfig::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::config::ContinuationConfig::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::config::ContinuationConfig::schema_name() -> alloc::borrow::Cow<'static, str>
+impl serde_core::ser::Serialize for bitrouter_sdk::config::ContinuationConfig
+pub fn bitrouter_sdk::config::ContinuationConfig::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::config::ContinuationConfig where bitrouter_sdk::config::ContinuationConfig: core::default::Default
+pub fn bitrouter_sdk::config::ContinuationConfig::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::config::ContinuationConfig
+impl core::marker::Send for bitrouter_sdk::config::ContinuationConfig
+impl core::marker::Sync for bitrouter_sdk::config::ContinuationConfig
+impl core::marker::Unpin for bitrouter_sdk::config::ContinuationConfig
+impl core::marker::UnsafeUnpin for bitrouter_sdk::config::ContinuationConfig
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::config::ContinuationConfig
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::config::ContinuationConfig
+pub struct bitrouter_sdk::config::DatabaseConfig
+pub bitrouter_sdk::config::DatabaseConfig::url: alloc::string::String
+impl core::clone::Clone for bitrouter_sdk::config::DatabaseConfig
+pub fn bitrouter_sdk::config::DatabaseConfig::clone(&self) -> bitrouter_sdk::config::DatabaseConfig
+impl core::default::Default for bitrouter_sdk::config::DatabaseConfig
+pub fn bitrouter_sdk::config::DatabaseConfig::default() -> Self
+impl core::fmt::Debug for bitrouter_sdk::config::DatabaseConfig
+pub fn bitrouter_sdk::config::DatabaseConfig::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::config::DatabaseConfig
+pub fn bitrouter_sdk::config::DatabaseConfig::inline_schema() -> bool
+pub fn bitrouter_sdk::config::DatabaseConfig::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::config::DatabaseConfig::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::config::DatabaseConfig::schema_name() -> alloc::borrow::Cow<'static, str>
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::config::DatabaseConfig where bitrouter_sdk::config::DatabaseConfig: core::default::Default
+pub fn bitrouter_sdk::config::DatabaseConfig::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::config::DatabaseConfig
+impl core::marker::Send for bitrouter_sdk::config::DatabaseConfig
+impl core::marker::Sync for bitrouter_sdk::config::DatabaseConfig
+impl core::marker::Unpin for bitrouter_sdk::config::DatabaseConfig
+impl core::marker::UnsafeUnpin for bitrouter_sdk::config::DatabaseConfig
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::config::DatabaseConfig
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::config::DatabaseConfig
+pub struct bitrouter_sdk::config::EvalAuthorityConfig
+pub bitrouter_sdk::config::EvalAuthorityConfig::allow_hard_fail: bool
+pub bitrouter_sdk::config::EvalAuthorityConfig::allowed_metrics: alloc::vec::Vec<alloc::string::String>
+pub bitrouter_sdk::config::EvalAuthorityConfig::api_key_ids: alloc::vec::Vec<alloc::string::String>
+pub bitrouter_sdk::config::EvalAuthorityConfig::kind: bitrouter_sdk::config::EvalAuthorityKind
+pub bitrouter_sdk::config::EvalAuthorityConfig::user_ids: alloc::vec::Vec<alloc::string::String>
+impl core::clone::Clone for bitrouter_sdk::config::EvalAuthorityConfig
+pub fn bitrouter_sdk::config::EvalAuthorityConfig::clone(&self) -> bitrouter_sdk::config::EvalAuthorityConfig
+impl core::default::Default for bitrouter_sdk::config::EvalAuthorityConfig
+pub fn bitrouter_sdk::config::EvalAuthorityConfig::default() -> bitrouter_sdk::config::EvalAuthorityConfig
+impl core::fmt::Debug for bitrouter_sdk::config::EvalAuthorityConfig
+pub fn bitrouter_sdk::config::EvalAuthorityConfig::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::config::EvalAuthorityConfig
+pub fn bitrouter_sdk::config::EvalAuthorityConfig::inline_schema() -> bool
+pub fn bitrouter_sdk::config::EvalAuthorityConfig::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::config::EvalAuthorityConfig::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::config::EvalAuthorityConfig::schema_name() -> alloc::borrow::Cow<'static, str>
+impl serde_core::ser::Serialize for bitrouter_sdk::config::EvalAuthorityConfig
+pub fn bitrouter_sdk::config::EvalAuthorityConfig::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::config::EvalAuthorityConfig where bitrouter_sdk::config::EvalAuthorityConfig: core::default::Default
+pub fn bitrouter_sdk::config::EvalAuthorityConfig::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::config::EvalAuthorityConfig
+impl core::marker::Send for bitrouter_sdk::config::EvalAuthorityConfig
+impl core::marker::Sync for bitrouter_sdk::config::EvalAuthorityConfig
+impl core::marker::Unpin for bitrouter_sdk::config::EvalAuthorityConfig
+impl core::marker::UnsafeUnpin for bitrouter_sdk::config::EvalAuthorityConfig
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::config::EvalAuthorityConfig
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::config::EvalAuthorityConfig
+pub struct bitrouter_sdk::config::EvalConfig
+pub bitrouter_sdk::config::EvalConfig::authorities: std::collections::hash::map::HashMap<alloc::string::String, bitrouter_sdk::config::EvalAuthorityConfig>
+impl core::clone::Clone for bitrouter_sdk::config::EvalConfig
+pub fn bitrouter_sdk::config::EvalConfig::clone(&self) -> bitrouter_sdk::config::EvalConfig
+impl core::default::Default for bitrouter_sdk::config::EvalConfig
+pub fn bitrouter_sdk::config::EvalConfig::default() -> bitrouter_sdk::config::EvalConfig
+impl core::fmt::Debug for bitrouter_sdk::config::EvalConfig
+pub fn bitrouter_sdk::config::EvalConfig::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::config::EvalConfig
+pub fn bitrouter_sdk::config::EvalConfig::inline_schema() -> bool
+pub fn bitrouter_sdk::config::EvalConfig::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::config::EvalConfig::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::config::EvalConfig::schema_name() -> alloc::borrow::Cow<'static, str>
+impl serde_core::ser::Serialize for bitrouter_sdk::config::EvalConfig
+pub fn bitrouter_sdk::config::EvalConfig::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::config::EvalConfig where bitrouter_sdk::config::EvalConfig: core::default::Default
+pub fn bitrouter_sdk::config::EvalConfig::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::config::EvalConfig
+impl core::marker::Send for bitrouter_sdk::config::EvalConfig
+impl core::marker::Sync for bitrouter_sdk::config::EvalConfig
+impl core::marker::Unpin for bitrouter_sdk::config::EvalConfig
+impl core::marker::UnsafeUnpin for bitrouter_sdk::config::EvalConfig
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::config::EvalConfig
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::config::EvalConfig
+pub struct bitrouter_sdk::config::McpAggregateConfig
+pub bitrouter_sdk::config::McpAggregateConfig::enabled: bool
+pub bitrouter_sdk::config::McpAggregateConfig::route: alloc::string::String
+impl core::clone::Clone for bitrouter_sdk::config::McpAggregateConfig
+pub fn bitrouter_sdk::config::McpAggregateConfig::clone(&self) -> bitrouter_sdk::config::McpAggregateConfig
+impl core::default::Default for bitrouter_sdk::config::McpAggregateConfig
+pub fn bitrouter_sdk::config::McpAggregateConfig::default() -> Self
+impl core::fmt::Debug for bitrouter_sdk::config::McpAggregateConfig
+pub fn bitrouter_sdk::config::McpAggregateConfig::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::config::McpAggregateConfig
+pub fn bitrouter_sdk::config::McpAggregateConfig::inline_schema() -> bool
+pub fn bitrouter_sdk::config::McpAggregateConfig::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::config::McpAggregateConfig::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::config::McpAggregateConfig::schema_name() -> alloc::borrow::Cow<'static, str>
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::config::McpAggregateConfig where bitrouter_sdk::config::McpAggregateConfig: core::default::Default
+pub fn bitrouter_sdk::config::McpAggregateConfig::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::config::McpAggregateConfig
+impl core::marker::Send for bitrouter_sdk::config::McpAggregateConfig
+impl core::marker::Sync for bitrouter_sdk::config::McpAggregateConfig
+impl core::marker::Unpin for bitrouter_sdk::config::McpAggregateConfig
+impl core::marker::UnsafeUnpin for bitrouter_sdk::config::McpAggregateConfig
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::config::McpAggregateConfig
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::config::McpAggregateConfig
+pub struct bitrouter_sdk::config::McpCacheConfig
+pub bitrouter_sdk::config::McpCacheConfig::enabled: bool
+pub bitrouter_sdk::config::McpCacheConfig::max_entries_per_server: usize
+pub bitrouter_sdk::config::McpCacheConfig::prompts_list_ttl_secs: u64
+pub bitrouter_sdk::config::McpCacheConfig::resources_list_ttl_secs: u64
+pub bitrouter_sdk::config::McpCacheConfig::resources_templates_list_ttl_secs: u64
+pub bitrouter_sdk::config::McpCacheConfig::tools_list_ttl_secs: u64
+impl core::clone::Clone for bitrouter_sdk::config::McpCacheConfig
+pub fn bitrouter_sdk::config::McpCacheConfig::clone(&self) -> bitrouter_sdk::config::McpCacheConfig
+impl core::convert::From<&bitrouter_sdk::config::McpCacheConfig> for bitrouter_sdk::mcp::caching_executor::CacheTtls
+pub fn bitrouter_sdk::mcp::caching_executor::CacheTtls::from(&bitrouter_sdk::config::McpCacheConfig) -> Self
+impl core::default::Default for bitrouter_sdk::config::McpCacheConfig
+pub fn bitrouter_sdk::config::McpCacheConfig::default() -> Self
+impl core::fmt::Debug for bitrouter_sdk::config::McpCacheConfig
+pub fn bitrouter_sdk::config::McpCacheConfig::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::config::McpCacheConfig
+pub fn bitrouter_sdk::config::McpCacheConfig::inline_schema() -> bool
+pub fn bitrouter_sdk::config::McpCacheConfig::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::config::McpCacheConfig::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::config::McpCacheConfig::schema_name() -> alloc::borrow::Cow<'static, str>
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::config::McpCacheConfig where bitrouter_sdk::config::McpCacheConfig: core::default::Default
+pub fn bitrouter_sdk::config::McpCacheConfig::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::config::McpCacheConfig
+impl core::marker::Send for bitrouter_sdk::config::McpCacheConfig
+impl core::marker::Sync for bitrouter_sdk::config::McpCacheConfig
+impl core::marker::Unpin for bitrouter_sdk::config::McpCacheConfig
+impl core::marker::UnsafeUnpin for bitrouter_sdk::config::McpCacheConfig
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::config::McpCacheConfig
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::config::McpCacheConfig
+pub struct bitrouter_sdk::config::McpConfig
+pub bitrouter_sdk::config::McpConfig::aggregate: bitrouter_sdk::config::McpAggregateConfig
+pub bitrouter_sdk::config::McpConfig::cache: bitrouter_sdk::config::McpCacheConfig
+pub bitrouter_sdk::config::McpConfig::upstream_protocol: bitrouter_sdk::config::McpUpstreamProtocol
+impl core::clone::Clone for bitrouter_sdk::config::McpConfig
+pub fn bitrouter_sdk::config::McpConfig::clone(&self) -> bitrouter_sdk::config::McpConfig
+impl core::default::Default for bitrouter_sdk::config::McpConfig
+pub fn bitrouter_sdk::config::McpConfig::default() -> bitrouter_sdk::config::McpConfig
+impl core::fmt::Debug for bitrouter_sdk::config::McpConfig
+pub fn bitrouter_sdk::config::McpConfig::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::config::McpConfig
+pub fn bitrouter_sdk::config::McpConfig::inline_schema() -> bool
+pub fn bitrouter_sdk::config::McpConfig::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::config::McpConfig::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::config::McpConfig::schema_name() -> alloc::borrow::Cow<'static, str>
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::config::McpConfig where bitrouter_sdk::config::McpConfig: core::default::Default
+pub fn bitrouter_sdk::config::McpConfig::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::config::McpConfig
+impl core::marker::Send for bitrouter_sdk::config::McpConfig
+impl core::marker::Sync for bitrouter_sdk::config::McpConfig
+impl core::marker::Unpin for bitrouter_sdk::config::McpConfig
+impl core::marker::UnsafeUnpin for bitrouter_sdk::config::McpConfig
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::config::McpConfig
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::config::McpConfig
+pub struct bitrouter_sdk::config::PatternMap<T>
+impl<T> bitrouter_sdk::config::pattern::PatternMap<T>
+pub fn bitrouter_sdk::config::pattern::PatternMap<T>::is_empty(&self) -> bool
+pub fn bitrouter_sdk::config::pattern::PatternMap<T>::new() -> Self
+pub fn bitrouter_sdk::config::pattern::PatternMap<T>::push(&mut self, bitrouter_sdk::config::pattern::Pattern, T)
+pub fn bitrouter_sdk::config::pattern::PatternMap<T>::resolve(&self, &str) -> core::option::Option<&T>
+impl<'de, T> serde_core::de::Deserialize<'de> for bitrouter_sdk::config::pattern::PatternMap<T> where T: serde_core::de::Deserialize<'de>
+pub fn bitrouter_sdk::config::pattern::PatternMap<T>::deserialize<D>(D) -> core::result::Result<Self, <D as serde_core::de::Deserializer>::Error> where D: serde_core::de::Deserializer<'de>
+impl<T: core::clone::Clone> core::clone::Clone for bitrouter_sdk::config::pattern::PatternMap<T>
+pub fn bitrouter_sdk::config::pattern::PatternMap<T>::clone(&self) -> bitrouter_sdk::config::pattern::PatternMap<T>
+impl<T: core::default::Default> core::default::Default for bitrouter_sdk::config::pattern::PatternMap<T>
+pub fn bitrouter_sdk::config::pattern::PatternMap<T>::default() -> bitrouter_sdk::config::pattern::PatternMap<T>
+impl<T: core::fmt::Debug> core::fmt::Debug for bitrouter_sdk::config::pattern::PatternMap<T>
+pub fn bitrouter_sdk::config::pattern::PatternMap<T>::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<T: schemars::JsonSchema> schemars::JsonSchema for bitrouter_sdk::config::pattern::PatternMap<T>
+pub fn bitrouter_sdk::config::pattern::PatternMap<T>::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::config::pattern::PatternMap<T>::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::config::pattern::PatternMap<T>::schema_name() -> alloc::borrow::Cow<'static, str>
+impl<T> core::marker::Freeze for bitrouter_sdk::config::pattern::PatternMap<T>
+impl<T> core::marker::Send for bitrouter_sdk::config::pattern::PatternMap<T> where T: core::marker::Send
+impl<T> core::marker::Sync for bitrouter_sdk::config::pattern::PatternMap<T> where T: core::marker::Sync
+impl<T> core::marker::Unpin for bitrouter_sdk::config::pattern::PatternMap<T> where T: core::marker::Unpin
+impl<T> core::marker::UnsafeUnpin for bitrouter_sdk::config::pattern::PatternMap<T>
+impl<T> core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::config::pattern::PatternMap<T> where T: core::panic::unwind_safe::RefUnwindSafe
+impl<T> core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::config::pattern::PatternMap<T> where T: core::panic::unwind_safe::UnwindSafe
+pub struct bitrouter_sdk::config::PolicyConfig
+pub bitrouter_sdk::config::PolicyConfig::mode: bitrouter_sdk::config::PolicyRuntimeMode
+pub bitrouter_sdk::config::PolicyConfig::path: core::option::Option<std::path::PathBuf>
+impl core::clone::Clone for bitrouter_sdk::config::PolicyConfig
+pub fn bitrouter_sdk::config::PolicyConfig::clone(&self) -> bitrouter_sdk::config::PolicyConfig
+impl core::default::Default for bitrouter_sdk::config::PolicyConfig
+pub fn bitrouter_sdk::config::PolicyConfig::default() -> bitrouter_sdk::config::PolicyConfig
+impl core::fmt::Debug for bitrouter_sdk::config::PolicyConfig
+pub fn bitrouter_sdk::config::PolicyConfig::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::config::PolicyConfig
+pub fn bitrouter_sdk::config::PolicyConfig::inline_schema() -> bool
+pub fn bitrouter_sdk::config::PolicyConfig::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::config::PolicyConfig::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::config::PolicyConfig::schema_name() -> alloc::borrow::Cow<'static, str>
+impl serde_core::ser::Serialize for bitrouter_sdk::config::PolicyConfig
+pub fn bitrouter_sdk::config::PolicyConfig::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::config::PolicyConfig where bitrouter_sdk::config::PolicyConfig: core::default::Default
+pub fn bitrouter_sdk::config::PolicyConfig::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::config::PolicyConfig
+impl core::marker::Send for bitrouter_sdk::config::PolicyConfig
+impl core::marker::Sync for bitrouter_sdk::config::PolicyConfig
+impl core::marker::Unpin for bitrouter_sdk::config::PolicyConfig
+impl core::marker::UnsafeUnpin for bitrouter_sdk::config::PolicyConfig
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::config::PolicyConfig
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::config::PolicyConfig
+pub struct bitrouter_sdk::config::PolicyTableConfig
+pub bitrouter_sdk::config::PolicyTableConfig::adequacy: bitrouter_sdk::config::AdequacyConfig
+pub bitrouter_sdk::config::PolicyTableConfig::default_tier: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::config::PolicyTableConfig::fingerprints: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+pub bitrouter_sdk::config::PolicyTableConfig::key_strategy: bitrouter_sdk::config::PolicyKeyStrategy
+pub bitrouter_sdk::config::PolicyTableConfig::tiers: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+pub bitrouter_sdk::config::PolicyTableConfig::tool_safe_tiers: alloc::vec::Vec<alloc::string::String>
+pub bitrouter_sdk::config::PolicyTableConfig::tool_use_tier: core::option::Option<alloc::string::String>
+impl core::clone::Clone for bitrouter_sdk::config::PolicyTableConfig
+pub fn bitrouter_sdk::config::PolicyTableConfig::clone(&self) -> bitrouter_sdk::config::PolicyTableConfig
+impl core::default::Default for bitrouter_sdk::config::PolicyTableConfig
+pub fn bitrouter_sdk::config::PolicyTableConfig::default() -> bitrouter_sdk::config::PolicyTableConfig
+impl core::fmt::Debug for bitrouter_sdk::config::PolicyTableConfig
+pub fn bitrouter_sdk::config::PolicyTableConfig::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::config::PolicyTableConfig
+pub fn bitrouter_sdk::config::PolicyTableConfig::inline_schema() -> bool
+pub fn bitrouter_sdk::config::PolicyTableConfig::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::config::PolicyTableConfig::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::config::PolicyTableConfig::schema_name() -> alloc::borrow::Cow<'static, str>
+impl serde_core::ser::Serialize for bitrouter_sdk::config::PolicyTableConfig
+pub fn bitrouter_sdk::config::PolicyTableConfig::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::config::PolicyTableConfig
+pub fn bitrouter_sdk::config::PolicyTableConfig::deserialize<D>(D) -> core::result::Result<Self, <D as serde_core::de::Deserializer>::Error> where D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::config::PolicyTableConfig
+impl core::marker::Send for bitrouter_sdk::config::PolicyTableConfig
+impl core::marker::Sync for bitrouter_sdk::config::PolicyTableConfig
+impl core::marker::Unpin for bitrouter_sdk::config::PolicyTableConfig
+impl core::marker::UnsafeUnpin for bitrouter_sdk::config::PolicyTableConfig
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::config::PolicyTableConfig
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::config::PolicyTableConfig
+pub struct bitrouter_sdk::config::PresetConfig
+pub bitrouter_sdk::config::PresetConfig::model: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::config::PresetConfig::params: serde_json::map::Map<alloc::string::String, serde_json::value::Value>
+pub bitrouter_sdk::config::PresetConfig::policy: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::config::PresetConfig::routing: bitrouter_sdk::config::RoutingConfig
+pub bitrouter_sdk::config::PresetConfig::system_prompt: core::option::Option<alloc::string::String>
+impl core::clone::Clone for bitrouter_sdk::config::PresetConfig
+pub fn bitrouter_sdk::config::PresetConfig::clone(&self) -> bitrouter_sdk::config::PresetConfig
+impl core::default::Default for bitrouter_sdk::config::PresetConfig
+pub fn bitrouter_sdk::config::PresetConfig::default() -> bitrouter_sdk::config::PresetConfig
+impl core::fmt::Debug for bitrouter_sdk::config::PresetConfig
+pub fn bitrouter_sdk::config::PresetConfig::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::config::PresetConfig
+pub fn bitrouter_sdk::config::PresetConfig::inline_schema() -> bool
+pub fn bitrouter_sdk::config::PresetConfig::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::config::PresetConfig::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::config::PresetConfig::schema_name() -> alloc::borrow::Cow<'static, str>
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::config::PresetConfig where bitrouter_sdk::config::PresetConfig: core::default::Default
+pub fn bitrouter_sdk::config::PresetConfig::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::config::PresetConfig
+impl core::marker::Send for bitrouter_sdk::config::PresetConfig
+impl core::marker::Sync for bitrouter_sdk::config::PresetConfig
+impl core::marker::Unpin for bitrouter_sdk::config::PresetConfig
+impl core::marker::UnsafeUnpin for bitrouter_sdk::config::PresetConfig
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::config::PresetConfig
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::config::PresetConfig
+pub struct bitrouter_sdk::config::PresetResolution
+pub bitrouter_sdk::config::PresetResolution::clean_model: alloc::string::String
+pub bitrouter_sdk::config::PresetResolution::overrides: bitrouter_sdk::language_model::routing::PromptOverrides
+pub bitrouter_sdk::config::PresetResolution::policy: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::config::PresetResolution::prefs: bitrouter_sdk::language_model::routing::RoutingPrefs
+pub bitrouter_sdk::config::PresetResolution::variant: core::option::Option<alloc::string::String>
+impl core::clone::Clone for bitrouter_sdk::config::presets::PresetResolution
+pub fn bitrouter_sdk::config::presets::PresetResolution::clone(&self) -> bitrouter_sdk::config::presets::PresetResolution
+impl core::fmt::Debug for bitrouter_sdk::config::presets::PresetResolution
+pub fn bitrouter_sdk::config::presets::PresetResolution::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::config::presets::PresetResolution
+impl core::marker::Send for bitrouter_sdk::config::presets::PresetResolution
+impl core::marker::Sync for bitrouter_sdk::config::presets::PresetResolution
+impl core::marker::Unpin for bitrouter_sdk::config::presets::PresetResolution
+impl core::marker::UnsafeUnpin for bitrouter_sdk::config::presets::PresetResolution
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::config::presets::PresetResolution
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::config::presets::PresetResolution
+pub struct bitrouter_sdk::config::PricingConfig
+pub bitrouter_sdk::config::PricingConfig::cache_read_micro_usd_per_token: core::option::Option<f64>
+pub bitrouter_sdk::config::PricingConfig::cache_write_micro_usd_per_token: core::option::Option<f64>
+pub bitrouter_sdk::config::PricingConfig::context_tiers: alloc::vec::Vec<bitrouter_sdk::config::PricingTierConfig>
+pub bitrouter_sdk::config::PricingConfig::input_micro_usd_per_token: core::option::Option<f64>
+pub bitrouter_sdk::config::PricingConfig::output_micro_usd_per_token: core::option::Option<f64>
+impl core::clone::Clone for bitrouter_sdk::config::PricingConfig
+pub fn bitrouter_sdk::config::PricingConfig::clone(&self) -> bitrouter_sdk::config::PricingConfig
+impl core::default::Default for bitrouter_sdk::config::PricingConfig
+pub fn bitrouter_sdk::config::PricingConfig::default() -> bitrouter_sdk::config::PricingConfig
+impl core::fmt::Debug for bitrouter_sdk::config::PricingConfig
+pub fn bitrouter_sdk::config::PricingConfig::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::config::PricingConfig
+pub fn bitrouter_sdk::config::PricingConfig::inline_schema() -> bool
+pub fn bitrouter_sdk::config::PricingConfig::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::config::PricingConfig::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::config::PricingConfig::schema_name() -> alloc::borrow::Cow<'static, str>
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::config::PricingConfig
+pub fn bitrouter_sdk::config::PricingConfig::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::config::PricingConfig
+impl core::marker::Send for bitrouter_sdk::config::PricingConfig
+impl core::marker::Sync for bitrouter_sdk::config::PricingConfig
+impl core::marker::Unpin for bitrouter_sdk::config::PricingConfig
+impl core::marker::UnsafeUnpin for bitrouter_sdk::config::PricingConfig
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::config::PricingConfig
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::config::PricingConfig
+pub struct bitrouter_sdk::config::PricingTierConfig
+pub bitrouter_sdk::config::PricingTierConfig::above_input_tokens: u64
+pub bitrouter_sdk::config::PricingTierConfig::cache_read_micro_usd_per_token: core::option::Option<f64>
+pub bitrouter_sdk::config::PricingTierConfig::cache_write_micro_usd_per_token: core::option::Option<f64>
+pub bitrouter_sdk::config::PricingTierConfig::input_micro_usd_per_token: core::option::Option<f64>
+pub bitrouter_sdk::config::PricingTierConfig::output_micro_usd_per_token: core::option::Option<f64>
+impl core::clone::Clone for bitrouter_sdk::config::PricingTierConfig
+pub fn bitrouter_sdk::config::PricingTierConfig::clone(&self) -> bitrouter_sdk::config::PricingTierConfig
+impl core::default::Default for bitrouter_sdk::config::PricingTierConfig
+pub fn bitrouter_sdk::config::PricingTierConfig::default() -> bitrouter_sdk::config::PricingTierConfig
+impl core::fmt::Debug for bitrouter_sdk::config::PricingTierConfig
+pub fn bitrouter_sdk::config::PricingTierConfig::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::config::PricingTierConfig
+pub fn bitrouter_sdk::config::PricingTierConfig::inline_schema() -> bool
+pub fn bitrouter_sdk::config::PricingTierConfig::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::config::PricingTierConfig::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::config::PricingTierConfig::schema_name() -> alloc::borrow::Cow<'static, str>
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::config::PricingTierConfig
+pub fn bitrouter_sdk::config::PricingTierConfig::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::config::PricingTierConfig
+impl core::marker::Send for bitrouter_sdk::config::PricingTierConfig
+impl core::marker::Sync for bitrouter_sdk::config::PricingTierConfig
+impl core::marker::Unpin for bitrouter_sdk::config::PricingTierConfig
+impl core::marker::UnsafeUnpin for bitrouter_sdk::config::PricingTierConfig
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::config::PricingTierConfig
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::config::PricingTierConfig
+pub struct bitrouter_sdk::config::PromptOverrides
+pub bitrouter_sdk::config::PromptOverrides::params: serde_json::map::Map<alloc::string::String, serde_json::value::Value>
+pub bitrouter_sdk::config::PromptOverrides::system_prompt: core::option::Option<alloc::string::String>
+impl bitrouter_sdk::language_model::routing::PromptOverrides
+pub fn bitrouter_sdk::language_model::routing::PromptOverrides::is_empty(&self) -> bool
+impl core::clone::Clone for bitrouter_sdk::language_model::routing::PromptOverrides
+pub fn bitrouter_sdk::language_model::routing::PromptOverrides::clone(&self) -> bitrouter_sdk::language_model::routing::PromptOverrides
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::routing::PromptOverrides
+pub fn bitrouter_sdk::language_model::routing::PromptOverrides::eq(&self, &bitrouter_sdk::language_model::routing::PromptOverrides) -> bool
+impl core::default::Default for bitrouter_sdk::language_model::routing::PromptOverrides
+pub fn bitrouter_sdk::language_model::routing::PromptOverrides::default() -> bitrouter_sdk::language_model::routing::PromptOverrides
+impl core::fmt::Debug for bitrouter_sdk::language_model::routing::PromptOverrides
+pub fn bitrouter_sdk::language_model::routing::PromptOverrides::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::routing::PromptOverrides
+impl core::marker::Freeze for bitrouter_sdk::language_model::routing::PromptOverrides
+impl core::marker::Send for bitrouter_sdk::language_model::routing::PromptOverrides
+impl core::marker::Sync for bitrouter_sdk::language_model::routing::PromptOverrides
+impl core::marker::Unpin for bitrouter_sdk::language_model::routing::PromptOverrides
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::routing::PromptOverrides
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::routing::PromptOverrides
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::routing::PromptOverrides
+pub struct bitrouter_sdk::config::ProviderAccount
+pub bitrouter_sdk::config::ProviderAccount::api_base: alloc::string::String
+pub bitrouter_sdk::config::ProviderAccount::api_key: alloc::string::String
+pub bitrouter_sdk::config::ProviderAccount::label: alloc::string::String
+impl core::clone::Clone for bitrouter_sdk::config::ProviderAccount
+pub fn bitrouter_sdk::config::ProviderAccount::clone(&self) -> bitrouter_sdk::config::ProviderAccount
+impl core::default::Default for bitrouter_sdk::config::ProviderAccount
+pub fn bitrouter_sdk::config::ProviderAccount::default() -> bitrouter_sdk::config::ProviderAccount
+impl core::fmt::Debug for bitrouter_sdk::config::ProviderAccount
+pub fn bitrouter_sdk::config::ProviderAccount::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::config::ProviderAccount
+pub fn bitrouter_sdk::config::ProviderAccount::inline_schema() -> bool
+pub fn bitrouter_sdk::config::ProviderAccount::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::config::ProviderAccount::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::config::ProviderAccount::schema_name() -> alloc::borrow::Cow<'static, str>
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::config::ProviderAccount where bitrouter_sdk::config::ProviderAccount: core::default::Default
+pub fn bitrouter_sdk::config::ProviderAccount::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::config::ProviderAccount
+impl core::marker::Send for bitrouter_sdk::config::ProviderAccount
+impl core::marker::Sync for bitrouter_sdk::config::ProviderAccount
+impl core::marker::Unpin for bitrouter_sdk::config::ProviderAccount
+impl core::marker::UnsafeUnpin for bitrouter_sdk::config::ProviderAccount
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::config::ProviderAccount
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::config::ProviderAccount
+pub struct bitrouter_sdk::config::ProviderConfig
+pub bitrouter_sdk::config::ProviderConfig::account_strategy: bitrouter_sdk::config::AccountStrategy
+pub bitrouter_sdk::config::ProviderConfig::accounts: alloc::vec::Vec<bitrouter_sdk::config::ProviderAccount>
+pub bitrouter_sdk::config::ProviderConfig::active: bool
+pub bitrouter_sdk::config::ProviderConfig::api_base: alloc::string::String
+pub bitrouter_sdk::config::ProviderConfig::api_key: alloc::string::String
+pub bitrouter_sdk::config::ProviderConfig::api_protocol: bitrouter_sdk::config::pattern::PatternMap<bitrouter_sdk::language_model::types::ProtocolList>
+pub bitrouter_sdk::config::ProviderConfig::auto_discover: bool
+pub bitrouter_sdk::config::ProviderConfig::class: core::option::Option<bitrouter_sdk::config::ProviderClass>
+pub bitrouter_sdk::config::ProviderConfig::derives: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::config::ProviderConfig::models: alloc::vec::Vec<bitrouter_sdk::config::ProviderModel>
+pub bitrouter_sdk::config::ProviderConfig::priority: core::option::Option<i32>
+pub bitrouter_sdk::config::ProviderConfig::protocol_endpoints: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+pub bitrouter_sdk::config::ProviderConfig::rate_limits: bitrouter_sdk::config::pattern::PatternMap<bitrouter_sdk::config::RateLimit>
+pub bitrouter_sdk::config::ProviderConfig::tags: alloc::vec::Vec<alloc::string::String>
+pub bitrouter_sdk::config::ProviderConfig::timeouts: bitrouter_sdk::config::TimeoutConfig
+impl bitrouter_sdk::config::ProviderConfig
+pub fn bitrouter_sdk::config::ProviderConfig::endpoint_for(&self, &bitrouter_sdk::language_model::types::ApiProtocol) -> core::option::Option<&str>
+pub fn bitrouter_sdk::config::ProviderConfig::protocol_for(&self, &str) -> bitrouter_sdk::language_model::types::ApiProtocol
+pub fn bitrouter_sdk::config::ProviderConfig::protocols_for(&self, &str) -> alloc::vec::Vec<bitrouter_sdk::language_model::types::ApiProtocol>
+impl bitrouter_sdk::config::ProviderConfig
+pub fn bitrouter_sdk::config::ProviderConfig::model_supports_capability(&self, &str, bitrouter_sdk::language_model::types::Capability) -> bool
+pub fn bitrouter_sdk::config::ProviderConfig::primary_api_key(&self) -> &str
+impl core::clone::Clone for bitrouter_sdk::config::ProviderConfig
+pub fn bitrouter_sdk::config::ProviderConfig::clone(&self) -> bitrouter_sdk::config::ProviderConfig
+impl core::default::Default for bitrouter_sdk::config::ProviderConfig
+pub fn bitrouter_sdk::config::ProviderConfig::default() -> Self
+impl core::fmt::Debug for bitrouter_sdk::config::ProviderConfig
+pub fn bitrouter_sdk::config::ProviderConfig::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::config::ProviderConfig
+pub fn bitrouter_sdk::config::ProviderConfig::inline_schema() -> bool
+pub fn bitrouter_sdk::config::ProviderConfig::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::config::ProviderConfig::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::config::ProviderConfig::schema_name() -> alloc::borrow::Cow<'static, str>
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::config::ProviderConfig where bitrouter_sdk::config::ProviderConfig: core::default::Default
+pub fn bitrouter_sdk::config::ProviderConfig::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::config::ProviderConfig
+impl core::marker::Send for bitrouter_sdk::config::ProviderConfig
+impl core::marker::Sync for bitrouter_sdk::config::ProviderConfig
+impl core::marker::Unpin for bitrouter_sdk::config::ProviderConfig
+impl core::marker::UnsafeUnpin for bitrouter_sdk::config::ProviderConfig
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::config::ProviderConfig
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::config::ProviderConfig
+pub struct bitrouter_sdk::config::ProviderModel
+pub bitrouter_sdk::config::ProviderModel::api_protocol: core::option::Option<bitrouter_sdk::language_model::types::ProtocolList>
+pub bitrouter_sdk::config::ProviderModel::capabilities: alloc::vec::Vec<bitrouter_sdk::language_model::types::Capability>
+pub bitrouter_sdk::config::ProviderModel::compatibility: bitrouter_sdk::language_model::types::ModelCompatibility
+pub bitrouter_sdk::config::ProviderModel::id: alloc::string::String
+pub bitrouter_sdk::config::ProviderModel::pricing: core::option::Option<bitrouter_sdk::config::PricingConfig>
+pub bitrouter_sdk::config::ProviderModel::provider_model_id: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::config::ProviderModel::rate_limits: core::option::Option<bitrouter_sdk::config::RateLimit>
+impl core::clone::Clone for bitrouter_sdk::config::ProviderModel
+pub fn bitrouter_sdk::config::ProviderModel::clone(&self) -> bitrouter_sdk::config::ProviderModel
+impl core::fmt::Debug for bitrouter_sdk::config::ProviderModel
+pub fn bitrouter_sdk::config::ProviderModel::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::config::ProviderModel
+pub fn bitrouter_sdk::config::ProviderModel::inline_schema() -> bool
+pub fn bitrouter_sdk::config::ProviderModel::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::config::ProviderModel::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::config::ProviderModel::schema_name() -> alloc::borrow::Cow<'static, str>
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::config::ProviderModel
+pub fn bitrouter_sdk::config::ProviderModel::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::config::ProviderModel
+impl core::marker::Send for bitrouter_sdk::config::ProviderModel
+impl core::marker::Sync for bitrouter_sdk::config::ProviderModel
+impl core::marker::Unpin for bitrouter_sdk::config::ProviderModel
+impl core::marker::UnsafeUnpin for bitrouter_sdk::config::ProviderModel
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::config::ProviderModel
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::config::ProviderModel
+pub struct bitrouter_sdk::config::RateLimit
+pub bitrouter_sdk::config::RateLimit::requests_per_minute: core::option::Option<u32>
+pub bitrouter_sdk::config::RateLimit::tokens_per_minute: core::option::Option<u32>
+impl core::clone::Clone for bitrouter_sdk::config::RateLimit
+pub fn bitrouter_sdk::config::RateLimit::clone(&self) -> bitrouter_sdk::config::RateLimit
+impl core::default::Default for bitrouter_sdk::config::RateLimit
+pub fn bitrouter_sdk::config::RateLimit::default() -> bitrouter_sdk::config::RateLimit
+impl core::fmt::Debug for bitrouter_sdk::config::RateLimit
+pub fn bitrouter_sdk::config::RateLimit::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for bitrouter_sdk::config::RateLimit
+impl schemars::JsonSchema for bitrouter_sdk::config::RateLimit
+pub fn bitrouter_sdk::config::RateLimit::inline_schema() -> bool
+pub fn bitrouter_sdk::config::RateLimit::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::config::RateLimit::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::config::RateLimit::schema_name() -> alloc::borrow::Cow<'static, str>
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::config::RateLimit
+pub fn bitrouter_sdk::config::RateLimit::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::config::RateLimit
+impl core::marker::Send for bitrouter_sdk::config::RateLimit
+impl core::marker::Sync for bitrouter_sdk::config::RateLimit
+impl core::marker::Unpin for bitrouter_sdk::config::RateLimit
+impl core::marker::UnsafeUnpin for bitrouter_sdk::config::RateLimit
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::config::RateLimit
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::config::RateLimit
+pub struct bitrouter_sdk::config::RegistryConfig
+pub bitrouter_sdk::config::RegistryConfig::enabled: bool
+pub bitrouter_sdk::config::RegistryConfig::provider_priority: alloc::vec::Vec<bitrouter_sdk::config::ProviderClass>
+pub bitrouter_sdk::config::RegistryConfig::url: alloc::string::String
+impl core::clone::Clone for bitrouter_sdk::config::RegistryConfig
+pub fn bitrouter_sdk::config::RegistryConfig::clone(&self) -> bitrouter_sdk::config::RegistryConfig
+impl core::default::Default for bitrouter_sdk::config::RegistryConfig
+pub fn bitrouter_sdk::config::RegistryConfig::default() -> Self
+impl core::fmt::Debug for bitrouter_sdk::config::RegistryConfig
+pub fn bitrouter_sdk::config::RegistryConfig::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::config::RegistryConfig
+pub fn bitrouter_sdk::config::RegistryConfig::inline_schema() -> bool
+pub fn bitrouter_sdk::config::RegistryConfig::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::config::RegistryConfig::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::config::RegistryConfig::schema_name() -> alloc::borrow::Cow<'static, str>
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::config::RegistryConfig where bitrouter_sdk::config::RegistryConfig: core::default::Default
+pub fn bitrouter_sdk::config::RegistryConfig::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::config::RegistryConfig
+impl core::marker::Send for bitrouter_sdk::config::RegistryConfig
+impl core::marker::Sync for bitrouter_sdk::config::RegistryConfig
+impl core::marker::Unpin for bitrouter_sdk::config::RegistryConfig
+impl core::marker::UnsafeUnpin for bitrouter_sdk::config::RegistryConfig
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::config::RegistryConfig
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::config::RegistryConfig
+pub struct bitrouter_sdk::config::RoutingConfig
+pub bitrouter_sdk::config::RoutingConfig::ignore: alloc::vec::Vec<alloc::string::String>
+pub bitrouter_sdk::config::RoutingConfig::only: alloc::vec::Vec<alloc::string::String>
+pub bitrouter_sdk::config::RoutingConfig::require_tags: alloc::vec::Vec<alloc::string::String>
+pub bitrouter_sdk::config::RoutingConfig::sort: core::option::Option<bitrouter_sdk::language_model::routing::SortOrder>
+impl core::clone::Clone for bitrouter_sdk::config::RoutingConfig
+pub fn bitrouter_sdk::config::RoutingConfig::clone(&self) -> bitrouter_sdk::config::RoutingConfig
+impl core::default::Default for bitrouter_sdk::config::RoutingConfig
+pub fn bitrouter_sdk::config::RoutingConfig::default() -> bitrouter_sdk::config::RoutingConfig
+impl core::fmt::Debug for bitrouter_sdk::config::RoutingConfig
+pub fn bitrouter_sdk::config::RoutingConfig::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::config::RoutingConfig
+pub fn bitrouter_sdk::config::RoutingConfig::inline_schema() -> bool
+pub fn bitrouter_sdk::config::RoutingConfig::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::config::RoutingConfig::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::config::RoutingConfig::schema_name() -> alloc::borrow::Cow<'static, str>
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::config::RoutingConfig where bitrouter_sdk::config::RoutingConfig: core::default::Default
+pub fn bitrouter_sdk::config::RoutingConfig::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::config::RoutingConfig
+impl core::marker::Send for bitrouter_sdk::config::RoutingConfig
+impl core::marker::Sync for bitrouter_sdk::config::RoutingConfig
+impl core::marker::Unpin for bitrouter_sdk::config::RoutingConfig
+impl core::marker::UnsafeUnpin for bitrouter_sdk::config::RoutingConfig
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::config::RoutingConfig
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::config::RoutingConfig
+pub struct bitrouter_sdk::config::ServerConfig
+pub bitrouter_sdk::config::ServerConfig::control_socket: alloc::string::String
+pub bitrouter_sdk::config::ServerConfig::listen: alloc::string::String
+pub bitrouter_sdk::config::ServerConfig::log_level: alloc::string::String
+pub bitrouter_sdk::config::ServerConfig::skip_auth: bool
+impl core::clone::Clone for bitrouter_sdk::config::ServerConfig
+pub fn bitrouter_sdk::config::ServerConfig::clone(&self) -> bitrouter_sdk::config::ServerConfig
+impl core::default::Default for bitrouter_sdk::config::ServerConfig
+pub fn bitrouter_sdk::config::ServerConfig::default() -> Self
+impl core::fmt::Debug for bitrouter_sdk::config::ServerConfig
+pub fn bitrouter_sdk::config::ServerConfig::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::config::ServerConfig
+pub fn bitrouter_sdk::config::ServerConfig::inline_schema() -> bool
+pub fn bitrouter_sdk::config::ServerConfig::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::config::ServerConfig::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::config::ServerConfig::schema_name() -> alloc::borrow::Cow<'static, str>
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::config::ServerConfig where bitrouter_sdk::config::ServerConfig: core::default::Default
+pub fn bitrouter_sdk::config::ServerConfig::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::config::ServerConfig
+impl core::marker::Send for bitrouter_sdk::config::ServerConfig
+impl core::marker::Sync for bitrouter_sdk::config::ServerConfig
+impl core::marker::Unpin for bitrouter_sdk::config::ServerConfig
+impl core::marker::UnsafeUnpin for bitrouter_sdk::config::ServerConfig
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::config::ServerConfig
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::config::ServerConfig
+pub struct bitrouter_sdk::config::TimeoutConfig
+pub bitrouter_sdk::config::TimeoutConfig::connect_secs: core::option::Option<u64>
+pub bitrouter_sdk::config::TimeoutConfig::pool_idle_secs: core::option::Option<u64>
+pub bitrouter_sdk::config::TimeoutConfig::read_secs: core::option::Option<u64>
+pub bitrouter_sdk::config::TimeoutConfig::tcp_keepalive_secs: core::option::Option<u64>
+pub bitrouter_sdk::config::TimeoutConfig::total_secs: core::option::Option<u64>
+impl bitrouter_sdk::config::TimeoutConfig
+pub fn bitrouter_sdk::config::TimeoutConfig::apply_to(&self, bitrouter_sdk::language_model::executor::HttpTimeouts) -> bitrouter_sdk::language_model::executor::HttpTimeouts
+impl core::clone::Clone for bitrouter_sdk::config::TimeoutConfig
+pub fn bitrouter_sdk::config::TimeoutConfig::clone(&self) -> bitrouter_sdk::config::TimeoutConfig
+impl core::default::Default for bitrouter_sdk::config::TimeoutConfig
+pub fn bitrouter_sdk::config::TimeoutConfig::default() -> bitrouter_sdk::config::TimeoutConfig
+impl core::fmt::Debug for bitrouter_sdk::config::TimeoutConfig
+pub fn bitrouter_sdk::config::TimeoutConfig::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::config::TimeoutConfig
+pub fn bitrouter_sdk::config::TimeoutConfig::inline_schema() -> bool
+pub fn bitrouter_sdk::config::TimeoutConfig::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::config::TimeoutConfig::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::config::TimeoutConfig::schema_name() -> alloc::borrow::Cow<'static, str>
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::config::TimeoutConfig where bitrouter_sdk::config::TimeoutConfig: core::default::Default
+pub fn bitrouter_sdk::config::TimeoutConfig::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::config::TimeoutConfig
+impl core::marker::Send for bitrouter_sdk::config::TimeoutConfig
+impl core::marker::Sync for bitrouter_sdk::config::TimeoutConfig
+impl core::marker::Unpin for bitrouter_sdk::config::TimeoutConfig
+impl core::marker::UnsafeUnpin for bitrouter_sdk::config::TimeoutConfig
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::config::TimeoutConfig
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::config::TimeoutConfig
+pub struct bitrouter_sdk::config::TrajectoryConfig
+pub bitrouter_sdk::config::TrajectoryConfig::enabled: bool
+pub bitrouter_sdk::config::TrajectoryConfig::outbox_batch_size: usize
+pub bitrouter_sdk::config::TrajectoryConfig::retention_days: u32
+impl core::clone::Clone for bitrouter_sdk::config::TrajectoryConfig
+pub fn bitrouter_sdk::config::TrajectoryConfig::clone(&self) -> bitrouter_sdk::config::TrajectoryConfig
+impl core::cmp::Eq for bitrouter_sdk::config::TrajectoryConfig
+impl core::cmp::PartialEq for bitrouter_sdk::config::TrajectoryConfig
+pub fn bitrouter_sdk::config::TrajectoryConfig::eq(&self, &bitrouter_sdk::config::TrajectoryConfig) -> bool
+impl core::default::Default for bitrouter_sdk::config::TrajectoryConfig
+pub fn bitrouter_sdk::config::TrajectoryConfig::default() -> Self
+impl core::fmt::Debug for bitrouter_sdk::config::TrajectoryConfig
+pub fn bitrouter_sdk::config::TrajectoryConfig::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::config::TrajectoryConfig
+impl schemars::JsonSchema for bitrouter_sdk::config::TrajectoryConfig
+pub fn bitrouter_sdk::config::TrajectoryConfig::inline_schema() -> bool
+pub fn bitrouter_sdk::config::TrajectoryConfig::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::config::TrajectoryConfig::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::config::TrajectoryConfig::schema_name() -> alloc::borrow::Cow<'static, str>
+impl serde_core::ser::Serialize for bitrouter_sdk::config::TrajectoryConfig
+pub fn bitrouter_sdk::config::TrajectoryConfig::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::config::TrajectoryConfig where bitrouter_sdk::config::TrajectoryConfig: core::default::Default
+pub fn bitrouter_sdk::config::TrajectoryConfig::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::config::TrajectoryConfig
+impl core::marker::Send for bitrouter_sdk::config::TrajectoryConfig
+impl core::marker::Sync for bitrouter_sdk::config::TrajectoryConfig
+impl core::marker::Unpin for bitrouter_sdk::config::TrajectoryConfig
+impl core::marker::UnsafeUnpin for bitrouter_sdk::config::TrajectoryConfig
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::config::TrajectoryConfig
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::config::TrajectoryConfig
+pub struct bitrouter_sdk::config::UpstreamConfig
+pub bitrouter_sdk::config::UpstreamConfig::fallback_backoff_ms: alloc::vec::Vec<u64>
+pub bitrouter_sdk::config::UpstreamConfig::timeouts: bitrouter_sdk::config::TimeoutConfig
+impl core::clone::Clone for bitrouter_sdk::config::UpstreamConfig
+pub fn bitrouter_sdk::config::UpstreamConfig::clone(&self) -> bitrouter_sdk::config::UpstreamConfig
+impl core::default::Default for bitrouter_sdk::config::UpstreamConfig
+pub fn bitrouter_sdk::config::UpstreamConfig::default() -> bitrouter_sdk::config::UpstreamConfig
+impl core::fmt::Debug for bitrouter_sdk::config::UpstreamConfig
+pub fn bitrouter_sdk::config::UpstreamConfig::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::config::UpstreamConfig
+pub fn bitrouter_sdk::config::UpstreamConfig::inline_schema() -> bool
+pub fn bitrouter_sdk::config::UpstreamConfig::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::config::UpstreamConfig::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::config::UpstreamConfig::schema_name() -> alloc::borrow::Cow<'static, str>
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::config::UpstreamConfig where bitrouter_sdk::config::UpstreamConfig: core::default::Default
+pub fn bitrouter_sdk::config::UpstreamConfig::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::config::UpstreamConfig
+impl core::marker::Send for bitrouter_sdk::config::UpstreamConfig
+impl core::marker::Sync for bitrouter_sdk::config::UpstreamConfig
+impl core::marker::Unpin for bitrouter_sdk::config::UpstreamConfig
+impl core::marker::UnsafeUnpin for bitrouter_sdk::config::UpstreamConfig
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::config::UpstreamConfig
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::config::UpstreamConfig
+pub struct bitrouter_sdk::config::VariantConfig
+pub bitrouter_sdk::config::VariantConfig::routing: bitrouter_sdk::config::RoutingConfig
+impl core::clone::Clone for bitrouter_sdk::config::VariantConfig
+pub fn bitrouter_sdk::config::VariantConfig::clone(&self) -> bitrouter_sdk::config::VariantConfig
+impl core::default::Default for bitrouter_sdk::config::VariantConfig
+pub fn bitrouter_sdk::config::VariantConfig::default() -> bitrouter_sdk::config::VariantConfig
+impl core::fmt::Debug for bitrouter_sdk::config::VariantConfig
+pub fn bitrouter_sdk::config::VariantConfig::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::config::VariantConfig
+pub fn bitrouter_sdk::config::VariantConfig::inline_schema() -> bool
+pub fn bitrouter_sdk::config::VariantConfig::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::config::VariantConfig::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::config::VariantConfig::schema_name() -> alloc::borrow::Cow<'static, str>
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::config::VariantConfig where bitrouter_sdk::config::VariantConfig: core::default::Default
+pub fn bitrouter_sdk::config::VariantConfig::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::config::VariantConfig
+impl core::marker::Send for bitrouter_sdk::config::VariantConfig
+impl core::marker::Sync for bitrouter_sdk::config::VariantConfig
+impl core::marker::Unpin for bitrouter_sdk::config::VariantConfig
+impl core::marker::UnsafeUnpin for bitrouter_sdk::config::VariantConfig
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::config::VariantConfig
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::config::VariantConfig
+pub struct bitrouter_sdk::config::VirtualEndpoint
+pub bitrouter_sdk::config::VirtualEndpoint::provider: alloc::string::String
+pub bitrouter_sdk::config::VirtualEndpoint::service_id: alloc::string::String
+impl core::clone::Clone for bitrouter_sdk::config::VirtualEndpoint
+pub fn bitrouter_sdk::config::VirtualEndpoint::clone(&self) -> bitrouter_sdk::config::VirtualEndpoint
+impl core::fmt::Debug for bitrouter_sdk::config::VirtualEndpoint
+pub fn bitrouter_sdk::config::VirtualEndpoint::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::config::VirtualEndpoint
+pub fn bitrouter_sdk::config::VirtualEndpoint::inline_schema() -> bool
+pub fn bitrouter_sdk::config::VirtualEndpoint::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::config::VirtualEndpoint::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::config::VirtualEndpoint::schema_name() -> alloc::borrow::Cow<'static, str>
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::config::VirtualEndpoint
+pub fn bitrouter_sdk::config::VirtualEndpoint::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::config::VirtualEndpoint
+impl core::marker::Send for bitrouter_sdk::config::VirtualEndpoint
+impl core::marker::Sync for bitrouter_sdk::config::VirtualEndpoint
+impl core::marker::Unpin for bitrouter_sdk::config::VirtualEndpoint
+impl core::marker::UnsafeUnpin for bitrouter_sdk::config::VirtualEndpoint
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::config::VirtualEndpoint
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::config::VirtualEndpoint
+pub struct bitrouter_sdk::config::VirtualModel
+pub bitrouter_sdk::config::VirtualModel::endpoints: alloc::vec::Vec<bitrouter_sdk::config::VirtualEndpoint>
+pub bitrouter_sdk::config::VirtualModel::pricing: core::option::Option<bitrouter_sdk::config::PricingConfig>
+pub bitrouter_sdk::config::VirtualModel::strategy: bitrouter_sdk::config::VirtualModelStrategy
+impl core::clone::Clone for bitrouter_sdk::config::VirtualModel
+pub fn bitrouter_sdk::config::VirtualModel::clone(&self) -> bitrouter_sdk::config::VirtualModel
+impl core::fmt::Debug for bitrouter_sdk::config::VirtualModel
+pub fn bitrouter_sdk::config::VirtualModel::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::config::VirtualModel
+pub fn bitrouter_sdk::config::VirtualModel::inline_schema() -> bool
+pub fn bitrouter_sdk::config::VirtualModel::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::config::VirtualModel::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::config::VirtualModel::schema_name() -> alloc::borrow::Cow<'static, str>
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::config::VirtualModel
+pub fn bitrouter_sdk::config::VirtualModel::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::config::VirtualModel
+impl core::marker::Send for bitrouter_sdk::config::VirtualModel
+impl core::marker::Sync for bitrouter_sdk::config::VirtualModel
+impl core::marker::Unpin for bitrouter_sdk::config::VirtualModel
+impl core::marker::UnsafeUnpin for bitrouter_sdk::config::VirtualModel
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::config::VirtualModel
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::config::VirtualModel
+pub const bitrouter_sdk::config::DEFAULT_REGISTRY_URL: &str
+pub const bitrouter_sdk::config::MAX_CONTINUATION_PRUNE_BATCH_SIZE: usize
+pub const bitrouter_sdk::config::MAX_TRAJECTORY_OUTBOX_BATCH_SIZE: usize
+pub async fn bitrouter_sdk::config::discover_models(&mut bitrouter_sdk::config::Config)
+pub fn bitrouter_sdk::config::env_lookup(&str) -> core::option::Option<alloc::string::String>
+pub fn bitrouter_sdk::config::infer_protocol(&str) -> bitrouter_sdk::language_model::types::ApiProtocol
+pub async fn bitrouter_sdk::config::load(impl core::convert::AsRef<std::path::Path>) -> bitrouter_sdk::error::Result<bitrouter_sdk::config::Config>
+pub fn bitrouter_sdk::config::parse(&str) -> bitrouter_sdk::error::Result<bitrouter_sdk::config::Config>
+pub fn bitrouter_sdk::config::parse_with<F>(&str, F) -> bitrouter_sdk::error::Result<bitrouter_sdk::config::Config> where F: core::ops::function::Fn(&str) -> core::option::Option<alloc::string::String>
+pub fn bitrouter_sdk::config::resolve_derivations(&mut bitrouter_sdk::config::Config) -> bitrouter_sdk::error::Result<()>
+pub fn bitrouter_sdk::config::resolve_presets(&str, &std::collections::hash::map::HashMap<alloc::string::String, bitrouter_sdk::config::PresetConfig>, &std::collections::hash::map::HashMap<alloc::string::String, bitrouter_sdk::config::VariantConfig>) -> bitrouter_sdk::error::Result<bitrouter_sdk::config::presets::PresetResolution>
+pub fn bitrouter_sdk::config::set_env_overrides(std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>)
+pub fn bitrouter_sdk::config::substitute_env(&str) -> bitrouter_sdk::error::Result<alloc::string::String>
+pub fn bitrouter_sdk::config::substitute_with<F>(&str, F) -> bitrouter_sdk::error::Result<alloc::string::String> where F: core::ops::function::Fn(&str) -> core::option::Option<alloc::string::String>
+pub fn bitrouter_sdk::config::validate_policy_table_config(&bitrouter_sdk::config::PolicyTableConfig) -> bitrouter_sdk::error::Result<()>
+pub mod bitrouter_sdk::error
+pub enum bitrouter_sdk::error::BitrouterError
+pub bitrouter_sdk::error::BitrouterError::BadRequest
+pub bitrouter_sdk::error::BitrouterError::BadRequest::message: alloc::string::String
+pub bitrouter_sdk::error::BitrouterError::Forbidden(alloc::string::String)
+pub bitrouter_sdk::error::BitrouterError::Internal(alloc::string::String)
+pub bitrouter_sdk::error::BitrouterError::NotFound(alloc::string::String)
+pub bitrouter_sdk::error::BitrouterError::PaymentRequired(alloc::string::String)
+pub bitrouter_sdk::error::BitrouterError::RateLimited
+pub bitrouter_sdk::error::BitrouterError::RateLimited::retry_after: core::option::Option<u64>
+pub bitrouter_sdk::error::BitrouterError::Unauthorized(alloc::string::String)
+pub bitrouter_sdk::error::BitrouterError::Upstream
+pub bitrouter_sdk::error::BitrouterError::Upstream::message: alloc::string::String
+pub bitrouter_sdk::error::BitrouterError::Upstream::status: u16
+pub bitrouter_sdk::error::BitrouterError::UpstreamAuth
+pub bitrouter_sdk::error::BitrouterError::UpstreamAuth::required_scope: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::error::BitrouterError::UpstreamAuth::status: u16
+pub bitrouter_sdk::error::BitrouterError::UpstreamAuth::www_authenticate: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::error::BitrouterError::UpstreamBadRequest
+pub bitrouter_sdk::error::BitrouterError::UpstreamBadRequest::error: serde_json::value::Value
+pub bitrouter_sdk::error::BitrouterError::UpstreamInvalidResponse
+pub bitrouter_sdk::error::BitrouterError::UpstreamInvalidResponse::message: alloc::string::String
+pub bitrouter_sdk::error::BitrouterError::UpstreamPaymentRequired
+pub bitrouter_sdk::error::BitrouterError::UpstreamPaymentRequired::detail: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::error::BitrouterError::UpstreamPolicyViolation
+pub bitrouter_sdk::error::BitrouterError::UpstreamPolicyViolation::message: alloc::string::String
+pub bitrouter_sdk::error::BitrouterError::UpstreamRateLimited
+pub bitrouter_sdk::error::BitrouterError::UpstreamRateLimited::detail: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::error::BitrouterError::UpstreamRateLimited::retry_after: core::option::Option<u64>
+pub bitrouter_sdk::error::BitrouterError::UpstreamTimeout
+pub bitrouter_sdk::error::BitrouterError::UpstreamUnavailable
+impl bitrouter_sdk::error::BitrouterError
+pub fn bitrouter_sdk::error::BitrouterError::bad_request(impl core::fmt::Display) -> Self
+pub fn bitrouter_sdk::error::BitrouterError::error_code(&self) -> &'static str
+pub fn bitrouter_sdk::error::BitrouterError::error_type(&self) -> &'static str
+pub fn bitrouter_sdk::error::BitrouterError::internal(impl core::fmt::Display) -> Self
+pub fn bitrouter_sdk::error::BitrouterError::kind(&self) -> bitrouter_sdk::error::ErrorKind
+pub fn bitrouter_sdk::error::BitrouterError::public_message(&self) -> alloc::string::String
+pub fn bitrouter_sdk::error::BitrouterError::status(&self) -> u16
+pub fn bitrouter_sdk::error::BitrouterError::to_envelope(&self) -> bitrouter_sdk::error::ErrorEnvelope
+pub fn bitrouter_sdk::error::BitrouterError::upstream_detail(&self) -> core::option::Option<&str>
+impl axum_core::response::into_response::IntoResponse for bitrouter_sdk::error::BitrouterError
+pub fn bitrouter_sdk::error::BitrouterError::into_response(self) -> axum_core::response::Response
+impl core::clone::Clone for bitrouter_sdk::error::BitrouterError
+pub fn bitrouter_sdk::error::BitrouterError::clone(&self) -> bitrouter_sdk::error::BitrouterError
+impl core::convert::From<bitrouter_sdk::language_model::hooks::DenyReason> for bitrouter_sdk::error::BitrouterError
+pub fn bitrouter_sdk::error::BitrouterError::from(bitrouter_sdk::language_model::hooks::DenyReason) -> Self
+impl core::error::Error for bitrouter_sdk::error::BitrouterError
+impl core::fmt::Debug for bitrouter_sdk::error::BitrouterError
+pub fn bitrouter_sdk::error::BitrouterError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitrouter_sdk::error::BitrouterError
+pub fn bitrouter_sdk::error::BitrouterError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::error::BitrouterError
+impl core::marker::Send for bitrouter_sdk::error::BitrouterError
+impl core::marker::Sync for bitrouter_sdk::error::BitrouterError
+impl core::marker::Unpin for bitrouter_sdk::error::BitrouterError
+impl core::marker::UnsafeUnpin for bitrouter_sdk::error::BitrouterError
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::error::BitrouterError
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::error::BitrouterError
+pub enum bitrouter_sdk::error::ErrorKind
+pub bitrouter_sdk::error::ErrorKind::BadRequest
+pub bitrouter_sdk::error::ErrorKind::Forbidden
+pub bitrouter_sdk::error::ErrorKind::Internal
+pub bitrouter_sdk::error::ErrorKind::NotFound
+pub bitrouter_sdk::error::ErrorKind::PaymentRequired
+pub bitrouter_sdk::error::ErrorKind::RateLimited
+pub bitrouter_sdk::error::ErrorKind::Unauthorized
+pub bitrouter_sdk::error::ErrorKind::Upstream
+pub bitrouter_sdk::error::ErrorKind::UpstreamAuth
+pub bitrouter_sdk::error::ErrorKind::UpstreamInvalidResponse
+pub bitrouter_sdk::error::ErrorKind::UpstreamPaymentRequired
+pub bitrouter_sdk::error::ErrorKind::UpstreamRateLimited
+pub bitrouter_sdk::error::ErrorKind::UpstreamTimeout
+pub bitrouter_sdk::error::ErrorKind::UpstreamUnavailable
+impl core::clone::Clone for bitrouter_sdk::error::ErrorKind
+pub fn bitrouter_sdk::error::ErrorKind::clone(&self) -> bitrouter_sdk::error::ErrorKind
+impl core::cmp::Eq for bitrouter_sdk::error::ErrorKind
+impl core::cmp::PartialEq for bitrouter_sdk::error::ErrorKind
+pub fn bitrouter_sdk::error::ErrorKind::eq(&self, &bitrouter_sdk::error::ErrorKind) -> bool
+impl core::fmt::Debug for bitrouter_sdk::error::ErrorKind
+pub fn bitrouter_sdk::error::ErrorKind::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for bitrouter_sdk::error::ErrorKind
+impl core::marker::StructuralPartialEq for bitrouter_sdk::error::ErrorKind
+impl serde_core::ser::Serialize for bitrouter_sdk::error::ErrorKind
+pub fn bitrouter_sdk::error::ErrorKind::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::error::ErrorKind
+pub fn bitrouter_sdk::error::ErrorKind::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::error::ErrorKind
+impl core::marker::Send for bitrouter_sdk::error::ErrorKind
+impl core::marker::Sync for bitrouter_sdk::error::ErrorKind
+impl core::marker::Unpin for bitrouter_sdk::error::ErrorKind
+impl core::marker::UnsafeUnpin for bitrouter_sdk::error::ErrorKind
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::error::ErrorKind
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::error::ErrorKind
+pub struct bitrouter_sdk::error::ErrorBody
+pub bitrouter_sdk::error::ErrorBody::context: alloc::vec::Vec<alloc::string::String>
+pub bitrouter_sdk::error::ErrorBody::hint: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::error::ErrorBody::kind: bitrouter_sdk::error::ErrorKind
+pub bitrouter_sdk::error::ErrorBody::message: alloc::string::String
+impl core::clone::Clone for bitrouter_sdk::error::ErrorBody
+pub fn bitrouter_sdk::error::ErrorBody::clone(&self) -> bitrouter_sdk::error::ErrorBody
+impl core::fmt::Debug for bitrouter_sdk::error::ErrorBody
+pub fn bitrouter_sdk::error::ErrorBody::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl serde_core::ser::Serialize for bitrouter_sdk::error::ErrorBody
+pub fn bitrouter_sdk::error::ErrorBody::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::error::ErrorBody
+pub fn bitrouter_sdk::error::ErrorBody::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::error::ErrorBody
+impl core::marker::Send for bitrouter_sdk::error::ErrorBody
+impl core::marker::Sync for bitrouter_sdk::error::ErrorBody
+impl core::marker::Unpin for bitrouter_sdk::error::ErrorBody
+impl core::marker::UnsafeUnpin for bitrouter_sdk::error::ErrorBody
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::error::ErrorBody
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::error::ErrorBody
+pub struct bitrouter_sdk::error::ErrorEnvelope
+pub bitrouter_sdk::error::ErrorEnvelope::error: bitrouter_sdk::error::ErrorBody
+impl core::clone::Clone for bitrouter_sdk::error::ErrorEnvelope
+pub fn bitrouter_sdk::error::ErrorEnvelope::clone(&self) -> bitrouter_sdk::error::ErrorEnvelope
+impl core::fmt::Debug for bitrouter_sdk::error::ErrorEnvelope
+pub fn bitrouter_sdk::error::ErrorEnvelope::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl serde_core::ser::Serialize for bitrouter_sdk::error::ErrorEnvelope
+pub fn bitrouter_sdk::error::ErrorEnvelope::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::error::ErrorEnvelope
+pub fn bitrouter_sdk::error::ErrorEnvelope::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::error::ErrorEnvelope
+impl core::marker::Send for bitrouter_sdk::error::ErrorEnvelope
+impl core::marker::Sync for bitrouter_sdk::error::ErrorEnvelope
+impl core::marker::Unpin for bitrouter_sdk::error::ErrorEnvelope
+impl core::marker::UnsafeUnpin for bitrouter_sdk::error::ErrorEnvelope
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::error::ErrorEnvelope
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::error::ErrorEnvelope
+pub type bitrouter_sdk::error::Result<T> = core::result::Result<T, bitrouter_sdk::error::BitrouterError>
+pub mod bitrouter_sdk::event
+pub struct bitrouter_sdk::event::EventBus
+impl bitrouter_sdk::event::EventBus
+pub fn bitrouter_sdk::event::EventBus::dump_json(&self) -> serde_json::value::Value
+pub fn bitrouter_sdk::event::EventBus::emit<E: bitrouter_sdk::event::PipelineEvent>(&mut self, E)
+pub fn bitrouter_sdk::event::EventBus::get<E: bitrouter_sdk::event::PipelineEvent>(&self) -> core::option::Option<&E>
+pub fn bitrouter_sdk::event::EventBus::get_all<E: bitrouter_sdk::event::PipelineEvent>(&self) -> alloc::vec::Vec<&E>
+pub fn bitrouter_sdk::event::EventBus::has<E: bitrouter_sdk::event::PipelineEvent>(&self) -> bool
+pub fn bitrouter_sdk::event::EventBus::is_empty(&self) -> bool
+pub fn bitrouter_sdk::event::EventBus::len(&self) -> usize
+pub fn bitrouter_sdk::event::EventBus::merge_from(&mut self, bitrouter_sdk::event::EventBus)
+pub fn bitrouter_sdk::event::EventBus::new() -> Self
+impl core::clone::Clone for bitrouter_sdk::event::EventBus
+pub fn bitrouter_sdk::event::EventBus::clone(&self) -> bitrouter_sdk::event::EventBus
+impl core::default::Default for bitrouter_sdk::event::EventBus
+pub fn bitrouter_sdk::event::EventBus::default() -> bitrouter_sdk::event::EventBus
+impl core::marker::Freeze for bitrouter_sdk::event::EventBus
+impl core::marker::Send for bitrouter_sdk::event::EventBus
+impl core::marker::Sync for bitrouter_sdk::event::EventBus
+impl core::marker::Unpin for bitrouter_sdk::event::EventBus
+impl core::marker::UnsafeUnpin for bitrouter_sdk::event::EventBus
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::event::EventBus
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::event::EventBus
+pub trait bitrouter_sdk::event::PipelineEvent: serde_core::ser::Serialize + core::any::Any + core::marker::Send + core::marker::Sync + 'static
+pub fn bitrouter_sdk::event::PipelineEvent::event_name(&self) -> &'static str
+impl bitrouter_sdk::event::PipelineEvent for bitrouter_sdk::otel::SpanAttributes
+pub fn bitrouter_sdk::otel::SpanAttributes::event_name(&self) -> &'static str
+pub mod bitrouter_sdk::language_model
+pub mod bitrouter_sdk::language_model::auth
+pub struct bitrouter_sdk::language_model::auth::AppliedAuth
+impl bitrouter_sdk::language_model::auth::AppliedAuth
+pub fn bitrouter_sdk::language_model::auth::AppliedAuth::into_request(self) -> reqwest::async_impl::request::Request
+pub fn bitrouter_sdk::language_model::auth::AppliedAuth::proven(reqwest::async_impl::request::Request, bitrouter_sdk::language_model::auth::CredentialAuthority) -> Self
+pub fn bitrouter_sdk::language_model::auth::AppliedAuth::proven_with_scheme(reqwest::async_impl::request::Request, bitrouter_sdk::language_model::auth::CredentialAuthority, bitrouter_sdk::language_model::types::AuthScheme) -> Self
+pub fn bitrouter_sdk::language_model::auth::AppliedAuth::unproven(reqwest::async_impl::request::Request) -> Self
+impl core::fmt::Debug for bitrouter_sdk::language_model::auth::AppliedAuth
+pub fn bitrouter_sdk::language_model::auth::AppliedAuth::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::ops::deref::Deref for bitrouter_sdk::language_model::auth::AppliedAuth
+pub type bitrouter_sdk::language_model::auth::AppliedAuth::Target = reqwest::async_impl::request::Request
+pub fn bitrouter_sdk::language_model::auth::AppliedAuth::deref(&self) -> &Self::Target
+impl core::ops::deref::DerefMut for bitrouter_sdk::language_model::auth::AppliedAuth
+pub fn bitrouter_sdk::language_model::auth::AppliedAuth::deref_mut(&mut self) -> &mut Self::Target
+impl !core::marker::Freeze for bitrouter_sdk::language_model::auth::AppliedAuth
+impl core::marker::Send for bitrouter_sdk::language_model::auth::AppliedAuth
+impl core::marker::Sync for bitrouter_sdk::language_model::auth::AppliedAuth
+impl core::marker::Unpin for bitrouter_sdk::language_model::auth::AppliedAuth
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::auth::AppliedAuth
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::auth::AppliedAuth
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::auth::AppliedAuth
+pub struct bitrouter_sdk::language_model::auth::AuthAppliers
+impl bitrouter_sdk::language_model::auth::AuthAppliers
+pub async fn bitrouter_sdk::language_model::auth::AuthAppliers::continuation_authority(&self, &bitrouter_sdk::language_model::types::RoutingTarget) -> bitrouter_sdk::error::Result<core::option::Option<bitrouter_sdk::language_model::auth::CredentialAuthority>>
+pub async fn bitrouter_sdk::language_model::auth::AuthAppliers::continuation_authority_proof(&self, &bitrouter_sdk::language_model::types::RoutingTarget) -> bitrouter_sdk::error::Result<core::option::Option<bitrouter_sdk::language_model::auth::ContinuationAuthority>>
+pub fn bitrouter_sdk::language_model::auth::AuthAppliers::is_empty(&self) -> bool
+pub fn bitrouter_sdk::language_model::auth::AuthAppliers::lookup(&self, &str) -> core::option::Option<&alloc::sync::Arc<dyn bitrouter_sdk::language_model::auth::AuthApplier>>
+pub fn bitrouter_sdk::language_model::auth::AuthAppliers::new() -> Self
+pub fn bitrouter_sdk::language_model::auth::AuthAppliers::register(&mut self, impl core::convert::Into<alloc::string::String>, alloc::sync::Arc<dyn bitrouter_sdk::language_model::auth::AuthApplier>)
+pub fn bitrouter_sdk::language_model::auth::AuthAppliers::with(self, impl core::convert::Into<alloc::string::String>, alloc::sync::Arc<dyn bitrouter_sdk::language_model::auth::AuthApplier>) -> Self
+impl core::clone::Clone for bitrouter_sdk::language_model::auth::AuthAppliers
+pub fn bitrouter_sdk::language_model::auth::AuthAppliers::clone(&self) -> bitrouter_sdk::language_model::auth::AuthAppliers
+impl core::default::Default for bitrouter_sdk::language_model::auth::AuthAppliers
+pub fn bitrouter_sdk::language_model::auth::AuthAppliers::default() -> bitrouter_sdk::language_model::auth::AuthAppliers
+impl core::marker::Freeze for bitrouter_sdk::language_model::auth::AuthAppliers
+impl core::marker::Send for bitrouter_sdk::language_model::auth::AuthAppliers
+impl core::marker::Sync for bitrouter_sdk::language_model::auth::AuthAppliers
+impl core::marker::Unpin for bitrouter_sdk::language_model::auth::AuthAppliers
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::auth::AuthAppliers
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::auth::AuthAppliers
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::auth::AuthAppliers
+pub struct bitrouter_sdk::language_model::auth::ContinuationAuthority
+impl bitrouter_sdk::language_model::auth::ContinuationAuthority
+pub fn bitrouter_sdk::language_model::auth::ContinuationAuthority::credential(&self) -> &bitrouter_sdk::language_model::auth::CredentialAuthority
+pub fn bitrouter_sdk::language_model::auth::ContinuationAuthority::effective_scheme(&self) -> bitrouter_sdk::language_model::types::AuthScheme
+pub fn bitrouter_sdk::language_model::auth::ContinuationAuthority::new(bitrouter_sdk::language_model::auth::CredentialAuthority, bitrouter_sdk::language_model::types::AuthScheme) -> Self
+impl core::clone::Clone for bitrouter_sdk::language_model::auth::ContinuationAuthority
+pub fn bitrouter_sdk::language_model::auth::ContinuationAuthority::clone(&self) -> bitrouter_sdk::language_model::auth::ContinuationAuthority
+impl core::cmp::Eq for bitrouter_sdk::language_model::auth::ContinuationAuthority
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::auth::ContinuationAuthority
+pub fn bitrouter_sdk::language_model::auth::ContinuationAuthority::eq(&self, &bitrouter_sdk::language_model::auth::ContinuationAuthority) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::auth::ContinuationAuthority
+pub fn bitrouter_sdk::language_model::auth::ContinuationAuthority::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::auth::ContinuationAuthority
+impl core::marker::Freeze for bitrouter_sdk::language_model::auth::ContinuationAuthority
+impl core::marker::Send for bitrouter_sdk::language_model::auth::ContinuationAuthority
+impl core::marker::Sync for bitrouter_sdk::language_model::auth::ContinuationAuthority
+impl core::marker::Unpin for bitrouter_sdk::language_model::auth::ContinuationAuthority
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::auth::ContinuationAuthority
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::auth::ContinuationAuthority
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::auth::ContinuationAuthority
+pub struct bitrouter_sdk::language_model::auth::CredentialAuthority(_)
+impl bitrouter_sdk::language_model::auth::CredentialAuthority
+pub fn bitrouter_sdk::language_model::auth::CredentialAuthority::derive(&str, &str) -> Self
+pub fn bitrouter_sdk::language_model::auth::CredentialAuthority::derive_scoped(&str, &str, &str) -> Self
+pub fn bitrouter_sdk::language_model::auth::CredentialAuthority::proof_bytes(&self) -> &[u8; 32]
+impl core::clone::Clone for bitrouter_sdk::language_model::auth::CredentialAuthority
+pub fn bitrouter_sdk::language_model::auth::CredentialAuthority::clone(&self) -> bitrouter_sdk::language_model::auth::CredentialAuthority
+impl core::cmp::Eq for bitrouter_sdk::language_model::auth::CredentialAuthority
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::auth::CredentialAuthority
+pub fn bitrouter_sdk::language_model::auth::CredentialAuthority::eq(&self, &bitrouter_sdk::language_model::auth::CredentialAuthority) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::auth::CredentialAuthority
+pub fn bitrouter_sdk::language_model::auth::CredentialAuthority::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::auth::CredentialAuthority
+impl core::marker::Freeze for bitrouter_sdk::language_model::auth::CredentialAuthority
+impl core::marker::Send for bitrouter_sdk::language_model::auth::CredentialAuthority
+impl core::marker::Sync for bitrouter_sdk::language_model::auth::CredentialAuthority
+impl core::marker::Unpin for bitrouter_sdk::language_model::auth::CredentialAuthority
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::auth::CredentialAuthority
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::auth::CredentialAuthority
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::auth::CredentialAuthority
+pub trait bitrouter_sdk::language_model::auth::AuthApplier: core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::language_model::auth::AuthApplier::apply<'life0, 'life1, 'async_trait>(&'life0 self, reqwest::async_impl::request::Request, &'life1 bitrouter_sdk::language_model::types::RoutingTarget) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<reqwest::async_impl::request::Request>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::auth::AuthApplier::apply_with_authority<'life0, 'life1, 'async_trait>(&'life0 self, reqwest::async_impl::request::Request, &'life1 bitrouter_sdk::language_model::types::RoutingTarget) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::auth::AppliedAuth>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::auth::AuthApplier::continuation_authority<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::types::RoutingTarget) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<core::option::Option<bitrouter_sdk::language_model::auth::CredentialAuthority>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::auth::AuthApplier::continuation_authority_proof<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::types::RoutingTarget) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<core::option::Option<bitrouter_sdk::language_model::auth::ContinuationAuthority>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::auth::AuthApplier::prepare_body<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 mut serde_json::value::Value, &'life2 bitrouter_sdk::language_model::types::RoutingTarget) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<()>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub fn bitrouter_sdk::language_model::auth::AuthApplier::refresh_after_unauthorized<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::types::RoutingTarget, core::option::Option<&'life2 http::header::value::HeaderValue>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bool>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub mod bitrouter_sdk::language_model::builder
+pub struct bitrouter_sdk::language_model::builder::PipelineBuilder
+impl bitrouter_sdk::language_model::builder::PipelineBuilder
+pub fn bitrouter_sdk::language_model::builder::PipelineBuilder::build(self) -> bitrouter_sdk::error::Result<bitrouter_sdk::language_model::pipeline::Pipeline>
+pub fn bitrouter_sdk::language_model::builder::PipelineBuilder::execution_hook(&mut self, impl bitrouter_sdk::language_model::hooks::ExecutionHook + 'static) -> &mut Self
+pub fn bitrouter_sdk::language_model::builder::PipelineBuilder::executor(&mut self, alloc::sync::Arc<dyn bitrouter_sdk::language_model::executor::Executor>) -> &mut Self
+pub fn bitrouter_sdk::language_model::builder::PipelineBuilder::fallback_backoff(&mut self, impl core::iter::traits::collect::IntoIterator<Item = core::time::Duration>) -> &mut Self
+pub fn bitrouter_sdk::language_model::builder::PipelineBuilder::fallback_policy(&mut self, alloc::sync::Arc<dyn bitrouter_sdk::language_model::routing::FallbackPolicy>) -> &mut Self
+pub fn bitrouter_sdk::language_model::builder::PipelineBuilder::is_configured(&self) -> bool
+pub fn bitrouter_sdk::language_model::builder::PipelineBuilder::keepalive_interval(&mut self, core::time::Duration) -> &mut Self
+pub fn bitrouter_sdk::language_model::builder::PipelineBuilder::model_selector(&mut self, alloc::sync::Arc<dyn bitrouter_sdk::language_model::routing::ModelSelector>) -> &mut Self
+pub fn bitrouter_sdk::language_model::builder::PipelineBuilder::new() -> Self
+pub fn bitrouter_sdk::language_model::builder::PipelineBuilder::observe_hook(&mut self, impl bitrouter_sdk::language_model::hooks::ObserveHook + 'static) -> &mut Self
+pub fn bitrouter_sdk::language_model::builder::PipelineBuilder::pre_request_hook(&mut self, impl bitrouter_sdk::language_model::hooks::PreRequestHook + 'static) -> &mut Self
+pub fn bitrouter_sdk::language_model::builder::PipelineBuilder::required_finalizer(&mut self, impl bitrouter_sdk::language_model::settlement::RequiredFinalizer + 'static) -> &mut Self
+pub fn bitrouter_sdk::language_model::builder::PipelineBuilder::route_hook(&mut self, impl bitrouter_sdk::language_model::hooks::RouteHook + 'static) -> &mut Self
+pub fn bitrouter_sdk::language_model::builder::PipelineBuilder::routing_table(&mut self, alloc::sync::Arc<dyn bitrouter_sdk::language_model::routing::RoutingTable>) -> &mut Self
+pub fn bitrouter_sdk::language_model::builder::PipelineBuilder::server_tool_loop(&mut self, alloc::sync::Arc<bitrouter_sdk::language_model::server_tools::loop_controller::ServerToolLoop>) -> &mut Self
+pub fn bitrouter_sdk::language_model::builder::PipelineBuilder::settlement_recorder(&mut self, impl bitrouter_sdk::language_model::settlement::SettlementRecorder + 'static) -> &mut Self
+pub fn bitrouter_sdk::language_model::builder::PipelineBuilder::stream_hook(&mut self, impl bitrouter_sdk::language_model::hooks::StreamHook + 'static) -> &mut Self
+impl core::default::Default for bitrouter_sdk::language_model::builder::PipelineBuilder
+pub fn bitrouter_sdk::language_model::builder::PipelineBuilder::default() -> Self
+impl core::marker::Freeze for bitrouter_sdk::language_model::builder::PipelineBuilder
+impl core::marker::Send for bitrouter_sdk::language_model::builder::PipelineBuilder
+impl core::marker::Sync for bitrouter_sdk::language_model::builder::PipelineBuilder
+impl core::marker::Unpin for bitrouter_sdk::language_model::builder::PipelineBuilder
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::builder::PipelineBuilder
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::builder::PipelineBuilder
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::builder::PipelineBuilder
+pub mod bitrouter_sdk::language_model::context
+pub struct bitrouter_sdk::language_model::context::PipelineContext
+pub bitrouter_sdk::language_model::context::PipelineContext::execution_result: core::option::Option<bitrouter_sdk::language_model::types::ExecutionResult>
+pub bitrouter_sdk::language_model::context::PipelineContext::route_chain: core::option::Option<alloc::vec::Vec<bitrouter_sdk::language_model::types::RoutingTarget>>
+impl bitrouter_sdk::language_model::context::PipelineContext
+pub fn bitrouter_sdk::language_model::context::PipelineContext::absorb_settlement(&mut self, bitrouter_sdk::language_model::settlement::SettlementContext)
+pub fn bitrouter_sdk::language_model::context::PipelineContext::absorb_stream(&mut self, bitrouter_sdk::language_model::context::StreamContext)
+pub fn bitrouter_sdk::language_model::context::PipelineContext::apply_preset_overrides(&mut self, &bitrouter_sdk::language_model::routing::PromptOverrides)
+pub fn bitrouter_sdk::language_model::context::PipelineContext::caller(&self) -> &bitrouter_sdk::caller::CallerContext
+pub fn bitrouter_sdk::language_model::context::PipelineContext::emit<E: bitrouter_sdk::event::PipelineEvent>(&mut self, E)
+pub fn bitrouter_sdk::language_model::context::PipelineContext::events(&self) -> &bitrouter_sdk::event::EventBus
+pub fn bitrouter_sdk::language_model::context::PipelineContext::extension<T: core::marker::Send + core::marker::Sync + 'static>(&self) -> core::option::Option<alloc::sync::Arc<T>>
+pub fn bitrouter_sdk::language_model::context::PipelineContext::first_token_timing(&self) -> core::option::Option<bitrouter_sdk::language_model::timing::FirstTokenTiming>
+pub fn bitrouter_sdk::language_model::context::PipelineContext::generation_duration_ms(&self) -> core::option::Option<u64>
+pub fn bitrouter_sdk::language_model::context::PipelineContext::get_event<E: bitrouter_sdk::event::PipelineEvent>(&self) -> core::option::Option<&E>
+pub fn bitrouter_sdk::language_model::context::PipelineContext::get_events<E: bitrouter_sdk::event::PipelineEvent>(&self) -> alloc::vec::Vec<&E>
+pub fn bitrouter_sdk::language_model::context::PipelineContext::get_metadata(&self, &bitrouter_sdk::plugin::PluginId) -> core::option::Option<&serde_json::value::Value>
+pub fn bitrouter_sdk::language_model::context::PipelineContext::has_event<E: bitrouter_sdk::event::PipelineEvent>(&self) -> bool
+pub fn bitrouter_sdk::language_model::context::PipelineContext::headers(&self) -> &http::header::map::HeaderMap
+pub fn bitrouter_sdk::language_model::context::PipelineContext::inbound_protocol(&self) -> core::option::Option<bitrouter_sdk::language_model::types::ApiProtocol>
+pub fn bitrouter_sdk::language_model::context::PipelineContext::insert_extension<T: core::marker::Send + core::marker::Sync + 'static>(&mut self, alloc::sync::Arc<T>)
+pub fn bitrouter_sdk::language_model::context::PipelineContext::into_response(self) -> bitrouter_sdk::language_model::types::PipelineResponse
+pub fn bitrouter_sdk::language_model::context::PipelineContext::metadata(&self) -> &std::collections::hash::map::HashMap<bitrouter_sdk::plugin::PluginId, serde_json::value::Value>
+pub fn bitrouter_sdk::language_model::context::PipelineContext::model(&self) -> &str
+pub fn bitrouter_sdk::language_model::context::PipelineContext::new(bitrouter_sdk::language_model::types::PipelineRequest) -> Self
+pub fn bitrouter_sdk::language_model::context::PipelineContext::prompt(&self) -> &bitrouter_sdk::language_model::types::Prompt
+pub fn bitrouter_sdk::language_model::context::PipelineContext::request_duration_ms(&self) -> u64
+pub fn bitrouter_sdk::language_model::context::PipelineContext::request_id(&self) -> &str
+pub fn bitrouter_sdk::language_model::context::PipelineContext::serving_target(&self) -> core::option::Option<bitrouter_sdk::language_model::types::RoutingTarget>
+pub fn bitrouter_sdk::language_model::context::PipelineContext::set_caller(&mut self, bitrouter_sdk::caller::CallerContext)
+pub fn bitrouter_sdk::language_model::context::PipelineContext::set_metadata(&mut self, &bitrouter_sdk::plugin::PluginId, serde_json::value::Value)
+pub fn bitrouter_sdk::language_model::context::PipelineContext::set_model(&mut self, impl core::convert::Into<alloc::string::String>)
+pub fn bitrouter_sdk::language_model::context::PipelineContext::set_outbound_trace_headers(&self, http::header::map::HeaderMap)
+pub fn bitrouter_sdk::language_model::context::PipelineContext::settlement_context(&mut self) -> bitrouter_sdk::language_model::settlement::SettlementContext
+pub fn bitrouter_sdk::language_model::context::PipelineContext::stream_context(&self) -> bitrouter_sdk::language_model::context::StreamContext
+pub fn bitrouter_sdk::language_model::context::PipelineContext::take_outbound_trace_headers(&self) -> core::option::Option<http::header::map::HeaderMap>
+impl !core::marker::Freeze for bitrouter_sdk::language_model::context::PipelineContext
+impl core::marker::Send for bitrouter_sdk::language_model::context::PipelineContext
+impl core::marker::Sync for bitrouter_sdk::language_model::context::PipelineContext
+impl core::marker::Unpin for bitrouter_sdk::language_model::context::PipelineContext
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::context::PipelineContext
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::context::PipelineContext
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::context::PipelineContext
+pub struct bitrouter_sdk::language_model::context::ProviderContinuation
+impl bitrouter_sdk::language_model::context::ProviderContinuation
+pub fn bitrouter_sdk::language_model::context::ProviderContinuation::new(alloc::string::String, &bitrouter_sdk::language_model::types::RoutingTarget, bitrouter_sdk::language_model::auth::ContinuationAuthority) -> Self
+impl core::clone::Clone for bitrouter_sdk::language_model::context::ProviderContinuation
+pub fn bitrouter_sdk::language_model::context::ProviderContinuation::clone(&self) -> bitrouter_sdk::language_model::context::ProviderContinuation
+impl core::marker::Freeze for bitrouter_sdk::language_model::context::ProviderContinuation
+impl core::marker::Send for bitrouter_sdk::language_model::context::ProviderContinuation
+impl core::marker::Sync for bitrouter_sdk::language_model::context::ProviderContinuation
+impl core::marker::Unpin for bitrouter_sdk::language_model::context::ProviderContinuation
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::context::ProviderContinuation
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::context::ProviderContinuation
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::context::ProviderContinuation
+pub struct bitrouter_sdk::language_model::context::RequireContinuationAuthority
+impl core::default::Default for bitrouter_sdk::language_model::context::RequireContinuationAuthority
+pub fn bitrouter_sdk::language_model::context::RequireContinuationAuthority::default() -> bitrouter_sdk::language_model::context::RequireContinuationAuthority
+impl core::fmt::Debug for bitrouter_sdk::language_model::context::RequireContinuationAuthority
+pub fn bitrouter_sdk::language_model::context::RequireContinuationAuthority::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::language_model::context::RequireContinuationAuthority
+impl core::marker::Send for bitrouter_sdk::language_model::context::RequireContinuationAuthority
+impl core::marker::Sync for bitrouter_sdk::language_model::context::RequireContinuationAuthority
+impl core::marker::Unpin for bitrouter_sdk::language_model::context::RequireContinuationAuthority
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::context::RequireContinuationAuthority
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::context::RequireContinuationAuthority
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::context::RequireContinuationAuthority
+pub struct bitrouter_sdk::language_model::context::StreamContext
+pub bitrouter_sdk::language_model::context::StreamContext::accumulated_usage: bitrouter_sdk::language_model::stream::UsageAccumulator
+pub bitrouter_sdk::language_model::context::StreamContext::caller: bitrouter_sdk::caller::CallerContext
+pub bitrouter_sdk::language_model::context::StreamContext::final_usage: core::option::Option<bitrouter_sdk::language_model::types::Usage>
+pub bitrouter_sdk::language_model::context::StreamContext::parts_emitted: u64
+pub bitrouter_sdk::language_model::context::StreamContext::request_id: alloc::string::String
+pub bitrouter_sdk::language_model::context::StreamContext::target: core::option::Option<bitrouter_sdk::language_model::types::RoutingTarget>
+impl bitrouter_sdk::language_model::context::StreamContext
+pub fn bitrouter_sdk::language_model::context::StreamContext::emit<E: bitrouter_sdk::event::PipelineEvent>(&mut self, E)
+pub fn bitrouter_sdk::language_model::context::StreamContext::extension<T: core::marker::Send + core::marker::Sync + 'static>(&self) -> core::option::Option<alloc::sync::Arc<T>>
+pub fn bitrouter_sdk::language_model::context::StreamContext::finish_reason(&self) -> core::option::Option<&bitrouter_sdk::language_model::types::FinishReason>
+pub fn bitrouter_sdk::language_model::context::StreamContext::first_token_timing(&self) -> core::option::Option<bitrouter_sdk::language_model::timing::FirstTokenTiming>
+pub fn bitrouter_sdk::language_model::context::StreamContext::generation_duration_ms(&self) -> core::option::Option<u64>
+pub fn bitrouter_sdk::language_model::context::StreamContext::get_event<E: bitrouter_sdk::event::PipelineEvent>(&self) -> core::option::Option<&E>
+pub fn bitrouter_sdk::language_model::context::StreamContext::get_metadata(&self, &bitrouter_sdk::plugin::PluginId) -> core::option::Option<&serde_json::value::Value>
+pub fn bitrouter_sdk::language_model::context::StreamContext::has_event<E: bitrouter_sdk::event::PipelineEvent>(&self) -> bool
+pub fn bitrouter_sdk::language_model::context::StreamContext::set_metadata(&mut self, &bitrouter_sdk::plugin::PluginId, serde_json::value::Value)
+impl core::marker::Freeze for bitrouter_sdk::language_model::context::StreamContext
+impl core::marker::Send for bitrouter_sdk::language_model::context::StreamContext
+impl core::marker::Sync for bitrouter_sdk::language_model::context::StreamContext
+impl core::marker::Unpin for bitrouter_sdk::language_model::context::StreamContext
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::context::StreamContext
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::context::StreamContext
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::context::StreamContext
+pub mod bitrouter_sdk::language_model::executor
+pub enum bitrouter_sdk::language_model::executor::MockResponse
+pub bitrouter_sdk::language_model::executor::MockResponse::Error(bitrouter_sdk::error::BitrouterError)
+pub bitrouter_sdk::language_model::executor::MockResponse::Generate(bitrouter_sdk::language_model::types::GenerateResult)
+pub bitrouter_sdk::language_model::executor::MockResponse::Stream(alloc::vec::Vec<bitrouter_sdk::language_model::types::StreamPart>)
+impl core::marker::Freeze for bitrouter_sdk::language_model::executor::MockResponse
+impl core::marker::Send for bitrouter_sdk::language_model::executor::MockResponse
+impl core::marker::Sync for bitrouter_sdk::language_model::executor::MockResponse
+impl core::marker::Unpin for bitrouter_sdk::language_model::executor::MockResponse
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::executor::MockResponse
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::executor::MockResponse
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::executor::MockResponse
+pub struct bitrouter_sdk::language_model::executor::DispatchExecutor
+impl bitrouter_sdk::language_model::executor::DispatchExecutor
+pub fn bitrouter_sdk::language_model::executor::DispatchExecutor::new(alloc::sync::Arc<dyn bitrouter_sdk::language_model::executor::Executor>) -> Self
+pub fn bitrouter_sdk::language_model::executor::DispatchExecutor::register(&mut self, bitrouter_sdk::language_model::types::ApiProtocol, alloc::sync::Arc<dyn bitrouter_sdk::language_model::executor::Executor>)
+pub fn bitrouter_sdk::language_model::executor::DispatchExecutor::with(self, bitrouter_sdk::language_model::types::ApiProtocol, alloc::sync::Arc<dyn bitrouter_sdk::language_model::executor::Executor>) -> Self
+impl bitrouter_sdk::language_model::executor::Executor for bitrouter_sdk::language_model::executor::DispatchExecutor
+pub fn bitrouter_sdk::language_model::executor::DispatchExecutor::execute<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::types::RoutingTarget, &'life2 bitrouter_sdk::language_model::types::Prompt, &'life3 bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::ExecutionResult>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub fn bitrouter_sdk::language_model::executor::DispatchExecutor::execute_stream<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::types::RoutingTarget, &'life2 bitrouter_sdk::language_model::types::Prompt, &'life3 bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::executor::StreamPartStream>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+impl core::marker::Freeze for bitrouter_sdk::language_model::executor::DispatchExecutor
+impl core::marker::Send for bitrouter_sdk::language_model::executor::DispatchExecutor
+impl core::marker::Sync for bitrouter_sdk::language_model::executor::DispatchExecutor
+impl core::marker::Unpin for bitrouter_sdk::language_model::executor::DispatchExecutor
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::executor::DispatchExecutor
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::executor::DispatchExecutor
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::executor::DispatchExecutor
+pub struct bitrouter_sdk::language_model::executor::HttpExecutor
+impl bitrouter_sdk::language_model::executor::HttpExecutor
+pub fn bitrouter_sdk::language_model::executor::HttpExecutor::new(bitrouter_sdk::language_model::executor::HttpTimeouts) -> bitrouter_sdk::error::Result<Self>
+pub fn bitrouter_sdk::language_model::executor::HttpExecutor::reload_provider_timeouts(&self, bitrouter_sdk::language_model::executor::HttpTimeouts, std::collections::hash::map::HashMap<alloc::string::String, bitrouter_sdk::language_model::executor::HttpTimeouts>) -> bitrouter_sdk::error::Result<()>
+pub fn bitrouter_sdk::language_model::executor::HttpExecutor::with_defaults() -> bitrouter_sdk::error::Result<Self>
+pub fn bitrouter_sdk::language_model::executor::HttpExecutor::with_dispatch(bitrouter_sdk::language_model::executor::HttpTimeouts, bitrouter_sdk::language_model::protocol::OutboundDispatch) -> bitrouter_sdk::error::Result<Self>
+pub fn bitrouter_sdk::language_model::executor::HttpExecutor::with_dispatch_and_auth(bitrouter_sdk::language_model::executor::HttpTimeouts, bitrouter_sdk::language_model::protocol::OutboundDispatch, bitrouter_sdk::language_model::auth::AuthAppliers) -> bitrouter_sdk::error::Result<Self>
+pub fn bitrouter_sdk::language_model::executor::HttpExecutor::with_provider_timeouts(bitrouter_sdk::language_model::executor::HttpTimeouts, std::collections::hash::map::HashMap<alloc::string::String, bitrouter_sdk::language_model::executor::HttpTimeouts>, bitrouter_sdk::language_model::protocol::OutboundDispatch, bitrouter_sdk::language_model::auth::AuthAppliers) -> bitrouter_sdk::error::Result<Self>
+impl bitrouter_sdk::language_model::executor::Executor for bitrouter_sdk::language_model::executor::HttpExecutor
+pub fn bitrouter_sdk::language_model::executor::HttpExecutor::execute<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::types::RoutingTarget, &'life2 bitrouter_sdk::language_model::types::Prompt, &'life3 bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::ExecutionResult>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub fn bitrouter_sdk::language_model::executor::HttpExecutor::execute_stream<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::types::RoutingTarget, &'life2 bitrouter_sdk::language_model::types::Prompt, &'life3 bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::executor::StreamPartStream>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+impl !core::marker::Freeze for bitrouter_sdk::language_model::executor::HttpExecutor
+impl core::marker::Send for bitrouter_sdk::language_model::executor::HttpExecutor
+impl core::marker::Sync for bitrouter_sdk::language_model::executor::HttpExecutor
+impl core::marker::Unpin for bitrouter_sdk::language_model::executor::HttpExecutor
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::executor::HttpExecutor
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::executor::HttpExecutor
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::executor::HttpExecutor
+pub struct bitrouter_sdk::language_model::executor::HttpTimeouts
+pub bitrouter_sdk::language_model::executor::HttpTimeouts::connect: core::time::Duration
+pub bitrouter_sdk::language_model::executor::HttpTimeouts::pool_idle: core::time::Duration
+pub bitrouter_sdk::language_model::executor::HttpTimeouts::read: core::time::Duration
+pub bitrouter_sdk::language_model::executor::HttpTimeouts::tcp_keepalive: core::time::Duration
+pub bitrouter_sdk::language_model::executor::HttpTimeouts::total: core::option::Option<core::time::Duration>
+impl core::clone::Clone for bitrouter_sdk::language_model::executor::HttpTimeouts
+pub fn bitrouter_sdk::language_model::executor::HttpTimeouts::clone(&self) -> bitrouter_sdk::language_model::executor::HttpTimeouts
+impl core::cmp::Eq for bitrouter_sdk::language_model::executor::HttpTimeouts
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::executor::HttpTimeouts
+pub fn bitrouter_sdk::language_model::executor::HttpTimeouts::eq(&self, &bitrouter_sdk::language_model::executor::HttpTimeouts) -> bool
+impl core::default::Default for bitrouter_sdk::language_model::executor::HttpTimeouts
+pub fn bitrouter_sdk::language_model::executor::HttpTimeouts::default() -> Self
+impl core::fmt::Debug for bitrouter_sdk::language_model::executor::HttpTimeouts
+pub fn bitrouter_sdk::language_model::executor::HttpTimeouts::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::executor::HttpTimeouts
+impl core::marker::Freeze for bitrouter_sdk::language_model::executor::HttpTimeouts
+impl core::marker::Send for bitrouter_sdk::language_model::executor::HttpTimeouts
+impl core::marker::Sync for bitrouter_sdk::language_model::executor::HttpTimeouts
+impl core::marker::Unpin for bitrouter_sdk::language_model::executor::HttpTimeouts
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::executor::HttpTimeouts
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::executor::HttpTimeouts
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::executor::HttpTimeouts
+pub struct bitrouter_sdk::language_model::executor::MockExecutor
+impl bitrouter_sdk::language_model::executor::MockExecutor
+pub fn bitrouter_sdk::language_model::executor::MockExecutor::always_text(impl core::convert::Into<alloc::string::String>) -> Self
+pub fn bitrouter_sdk::language_model::executor::MockExecutor::new(alloc::vec::Vec<bitrouter_sdk::language_model::executor::MockResponse>) -> Self
+impl bitrouter_sdk::language_model::executor::Executor for bitrouter_sdk::language_model::executor::MockExecutor
+pub fn bitrouter_sdk::language_model::executor::MockExecutor::execute<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::types::RoutingTarget, &'life2 bitrouter_sdk::language_model::types::Prompt, &'life3 bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::ExecutionResult>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub fn bitrouter_sdk::language_model::executor::MockExecutor::execute_stream<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::types::RoutingTarget, &'life2 bitrouter_sdk::language_model::types::Prompt, &'life3 bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::executor::StreamPartStream>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+impl !core::marker::Freeze for bitrouter_sdk::language_model::executor::MockExecutor
+impl core::marker::Send for bitrouter_sdk::language_model::executor::MockExecutor
+impl core::marker::Sync for bitrouter_sdk::language_model::executor::MockExecutor
+impl core::marker::Unpin for bitrouter_sdk::language_model::executor::MockExecutor
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::executor::MockExecutor
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::executor::MockExecutor
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::executor::MockExecutor
+pub trait bitrouter_sdk::language_model::executor::Executor: core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::language_model::executor::Executor::execute<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::types::RoutingTarget, &'life2 bitrouter_sdk::language_model::types::Prompt, &'life3 bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::ExecutionResult>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub fn bitrouter_sdk::language_model::executor::Executor::execute_stream<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::types::RoutingTarget, &'life2 bitrouter_sdk::language_model::types::Prompt, &'life3 bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::executor::StreamPartStream>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+impl bitrouter_sdk::language_model::executor::Executor for bitrouter_sdk::language_model::executor::DispatchExecutor
+pub fn bitrouter_sdk::language_model::executor::DispatchExecutor::execute<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::types::RoutingTarget, &'life2 bitrouter_sdk::language_model::types::Prompt, &'life3 bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::ExecutionResult>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub fn bitrouter_sdk::language_model::executor::DispatchExecutor::execute_stream<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::types::RoutingTarget, &'life2 bitrouter_sdk::language_model::types::Prompt, &'life3 bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::executor::StreamPartStream>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+impl bitrouter_sdk::language_model::executor::Executor for bitrouter_sdk::language_model::executor::HttpExecutor
+pub fn bitrouter_sdk::language_model::executor::HttpExecutor::execute<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::types::RoutingTarget, &'life2 bitrouter_sdk::language_model::types::Prompt, &'life3 bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::ExecutionResult>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub fn bitrouter_sdk::language_model::executor::HttpExecutor::execute_stream<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::types::RoutingTarget, &'life2 bitrouter_sdk::language_model::types::Prompt, &'life3 bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::executor::StreamPartStream>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+impl bitrouter_sdk::language_model::executor::Executor for bitrouter_sdk::language_model::executor::MockExecutor
+pub fn bitrouter_sdk::language_model::executor::MockExecutor::execute<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::types::RoutingTarget, &'life2 bitrouter_sdk::language_model::types::Prompt, &'life3 bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::ExecutionResult>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub fn bitrouter_sdk::language_model::executor::MockExecutor::execute_stream<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::types::RoutingTarget, &'life2 bitrouter_sdk::language_model::types::Prompt, &'life3 bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::executor::StreamPartStream>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub type bitrouter_sdk::language_model::executor::StreamPartStream = core::pin::Pin<alloc::boxed::Box<(dyn futures_core::stream::Stream<Item = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::StreamPart>> + core::marker::Send)>>
+pub mod bitrouter_sdk::language_model::hooks
+pub enum bitrouter_sdk::language_model::hooks::DenyReason
+pub bitrouter_sdk::language_model::hooks::DenyReason::BadRequest(alloc::string::String)
+pub bitrouter_sdk::language_model::hooks::DenyReason::Custom(u16, alloc::string::String)
+pub bitrouter_sdk::language_model::hooks::DenyReason::Forbidden(alloc::string::String)
+pub bitrouter_sdk::language_model::hooks::DenyReason::GuardrailViolation(alloc::string::String)
+pub bitrouter_sdk::language_model::hooks::DenyReason::PaymentRequired(alloc::string::String)
+pub bitrouter_sdk::language_model::hooks::DenyReason::RateLimited
+pub bitrouter_sdk::language_model::hooks::DenyReason::RateLimited::retry_after: core::option::Option<u64>
+pub bitrouter_sdk::language_model::hooks::DenyReason::Unauthorized(alloc::string::String)
+impl core::convert::From<bitrouter_sdk::language_model::hooks::DenyReason> for bitrouter_sdk::error::BitrouterError
+pub fn bitrouter_sdk::error::BitrouterError::from(bitrouter_sdk::language_model::hooks::DenyReason) -> Self
+impl core::fmt::Debug for bitrouter_sdk::language_model::hooks::DenyReason
+pub fn bitrouter_sdk::language_model::hooks::DenyReason::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::language_model::hooks::DenyReason
+impl core::marker::Send for bitrouter_sdk::language_model::hooks::DenyReason
+impl core::marker::Sync for bitrouter_sdk::language_model::hooks::DenyReason
+impl core::marker::Unpin for bitrouter_sdk::language_model::hooks::DenyReason
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::hooks::DenyReason
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::hooks::DenyReason
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::hooks::DenyReason
+pub enum bitrouter_sdk::language_model::hooks::FallbackDecision
+pub bitrouter_sdk::language_model::hooks::FallbackDecision::Fail(bitrouter_sdk::error::BitrouterError)
+pub bitrouter_sdk::language_model::hooks::FallbackDecision::TryNext
+impl core::fmt::Debug for bitrouter_sdk::language_model::hooks::FallbackDecision
+pub fn bitrouter_sdk::language_model::hooks::FallbackDecision::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::language_model::hooks::FallbackDecision
+impl core::marker::Send for bitrouter_sdk::language_model::hooks::FallbackDecision
+impl core::marker::Sync for bitrouter_sdk::language_model::hooks::FallbackDecision
+impl core::marker::Unpin for bitrouter_sdk::language_model::hooks::FallbackDecision
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::hooks::FallbackDecision
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::hooks::FallbackDecision
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::hooks::FallbackDecision
+pub enum bitrouter_sdk::language_model::hooks::HookDecision
+pub bitrouter_sdk::language_model::hooks::HookDecision::Allow
+pub bitrouter_sdk::language_model::hooks::HookDecision::Deny(bitrouter_sdk::language_model::hooks::DenyReason)
+impl core::fmt::Debug for bitrouter_sdk::language_model::hooks::HookDecision
+pub fn bitrouter_sdk::language_model::hooks::HookDecision::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::language_model::hooks::HookDecision
+impl core::marker::Send for bitrouter_sdk::language_model::hooks::HookDecision
+impl core::marker::Sync for bitrouter_sdk::language_model::hooks::HookDecision
+impl core::marker::Unpin for bitrouter_sdk::language_model::hooks::HookDecision
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::hooks::HookDecision
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::hooks::HookDecision
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::hooks::HookDecision
+pub enum bitrouter_sdk::language_model::hooks::HopOutcome<'a>
+pub bitrouter_sdk::language_model::hooks::HopOutcome::Failed(&'a bitrouter_sdk::error::BitrouterError)
+pub bitrouter_sdk::language_model::hooks::HopOutcome::Generated(&'a bitrouter_sdk::language_model::types::ExecutionResult)
+pub bitrouter_sdk::language_model::hooks::HopOutcome::StreamStarted
+impl<'a> core::clone::Clone for bitrouter_sdk::language_model::hooks::HopOutcome<'a>
+pub fn bitrouter_sdk::language_model::hooks::HopOutcome<'a>::clone(&self) -> bitrouter_sdk::language_model::hooks::HopOutcome<'a>
+impl<'a> core::fmt::Debug for bitrouter_sdk::language_model::hooks::HopOutcome<'a>
+pub fn bitrouter_sdk::language_model::hooks::HopOutcome<'a>::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<'a> core::marker::Copy for bitrouter_sdk::language_model::hooks::HopOutcome<'a>
+impl<'a> core::marker::Freeze for bitrouter_sdk::language_model::hooks::HopOutcome<'a>
+impl<'a> core::marker::Send for bitrouter_sdk::language_model::hooks::HopOutcome<'a>
+impl<'a> core::marker::Sync for bitrouter_sdk::language_model::hooks::HopOutcome<'a>
+impl<'a> core::marker::Unpin for bitrouter_sdk::language_model::hooks::HopOutcome<'a>
+impl<'a> core::marker::UnsafeUnpin for bitrouter_sdk::language_model::hooks::HopOutcome<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::hooks::HopOutcome<'a>
+impl<'a> core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::hooks::HopOutcome<'a>
+pub enum bitrouter_sdk::language_model::hooks::Phase
+pub bitrouter_sdk::language_model::hooks::Phase::Execution
+pub bitrouter_sdk::language_model::hooks::Phase::PreRequest
+pub bitrouter_sdk::language_model::hooks::Phase::Route
+pub bitrouter_sdk::language_model::hooks::Phase::Settlement
+impl core::clone::Clone for bitrouter_sdk::language_model::hooks::Phase
+pub fn bitrouter_sdk::language_model::hooks::Phase::clone(&self) -> bitrouter_sdk::language_model::hooks::Phase
+impl core::cmp::Eq for bitrouter_sdk::language_model::hooks::Phase
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::hooks::Phase
+pub fn bitrouter_sdk::language_model::hooks::Phase::eq(&self, &bitrouter_sdk::language_model::hooks::Phase) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::hooks::Phase
+pub fn bitrouter_sdk::language_model::hooks::Phase::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for bitrouter_sdk::language_model::hooks::Phase
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::hooks::Phase
+impl core::marker::Freeze for bitrouter_sdk::language_model::hooks::Phase
+impl core::marker::Send for bitrouter_sdk::language_model::hooks::Phase
+impl core::marker::Sync for bitrouter_sdk::language_model::hooks::Phase
+impl core::marker::Unpin for bitrouter_sdk::language_model::hooks::Phase
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::hooks::Phase
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::hooks::Phase
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::hooks::Phase
+pub enum bitrouter_sdk::language_model::hooks::RequestOutcome
+pub bitrouter_sdk::language_model::hooks::RequestOutcome::ClientDisconnected
+pub bitrouter_sdk::language_model::hooks::RequestOutcome::Completed
+pub bitrouter_sdk::language_model::hooks::RequestOutcome::Failed(bitrouter_sdk::error::BitrouterError)
+impl core::fmt::Debug for bitrouter_sdk::language_model::hooks::RequestOutcome
+pub fn bitrouter_sdk::language_model::hooks::RequestOutcome::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::language_model::hooks::RequestOutcome
+impl core::marker::Send for bitrouter_sdk::language_model::hooks::RequestOutcome
+impl core::marker::Sync for bitrouter_sdk::language_model::hooks::RequestOutcome
+impl core::marker::Unpin for bitrouter_sdk::language_model::hooks::RequestOutcome
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::hooks::RequestOutcome
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::hooks::RequestOutcome
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::hooks::RequestOutcome
+pub enum bitrouter_sdk::language_model::hooks::StreamHopOutcome<'a>
+pub bitrouter_sdk::language_model::hooks::StreamHopOutcome::Completed
+pub bitrouter_sdk::language_model::hooks::StreamHopOutcome::Dropped
+pub bitrouter_sdk::language_model::hooks::StreamHopOutcome::Failed(&'a bitrouter_sdk::error::BitrouterError)
+impl<'a> core::clone::Clone for bitrouter_sdk::language_model::hooks::StreamHopOutcome<'a>
+pub fn bitrouter_sdk::language_model::hooks::StreamHopOutcome<'a>::clone(&self) -> bitrouter_sdk::language_model::hooks::StreamHopOutcome<'a>
+impl<'a> core::fmt::Debug for bitrouter_sdk::language_model::hooks::StreamHopOutcome<'a>
+pub fn bitrouter_sdk::language_model::hooks::StreamHopOutcome<'a>::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<'a> core::marker::Copy for bitrouter_sdk::language_model::hooks::StreamHopOutcome<'a>
+impl<'a> core::marker::Freeze for bitrouter_sdk::language_model::hooks::StreamHopOutcome<'a>
+impl<'a> core::marker::Send for bitrouter_sdk::language_model::hooks::StreamHopOutcome<'a>
+impl<'a> core::marker::Sync for bitrouter_sdk::language_model::hooks::StreamHopOutcome<'a>
+impl<'a> core::marker::Unpin for bitrouter_sdk::language_model::hooks::StreamHopOutcome<'a>
+impl<'a> core::marker::UnsafeUnpin for bitrouter_sdk::language_model::hooks::StreamHopOutcome<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::hooks::StreamHopOutcome<'a>
+impl<'a> core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::hooks::StreamHopOutcome<'a>
+pub trait bitrouter_sdk::language_model::hooks::ExecutionHook: core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::language_model::hooks::ExecutionHook::on_failure<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::context::PipelineContext, &'life2 bitrouter_sdk::error::BitrouterError) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::language_model::hooks::FallbackDecision> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub fn bitrouter_sdk::language_model::hooks::ExecutionHook::on_success<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::context::PipelineContext, &'life2 bitrouter_sdk::language_model::types::ExecutionResult) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<()>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub trait bitrouter_sdk::language_model::hooks::ObserveHook: core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::language_model::hooks::ObserveHook::after_phase<'life0, 'life1, 'async_trait>(&'life0 self, bitrouter_sdk::language_model::hooks::Phase, &'life1 bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = ()> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::hooks::ObserveHook::on_hop_end<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::context::PipelineContext, &'life2 bitrouter_sdk::language_model::types::RoutingTarget, bitrouter_sdk::language_model::hooks::HopOutcome<'life3>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = ()> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub fn bitrouter_sdk::language_model::hooks::ObserveHook::on_hop_start<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::context::PipelineContext, &'life2 bitrouter_sdk::language_model::types::RoutingTarget) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = ()> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub fn bitrouter_sdk::language_model::hooks::ObserveHook::on_request_end<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::context::PipelineContext, &'life2 bitrouter_sdk::language_model::hooks::RequestOutcome) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = ()> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub fn bitrouter_sdk::language_model::hooks::ObserveHook::on_request_start<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = ()> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::hooks::ObserveHook::on_stream_hop_end(&self, &str, &bitrouter_sdk::language_model::types::RoutingTarget, bitrouter_sdk::language_model::hooks::StreamHopOutcome<'_>, u64)
+pub fn bitrouter_sdk::language_model::hooks::ObserveHook::on_stream_part<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::context::StreamContext, &'life2 bitrouter_sdk::language_model::types::StreamPart) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = ()> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub fn bitrouter_sdk::language_model::hooks::ObserveHook::stream_interest(&self) -> bitrouter_sdk::language_model::stream::StreamInterest
+impl bitrouter_sdk::language_model::hooks::ObserveHook for bitrouter_sdk::otel::OtelExporter
+pub fn bitrouter_sdk::otel::OtelExporter::after_phase<'life0, 'life1, 'async_trait>(&'life0 self, bitrouter_sdk::language_model::hooks::Phase, &'life1 bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = ()> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::otel::OtelExporter::on_hop_end<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::context::PipelineContext, &'life2 bitrouter_sdk::language_model::types::RoutingTarget, bitrouter_sdk::language_model::hooks::HopOutcome<'life3>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = ()> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub fn bitrouter_sdk::otel::OtelExporter::on_hop_start<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::context::PipelineContext, &'life2 bitrouter_sdk::language_model::types::RoutingTarget) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = ()> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub fn bitrouter_sdk::otel::OtelExporter::on_request_end<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::context::PipelineContext, &'life2 bitrouter_sdk::language_model::hooks::RequestOutcome) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = ()> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub fn bitrouter_sdk::otel::OtelExporter::on_request_start<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = ()> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::otel::OtelExporter::on_stream_hop_end(&self, &str, &bitrouter_sdk::language_model::types::RoutingTarget, bitrouter_sdk::language_model::hooks::StreamHopOutcome<'_>, u64)
+pub fn bitrouter_sdk::otel::OtelExporter::on_stream_part<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::context::StreamContext, &'life2 bitrouter_sdk::language_model::types::StreamPart) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = ()> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub fn bitrouter_sdk::otel::OtelExporter::stream_interest(&self) -> bitrouter_sdk::language_model::stream::StreamInterest
+impl bitrouter_sdk::language_model::hooks::ObserveHook for bitrouter_sdk::otel::OtelObserveHook
+pub fn bitrouter_sdk::otel::OtelObserveHook::after_phase<'life0, 'life1, 'async_trait>(&'life0 self, bitrouter_sdk::language_model::hooks::Phase, &'life1 bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = ()> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::otel::OtelObserveHook::on_hop_end<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::context::PipelineContext, &'life2 bitrouter_sdk::language_model::types::RoutingTarget, bitrouter_sdk::language_model::hooks::HopOutcome<'life3>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = ()> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub fn bitrouter_sdk::otel::OtelObserveHook::on_hop_start<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::context::PipelineContext, &'life2 bitrouter_sdk::language_model::types::RoutingTarget) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = ()> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub fn bitrouter_sdk::otel::OtelObserveHook::on_request_end<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::context::PipelineContext, &'life2 bitrouter_sdk::language_model::hooks::RequestOutcome) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = ()> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub fn bitrouter_sdk::otel::OtelObserveHook::on_request_start<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = ()> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::otel::OtelObserveHook::on_stream_hop_end(&self, &str, &bitrouter_sdk::language_model::types::RoutingTarget, bitrouter_sdk::language_model::hooks::StreamHopOutcome<'_>, u64)
+pub fn bitrouter_sdk::otel::OtelObserveHook::on_stream_part<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::context::StreamContext, &'life2 bitrouter_sdk::language_model::types::StreamPart) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = ()> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub fn bitrouter_sdk::otel::OtelObserveHook::stream_interest(&self) -> bitrouter_sdk::language_model::stream::StreamInterest
+pub trait bitrouter_sdk::language_model::hooks::PreRequestHook: core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::language_model::hooks::PreRequestHook::check<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 mut bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::hooks::HookDecision>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+impl bitrouter_sdk::language_model::hooks::PreRequestHook for bitrouter_sdk::language_model::server_tools::declarations::ServerToolDeclarationsHook
+pub fn bitrouter_sdk::language_model::server_tools::declarations::ServerToolDeclarationsHook::check<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 mut bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::hooks::HookDecision>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub trait bitrouter_sdk::language_model::hooks::RouteHook: core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::language_model::hooks::RouteHook::resolve<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 mut alloc::vec::Vec<bitrouter_sdk::language_model::types::RoutingTarget>, &'life2 mut bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<()>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub trait bitrouter_sdk::language_model::hooks::StreamHook: core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::language_model::hooks::StreamHook::interest(&self) -> bitrouter_sdk::language_model::stream::StreamInterest
+pub fn bitrouter_sdk::language_model::hooks::StreamHook::on_part<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 mut bitrouter_sdk::language_model::context::StreamContext, bitrouter_sdk::language_model::types::StreamPart) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::stream::StreamAction>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::hooks::StreamHook::on_stream_end<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 mut bitrouter_sdk::language_model::context::StreamContext, &'life2 bitrouter_sdk::language_model::stream::StreamOutcome) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<()>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub mod bitrouter_sdk::language_model::pipeline
+pub struct bitrouter_sdk::language_model::pipeline::Pipeline
+impl bitrouter_sdk::language_model::pipeline::Pipeline
+pub async fn bitrouter_sdk::language_model::pipeline::Pipeline::drain_pending_settlements(&self) -> usize
+pub async fn bitrouter_sdk::language_model::pipeline::Pipeline::drain_required_pending_settlements(&self) -> bitrouter_sdk::error::Result<usize>
+pub async fn bitrouter_sdk::language_model::pipeline::Pipeline::execute(&self, bitrouter_sdk::language_model::types::PipelineRequest) -> bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::PipelineResponse>
+pub async fn bitrouter_sdk::language_model::pipeline::Pipeline::execute_detached(alloc::sync::Arc<Self>, bitrouter_sdk::language_model::types::PipelineRequest) -> bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::PipelineResponse>
+pub async fn bitrouter_sdk::language_model::pipeline::Pipeline::execute_stream(alloc::sync::Arc<Self>, bitrouter_sdk::language_model::types::PipelineRequest) -> bitrouter_sdk::error::Result<core::pin::Pin<alloc::boxed::Box<(dyn futures_core::stream::Stream<Item = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::StreamPart>> + core::marker::Send)>>>
+pub fn bitrouter_sdk::language_model::pipeline::Pipeline::keepalive_interval(&self) -> core::time::Duration
+pub fn bitrouter_sdk::language_model::pipeline::Pipeline::routing_table(&self) -> &alloc::sync::Arc<dyn bitrouter_sdk::language_model::routing::RoutingTable>
+impl core::marker::Freeze for bitrouter_sdk::language_model::pipeline::Pipeline
+impl core::marker::Send for bitrouter_sdk::language_model::pipeline::Pipeline
+impl core::marker::Sync for bitrouter_sdk::language_model::pipeline::Pipeline
+impl core::marker::Unpin for bitrouter_sdk::language_model::pipeline::Pipeline
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::pipeline::Pipeline
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::pipeline::Pipeline
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::pipeline::Pipeline
+pub const bitrouter_sdk::language_model::pipeline::DEFAULT_KEEPALIVE: core::time::Duration
+pub mod bitrouter_sdk::language_model::protocol
+pub mod bitrouter_sdk::language_model::protocol::chat_completions
+pub enum bitrouter_sdk::language_model::protocol::chat_completions::ChatResponseFormat
+pub bitrouter_sdk::language_model::protocol::chat_completions::ChatResponseFormat::JsonObject
+pub bitrouter_sdk::language_model::protocol::chat_completions::ChatResponseFormat::JsonSchema
+pub bitrouter_sdk::language_model::protocol::chat_completions::ChatResponseFormat::JsonSchema::json_schema: bitrouter_sdk::language_model::protocol::chat_completions::ChatJsonSchema
+pub bitrouter_sdk::language_model::protocol::chat_completions::ChatResponseFormat::Text
+impl core::clone::Clone for bitrouter_sdk::language_model::protocol::chat_completions::ChatResponseFormat
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatResponseFormat::clone(&self) -> bitrouter_sdk::language_model::protocol::chat_completions::ChatResponseFormat
+impl core::fmt::Debug for bitrouter_sdk::language_model::protocol::chat_completions::ChatResponseFormat
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatResponseFormat::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::language_model::protocol::chat_completions::ChatResponseFormat
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatResponseFormat::inline_schema() -> bool
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatResponseFormat::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatResponseFormat::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatResponseFormat::schema_name() -> alloc::borrow::Cow<'static, str>
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::protocol::chat_completions::ChatResponseFormat
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatResponseFormat::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::protocol::chat_completions::ChatResponseFormat
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatResponseFormat::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::protocol::chat_completions::ChatResponseFormat
+impl core::marker::Send for bitrouter_sdk::language_model::protocol::chat_completions::ChatResponseFormat
+impl core::marker::Sync for bitrouter_sdk::language_model::protocol::chat_completions::ChatResponseFormat
+impl core::marker::Unpin for bitrouter_sdk::language_model::protocol::chat_completions::ChatResponseFormat
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::protocol::chat_completions::ChatResponseFormat
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::protocol::chat_completions::ChatResponseFormat
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::protocol::chat_completions::ChatResponseFormat
+pub struct bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsAdapter
+impl bitrouter_sdk::language_model::protocol::InboundAdapter for bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsAdapter
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsAdapter::parse_request(&self, serde_json::value::Value) -> bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::Prompt>
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsAdapter::protocol(&self) -> bitrouter_sdk::language_model::types::ApiProtocol
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsAdapter::render_response(&self, &bitrouter_sdk::language_model::types::GenerateResult, &bitrouter_sdk::language_model::types::Prompt, &str) -> bitrouter_sdk::error::Result<serde_json::value::Value>
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsAdapter::stream_encoder(&self, &str, &str) -> alloc::boxed::Box<dyn bitrouter_sdk::language_model::protocol::StreamEncoder>
+impl bitrouter_sdk::language_model::protocol::OutboundAdapter for bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsAdapter
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsAdapter::parse_response(&self, serde_json::value::Value) -> bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::GenerateResult>
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsAdapter::protocol(&self) -> bitrouter_sdk::language_model::types::ApiProtocol
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsAdapter::render_request(&self, &bitrouter_sdk::language_model::types::Prompt) -> bitrouter_sdk::error::Result<serde_json::value::Value>
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsAdapter::render_request_for_target(&self, &bitrouter_sdk::language_model::types::Prompt, &bitrouter_sdk::language_model::types::RoutingTarget) -> bitrouter_sdk::error::Result<serde_json::value::Value>
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsAdapter::stream_decoder(&self) -> alloc::boxed::Box<dyn bitrouter_sdk::language_model::protocol::StreamDecoder>
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsAdapter::supports_response_format(&self) -> bool
+impl core::marker::Freeze for bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsAdapter
+impl core::marker::Send for bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsAdapter
+impl core::marker::Sync for bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsAdapter
+impl core::marker::Unpin for bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsAdapter
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsAdapter
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsAdapter
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsAdapter
+pub struct bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsTransport
+impl bitrouter_sdk::language_model::protocol::Transport for bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsTransport
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsTransport::authorise<'life0, 'life1, 'async_trait>(&'life0 self, reqwest::async_impl::request::Request, &'life1 bitrouter_sdk::language_model::types::RoutingTarget) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<reqwest::async_impl::request::Request>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsTransport::endpoint_url(&self, &bitrouter_sdk::language_model::types::RoutingTarget, bool) -> alloc::string::String
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsTransport::protocol(&self) -> bitrouter_sdk::language_model::types::ApiProtocol
+impl core::marker::Freeze for bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsTransport
+impl core::marker::Send for bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsTransport
+impl core::marker::Sync for bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsTransport
+impl core::marker::Unpin for bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsTransport
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsTransport
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsTransport
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsTransport
+pub struct bitrouter_sdk::language_model::protocol::chat_completions::ChatFunctionCall
+impl core::default::Default for bitrouter_sdk::language_model::protocol::chat_completions::ChatFunctionCall
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatFunctionCall::default() -> bitrouter_sdk::language_model::protocol::chat_completions::ChatFunctionCall
+impl core::fmt::Debug for bitrouter_sdk::language_model::protocol::chat_completions::ChatFunctionCall
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatFunctionCall::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::language_model::protocol::chat_completions::ChatFunctionCall
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatFunctionCall::inline_schema() -> bool
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatFunctionCall::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatFunctionCall::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatFunctionCall::schema_name() -> alloc::borrow::Cow<'static, str>
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::protocol::chat_completions::ChatFunctionCall
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatFunctionCall::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::protocol::chat_completions::ChatFunctionCall
+impl core::marker::Send for bitrouter_sdk::language_model::protocol::chat_completions::ChatFunctionCall
+impl core::marker::Sync for bitrouter_sdk::language_model::protocol::chat_completions::ChatFunctionCall
+impl core::marker::Unpin for bitrouter_sdk::language_model::protocol::chat_completions::ChatFunctionCall
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::protocol::chat_completions::ChatFunctionCall
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::protocol::chat_completions::ChatFunctionCall
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::protocol::chat_completions::ChatFunctionCall
+pub struct bitrouter_sdk::language_model::protocol::chat_completions::ChatJsonSchema
+impl core::clone::Clone for bitrouter_sdk::language_model::protocol::chat_completions::ChatJsonSchema
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatJsonSchema::clone(&self) -> bitrouter_sdk::language_model::protocol::chat_completions::ChatJsonSchema
+impl core::fmt::Debug for bitrouter_sdk::language_model::protocol::chat_completions::ChatJsonSchema
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatJsonSchema::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::language_model::protocol::chat_completions::ChatJsonSchema
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatJsonSchema::inline_schema() -> bool
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatJsonSchema::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatJsonSchema::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatJsonSchema::schema_name() -> alloc::borrow::Cow<'static, str>
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::protocol::chat_completions::ChatJsonSchema
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatJsonSchema::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::protocol::chat_completions::ChatJsonSchema
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatJsonSchema::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::protocol::chat_completions::ChatJsonSchema
+impl core::marker::Send for bitrouter_sdk::language_model::protocol::chat_completions::ChatJsonSchema
+impl core::marker::Sync for bitrouter_sdk::language_model::protocol::chat_completions::ChatJsonSchema
+impl core::marker::Unpin for bitrouter_sdk::language_model::protocol::chat_completions::ChatJsonSchema
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::protocol::chat_completions::ChatJsonSchema
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::protocol::chat_completions::ChatJsonSchema
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::protocol::chat_completions::ChatJsonSchema
+pub struct bitrouter_sdk::language_model::protocol::chat_completions::ChatMessage
+impl core::fmt::Debug for bitrouter_sdk::language_model::protocol::chat_completions::ChatMessage
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatMessage::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::language_model::protocol::chat_completions::ChatMessage
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatMessage::inline_schema() -> bool
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatMessage::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatMessage::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatMessage::schema_name() -> alloc::borrow::Cow<'static, str>
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::protocol::chat_completions::ChatMessage
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatMessage::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::protocol::chat_completions::ChatMessage
+impl core::marker::Send for bitrouter_sdk::language_model::protocol::chat_completions::ChatMessage
+impl core::marker::Sync for bitrouter_sdk::language_model::protocol::chat_completions::ChatMessage
+impl core::marker::Unpin for bitrouter_sdk::language_model::protocol::chat_completions::ChatMessage
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::protocol::chat_completions::ChatMessage
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::protocol::chat_completions::ChatMessage
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::protocol::chat_completions::ChatMessage
+pub struct bitrouter_sdk::language_model::protocol::chat_completions::ChatRequest
+impl core::fmt::Debug for bitrouter_sdk::language_model::protocol::chat_completions::ChatRequest
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatRequest::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::language_model::protocol::chat_completions::ChatRequest
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatRequest::inline_schema() -> bool
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatRequest::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatRequest::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatRequest::schema_name() -> alloc::borrow::Cow<'static, str>
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::protocol::chat_completions::ChatRequest
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatRequest::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::protocol::chat_completions::ChatRequest
+impl core::marker::Send for bitrouter_sdk::language_model::protocol::chat_completions::ChatRequest
+impl core::marker::Sync for bitrouter_sdk::language_model::protocol::chat_completions::ChatRequest
+impl core::marker::Unpin for bitrouter_sdk::language_model::protocol::chat_completions::ChatRequest
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::protocol::chat_completions::ChatRequest
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::protocol::chat_completions::ChatRequest
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::protocol::chat_completions::ChatRequest
+pub struct bitrouter_sdk::language_model::protocol::chat_completions::ChatTool
+impl core::fmt::Debug for bitrouter_sdk::language_model::protocol::chat_completions::ChatTool
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatTool::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::language_model::protocol::chat_completions::ChatTool
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatTool::inline_schema() -> bool
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatTool::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatTool::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatTool::schema_name() -> alloc::borrow::Cow<'static, str>
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::protocol::chat_completions::ChatTool
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatTool::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::protocol::chat_completions::ChatTool
+impl core::marker::Send for bitrouter_sdk::language_model::protocol::chat_completions::ChatTool
+impl core::marker::Sync for bitrouter_sdk::language_model::protocol::chat_completions::ChatTool
+impl core::marker::Unpin for bitrouter_sdk::language_model::protocol::chat_completions::ChatTool
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::protocol::chat_completions::ChatTool
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::protocol::chat_completions::ChatTool
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::protocol::chat_completions::ChatTool
+pub struct bitrouter_sdk::language_model::protocol::chat_completions::ChatToolCall
+impl core::fmt::Debug for bitrouter_sdk::language_model::protocol::chat_completions::ChatToolCall
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatToolCall::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::language_model::protocol::chat_completions::ChatToolCall
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatToolCall::inline_schema() -> bool
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatToolCall::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatToolCall::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatToolCall::schema_name() -> alloc::borrow::Cow<'static, str>
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::protocol::chat_completions::ChatToolCall
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatToolCall::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::protocol::chat_completions::ChatToolCall
+impl core::marker::Send for bitrouter_sdk::language_model::protocol::chat_completions::ChatToolCall
+impl core::marker::Sync for bitrouter_sdk::language_model::protocol::chat_completions::ChatToolCall
+impl core::marker::Unpin for bitrouter_sdk::language_model::protocol::chat_completions::ChatToolCall
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::protocol::chat_completions::ChatToolCall
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::protocol::chat_completions::ChatToolCall
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::protocol::chat_completions::ChatToolCall
+pub struct bitrouter_sdk::language_model::protocol::chat_completions::ChatToolFunction
+impl core::default::Default for bitrouter_sdk::language_model::protocol::chat_completions::ChatToolFunction
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatToolFunction::default() -> bitrouter_sdk::language_model::protocol::chat_completions::ChatToolFunction
+impl core::fmt::Debug for bitrouter_sdk::language_model::protocol::chat_completions::ChatToolFunction
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatToolFunction::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::language_model::protocol::chat_completions::ChatToolFunction
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatToolFunction::inline_schema() -> bool
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatToolFunction::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatToolFunction::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatToolFunction::schema_name() -> alloc::borrow::Cow<'static, str>
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::protocol::chat_completions::ChatToolFunction
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatToolFunction::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::protocol::chat_completions::ChatToolFunction
+impl core::marker::Send for bitrouter_sdk::language_model::protocol::chat_completions::ChatToolFunction
+impl core::marker::Sync for bitrouter_sdk::language_model::protocol::chat_completions::ChatToolFunction
+impl core::marker::Unpin for bitrouter_sdk::language_model::protocol::chat_completions::ChatToolFunction
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::protocol::chat_completions::ChatToolFunction
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::protocol::chat_completions::ChatToolFunction
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::protocol::chat_completions::ChatToolFunction
+pub mod bitrouter_sdk::language_model::protocol::generate_content
+pub struct bitrouter_sdk::language_model::protocol::generate_content::GenerateContentAdapter
+impl bitrouter_sdk::language_model::protocol::InboundAdapter for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentAdapter
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentAdapter::parse_request(&self, serde_json::value::Value) -> bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::Prompt>
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentAdapter::protocol(&self) -> bitrouter_sdk::language_model::types::ApiProtocol
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentAdapter::render_response(&self, &bitrouter_sdk::language_model::types::GenerateResult, &bitrouter_sdk::language_model::types::Prompt, &str) -> bitrouter_sdk::error::Result<serde_json::value::Value>
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentAdapter::stream_encoder(&self, &str, &str) -> alloc::boxed::Box<dyn bitrouter_sdk::language_model::protocol::StreamEncoder>
+impl bitrouter_sdk::language_model::protocol::OutboundAdapter for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentAdapter
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentAdapter::parse_response(&self, serde_json::value::Value) -> bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::GenerateResult>
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentAdapter::protocol(&self) -> bitrouter_sdk::language_model::types::ApiProtocol
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentAdapter::render_request(&self, &bitrouter_sdk::language_model::types::Prompt) -> bitrouter_sdk::error::Result<serde_json::value::Value>
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentAdapter::render_request_for_target(&self, &bitrouter_sdk::language_model::types::Prompt, &bitrouter_sdk::language_model::types::RoutingTarget) -> bitrouter_sdk::error::Result<serde_json::value::Value>
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentAdapter::stream_decoder(&self) -> alloc::boxed::Box<dyn bitrouter_sdk::language_model::protocol::StreamDecoder>
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentAdapter::supports_response_format(&self) -> bool
+impl core::marker::Freeze for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentAdapter
+impl core::marker::Send for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentAdapter
+impl core::marker::Sync for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentAdapter
+impl core::marker::Unpin for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentAdapter
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentAdapter
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentAdapter
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentAdapter
+pub struct bitrouter_sdk::language_model::protocol::generate_content::GenerateContentContent
+impl core::fmt::Debug for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentContent
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentContent::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentContent
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentContent::inline_schema() -> bool
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentContent::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentContent::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentContent::schema_name() -> alloc::borrow::Cow<'static, str>
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentContent
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentContent::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentContent
+impl core::marker::Send for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentContent
+impl core::marker::Sync for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentContent
+impl core::marker::Unpin for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentContent
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentContent
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentContent
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentContent
+pub struct bitrouter_sdk::language_model::protocol::generate_content::GenerateContentFunctionDecl
+impl core::fmt::Debug for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentFunctionDecl
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentFunctionDecl::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentFunctionDecl
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentFunctionDecl::inline_schema() -> bool
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentFunctionDecl::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentFunctionDecl::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentFunctionDecl::schema_name() -> alloc::borrow::Cow<'static, str>
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentFunctionDecl
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentFunctionDecl::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentFunctionDecl
+impl core::marker::Send for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentFunctionDecl
+impl core::marker::Sync for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentFunctionDecl
+impl core::marker::Unpin for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentFunctionDecl
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentFunctionDecl
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentFunctionDecl
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentFunctionDecl
+pub struct bitrouter_sdk::language_model::protocol::generate_content::GenerateContentGenerationConfig
+impl core::fmt::Debug for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentGenerationConfig
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentGenerationConfig::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentGenerationConfig
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentGenerationConfig::inline_schema() -> bool
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentGenerationConfig::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentGenerationConfig::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentGenerationConfig::schema_name() -> alloc::borrow::Cow<'static, str>
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentGenerationConfig
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentGenerationConfig::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentGenerationConfig
+impl core::marker::Send for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentGenerationConfig
+impl core::marker::Sync for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentGenerationConfig
+impl core::marker::Unpin for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentGenerationConfig
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentGenerationConfig
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentGenerationConfig
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentGenerationConfig
+pub struct bitrouter_sdk::language_model::protocol::generate_content::GenerateContentRequest
+impl core::fmt::Debug for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentRequest
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentRequest::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentRequest
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentRequest::inline_schema() -> bool
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentRequest::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentRequest::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentRequest::schema_name() -> alloc::borrow::Cow<'static, str>
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentRequest
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentRequest::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentRequest
+impl core::marker::Send for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentRequest
+impl core::marker::Sync for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentRequest
+impl core::marker::Unpin for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentRequest
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentRequest
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentRequest
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentRequest
+pub struct bitrouter_sdk::language_model::protocol::generate_content::GenerateContentTool
+impl core::fmt::Debug for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentTool
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentTool::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentTool
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentTool::inline_schema() -> bool
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentTool::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentTool::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentTool::schema_name() -> alloc::borrow::Cow<'static, str>
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentTool
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentTool::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentTool
+impl core::marker::Send for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentTool
+impl core::marker::Sync for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentTool
+impl core::marker::Unpin for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentTool
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentTool
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentTool
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentTool
+pub struct bitrouter_sdk::language_model::protocol::generate_content::GenerateContentTransport
+impl bitrouter_sdk::language_model::protocol::Transport for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentTransport
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentTransport::authorise<'life0, 'life1, 'async_trait>(&'life0 self, reqwest::async_impl::request::Request, &'life1 bitrouter_sdk::language_model::types::RoutingTarget) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<reqwest::async_impl::request::Request>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentTransport::endpoint_url(&self, &bitrouter_sdk::language_model::types::RoutingTarget, bool) -> alloc::string::String
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentTransport::protocol(&self) -> bitrouter_sdk::language_model::types::ApiProtocol
+impl core::marker::Freeze for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentTransport
+impl core::marker::Send for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentTransport
+impl core::marker::Sync for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentTransport
+impl core::marker::Unpin for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentTransport
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentTransport
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentTransport
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentTransport
+pub mod bitrouter_sdk::language_model::protocol::messages
+pub enum bitrouter_sdk::language_model::protocol::messages::MessagesOutputFormat
+pub bitrouter_sdk::language_model::protocol::messages::MessagesOutputFormat::JsonSchema
+pub bitrouter_sdk::language_model::protocol::messages::MessagesOutputFormat::JsonSchema::schema: serde_json::value::Value
+impl core::clone::Clone for bitrouter_sdk::language_model::protocol::messages::MessagesOutputFormat
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesOutputFormat::clone(&self) -> bitrouter_sdk::language_model::protocol::messages::MessagesOutputFormat
+impl core::fmt::Debug for bitrouter_sdk::language_model::protocol::messages::MessagesOutputFormat
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesOutputFormat::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::language_model::protocol::messages::MessagesOutputFormat
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesOutputFormat::inline_schema() -> bool
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesOutputFormat::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesOutputFormat::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesOutputFormat::schema_name() -> alloc::borrow::Cow<'static, str>
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::protocol::messages::MessagesOutputFormat
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesOutputFormat::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::protocol::messages::MessagesOutputFormat
+impl core::marker::Send for bitrouter_sdk::language_model::protocol::messages::MessagesOutputFormat
+impl core::marker::Sync for bitrouter_sdk::language_model::protocol::messages::MessagesOutputFormat
+impl core::marker::Unpin for bitrouter_sdk::language_model::protocol::messages::MessagesOutputFormat
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::protocol::messages::MessagesOutputFormat
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::protocol::messages::MessagesOutputFormat
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::protocol::messages::MessagesOutputFormat
+pub struct bitrouter_sdk::language_model::protocol::messages::MessagesAdapter
+impl bitrouter_sdk::language_model::protocol::InboundAdapter for bitrouter_sdk::language_model::protocol::messages::MessagesAdapter
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesAdapter::parse_request(&self, serde_json::value::Value) -> bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::Prompt>
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesAdapter::protocol(&self) -> bitrouter_sdk::language_model::types::ApiProtocol
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesAdapter::render_response(&self, &bitrouter_sdk::language_model::types::GenerateResult, &bitrouter_sdk::language_model::types::Prompt, &str) -> bitrouter_sdk::error::Result<serde_json::value::Value>
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesAdapter::stream_encoder(&self, &str, &str) -> alloc::boxed::Box<dyn bitrouter_sdk::language_model::protocol::StreamEncoder>
+impl bitrouter_sdk::language_model::protocol::OutboundAdapter for bitrouter_sdk::language_model::protocol::messages::MessagesAdapter
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesAdapter::parse_response(&self, serde_json::value::Value) -> bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::GenerateResult>
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesAdapter::protocol(&self) -> bitrouter_sdk::language_model::types::ApiProtocol
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesAdapter::render_request(&self, &bitrouter_sdk::language_model::types::Prompt) -> bitrouter_sdk::error::Result<serde_json::value::Value>
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesAdapter::render_request_for_target(&self, &bitrouter_sdk::language_model::types::Prompt, &bitrouter_sdk::language_model::types::RoutingTarget) -> bitrouter_sdk::error::Result<serde_json::value::Value>
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesAdapter::stream_decoder(&self) -> alloc::boxed::Box<dyn bitrouter_sdk::language_model::protocol::StreamDecoder>
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesAdapter::supports_response_format(&self) -> bool
+impl core::marker::Freeze for bitrouter_sdk::language_model::protocol::messages::MessagesAdapter
+impl core::marker::Send for bitrouter_sdk::language_model::protocol::messages::MessagesAdapter
+impl core::marker::Sync for bitrouter_sdk::language_model::protocol::messages::MessagesAdapter
+impl core::marker::Unpin for bitrouter_sdk::language_model::protocol::messages::MessagesAdapter
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::protocol::messages::MessagesAdapter
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::protocol::messages::MessagesAdapter
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::protocol::messages::MessagesAdapter
+pub struct bitrouter_sdk::language_model::protocol::messages::MessagesMessage
+impl core::fmt::Debug for bitrouter_sdk::language_model::protocol::messages::MessagesMessage
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesMessage::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::language_model::protocol::messages::MessagesMessage
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesMessage::inline_schema() -> bool
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesMessage::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesMessage::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesMessage::schema_name() -> alloc::borrow::Cow<'static, str>
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::protocol::messages::MessagesMessage
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesMessage::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::protocol::messages::MessagesMessage
+impl core::marker::Send for bitrouter_sdk::language_model::protocol::messages::MessagesMessage
+impl core::marker::Sync for bitrouter_sdk::language_model::protocol::messages::MessagesMessage
+impl core::marker::Unpin for bitrouter_sdk::language_model::protocol::messages::MessagesMessage
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::protocol::messages::MessagesMessage
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::protocol::messages::MessagesMessage
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::protocol::messages::MessagesMessage
+pub struct bitrouter_sdk::language_model::protocol::messages::MessagesOutputConfig
+impl core::fmt::Debug for bitrouter_sdk::language_model::protocol::messages::MessagesOutputConfig
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesOutputConfig::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::language_model::protocol::messages::MessagesOutputConfig
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesOutputConfig::inline_schema() -> bool
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesOutputConfig::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesOutputConfig::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesOutputConfig::schema_name() -> alloc::borrow::Cow<'static, str>
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::protocol::messages::MessagesOutputConfig
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesOutputConfig::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::protocol::messages::MessagesOutputConfig
+impl core::marker::Send for bitrouter_sdk::language_model::protocol::messages::MessagesOutputConfig
+impl core::marker::Sync for bitrouter_sdk::language_model::protocol::messages::MessagesOutputConfig
+impl core::marker::Unpin for bitrouter_sdk::language_model::protocol::messages::MessagesOutputConfig
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::protocol::messages::MessagesOutputConfig
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::protocol::messages::MessagesOutputConfig
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::protocol::messages::MessagesOutputConfig
+pub struct bitrouter_sdk::language_model::protocol::messages::MessagesRequest
+impl core::fmt::Debug for bitrouter_sdk::language_model::protocol::messages::MessagesRequest
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesRequest::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::language_model::protocol::messages::MessagesRequest
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesRequest::inline_schema() -> bool
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesRequest::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesRequest::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesRequest::schema_name() -> alloc::borrow::Cow<'static, str>
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::protocol::messages::MessagesRequest
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesRequest::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::protocol::messages::MessagesRequest
+impl core::marker::Send for bitrouter_sdk::language_model::protocol::messages::MessagesRequest
+impl core::marker::Sync for bitrouter_sdk::language_model::protocol::messages::MessagesRequest
+impl core::marker::Unpin for bitrouter_sdk::language_model::protocol::messages::MessagesRequest
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::protocol::messages::MessagesRequest
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::protocol::messages::MessagesRequest
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::protocol::messages::MessagesRequest
+pub struct bitrouter_sdk::language_model::protocol::messages::MessagesTool
+impl core::fmt::Debug for bitrouter_sdk::language_model::protocol::messages::MessagesTool
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesTool::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::language_model::protocol::messages::MessagesTool
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesTool::inline_schema() -> bool
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesTool::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesTool::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesTool::schema_name() -> alloc::borrow::Cow<'static, str>
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::protocol::messages::MessagesTool
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesTool::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::protocol::messages::MessagesTool
+impl core::marker::Send for bitrouter_sdk::language_model::protocol::messages::MessagesTool
+impl core::marker::Sync for bitrouter_sdk::language_model::protocol::messages::MessagesTool
+impl core::marker::Unpin for bitrouter_sdk::language_model::protocol::messages::MessagesTool
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::protocol::messages::MessagesTool
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::protocol::messages::MessagesTool
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::protocol::messages::MessagesTool
+pub struct bitrouter_sdk::language_model::protocol::messages::MessagesTransport
+impl bitrouter_sdk::language_model::protocol::Transport for bitrouter_sdk::language_model::protocol::messages::MessagesTransport
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesTransport::authorise<'life0, 'life1, 'async_trait>(&'life0 self, reqwest::async_impl::request::Request, &'life1 bitrouter_sdk::language_model::types::RoutingTarget) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<reqwest::async_impl::request::Request>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesTransport::endpoint_url(&self, &bitrouter_sdk::language_model::types::RoutingTarget, bool) -> alloc::string::String
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesTransport::protocol(&self) -> bitrouter_sdk::language_model::types::ApiProtocol
+impl core::marker::Freeze for bitrouter_sdk::language_model::protocol::messages::MessagesTransport
+impl core::marker::Send for bitrouter_sdk::language_model::protocol::messages::MessagesTransport
+impl core::marker::Sync for bitrouter_sdk::language_model::protocol::messages::MessagesTransport
+impl core::marker::Unpin for bitrouter_sdk::language_model::protocol::messages::MessagesTransport
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::protocol::messages::MessagesTransport
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::protocol::messages::MessagesTransport
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::protocol::messages::MessagesTransport
+pub mod bitrouter_sdk::language_model::protocol::responses
+pub enum bitrouter_sdk::language_model::protocol::responses::ResponsesTextFormat
+pub bitrouter_sdk::language_model::protocol::responses::ResponsesTextFormat::JsonObject
+pub bitrouter_sdk::language_model::protocol::responses::ResponsesTextFormat::JsonSchema
+pub bitrouter_sdk::language_model::protocol::responses::ResponsesTextFormat::JsonSchema::description: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::protocol::responses::ResponsesTextFormat::JsonSchema::name: alloc::string::String
+pub bitrouter_sdk::language_model::protocol::responses::ResponsesTextFormat::JsonSchema::schema: serde_json::value::Value
+pub bitrouter_sdk::language_model::protocol::responses::ResponsesTextFormat::JsonSchema::strict: core::option::Option<bool>
+pub bitrouter_sdk::language_model::protocol::responses::ResponsesTextFormat::Text
+impl core::clone::Clone for bitrouter_sdk::language_model::protocol::responses::ResponsesTextFormat
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesTextFormat::clone(&self) -> bitrouter_sdk::language_model::protocol::responses::ResponsesTextFormat
+impl core::fmt::Debug for bitrouter_sdk::language_model::protocol::responses::ResponsesTextFormat
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesTextFormat::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::language_model::protocol::responses::ResponsesTextFormat
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesTextFormat::inline_schema() -> bool
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesTextFormat::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesTextFormat::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesTextFormat::schema_name() -> alloc::borrow::Cow<'static, str>
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::protocol::responses::ResponsesTextFormat
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesTextFormat::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::protocol::responses::ResponsesTextFormat
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesTextFormat::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::protocol::responses::ResponsesTextFormat
+impl core::marker::Send for bitrouter_sdk::language_model::protocol::responses::ResponsesTextFormat
+impl core::marker::Sync for bitrouter_sdk::language_model::protocol::responses::ResponsesTextFormat
+impl core::marker::Unpin for bitrouter_sdk::language_model::protocol::responses::ResponsesTextFormat
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::protocol::responses::ResponsesTextFormat
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::protocol::responses::ResponsesTextFormat
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::protocol::responses::ResponsesTextFormat
+pub struct bitrouter_sdk::language_model::protocol::responses::ResponsesAdapter
+impl bitrouter_sdk::language_model::protocol::InboundAdapter for bitrouter_sdk::language_model::protocol::responses::ResponsesAdapter
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesAdapter::parse_request(&self, serde_json::value::Value) -> bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::Prompt>
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesAdapter::protocol(&self) -> bitrouter_sdk::language_model::types::ApiProtocol
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesAdapter::render_response(&self, &bitrouter_sdk::language_model::types::GenerateResult, &bitrouter_sdk::language_model::types::Prompt, &str) -> bitrouter_sdk::error::Result<serde_json::value::Value>
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesAdapter::stream_encoder(&self, &str, &str) -> alloc::boxed::Box<dyn bitrouter_sdk::language_model::protocol::StreamEncoder>
+impl bitrouter_sdk::language_model::protocol::OutboundAdapter for bitrouter_sdk::language_model::protocol::responses::ResponsesAdapter
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesAdapter::parse_response(&self, serde_json::value::Value) -> bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::GenerateResult>
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesAdapter::protocol(&self) -> bitrouter_sdk::language_model::types::ApiProtocol
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesAdapter::render_request(&self, &bitrouter_sdk::language_model::types::Prompt) -> bitrouter_sdk::error::Result<serde_json::value::Value>
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesAdapter::render_request_for_target(&self, &bitrouter_sdk::language_model::types::Prompt, &bitrouter_sdk::language_model::types::RoutingTarget) -> bitrouter_sdk::error::Result<serde_json::value::Value>
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesAdapter::stream_decoder(&self) -> alloc::boxed::Box<dyn bitrouter_sdk::language_model::protocol::StreamDecoder>
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesAdapter::supports_response_format(&self) -> bool
+impl core::marker::Freeze for bitrouter_sdk::language_model::protocol::responses::ResponsesAdapter
+impl core::marker::Send for bitrouter_sdk::language_model::protocol::responses::ResponsesAdapter
+impl core::marker::Sync for bitrouter_sdk::language_model::protocol::responses::ResponsesAdapter
+impl core::marker::Unpin for bitrouter_sdk::language_model::protocol::responses::ResponsesAdapter
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::protocol::responses::ResponsesAdapter
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::protocol::responses::ResponsesAdapter
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::protocol::responses::ResponsesAdapter
+pub struct bitrouter_sdk::language_model::protocol::responses::ResponsesReasoningConfig
+impl core::default::Default for bitrouter_sdk::language_model::protocol::responses::ResponsesReasoningConfig
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesReasoningConfig::default() -> bitrouter_sdk::language_model::protocol::responses::ResponsesReasoningConfig
+impl core::fmt::Debug for bitrouter_sdk::language_model::protocol::responses::ResponsesReasoningConfig
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesReasoningConfig::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::language_model::protocol::responses::ResponsesReasoningConfig
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesReasoningConfig::inline_schema() -> bool
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesReasoningConfig::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesReasoningConfig::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesReasoningConfig::schema_name() -> alloc::borrow::Cow<'static, str>
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::protocol::responses::ResponsesReasoningConfig
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesReasoningConfig::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::protocol::responses::ResponsesReasoningConfig
+impl core::marker::Send for bitrouter_sdk::language_model::protocol::responses::ResponsesReasoningConfig
+impl core::marker::Sync for bitrouter_sdk::language_model::protocol::responses::ResponsesReasoningConfig
+impl core::marker::Unpin for bitrouter_sdk::language_model::protocol::responses::ResponsesReasoningConfig
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::protocol::responses::ResponsesReasoningConfig
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::protocol::responses::ResponsesReasoningConfig
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::protocol::responses::ResponsesReasoningConfig
+pub struct bitrouter_sdk::language_model::protocol::responses::ResponsesRequest
+impl core::fmt::Debug for bitrouter_sdk::language_model::protocol::responses::ResponsesRequest
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesRequest::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::language_model::protocol::responses::ResponsesRequest
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesRequest::inline_schema() -> bool
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesRequest::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesRequest::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesRequest::schema_name() -> alloc::borrow::Cow<'static, str>
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::protocol::responses::ResponsesRequest
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesRequest::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::protocol::responses::ResponsesRequest
+impl core::marker::Send for bitrouter_sdk::language_model::protocol::responses::ResponsesRequest
+impl core::marker::Sync for bitrouter_sdk::language_model::protocol::responses::ResponsesRequest
+impl core::marker::Unpin for bitrouter_sdk::language_model::protocol::responses::ResponsesRequest
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::protocol::responses::ResponsesRequest
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::protocol::responses::ResponsesRequest
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::protocol::responses::ResponsesRequest
+pub struct bitrouter_sdk::language_model::protocol::responses::ResponsesText
+impl core::fmt::Debug for bitrouter_sdk::language_model::protocol::responses::ResponsesText
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesText::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::language_model::protocol::responses::ResponsesText
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesText::inline_schema() -> bool
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesText::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesText::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesText::schema_name() -> alloc::borrow::Cow<'static, str>
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::protocol::responses::ResponsesText
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesText::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::protocol::responses::ResponsesText
+impl core::marker::Send for bitrouter_sdk::language_model::protocol::responses::ResponsesText
+impl core::marker::Sync for bitrouter_sdk::language_model::protocol::responses::ResponsesText
+impl core::marker::Unpin for bitrouter_sdk::language_model::protocol::responses::ResponsesText
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::protocol::responses::ResponsesText
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::protocol::responses::ResponsesText
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::protocol::responses::ResponsesText
+pub struct bitrouter_sdk::language_model::protocol::responses::ResponsesTool
+impl core::default::Default for bitrouter_sdk::language_model::protocol::responses::ResponsesTool
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesTool::default() -> bitrouter_sdk::language_model::protocol::responses::ResponsesTool
+impl core::fmt::Debug for bitrouter_sdk::language_model::protocol::responses::ResponsesTool
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesTool::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::language_model::protocol::responses::ResponsesTool
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesTool::inline_schema() -> bool
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesTool::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesTool::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesTool::schema_name() -> alloc::borrow::Cow<'static, str>
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::protocol::responses::ResponsesTool
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesTool::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::protocol::responses::ResponsesTool
+impl core::marker::Send for bitrouter_sdk::language_model::protocol::responses::ResponsesTool
+impl core::marker::Sync for bitrouter_sdk::language_model::protocol::responses::ResponsesTool
+impl core::marker::Unpin for bitrouter_sdk::language_model::protocol::responses::ResponsesTool
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::protocol::responses::ResponsesTool
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::protocol::responses::ResponsesTool
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::protocol::responses::ResponsesTool
+pub struct bitrouter_sdk::language_model::protocol::responses::ResponsesTransport
+impl bitrouter_sdk::language_model::protocol::Transport for bitrouter_sdk::language_model::protocol::responses::ResponsesTransport
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesTransport::authorise<'life0, 'life1, 'async_trait>(&'life0 self, reqwest::async_impl::request::Request, &'life1 bitrouter_sdk::language_model::types::RoutingTarget) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<reqwest::async_impl::request::Request>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesTransport::endpoint_url(&self, &bitrouter_sdk::language_model::types::RoutingTarget, bool) -> alloc::string::String
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesTransport::protocol(&self) -> bitrouter_sdk::language_model::types::ApiProtocol
+impl core::marker::Freeze for bitrouter_sdk::language_model::protocol::responses::ResponsesTransport
+impl core::marker::Send for bitrouter_sdk::language_model::protocol::responses::ResponsesTransport
+impl core::marker::Sync for bitrouter_sdk::language_model::protocol::responses::ResponsesTransport
+impl core::marker::Unpin for bitrouter_sdk::language_model::protocol::responses::ResponsesTransport
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::protocol::responses::ResponsesTransport
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::protocol::responses::ResponsesTransport
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::protocol::responses::ResponsesTransport
+pub fn bitrouter_sdk::language_model::protocol::responses::decode_gateway_continuation_id(&str) -> bitrouter_sdk::error::Result<core::option::Option<alloc::string::String>>
+pub fn bitrouter_sdk::language_model::protocol::responses::encode_gateway_continuation_id(&str) -> bitrouter_sdk::error::Result<alloc::string::String>
+pub struct bitrouter_sdk::language_model::protocol::OutboundDispatch
+impl bitrouter_sdk::language_model::protocol::OutboundDispatch
+pub fn bitrouter_sdk::language_model::protocol::OutboundDispatch::builtin() -> Self
+pub fn bitrouter_sdk::language_model::protocol::OutboundDispatch::empty() -> Self
+pub fn bitrouter_sdk::language_model::protocol::OutboundDispatch::lookup(&self, &bitrouter_sdk::language_model::types::ApiProtocol) -> core::option::Option<bitrouter_sdk::language_model::protocol::DispatchHandle<'_>>
+pub fn bitrouter_sdk::language_model::protocol::OutboundDispatch::register(&mut self, alloc::sync::Arc<dyn bitrouter_sdk::language_model::protocol::OutboundAdapter>, alloc::sync::Arc<dyn bitrouter_sdk::language_model::protocol::Transport>)
+impl core::default::Default for bitrouter_sdk::language_model::protocol::OutboundDispatch
+pub fn bitrouter_sdk::language_model::protocol::OutboundDispatch::default() -> Self
+impl core::marker::Freeze for bitrouter_sdk::language_model::protocol::OutboundDispatch
+impl core::marker::Send for bitrouter_sdk::language_model::protocol::OutboundDispatch
+impl core::marker::Sync for bitrouter_sdk::language_model::protocol::OutboundDispatch
+impl core::marker::Unpin for bitrouter_sdk::language_model::protocol::OutboundDispatch
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::protocol::OutboundDispatch
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::protocol::OutboundDispatch
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::protocol::OutboundDispatch
+pub struct bitrouter_sdk::language_model::protocol::SseEvent
+pub bitrouter_sdk::language_model::protocol::SseEvent::data: alloc::string::String
+pub bitrouter_sdk::language_model::protocol::SseEvent::event: core::option::Option<alloc::string::String>
+impl core::clone::Clone for bitrouter_sdk::language_model::protocol::SseEvent
+pub fn bitrouter_sdk::language_model::protocol::SseEvent::clone(&self) -> bitrouter_sdk::language_model::protocol::SseEvent
+impl core::default::Default for bitrouter_sdk::language_model::protocol::SseEvent
+pub fn bitrouter_sdk::language_model::protocol::SseEvent::default() -> bitrouter_sdk::language_model::protocol::SseEvent
+impl core::fmt::Debug for bitrouter_sdk::language_model::protocol::SseEvent
+pub fn bitrouter_sdk::language_model::protocol::SseEvent::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::language_model::protocol::SseEvent
+impl core::marker::Send for bitrouter_sdk::language_model::protocol::SseEvent
+impl core::marker::Sync for bitrouter_sdk::language_model::protocol::SseEvent
+impl core::marker::Unpin for bitrouter_sdk::language_model::protocol::SseEvent
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::protocol::SseEvent
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::protocol::SseEvent
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::protocol::SseEvent
+pub trait bitrouter_sdk::language_model::protocol::InboundAdapter: core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::language_model::protocol::InboundAdapter::parse_request(&self, serde_json::value::Value) -> bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::Prompt>
+pub fn bitrouter_sdk::language_model::protocol::InboundAdapter::protocol(&self) -> bitrouter_sdk::language_model::types::ApiProtocol
+pub fn bitrouter_sdk::language_model::protocol::InboundAdapter::render_response(&self, &bitrouter_sdk::language_model::types::GenerateResult, &bitrouter_sdk::language_model::types::Prompt, &str) -> bitrouter_sdk::error::Result<serde_json::value::Value>
+pub fn bitrouter_sdk::language_model::protocol::InboundAdapter::stream_encoder(&self, &str, &str) -> alloc::boxed::Box<dyn bitrouter_sdk::language_model::protocol::StreamEncoder>
+impl bitrouter_sdk::language_model::protocol::InboundAdapter for bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsAdapter
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsAdapter::parse_request(&self, serde_json::value::Value) -> bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::Prompt>
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsAdapter::protocol(&self) -> bitrouter_sdk::language_model::types::ApiProtocol
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsAdapter::render_response(&self, &bitrouter_sdk::language_model::types::GenerateResult, &bitrouter_sdk::language_model::types::Prompt, &str) -> bitrouter_sdk::error::Result<serde_json::value::Value>
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsAdapter::stream_encoder(&self, &str, &str) -> alloc::boxed::Box<dyn bitrouter_sdk::language_model::protocol::StreamEncoder>
+impl bitrouter_sdk::language_model::protocol::InboundAdapter for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentAdapter
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentAdapter::parse_request(&self, serde_json::value::Value) -> bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::Prompt>
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentAdapter::protocol(&self) -> bitrouter_sdk::language_model::types::ApiProtocol
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentAdapter::render_response(&self, &bitrouter_sdk::language_model::types::GenerateResult, &bitrouter_sdk::language_model::types::Prompt, &str) -> bitrouter_sdk::error::Result<serde_json::value::Value>
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentAdapter::stream_encoder(&self, &str, &str) -> alloc::boxed::Box<dyn bitrouter_sdk::language_model::protocol::StreamEncoder>
+impl bitrouter_sdk::language_model::protocol::InboundAdapter for bitrouter_sdk::language_model::protocol::messages::MessagesAdapter
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesAdapter::parse_request(&self, serde_json::value::Value) -> bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::Prompt>
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesAdapter::protocol(&self) -> bitrouter_sdk::language_model::types::ApiProtocol
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesAdapter::render_response(&self, &bitrouter_sdk::language_model::types::GenerateResult, &bitrouter_sdk::language_model::types::Prompt, &str) -> bitrouter_sdk::error::Result<serde_json::value::Value>
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesAdapter::stream_encoder(&self, &str, &str) -> alloc::boxed::Box<dyn bitrouter_sdk::language_model::protocol::StreamEncoder>
+impl bitrouter_sdk::language_model::protocol::InboundAdapter for bitrouter_sdk::language_model::protocol::responses::ResponsesAdapter
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesAdapter::parse_request(&self, serde_json::value::Value) -> bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::Prompt>
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesAdapter::protocol(&self) -> bitrouter_sdk::language_model::types::ApiProtocol
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesAdapter::render_response(&self, &bitrouter_sdk::language_model::types::GenerateResult, &bitrouter_sdk::language_model::types::Prompt, &str) -> bitrouter_sdk::error::Result<serde_json::value::Value>
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesAdapter::stream_encoder(&self, &str, &str) -> alloc::boxed::Box<dyn bitrouter_sdk::language_model::protocol::StreamEncoder>
+pub trait bitrouter_sdk::language_model::protocol::OutboundAdapter: core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::language_model::protocol::OutboundAdapter::parse_response(&self, serde_json::value::Value) -> bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::GenerateResult>
+pub fn bitrouter_sdk::language_model::protocol::OutboundAdapter::protocol(&self) -> bitrouter_sdk::language_model::types::ApiProtocol
+pub fn bitrouter_sdk::language_model::protocol::OutboundAdapter::render_request(&self, &bitrouter_sdk::language_model::types::Prompt) -> bitrouter_sdk::error::Result<serde_json::value::Value>
+pub fn bitrouter_sdk::language_model::protocol::OutboundAdapter::render_request_for_target(&self, &bitrouter_sdk::language_model::types::Prompt, &bitrouter_sdk::language_model::types::RoutingTarget) -> bitrouter_sdk::error::Result<serde_json::value::Value>
+pub fn bitrouter_sdk::language_model::protocol::OutboundAdapter::stream_decoder(&self) -> alloc::boxed::Box<dyn bitrouter_sdk::language_model::protocol::StreamDecoder>
+pub fn bitrouter_sdk::language_model::protocol::OutboundAdapter::supports_response_format(&self) -> bool
+impl bitrouter_sdk::language_model::protocol::OutboundAdapter for bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsAdapter
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsAdapter::parse_response(&self, serde_json::value::Value) -> bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::GenerateResult>
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsAdapter::protocol(&self) -> bitrouter_sdk::language_model::types::ApiProtocol
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsAdapter::render_request(&self, &bitrouter_sdk::language_model::types::Prompt) -> bitrouter_sdk::error::Result<serde_json::value::Value>
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsAdapter::render_request_for_target(&self, &bitrouter_sdk::language_model::types::Prompt, &bitrouter_sdk::language_model::types::RoutingTarget) -> bitrouter_sdk::error::Result<serde_json::value::Value>
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsAdapter::stream_decoder(&self) -> alloc::boxed::Box<dyn bitrouter_sdk::language_model::protocol::StreamDecoder>
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsAdapter::supports_response_format(&self) -> bool
+impl bitrouter_sdk::language_model::protocol::OutboundAdapter for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentAdapter
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentAdapter::parse_response(&self, serde_json::value::Value) -> bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::GenerateResult>
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentAdapter::protocol(&self) -> bitrouter_sdk::language_model::types::ApiProtocol
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentAdapter::render_request(&self, &bitrouter_sdk::language_model::types::Prompt) -> bitrouter_sdk::error::Result<serde_json::value::Value>
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentAdapter::render_request_for_target(&self, &bitrouter_sdk::language_model::types::Prompt, &bitrouter_sdk::language_model::types::RoutingTarget) -> bitrouter_sdk::error::Result<serde_json::value::Value>
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentAdapter::stream_decoder(&self) -> alloc::boxed::Box<dyn bitrouter_sdk::language_model::protocol::StreamDecoder>
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentAdapter::supports_response_format(&self) -> bool
+impl bitrouter_sdk::language_model::protocol::OutboundAdapter for bitrouter_sdk::language_model::protocol::messages::MessagesAdapter
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesAdapter::parse_response(&self, serde_json::value::Value) -> bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::GenerateResult>
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesAdapter::protocol(&self) -> bitrouter_sdk::language_model::types::ApiProtocol
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesAdapter::render_request(&self, &bitrouter_sdk::language_model::types::Prompt) -> bitrouter_sdk::error::Result<serde_json::value::Value>
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesAdapter::render_request_for_target(&self, &bitrouter_sdk::language_model::types::Prompt, &bitrouter_sdk::language_model::types::RoutingTarget) -> bitrouter_sdk::error::Result<serde_json::value::Value>
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesAdapter::stream_decoder(&self) -> alloc::boxed::Box<dyn bitrouter_sdk::language_model::protocol::StreamDecoder>
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesAdapter::supports_response_format(&self) -> bool
+impl bitrouter_sdk::language_model::protocol::OutboundAdapter for bitrouter_sdk::language_model::protocol::responses::ResponsesAdapter
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesAdapter::parse_response(&self, serde_json::value::Value) -> bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::GenerateResult>
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesAdapter::protocol(&self) -> bitrouter_sdk::language_model::types::ApiProtocol
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesAdapter::render_request(&self, &bitrouter_sdk::language_model::types::Prompt) -> bitrouter_sdk::error::Result<serde_json::value::Value>
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesAdapter::render_request_for_target(&self, &bitrouter_sdk::language_model::types::Prompt, &bitrouter_sdk::language_model::types::RoutingTarget) -> bitrouter_sdk::error::Result<serde_json::value::Value>
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesAdapter::stream_decoder(&self) -> alloc::boxed::Box<dyn bitrouter_sdk::language_model::protocol::StreamDecoder>
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesAdapter::supports_response_format(&self) -> bool
+pub trait bitrouter_sdk::language_model::protocol::StreamDecoder: core::marker::Send
+pub fn bitrouter_sdk::language_model::protocol::StreamDecoder::decode(&mut self, &bitrouter_sdk::language_model::protocol::SseEvent) -> bitrouter_sdk::error::Result<alloc::vec::Vec<bitrouter_sdk::language_model::types::StreamPart>>
+pub fn bitrouter_sdk::language_model::protocol::StreamDecoder::finish(&mut self) -> bitrouter_sdk::error::Result<alloc::vec::Vec<bitrouter_sdk::language_model::types::StreamPart>>
+pub trait bitrouter_sdk::language_model::protocol::StreamEncoder: core::marker::Send
+pub fn bitrouter_sdk::language_model::protocol::StreamEncoder::encode(&mut self, &bitrouter_sdk::language_model::types::StreamPart) -> bitrouter_sdk::error::Result<alloc::vec::Vec<bitrouter_sdk::language_model::stream::SseFrame>>
+pub fn bitrouter_sdk::language_model::protocol::StreamEncoder::encode_bitrouter_error(&mut self, &bitrouter_sdk::error::BitrouterError) -> alloc::vec::Vec<bitrouter_sdk::language_model::stream::SseFrame>
+pub fn bitrouter_sdk::language_model::protocol::StreamEncoder::encode_error(&mut self, &str) -> alloc::vec::Vec<bitrouter_sdk::language_model::stream::SseFrame>
+pub fn bitrouter_sdk::language_model::protocol::StreamEncoder::finish(&mut self) -> bitrouter_sdk::error::Result<alloc::vec::Vec<bitrouter_sdk::language_model::stream::SseFrame>>
+pub trait bitrouter_sdk::language_model::protocol::Transport: core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::language_model::protocol::Transport::authorise<'life0, 'life1, 'async_trait>(&'life0 self, reqwest::async_impl::request::Request, &'life1 bitrouter_sdk::language_model::types::RoutingTarget) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<reqwest::async_impl::request::Request>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::protocol::Transport::endpoint_url(&self, &bitrouter_sdk::language_model::types::RoutingTarget, bool) -> alloc::string::String
+pub fn bitrouter_sdk::language_model::protocol::Transport::protocol(&self) -> bitrouter_sdk::language_model::types::ApiProtocol
+impl bitrouter_sdk::language_model::protocol::Transport for bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsTransport
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsTransport::authorise<'life0, 'life1, 'async_trait>(&'life0 self, reqwest::async_impl::request::Request, &'life1 bitrouter_sdk::language_model::types::RoutingTarget) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<reqwest::async_impl::request::Request>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsTransport::endpoint_url(&self, &bitrouter_sdk::language_model::types::RoutingTarget, bool) -> alloc::string::String
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsTransport::protocol(&self) -> bitrouter_sdk::language_model::types::ApiProtocol
+impl bitrouter_sdk::language_model::protocol::Transport for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentTransport
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentTransport::authorise<'life0, 'life1, 'async_trait>(&'life0 self, reqwest::async_impl::request::Request, &'life1 bitrouter_sdk::language_model::types::RoutingTarget) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<reqwest::async_impl::request::Request>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentTransport::endpoint_url(&self, &bitrouter_sdk::language_model::types::RoutingTarget, bool) -> alloc::string::String
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentTransport::protocol(&self) -> bitrouter_sdk::language_model::types::ApiProtocol
+impl bitrouter_sdk::language_model::protocol::Transport for bitrouter_sdk::language_model::protocol::messages::MessagesTransport
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesTransport::authorise<'life0, 'life1, 'async_trait>(&'life0 self, reqwest::async_impl::request::Request, &'life1 bitrouter_sdk::language_model::types::RoutingTarget) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<reqwest::async_impl::request::Request>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesTransport::endpoint_url(&self, &bitrouter_sdk::language_model::types::RoutingTarget, bool) -> alloc::string::String
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesTransport::protocol(&self) -> bitrouter_sdk::language_model::types::ApiProtocol
+impl bitrouter_sdk::language_model::protocol::Transport for bitrouter_sdk::language_model::protocol::responses::ResponsesTransport
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesTransport::authorise<'life0, 'life1, 'async_trait>(&'life0 self, reqwest::async_impl::request::Request, &'life1 bitrouter_sdk::language_model::types::RoutingTarget) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<reqwest::async_impl::request::Request>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesTransport::endpoint_url(&self, &bitrouter_sdk::language_model::types::RoutingTarget, bool) -> alloc::string::String
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesTransport::protocol(&self) -> bitrouter_sdk::language_model::types::ApiProtocol
+pub fn bitrouter_sdk::language_model::protocol::describe_deser_error(&str, &serde_json::error::Error, &serde_json::value::Value) -> bitrouter_sdk::error::BitrouterError
+pub fn bitrouter_sdk::language_model::protocol::inbound_adapter_for(&bitrouter_sdk::language_model::types::ApiProtocol) -> core::option::Option<alloc::boxed::Box<dyn bitrouter_sdk::language_model::protocol::InboundAdapter>>
+pub fn bitrouter_sdk::language_model::protocol::sanitize_model_name(&str) -> alloc::string::String
+pub type bitrouter_sdk::language_model::protocol::DispatchHandle<'a> = (&'a alloc::sync::Arc<dyn bitrouter_sdk::language_model::protocol::OutboundAdapter>, &'a alloc::sync::Arc<dyn bitrouter_sdk::language_model::protocol::Transport>)
+pub mod bitrouter_sdk::language_model::routing
+pub enum bitrouter_sdk::language_model::routing::SortOrder
+pub bitrouter_sdk::language_model::routing::SortOrder::Alphabetical
+pub bitrouter_sdk::language_model::routing::SortOrder::Cost
+pub bitrouter_sdk::language_model::routing::SortOrder::Latency
+impl core::clone::Clone for bitrouter_sdk::language_model::routing::SortOrder
+pub fn bitrouter_sdk::language_model::routing::SortOrder::clone(&self) -> bitrouter_sdk::language_model::routing::SortOrder
+impl core::cmp::Eq for bitrouter_sdk::language_model::routing::SortOrder
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::routing::SortOrder
+pub fn bitrouter_sdk::language_model::routing::SortOrder::eq(&self, &bitrouter_sdk::language_model::routing::SortOrder) -> bool
+impl core::default::Default for bitrouter_sdk::language_model::routing::SortOrder
+pub fn bitrouter_sdk::language_model::routing::SortOrder::default() -> bitrouter_sdk::language_model::routing::SortOrder
+impl core::fmt::Debug for bitrouter_sdk::language_model::routing::SortOrder
+pub fn bitrouter_sdk::language_model::routing::SortOrder::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for bitrouter_sdk::language_model::routing::SortOrder
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::routing::SortOrder
+impl schemars::JsonSchema for bitrouter_sdk::language_model::routing::SortOrder
+pub fn bitrouter_sdk::language_model::routing::SortOrder::inline_schema() -> bool
+pub fn bitrouter_sdk::language_model::routing::SortOrder::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::language_model::routing::SortOrder::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::language_model::routing::SortOrder::schema_name() -> alloc::borrow::Cow<'static, str>
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::routing::SortOrder
+pub fn bitrouter_sdk::language_model::routing::SortOrder::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::routing::SortOrder
+pub fn bitrouter_sdk::language_model::routing::SortOrder::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::routing::SortOrder
+impl core::marker::Send for bitrouter_sdk::language_model::routing::SortOrder
+impl core::marker::Sync for bitrouter_sdk::language_model::routing::SortOrder
+impl core::marker::Unpin for bitrouter_sdk::language_model::routing::SortOrder
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::routing::SortOrder
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::routing::SortOrder
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::routing::SortOrder
+pub struct bitrouter_sdk::language_model::routing::DefaultFallbackPolicy
+impl bitrouter_sdk::language_model::routing::FallbackPolicy for bitrouter_sdk::language_model::routing::DefaultFallbackPolicy
+pub fn bitrouter_sdk::language_model::routing::DefaultFallbackPolicy::classify(&self, &bitrouter_sdk::error::BitrouterError, &bitrouter_sdk::language_model::types::RoutingTarget) -> bitrouter_sdk::language_model::hooks::FallbackDecision
+impl core::clone::Clone for bitrouter_sdk::language_model::routing::DefaultFallbackPolicy
+pub fn bitrouter_sdk::language_model::routing::DefaultFallbackPolicy::clone(&self) -> bitrouter_sdk::language_model::routing::DefaultFallbackPolicy
+impl core::default::Default for bitrouter_sdk::language_model::routing::DefaultFallbackPolicy
+pub fn bitrouter_sdk::language_model::routing::DefaultFallbackPolicy::default() -> bitrouter_sdk::language_model::routing::DefaultFallbackPolicy
+impl core::fmt::Debug for bitrouter_sdk::language_model::routing::DefaultFallbackPolicy
+pub fn bitrouter_sdk::language_model::routing::DefaultFallbackPolicy::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for bitrouter_sdk::language_model::routing::DefaultFallbackPolicy
+impl core::marker::Freeze for bitrouter_sdk::language_model::routing::DefaultFallbackPolicy
+impl core::marker::Send for bitrouter_sdk::language_model::routing::DefaultFallbackPolicy
+impl core::marker::Sync for bitrouter_sdk::language_model::routing::DefaultFallbackPolicy
+impl core::marker::Unpin for bitrouter_sdk::language_model::routing::DefaultFallbackPolicy
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::routing::DefaultFallbackPolicy
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::routing::DefaultFallbackPolicy
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::routing::DefaultFallbackPolicy
+pub struct bitrouter_sdk::language_model::routing::ModelInfo
+pub bitrouter_sdk::language_model::routing::ModelInfo::id: alloc::string::String
+pub bitrouter_sdk::language_model::routing::ModelInfo::providers: alloc::vec::Vec<alloc::string::String>
+impl core::clone::Clone for bitrouter_sdk::language_model::routing::ModelInfo
+pub fn bitrouter_sdk::language_model::routing::ModelInfo::clone(&self) -> bitrouter_sdk::language_model::routing::ModelInfo
+impl core::fmt::Debug for bitrouter_sdk::language_model::routing::ModelInfo
+pub fn bitrouter_sdk::language_model::routing::ModelInfo::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::routing::ModelInfo
+pub fn bitrouter_sdk::language_model::routing::ModelInfo::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::routing::ModelInfo
+pub fn bitrouter_sdk::language_model::routing::ModelInfo::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::routing::ModelInfo
+impl core::marker::Send for bitrouter_sdk::language_model::routing::ModelInfo
+impl core::marker::Sync for bitrouter_sdk::language_model::routing::ModelInfo
+impl core::marker::Unpin for bitrouter_sdk::language_model::routing::ModelInfo
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::routing::ModelInfo
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::routing::ModelInfo
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::routing::ModelInfo
+pub struct bitrouter_sdk::language_model::routing::ModelResolution
+pub bitrouter_sdk::language_model::routing::ModelResolution::clean_model: alloc::string::String
+pub bitrouter_sdk::language_model::routing::ModelResolution::overrides: bitrouter_sdk::language_model::routing::PromptOverrides
+pub bitrouter_sdk::language_model::routing::ModelResolution::policy: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::routing::ModelResolution::prefs: bitrouter_sdk::language_model::routing::RoutingPrefs
+pub bitrouter_sdk::language_model::routing::ModelResolution::variant: core::option::Option<alloc::string::String>
+impl bitrouter_sdk::language_model::routing::ModelResolution
+pub fn bitrouter_sdk::language_model::routing::ModelResolution::passthrough(&str) -> Self
+impl core::clone::Clone for bitrouter_sdk::language_model::routing::ModelResolution
+pub fn bitrouter_sdk::language_model::routing::ModelResolution::clone(&self) -> bitrouter_sdk::language_model::routing::ModelResolution
+impl core::fmt::Debug for bitrouter_sdk::language_model::routing::ModelResolution
+pub fn bitrouter_sdk::language_model::routing::ModelResolution::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::language_model::routing::ModelResolution
+impl core::marker::Send for bitrouter_sdk::language_model::routing::ModelResolution
+impl core::marker::Sync for bitrouter_sdk::language_model::routing::ModelResolution
+impl core::marker::Unpin for bitrouter_sdk::language_model::routing::ModelResolution
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::routing::ModelResolution
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::routing::ModelResolution
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::routing::ModelResolution
+pub struct bitrouter_sdk::language_model::routing::PromptOverrides
+pub bitrouter_sdk::language_model::routing::PromptOverrides::params: serde_json::map::Map<alloc::string::String, serde_json::value::Value>
+pub bitrouter_sdk::language_model::routing::PromptOverrides::system_prompt: core::option::Option<alloc::string::String>
+impl bitrouter_sdk::language_model::routing::PromptOverrides
+pub fn bitrouter_sdk::language_model::routing::PromptOverrides::is_empty(&self) -> bool
+impl core::clone::Clone for bitrouter_sdk::language_model::routing::PromptOverrides
+pub fn bitrouter_sdk::language_model::routing::PromptOverrides::clone(&self) -> bitrouter_sdk::language_model::routing::PromptOverrides
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::routing::PromptOverrides
+pub fn bitrouter_sdk::language_model::routing::PromptOverrides::eq(&self, &bitrouter_sdk::language_model::routing::PromptOverrides) -> bool
+impl core::default::Default for bitrouter_sdk::language_model::routing::PromptOverrides
+pub fn bitrouter_sdk::language_model::routing::PromptOverrides::default() -> bitrouter_sdk::language_model::routing::PromptOverrides
+impl core::fmt::Debug for bitrouter_sdk::language_model::routing::PromptOverrides
+pub fn bitrouter_sdk::language_model::routing::PromptOverrides::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::routing::PromptOverrides
+impl core::marker::Freeze for bitrouter_sdk::language_model::routing::PromptOverrides
+impl core::marker::Send for bitrouter_sdk::language_model::routing::PromptOverrides
+impl core::marker::Sync for bitrouter_sdk::language_model::routing::PromptOverrides
+impl core::marker::Unpin for bitrouter_sdk::language_model::routing::PromptOverrides
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::routing::PromptOverrides
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::routing::PromptOverrides
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::routing::PromptOverrides
+pub struct bitrouter_sdk::language_model::routing::RoutingPrefs
+pub bitrouter_sdk::language_model::routing::RoutingPrefs::ignore: alloc::vec::Vec<alloc::string::String>
+pub bitrouter_sdk::language_model::routing::RoutingPrefs::inbound_protocol: core::option::Option<bitrouter_sdk::language_model::types::ApiProtocol>
+pub bitrouter_sdk::language_model::routing::RoutingPrefs::only: alloc::vec::Vec<alloc::string::String>
+pub bitrouter_sdk::language_model::routing::RoutingPrefs::require_capabilities: alloc::vec::Vec<bitrouter_sdk::language_model::types::Capability>
+pub bitrouter_sdk::language_model::routing::RoutingPrefs::require_tags: alloc::vec::Vec<alloc::string::String>
+pub bitrouter_sdk::language_model::routing::RoutingPrefs::sort: bitrouter_sdk::language_model::routing::SortOrder
+impl core::clone::Clone for bitrouter_sdk::language_model::routing::RoutingPrefs
+pub fn bitrouter_sdk::language_model::routing::RoutingPrefs::clone(&self) -> bitrouter_sdk::language_model::routing::RoutingPrefs
+impl core::default::Default for bitrouter_sdk::language_model::routing::RoutingPrefs
+pub fn bitrouter_sdk::language_model::routing::RoutingPrefs::default() -> bitrouter_sdk::language_model::routing::RoutingPrefs
+impl core::fmt::Debug for bitrouter_sdk::language_model::routing::RoutingPrefs
+pub fn bitrouter_sdk::language_model::routing::RoutingPrefs::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::language_model::routing::RoutingPrefs
+impl core::marker::Send for bitrouter_sdk::language_model::routing::RoutingPrefs
+impl core::marker::Sync for bitrouter_sdk::language_model::routing::RoutingPrefs
+impl core::marker::Unpin for bitrouter_sdk::language_model::routing::RoutingPrefs
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::routing::RoutingPrefs
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::routing::RoutingPrefs
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::routing::RoutingPrefs
+pub struct bitrouter_sdk::language_model::routing::StaticRoutingTable
+impl bitrouter_sdk::language_model::routing::StaticRoutingTable
+pub fn bitrouter_sdk::language_model::routing::StaticRoutingTable::insert(&self, impl core::convert::Into<alloc::string::String>, alloc::vec::Vec<bitrouter_sdk::language_model::types::RoutingTarget>)
+pub fn bitrouter_sdk::language_model::routing::StaticRoutingTable::new() -> Self
+impl bitrouter_sdk::language_model::routing::RoutingTable for bitrouter_sdk::language_model::routing::StaticRoutingTable
+pub fn bitrouter_sdk::language_model::routing::StaticRoutingTable::list_models(&self) -> alloc::vec::Vec<bitrouter_sdk::language_model::routing::ModelInfo>
+pub fn bitrouter_sdk::language_model::routing::StaticRoutingTable::model_info(&self, &str) -> core::option::Option<bitrouter_sdk::language_model::routing::ModelInfo>
+pub fn bitrouter_sdk::language_model::routing::StaticRoutingTable::preset_overrides<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 str) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::routing::PromptOverrides>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::routing::StaticRoutingTable::reload<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<()>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn bitrouter_sdk::language_model::routing::StaticRoutingTable::resolve_model<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 str) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::routing::ModelResolution>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::routing::StaticRoutingTable::route_chain<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 str, &'life2 bitrouter_sdk::language_model::routing::RoutingPrefs, &'life3 bitrouter_sdk::caller::CallerContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<alloc::vec::Vec<bitrouter_sdk::language_model::types::RoutingTarget>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub fn bitrouter_sdk::language_model::routing::StaticRoutingTable::route_resolved<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 str, &'life2 bitrouter_sdk::language_model::routing::RoutingPrefs, &'life3 bitrouter_sdk::caller::CallerContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<alloc::vec::Vec<bitrouter_sdk::language_model::types::RoutingTarget>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+impl core::default::Default for bitrouter_sdk::language_model::routing::StaticRoutingTable
+pub fn bitrouter_sdk::language_model::routing::StaticRoutingTable::default() -> Self
+impl !core::marker::Freeze for bitrouter_sdk::language_model::routing::StaticRoutingTable
+impl core::marker::Send for bitrouter_sdk::language_model::routing::StaticRoutingTable
+impl core::marker::Sync for bitrouter_sdk::language_model::routing::StaticRoutingTable
+impl core::marker::Unpin for bitrouter_sdk::language_model::routing::StaticRoutingTable
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::routing::StaticRoutingTable
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::routing::StaticRoutingTable
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::routing::StaticRoutingTable
+pub trait bitrouter_sdk::language_model::routing::FallbackPolicy: core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::language_model::routing::FallbackPolicy::classify(&self, &bitrouter_sdk::error::BitrouterError, &bitrouter_sdk::language_model::types::RoutingTarget) -> bitrouter_sdk::language_model::hooks::FallbackDecision
+impl bitrouter_sdk::language_model::routing::FallbackPolicy for bitrouter_sdk::language_model::routing::DefaultFallbackPolicy
+pub fn bitrouter_sdk::language_model::routing::DefaultFallbackPolicy::classify(&self, &bitrouter_sdk::error::BitrouterError, &bitrouter_sdk::language_model::types::RoutingTarget) -> bitrouter_sdk::language_model::hooks::FallbackDecision
+pub trait bitrouter_sdk::language_model::routing::ModelSelector: core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::language_model::routing::ModelSelector::select_variant<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 str, core::option::Option<&'life2 str>, &'life3 mut bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<()>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub trait bitrouter_sdk::language_model::routing::RoutingTable: core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::language_model::routing::RoutingTable::list_models(&self) -> alloc::vec::Vec<bitrouter_sdk::language_model::routing::ModelInfo>
+pub fn bitrouter_sdk::language_model::routing::RoutingTable::model_info(&self, &str) -> core::option::Option<bitrouter_sdk::language_model::routing::ModelInfo>
+pub fn bitrouter_sdk::language_model::routing::RoutingTable::preset_overrides<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 str) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::routing::PromptOverrides>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::routing::RoutingTable::reload<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<()>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn bitrouter_sdk::language_model::routing::RoutingTable::resolve_model<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 str) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::routing::ModelResolution>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::routing::RoutingTable::route_chain<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 str, &'life2 bitrouter_sdk::language_model::routing::RoutingPrefs, &'life3 bitrouter_sdk::caller::CallerContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<alloc::vec::Vec<bitrouter_sdk::language_model::types::RoutingTarget>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub fn bitrouter_sdk::language_model::routing::RoutingTable::route_resolved<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 str, &'life2 bitrouter_sdk::language_model::routing::RoutingPrefs, &'life3 bitrouter_sdk::caller::CallerContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<alloc::vec::Vec<bitrouter_sdk::language_model::types::RoutingTarget>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+impl bitrouter_sdk::language_model::routing::RoutingTable for bitrouter_sdk::config::routing_table::ConfigRoutingTable
+pub fn bitrouter_sdk::config::routing_table::ConfigRoutingTable::list_models(&self) -> alloc::vec::Vec<bitrouter_sdk::language_model::routing::ModelInfo>
+pub fn bitrouter_sdk::config::routing_table::ConfigRoutingTable::model_info(&self, &str) -> core::option::Option<bitrouter_sdk::language_model::routing::ModelInfo>
+pub fn bitrouter_sdk::config::routing_table::ConfigRoutingTable::preset_overrides<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 str) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::routing::PromptOverrides>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::config::routing_table::ConfigRoutingTable::reload<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<()>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn bitrouter_sdk::config::routing_table::ConfigRoutingTable::resolve_model<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 str) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::routing::ModelResolution>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::config::routing_table::ConfigRoutingTable::route_chain<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 str, &'life2 bitrouter_sdk::language_model::routing::RoutingPrefs, &'life3 bitrouter_sdk::caller::CallerContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<alloc::vec::Vec<bitrouter_sdk::language_model::types::RoutingTarget>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub fn bitrouter_sdk::config::routing_table::ConfigRoutingTable::route_resolved<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 str, &'life2 bitrouter_sdk::language_model::routing::RoutingPrefs, &'life3 bitrouter_sdk::caller::CallerContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<alloc::vec::Vec<bitrouter_sdk::language_model::types::RoutingTarget>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+impl bitrouter_sdk::language_model::routing::RoutingTable for bitrouter_sdk::language_model::routing::StaticRoutingTable
+pub fn bitrouter_sdk::language_model::routing::StaticRoutingTable::list_models(&self) -> alloc::vec::Vec<bitrouter_sdk::language_model::routing::ModelInfo>
+pub fn bitrouter_sdk::language_model::routing::StaticRoutingTable::model_info(&self, &str) -> core::option::Option<bitrouter_sdk::language_model::routing::ModelInfo>
+pub fn bitrouter_sdk::language_model::routing::StaticRoutingTable::preset_overrides<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 str) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::routing::PromptOverrides>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::routing::StaticRoutingTable::reload<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<()>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn bitrouter_sdk::language_model::routing::StaticRoutingTable::resolve_model<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 str) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::routing::ModelResolution>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::routing::StaticRoutingTable::route_chain<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 str, &'life2 bitrouter_sdk::language_model::routing::RoutingPrefs, &'life3 bitrouter_sdk::caller::CallerContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<alloc::vec::Vec<bitrouter_sdk::language_model::types::RoutingTarget>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub fn bitrouter_sdk::language_model::routing::StaticRoutingTable::route_resolved<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 str, &'life2 bitrouter_sdk::language_model::routing::RoutingPrefs, &'life3 bitrouter_sdk::caller::CallerContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<alloc::vec::Vec<bitrouter_sdk::language_model::types::RoutingTarget>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub mod bitrouter_sdk::language_model::server_tools
+pub mod bitrouter_sdk::language_model::server_tools::advisor
+pub struct bitrouter_sdk::language_model::server_tools::advisor::AdvisorToolset
+impl bitrouter_sdk::language_model::server_tools::advisor::AdvisorToolset
+pub fn bitrouter_sdk::language_model::server_tools::advisor::AdvisorToolset::new(alloc::sync::Arc<dyn bitrouter_sdk::language_model::server_tools::nested::NestedRunner>) -> Self
+impl bitrouter_sdk::language_model::server_tools::toolset::RouterToolset for bitrouter_sdk::language_model::server_tools::advisor::AdvisorToolset
+pub fn bitrouter_sdk::language_model::server_tools::advisor::AdvisorToolset::call_tool<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 str, &'life2 str, &'life3 bitrouter_sdk::language_model::server_tools::toolset::ToolContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::ToolResultOutput>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub fn bitrouter_sdk::language_model::server_tools::advisor::AdvisorToolset::list_tools<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::server_tools::toolset::ToolContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<alloc::vec::Vec<bitrouter_sdk::language_model::types::Tool>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::server_tools::advisor::AdvisorToolset::owns(&self, &str) -> bool
+pub fn bitrouter_sdk::language_model::server_tools::advisor::AdvisorToolset::server_name(&self) -> core::option::Option<&str>
+impl core::marker::Freeze for bitrouter_sdk::language_model::server_tools::advisor::AdvisorToolset
+impl core::marker::Send for bitrouter_sdk::language_model::server_tools::advisor::AdvisorToolset
+impl core::marker::Sync for bitrouter_sdk::language_model::server_tools::advisor::AdvisorToolset
+impl core::marker::Unpin for bitrouter_sdk::language_model::server_tools::advisor::AdvisorToolset
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::server_tools::advisor::AdvisorToolset
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::server_tools::advisor::AdvisorToolset
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::server_tools::advisor::AdvisorToolset
+pub mod bitrouter_sdk::language_model::server_tools::approval
+pub struct bitrouter_sdk::language_model::server_tools::approval::AllowAll
+impl bitrouter_sdk::language_model::server_tools::approval::ApprovalPolicy for bitrouter_sdk::language_model::server_tools::approval::AllowAll
+pub fn bitrouter_sdk::language_model::server_tools::approval::AllowAll::allow<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::server_tools::classify::RouterCall, &'life2 bitrouter_sdk::caller::CallerContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bool> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+impl core::marker::Freeze for bitrouter_sdk::language_model::server_tools::approval::AllowAll
+impl core::marker::Send for bitrouter_sdk::language_model::server_tools::approval::AllowAll
+impl core::marker::Sync for bitrouter_sdk::language_model::server_tools::approval::AllowAll
+impl core::marker::Unpin for bitrouter_sdk::language_model::server_tools::approval::AllowAll
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::server_tools::approval::AllowAll
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::server_tools::approval::AllowAll
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::server_tools::approval::AllowAll
+pub trait bitrouter_sdk::language_model::server_tools::approval::ApprovalPolicy: core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::language_model::server_tools::approval::ApprovalPolicy::allow<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::server_tools::classify::RouterCall, &'life2 bitrouter_sdk::caller::CallerContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bool> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+impl bitrouter_sdk::language_model::server_tools::approval::ApprovalPolicy for bitrouter_sdk::language_model::server_tools::approval::AllowAll
+pub fn bitrouter_sdk::language_model::server_tools::approval::AllowAll::allow<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::server_tools::classify::RouterCall, &'life2 bitrouter_sdk::caller::CallerContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bool> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub mod bitrouter_sdk::language_model::server_tools::classify
+pub enum bitrouter_sdk::language_model::server_tools::classify::TurnDisposition
+pub bitrouter_sdk::language_model::server_tools::classify::TurnDisposition::Done
+pub bitrouter_sdk::language_model::server_tools::classify::TurnDisposition::Execute(alloc::vec::Vec<bitrouter_sdk::language_model::server_tools::classify::RouterCall>)
+pub bitrouter_sdk::language_model::server_tools::classify::TurnDisposition::HandBack
+impl core::cmp::Eq for bitrouter_sdk::language_model::server_tools::classify::TurnDisposition
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::server_tools::classify::TurnDisposition
+pub fn bitrouter_sdk::language_model::server_tools::classify::TurnDisposition::eq(&self, &bitrouter_sdk::language_model::server_tools::classify::TurnDisposition) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::server_tools::classify::TurnDisposition
+pub fn bitrouter_sdk::language_model::server_tools::classify::TurnDisposition::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::server_tools::classify::TurnDisposition
+impl core::marker::Freeze for bitrouter_sdk::language_model::server_tools::classify::TurnDisposition
+impl core::marker::Send for bitrouter_sdk::language_model::server_tools::classify::TurnDisposition
+impl core::marker::Sync for bitrouter_sdk::language_model::server_tools::classify::TurnDisposition
+impl core::marker::Unpin for bitrouter_sdk::language_model::server_tools::classify::TurnDisposition
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::server_tools::classify::TurnDisposition
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::server_tools::classify::TurnDisposition
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::server_tools::classify::TurnDisposition
+pub struct bitrouter_sdk::language_model::server_tools::classify::RouterCall
+pub bitrouter_sdk::language_model::server_tools::classify::RouterCall::arguments: alloc::string::String
+pub bitrouter_sdk::language_model::server_tools::classify::RouterCall::id: alloc::string::String
+pub bitrouter_sdk::language_model::server_tools::classify::RouterCall::name: alloc::string::String
+impl core::clone::Clone for bitrouter_sdk::language_model::server_tools::classify::RouterCall
+pub fn bitrouter_sdk::language_model::server_tools::classify::RouterCall::clone(&self) -> bitrouter_sdk::language_model::server_tools::classify::RouterCall
+impl core::cmp::Eq for bitrouter_sdk::language_model::server_tools::classify::RouterCall
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::server_tools::classify::RouterCall
+pub fn bitrouter_sdk::language_model::server_tools::classify::RouterCall::eq(&self, &bitrouter_sdk::language_model::server_tools::classify::RouterCall) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::server_tools::classify::RouterCall
+pub fn bitrouter_sdk::language_model::server_tools::classify::RouterCall::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::server_tools::classify::RouterCall
+impl core::marker::Freeze for bitrouter_sdk::language_model::server_tools::classify::RouterCall
+impl core::marker::Send for bitrouter_sdk::language_model::server_tools::classify::RouterCall
+impl core::marker::Sync for bitrouter_sdk::language_model::server_tools::classify::RouterCall
+impl core::marker::Unpin for bitrouter_sdk::language_model::server_tools::classify::RouterCall
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::server_tools::classify::RouterCall
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::server_tools::classify::RouterCall
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::server_tools::classify::RouterCall
+pub fn bitrouter_sdk::language_model::server_tools::classify::classify_turn(&[bitrouter_sdk::language_model::types::Content], &alloc::collections::btree::set::BTreeSet<alloc::string::String>) -> bitrouter_sdk::language_model::server_tools::classify::TurnDisposition
+pub mod bitrouter_sdk::language_model::server_tools::config
+pub struct bitrouter_sdk::language_model::server_tools::config::ServerToolLoopConfig
+pub bitrouter_sdk::language_model::server_tools::config::ServerToolLoopConfig::max_consecutive_errors: u32
+pub bitrouter_sdk::language_model::server_tools::config::ServerToolLoopConfig::max_iterations: u32
+pub bitrouter_sdk::language_model::server_tools::config::ServerToolLoopConfig::tool_timeout: core::time::Duration
+pub bitrouter_sdk::language_model::server_tools::config::ServerToolLoopConfig::total_budget: core::time::Duration
+impl core::clone::Clone for bitrouter_sdk::language_model::server_tools::config::ServerToolLoopConfig
+pub fn bitrouter_sdk::language_model::server_tools::config::ServerToolLoopConfig::clone(&self) -> bitrouter_sdk::language_model::server_tools::config::ServerToolLoopConfig
+impl core::default::Default for bitrouter_sdk::language_model::server_tools::config::ServerToolLoopConfig
+pub fn bitrouter_sdk::language_model::server_tools::config::ServerToolLoopConfig::default() -> Self
+impl core::fmt::Debug for bitrouter_sdk::language_model::server_tools::config::ServerToolLoopConfig
+pub fn bitrouter_sdk::language_model::server_tools::config::ServerToolLoopConfig::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::language_model::server_tools::config::ServerToolLoopConfig
+impl core::marker::Send for bitrouter_sdk::language_model::server_tools::config::ServerToolLoopConfig
+impl core::marker::Sync for bitrouter_sdk::language_model::server_tools::config::ServerToolLoopConfig
+impl core::marker::Unpin for bitrouter_sdk::language_model::server_tools::config::ServerToolLoopConfig
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::server_tools::config::ServerToolLoopConfig
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::server_tools::config::ServerToolLoopConfig
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::server_tools::config::ServerToolLoopConfig
+pub struct bitrouter_sdk::language_model::server_tools::config::ServerToolsConfig
+pub bitrouter_sdk::language_model::server_tools::config::ServerToolsConfig::advisor: bool
+pub bitrouter_sdk::language_model::server_tools::config::ServerToolsConfig::fusion: core::option::Option<bitrouter_sdk::language_model::server_tools::fusion::config::FusionSettings>
+pub bitrouter_sdk::language_model::server_tools::config::ServerToolsConfig::max_iterations: core::option::Option<u32>
+pub bitrouter_sdk::language_model::server_tools::config::ServerToolsConfig::mcp_servers: alloc::vec::Vec<alloc::string::String>
+pub bitrouter_sdk::language_model::server_tools::config::ServerToolsConfig::subagent: bool
+pub bitrouter_sdk::language_model::server_tools::config::ServerToolsConfig::web_fetch: core::option::Option<bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchSettings>
+pub bitrouter_sdk::language_model::server_tools::config::ServerToolsConfig::web_search: core::option::Option<bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchSettings>
+impl core::clone::Clone for bitrouter_sdk::language_model::server_tools::config::ServerToolsConfig
+pub fn bitrouter_sdk::language_model::server_tools::config::ServerToolsConfig::clone(&self) -> bitrouter_sdk::language_model::server_tools::config::ServerToolsConfig
+impl core::default::Default for bitrouter_sdk::language_model::server_tools::config::ServerToolsConfig
+pub fn bitrouter_sdk::language_model::server_tools::config::ServerToolsConfig::default() -> bitrouter_sdk::language_model::server_tools::config::ServerToolsConfig
+impl core::fmt::Debug for bitrouter_sdk::language_model::server_tools::config::ServerToolsConfig
+pub fn bitrouter_sdk::language_model::server_tools::config::ServerToolsConfig::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::language_model::server_tools::config::ServerToolsConfig
+pub fn bitrouter_sdk::language_model::server_tools::config::ServerToolsConfig::inline_schema() -> bool
+pub fn bitrouter_sdk::language_model::server_tools::config::ServerToolsConfig::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::language_model::server_tools::config::ServerToolsConfig::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::language_model::server_tools::config::ServerToolsConfig::schema_name() -> alloc::borrow::Cow<'static, str>
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::server_tools::config::ServerToolsConfig where bitrouter_sdk::language_model::server_tools::config::ServerToolsConfig: core::default::Default
+pub fn bitrouter_sdk::language_model::server_tools::config::ServerToolsConfig::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::server_tools::config::ServerToolsConfig
+impl core::marker::Send for bitrouter_sdk::language_model::server_tools::config::ServerToolsConfig
+impl core::marker::Sync for bitrouter_sdk::language_model::server_tools::config::ServerToolsConfig
+impl core::marker::Unpin for bitrouter_sdk::language_model::server_tools::config::ServerToolsConfig
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::server_tools::config::ServerToolsConfig
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::server_tools::config::ServerToolsConfig
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::server_tools::config::ServerToolsConfig
+pub mod bitrouter_sdk::language_model::server_tools::declarations
+pub struct bitrouter_sdk::language_model::server_tools::declarations::AdvisorConfig
+pub bitrouter_sdk::language_model::server_tools::declarations::AdvisorConfig::instructions: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::server_tools::declarations::AdvisorConfig::model: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::server_tools::declarations::AdvisorConfig::tools: alloc::vec::Vec<serde_json::value::Value>
+impl core::clone::Clone for bitrouter_sdk::language_model::server_tools::declarations::AdvisorConfig
+pub fn bitrouter_sdk::language_model::server_tools::declarations::AdvisorConfig::clone(&self) -> bitrouter_sdk::language_model::server_tools::declarations::AdvisorConfig
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::server_tools::declarations::AdvisorConfig
+pub fn bitrouter_sdk::language_model::server_tools::declarations::AdvisorConfig::eq(&self, &bitrouter_sdk::language_model::server_tools::declarations::AdvisorConfig) -> bool
+impl core::default::Default for bitrouter_sdk::language_model::server_tools::declarations::AdvisorConfig
+pub fn bitrouter_sdk::language_model::server_tools::declarations::AdvisorConfig::default() -> bitrouter_sdk::language_model::server_tools::declarations::AdvisorConfig
+impl core::fmt::Debug for bitrouter_sdk::language_model::server_tools::declarations::AdvisorConfig
+pub fn bitrouter_sdk::language_model::server_tools::declarations::AdvisorConfig::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::server_tools::declarations::AdvisorConfig
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::server_tools::declarations::AdvisorConfig
+pub fn bitrouter_sdk::language_model::server_tools::declarations::AdvisorConfig::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::server_tools::declarations::AdvisorConfig
+pub fn bitrouter_sdk::language_model::server_tools::declarations::AdvisorConfig::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::server_tools::declarations::AdvisorConfig
+impl core::marker::Send for bitrouter_sdk::language_model::server_tools::declarations::AdvisorConfig
+impl core::marker::Sync for bitrouter_sdk::language_model::server_tools::declarations::AdvisorConfig
+impl core::marker::Unpin for bitrouter_sdk::language_model::server_tools::declarations::AdvisorConfig
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::server_tools::declarations::AdvisorConfig
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::server_tools::declarations::AdvisorConfig
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::server_tools::declarations::AdvisorConfig
+pub struct bitrouter_sdk::language_model::server_tools::declarations::ServerToolDeclarations
+pub bitrouter_sdk::language_model::server_tools::declarations::ServerToolDeclarations::advisor: core::option::Option<bitrouter_sdk::language_model::server_tools::declarations::AdvisorConfig>
+pub bitrouter_sdk::language_model::server_tools::declarations::ServerToolDeclarations::fusion: core::option::Option<bitrouter_sdk::language_model::server_tools::fusion::config::FusionConfig>
+pub bitrouter_sdk::language_model::server_tools::declarations::ServerToolDeclarations::parent_model: alloc::string::String
+pub bitrouter_sdk::language_model::server_tools::declarations::ServerToolDeclarations::subagent: core::option::Option<bitrouter_sdk::language_model::server_tools::declarations::SubAgentConfig>
+pub bitrouter_sdk::language_model::server_tools::declarations::ServerToolDeclarations::web_fetch: core::option::Option<bitrouter_sdk::language_model::server_tools::declarations::WebFetchDeclaration>
+pub bitrouter_sdk::language_model::server_tools::declarations::ServerToolDeclarations::web_search: core::option::Option<bitrouter_sdk::language_model::server_tools::declarations::WebSearchDeclaration>
+impl bitrouter_sdk::language_model::server_tools::declarations::ServerToolDeclarations
+pub fn bitrouter_sdk::language_model::server_tools::declarations::ServerToolDeclarations::from_context(&bitrouter_sdk::language_model::server_tools::toolset::ToolContext) -> core::option::Option<Self>
+pub fn bitrouter_sdk::language_model::server_tools::declarations::ServerToolDeclarations::from_prompt(&bitrouter_sdk::language_model::types::Prompt) -> Self
+pub fn bitrouter_sdk::language_model::server_tools::declarations::ServerToolDeclarations::is_empty(&self) -> bool
+impl core::clone::Clone for bitrouter_sdk::language_model::server_tools::declarations::ServerToolDeclarations
+pub fn bitrouter_sdk::language_model::server_tools::declarations::ServerToolDeclarations::clone(&self) -> bitrouter_sdk::language_model::server_tools::declarations::ServerToolDeclarations
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::server_tools::declarations::ServerToolDeclarations
+pub fn bitrouter_sdk::language_model::server_tools::declarations::ServerToolDeclarations::eq(&self, &bitrouter_sdk::language_model::server_tools::declarations::ServerToolDeclarations) -> bool
+impl core::default::Default for bitrouter_sdk::language_model::server_tools::declarations::ServerToolDeclarations
+pub fn bitrouter_sdk::language_model::server_tools::declarations::ServerToolDeclarations::default() -> bitrouter_sdk::language_model::server_tools::declarations::ServerToolDeclarations
+impl core::fmt::Debug for bitrouter_sdk::language_model::server_tools::declarations::ServerToolDeclarations
+pub fn bitrouter_sdk::language_model::server_tools::declarations::ServerToolDeclarations::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::server_tools::declarations::ServerToolDeclarations
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::server_tools::declarations::ServerToolDeclarations
+pub fn bitrouter_sdk::language_model::server_tools::declarations::ServerToolDeclarations::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::server_tools::declarations::ServerToolDeclarations
+pub fn bitrouter_sdk::language_model::server_tools::declarations::ServerToolDeclarations::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::server_tools::declarations::ServerToolDeclarations
+impl core::marker::Send for bitrouter_sdk::language_model::server_tools::declarations::ServerToolDeclarations
+impl core::marker::Sync for bitrouter_sdk::language_model::server_tools::declarations::ServerToolDeclarations
+impl core::marker::Unpin for bitrouter_sdk::language_model::server_tools::declarations::ServerToolDeclarations
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::server_tools::declarations::ServerToolDeclarations
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::server_tools::declarations::ServerToolDeclarations
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::server_tools::declarations::ServerToolDeclarations
+pub struct bitrouter_sdk::language_model::server_tools::declarations::ServerToolDeclarationsHook
+impl bitrouter_sdk::language_model::hooks::PreRequestHook for bitrouter_sdk::language_model::server_tools::declarations::ServerToolDeclarationsHook
+pub fn bitrouter_sdk::language_model::server_tools::declarations::ServerToolDeclarationsHook::check<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 mut bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::hooks::HookDecision>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+impl core::marker::Freeze for bitrouter_sdk::language_model::server_tools::declarations::ServerToolDeclarationsHook
+impl core::marker::Send for bitrouter_sdk::language_model::server_tools::declarations::ServerToolDeclarationsHook
+impl core::marker::Sync for bitrouter_sdk::language_model::server_tools::declarations::ServerToolDeclarationsHook
+impl core::marker::Unpin for bitrouter_sdk::language_model::server_tools::declarations::ServerToolDeclarationsHook
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::server_tools::declarations::ServerToolDeclarationsHook
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::server_tools::declarations::ServerToolDeclarationsHook
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::server_tools::declarations::ServerToolDeclarationsHook
+pub struct bitrouter_sdk::language_model::server_tools::declarations::SubAgentConfig
+pub bitrouter_sdk::language_model::server_tools::declarations::SubAgentConfig::instructions: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::server_tools::declarations::SubAgentConfig::model: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::server_tools::declarations::SubAgentConfig::tools: alloc::vec::Vec<serde_json::value::Value>
+impl core::clone::Clone for bitrouter_sdk::language_model::server_tools::declarations::SubAgentConfig
+pub fn bitrouter_sdk::language_model::server_tools::declarations::SubAgentConfig::clone(&self) -> bitrouter_sdk::language_model::server_tools::declarations::SubAgentConfig
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::server_tools::declarations::SubAgentConfig
+pub fn bitrouter_sdk::language_model::server_tools::declarations::SubAgentConfig::eq(&self, &bitrouter_sdk::language_model::server_tools::declarations::SubAgentConfig) -> bool
+impl core::default::Default for bitrouter_sdk::language_model::server_tools::declarations::SubAgentConfig
+pub fn bitrouter_sdk::language_model::server_tools::declarations::SubAgentConfig::default() -> bitrouter_sdk::language_model::server_tools::declarations::SubAgentConfig
+impl core::fmt::Debug for bitrouter_sdk::language_model::server_tools::declarations::SubAgentConfig
+pub fn bitrouter_sdk::language_model::server_tools::declarations::SubAgentConfig::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::server_tools::declarations::SubAgentConfig
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::server_tools::declarations::SubAgentConfig
+pub fn bitrouter_sdk::language_model::server_tools::declarations::SubAgentConfig::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::server_tools::declarations::SubAgentConfig
+pub fn bitrouter_sdk::language_model::server_tools::declarations::SubAgentConfig::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::server_tools::declarations::SubAgentConfig
+impl core::marker::Send for bitrouter_sdk::language_model::server_tools::declarations::SubAgentConfig
+impl core::marker::Sync for bitrouter_sdk::language_model::server_tools::declarations::SubAgentConfig
+impl core::marker::Unpin for bitrouter_sdk::language_model::server_tools::declarations::SubAgentConfig
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::server_tools::declarations::SubAgentConfig
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::server_tools::declarations::SubAgentConfig
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::server_tools::declarations::SubAgentConfig
+pub struct bitrouter_sdk::language_model::server_tools::declarations::WebFetchDeclaration
+pub bitrouter_sdk::language_model::server_tools::declarations::WebFetchDeclaration::backend: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::server_tools::declarations::WebFetchDeclaration::max_content_tokens: core::option::Option<u32>
+impl core::clone::Clone for bitrouter_sdk::language_model::server_tools::declarations::WebFetchDeclaration
+pub fn bitrouter_sdk::language_model::server_tools::declarations::WebFetchDeclaration::clone(&self) -> bitrouter_sdk::language_model::server_tools::declarations::WebFetchDeclaration
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::server_tools::declarations::WebFetchDeclaration
+pub fn bitrouter_sdk::language_model::server_tools::declarations::WebFetchDeclaration::eq(&self, &bitrouter_sdk::language_model::server_tools::declarations::WebFetchDeclaration) -> bool
+impl core::default::Default for bitrouter_sdk::language_model::server_tools::declarations::WebFetchDeclaration
+pub fn bitrouter_sdk::language_model::server_tools::declarations::WebFetchDeclaration::default() -> bitrouter_sdk::language_model::server_tools::declarations::WebFetchDeclaration
+impl core::fmt::Debug for bitrouter_sdk::language_model::server_tools::declarations::WebFetchDeclaration
+pub fn bitrouter_sdk::language_model::server_tools::declarations::WebFetchDeclaration::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::server_tools::declarations::WebFetchDeclaration
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::server_tools::declarations::WebFetchDeclaration
+pub fn bitrouter_sdk::language_model::server_tools::declarations::WebFetchDeclaration::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::server_tools::declarations::WebFetchDeclaration
+pub fn bitrouter_sdk::language_model::server_tools::declarations::WebFetchDeclaration::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::server_tools::declarations::WebFetchDeclaration
+impl core::marker::Send for bitrouter_sdk::language_model::server_tools::declarations::WebFetchDeclaration
+impl core::marker::Sync for bitrouter_sdk::language_model::server_tools::declarations::WebFetchDeclaration
+impl core::marker::Unpin for bitrouter_sdk::language_model::server_tools::declarations::WebFetchDeclaration
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::server_tools::declarations::WebFetchDeclaration
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::server_tools::declarations::WebFetchDeclaration
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::server_tools::declarations::WebFetchDeclaration
+pub struct bitrouter_sdk::language_model::server_tools::declarations::WebSearchDeclaration
+pub bitrouter_sdk::language_model::server_tools::declarations::WebSearchDeclaration::backend: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::server_tools::declarations::WebSearchDeclaration::max_results: core::option::Option<u32>
+impl core::clone::Clone for bitrouter_sdk::language_model::server_tools::declarations::WebSearchDeclaration
+pub fn bitrouter_sdk::language_model::server_tools::declarations::WebSearchDeclaration::clone(&self) -> bitrouter_sdk::language_model::server_tools::declarations::WebSearchDeclaration
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::server_tools::declarations::WebSearchDeclaration
+pub fn bitrouter_sdk::language_model::server_tools::declarations::WebSearchDeclaration::eq(&self, &bitrouter_sdk::language_model::server_tools::declarations::WebSearchDeclaration) -> bool
+impl core::default::Default for bitrouter_sdk::language_model::server_tools::declarations::WebSearchDeclaration
+pub fn bitrouter_sdk::language_model::server_tools::declarations::WebSearchDeclaration::default() -> bitrouter_sdk::language_model::server_tools::declarations::WebSearchDeclaration
+impl core::fmt::Debug for bitrouter_sdk::language_model::server_tools::declarations::WebSearchDeclaration
+pub fn bitrouter_sdk::language_model::server_tools::declarations::WebSearchDeclaration::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::server_tools::declarations::WebSearchDeclaration
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::server_tools::declarations::WebSearchDeclaration
+pub fn bitrouter_sdk::language_model::server_tools::declarations::WebSearchDeclaration::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::server_tools::declarations::WebSearchDeclaration
+pub fn bitrouter_sdk::language_model::server_tools::declarations::WebSearchDeclaration::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::server_tools::declarations::WebSearchDeclaration
+impl core::marker::Send for bitrouter_sdk::language_model::server_tools::declarations::WebSearchDeclaration
+impl core::marker::Sync for bitrouter_sdk::language_model::server_tools::declarations::WebSearchDeclaration
+impl core::marker::Unpin for bitrouter_sdk::language_model::server_tools::declarations::WebSearchDeclaration
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::server_tools::declarations::WebSearchDeclaration
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::server_tools::declarations::WebSearchDeclaration
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::server_tools::declarations::WebSearchDeclaration
+pub const bitrouter_sdk::language_model::server_tools::declarations::ADVISOR_TOOL: &str
+pub const bitrouter_sdk::language_model::server_tools::declarations::SUBAGENT_TOOL: &str
+pub const bitrouter_sdk::language_model::server_tools::declarations::WEB_FETCH_TOOL: &str
+pub const bitrouter_sdk::language_model::server_tools::declarations::WEB_SEARCH_TOOL: &str
+pub fn bitrouter_sdk::language_model::server_tools::declarations::declarations_plugin_id() -> &'static bitrouter_sdk::plugin::PluginId
+pub fn bitrouter_sdk::language_model::server_tools::declarations::forwarded_tools(&[serde_json::value::Value]) -> alloc::vec::Vec<bitrouter_sdk::language_model::types::Tool>
+pub mod bitrouter_sdk::language_model::server_tools::fusion
+pub mod bitrouter_sdk::language_model::server_tools::fusion::alias
+pub struct bitrouter_sdk::language_model::server_tools::fusion::alias::FusionAliasConfig
+pub bitrouter_sdk::language_model::server_tools::fusion::alias::FusionAliasConfig::alias: alloc::string::String
+pub bitrouter_sdk::language_model::server_tools::fusion::alias::FusionAliasConfig::judge: alloc::string::String
+pub bitrouter_sdk::language_model::server_tools::fusion::alias::FusionAliasConfig::outer_model: alloc::string::String
+pub bitrouter_sdk::language_model::server_tools::fusion::alias::FusionAliasConfig::panel: alloc::vec::Vec<alloc::string::String>
+pub bitrouter_sdk::language_model::server_tools::fusion::alias::FusionAliasConfig::synthesizer: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::server_tools::fusion::alias::FusionAliasConfig::web_tools: alloc::vec::Vec<serde_json::value::Value>
+impl bitrouter_sdk::language_model::server_tools::fusion::alias::FusionAliasConfig
+pub fn bitrouter_sdk::language_model::server_tools::fusion::alias::FusionAliasConfig::apply(&self, &mut bitrouter_sdk::language_model::types::Prompt) -> bool
+pub fn bitrouter_sdk::language_model::server_tools::fusion::alias::FusionAliasConfig::from_settings(&bitrouter_sdk::language_model::server_tools::fusion::config::FusionSettings) -> core::option::Option<Self>
+impl bitrouter_sdk::app::PromptTransform for bitrouter_sdk::language_model::server_tools::fusion::alias::FusionAliasConfig
+pub fn bitrouter_sdk::language_model::server_tools::fusion::alias::FusionAliasConfig::apply(&self, &mut bitrouter_sdk::language_model::types::Prompt)
+pub fn bitrouter_sdk::language_model::server_tools::fusion::alias::FusionAliasConfig::apply_with_headers(&self, &mut bitrouter_sdk::language_model::types::Prompt, &http::header::map::HeaderMap)
+impl core::clone::Clone for bitrouter_sdk::language_model::server_tools::fusion::alias::FusionAliasConfig
+pub fn bitrouter_sdk::language_model::server_tools::fusion::alias::FusionAliasConfig::clone(&self) -> bitrouter_sdk::language_model::server_tools::fusion::alias::FusionAliasConfig
+impl core::fmt::Debug for bitrouter_sdk::language_model::server_tools::fusion::alias::FusionAliasConfig
+pub fn bitrouter_sdk::language_model::server_tools::fusion::alias::FusionAliasConfig::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::language_model::server_tools::fusion::alias::FusionAliasConfig
+impl core::marker::Send for bitrouter_sdk::language_model::server_tools::fusion::alias::FusionAliasConfig
+impl core::marker::Sync for bitrouter_sdk::language_model::server_tools::fusion::alias::FusionAliasConfig
+impl core::marker::Unpin for bitrouter_sdk::language_model::server_tools::fusion::alias::FusionAliasConfig
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::server_tools::fusion::alias::FusionAliasConfig
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::server_tools::fusion::alias::FusionAliasConfig
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::server_tools::fusion::alias::FusionAliasConfig
+pub mod bitrouter_sdk::language_model::server_tools::fusion::config
+pub struct bitrouter_sdk::language_model::server_tools::fusion::config::FusionConfig
+pub bitrouter_sdk::language_model::server_tools::fusion::config::FusionConfig::judge: bitrouter_sdk::language_model::server_tools::fusion::config::JudgeSpec
+pub bitrouter_sdk::language_model::server_tools::fusion::config::FusionConfig::panel: alloc::vec::Vec<bitrouter_sdk::language_model::server_tools::fusion::config::PanelMemberSpec>
+pub bitrouter_sdk::language_model::server_tools::fusion::config::FusionConfig::synthesizer: core::option::Option<alloc::string::String>
+impl bitrouter_sdk::language_model::server_tools::fusion::config::FusionConfig
+pub fn bitrouter_sdk::language_model::server_tools::fusion::config::FusionConfig::from_tool(&bitrouter_sdk::language_model::types::Tool, &str) -> core::option::Option<Self>
+pub fn bitrouter_sdk::language_model::server_tools::fusion::config::FusionConfig::single(&str) -> Self
+impl core::clone::Clone for bitrouter_sdk::language_model::server_tools::fusion::config::FusionConfig
+pub fn bitrouter_sdk::language_model::server_tools::fusion::config::FusionConfig::clone(&self) -> bitrouter_sdk::language_model::server_tools::fusion::config::FusionConfig
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::server_tools::fusion::config::FusionConfig
+pub fn bitrouter_sdk::language_model::server_tools::fusion::config::FusionConfig::eq(&self, &bitrouter_sdk::language_model::server_tools::fusion::config::FusionConfig) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::server_tools::fusion::config::FusionConfig
+pub fn bitrouter_sdk::language_model::server_tools::fusion::config::FusionConfig::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::server_tools::fusion::config::FusionConfig
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::server_tools::fusion::config::FusionConfig
+pub fn bitrouter_sdk::language_model::server_tools::fusion::config::FusionConfig::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::server_tools::fusion::config::FusionConfig
+pub fn bitrouter_sdk::language_model::server_tools::fusion::config::FusionConfig::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::server_tools::fusion::config::FusionConfig
+impl core::marker::Send for bitrouter_sdk::language_model::server_tools::fusion::config::FusionConfig
+impl core::marker::Sync for bitrouter_sdk::language_model::server_tools::fusion::config::FusionConfig
+impl core::marker::Unpin for bitrouter_sdk::language_model::server_tools::fusion::config::FusionConfig
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::server_tools::fusion::config::FusionConfig
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::server_tools::fusion::config::FusionConfig
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::server_tools::fusion::config::FusionConfig
+pub struct bitrouter_sdk::language_model::server_tools::fusion::config::FusionSettings
+pub bitrouter_sdk::language_model::server_tools::fusion::config::FusionSettings::alias: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::server_tools::fusion::config::FusionSettings::judge: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::server_tools::fusion::config::FusionSettings::outer_model: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::server_tools::fusion::config::FusionSettings::panel: alloc::vec::Vec<alloc::string::String>
+pub bitrouter_sdk::language_model::server_tools::fusion::config::FusionSettings::synthesizer: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::server_tools::fusion::config::FusionSettings::web_tools: alloc::vec::Vec<serde_json::value::Value>
+impl core::clone::Clone for bitrouter_sdk::language_model::server_tools::fusion::config::FusionSettings
+pub fn bitrouter_sdk::language_model::server_tools::fusion::config::FusionSettings::clone(&self) -> bitrouter_sdk::language_model::server_tools::fusion::config::FusionSettings
+impl core::default::Default for bitrouter_sdk::language_model::server_tools::fusion::config::FusionSettings
+pub fn bitrouter_sdk::language_model::server_tools::fusion::config::FusionSettings::default() -> bitrouter_sdk::language_model::server_tools::fusion::config::FusionSettings
+impl core::fmt::Debug for bitrouter_sdk::language_model::server_tools::fusion::config::FusionSettings
+pub fn bitrouter_sdk::language_model::server_tools::fusion::config::FusionSettings::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::language_model::server_tools::fusion::config::FusionSettings
+pub fn bitrouter_sdk::language_model::server_tools::fusion::config::FusionSettings::inline_schema() -> bool
+pub fn bitrouter_sdk::language_model::server_tools::fusion::config::FusionSettings::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::language_model::server_tools::fusion::config::FusionSettings::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::language_model::server_tools::fusion::config::FusionSettings::schema_name() -> alloc::borrow::Cow<'static, str>
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::server_tools::fusion::config::FusionSettings where bitrouter_sdk::language_model::server_tools::fusion::config::FusionSettings: core::default::Default
+pub fn bitrouter_sdk::language_model::server_tools::fusion::config::FusionSettings::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::server_tools::fusion::config::FusionSettings
+impl core::marker::Send for bitrouter_sdk::language_model::server_tools::fusion::config::FusionSettings
+impl core::marker::Sync for bitrouter_sdk::language_model::server_tools::fusion::config::FusionSettings
+impl core::marker::Unpin for bitrouter_sdk::language_model::server_tools::fusion::config::FusionSettings
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::server_tools::fusion::config::FusionSettings
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::server_tools::fusion::config::FusionSettings
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::server_tools::fusion::config::FusionSettings
+pub struct bitrouter_sdk::language_model::server_tools::fusion::config::JudgeSpec
+pub bitrouter_sdk::language_model::server_tools::fusion::config::JudgeSpec::model: alloc::string::String
+impl core::clone::Clone for bitrouter_sdk::language_model::server_tools::fusion::config::JudgeSpec
+pub fn bitrouter_sdk::language_model::server_tools::fusion::config::JudgeSpec::clone(&self) -> bitrouter_sdk::language_model::server_tools::fusion::config::JudgeSpec
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::server_tools::fusion::config::JudgeSpec
+pub fn bitrouter_sdk::language_model::server_tools::fusion::config::JudgeSpec::eq(&self, &bitrouter_sdk::language_model::server_tools::fusion::config::JudgeSpec) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::server_tools::fusion::config::JudgeSpec
+pub fn bitrouter_sdk::language_model::server_tools::fusion::config::JudgeSpec::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::server_tools::fusion::config::JudgeSpec
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::server_tools::fusion::config::JudgeSpec
+pub fn bitrouter_sdk::language_model::server_tools::fusion::config::JudgeSpec::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::server_tools::fusion::config::JudgeSpec
+pub fn bitrouter_sdk::language_model::server_tools::fusion::config::JudgeSpec::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::server_tools::fusion::config::JudgeSpec
+impl core::marker::Send for bitrouter_sdk::language_model::server_tools::fusion::config::JudgeSpec
+impl core::marker::Sync for bitrouter_sdk::language_model::server_tools::fusion::config::JudgeSpec
+impl core::marker::Unpin for bitrouter_sdk::language_model::server_tools::fusion::config::JudgeSpec
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::server_tools::fusion::config::JudgeSpec
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::server_tools::fusion::config::JudgeSpec
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::server_tools::fusion::config::JudgeSpec
+pub struct bitrouter_sdk::language_model::server_tools::fusion::config::PanelMemberSpec
+pub bitrouter_sdk::language_model::server_tools::fusion::config::PanelMemberSpec::model: alloc::string::String
+pub bitrouter_sdk::language_model::server_tools::fusion::config::PanelMemberSpec::tools: alloc::vec::Vec<serde_json::value::Value>
+impl core::clone::Clone for bitrouter_sdk::language_model::server_tools::fusion::config::PanelMemberSpec
+pub fn bitrouter_sdk::language_model::server_tools::fusion::config::PanelMemberSpec::clone(&self) -> bitrouter_sdk::language_model::server_tools::fusion::config::PanelMemberSpec
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::server_tools::fusion::config::PanelMemberSpec
+pub fn bitrouter_sdk::language_model::server_tools::fusion::config::PanelMemberSpec::eq(&self, &bitrouter_sdk::language_model::server_tools::fusion::config::PanelMemberSpec) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::server_tools::fusion::config::PanelMemberSpec
+pub fn bitrouter_sdk::language_model::server_tools::fusion::config::PanelMemberSpec::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::server_tools::fusion::config::PanelMemberSpec
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::server_tools::fusion::config::PanelMemberSpec
+pub fn bitrouter_sdk::language_model::server_tools::fusion::config::PanelMemberSpec::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::server_tools::fusion::config::PanelMemberSpec
+pub fn bitrouter_sdk::language_model::server_tools::fusion::config::PanelMemberSpec::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::server_tools::fusion::config::PanelMemberSpec
+impl core::marker::Send for bitrouter_sdk::language_model::server_tools::fusion::config::PanelMemberSpec
+impl core::marker::Sync for bitrouter_sdk::language_model::server_tools::fusion::config::PanelMemberSpec
+impl core::marker::Unpin for bitrouter_sdk::language_model::server_tools::fusion::config::PanelMemberSpec
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::server_tools::fusion::config::PanelMemberSpec
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::server_tools::fusion::config::PanelMemberSpec
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::server_tools::fusion::config::PanelMemberSpec
+pub const bitrouter_sdk::language_model::server_tools::fusion::config::FUSION_TOOL: &str
+pub const bitrouter_sdk::language_model::server_tools::fusion::config::MAX_PANEL: usize
+pub fn bitrouter_sdk::language_model::server_tools::fusion::config::is_fusion_name(&str) -> bool
+pub mod bitrouter_sdk::language_model::server_tools::fusion::engine
+pub struct bitrouter_sdk::language_model::server_tools::fusion::engine::FusionOutcome
+pub bitrouter_sdk::language_model::server_tools::fusion::engine::FusionOutcome::output: bitrouter_sdk::language_model::types::ToolResultOutput
+pub bitrouter_sdk::language_model::server_tools::fusion::engine::FusionOutcome::usage: bitrouter_sdk::language_model::types::Usage
+impl core::marker::Freeze for bitrouter_sdk::language_model::server_tools::fusion::engine::FusionOutcome
+impl core::marker::Send for bitrouter_sdk::language_model::server_tools::fusion::engine::FusionOutcome
+impl core::marker::Sync for bitrouter_sdk::language_model::server_tools::fusion::engine::FusionOutcome
+impl core::marker::Unpin for bitrouter_sdk::language_model::server_tools::fusion::engine::FusionOutcome
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::server_tools::fusion::engine::FusionOutcome
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::server_tools::fusion::engine::FusionOutcome
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::server_tools::fusion::engine::FusionOutcome
+pub async fn bitrouter_sdk::language_model::server_tools::fusion::engine::run_fusion(&bitrouter_sdk::language_model::server_tools::fusion::config::FusionConfig, alloc::sync::Arc<dyn bitrouter_sdk::language_model::server_tools::nested::NestedRunner>, &str, &bitrouter_sdk::language_model::server_tools::toolset::ToolContext) -> core::result::Result<bitrouter_sdk::language_model::server_tools::fusion::engine::FusionOutcome, alloc::string::String>
+pub mod bitrouter_sdk::language_model::server_tools::fusion::judge
+pub struct bitrouter_sdk::language_model::server_tools::fusion::judge::JudgeAnalysis
+pub bitrouter_sdk::language_model::server_tools::fusion::judge::JudgeAnalysis::blind_spots: alloc::vec::Vec<alloc::string::String>
+pub bitrouter_sdk::language_model::server_tools::fusion::judge::JudgeAnalysis::consensus: alloc::vec::Vec<alloc::string::String>
+pub bitrouter_sdk::language_model::server_tools::fusion::judge::JudgeAnalysis::contradictions: alloc::vec::Vec<alloc::string::String>
+pub bitrouter_sdk::language_model::server_tools::fusion::judge::JudgeAnalysis::partial_coverage: alloc::vec::Vec<alloc::string::String>
+pub bitrouter_sdk::language_model::server_tools::fusion::judge::JudgeAnalysis::unique_insights: alloc::vec::Vec<alloc::string::String>
+impl bitrouter_sdk::language_model::server_tools::fusion::judge::JudgeAnalysis
+pub fn bitrouter_sdk::language_model::server_tools::fusion::judge::JudgeAnalysis::parse_lenient(&str) -> core::result::Result<Self, alloc::string::String>
+impl core::clone::Clone for bitrouter_sdk::language_model::server_tools::fusion::judge::JudgeAnalysis
+pub fn bitrouter_sdk::language_model::server_tools::fusion::judge::JudgeAnalysis::clone(&self) -> bitrouter_sdk::language_model::server_tools::fusion::judge::JudgeAnalysis
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::server_tools::fusion::judge::JudgeAnalysis
+pub fn bitrouter_sdk::language_model::server_tools::fusion::judge::JudgeAnalysis::eq(&self, &bitrouter_sdk::language_model::server_tools::fusion::judge::JudgeAnalysis) -> bool
+impl core::default::Default for bitrouter_sdk::language_model::server_tools::fusion::judge::JudgeAnalysis
+pub fn bitrouter_sdk::language_model::server_tools::fusion::judge::JudgeAnalysis::default() -> bitrouter_sdk::language_model::server_tools::fusion::judge::JudgeAnalysis
+impl core::fmt::Debug for bitrouter_sdk::language_model::server_tools::fusion::judge::JudgeAnalysis
+pub fn bitrouter_sdk::language_model::server_tools::fusion::judge::JudgeAnalysis::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::server_tools::fusion::judge::JudgeAnalysis
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::server_tools::fusion::judge::JudgeAnalysis
+pub fn bitrouter_sdk::language_model::server_tools::fusion::judge::JudgeAnalysis::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::server_tools::fusion::judge::JudgeAnalysis
+pub fn bitrouter_sdk::language_model::server_tools::fusion::judge::JudgeAnalysis::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::server_tools::fusion::judge::JudgeAnalysis
+impl core::marker::Send for bitrouter_sdk::language_model::server_tools::fusion::judge::JudgeAnalysis
+impl core::marker::Sync for bitrouter_sdk::language_model::server_tools::fusion::judge::JudgeAnalysis
+impl core::marker::Unpin for bitrouter_sdk::language_model::server_tools::fusion::judge::JudgeAnalysis
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::server_tools::fusion::judge::JudgeAnalysis
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::server_tools::fusion::judge::JudgeAnalysis
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::server_tools::fusion::judge::JudgeAnalysis
+pub fn bitrouter_sdk::language_model::server_tools::fusion::judge::analysis_schema() -> serde_json::value::Value
+pub fn bitrouter_sdk::language_model::server_tools::fusion::judge::judge_system_prompt() -> &'static str
+pub struct bitrouter_sdk::language_model::server_tools::fusion::FusionToolset
+impl bitrouter_sdk::language_model::server_tools::fusion::FusionToolset
+pub fn bitrouter_sdk::language_model::server_tools::fusion::FusionToolset::new(alloc::sync::Arc<dyn bitrouter_sdk::language_model::server_tools::nested::NestedRunner>) -> Self
+impl bitrouter_sdk::language_model::server_tools::toolset::RouterToolset for bitrouter_sdk::language_model::server_tools::fusion::FusionToolset
+pub fn bitrouter_sdk::language_model::server_tools::fusion::FusionToolset::call_tool<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 str, &'life2 str, &'life3 bitrouter_sdk::language_model::server_tools::toolset::ToolContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::ToolResultOutput>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub fn bitrouter_sdk::language_model::server_tools::fusion::FusionToolset::list_tools<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::server_tools::toolset::ToolContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<alloc::vec::Vec<bitrouter_sdk::language_model::types::Tool>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::server_tools::fusion::FusionToolset::owns(&self, &str) -> bool
+pub fn bitrouter_sdk::language_model::server_tools::fusion::FusionToolset::server_name(&self) -> core::option::Option<&str>
+impl core::marker::Freeze for bitrouter_sdk::language_model::server_tools::fusion::FusionToolset
+impl core::marker::Send for bitrouter_sdk::language_model::server_tools::fusion::FusionToolset
+impl core::marker::Sync for bitrouter_sdk::language_model::server_tools::fusion::FusionToolset
+impl core::marker::Unpin for bitrouter_sdk::language_model::server_tools::fusion::FusionToolset
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::server_tools::fusion::FusionToolset
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::server_tools::fusion::FusionToolset
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::server_tools::fusion::FusionToolset
+pub mod bitrouter_sdk::language_model::server_tools::loop_controller
+pub struct bitrouter_sdk::language_model::server_tools::loop_controller::ServerToolLoop
+impl bitrouter_sdk::language_model::server_tools::loop_controller::ServerToolLoop
+pub fn bitrouter_sdk::language_model::server_tools::loop_controller::ServerToolLoop::config(&self) -> &bitrouter_sdk::language_model::server_tools::config::ServerToolLoopConfig
+pub fn bitrouter_sdk::language_model::server_tools::loop_controller::ServerToolLoop::new(bitrouter_sdk::language_model::server_tools::toolset::ToolsetRegistry, bitrouter_sdk::language_model::server_tools::config::ServerToolLoopConfig, alloc::sync::Arc<dyn bitrouter_sdk::language_model::server_tools::approval::ApprovalPolicy>) -> Self
+pub async fn bitrouter_sdk::language_model::server_tools::loop_controller::ServerToolLoop::run(&self, &bitrouter_sdk::language_model::types::Prompt, &bitrouter_sdk::language_model::server_tools::toolset::ToolContext, &dyn bitrouter_sdk::language_model::server_tools::loop_controller::UpstreamTurn) -> bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::ExecutionResult>
+impl bitrouter_sdk::language_model::server_tools::loop_controller::ServerToolLoop
+pub async fn bitrouter_sdk::language_model::server_tools::loop_controller::ServerToolLoop::run_stream(alloc::sync::Arc<Self>, &bitrouter_sdk::language_model::types::Prompt, &bitrouter_sdk::language_model::server_tools::toolset::ToolContext, alloc::sync::Arc<dyn bitrouter_sdk::language_model::server_tools::stream::UpstreamStream>) -> bitrouter_sdk::error::Result<bitrouter_sdk::language_model::executor::StreamPartStream>
+impl core::marker::Freeze for bitrouter_sdk::language_model::server_tools::loop_controller::ServerToolLoop
+impl core::marker::Send for bitrouter_sdk::language_model::server_tools::loop_controller::ServerToolLoop
+impl core::marker::Sync for bitrouter_sdk::language_model::server_tools::loop_controller::ServerToolLoop
+impl core::marker::Unpin for bitrouter_sdk::language_model::server_tools::loop_controller::ServerToolLoop
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::server_tools::loop_controller::ServerToolLoop
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::server_tools::loop_controller::ServerToolLoop
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::server_tools::loop_controller::ServerToolLoop
+pub trait bitrouter_sdk::language_model::server_tools::loop_controller::UpstreamTurn: core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::language_model::server_tools::loop_controller::UpstreamTurn::run<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::types::Prompt) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::ExecutionResult>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub mod bitrouter_sdk::language_model::server_tools::mcp_toolset
+pub struct bitrouter_sdk::language_model::server_tools::mcp_toolset::McpRouterToolset
+impl bitrouter_sdk::language_model::server_tools::mcp_toolset::McpRouterToolset
+pub fn bitrouter_sdk::language_model::server_tools::mcp_toolset::McpRouterToolset::new(alloc::sync::Arc<dyn bitrouter_sdk::mcp::Executor>, alloc::sync::Arc<dyn bitrouter_sdk::mcp::RoutingTable>, impl core::convert::Into<alloc::string::String>, core::option::Option<alloc::string::String>) -> Self
+impl bitrouter_sdk::language_model::server_tools::toolset::RouterToolset for bitrouter_sdk::language_model::server_tools::mcp_toolset::McpRouterToolset
+pub fn bitrouter_sdk::language_model::server_tools::mcp_toolset::McpRouterToolset::call_tool<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 str, &'life2 str, &'life3 bitrouter_sdk::language_model::server_tools::toolset::ToolContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::ToolResultOutput>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub fn bitrouter_sdk::language_model::server_tools::mcp_toolset::McpRouterToolset::list_tools<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::server_tools::toolset::ToolContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<alloc::vec::Vec<bitrouter_sdk::language_model::types::Tool>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::server_tools::mcp_toolset::McpRouterToolset::owns(&self, &str) -> bool
+pub fn bitrouter_sdk::language_model::server_tools::mcp_toolset::McpRouterToolset::server_name(&self) -> core::option::Option<&str>
+impl !core::marker::Freeze for bitrouter_sdk::language_model::server_tools::mcp_toolset::McpRouterToolset
+impl core::marker::Send for bitrouter_sdk::language_model::server_tools::mcp_toolset::McpRouterToolset
+impl core::marker::Sync for bitrouter_sdk::language_model::server_tools::mcp_toolset::McpRouterToolset
+impl core::marker::Unpin for bitrouter_sdk::language_model::server_tools::mcp_toolset::McpRouterToolset
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::server_tools::mcp_toolset::McpRouterToolset
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::server_tools::mcp_toolset::McpRouterToolset
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::server_tools::mcp_toolset::McpRouterToolset
+pub mod bitrouter_sdk::language_model::server_tools::nested
+pub struct bitrouter_sdk::language_model::server_tools::nested::NestedOutcome
+pub bitrouter_sdk::language_model::server_tools::nested::NestedOutcome::model: alloc::string::String
+pub bitrouter_sdk::language_model::server_tools::nested::NestedOutcome::text: alloc::string::String
+pub bitrouter_sdk::language_model::server_tools::nested::NestedOutcome::usage: bitrouter_sdk::language_model::types::Usage
+impl core::clone::Clone for bitrouter_sdk::language_model::server_tools::nested::NestedOutcome
+pub fn bitrouter_sdk::language_model::server_tools::nested::NestedOutcome::clone(&self) -> bitrouter_sdk::language_model::server_tools::nested::NestedOutcome
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::server_tools::nested::NestedOutcome
+pub fn bitrouter_sdk::language_model::server_tools::nested::NestedOutcome::eq(&self, &bitrouter_sdk::language_model::server_tools::nested::NestedOutcome) -> bool
+impl core::default::Default for bitrouter_sdk::language_model::server_tools::nested::NestedOutcome
+pub fn bitrouter_sdk::language_model::server_tools::nested::NestedOutcome::default() -> bitrouter_sdk::language_model::server_tools::nested::NestedOutcome
+impl core::fmt::Debug for bitrouter_sdk::language_model::server_tools::nested::NestedOutcome
+pub fn bitrouter_sdk::language_model::server_tools::nested::NestedOutcome::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::server_tools::nested::NestedOutcome
+impl core::marker::Freeze for bitrouter_sdk::language_model::server_tools::nested::NestedOutcome
+impl core::marker::Send for bitrouter_sdk::language_model::server_tools::nested::NestedOutcome
+impl core::marker::Sync for bitrouter_sdk::language_model::server_tools::nested::NestedOutcome
+impl core::marker::Unpin for bitrouter_sdk::language_model::server_tools::nested::NestedOutcome
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::server_tools::nested::NestedOutcome
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::server_tools::nested::NestedOutcome
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::server_tools::nested::NestedOutcome
+pub struct bitrouter_sdk::language_model::server_tools::nested::NestedRequest
+pub bitrouter_sdk::language_model::server_tools::nested::NestedRequest::model: alloc::string::String
+pub bitrouter_sdk::language_model::server_tools::nested::NestedRequest::response_format: core::option::Option<bitrouter_sdk::language_model::types::ResponseFormat>
+pub bitrouter_sdk::language_model::server_tools::nested::NestedRequest::system: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::server_tools::nested::NestedRequest::tools: alloc::vec::Vec<bitrouter_sdk::language_model::types::Tool>
+pub bitrouter_sdk::language_model::server_tools::nested::NestedRequest::user: alloc::string::String
+impl core::clone::Clone for bitrouter_sdk::language_model::server_tools::nested::NestedRequest
+pub fn bitrouter_sdk::language_model::server_tools::nested::NestedRequest::clone(&self) -> bitrouter_sdk::language_model::server_tools::nested::NestedRequest
+impl core::fmt::Debug for bitrouter_sdk::language_model::server_tools::nested::NestedRequest
+pub fn bitrouter_sdk::language_model::server_tools::nested::NestedRequest::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::language_model::server_tools::nested::NestedRequest
+impl core::marker::Send for bitrouter_sdk::language_model::server_tools::nested::NestedRequest
+impl core::marker::Sync for bitrouter_sdk::language_model::server_tools::nested::NestedRequest
+impl core::marker::Unpin for bitrouter_sdk::language_model::server_tools::nested::NestedRequest
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::server_tools::nested::NestedRequest
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::server_tools::nested::NestedRequest
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::server_tools::nested::NestedRequest
+pub struct bitrouter_sdk::language_model::server_tools::nested::PipelineNestedRunner
+impl bitrouter_sdk::language_model::server_tools::nested::PipelineNestedRunner
+pub fn bitrouter_sdk::language_model::server_tools::nested::PipelineNestedRunner::new(alloc::sync::Arc<bitrouter_sdk::language_model::pipeline::Pipeline>) -> Self
+impl bitrouter_sdk::language_model::server_tools::nested::NestedRunner for bitrouter_sdk::language_model::server_tools::nested::PipelineNestedRunner
+pub fn bitrouter_sdk::language_model::server_tools::nested::PipelineNestedRunner::run<'life0, 'life1, 'async_trait>(&'life0 self, bitrouter_sdk::language_model::server_tools::nested::NestedRequest, &'life1 bitrouter_sdk::language_model::server_tools::toolset::ToolContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<bitrouter_sdk::language_model::server_tools::nested::NestedOutcome, alloc::string::String>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+impl core::marker::Freeze for bitrouter_sdk::language_model::server_tools::nested::PipelineNestedRunner
+impl core::marker::Send for bitrouter_sdk::language_model::server_tools::nested::PipelineNestedRunner
+impl core::marker::Sync for bitrouter_sdk::language_model::server_tools::nested::PipelineNestedRunner
+impl core::marker::Unpin for bitrouter_sdk::language_model::server_tools::nested::PipelineNestedRunner
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::server_tools::nested::PipelineNestedRunner
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::server_tools::nested::PipelineNestedRunner
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::server_tools::nested::PipelineNestedRunner
+pub trait bitrouter_sdk::language_model::server_tools::nested::NestedRunner: core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::language_model::server_tools::nested::NestedRunner::run<'life0, 'life1, 'async_trait>(&'life0 self, bitrouter_sdk::language_model::server_tools::nested::NestedRequest, &'life1 bitrouter_sdk::language_model::server_tools::toolset::ToolContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<bitrouter_sdk::language_model::server_tools::nested::NestedOutcome, alloc::string::String>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+impl bitrouter_sdk::language_model::server_tools::nested::NestedRunner for bitrouter_sdk::language_model::server_tools::nested::PipelineNestedRunner
+pub fn bitrouter_sdk::language_model::server_tools::nested::PipelineNestedRunner::run<'life0, 'life1, 'async_trait>(&'life0 self, bitrouter_sdk::language_model::server_tools::nested::NestedRequest, &'life1 bitrouter_sdk::language_model::server_tools::toolset::ToolContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<bitrouter_sdk::language_model::server_tools::nested::NestedOutcome, alloc::string::String>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub mod bitrouter_sdk::language_model::server_tools::stream
+pub trait bitrouter_sdk::language_model::server_tools::stream::UpstreamStream: core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::language_model::server_tools::stream::UpstreamStream::run<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::types::Prompt) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::executor::StreamPartStream>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub mod bitrouter_sdk::language_model::server_tools::sub_agent
+pub struct bitrouter_sdk::language_model::server_tools::sub_agent::SubAgentToolset
+impl bitrouter_sdk::language_model::server_tools::sub_agent::SubAgentToolset
+pub fn bitrouter_sdk::language_model::server_tools::sub_agent::SubAgentToolset::new(alloc::sync::Arc<dyn bitrouter_sdk::language_model::server_tools::nested::NestedRunner>) -> Self
+impl bitrouter_sdk::language_model::server_tools::toolset::RouterToolset for bitrouter_sdk::language_model::server_tools::sub_agent::SubAgentToolset
+pub fn bitrouter_sdk::language_model::server_tools::sub_agent::SubAgentToolset::call_tool<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 str, &'life2 str, &'life3 bitrouter_sdk::language_model::server_tools::toolset::ToolContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::ToolResultOutput>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub fn bitrouter_sdk::language_model::server_tools::sub_agent::SubAgentToolset::list_tools<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::server_tools::toolset::ToolContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<alloc::vec::Vec<bitrouter_sdk::language_model::types::Tool>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::server_tools::sub_agent::SubAgentToolset::owns(&self, &str) -> bool
+pub fn bitrouter_sdk::language_model::server_tools::sub_agent::SubAgentToolset::server_name(&self) -> core::option::Option<&str>
+impl core::marker::Freeze for bitrouter_sdk::language_model::server_tools::sub_agent::SubAgentToolset
+impl core::marker::Send for bitrouter_sdk::language_model::server_tools::sub_agent::SubAgentToolset
+impl core::marker::Sync for bitrouter_sdk::language_model::server_tools::sub_agent::SubAgentToolset
+impl core::marker::Unpin for bitrouter_sdk::language_model::server_tools::sub_agent::SubAgentToolset
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::server_tools::sub_agent::SubAgentToolset
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::server_tools::sub_agent::SubAgentToolset
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::server_tools::sub_agent::SubAgentToolset
+pub mod bitrouter_sdk::language_model::server_tools::toolset
+pub struct bitrouter_sdk::language_model::server_tools::toolset::ToolContext
+impl bitrouter_sdk::language_model::server_tools::toolset::ToolContext
+pub fn bitrouter_sdk::language_model::server_tools::toolset::ToolContext::caller(&self) -> &bitrouter_sdk::caller::CallerContext
+pub fn bitrouter_sdk::language_model::server_tools::toolset::ToolContext::from_pipeline(&bitrouter_sdk::language_model::context::PipelineContext) -> Self
+pub fn bitrouter_sdk::language_model::server_tools::toolset::ToolContext::get_metadata(&self, &bitrouter_sdk::plugin::PluginId) -> core::option::Option<&serde_json::value::Value>
+pub fn bitrouter_sdk::language_model::server_tools::toolset::ToolContext::new(bitrouter_sdk::caller::CallerContext, std::collections::hash::map::HashMap<bitrouter_sdk::plugin::PluginId, serde_json::value::Value>) -> Self
+impl core::clone::Clone for bitrouter_sdk::language_model::server_tools::toolset::ToolContext
+pub fn bitrouter_sdk::language_model::server_tools::toolset::ToolContext::clone(&self) -> bitrouter_sdk::language_model::server_tools::toolset::ToolContext
+impl core::fmt::Debug for bitrouter_sdk::language_model::server_tools::toolset::ToolContext
+pub fn bitrouter_sdk::language_model::server_tools::toolset::ToolContext::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::language_model::server_tools::toolset::ToolContext
+impl core::marker::Send for bitrouter_sdk::language_model::server_tools::toolset::ToolContext
+impl core::marker::Sync for bitrouter_sdk::language_model::server_tools::toolset::ToolContext
+impl core::marker::Unpin for bitrouter_sdk::language_model::server_tools::toolset::ToolContext
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::server_tools::toolset::ToolContext
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::server_tools::toolset::ToolContext
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::server_tools::toolset::ToolContext
+pub struct bitrouter_sdk::language_model::server_tools::toolset::ToolsetRegistry
+impl bitrouter_sdk::language_model::server_tools::toolset::ToolsetRegistry
+pub async fn bitrouter_sdk::language_model::server_tools::toolset::ToolsetRegistry::list_all(&self, &bitrouter_sdk::language_model::server_tools::toolset::ToolContext) -> bitrouter_sdk::error::Result<(alloc::vec::Vec<bitrouter_sdk::language_model::types::Tool>, alloc::collections::btree::set::BTreeSet<alloc::string::String>)>
+pub fn bitrouter_sdk::language_model::server_tools::toolset::ToolsetRegistry::new(alloc::vec::Vec<alloc::sync::Arc<dyn bitrouter_sdk::language_model::server_tools::toolset::RouterToolset>>) -> Self
+pub fn bitrouter_sdk::language_model::server_tools::toolset::ToolsetRegistry::resolve(&self, &str) -> core::option::Option<&alloc::sync::Arc<dyn bitrouter_sdk::language_model::server_tools::toolset::RouterToolset>>
+impl core::marker::Freeze for bitrouter_sdk::language_model::server_tools::toolset::ToolsetRegistry
+impl core::marker::Send for bitrouter_sdk::language_model::server_tools::toolset::ToolsetRegistry
+impl core::marker::Sync for bitrouter_sdk::language_model::server_tools::toolset::ToolsetRegistry
+impl core::marker::Unpin for bitrouter_sdk::language_model::server_tools::toolset::ToolsetRegistry
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::server_tools::toolset::ToolsetRegistry
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::server_tools::toolset::ToolsetRegistry
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::server_tools::toolset::ToolsetRegistry
+pub trait bitrouter_sdk::language_model::server_tools::toolset::RouterToolset: core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::language_model::server_tools::toolset::RouterToolset::call_tool<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 str, &'life2 str, &'life3 bitrouter_sdk::language_model::server_tools::toolset::ToolContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::ToolResultOutput>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub fn bitrouter_sdk::language_model::server_tools::toolset::RouterToolset::list_tools<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::server_tools::toolset::ToolContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<alloc::vec::Vec<bitrouter_sdk::language_model::types::Tool>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::server_tools::toolset::RouterToolset::owns(&self, &str) -> bool
+pub fn bitrouter_sdk::language_model::server_tools::toolset::RouterToolset::server_name(&self) -> core::option::Option<&str>
+impl bitrouter_sdk::language_model::server_tools::toolset::RouterToolset for bitrouter_sdk::language_model::server_tools::advisor::AdvisorToolset
+pub fn bitrouter_sdk::language_model::server_tools::advisor::AdvisorToolset::call_tool<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 str, &'life2 str, &'life3 bitrouter_sdk::language_model::server_tools::toolset::ToolContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::ToolResultOutput>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub fn bitrouter_sdk::language_model::server_tools::advisor::AdvisorToolset::list_tools<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::server_tools::toolset::ToolContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<alloc::vec::Vec<bitrouter_sdk::language_model::types::Tool>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::server_tools::advisor::AdvisorToolset::owns(&self, &str) -> bool
+pub fn bitrouter_sdk::language_model::server_tools::advisor::AdvisorToolset::server_name(&self) -> core::option::Option<&str>
+impl bitrouter_sdk::language_model::server_tools::toolset::RouterToolset for bitrouter_sdk::language_model::server_tools::fusion::FusionToolset
+pub fn bitrouter_sdk::language_model::server_tools::fusion::FusionToolset::call_tool<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 str, &'life2 str, &'life3 bitrouter_sdk::language_model::server_tools::toolset::ToolContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::ToolResultOutput>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub fn bitrouter_sdk::language_model::server_tools::fusion::FusionToolset::list_tools<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::server_tools::toolset::ToolContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<alloc::vec::Vec<bitrouter_sdk::language_model::types::Tool>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::server_tools::fusion::FusionToolset::owns(&self, &str) -> bool
+pub fn bitrouter_sdk::language_model::server_tools::fusion::FusionToolset::server_name(&self) -> core::option::Option<&str>
+impl bitrouter_sdk::language_model::server_tools::toolset::RouterToolset for bitrouter_sdk::language_model::server_tools::mcp_toolset::McpRouterToolset
+pub fn bitrouter_sdk::language_model::server_tools::mcp_toolset::McpRouterToolset::call_tool<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 str, &'life2 str, &'life3 bitrouter_sdk::language_model::server_tools::toolset::ToolContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::ToolResultOutput>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub fn bitrouter_sdk::language_model::server_tools::mcp_toolset::McpRouterToolset::list_tools<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::server_tools::toolset::ToolContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<alloc::vec::Vec<bitrouter_sdk::language_model::types::Tool>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::server_tools::mcp_toolset::McpRouterToolset::owns(&self, &str) -> bool
+pub fn bitrouter_sdk::language_model::server_tools::mcp_toolset::McpRouterToolset::server_name(&self) -> core::option::Option<&str>
+impl bitrouter_sdk::language_model::server_tools::toolset::RouterToolset for bitrouter_sdk::language_model::server_tools::sub_agent::SubAgentToolset
+pub fn bitrouter_sdk::language_model::server_tools::sub_agent::SubAgentToolset::call_tool<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 str, &'life2 str, &'life3 bitrouter_sdk::language_model::server_tools::toolset::ToolContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::ToolResultOutput>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub fn bitrouter_sdk::language_model::server_tools::sub_agent::SubAgentToolset::list_tools<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::server_tools::toolset::ToolContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<alloc::vec::Vec<bitrouter_sdk::language_model::types::Tool>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::server_tools::sub_agent::SubAgentToolset::owns(&self, &str) -> bool
+pub fn bitrouter_sdk::language_model::server_tools::sub_agent::SubAgentToolset::server_name(&self) -> core::option::Option<&str>
+impl bitrouter_sdk::language_model::server_tools::toolset::RouterToolset for bitrouter_sdk::language_model::server_tools::web_fetch::toolset::WebFetchToolset
+pub fn bitrouter_sdk::language_model::server_tools::web_fetch::toolset::WebFetchToolset::call_tool<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 str, &'life2 str, &'life3 bitrouter_sdk::language_model::server_tools::toolset::ToolContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::ToolResultOutput>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub fn bitrouter_sdk::language_model::server_tools::web_fetch::toolset::WebFetchToolset::list_tools<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::server_tools::toolset::ToolContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<alloc::vec::Vec<bitrouter_sdk::language_model::types::Tool>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::server_tools::web_fetch::toolset::WebFetchToolset::owns(&self, &str) -> bool
+pub fn bitrouter_sdk::language_model::server_tools::web_fetch::toolset::WebFetchToolset::server_name(&self) -> core::option::Option<&str>
+impl bitrouter_sdk::language_model::server_tools::toolset::RouterToolset for bitrouter_sdk::language_model::server_tools::web_search::toolset::WebSearchToolset
+pub fn bitrouter_sdk::language_model::server_tools::web_search::toolset::WebSearchToolset::call_tool<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 str, &'life2 str, &'life3 bitrouter_sdk::language_model::server_tools::toolset::ToolContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::ToolResultOutput>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub fn bitrouter_sdk::language_model::server_tools::web_search::toolset::WebSearchToolset::list_tools<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::server_tools::toolset::ToolContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<alloc::vec::Vec<bitrouter_sdk::language_model::types::Tool>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::server_tools::web_search::toolset::WebSearchToolset::owns(&self, &str) -> bool
+pub fn bitrouter_sdk::language_model::server_tools::web_search::toolset::WebSearchToolset::server_name(&self) -> core::option::Option<&str>
+pub mod bitrouter_sdk::language_model::server_tools::web_fetch
+pub mod bitrouter_sdk::language_model::server_tools::web_fetch::backend
+pub struct bitrouter_sdk::language_model::server_tools::web_fetch::backend::FetchOptions
+pub bitrouter_sdk::language_model::server_tools::web_fetch::backend::FetchOptions::max_content_tokens: u32
+impl core::clone::Clone for bitrouter_sdk::language_model::server_tools::web_fetch::backend::FetchOptions
+pub fn bitrouter_sdk::language_model::server_tools::web_fetch::backend::FetchOptions::clone(&self) -> bitrouter_sdk::language_model::server_tools::web_fetch::backend::FetchOptions
+impl core::fmt::Debug for bitrouter_sdk::language_model::server_tools::web_fetch::backend::FetchOptions
+pub fn bitrouter_sdk::language_model::server_tools::web_fetch::backend::FetchOptions::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::language_model::server_tools::web_fetch::backend::FetchOptions
+impl core::marker::Send for bitrouter_sdk::language_model::server_tools::web_fetch::backend::FetchOptions
+impl core::marker::Sync for bitrouter_sdk::language_model::server_tools::web_fetch::backend::FetchOptions
+impl core::marker::Unpin for bitrouter_sdk::language_model::server_tools::web_fetch::backend::FetchOptions
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::server_tools::web_fetch::backend::FetchOptions
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::server_tools::web_fetch::backend::FetchOptions
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::server_tools::web_fetch::backend::FetchOptions
+pub struct bitrouter_sdk::language_model::server_tools::web_fetch::backend::WebFetchResult
+pub bitrouter_sdk::language_model::server_tools::web_fetch::backend::WebFetchResult::backend: alloc::string::String
+pub bitrouter_sdk::language_model::server_tools::web_fetch::backend::WebFetchResult::content: alloc::string::String
+pub bitrouter_sdk::language_model::server_tools::web_fetch::backend::WebFetchResult::published: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::server_tools::web_fetch::backend::WebFetchResult::title: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::server_tools::web_fetch::backend::WebFetchResult::url: alloc::string::String
+impl core::clone::Clone for bitrouter_sdk::language_model::server_tools::web_fetch::backend::WebFetchResult
+pub fn bitrouter_sdk::language_model::server_tools::web_fetch::backend::WebFetchResult::clone(&self) -> bitrouter_sdk::language_model::server_tools::web_fetch::backend::WebFetchResult
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::server_tools::web_fetch::backend::WebFetchResult
+pub fn bitrouter_sdk::language_model::server_tools::web_fetch::backend::WebFetchResult::eq(&self, &bitrouter_sdk::language_model::server_tools::web_fetch::backend::WebFetchResult) -> bool
+impl core::default::Default for bitrouter_sdk::language_model::server_tools::web_fetch::backend::WebFetchResult
+pub fn bitrouter_sdk::language_model::server_tools::web_fetch::backend::WebFetchResult::default() -> bitrouter_sdk::language_model::server_tools::web_fetch::backend::WebFetchResult
+impl core::fmt::Debug for bitrouter_sdk::language_model::server_tools::web_fetch::backend::WebFetchResult
+pub fn bitrouter_sdk::language_model::server_tools::web_fetch::backend::WebFetchResult::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::server_tools::web_fetch::backend::WebFetchResult
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::server_tools::web_fetch::backend::WebFetchResult
+pub fn bitrouter_sdk::language_model::server_tools::web_fetch::backend::WebFetchResult::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl core::marker::Freeze for bitrouter_sdk::language_model::server_tools::web_fetch::backend::WebFetchResult
+impl core::marker::Send for bitrouter_sdk::language_model::server_tools::web_fetch::backend::WebFetchResult
+impl core::marker::Sync for bitrouter_sdk::language_model::server_tools::web_fetch::backend::WebFetchResult
+impl core::marker::Unpin for bitrouter_sdk::language_model::server_tools::web_fetch::backend::WebFetchResult
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::server_tools::web_fetch::backend::WebFetchResult
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::server_tools::web_fetch::backend::WebFetchResult
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::server_tools::web_fetch::backend::WebFetchResult
+pub const bitrouter_sdk::language_model::server_tools::web_fetch::backend::CHARS_PER_TOKEN: u64
+pub trait bitrouter_sdk::language_model::server_tools::web_fetch::backend::WebFetchBackend: core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::language_model::server_tools::web_fetch::backend::WebFetchBackend::fetch<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 str, &'life2 bitrouter_sdk::language_model::server_tools::web_fetch::backend::FetchOptions, &'life3 bitrouter_sdk::language_model::server_tools::toolset::ToolContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<bitrouter_sdk::language_model::server_tools::web_fetch::backend::WebFetchResult, alloc::string::String>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub fn bitrouter_sdk::language_model::server_tools::web_fetch::backend::WebFetchBackend::name(&self) -> &str
+impl bitrouter_sdk::language_model::server_tools::web_fetch::backend::WebFetchBackend for bitrouter_sdk::language_model::server_tools::web_fetch::http::HttpFetchBackend
+pub fn bitrouter_sdk::language_model::server_tools::web_fetch::http::HttpFetchBackend::fetch<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 str, &'life2 bitrouter_sdk::language_model::server_tools::web_fetch::backend::FetchOptions, &'life3 bitrouter_sdk::language_model::server_tools::toolset::ToolContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<bitrouter_sdk::language_model::server_tools::web_fetch::backend::WebFetchResult, alloc::string::String>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub fn bitrouter_sdk::language_model::server_tools::web_fetch::http::HttpFetchBackend::name(&self) -> &str
+pub mod bitrouter_sdk::language_model::server_tools::web_fetch::config
+pub enum bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchBackendConfig
+pub bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchBackendConfig::Exa
+pub bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchBackendConfig::Exa::api_base: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchBackendConfig::Exa::api_key: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchBackendConfig::Firecrawl
+pub bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchBackendConfig::Firecrawl::api_base: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchBackendConfig::Firecrawl::api_key: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchBackendConfig::Tavily
+pub bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchBackendConfig::Tavily::api_base: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchBackendConfig::Tavily::api_key: core::option::Option<alloc::string::String>
+impl core::clone::Clone for bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchBackendConfig
+pub fn bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchBackendConfig::clone(&self) -> bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchBackendConfig
+impl core::fmt::Debug for bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchBackendConfig
+pub fn bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchBackendConfig::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchBackendConfig
+pub fn bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchBackendConfig::inline_schema() -> bool
+pub fn bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchBackendConfig::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchBackendConfig::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchBackendConfig::schema_name() -> alloc::borrow::Cow<'static, str>
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchBackendConfig
+pub fn bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchBackendConfig::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchBackendConfig
+impl core::marker::Send for bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchBackendConfig
+impl core::marker::Sync for bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchBackendConfig
+impl core::marker::Unpin for bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchBackendConfig
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchBackendConfig
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchBackendConfig
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchBackendConfig
+pub struct bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchSettings
+pub bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchSettings::backends: alloc::vec::Vec<bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchBackendConfig>
+pub bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchSettings::max_content_tokens: core::option::Option<u32>
+impl core::clone::Clone for bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchSettings
+pub fn bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchSettings::clone(&self) -> bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchSettings
+impl core::default::Default for bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchSettings
+pub fn bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchSettings::default() -> bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchSettings
+impl core::fmt::Debug for bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchSettings
+pub fn bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchSettings::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchSettings
+pub fn bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchSettings::inline_schema() -> bool
+pub fn bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchSettings::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchSettings::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchSettings::schema_name() -> alloc::borrow::Cow<'static, str>
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchSettings where bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchSettings: core::default::Default
+pub fn bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchSettings::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchSettings
+impl core::marker::Send for bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchSettings
+impl core::marker::Sync for bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchSettings
+impl core::marker::Unpin for bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchSettings
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchSettings
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchSettings
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::server_tools::web_fetch::config::WebFetchSettings
+pub const bitrouter_sdk::language_model::server_tools::web_fetch::config::DEFAULT_MAX_CONTENT_TOKENS: u32
+pub mod bitrouter_sdk::language_model::server_tools::web_fetch::http
+pub enum bitrouter_sdk::language_model::server_tools::web_fetch::http::HttpFetchEngine
+pub bitrouter_sdk::language_model::server_tools::web_fetch::http::HttpFetchEngine::Exa
+pub bitrouter_sdk::language_model::server_tools::web_fetch::http::HttpFetchEngine::Firecrawl
+pub bitrouter_sdk::language_model::server_tools::web_fetch::http::HttpFetchEngine::Tavily
+impl bitrouter_sdk::language_model::server_tools::web_fetch::http::HttpFetchEngine
+pub fn bitrouter_sdk::language_model::server_tools::web_fetch::http::HttpFetchEngine::env_var(self) -> &'static str
+pub fn bitrouter_sdk::language_model::server_tools::web_fetch::http::HttpFetchEngine::name(self) -> &'static str
+impl core::clone::Clone for bitrouter_sdk::language_model::server_tools::web_fetch::http::HttpFetchEngine
+pub fn bitrouter_sdk::language_model::server_tools::web_fetch::http::HttpFetchEngine::clone(&self) -> bitrouter_sdk::language_model::server_tools::web_fetch::http::HttpFetchEngine
+impl core::cmp::Eq for bitrouter_sdk::language_model::server_tools::web_fetch::http::HttpFetchEngine
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::server_tools::web_fetch::http::HttpFetchEngine
+pub fn bitrouter_sdk::language_model::server_tools::web_fetch::http::HttpFetchEngine::eq(&self, &bitrouter_sdk::language_model::server_tools::web_fetch::http::HttpFetchEngine) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::server_tools::web_fetch::http::HttpFetchEngine
+pub fn bitrouter_sdk::language_model::server_tools::web_fetch::http::HttpFetchEngine::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for bitrouter_sdk::language_model::server_tools::web_fetch::http::HttpFetchEngine
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::server_tools::web_fetch::http::HttpFetchEngine
+impl core::marker::Freeze for bitrouter_sdk::language_model::server_tools::web_fetch::http::HttpFetchEngine
+impl core::marker::Send for bitrouter_sdk::language_model::server_tools::web_fetch::http::HttpFetchEngine
+impl core::marker::Sync for bitrouter_sdk::language_model::server_tools::web_fetch::http::HttpFetchEngine
+impl core::marker::Unpin for bitrouter_sdk::language_model::server_tools::web_fetch::http::HttpFetchEngine
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::server_tools::web_fetch::http::HttpFetchEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::server_tools::web_fetch::http::HttpFetchEngine
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::server_tools::web_fetch::http::HttpFetchEngine
+pub struct bitrouter_sdk::language_model::server_tools::web_fetch::http::HttpFetchBackend
+impl bitrouter_sdk::language_model::server_tools::web_fetch::http::HttpFetchBackend
+pub fn bitrouter_sdk::language_model::server_tools::web_fetch::http::HttpFetchBackend::new(bitrouter_sdk::language_model::server_tools::web_fetch::http::HttpFetchEngine, alloc::string::String, core::option::Option<alloc::string::String>, reqwest::async_impl::client::Client) -> Self
+impl bitrouter_sdk::language_model::server_tools::web_fetch::backend::WebFetchBackend for bitrouter_sdk::language_model::server_tools::web_fetch::http::HttpFetchBackend
+pub fn bitrouter_sdk::language_model::server_tools::web_fetch::http::HttpFetchBackend::fetch<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 str, &'life2 bitrouter_sdk::language_model::server_tools::web_fetch::backend::FetchOptions, &'life3 bitrouter_sdk::language_model::server_tools::toolset::ToolContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<bitrouter_sdk::language_model::server_tools::web_fetch::backend::WebFetchResult, alloc::string::String>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub fn bitrouter_sdk::language_model::server_tools::web_fetch::http::HttpFetchBackend::name(&self) -> &str
+impl core::marker::Freeze for bitrouter_sdk::language_model::server_tools::web_fetch::http::HttpFetchBackend
+impl core::marker::Send for bitrouter_sdk::language_model::server_tools::web_fetch::http::HttpFetchBackend
+impl core::marker::Sync for bitrouter_sdk::language_model::server_tools::web_fetch::http::HttpFetchBackend
+impl core::marker::Unpin for bitrouter_sdk::language_model::server_tools::web_fetch::http::HttpFetchBackend
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::server_tools::web_fetch::http::HttpFetchBackend
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::server_tools::web_fetch::http::HttpFetchBackend
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::server_tools::web_fetch::http::HttpFetchBackend
+pub mod bitrouter_sdk::language_model::server_tools::web_fetch::toolset
+pub struct bitrouter_sdk::language_model::server_tools::web_fetch::toolset::WebFetchToolset
+impl bitrouter_sdk::language_model::server_tools::web_fetch::toolset::WebFetchToolset
+pub fn bitrouter_sdk::language_model::server_tools::web_fetch::toolset::WebFetchToolset::new(alloc::vec::Vec<alloc::sync::Arc<dyn bitrouter_sdk::language_model::server_tools::web_fetch::backend::WebFetchBackend>>, u32) -> Self
+impl bitrouter_sdk::language_model::server_tools::toolset::RouterToolset for bitrouter_sdk::language_model::server_tools::web_fetch::toolset::WebFetchToolset
+pub fn bitrouter_sdk::language_model::server_tools::web_fetch::toolset::WebFetchToolset::call_tool<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 str, &'life2 str, &'life3 bitrouter_sdk::language_model::server_tools::toolset::ToolContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::ToolResultOutput>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub fn bitrouter_sdk::language_model::server_tools::web_fetch::toolset::WebFetchToolset::list_tools<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::server_tools::toolset::ToolContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<alloc::vec::Vec<bitrouter_sdk::language_model::types::Tool>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::server_tools::web_fetch::toolset::WebFetchToolset::owns(&self, &str) -> bool
+pub fn bitrouter_sdk::language_model::server_tools::web_fetch::toolset::WebFetchToolset::server_name(&self) -> core::option::Option<&str>
+impl core::marker::Freeze for bitrouter_sdk::language_model::server_tools::web_fetch::toolset::WebFetchToolset
+impl core::marker::Send for bitrouter_sdk::language_model::server_tools::web_fetch::toolset::WebFetchToolset
+impl core::marker::Sync for bitrouter_sdk::language_model::server_tools::web_fetch::toolset::WebFetchToolset
+impl core::marker::Unpin for bitrouter_sdk::language_model::server_tools::web_fetch::toolset::WebFetchToolset
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::server_tools::web_fetch::toolset::WebFetchToolset
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::server_tools::web_fetch::toolset::WebFetchToolset
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::server_tools::web_fetch::toolset::WebFetchToolset
+pub mod bitrouter_sdk::language_model::server_tools::web_search
+pub mod bitrouter_sdk::language_model::server_tools::web_search::backend
+pub struct bitrouter_sdk::language_model::server_tools::web_search::backend::SearchOptions
+pub bitrouter_sdk::language_model::server_tools::web_search::backend::SearchOptions::max_results: u32
+impl core::clone::Clone for bitrouter_sdk::language_model::server_tools::web_search::backend::SearchOptions
+pub fn bitrouter_sdk::language_model::server_tools::web_search::backend::SearchOptions::clone(&self) -> bitrouter_sdk::language_model::server_tools::web_search::backend::SearchOptions
+impl core::fmt::Debug for bitrouter_sdk::language_model::server_tools::web_search::backend::SearchOptions
+pub fn bitrouter_sdk::language_model::server_tools::web_search::backend::SearchOptions::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::language_model::server_tools::web_search::backend::SearchOptions
+impl core::marker::Send for bitrouter_sdk::language_model::server_tools::web_search::backend::SearchOptions
+impl core::marker::Sync for bitrouter_sdk::language_model::server_tools::web_search::backend::SearchOptions
+impl core::marker::Unpin for bitrouter_sdk::language_model::server_tools::web_search::backend::SearchOptions
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::server_tools::web_search::backend::SearchOptions
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::server_tools::web_search::backend::SearchOptions
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::server_tools::web_search::backend::SearchOptions
+pub struct bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResult
+pub bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResult::content: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResult::published: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResult::score: core::option::Option<f64>
+pub bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResult::snippet: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResult::title: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResult::url: alloc::string::String
+impl core::clone::Clone for bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResult
+pub fn bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResult::clone(&self) -> bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResult
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResult
+pub fn bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResult::eq(&self, &bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResult) -> bool
+impl core::default::Default for bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResult
+pub fn bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResult::default() -> bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResult
+impl core::fmt::Debug for bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResult
+pub fn bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResult::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResult
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResult
+pub fn bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResult::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl core::marker::Freeze for bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResult
+impl core::marker::Send for bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResult
+impl core::marker::Sync for bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResult
+impl core::marker::Unpin for bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResult
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResult
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResult
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResult
+pub struct bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResults
+pub bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResults::answer: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResults::backend: alloc::string::String
+pub bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResults::results: alloc::vec::Vec<bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResult>
+impl core::clone::Clone for bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResults
+pub fn bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResults::clone(&self) -> bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResults
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResults
+pub fn bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResults::eq(&self, &bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResults) -> bool
+impl core::default::Default for bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResults
+pub fn bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResults::default() -> bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResults
+impl core::fmt::Debug for bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResults
+pub fn bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResults::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResults
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResults
+pub fn bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResults::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl core::marker::Freeze for bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResults
+impl core::marker::Send for bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResults
+impl core::marker::Sync for bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResults
+impl core::marker::Unpin for bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResults
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResults
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResults
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResults
+pub trait bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchBackend: core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchBackend::name(&self) -> &str
+pub fn bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchBackend::search<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 str, &'life2 bitrouter_sdk::language_model::server_tools::web_search::backend::SearchOptions, &'life3 bitrouter_sdk::language_model::server_tools::toolset::ToolContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResults, alloc::string::String>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+impl bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchBackend for bitrouter_sdk::language_model::server_tools::web_search::http::HttpSearchBackend
+pub fn bitrouter_sdk::language_model::server_tools::web_search::http::HttpSearchBackend::name(&self) -> &str
+pub fn bitrouter_sdk::language_model::server_tools::web_search::http::HttpSearchBackend::search<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 str, &'life2 bitrouter_sdk::language_model::server_tools::web_search::backend::SearchOptions, &'life3 bitrouter_sdk::language_model::server_tools::toolset::ToolContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResults, alloc::string::String>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+impl bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchBackend for bitrouter_sdk::language_model::server_tools::web_search::nested::NestedSearchBackend
+pub fn bitrouter_sdk::language_model::server_tools::web_search::nested::NestedSearchBackend::name(&self) -> &str
+pub fn bitrouter_sdk::language_model::server_tools::web_search::nested::NestedSearchBackend::search<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 str, &'life2 bitrouter_sdk::language_model::server_tools::web_search::backend::SearchOptions, &'life3 bitrouter_sdk::language_model::server_tools::toolset::ToolContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResults, alloc::string::String>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub mod bitrouter_sdk::language_model::server_tools::web_search::config
+pub enum bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchBackendConfig
+pub bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchBackendConfig::Exa
+pub bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchBackendConfig::Exa::api_base: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchBackendConfig::Exa::api_key: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchBackendConfig::Firecrawl
+pub bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchBackendConfig::Firecrawl::api_base: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchBackendConfig::Firecrawl::api_key: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchBackendConfig::Native
+pub bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchBackendConfig::Native::model: alloc::string::String
+pub bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchBackendConfig::Native::name: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchBackendConfig::Native::tool: serde_json::value::Value
+pub bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchBackendConfig::Parallel
+pub bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchBackendConfig::Parallel::api_base: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchBackendConfig::Parallel::api_key: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchBackendConfig::Tavily
+pub bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchBackendConfig::Tavily::api_base: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchBackendConfig::Tavily::api_key: core::option::Option<alloc::string::String>
+impl core::clone::Clone for bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchBackendConfig
+pub fn bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchBackendConfig::clone(&self) -> bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchBackendConfig
+impl core::fmt::Debug for bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchBackendConfig
+pub fn bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchBackendConfig::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchBackendConfig
+pub fn bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchBackendConfig::inline_schema() -> bool
+pub fn bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchBackendConfig::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchBackendConfig::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchBackendConfig::schema_name() -> alloc::borrow::Cow<'static, str>
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchBackendConfig
+pub fn bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchBackendConfig::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchBackendConfig
+impl core::marker::Send for bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchBackendConfig
+impl core::marker::Sync for bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchBackendConfig
+impl core::marker::Unpin for bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchBackendConfig
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchBackendConfig
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchBackendConfig
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchBackendConfig
+pub struct bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchSettings
+pub bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchSettings::backends: alloc::vec::Vec<bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchBackendConfig>
+pub bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchSettings::max_results: core::option::Option<u32>
+impl core::clone::Clone for bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchSettings
+pub fn bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchSettings::clone(&self) -> bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchSettings
+impl core::default::Default for bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchSettings
+pub fn bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchSettings::default() -> bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchSettings
+impl core::fmt::Debug for bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchSettings
+pub fn bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchSettings::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchSettings
+pub fn bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchSettings::inline_schema() -> bool
+pub fn bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchSettings::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchSettings::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchSettings::schema_name() -> alloc::borrow::Cow<'static, str>
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchSettings where bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchSettings: core::default::Default
+pub fn bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchSettings::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchSettings
+impl core::marker::Send for bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchSettings
+impl core::marker::Sync for bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchSettings
+impl core::marker::Unpin for bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchSettings
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchSettings
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchSettings
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::server_tools::web_search::config::WebSearchSettings
+pub const bitrouter_sdk::language_model::server_tools::web_search::config::DEFAULT_MAX_RESULTS: u32
+pub mod bitrouter_sdk::language_model::server_tools::web_search::http
+pub enum bitrouter_sdk::language_model::server_tools::web_search::http::HttpEngine
+pub bitrouter_sdk::language_model::server_tools::web_search::http::HttpEngine::Exa
+pub bitrouter_sdk::language_model::server_tools::web_search::http::HttpEngine::Firecrawl
+pub bitrouter_sdk::language_model::server_tools::web_search::http::HttpEngine::Parallel
+pub bitrouter_sdk::language_model::server_tools::web_search::http::HttpEngine::Tavily
+impl bitrouter_sdk::language_model::server_tools::web_search::http::HttpEngine
+pub fn bitrouter_sdk::language_model::server_tools::web_search::http::HttpEngine::env_var(self) -> &'static str
+pub fn bitrouter_sdk::language_model::server_tools::web_search::http::HttpEngine::name(self) -> &'static str
+impl core::clone::Clone for bitrouter_sdk::language_model::server_tools::web_search::http::HttpEngine
+pub fn bitrouter_sdk::language_model::server_tools::web_search::http::HttpEngine::clone(&self) -> bitrouter_sdk::language_model::server_tools::web_search::http::HttpEngine
+impl core::cmp::Eq for bitrouter_sdk::language_model::server_tools::web_search::http::HttpEngine
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::server_tools::web_search::http::HttpEngine
+pub fn bitrouter_sdk::language_model::server_tools::web_search::http::HttpEngine::eq(&self, &bitrouter_sdk::language_model::server_tools::web_search::http::HttpEngine) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::server_tools::web_search::http::HttpEngine
+pub fn bitrouter_sdk::language_model::server_tools::web_search::http::HttpEngine::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for bitrouter_sdk::language_model::server_tools::web_search::http::HttpEngine
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::server_tools::web_search::http::HttpEngine
+impl core::marker::Freeze for bitrouter_sdk::language_model::server_tools::web_search::http::HttpEngine
+impl core::marker::Send for bitrouter_sdk::language_model::server_tools::web_search::http::HttpEngine
+impl core::marker::Sync for bitrouter_sdk::language_model::server_tools::web_search::http::HttpEngine
+impl core::marker::Unpin for bitrouter_sdk::language_model::server_tools::web_search::http::HttpEngine
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::server_tools::web_search::http::HttpEngine
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::server_tools::web_search::http::HttpEngine
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::server_tools::web_search::http::HttpEngine
+pub struct bitrouter_sdk::language_model::server_tools::web_search::http::HttpSearchBackend
+impl bitrouter_sdk::language_model::server_tools::web_search::http::HttpSearchBackend
+pub fn bitrouter_sdk::language_model::server_tools::web_search::http::HttpSearchBackend::new(bitrouter_sdk::language_model::server_tools::web_search::http::HttpEngine, alloc::string::String, core::option::Option<alloc::string::String>, reqwest::async_impl::client::Client) -> Self
+impl bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchBackend for bitrouter_sdk::language_model::server_tools::web_search::http::HttpSearchBackend
+pub fn bitrouter_sdk::language_model::server_tools::web_search::http::HttpSearchBackend::name(&self) -> &str
+pub fn bitrouter_sdk::language_model::server_tools::web_search::http::HttpSearchBackend::search<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 str, &'life2 bitrouter_sdk::language_model::server_tools::web_search::backend::SearchOptions, &'life3 bitrouter_sdk::language_model::server_tools::toolset::ToolContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResults, alloc::string::String>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+impl core::marker::Freeze for bitrouter_sdk::language_model::server_tools::web_search::http::HttpSearchBackend
+impl core::marker::Send for bitrouter_sdk::language_model::server_tools::web_search::http::HttpSearchBackend
+impl core::marker::Sync for bitrouter_sdk::language_model::server_tools::web_search::http::HttpSearchBackend
+impl core::marker::Unpin for bitrouter_sdk::language_model::server_tools::web_search::http::HttpSearchBackend
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::server_tools::web_search::http::HttpSearchBackend
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::server_tools::web_search::http::HttpSearchBackend
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::server_tools::web_search::http::HttpSearchBackend
+pub mod bitrouter_sdk::language_model::server_tools::web_search::nested
+pub struct bitrouter_sdk::language_model::server_tools::web_search::nested::NestedSearchBackend
+impl bitrouter_sdk::language_model::server_tools::web_search::nested::NestedSearchBackend
+pub fn bitrouter_sdk::language_model::server_tools::web_search::nested::NestedSearchBackend::new(alloc::string::String, alloc::sync::Arc<dyn bitrouter_sdk::language_model::server_tools::nested::NestedRunner>, alloc::string::String, alloc::vec::Vec<bitrouter_sdk::language_model::types::Tool>) -> Self
+impl bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchBackend for bitrouter_sdk::language_model::server_tools::web_search::nested::NestedSearchBackend
+pub fn bitrouter_sdk::language_model::server_tools::web_search::nested::NestedSearchBackend::name(&self) -> &str
+pub fn bitrouter_sdk::language_model::server_tools::web_search::nested::NestedSearchBackend::search<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 str, &'life2 bitrouter_sdk::language_model::server_tools::web_search::backend::SearchOptions, &'life3 bitrouter_sdk::language_model::server_tools::toolset::ToolContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::result::Result<bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchResults, alloc::string::String>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+impl core::marker::Freeze for bitrouter_sdk::language_model::server_tools::web_search::nested::NestedSearchBackend
+impl core::marker::Send for bitrouter_sdk::language_model::server_tools::web_search::nested::NestedSearchBackend
+impl core::marker::Sync for bitrouter_sdk::language_model::server_tools::web_search::nested::NestedSearchBackend
+impl core::marker::Unpin for bitrouter_sdk::language_model::server_tools::web_search::nested::NestedSearchBackend
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::server_tools::web_search::nested::NestedSearchBackend
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::server_tools::web_search::nested::NestedSearchBackend
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::server_tools::web_search::nested::NestedSearchBackend
+pub mod bitrouter_sdk::language_model::server_tools::web_search::toolset
+pub struct bitrouter_sdk::language_model::server_tools::web_search::toolset::WebSearchToolset
+impl bitrouter_sdk::language_model::server_tools::web_search::toolset::WebSearchToolset
+pub fn bitrouter_sdk::language_model::server_tools::web_search::toolset::WebSearchToolset::new(alloc::vec::Vec<alloc::sync::Arc<dyn bitrouter_sdk::language_model::server_tools::web_search::backend::WebSearchBackend>>, u32) -> Self
+impl bitrouter_sdk::language_model::server_tools::toolset::RouterToolset for bitrouter_sdk::language_model::server_tools::web_search::toolset::WebSearchToolset
+pub fn bitrouter_sdk::language_model::server_tools::web_search::toolset::WebSearchToolset::call_tool<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 str, &'life2 str, &'life3 bitrouter_sdk::language_model::server_tools::toolset::ToolContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::ToolResultOutput>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub fn bitrouter_sdk::language_model::server_tools::web_search::toolset::WebSearchToolset::list_tools<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::server_tools::toolset::ToolContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<alloc::vec::Vec<bitrouter_sdk::language_model::types::Tool>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::server_tools::web_search::toolset::WebSearchToolset::owns(&self, &str) -> bool
+pub fn bitrouter_sdk::language_model::server_tools::web_search::toolset::WebSearchToolset::server_name(&self) -> core::option::Option<&str>
+impl core::marker::Freeze for bitrouter_sdk::language_model::server_tools::web_search::toolset::WebSearchToolset
+impl core::marker::Send for bitrouter_sdk::language_model::server_tools::web_search::toolset::WebSearchToolset
+impl core::marker::Sync for bitrouter_sdk::language_model::server_tools::web_search::toolset::WebSearchToolset
+impl core::marker::Unpin for bitrouter_sdk::language_model::server_tools::web_search::toolset::WebSearchToolset
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::server_tools::web_search::toolset::WebSearchToolset
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::server_tools::web_search::toolset::WebSearchToolset
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::server_tools::web_search::toolset::WebSearchToolset
+pub mod bitrouter_sdk::language_model::settlement
+pub enum bitrouter_sdk::language_model::settlement::DeliveryAcknowledgement
+pub bitrouter_sdk::language_model::settlement::DeliveryAcknowledgement::Delivered
+pub bitrouter_sdk::language_model::settlement::DeliveryAcknowledgement::Failed(bitrouter_sdk::error::BitrouterError)
+impl core::fmt::Debug for bitrouter_sdk::language_model::settlement::DeliveryAcknowledgement
+pub fn bitrouter_sdk::language_model::settlement::DeliveryAcknowledgement::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::language_model::settlement::DeliveryAcknowledgement
+impl core::marker::Send for bitrouter_sdk::language_model::settlement::DeliveryAcknowledgement
+impl core::marker::Sync for bitrouter_sdk::language_model::settlement::DeliveryAcknowledgement
+impl core::marker::Unpin for bitrouter_sdk::language_model::settlement::DeliveryAcknowledgement
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::settlement::DeliveryAcknowledgement
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::settlement::DeliveryAcknowledgement
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::settlement::DeliveryAcknowledgement
+pub struct bitrouter_sdk::language_model::settlement::RequiredDeliveryHandshake
+impl bitrouter_sdk::language_model::settlement::RequiredDeliveryHandshake
+pub fn bitrouter_sdk::language_model::settlement::RequiredDeliveryHandshake::complete_activation(&self, bitrouter_sdk::error::Result<()>) -> bool
+pub fn bitrouter_sdk::language_model::settlement::RequiredDeliveryHandshake::new(tokio::sync::oneshot::Sender<bitrouter_sdk::error::Result<()>>, tokio::sync::oneshot::Receiver<bitrouter_sdk::language_model::settlement::DeliveryAcknowledgement>) -> Self
+pub fn bitrouter_sdk::language_model::settlement::RequiredDeliveryHandshake::new_with_completion(tokio::sync::oneshot::Sender<bitrouter_sdk::error::Result<()>>, tokio::sync::oneshot::Receiver<bitrouter_sdk::language_model::settlement::DeliveryAcknowledgement>, tokio::sync::oneshot::Sender<bitrouter_sdk::error::Result<()>>, tokio::sync::oneshot::Receiver<()>) -> Self
+pub fn bitrouter_sdk::language_model::settlement::RequiredDeliveryHandshake::reject(&self, bitrouter_sdk::error::BitrouterError)
+pub async fn bitrouter_sdk::language_model::settlement::RequiredDeliveryHandshake::wait_for_delivery(&self) -> bitrouter_sdk::error::Result<bool>
+pub async fn bitrouter_sdk::language_model::settlement::RequiredDeliveryHandshake::wait_for_delivery_acknowledgement(&self) -> bitrouter_sdk::error::Result<bool>
+pub async fn bitrouter_sdk::language_model::settlement::RequiredDeliveryHandshake::wait_for_terminal_commit(&self) -> bool
+impl core::clone::Clone for bitrouter_sdk::language_model::settlement::RequiredDeliveryHandshake
+pub fn bitrouter_sdk::language_model::settlement::RequiredDeliveryHandshake::clone(&self) -> bitrouter_sdk::language_model::settlement::RequiredDeliveryHandshake
+impl core::marker::Freeze for bitrouter_sdk::language_model::settlement::RequiredDeliveryHandshake
+impl core::marker::Send for bitrouter_sdk::language_model::settlement::RequiredDeliveryHandshake
+impl core::marker::Sync for bitrouter_sdk::language_model::settlement::RequiredDeliveryHandshake
+impl core::marker::Unpin for bitrouter_sdk::language_model::settlement::RequiredDeliveryHandshake
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::settlement::RequiredDeliveryHandshake
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::settlement::RequiredDeliveryHandshake
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::settlement::RequiredDeliveryHandshake
+pub struct bitrouter_sdk::language_model::settlement::RequiredFinalizationContext
+pub bitrouter_sdk::language_model::settlement::RequiredFinalizationContext::caller: bitrouter_sdk::caller::CallerContext
+pub bitrouter_sdk::language_model::settlement::RequiredFinalizationContext::credential_authority: core::option::Option<bitrouter_sdk::language_model::auth::ContinuationAuthority>
+pub bitrouter_sdk::language_model::settlement::RequiredFinalizationContext::delivery_attempt_id: u64
+pub bitrouter_sdk::language_model::settlement::RequiredFinalizationContext::finish_reason: core::option::Option<bitrouter_sdk::language_model::types::FinishReason>
+pub bitrouter_sdk::language_model::settlement::RequiredFinalizationContext::inbound_protocol: core::option::Option<bitrouter_sdk::language_model::types::ApiProtocol>
+pub bitrouter_sdk::language_model::settlement::RequiredFinalizationContext::native_response_completed: bool
+pub bitrouter_sdk::language_model::settlement::RequiredFinalizationContext::request_id: alloc::string::String
+pub bitrouter_sdk::language_model::settlement::RequiredFinalizationContext::response_id: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::settlement::RequiredFinalizationContext::streamed: bool
+pub bitrouter_sdk::language_model::settlement::RequiredFinalizationContext::successful_terminal: bool
+pub bitrouter_sdk::language_model::settlement::RequiredFinalizationContext::target: core::option::Option<bitrouter_sdk::language_model::types::RoutingTarget>
+impl core::clone::Clone for bitrouter_sdk::language_model::settlement::RequiredFinalizationContext
+pub fn bitrouter_sdk::language_model::settlement::RequiredFinalizationContext::clone(&self) -> bitrouter_sdk::language_model::settlement::RequiredFinalizationContext
+impl core::marker::Freeze for bitrouter_sdk::language_model::settlement::RequiredFinalizationContext
+impl core::marker::Send for bitrouter_sdk::language_model::settlement::RequiredFinalizationContext
+impl core::marker::Sync for bitrouter_sdk::language_model::settlement::RequiredFinalizationContext
+impl core::marker::Unpin for bitrouter_sdk::language_model::settlement::RequiredFinalizationContext
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::settlement::RequiredFinalizationContext
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::settlement::RequiredFinalizationContext
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::settlement::RequiredFinalizationContext
+pub struct bitrouter_sdk::language_model::settlement::RequiredFinalizationReceipt(_)
+impl bitrouter_sdk::language_model::settlement::RequiredFinalizationReceipt
+pub fn bitrouter_sdk::language_model::settlement::RequiredFinalizationReceipt::same_invocation(&self, &Self) -> bool
+impl core::clone::Clone for bitrouter_sdk::language_model::settlement::RequiredFinalizationReceipt
+pub fn bitrouter_sdk::language_model::settlement::RequiredFinalizationReceipt::clone(&self) -> bitrouter_sdk::language_model::settlement::RequiredFinalizationReceipt
+impl core::marker::Freeze for bitrouter_sdk::language_model::settlement::RequiredFinalizationReceipt
+impl core::marker::Send for bitrouter_sdk::language_model::settlement::RequiredFinalizationReceipt
+impl core::marker::Sync for bitrouter_sdk::language_model::settlement::RequiredFinalizationReceipt
+impl core::marker::Unpin for bitrouter_sdk::language_model::settlement::RequiredFinalizationReceipt
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::settlement::RequiredFinalizationReceipt
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::settlement::RequiredFinalizationReceipt
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::settlement::RequiredFinalizationReceipt
+pub struct bitrouter_sdk::language_model::settlement::SettlementContext
+pub bitrouter_sdk::language_model::settlement::SettlementContext::account_label: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::settlement::SettlementContext::cache_read_tokens: u64
+pub bitrouter_sdk::language_model::settlement::SettlementContext::cache_write_tokens: u64
+pub bitrouter_sdk::language_model::settlement::SettlementContext::caller: bitrouter_sdk::caller::CallerContext
+pub bitrouter_sdk::language_model::settlement::SettlementContext::completion_tokens: u64
+pub bitrouter_sdk::language_model::settlement::SettlementContext::error: core::option::Option<bitrouter_sdk::error::BitrouterError>
+pub bitrouter_sdk::language_model::settlement::SettlementContext::events: bitrouter_sdk::event::EventBus
+pub bitrouter_sdk::language_model::settlement::SettlementContext::finish_reason: core::option::Option<bitrouter_sdk::language_model::types::FinishReason>
+pub bitrouter_sdk::language_model::settlement::SettlementContext::first_token_kind: core::option::Option<bitrouter_sdk::language_model::timing::FirstTokenKind>
+pub bitrouter_sdk::language_model::settlement::SettlementContext::generation_duration_ms: core::option::Option<u64>
+pub bitrouter_sdk::language_model::settlement::SettlementContext::media_input_count: u64
+pub bitrouter_sdk::language_model::settlement::SettlementContext::media_output_count: u64
+pub bitrouter_sdk::language_model::settlement::SettlementContext::model_id: alloc::string::String
+pub bitrouter_sdk::language_model::settlement::SettlementContext::prompt_tokens: u64
+pub bitrouter_sdk::language_model::settlement::SettlementContext::provider_id: alloc::string::String
+pub bitrouter_sdk::language_model::settlement::SettlementContext::raw_usage: core::option::Option<serde_json::value::Value>
+pub bitrouter_sdk::language_model::settlement::SettlementContext::reasoning_tokens: u64
+pub bitrouter_sdk::language_model::settlement::SettlementContext::request_duration_ms: u64
+pub bitrouter_sdk::language_model::settlement::SettlementContext::request_id: alloc::string::String
+pub bitrouter_sdk::language_model::settlement::SettlementContext::server_tool_calls: alloc::vec::Vec<bitrouter_sdk::language_model::types::ServerToolCall>
+pub bitrouter_sdk::language_model::settlement::SettlementContext::streamed: bool
+pub bitrouter_sdk::language_model::settlement::SettlementContext::target: core::option::Option<bitrouter_sdk::language_model::types::RoutingTarget>
+pub bitrouter_sdk::language_model::settlement::SettlementContext::ttft_ms: core::option::Option<u64>
+pub bitrouter_sdk::language_model::settlement::SettlementContext::upstream_duration_ms: core::option::Option<u64>
+pub bitrouter_sdk::language_model::settlement::SettlementContext::usage_origin: bitrouter_sdk::language_model::types::UsageOrigin
+pub bitrouter_sdk::language_model::settlement::SettlementContext::web_search_count: u64
+impl bitrouter_sdk::language_model::settlement::SettlementContext
+pub fn bitrouter_sdk::language_model::settlement::SettlementContext::emit<E: bitrouter_sdk::event::PipelineEvent>(&mut self, E)
+pub fn bitrouter_sdk::language_model::settlement::SettlementContext::get_event<E: bitrouter_sdk::event::PipelineEvent>(&self) -> core::option::Option<&E>
+pub fn bitrouter_sdk::language_model::settlement::SettlementContext::get_events<E: bitrouter_sdk::event::PipelineEvent>(&self) -> alloc::vec::Vec<&E>
+pub fn bitrouter_sdk::language_model::settlement::SettlementContext::has_event<E: bitrouter_sdk::event::PipelineEvent>(&self) -> bool
+impl core::marker::Freeze for bitrouter_sdk::language_model::settlement::SettlementContext
+impl core::marker::Send for bitrouter_sdk::language_model::settlement::SettlementContext
+impl core::marker::Sync for bitrouter_sdk::language_model::settlement::SettlementContext
+impl core::marker::Unpin for bitrouter_sdk::language_model::settlement::SettlementContext
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::settlement::SettlementContext
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::settlement::SettlementContext
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::settlement::SettlementContext
+pub trait bitrouter_sdk::language_model::settlement::RequiredFinalizer: core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::language_model::settlement::RequiredFinalizer::commit<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::settlement::RequiredFinalizationContext, &'life2 bitrouter_sdk::language_model::settlement::RequiredDeliveryHandshake) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bool>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub fn bitrouter_sdk::language_model::settlement::RequiredFinalizer::commit_with_receipt<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::settlement::RequiredFinalizationContext, &'life2 bitrouter_sdk::language_model::settlement::RequiredFinalizationReceipt, &'life3 bitrouter_sdk::language_model::settlement::RequiredDeliveryHandshake) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bool>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub fn bitrouter_sdk::language_model::settlement::RequiredFinalizer::drain_pending_work<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<()>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn bitrouter_sdk::language_model::settlement::RequiredFinalizer::finalize<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::settlement::RequiredFinalizationContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<()>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::settlement::RequiredFinalizer::finalize_with_receipt<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::settlement::RequiredFinalizationContext, &'life2 bitrouter_sdk::language_model::settlement::RequiredFinalizationReceipt) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<()>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub fn bitrouter_sdk::language_model::settlement::RequiredFinalizer::rollback<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::settlement::RequiredFinalizationContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<()>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::settlement::RequiredFinalizer::rollback_with_receipt<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::settlement::RequiredFinalizationContext, &'life2 bitrouter_sdk::language_model::settlement::RequiredFinalizationReceipt) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<()>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub trait bitrouter_sdk::language_model::settlement::SettlementRecorder: core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::language_model::settlement::SettlementRecorder::record<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 mut bitrouter_sdk::language_model::settlement::SettlementContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<()>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub mod bitrouter_sdk::language_model::stream
+pub enum bitrouter_sdk::language_model::stream::SseFrame
+pub bitrouter_sdk::language_model::stream::SseFrame::Comment(alloc::string::String)
+pub bitrouter_sdk::language_model::stream::SseFrame::Event
+pub bitrouter_sdk::language_model::stream::SseFrame::Event::data: alloc::string::String
+pub bitrouter_sdk::language_model::stream::SseFrame::Event::event: core::option::Option<alloc::string::String>
+impl bitrouter_sdk::language_model::stream::SseFrame
+pub fn bitrouter_sdk::language_model::stream::SseFrame::to_wire(&self) -> alloc::string::String
+impl core::clone::Clone for bitrouter_sdk::language_model::stream::SseFrame
+pub fn bitrouter_sdk::language_model::stream::SseFrame::clone(&self) -> bitrouter_sdk::language_model::stream::SseFrame
+impl core::cmp::Eq for bitrouter_sdk::language_model::stream::SseFrame
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::stream::SseFrame
+pub fn bitrouter_sdk::language_model::stream::SseFrame::eq(&self, &bitrouter_sdk::language_model::stream::SseFrame) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::stream::SseFrame
+pub fn bitrouter_sdk::language_model::stream::SseFrame::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::stream::SseFrame
+impl core::marker::Freeze for bitrouter_sdk::language_model::stream::SseFrame
+impl core::marker::Send for bitrouter_sdk::language_model::stream::SseFrame
+impl core::marker::Sync for bitrouter_sdk::language_model::stream::SseFrame
+impl core::marker::Unpin for bitrouter_sdk::language_model::stream::SseFrame
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::stream::SseFrame
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::stream::SseFrame
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::stream::SseFrame
+pub enum bitrouter_sdk::language_model::stream::StreamAction
+pub bitrouter_sdk::language_model::stream::StreamAction::Abort(bitrouter_sdk::error::BitrouterError)
+pub bitrouter_sdk::language_model::stream::StreamAction::Drop
+pub bitrouter_sdk::language_model::stream::StreamAction::Pass
+pub bitrouter_sdk::language_model::stream::StreamAction::Replace(alloc::vec::Vec<bitrouter_sdk::language_model::types::StreamPart>)
+impl core::fmt::Debug for bitrouter_sdk::language_model::stream::StreamAction
+pub fn bitrouter_sdk::language_model::stream::StreamAction::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::language_model::stream::StreamAction
+impl core::marker::Send for bitrouter_sdk::language_model::stream::StreamAction
+impl core::marker::Sync for bitrouter_sdk::language_model::stream::StreamAction
+impl core::marker::Unpin for bitrouter_sdk::language_model::stream::StreamAction
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::stream::StreamAction
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::stream::StreamAction
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::stream::StreamAction
+pub enum bitrouter_sdk::language_model::stream::StreamOutcome
+pub bitrouter_sdk::language_model::stream::StreamOutcome::Aborted(bitrouter_sdk::error::BitrouterError)
+pub bitrouter_sdk::language_model::stream::StreamOutcome::ClientDisconnected
+pub bitrouter_sdk::language_model::stream::StreamOutcome::Completed
+pub bitrouter_sdk::language_model::stream::StreamOutcome::UpstreamError(bitrouter_sdk::error::BitrouterError)
+impl core::clone::Clone for bitrouter_sdk::language_model::stream::StreamOutcome
+pub fn bitrouter_sdk::language_model::stream::StreamOutcome::clone(&self) -> bitrouter_sdk::language_model::stream::StreamOutcome
+impl core::fmt::Debug for bitrouter_sdk::language_model::stream::StreamOutcome
+pub fn bitrouter_sdk::language_model::stream::StreamOutcome::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::language_model::stream::StreamOutcome
+impl core::marker::Send for bitrouter_sdk::language_model::stream::StreamOutcome
+impl core::marker::Sync for bitrouter_sdk::language_model::stream::StreamOutcome
+impl core::marker::Unpin for bitrouter_sdk::language_model::stream::StreamOutcome
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::stream::StreamOutcome
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::stream::StreamOutcome
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::stream::StreamOutcome
+pub struct bitrouter_sdk::language_model::stream::SseKeepaliveStream<S>
+impl<S> bitrouter_sdk::language_model::stream::SseKeepaliveStream<S>
+pub fn bitrouter_sdk::language_model::stream::SseKeepaliveStream<S>::new(S, core::time::Duration) -> Self
+impl<'__pin, S> core::marker::Unpin for bitrouter_sdk::language_model::stream::SseKeepaliveStream<S> where pin_project_lite::__private::PinnedFieldsOf<__Origin<'__pin, S>>: core::marker::Unpin
+impl<S> futures_core::stream::Stream for bitrouter_sdk::language_model::stream::SseKeepaliveStream<S> where S: futures_core::stream::Stream<Item = bitrouter_sdk::language_model::stream::SseFrame>
+pub type bitrouter_sdk::language_model::stream::SseKeepaliveStream<S>::Item = bitrouter_sdk::language_model::stream::SseFrame
+pub fn bitrouter_sdk::language_model::stream::SseKeepaliveStream<S>::poll_next(core::pin::Pin<&mut Self>, &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<core::option::Option<Self::Item>>
+impl<S> !core::marker::Freeze for bitrouter_sdk::language_model::stream::SseKeepaliveStream<S>
+impl<S> core::marker::Send for bitrouter_sdk::language_model::stream::SseKeepaliveStream<S> where S: core::marker::Send
+impl<S> core::marker::Sync for bitrouter_sdk::language_model::stream::SseKeepaliveStream<S> where S: core::marker::Sync
+impl<S> !core::marker::UnsafeUnpin for bitrouter_sdk::language_model::stream::SseKeepaliveStream<S>
+impl<S> !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::stream::SseKeepaliveStream<S>
+impl<S> !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::stream::SseKeepaliveStream<S>
+pub struct bitrouter_sdk::language_model::stream::StreamInterest(_)
+impl bitrouter_sdk::language_model::stream::StreamInterest
+pub const fn bitrouter_sdk::language_model::stream::StreamInterest::all() -> Self
+pub fn bitrouter_sdk::language_model::stream::StreamInterest::is_empty(&self) -> bool
+pub fn bitrouter_sdk::language_model::stream::StreamInterest::matches(&self, &bitrouter_sdk::language_model::types::StreamPart) -> bool
+pub const fn bitrouter_sdk::language_model::stream::StreamInterest::none() -> Self
+pub const fn bitrouter_sdk::language_model::stream::StreamInterest::with_finish(self) -> Self
+pub const fn bitrouter_sdk::language_model::stream::StreamInterest::with_reasoning_delta(self) -> Self
+pub const fn bitrouter_sdk::language_model::stream::StreamInterest::with_response_started(self) -> Self
+pub const fn bitrouter_sdk::language_model::stream::StreamInterest::with_text_delta(self) -> Self
+pub const fn bitrouter_sdk::language_model::stream::StreamInterest::with_tool_call_delta(self) -> Self
+pub const fn bitrouter_sdk::language_model::stream::StreamInterest::with_usage(self) -> Self
+impl core::clone::Clone for bitrouter_sdk::language_model::stream::StreamInterest
+pub fn bitrouter_sdk::language_model::stream::StreamInterest::clone(&self) -> bitrouter_sdk::language_model::stream::StreamInterest
+impl core::cmp::Eq for bitrouter_sdk::language_model::stream::StreamInterest
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::stream::StreamInterest
+pub fn bitrouter_sdk::language_model::stream::StreamInterest::eq(&self, &bitrouter_sdk::language_model::stream::StreamInterest) -> bool
+impl core::default::Default for bitrouter_sdk::language_model::stream::StreamInterest
+pub fn bitrouter_sdk::language_model::stream::StreamInterest::default() -> bitrouter_sdk::language_model::stream::StreamInterest
+impl core::fmt::Debug for bitrouter_sdk::language_model::stream::StreamInterest
+pub fn bitrouter_sdk::language_model::stream::StreamInterest::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for bitrouter_sdk::language_model::stream::StreamInterest
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::stream::StreamInterest
+impl core::marker::Freeze for bitrouter_sdk::language_model::stream::StreamInterest
+impl core::marker::Send for bitrouter_sdk::language_model::stream::StreamInterest
+impl core::marker::Sync for bitrouter_sdk::language_model::stream::StreamInterest
+impl core::marker::Unpin for bitrouter_sdk::language_model::stream::StreamInterest
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::stream::StreamInterest
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::stream::StreamInterest
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::stream::StreamInterest
+pub struct bitrouter_sdk::language_model::stream::StreamProcessor
+impl bitrouter_sdk::language_model::stream::StreamProcessor
+pub fn bitrouter_sdk::language_model::stream::StreamProcessor::context(&self) -> &bitrouter_sdk::language_model::context::StreamContext
+pub async fn bitrouter_sdk::language_model::stream::StreamProcessor::finish(&mut self, bitrouter_sdk::language_model::stream::StreamOutcome) -> &bitrouter_sdk::language_model::context::StreamContext
+pub fn bitrouter_sdk::language_model::stream::StreamProcessor::into_context(self) -> bitrouter_sdk::language_model::context::StreamContext
+pub fn bitrouter_sdk::language_model::stream::StreamProcessor::new(alloc::vec::Vec<alloc::sync::Arc<dyn bitrouter_sdk::language_model::hooks::StreamHook>>, alloc::vec::Vec<alloc::sync::Arc<dyn bitrouter_sdk::language_model::hooks::ObserveHook>>, bitrouter_sdk::language_model::context::StreamContext) -> Self
+pub async fn bitrouter_sdk::language_model::stream::StreamProcessor::process_part(&mut self, bitrouter_sdk::language_model::types::StreamPart) -> bitrouter_sdk::error::Result<alloc::vec::Vec<bitrouter_sdk::language_model::types::StreamPart>>
+impl core::marker::Freeze for bitrouter_sdk::language_model::stream::StreamProcessor
+impl core::marker::Send for bitrouter_sdk::language_model::stream::StreamProcessor
+impl core::marker::Sync for bitrouter_sdk::language_model::stream::StreamProcessor
+impl core::marker::Unpin for bitrouter_sdk::language_model::stream::StreamProcessor
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::stream::StreamProcessor
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::stream::StreamProcessor
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::stream::StreamProcessor
+pub struct bitrouter_sdk::language_model::stream::UsageAccumulator
+impl bitrouter_sdk::language_model::stream::UsageAccumulator
+pub fn bitrouter_sdk::language_model::stream::UsageAccumulator::estimated_output_tokens(&self) -> u64
+pub fn bitrouter_sdk::language_model::stream::UsageAccumulator::estimated_prompt_tokens(&self) -> u64
+pub fn bitrouter_sdk::language_model::stream::UsageAccumulator::finalized(&self) -> core::option::Option<bitrouter_sdk::language_model::types::Usage>
+pub fn bitrouter_sdk::language_model::stream::UsageAccumulator::observe(&mut self, &bitrouter_sdk::language_model::types::StreamPart)
+pub fn bitrouter_sdk::language_model::stream::UsageAccumulator::with_prompt_chars(u64) -> Self
+impl core::clone::Clone for bitrouter_sdk::language_model::stream::UsageAccumulator
+pub fn bitrouter_sdk::language_model::stream::UsageAccumulator::clone(&self) -> bitrouter_sdk::language_model::stream::UsageAccumulator
+impl core::default::Default for bitrouter_sdk::language_model::stream::UsageAccumulator
+pub fn bitrouter_sdk::language_model::stream::UsageAccumulator::default() -> bitrouter_sdk::language_model::stream::UsageAccumulator
+impl core::fmt::Debug for bitrouter_sdk::language_model::stream::UsageAccumulator
+pub fn bitrouter_sdk::language_model::stream::UsageAccumulator::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::language_model::stream::UsageAccumulator
+impl core::marker::Send for bitrouter_sdk::language_model::stream::UsageAccumulator
+impl core::marker::Sync for bitrouter_sdk::language_model::stream::UsageAccumulator
+impl core::marker::Unpin for bitrouter_sdk::language_model::stream::UsageAccumulator
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::stream::UsageAccumulator
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::stream::UsageAccumulator
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::stream::UsageAccumulator
+pub mod bitrouter_sdk::language_model::timing
+pub enum bitrouter_sdk::language_model::timing::FirstTokenKind
+pub bitrouter_sdk::language_model::timing::FirstTokenKind::Reasoning
+pub bitrouter_sdk::language_model::timing::FirstTokenKind::Text
+pub bitrouter_sdk::language_model::timing::FirstTokenKind::Tool
+impl bitrouter_sdk::language_model::timing::FirstTokenKind
+pub fn bitrouter_sdk::language_model::timing::FirstTokenKind::as_str(self) -> &'static str
+impl core::clone::Clone for bitrouter_sdk::language_model::timing::FirstTokenKind
+pub fn bitrouter_sdk::language_model::timing::FirstTokenKind::clone(&self) -> bitrouter_sdk::language_model::timing::FirstTokenKind
+impl core::cmp::Eq for bitrouter_sdk::language_model::timing::FirstTokenKind
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::timing::FirstTokenKind
+pub fn bitrouter_sdk::language_model::timing::FirstTokenKind::eq(&self, &bitrouter_sdk::language_model::timing::FirstTokenKind) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::timing::FirstTokenKind
+pub fn bitrouter_sdk::language_model::timing::FirstTokenKind::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for bitrouter_sdk::language_model::timing::FirstTokenKind
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::timing::FirstTokenKind
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::timing::FirstTokenKind
+pub fn bitrouter_sdk::language_model::timing::FirstTokenKind::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::timing::FirstTokenKind
+pub fn bitrouter_sdk::language_model::timing::FirstTokenKind::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::timing::FirstTokenKind
+impl core::marker::Send for bitrouter_sdk::language_model::timing::FirstTokenKind
+impl core::marker::Sync for bitrouter_sdk::language_model::timing::FirstTokenKind
+impl core::marker::Unpin for bitrouter_sdk::language_model::timing::FirstTokenKind
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::timing::FirstTokenKind
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::timing::FirstTokenKind
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::timing::FirstTokenKind
+pub struct bitrouter_sdk::language_model::timing::FirstTokenTiming
+pub bitrouter_sdk::language_model::timing::FirstTokenTiming::kind: bitrouter_sdk::language_model::timing::FirstTokenKind
+pub bitrouter_sdk::language_model::timing::FirstTokenTiming::ttft_ms: u64
+impl core::clone::Clone for bitrouter_sdk::language_model::timing::FirstTokenTiming
+pub fn bitrouter_sdk::language_model::timing::FirstTokenTiming::clone(&self) -> bitrouter_sdk::language_model::timing::FirstTokenTiming
+impl core::cmp::Eq for bitrouter_sdk::language_model::timing::FirstTokenTiming
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::timing::FirstTokenTiming
+pub fn bitrouter_sdk::language_model::timing::FirstTokenTiming::eq(&self, &bitrouter_sdk::language_model::timing::FirstTokenTiming) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::timing::FirstTokenTiming
+pub fn bitrouter_sdk::language_model::timing::FirstTokenTiming::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for bitrouter_sdk::language_model::timing::FirstTokenTiming
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::timing::FirstTokenTiming
+impl core::marker::Freeze for bitrouter_sdk::language_model::timing::FirstTokenTiming
+impl core::marker::Send for bitrouter_sdk::language_model::timing::FirstTokenTiming
+impl core::marker::Sync for bitrouter_sdk::language_model::timing::FirstTokenTiming
+impl core::marker::Unpin for bitrouter_sdk::language_model::timing::FirstTokenTiming
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::timing::FirstTokenTiming
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::timing::FirstTokenTiming
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::timing::FirstTokenTiming
+pub mod bitrouter_sdk::language_model::types
+pub enum bitrouter_sdk::language_model::types::ApiProtocol
+pub bitrouter_sdk::language_model::types::ApiProtocol::ChatCompletions
+pub bitrouter_sdk::language_model::types::ApiProtocol::Custom(alloc::string::String)
+pub bitrouter_sdk::language_model::types::ApiProtocol::GenerateContent
+pub bitrouter_sdk::language_model::types::ApiProtocol::Messages
+pub bitrouter_sdk::language_model::types::ApiProtocol::Responses
+impl bitrouter_sdk::language_model::types::ApiProtocol
+pub fn bitrouter_sdk::language_model::types::ApiProtocol::as_str(&self) -> &str
+impl core::clone::Clone for bitrouter_sdk::language_model::types::ApiProtocol
+pub fn bitrouter_sdk::language_model::types::ApiProtocol::clone(&self) -> bitrouter_sdk::language_model::types::ApiProtocol
+impl core::cmp::Eq for bitrouter_sdk::language_model::types::ApiProtocol
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::types::ApiProtocol
+pub fn bitrouter_sdk::language_model::types::ApiProtocol::eq(&self, &bitrouter_sdk::language_model::types::ApiProtocol) -> bool
+impl core::convert::From<bitrouter_sdk::language_model::types::ApiProtocol> for bitrouter_sdk::language_model::types::ProtocolList
+pub fn bitrouter_sdk::language_model::types::ProtocolList::from(bitrouter_sdk::language_model::types::ApiProtocol) -> Self
+impl core::default::Default for bitrouter_sdk::language_model::types::ApiProtocol
+pub fn bitrouter_sdk::language_model::types::ApiProtocol::default() -> bitrouter_sdk::language_model::types::ApiProtocol
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::ApiProtocol
+pub fn bitrouter_sdk::language_model::types::ApiProtocol::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitrouter_sdk::language_model::types::ApiProtocol
+pub fn bitrouter_sdk::language_model::types::ApiProtocol::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for bitrouter_sdk::language_model::types::ApiProtocol
+pub fn bitrouter_sdk::language_model::types::ApiProtocol::hash<__H: core::hash::Hasher>(&self, &mut __H)
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::types::ApiProtocol
+impl schemars::JsonSchema for bitrouter_sdk::language_model::types::ApiProtocol
+pub fn bitrouter_sdk::language_model::types::ApiProtocol::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::language_model::types::ApiProtocol::schema_name() -> alloc::borrow::Cow<'static, str>
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::types::ApiProtocol
+pub fn bitrouter_sdk::language_model::types::ApiProtocol::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::types::ApiProtocol
+pub fn bitrouter_sdk::language_model::types::ApiProtocol::deserialize<D: serde_core::de::Deserializer<'de>>(D) -> core::result::Result<Self, <D as serde_core::de::Deserializer>::Error>
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::ApiProtocol
+impl core::marker::Send for bitrouter_sdk::language_model::types::ApiProtocol
+impl core::marker::Sync for bitrouter_sdk::language_model::types::ApiProtocol
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::ApiProtocol
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::ApiProtocol
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::ApiProtocol
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::ApiProtocol
+pub enum bitrouter_sdk::language_model::types::AuthScheme
+pub bitrouter_sdk::language_model::types::AuthScheme::Bearer
+pub bitrouter_sdk::language_model::types::AuthScheme::XApiKey
+impl core::clone::Clone for bitrouter_sdk::language_model::types::AuthScheme
+pub fn bitrouter_sdk::language_model::types::AuthScheme::clone(&self) -> bitrouter_sdk::language_model::types::AuthScheme
+impl core::cmp::Eq for bitrouter_sdk::language_model::types::AuthScheme
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::types::AuthScheme
+pub fn bitrouter_sdk::language_model::types::AuthScheme::eq(&self, &bitrouter_sdk::language_model::types::AuthScheme) -> bool
+impl core::default::Default for bitrouter_sdk::language_model::types::AuthScheme
+pub fn bitrouter_sdk::language_model::types::AuthScheme::default() -> bitrouter_sdk::language_model::types::AuthScheme
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::AuthScheme
+pub fn bitrouter_sdk::language_model::types::AuthScheme::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for bitrouter_sdk::language_model::types::AuthScheme
+pub fn bitrouter_sdk::language_model::types::AuthScheme::hash<__H: core::hash::Hasher>(&self, &mut __H)
+impl core::marker::Copy for bitrouter_sdk::language_model::types::AuthScheme
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::types::AuthScheme
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::types::AuthScheme
+pub fn bitrouter_sdk::language_model::types::AuthScheme::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::types::AuthScheme
+pub fn bitrouter_sdk::language_model::types::AuthScheme::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::AuthScheme
+impl core::marker::Send for bitrouter_sdk::language_model::types::AuthScheme
+impl core::marker::Sync for bitrouter_sdk::language_model::types::AuthScheme
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::AuthScheme
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::AuthScheme
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::AuthScheme
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::AuthScheme
+pub enum bitrouter_sdk::language_model::types::Capability
+pub bitrouter_sdk::language_model::types::Capability::AudioInput
+pub bitrouter_sdk::language_model::types::Capability::AudioOutput
+pub bitrouter_sdk::language_model::types::Capability::FileInput
+pub bitrouter_sdk::language_model::types::Capability::ImageInput
+pub bitrouter_sdk::language_model::types::Capability::ImageOutput
+pub bitrouter_sdk::language_model::types::Capability::Logprobs
+pub bitrouter_sdk::language_model::types::Capability::Reasoning
+pub bitrouter_sdk::language_model::types::Capability::StructuredOutputs
+pub bitrouter_sdk::language_model::types::Capability::Tools
+pub bitrouter_sdk::language_model::types::Capability::VideoInput
+pub bitrouter_sdk::language_model::types::Capability::WebSearch
+impl bitrouter_sdk::language_model::types::Capability
+pub fn bitrouter_sdk::language_model::types::Capability::as_str(&self) -> &'static str
+impl core::clone::Clone for bitrouter_sdk::language_model::types::Capability
+pub fn bitrouter_sdk::language_model::types::Capability::clone(&self) -> bitrouter_sdk::language_model::types::Capability
+impl core::cmp::Eq for bitrouter_sdk::language_model::types::Capability
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::types::Capability
+pub fn bitrouter_sdk::language_model::types::Capability::eq(&self, &bitrouter_sdk::language_model::types::Capability) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::Capability
+pub fn bitrouter_sdk::language_model::types::Capability::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for bitrouter_sdk::language_model::types::Capability
+pub fn bitrouter_sdk::language_model::types::Capability::hash<__H: core::hash::Hasher>(&self, &mut __H)
+impl core::marker::Copy for bitrouter_sdk::language_model::types::Capability
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::types::Capability
+impl schemars::JsonSchema for bitrouter_sdk::language_model::types::Capability
+pub fn bitrouter_sdk::language_model::types::Capability::inline_schema() -> bool
+pub fn bitrouter_sdk::language_model::types::Capability::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::language_model::types::Capability::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::language_model::types::Capability::schema_name() -> alloc::borrow::Cow<'static, str>
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::types::Capability
+pub fn bitrouter_sdk::language_model::types::Capability::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::types::Capability
+pub fn bitrouter_sdk::language_model::types::Capability::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::Capability
+impl core::marker::Send for bitrouter_sdk::language_model::types::Capability
+impl core::marker::Sync for bitrouter_sdk::language_model::types::Capability
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::Capability
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::Capability
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::Capability
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::Capability
+pub enum bitrouter_sdk::language_model::types::ChatTokenLimitField
+pub bitrouter_sdk::language_model::types::ChatTokenLimitField::MaxCompletionTokens
+pub bitrouter_sdk::language_model::types::ChatTokenLimitField::MaxTokens
+impl core::clone::Clone for bitrouter_sdk::language_model::types::ChatTokenLimitField
+pub fn bitrouter_sdk::language_model::types::ChatTokenLimitField::clone(&self) -> bitrouter_sdk::language_model::types::ChatTokenLimitField
+impl core::cmp::Eq for bitrouter_sdk::language_model::types::ChatTokenLimitField
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::types::ChatTokenLimitField
+pub fn bitrouter_sdk::language_model::types::ChatTokenLimitField::eq(&self, &bitrouter_sdk::language_model::types::ChatTokenLimitField) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::ChatTokenLimitField
+pub fn bitrouter_sdk::language_model::types::ChatTokenLimitField::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for bitrouter_sdk::language_model::types::ChatTokenLimitField
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::types::ChatTokenLimitField
+impl schemars::JsonSchema for bitrouter_sdk::language_model::types::ChatTokenLimitField
+pub fn bitrouter_sdk::language_model::types::ChatTokenLimitField::inline_schema() -> bool
+pub fn bitrouter_sdk::language_model::types::ChatTokenLimitField::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::language_model::types::ChatTokenLimitField::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::language_model::types::ChatTokenLimitField::schema_name() -> alloc::borrow::Cow<'static, str>
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::types::ChatTokenLimitField
+pub fn bitrouter_sdk::language_model::types::ChatTokenLimitField::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::types::ChatTokenLimitField
+pub fn bitrouter_sdk::language_model::types::ChatTokenLimitField::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::ChatTokenLimitField
+impl core::marker::Send for bitrouter_sdk::language_model::types::ChatTokenLimitField
+impl core::marker::Sync for bitrouter_sdk::language_model::types::ChatTokenLimitField
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::ChatTokenLimitField
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::ChatTokenLimitField
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::ChatTokenLimitField
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::ChatTokenLimitField
+pub enum bitrouter_sdk::language_model::types::Content
+pub bitrouter_sdk::language_model::types::Content::File
+pub bitrouter_sdk::language_model::types::Content::File::data: bitrouter_sdk::language_model::types::DataContent
+pub bitrouter_sdk::language_model::types::Content::File::filename: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::types::Content::File::media_type: alloc::string::String
+pub bitrouter_sdk::language_model::types::Content::File::provider_metadata: bitrouter_sdk::language_model::types::ProviderMetadata
+pub bitrouter_sdk::language_model::types::Content::Reasoning
+pub bitrouter_sdk::language_model::types::Content::Reasoning::provider_metadata: bitrouter_sdk::language_model::types::ProviderMetadata
+pub bitrouter_sdk::language_model::types::Content::Reasoning::text: alloc::string::String
+pub bitrouter_sdk::language_model::types::Content::Source
+pub bitrouter_sdk::language_model::types::Content::Source::provider_metadata: bitrouter_sdk::language_model::types::ProviderMetadata
+pub bitrouter_sdk::language_model::types::Content::Source::source: bitrouter_sdk::language_model::types::Source
+pub bitrouter_sdk::language_model::types::Content::Text
+pub bitrouter_sdk::language_model::types::Content::Text::provider_metadata: bitrouter_sdk::language_model::types::ProviderMetadata
+pub bitrouter_sdk::language_model::types::Content::Text::text: alloc::string::String
+pub bitrouter_sdk::language_model::types::Content::ToolApprovalRequest
+pub bitrouter_sdk::language_model::types::Content::ToolApprovalRequest::approval_id: alloc::string::String
+pub bitrouter_sdk::language_model::types::Content::ToolApprovalRequest::provider_metadata: bitrouter_sdk::language_model::types::ProviderMetadata
+pub bitrouter_sdk::language_model::types::Content::ToolApprovalRequest::tool_call_id: alloc::string::String
+pub bitrouter_sdk::language_model::types::Content::ToolApprovalResponse
+pub bitrouter_sdk::language_model::types::Content::ToolApprovalResponse::approval_id: alloc::string::String
+pub bitrouter_sdk::language_model::types::Content::ToolApprovalResponse::approved: bool
+pub bitrouter_sdk::language_model::types::Content::ToolApprovalResponse::provider_metadata: bitrouter_sdk::language_model::types::ProviderMetadata
+pub bitrouter_sdk::language_model::types::Content::ToolApprovalResponse::reason: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::types::Content::ToolCall
+pub bitrouter_sdk::language_model::types::Content::ToolCall::arguments: alloc::string::String
+pub bitrouter_sdk::language_model::types::Content::ToolCall::dynamic: bool
+pub bitrouter_sdk::language_model::types::Content::ToolCall::id: alloc::string::String
+pub bitrouter_sdk::language_model::types::Content::ToolCall::name: alloc::string::String
+pub bitrouter_sdk::language_model::types::Content::ToolCall::provider_executed: bool
+pub bitrouter_sdk::language_model::types::Content::ToolCall::provider_metadata: bitrouter_sdk::language_model::types::ProviderMetadata
+pub bitrouter_sdk::language_model::types::Content::ToolResult
+pub bitrouter_sdk::language_model::types::Content::ToolResult::call_id: alloc::string::String
+pub bitrouter_sdk::language_model::types::Content::ToolResult::dynamic: bool
+pub bitrouter_sdk::language_model::types::Content::ToolResult::output: bitrouter_sdk::language_model::types::ToolResultOutput
+pub bitrouter_sdk::language_model::types::Content::ToolResult::provider_metadata: bitrouter_sdk::language_model::types::ProviderMetadata
+pub bitrouter_sdk::language_model::types::Content::ToolResult::tool_name: core::option::Option<alloc::string::String>
+impl core::clone::Clone for bitrouter_sdk::language_model::types::Content
+pub fn bitrouter_sdk::language_model::types::Content::clone(&self) -> bitrouter_sdk::language_model::types::Content
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::types::Content
+pub fn bitrouter_sdk::language_model::types::Content::eq(&self, &bitrouter_sdk::language_model::types::Content) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::Content
+pub fn bitrouter_sdk::language_model::types::Content::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::types::Content
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::types::Content
+pub fn bitrouter_sdk::language_model::types::Content::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::types::Content
+pub fn bitrouter_sdk::language_model::types::Content::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::Content
+impl core::marker::Send for bitrouter_sdk::language_model::types::Content
+impl core::marker::Sync for bitrouter_sdk::language_model::types::Content
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::Content
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::Content
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::Content
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::Content
+pub enum bitrouter_sdk::language_model::types::DataContent
+pub bitrouter_sdk::language_model::types::DataContent::Base64
+pub bitrouter_sdk::language_model::types::DataContent::Base64::data: alloc::string::String
+pub bitrouter_sdk::language_model::types::DataContent::Url
+pub bitrouter_sdk::language_model::types::DataContent::Url::url: alloc::string::String
+impl bitrouter_sdk::language_model::types::DataContent
+pub fn bitrouter_sdk::language_model::types::DataContent::from_url(&str) -> (core::option::Option<alloc::string::String>, bitrouter_sdk::language_model::types::DataContent)
+pub fn bitrouter_sdk::language_model::types::DataContent::to_url(&self, &str) -> alloc::string::String
+impl core::clone::Clone for bitrouter_sdk::language_model::types::DataContent
+pub fn bitrouter_sdk::language_model::types::DataContent::clone(&self) -> bitrouter_sdk::language_model::types::DataContent
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::types::DataContent
+pub fn bitrouter_sdk::language_model::types::DataContent::eq(&self, &bitrouter_sdk::language_model::types::DataContent) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::DataContent
+pub fn bitrouter_sdk::language_model::types::DataContent::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::types::DataContent
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::types::DataContent
+pub fn bitrouter_sdk::language_model::types::DataContent::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::types::DataContent
+pub fn bitrouter_sdk::language_model::types::DataContent::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::DataContent
+impl core::marker::Send for bitrouter_sdk::language_model::types::DataContent
+impl core::marker::Sync for bitrouter_sdk::language_model::types::DataContent
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::DataContent
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::DataContent
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::DataContent
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::DataContent
+pub enum bitrouter_sdk::language_model::types::FinishReason
+pub bitrouter_sdk::language_model::types::FinishReason::ContentFilter
+pub bitrouter_sdk::language_model::types::FinishReason::Error(alloc::string::String)
+pub bitrouter_sdk::language_model::types::FinishReason::Length
+pub bitrouter_sdk::language_model::types::FinishReason::Other(alloc::string::String)
+pub bitrouter_sdk::language_model::types::FinishReason::Stop
+pub bitrouter_sdk::language_model::types::FinishReason::ToolCalls
+impl core::clone::Clone for bitrouter_sdk::language_model::types::FinishReason
+pub fn bitrouter_sdk::language_model::types::FinishReason::clone(&self) -> bitrouter_sdk::language_model::types::FinishReason
+impl core::cmp::Eq for bitrouter_sdk::language_model::types::FinishReason
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::types::FinishReason
+pub fn bitrouter_sdk::language_model::types::FinishReason::eq(&self, &bitrouter_sdk::language_model::types::FinishReason) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::FinishReason
+pub fn bitrouter_sdk::language_model::types::FinishReason::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::types::FinishReason
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::types::FinishReason
+pub fn bitrouter_sdk::language_model::types::FinishReason::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::types::FinishReason
+pub fn bitrouter_sdk::language_model::types::FinishReason::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::FinishReason
+impl core::marker::Send for bitrouter_sdk::language_model::types::FinishReason
+impl core::marker::Sync for bitrouter_sdk::language_model::types::FinishReason
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::FinishReason
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::FinishReason
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::FinishReason
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::FinishReason
+pub enum bitrouter_sdk::language_model::types::Modality
+pub bitrouter_sdk::language_model::types::Modality::Audio
+pub bitrouter_sdk::language_model::types::Modality::Image
+pub bitrouter_sdk::language_model::types::Modality::Text
+impl core::clone::Clone for bitrouter_sdk::language_model::types::Modality
+pub fn bitrouter_sdk::language_model::types::Modality::clone(&self) -> bitrouter_sdk::language_model::types::Modality
+impl core::cmp::Eq for bitrouter_sdk::language_model::types::Modality
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::types::Modality
+pub fn bitrouter_sdk::language_model::types::Modality::eq(&self, &bitrouter_sdk::language_model::types::Modality) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::Modality
+pub fn bitrouter_sdk::language_model::types::Modality::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for bitrouter_sdk::language_model::types::Modality
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::types::Modality
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::types::Modality
+pub fn bitrouter_sdk::language_model::types::Modality::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::types::Modality
+pub fn bitrouter_sdk::language_model::types::Modality::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::Modality
+impl core::marker::Send for bitrouter_sdk::language_model::types::Modality
+impl core::marker::Sync for bitrouter_sdk::language_model::types::Modality
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::Modality
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::Modality
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::Modality
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::Modality
+pub enum bitrouter_sdk::language_model::types::ResponseFormat
+pub bitrouter_sdk::language_model::types::ResponseFormat::JsonSchema
+pub bitrouter_sdk::language_model::types::ResponseFormat::JsonSchema::description: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::types::ResponseFormat::JsonSchema::name: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::types::ResponseFormat::JsonSchema::schema: serde_json::value::Value
+pub bitrouter_sdk::language_model::types::ResponseFormat::JsonSchema::strict: core::option::Option<bool>
+impl core::clone::Clone for bitrouter_sdk::language_model::types::ResponseFormat
+pub fn bitrouter_sdk::language_model::types::ResponseFormat::clone(&self) -> bitrouter_sdk::language_model::types::ResponseFormat
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::types::ResponseFormat
+pub fn bitrouter_sdk::language_model::types::ResponseFormat::eq(&self, &bitrouter_sdk::language_model::types::ResponseFormat) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::ResponseFormat
+pub fn bitrouter_sdk::language_model::types::ResponseFormat::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::types::ResponseFormat
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::types::ResponseFormat
+pub fn bitrouter_sdk::language_model::types::ResponseFormat::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::types::ResponseFormat
+pub fn bitrouter_sdk::language_model::types::ResponseFormat::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::ResponseFormat
+impl core::marker::Send for bitrouter_sdk::language_model::types::ResponseFormat
+impl core::marker::Sync for bitrouter_sdk::language_model::types::ResponseFormat
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::ResponseFormat
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::ResponseFormat
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::ResponseFormat
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::ResponseFormat
+pub enum bitrouter_sdk::language_model::types::Role
+pub bitrouter_sdk::language_model::types::Role::Assistant
+pub bitrouter_sdk::language_model::types::Role::System
+pub bitrouter_sdk::language_model::types::Role::Tool
+pub bitrouter_sdk::language_model::types::Role::User
+impl core::clone::Clone for bitrouter_sdk::language_model::types::Role
+pub fn bitrouter_sdk::language_model::types::Role::clone(&self) -> bitrouter_sdk::language_model::types::Role
+impl core::cmp::Eq for bitrouter_sdk::language_model::types::Role
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::types::Role
+pub fn bitrouter_sdk::language_model::types::Role::eq(&self, &bitrouter_sdk::language_model::types::Role) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::Role
+pub fn bitrouter_sdk::language_model::types::Role::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for bitrouter_sdk::language_model::types::Role
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::types::Role
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::types::Role
+pub fn bitrouter_sdk::language_model::types::Role::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::types::Role
+pub fn bitrouter_sdk::language_model::types::Role::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::Role
+impl core::marker::Send for bitrouter_sdk::language_model::types::Role
+impl core::marker::Sync for bitrouter_sdk::language_model::types::Role
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::Role
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::Role
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::Role
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::Role
+#[non_exhaustive] pub enum bitrouter_sdk::language_model::types::ServerToolKind
+pub bitrouter_sdk::language_model::types::ServerToolKind::Provider
+pub bitrouter_sdk::language_model::types::ServerToolKind::Router
+impl core::clone::Clone for bitrouter_sdk::language_model::types::ServerToolKind
+pub fn bitrouter_sdk::language_model::types::ServerToolKind::clone(&self) -> bitrouter_sdk::language_model::types::ServerToolKind
+impl core::cmp::Eq for bitrouter_sdk::language_model::types::ServerToolKind
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::types::ServerToolKind
+pub fn bitrouter_sdk::language_model::types::ServerToolKind::eq(&self, &bitrouter_sdk::language_model::types::ServerToolKind) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::ServerToolKind
+pub fn bitrouter_sdk::language_model::types::ServerToolKind::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for bitrouter_sdk::language_model::types::ServerToolKind
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::types::ServerToolKind
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::types::ServerToolKind
+pub fn bitrouter_sdk::language_model::types::ServerToolKind::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::types::ServerToolKind
+pub fn bitrouter_sdk::language_model::types::ServerToolKind::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::ServerToolKind
+impl core::marker::Send for bitrouter_sdk::language_model::types::ServerToolKind
+impl core::marker::Sync for bitrouter_sdk::language_model::types::ServerToolKind
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::ServerToolKind
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::ServerToolKind
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::ServerToolKind
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::ServerToolKind
+#[non_exhaustive] pub enum bitrouter_sdk::language_model::types::ServerToolStatus
+pub bitrouter_sdk::language_model::types::ServerToolStatus::Denied
+pub bitrouter_sdk::language_model::types::ServerToolStatus::Error
+pub bitrouter_sdk::language_model::types::ServerToolStatus::Ok
+pub bitrouter_sdk::language_model::types::ServerToolStatus::Timeout
+impl core::clone::Clone for bitrouter_sdk::language_model::types::ServerToolStatus
+pub fn bitrouter_sdk::language_model::types::ServerToolStatus::clone(&self) -> bitrouter_sdk::language_model::types::ServerToolStatus
+impl core::cmp::Eq for bitrouter_sdk::language_model::types::ServerToolStatus
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::types::ServerToolStatus
+pub fn bitrouter_sdk::language_model::types::ServerToolStatus::eq(&self, &bitrouter_sdk::language_model::types::ServerToolStatus) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::ServerToolStatus
+pub fn bitrouter_sdk::language_model::types::ServerToolStatus::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for bitrouter_sdk::language_model::types::ServerToolStatus
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::types::ServerToolStatus
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::types::ServerToolStatus
+pub fn bitrouter_sdk::language_model::types::ServerToolStatus::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::types::ServerToolStatus
+pub fn bitrouter_sdk::language_model::types::ServerToolStatus::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::ServerToolStatus
+impl core::marker::Send for bitrouter_sdk::language_model::types::ServerToolStatus
+impl core::marker::Sync for bitrouter_sdk::language_model::types::ServerToolStatus
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::ServerToolStatus
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::ServerToolStatus
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::ServerToolStatus
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::ServerToolStatus
+pub enum bitrouter_sdk::language_model::types::Source
+pub bitrouter_sdk::language_model::types::Source::Document
+pub bitrouter_sdk::language_model::types::Source::Document::filename: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::types::Source::Document::id: alloc::string::String
+pub bitrouter_sdk::language_model::types::Source::Document::media_type: alloc::string::String
+pub bitrouter_sdk::language_model::types::Source::Document::title: alloc::string::String
+pub bitrouter_sdk::language_model::types::Source::Url
+pub bitrouter_sdk::language_model::types::Source::Url::id: alloc::string::String
+pub bitrouter_sdk::language_model::types::Source::Url::title: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::types::Source::Url::url: alloc::string::String
+impl bitrouter_sdk::language_model::types::Source
+pub fn bitrouter_sdk::language_model::types::Source::synthesize_id(&str, usize) -> alloc::string::String
+impl core::clone::Clone for bitrouter_sdk::language_model::types::Source
+pub fn bitrouter_sdk::language_model::types::Source::clone(&self) -> bitrouter_sdk::language_model::types::Source
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::types::Source
+pub fn bitrouter_sdk::language_model::types::Source::eq(&self, &bitrouter_sdk::language_model::types::Source) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::Source
+pub fn bitrouter_sdk::language_model::types::Source::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::types::Source
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::types::Source
+pub fn bitrouter_sdk::language_model::types::Source::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::types::Source
+pub fn bitrouter_sdk::language_model::types::Source::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::Source
+impl core::marker::Send for bitrouter_sdk::language_model::types::Source
+impl core::marker::Sync for bitrouter_sdk::language_model::types::Source
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::Source
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::Source
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::Source
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::Source
+pub enum bitrouter_sdk::language_model::types::StreamPart
+pub bitrouter_sdk::language_model::types::StreamPart::File
+pub bitrouter_sdk::language_model::types::StreamPart::File::data: bitrouter_sdk::language_model::types::DataContent
+pub bitrouter_sdk::language_model::types::StreamPart::File::media_type: alloc::string::String
+pub bitrouter_sdk::language_model::types::StreamPart::Finish
+pub bitrouter_sdk::language_model::types::StreamPart::Finish::reason: bitrouter_sdk::language_model::types::FinishReason
+pub bitrouter_sdk::language_model::types::StreamPart::ReasoningDelta
+pub bitrouter_sdk::language_model::types::StreamPart::ReasoningDelta::text: alloc::string::String
+pub bitrouter_sdk::language_model::types::StreamPart::ReasoningEnd
+pub bitrouter_sdk::language_model::types::StreamPart::ReasoningEnd::id: alloc::string::String
+pub bitrouter_sdk::language_model::types::StreamPart::ReasoningEnd::signature: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::types::StreamPart::ReasoningStart
+pub bitrouter_sdk::language_model::types::StreamPart::ReasoningStart::id: alloc::string::String
+pub bitrouter_sdk::language_model::types::StreamPart::ResponseCompleted
+pub bitrouter_sdk::language_model::types::StreamPart::ResponseCompleted::id: alloc::string::String
+pub bitrouter_sdk::language_model::types::StreamPart::ResponseCompleted::source_protocol: bitrouter_sdk::language_model::types::ApiProtocol
+pub bitrouter_sdk::language_model::types::StreamPart::ResponseCompleted::status: alloc::string::String
+pub bitrouter_sdk::language_model::types::StreamPart::ResponseCompleted::usage: core::option::Option<bitrouter_sdk::language_model::types::Usage>
+pub bitrouter_sdk::language_model::types::StreamPart::ResponseStarted
+pub bitrouter_sdk::language_model::types::StreamPart::ResponseStarted::id: alloc::string::String
+pub bitrouter_sdk::language_model::types::StreamPart::ResponseStarted::source_protocol: bitrouter_sdk::language_model::types::ApiProtocol
+pub bitrouter_sdk::language_model::types::StreamPart::ServerToolCall
+pub bitrouter_sdk::language_model::types::StreamPart::ServerToolCall::arguments: alloc::string::String
+pub bitrouter_sdk::language_model::types::StreamPart::ServerToolCall::dynamic: bool
+pub bitrouter_sdk::language_model::types::StreamPart::ServerToolCall::id: alloc::string::String
+pub bitrouter_sdk::language_model::types::StreamPart::ServerToolCall::name: alloc::string::String
+pub bitrouter_sdk::language_model::types::StreamPart::ServerToolCall::server_name: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::types::StreamPart::ServerToolResult
+pub bitrouter_sdk::language_model::types::StreamPart::ServerToolResult::call_id: alloc::string::String
+pub bitrouter_sdk::language_model::types::StreamPart::ServerToolResult::dynamic: bool
+pub bitrouter_sdk::language_model::types::StreamPart::ServerToolResult::output: bitrouter_sdk::language_model::types::ToolResultOutput
+pub bitrouter_sdk::language_model::types::StreamPart::ServerToolResult::tool_name: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::types::StreamPart::Source
+pub bitrouter_sdk::language_model::types::StreamPart::Source::source: bitrouter_sdk::language_model::types::Source
+pub bitrouter_sdk::language_model::types::StreamPart::TextDelta
+pub bitrouter_sdk::language_model::types::StreamPart::TextDelta::text: alloc::string::String
+pub bitrouter_sdk::language_model::types::StreamPart::TextEnd
+pub bitrouter_sdk::language_model::types::StreamPart::TextEnd::id: alloc::string::String
+pub bitrouter_sdk::language_model::types::StreamPart::TextStart
+pub bitrouter_sdk::language_model::types::StreamPart::TextStart::id: alloc::string::String
+pub bitrouter_sdk::language_model::types::StreamPart::ToolCallDelta
+pub bitrouter_sdk::language_model::types::StreamPart::ToolCallDelta::arguments: alloc::string::String
+pub bitrouter_sdk::language_model::types::StreamPart::ToolCallDelta::id: alloc::string::String
+pub bitrouter_sdk::language_model::types::StreamPart::ToolCallDelta::name: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::types::StreamPart::Usage
+pub bitrouter_sdk::language_model::types::StreamPart::Usage::usage: bitrouter_sdk::language_model::types::Usage
+impl bitrouter_sdk::language_model::types::StreamPart
+pub fn bitrouter_sdk::language_model::types::StreamPart::is_terminal(&self) -> bool
+impl core::clone::Clone for bitrouter_sdk::language_model::types::StreamPart
+pub fn bitrouter_sdk::language_model::types::StreamPart::clone(&self) -> bitrouter_sdk::language_model::types::StreamPart
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::types::StreamPart
+pub fn bitrouter_sdk::language_model::types::StreamPart::eq(&self, &bitrouter_sdk::language_model::types::StreamPart) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::StreamPart
+pub fn bitrouter_sdk::language_model::types::StreamPart::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::types::StreamPart
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::types::StreamPart
+pub fn bitrouter_sdk::language_model::types::StreamPart::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::types::StreamPart
+pub fn bitrouter_sdk::language_model::types::StreamPart::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::StreamPart
+impl core::marker::Send for bitrouter_sdk::language_model::types::StreamPart
+impl core::marker::Sync for bitrouter_sdk::language_model::types::StreamPart
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::StreamPart
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::StreamPart
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::StreamPart
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::StreamPart
+pub enum bitrouter_sdk::language_model::types::Tool
+pub bitrouter_sdk::language_model::types::Tool::Function
+pub bitrouter_sdk::language_model::types::Tool::Function::description: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::types::Tool::Function::name: alloc::string::String
+pub bitrouter_sdk::language_model::types::Tool::Function::parameters: serde_json::value::Value
+pub bitrouter_sdk::language_model::types::Tool::Function::provider_metadata: bitrouter_sdk::language_model::types::ProviderMetadata
+pub bitrouter_sdk::language_model::types::Tool::Function::strict: core::option::Option<bool>
+pub bitrouter_sdk::language_model::types::Tool::ProviderDefined
+pub bitrouter_sdk::language_model::types::Tool::ProviderDefined::args: serde_json::value::Value
+pub bitrouter_sdk::language_model::types::Tool::ProviderDefined::id: alloc::string::String
+pub bitrouter_sdk::language_model::types::Tool::ProviderDefined::name: alloc::string::String
+pub bitrouter_sdk::language_model::types::Tool::ProviderDefined::provider_metadata: bitrouter_sdk::language_model::types::ProviderMetadata
+impl bitrouter_sdk::language_model::types::Tool
+pub fn bitrouter_sdk::language_model::types::Tool::name(&self) -> &str
+impl core::clone::Clone for bitrouter_sdk::language_model::types::Tool
+pub fn bitrouter_sdk::language_model::types::Tool::clone(&self) -> bitrouter_sdk::language_model::types::Tool
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::types::Tool
+pub fn bitrouter_sdk::language_model::types::Tool::eq(&self, &bitrouter_sdk::language_model::types::Tool) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::Tool
+pub fn bitrouter_sdk::language_model::types::Tool::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::types::Tool
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::types::Tool
+pub fn bitrouter_sdk::language_model::types::Tool::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::types::Tool
+pub fn bitrouter_sdk::language_model::types::Tool::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::Tool
+impl core::marker::Send for bitrouter_sdk::language_model::types::Tool
+impl core::marker::Sync for bitrouter_sdk::language_model::types::Tool
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::Tool
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::Tool
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::Tool
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::Tool
+pub enum bitrouter_sdk::language_model::types::ToolChoice
+pub bitrouter_sdk::language_model::types::ToolChoice::Auto
+pub bitrouter_sdk::language_model::types::ToolChoice::None
+pub bitrouter_sdk::language_model::types::ToolChoice::Required
+pub bitrouter_sdk::language_model::types::ToolChoice::Tool
+pub bitrouter_sdk::language_model::types::ToolChoice::Tool::name: alloc::string::String
+impl core::clone::Clone for bitrouter_sdk::language_model::types::ToolChoice
+pub fn bitrouter_sdk::language_model::types::ToolChoice::clone(&self) -> bitrouter_sdk::language_model::types::ToolChoice
+impl core::cmp::Eq for bitrouter_sdk::language_model::types::ToolChoice
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::types::ToolChoice
+pub fn bitrouter_sdk::language_model::types::ToolChoice::eq(&self, &bitrouter_sdk::language_model::types::ToolChoice) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::ToolChoice
+pub fn bitrouter_sdk::language_model::types::ToolChoice::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::types::ToolChoice
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::types::ToolChoice
+pub fn bitrouter_sdk::language_model::types::ToolChoice::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::types::ToolChoice
+pub fn bitrouter_sdk::language_model::types::ToolChoice::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::ToolChoice
+impl core::marker::Send for bitrouter_sdk::language_model::types::ToolChoice
+impl core::marker::Sync for bitrouter_sdk::language_model::types::ToolChoice
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::ToolChoice
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::ToolChoice
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::ToolChoice
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::ToolChoice
+pub enum bitrouter_sdk::language_model::types::ToolResultContentPart
+pub bitrouter_sdk::language_model::types::ToolResultContentPart::FileId
+pub bitrouter_sdk::language_model::types::ToolResultContentPart::FileId::id: alloc::string::String
+pub bitrouter_sdk::language_model::types::ToolResultContentPart::FileId::media_type: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::types::ToolResultContentPart::Media
+pub bitrouter_sdk::language_model::types::ToolResultContentPart::Media::data: bitrouter_sdk::language_model::types::DataContent
+pub bitrouter_sdk::language_model::types::ToolResultContentPart::Media::media_type: alloc::string::String
+pub bitrouter_sdk::language_model::types::ToolResultContentPart::Text
+pub bitrouter_sdk::language_model::types::ToolResultContentPart::Text::text: alloc::string::String
+impl core::clone::Clone for bitrouter_sdk::language_model::types::ToolResultContentPart
+pub fn bitrouter_sdk::language_model::types::ToolResultContentPart::clone(&self) -> bitrouter_sdk::language_model::types::ToolResultContentPart
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::types::ToolResultContentPart
+pub fn bitrouter_sdk::language_model::types::ToolResultContentPart::eq(&self, &bitrouter_sdk::language_model::types::ToolResultContentPart) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::ToolResultContentPart
+pub fn bitrouter_sdk::language_model::types::ToolResultContentPart::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::types::ToolResultContentPart
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::types::ToolResultContentPart
+pub fn bitrouter_sdk::language_model::types::ToolResultContentPart::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::types::ToolResultContentPart
+pub fn bitrouter_sdk::language_model::types::ToolResultContentPart::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::ToolResultContentPart
+impl core::marker::Send for bitrouter_sdk::language_model::types::ToolResultContentPart
+impl core::marker::Sync for bitrouter_sdk::language_model::types::ToolResultContentPart
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::ToolResultContentPart
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::ToolResultContentPart
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::ToolResultContentPart
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::ToolResultContentPart
+pub enum bitrouter_sdk::language_model::types::ToolResultOutput
+pub bitrouter_sdk::language_model::types::ToolResultOutput::Content
+pub bitrouter_sdk::language_model::types::ToolResultOutput::Content::value: alloc::vec::Vec<bitrouter_sdk::language_model::types::ToolResultContentPart>
+pub bitrouter_sdk::language_model::types::ToolResultOutput::ErrorJson
+pub bitrouter_sdk::language_model::types::ToolResultOutput::ErrorJson::value: serde_json::value::Value
+pub bitrouter_sdk::language_model::types::ToolResultOutput::ErrorText
+pub bitrouter_sdk::language_model::types::ToolResultOutput::ErrorText::value: alloc::string::String
+pub bitrouter_sdk::language_model::types::ToolResultOutput::ExecutionDenied
+pub bitrouter_sdk::language_model::types::ToolResultOutput::ExecutionDenied::reason: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::types::ToolResultOutput::Json
+pub bitrouter_sdk::language_model::types::ToolResultOutput::Json::value: serde_json::value::Value
+pub bitrouter_sdk::language_model::types::ToolResultOutput::Text
+pub bitrouter_sdk::language_model::types::ToolResultOutput::Text::value: alloc::string::String
+impl bitrouter_sdk::language_model::types::ToolResultOutput
+pub fn bitrouter_sdk::language_model::types::ToolResultOutput::from_untyped_value(&serde_json::value::Value) -> Self
+pub fn bitrouter_sdk::language_model::types::ToolResultOutput::is_error(&self) -> bool
+pub fn bitrouter_sdk::language_model::types::ToolResultOutput::to_provider_string(&self) -> alloc::string::String
+impl core::clone::Clone for bitrouter_sdk::language_model::types::ToolResultOutput
+pub fn bitrouter_sdk::language_model::types::ToolResultOutput::clone(&self) -> bitrouter_sdk::language_model::types::ToolResultOutput
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::types::ToolResultOutput
+pub fn bitrouter_sdk::language_model::types::ToolResultOutput::eq(&self, &bitrouter_sdk::language_model::types::ToolResultOutput) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::ToolResultOutput
+pub fn bitrouter_sdk::language_model::types::ToolResultOutput::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::types::ToolResultOutput
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::types::ToolResultOutput
+pub fn bitrouter_sdk::language_model::types::ToolResultOutput::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::types::ToolResultOutput
+pub fn bitrouter_sdk::language_model::types::ToolResultOutput::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::ToolResultOutput
+impl core::marker::Send for bitrouter_sdk::language_model::types::ToolResultOutput
+impl core::marker::Sync for bitrouter_sdk::language_model::types::ToolResultOutput
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::ToolResultOutput
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::ToolResultOutput
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::ToolResultOutput
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::ToolResultOutput
+pub enum bitrouter_sdk::language_model::types::UsageNormalizationError
+pub bitrouter_sdk::language_model::types::UsageNormalizationError::InputBucketsOverlap
+pub bitrouter_sdk::language_model::types::UsageNormalizationError::OutputBucketsOverlap
+impl core::clone::Clone for bitrouter_sdk::language_model::types::UsageNormalizationError
+pub fn bitrouter_sdk::language_model::types::UsageNormalizationError::clone(&self) -> bitrouter_sdk::language_model::types::UsageNormalizationError
+impl core::cmp::Eq for bitrouter_sdk::language_model::types::UsageNormalizationError
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::types::UsageNormalizationError
+pub fn bitrouter_sdk::language_model::types::UsageNormalizationError::eq(&self, &bitrouter_sdk::language_model::types::UsageNormalizationError) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::UsageNormalizationError
+pub fn bitrouter_sdk::language_model::types::UsageNormalizationError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for bitrouter_sdk::language_model::types::UsageNormalizationError
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::types::UsageNormalizationError
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::UsageNormalizationError
+impl core::marker::Send for bitrouter_sdk::language_model::types::UsageNormalizationError
+impl core::marker::Sync for bitrouter_sdk::language_model::types::UsageNormalizationError
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::UsageNormalizationError
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::UsageNormalizationError
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::UsageNormalizationError
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::UsageNormalizationError
+pub enum bitrouter_sdk::language_model::types::UsageOrigin
+pub bitrouter_sdk::language_model::types::UsageOrigin::AuthoritativeReceipt
+pub bitrouter_sdk::language_model::types::UsageOrigin::Estimated
+pub bitrouter_sdk::language_model::types::UsageOrigin::ProviderReported
+pub bitrouter_sdk::language_model::types::UsageOrigin::Unknown
+impl bitrouter_sdk::language_model::types::UsageOrigin
+pub fn bitrouter_sdk::language_model::types::UsageOrigin::as_str(self) -> &'static str
+impl core::clone::Clone for bitrouter_sdk::language_model::types::UsageOrigin
+pub fn bitrouter_sdk::language_model::types::UsageOrigin::clone(&self) -> bitrouter_sdk::language_model::types::UsageOrigin
+impl core::cmp::Eq for bitrouter_sdk::language_model::types::UsageOrigin
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::types::UsageOrigin
+pub fn bitrouter_sdk::language_model::types::UsageOrigin::eq(&self, &bitrouter_sdk::language_model::types::UsageOrigin) -> bool
+impl core::default::Default for bitrouter_sdk::language_model::types::UsageOrigin
+pub fn bitrouter_sdk::language_model::types::UsageOrigin::default() -> bitrouter_sdk::language_model::types::UsageOrigin
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::UsageOrigin
+pub fn bitrouter_sdk::language_model::types::UsageOrigin::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for bitrouter_sdk::language_model::types::UsageOrigin
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::types::UsageOrigin
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::types::UsageOrigin
+pub fn bitrouter_sdk::language_model::types::UsageOrigin::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::types::UsageOrigin
+pub fn bitrouter_sdk::language_model::types::UsageOrigin::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::UsageOrigin
+impl core::marker::Send for bitrouter_sdk::language_model::types::UsageOrigin
+impl core::marker::Sync for bitrouter_sdk::language_model::types::UsageOrigin
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::UsageOrigin
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::UsageOrigin
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::UsageOrigin
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::UsageOrigin
+pub struct bitrouter_sdk::language_model::types::ChatCompletionsCompatibility
+pub bitrouter_sdk::language_model::types::ChatCompletionsCompatibility::supports_store: core::option::Option<bool>
+pub bitrouter_sdk::language_model::types::ChatCompletionsCompatibility::supports_stream_options: core::option::Option<bool>
+pub bitrouter_sdk::language_model::types::ChatCompletionsCompatibility::token_limit_field: core::option::Option<bitrouter_sdk::language_model::types::ChatTokenLimitField>
+impl core::clone::Clone for bitrouter_sdk::language_model::types::ChatCompletionsCompatibility
+pub fn bitrouter_sdk::language_model::types::ChatCompletionsCompatibility::clone(&self) -> bitrouter_sdk::language_model::types::ChatCompletionsCompatibility
+impl core::default::Default for bitrouter_sdk::language_model::types::ChatCompletionsCompatibility
+pub fn bitrouter_sdk::language_model::types::ChatCompletionsCompatibility::default() -> bitrouter_sdk::language_model::types::ChatCompletionsCompatibility
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::ChatCompletionsCompatibility
+pub fn bitrouter_sdk::language_model::types::ChatCompletionsCompatibility::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::language_model::types::ChatCompletionsCompatibility
+pub fn bitrouter_sdk::language_model::types::ChatCompletionsCompatibility::inline_schema() -> bool
+pub fn bitrouter_sdk::language_model::types::ChatCompletionsCompatibility::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::language_model::types::ChatCompletionsCompatibility::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::language_model::types::ChatCompletionsCompatibility::schema_name() -> alloc::borrow::Cow<'static, str>
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::types::ChatCompletionsCompatibility
+pub fn bitrouter_sdk::language_model::types::ChatCompletionsCompatibility::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::types::ChatCompletionsCompatibility where bitrouter_sdk::language_model::types::ChatCompletionsCompatibility: core::default::Default
+pub fn bitrouter_sdk::language_model::types::ChatCompletionsCompatibility::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::ChatCompletionsCompatibility
+impl core::marker::Send for bitrouter_sdk::language_model::types::ChatCompletionsCompatibility
+impl core::marker::Sync for bitrouter_sdk::language_model::types::ChatCompletionsCompatibility
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::ChatCompletionsCompatibility
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::ChatCompletionsCompatibility
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::ChatCompletionsCompatibility
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::ChatCompletionsCompatibility
+pub struct bitrouter_sdk::language_model::types::ChatStreamOptions
+pub bitrouter_sdk::language_model::types::ChatStreamOptions::extra: std::collections::hash::map::HashMap<alloc::string::String, serde_json::value::Value>
+pub bitrouter_sdk::language_model::types::ChatStreamOptions::include_obfuscation: core::option::Option<bool>
+pub bitrouter_sdk::language_model::types::ChatStreamOptions::include_usage: core::option::Option<bool>
+impl core::clone::Clone for bitrouter_sdk::language_model::types::ChatStreamOptions
+pub fn bitrouter_sdk::language_model::types::ChatStreamOptions::clone(&self) -> bitrouter_sdk::language_model::types::ChatStreamOptions
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::types::ChatStreamOptions
+pub fn bitrouter_sdk::language_model::types::ChatStreamOptions::eq(&self, &bitrouter_sdk::language_model::types::ChatStreamOptions) -> bool
+impl core::default::Default for bitrouter_sdk::language_model::types::ChatStreamOptions
+pub fn bitrouter_sdk::language_model::types::ChatStreamOptions::default() -> bitrouter_sdk::language_model::types::ChatStreamOptions
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::ChatStreamOptions
+pub fn bitrouter_sdk::language_model::types::ChatStreamOptions::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::types::ChatStreamOptions
+impl schemars::JsonSchema for bitrouter_sdk::language_model::types::ChatStreamOptions
+pub fn bitrouter_sdk::language_model::types::ChatStreamOptions::inline_schema() -> bool
+pub fn bitrouter_sdk::language_model::types::ChatStreamOptions::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::language_model::types::ChatStreamOptions::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::language_model::types::ChatStreamOptions::schema_name() -> alloc::borrow::Cow<'static, str>
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::types::ChatStreamOptions
+pub fn bitrouter_sdk::language_model::types::ChatStreamOptions::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::types::ChatStreamOptions
+pub fn bitrouter_sdk::language_model::types::ChatStreamOptions::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::ChatStreamOptions
+impl core::marker::Send for bitrouter_sdk::language_model::types::ChatStreamOptions
+impl core::marker::Sync for bitrouter_sdk::language_model::types::ChatStreamOptions
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::ChatStreamOptions
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::ChatStreamOptions
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::ChatStreamOptions
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::ChatStreamOptions
+pub struct bitrouter_sdk::language_model::types::ExecutionResult
+pub bitrouter_sdk::language_model::types::ExecutionResult::account_label: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::types::ExecutionResult::model_id: alloc::string::String
+pub bitrouter_sdk::language_model::types::ExecutionResult::provider_id: alloc::string::String
+pub bitrouter_sdk::language_model::types::ExecutionResult::request_duration_ms: u64
+pub bitrouter_sdk::language_model::types::ExecutionResult::result: bitrouter_sdk::language_model::types::GenerateResult
+pub bitrouter_sdk::language_model::types::ExecutionResult::server_tool_calls: alloc::vec::Vec<bitrouter_sdk::language_model::types::ServerToolCall>
+pub bitrouter_sdk::language_model::types::ExecutionResult::upstream_duration_ms: core::option::Option<u64>
+impl core::clone::Clone for bitrouter_sdk::language_model::types::ExecutionResult
+pub fn bitrouter_sdk::language_model::types::ExecutionResult::clone(&self) -> bitrouter_sdk::language_model::types::ExecutionResult
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::ExecutionResult
+pub fn bitrouter_sdk::language_model::types::ExecutionResult::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::ExecutionResult
+impl core::marker::Send for bitrouter_sdk::language_model::types::ExecutionResult
+impl core::marker::Sync for bitrouter_sdk::language_model::types::ExecutionResult
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::ExecutionResult
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::ExecutionResult
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::ExecutionResult
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::ExecutionResult
+pub struct bitrouter_sdk::language_model::types::GenerateResult
+pub bitrouter_sdk::language_model::types::GenerateResult::content: alloc::vec::Vec<bitrouter_sdk::language_model::types::Content>
+pub bitrouter_sdk::language_model::types::GenerateResult::finish_reason: core::option::Option<bitrouter_sdk::language_model::types::FinishReason>
+pub bitrouter_sdk::language_model::types::GenerateResult::provider_metadata: bitrouter_sdk::language_model::types::ProviderMetadata
+pub bitrouter_sdk::language_model::types::GenerateResult::response_id: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::types::GenerateResult::stop_details: core::option::Option<bitrouter_sdk::language_model::types::StopDetails>
+pub bitrouter_sdk::language_model::types::GenerateResult::usage: core::option::Option<bitrouter_sdk::language_model::types::Usage>
+impl core::clone::Clone for bitrouter_sdk::language_model::types::GenerateResult
+pub fn bitrouter_sdk::language_model::types::GenerateResult::clone(&self) -> bitrouter_sdk::language_model::types::GenerateResult
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::types::GenerateResult
+pub fn bitrouter_sdk::language_model::types::GenerateResult::eq(&self, &bitrouter_sdk::language_model::types::GenerateResult) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::GenerateResult
+pub fn bitrouter_sdk::language_model::types::GenerateResult::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::types::GenerateResult
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::types::GenerateResult
+pub fn bitrouter_sdk::language_model::types::GenerateResult::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::types::GenerateResult
+pub fn bitrouter_sdk::language_model::types::GenerateResult::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::GenerateResult
+impl core::marker::Send for bitrouter_sdk::language_model::types::GenerateResult
+impl core::marker::Sync for bitrouter_sdk::language_model::types::GenerateResult
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::GenerateResult
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::GenerateResult
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::GenerateResult
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::GenerateResult
+pub struct bitrouter_sdk::language_model::types::GenerationParams
+pub bitrouter_sdk::language_model::types::GenerationParams::chat_stream_options: core::option::Option<bitrouter_sdk::language_model::types::ChatStreamOptions>
+pub bitrouter_sdk::language_model::types::GenerationParams::chat_token_limit_field: core::option::Option<bitrouter_sdk::language_model::types::ChatTokenLimitField>
+pub bitrouter_sdk::language_model::types::GenerationParams::extra: std::collections::hash::map::HashMap<alloc::string::String, serde_json::value::Value>
+pub bitrouter_sdk::language_model::types::GenerationParams::extra_protocol: core::option::Option<bitrouter_sdk::language_model::types::ApiProtocol>
+pub bitrouter_sdk::language_model::types::GenerationParams::frequency_penalty: core::option::Option<f64>
+pub bitrouter_sdk::language_model::types::GenerationParams::max_tokens: core::option::Option<u32>
+pub bitrouter_sdk::language_model::types::GenerationParams::parallel_tool_calls: core::option::Option<bool>
+pub bitrouter_sdk::language_model::types::GenerationParams::presence_penalty: core::option::Option<f64>
+pub bitrouter_sdk::language_model::types::GenerationParams::reasoning_effort: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::types::GenerationParams::response_modalities: alloc::vec::Vec<bitrouter_sdk::language_model::types::Modality>
+pub bitrouter_sdk::language_model::types::GenerationParams::seed: core::option::Option<i64>
+pub bitrouter_sdk::language_model::types::GenerationParams::stop: alloc::vec::Vec<alloc::string::String>
+pub bitrouter_sdk::language_model::types::GenerationParams::store: core::option::Option<bool>
+pub bitrouter_sdk::language_model::types::GenerationParams::supplemental_extra: std::collections::hash::map::HashMap<alloc::string::String, serde_json::value::Value>
+pub bitrouter_sdk::language_model::types::GenerationParams::temperature: core::option::Option<f64>
+pub bitrouter_sdk::language_model::types::GenerationParams::top_k: core::option::Option<u32>
+pub bitrouter_sdk::language_model::types::GenerationParams::top_p: core::option::Option<f64>
+impl bitrouter_sdk::language_model::types::GenerationParams
+pub fn bitrouter_sdk::language_model::types::GenerationParams::extra_value_for_protocol(&self, &bitrouter_sdk::language_model::types::ApiProtocol, &str) -> core::option::Option<&serde_json::value::Value>
+pub fn bitrouter_sdk::language_model::types::GenerationParams::extras_for_protocol<'a>(&'a self, &'a bitrouter_sdk::language_model::types::ApiProtocol) -> impl core::iter::traits::iterator::Iterator<Item = (&'a alloc::string::String, &'a serde_json::value::Value)> + 'a
+impl core::clone::Clone for bitrouter_sdk::language_model::types::GenerationParams
+pub fn bitrouter_sdk::language_model::types::GenerationParams::clone(&self) -> bitrouter_sdk::language_model::types::GenerationParams
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::types::GenerationParams
+pub fn bitrouter_sdk::language_model::types::GenerationParams::eq(&self, &bitrouter_sdk::language_model::types::GenerationParams) -> bool
+impl core::default::Default for bitrouter_sdk::language_model::types::GenerationParams
+pub fn bitrouter_sdk::language_model::types::GenerationParams::default() -> bitrouter_sdk::language_model::types::GenerationParams
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::GenerationParams
+pub fn bitrouter_sdk::language_model::types::GenerationParams::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::types::GenerationParams
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::types::GenerationParams
+pub fn bitrouter_sdk::language_model::types::GenerationParams::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::types::GenerationParams
+pub fn bitrouter_sdk::language_model::types::GenerationParams::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::GenerationParams
+impl core::marker::Send for bitrouter_sdk::language_model::types::GenerationParams
+impl core::marker::Sync for bitrouter_sdk::language_model::types::GenerationParams
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::GenerationParams
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::GenerationParams
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::GenerationParams
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::GenerationParams
+pub struct bitrouter_sdk::language_model::types::Message
+pub bitrouter_sdk::language_model::types::Message::content: alloc::vec::Vec<bitrouter_sdk::language_model::types::Content>
+pub bitrouter_sdk::language_model::types::Message::role: bitrouter_sdk::language_model::types::Role
+impl bitrouter_sdk::language_model::types::Message
+pub fn bitrouter_sdk::language_model::types::Message::text(bitrouter_sdk::language_model::types::Role, impl core::convert::Into<alloc::string::String>) -> Self
+impl core::clone::Clone for bitrouter_sdk::language_model::types::Message
+pub fn bitrouter_sdk::language_model::types::Message::clone(&self) -> bitrouter_sdk::language_model::types::Message
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::types::Message
+pub fn bitrouter_sdk::language_model::types::Message::eq(&self, &bitrouter_sdk::language_model::types::Message) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::Message
+pub fn bitrouter_sdk::language_model::types::Message::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::types::Message
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::types::Message
+pub fn bitrouter_sdk::language_model::types::Message::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::types::Message
+pub fn bitrouter_sdk::language_model::types::Message::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::Message
+impl core::marker::Send for bitrouter_sdk::language_model::types::Message
+impl core::marker::Sync for bitrouter_sdk::language_model::types::Message
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::Message
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::Message
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::Message
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::Message
+pub struct bitrouter_sdk::language_model::types::ModelCompatibility
+pub bitrouter_sdk::language_model::types::ModelCompatibility::chat_completions: bitrouter_sdk::language_model::types::ChatCompletionsCompatibility
+impl core::clone::Clone for bitrouter_sdk::language_model::types::ModelCompatibility
+pub fn bitrouter_sdk::language_model::types::ModelCompatibility::clone(&self) -> bitrouter_sdk::language_model::types::ModelCompatibility
+impl core::default::Default for bitrouter_sdk::language_model::types::ModelCompatibility
+pub fn bitrouter_sdk::language_model::types::ModelCompatibility::default() -> bitrouter_sdk::language_model::types::ModelCompatibility
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::ModelCompatibility
+pub fn bitrouter_sdk::language_model::types::ModelCompatibility::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::language_model::types::ModelCompatibility
+pub fn bitrouter_sdk::language_model::types::ModelCompatibility::inline_schema() -> bool
+pub fn bitrouter_sdk::language_model::types::ModelCompatibility::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::language_model::types::ModelCompatibility::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::language_model::types::ModelCompatibility::schema_name() -> alloc::borrow::Cow<'static, str>
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::types::ModelCompatibility
+pub fn bitrouter_sdk::language_model::types::ModelCompatibility::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::types::ModelCompatibility where bitrouter_sdk::language_model::types::ModelCompatibility: core::default::Default
+pub fn bitrouter_sdk::language_model::types::ModelCompatibility::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::ModelCompatibility
+impl core::marker::Send for bitrouter_sdk::language_model::types::ModelCompatibility
+impl core::marker::Sync for bitrouter_sdk::language_model::types::ModelCompatibility
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::ModelCompatibility
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::ModelCompatibility
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::ModelCompatibility
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::ModelCompatibility
+pub struct bitrouter_sdk::language_model::types::NormalizedUsage
+pub bitrouter_sdk::language_model::types::NormalizedUsage::cache_read_tokens: u64
+pub bitrouter_sdk::language_model::types::NormalizedUsage::cache_write_tokens: u64
+pub bitrouter_sdk::language_model::types::NormalizedUsage::output_tokens: u64
+pub bitrouter_sdk::language_model::types::NormalizedUsage::reasoning_tokens: u64
+pub bitrouter_sdk::language_model::types::NormalizedUsage::uncached_input_tokens: u64
+impl core::clone::Clone for bitrouter_sdk::language_model::types::NormalizedUsage
+pub fn bitrouter_sdk::language_model::types::NormalizedUsage::clone(&self) -> bitrouter_sdk::language_model::types::NormalizedUsage
+impl core::cmp::Eq for bitrouter_sdk::language_model::types::NormalizedUsage
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::types::NormalizedUsage
+pub fn bitrouter_sdk::language_model::types::NormalizedUsage::eq(&self, &bitrouter_sdk::language_model::types::NormalizedUsage) -> bool
+impl core::default::Default for bitrouter_sdk::language_model::types::NormalizedUsage
+pub fn bitrouter_sdk::language_model::types::NormalizedUsage::default() -> bitrouter_sdk::language_model::types::NormalizedUsage
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::NormalizedUsage
+pub fn bitrouter_sdk::language_model::types::NormalizedUsage::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for bitrouter_sdk::language_model::types::NormalizedUsage
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::types::NormalizedUsage
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::types::NormalizedUsage
+pub fn bitrouter_sdk::language_model::types::NormalizedUsage::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::types::NormalizedUsage
+pub fn bitrouter_sdk::language_model::types::NormalizedUsage::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::NormalizedUsage
+impl core::marker::Send for bitrouter_sdk::language_model::types::NormalizedUsage
+impl core::marker::Sync for bitrouter_sdk::language_model::types::NormalizedUsage
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::NormalizedUsage
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::NormalizedUsage
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::NormalizedUsage
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::NormalizedUsage
+pub struct bitrouter_sdk::language_model::types::PipelineRequest
+pub bitrouter_sdk::language_model::types::PipelineRequest::caller: bitrouter_sdk::caller::CallerContext
+pub bitrouter_sdk::language_model::types::PipelineRequest::headers: http::header::map::HeaderMap
+pub bitrouter_sdk::language_model::types::PipelineRequest::inbound_protocol: core::option::Option<bitrouter_sdk::language_model::types::ApiProtocol>
+pub bitrouter_sdk::language_model::types::PipelineRequest::model: alloc::string::String
+pub bitrouter_sdk::language_model::types::PipelineRequest::prompt: bitrouter_sdk::language_model::types::Prompt
+pub bitrouter_sdk::language_model::types::PipelineRequest::request_id: alloc::string::String
+impl bitrouter_sdk::language_model::types::PipelineRequest
+pub fn bitrouter_sdk::language_model::types::PipelineRequest::new(impl core::convert::Into<alloc::string::String>, bitrouter_sdk::caller::CallerContext, bitrouter_sdk::language_model::types::Prompt) -> Self
+impl core::clone::Clone for bitrouter_sdk::language_model::types::PipelineRequest
+pub fn bitrouter_sdk::language_model::types::PipelineRequest::clone(&self) -> bitrouter_sdk::language_model::types::PipelineRequest
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::PipelineRequest
+pub fn bitrouter_sdk::language_model::types::PipelineRequest::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::PipelineRequest
+impl core::marker::Send for bitrouter_sdk::language_model::types::PipelineRequest
+impl core::marker::Sync for bitrouter_sdk::language_model::types::PipelineRequest
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::PipelineRequest
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::PipelineRequest
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::PipelineRequest
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::PipelineRequest
+pub struct bitrouter_sdk::language_model::types::PipelineResponse
+pub bitrouter_sdk::language_model::types::PipelineResponse::request_id: alloc::string::String
+pub bitrouter_sdk::language_model::types::PipelineResponse::result: bitrouter_sdk::language_model::types::GenerateResult
+impl core::clone::Clone for bitrouter_sdk::language_model::types::PipelineResponse
+pub fn bitrouter_sdk::language_model::types::PipelineResponse::clone(&self) -> bitrouter_sdk::language_model::types::PipelineResponse
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::PipelineResponse
+pub fn bitrouter_sdk::language_model::types::PipelineResponse::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::PipelineResponse
+impl core::marker::Send for bitrouter_sdk::language_model::types::PipelineResponse
+impl core::marker::Sync for bitrouter_sdk::language_model::types::PipelineResponse
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::PipelineResponse
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::PipelineResponse
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::PipelineResponse
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::PipelineResponse
+pub struct bitrouter_sdk::language_model::types::Prompt
+pub bitrouter_sdk::language_model::types::Prompt::messages: alloc::vec::Vec<bitrouter_sdk::language_model::types::Message>
+pub bitrouter_sdk::language_model::types::Prompt::model: alloc::string::String
+pub bitrouter_sdk::language_model::types::Prompt::params: bitrouter_sdk::language_model::types::GenerationParams
+pub bitrouter_sdk::language_model::types::Prompt::response_format: core::option::Option<bitrouter_sdk::language_model::types::ResponseFormat>
+pub bitrouter_sdk::language_model::types::Prompt::stream: bool
+pub bitrouter_sdk::language_model::types::Prompt::system: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::types::Prompt::system_provider_metadata: bitrouter_sdk::language_model::types::ProviderMetadata
+pub bitrouter_sdk::language_model::types::Prompt::tool_choice: core::option::Option<bitrouter_sdk::language_model::types::ToolChoice>
+pub bitrouter_sdk::language_model::types::Prompt::tools: alloc::vec::Vec<bitrouter_sdk::language_model::types::Tool>
+impl bitrouter_sdk::language_model::types::Prompt
+pub fn bitrouter_sdk::language_model::types::Prompt::required_capabilities(&self) -> alloc::vec::Vec<bitrouter_sdk::language_model::types::Capability>
+impl core::clone::Clone for bitrouter_sdk::language_model::types::Prompt
+pub fn bitrouter_sdk::language_model::types::Prompt::clone(&self) -> bitrouter_sdk::language_model::types::Prompt
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::types::Prompt
+pub fn bitrouter_sdk::language_model::types::Prompt::eq(&self, &bitrouter_sdk::language_model::types::Prompt) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::Prompt
+pub fn bitrouter_sdk::language_model::types::Prompt::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::types::Prompt
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::types::Prompt
+pub fn bitrouter_sdk::language_model::types::Prompt::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::types::Prompt
+pub fn bitrouter_sdk::language_model::types::Prompt::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::Prompt
+impl core::marker::Send for bitrouter_sdk::language_model::types::Prompt
+impl core::marker::Sync for bitrouter_sdk::language_model::types::Prompt
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::Prompt
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::Prompt
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::Prompt
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::Prompt
+pub struct bitrouter_sdk::language_model::types::ProtocolList(pub alloc::vec::Vec<bitrouter_sdk::language_model::types::ApiProtocol>)
+impl bitrouter_sdk::language_model::types::ProtocolList
+pub fn bitrouter_sdk::language_model::types::ProtocolList::as_slice(&self) -> &[bitrouter_sdk::language_model::types::ApiProtocol]
+pub fn bitrouter_sdk::language_model::types::ProtocolList::contains(&self, &bitrouter_sdk::language_model::types::ApiProtocol) -> bool
+pub fn bitrouter_sdk::language_model::types::ProtocolList::is_empty(&self) -> bool
+pub fn bitrouter_sdk::language_model::types::ProtocolList::preferred(&self) -> core::option::Option<&bitrouter_sdk::language_model::types::ApiProtocol>
+impl core::clone::Clone for bitrouter_sdk::language_model::types::ProtocolList
+pub fn bitrouter_sdk::language_model::types::ProtocolList::clone(&self) -> bitrouter_sdk::language_model::types::ProtocolList
+impl core::cmp::Eq for bitrouter_sdk::language_model::types::ProtocolList
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::types::ProtocolList
+pub fn bitrouter_sdk::language_model::types::ProtocolList::eq(&self, &bitrouter_sdk::language_model::types::ProtocolList) -> bool
+impl core::convert::From<bitrouter_sdk::language_model::types::ApiProtocol> for bitrouter_sdk::language_model::types::ProtocolList
+pub fn bitrouter_sdk::language_model::types::ProtocolList::from(bitrouter_sdk::language_model::types::ApiProtocol) -> Self
+impl core::default::Default for bitrouter_sdk::language_model::types::ProtocolList
+pub fn bitrouter_sdk::language_model::types::ProtocolList::default() -> bitrouter_sdk::language_model::types::ProtocolList
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::ProtocolList
+pub fn bitrouter_sdk::language_model::types::ProtocolList::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::types::ProtocolList
+impl schemars::JsonSchema for bitrouter_sdk::language_model::types::ProtocolList
+pub fn bitrouter_sdk::language_model::types::ProtocolList::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::language_model::types::ProtocolList::schema_name() -> alloc::borrow::Cow<'static, str>
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::types::ProtocolList
+pub fn bitrouter_sdk::language_model::types::ProtocolList::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::types::ProtocolList
+pub fn bitrouter_sdk::language_model::types::ProtocolList::deserialize<D: serde_core::de::Deserializer<'de>>(D) -> core::result::Result<Self, <D as serde_core::de::Deserializer>::Error>
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::ProtocolList
+impl core::marker::Send for bitrouter_sdk::language_model::types::ProtocolList
+impl core::marker::Sync for bitrouter_sdk::language_model::types::ProtocolList
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::ProtocolList
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::ProtocolList
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::ProtocolList
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::ProtocolList
+pub struct bitrouter_sdk::language_model::types::RoutingTarget
+pub bitrouter_sdk::language_model::types::RoutingTarget::account_label: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::types::RoutingTarget::api_base: alloc::string::String
+pub bitrouter_sdk::language_model::types::RoutingTarget::api_base_override: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::types::RoutingTarget::api_key: alloc::string::String
+pub bitrouter_sdk::language_model::types::RoutingTarget::api_key_override: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::types::RoutingTarget::api_protocol: bitrouter_sdk::language_model::types::ApiProtocol
+pub bitrouter_sdk::language_model::types::RoutingTarget::auth_scheme: bitrouter_sdk::language_model::types::AuthScheme
+pub bitrouter_sdk::language_model::types::RoutingTarget::chat_supports_store: core::option::Option<bool>
+pub bitrouter_sdk::language_model::types::RoutingTarget::chat_supports_stream_options: core::option::Option<bool>
+pub bitrouter_sdk::language_model::types::RoutingTarget::chat_token_limit_field: core::option::Option<bitrouter_sdk::language_model::types::ChatTokenLimitField>
+pub bitrouter_sdk::language_model::types::RoutingTarget::provider_name: alloc::string::String
+pub bitrouter_sdk::language_model::types::RoutingTarget::service_id: alloc::string::String
+impl bitrouter_sdk::language_model::types::RoutingTarget
+pub fn bitrouter_sdk::language_model::types::RoutingTarget::effective_api_base(&self) -> &str
+pub fn bitrouter_sdk::language_model::types::RoutingTarget::effective_api_key(&self) -> &str
+impl core::clone::Clone for bitrouter_sdk::language_model::types::RoutingTarget
+pub fn bitrouter_sdk::language_model::types::RoutingTarget::clone(&self) -> bitrouter_sdk::language_model::types::RoutingTarget
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::RoutingTarget
+pub fn bitrouter_sdk::language_model::types::RoutingTarget::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::RoutingTarget
+impl core::marker::Send for bitrouter_sdk::language_model::types::RoutingTarget
+impl core::marker::Sync for bitrouter_sdk::language_model::types::RoutingTarget
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::RoutingTarget
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::RoutingTarget
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::RoutingTarget
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::RoutingTarget
+pub struct bitrouter_sdk::language_model::types::ServerToolCall
+pub bitrouter_sdk::language_model::types::ServerToolCall::call_id: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::types::ServerToolCall::kind: bitrouter_sdk::language_model::types::ServerToolKind
+pub bitrouter_sdk::language_model::types::ServerToolCall::name: alloc::string::String
+pub bitrouter_sdk::language_model::types::ServerToolCall::result_count: u32
+pub bitrouter_sdk::language_model::types::ServerToolCall::status: bitrouter_sdk::language_model::types::ServerToolStatus
+impl core::clone::Clone for bitrouter_sdk::language_model::types::ServerToolCall
+pub fn bitrouter_sdk::language_model::types::ServerToolCall::clone(&self) -> bitrouter_sdk::language_model::types::ServerToolCall
+impl core::cmp::Eq for bitrouter_sdk::language_model::types::ServerToolCall
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::types::ServerToolCall
+pub fn bitrouter_sdk::language_model::types::ServerToolCall::eq(&self, &bitrouter_sdk::language_model::types::ServerToolCall) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::ServerToolCall
+pub fn bitrouter_sdk::language_model::types::ServerToolCall::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::types::ServerToolCall
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::types::ServerToolCall
+pub fn bitrouter_sdk::language_model::types::ServerToolCall::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::types::ServerToolCall
+pub fn bitrouter_sdk::language_model::types::ServerToolCall::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::ServerToolCall
+impl core::marker::Send for bitrouter_sdk::language_model::types::ServerToolCall
+impl core::marker::Sync for bitrouter_sdk::language_model::types::ServerToolCall
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::ServerToolCall
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::ServerToolCall
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::ServerToolCall
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::ServerToolCall
+pub struct bitrouter_sdk::language_model::types::StopDetails
+pub bitrouter_sdk::language_model::types::StopDetails::category: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::types::StopDetails::explanation: core::option::Option<alloc::string::String>
+impl core::clone::Clone for bitrouter_sdk::language_model::types::StopDetails
+pub fn bitrouter_sdk::language_model::types::StopDetails::clone(&self) -> bitrouter_sdk::language_model::types::StopDetails
+impl core::cmp::Eq for bitrouter_sdk::language_model::types::StopDetails
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::types::StopDetails
+pub fn bitrouter_sdk::language_model::types::StopDetails::eq(&self, &bitrouter_sdk::language_model::types::StopDetails) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::StopDetails
+pub fn bitrouter_sdk::language_model::types::StopDetails::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::types::StopDetails
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::types::StopDetails
+pub fn bitrouter_sdk::language_model::types::StopDetails::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::types::StopDetails
+pub fn bitrouter_sdk::language_model::types::StopDetails::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::StopDetails
+impl core::marker::Send for bitrouter_sdk::language_model::types::StopDetails
+impl core::marker::Sync for bitrouter_sdk::language_model::types::StopDetails
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::StopDetails
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::StopDetails
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::StopDetails
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::StopDetails
+pub struct bitrouter_sdk::language_model::types::Usage
+pub bitrouter_sdk::language_model::types::Usage::cache_read_tokens: u64
+pub bitrouter_sdk::language_model::types::Usage::cache_write_tokens: u64
+pub bitrouter_sdk::language_model::types::Usage::completion_tokens: u64
+pub bitrouter_sdk::language_model::types::Usage::origin: bitrouter_sdk::language_model::types::UsageOrigin
+pub bitrouter_sdk::language_model::types::Usage::prompt_tokens: u64
+pub bitrouter_sdk::language_model::types::Usage::raw: core::option::Option<alloc::boxed::Box<serde_json::value::Value>>
+pub bitrouter_sdk::language_model::types::Usage::reasoning_tokens: u64
+pub bitrouter_sdk::language_model::types::Usage::web_search_count: u64
+impl bitrouter_sdk::language_model::types::Usage
+pub fn bitrouter_sdk::language_model::types::Usage::normalized_buckets(&self) -> core::result::Result<bitrouter_sdk::language_model::types::NormalizedUsage, bitrouter_sdk::language_model::types::UsageNormalizationError>
+pub fn bitrouter_sdk::language_model::types::Usage::total(&self) -> u64
+impl core::clone::Clone for bitrouter_sdk::language_model::types::Usage
+pub fn bitrouter_sdk::language_model::types::Usage::clone(&self) -> bitrouter_sdk::language_model::types::Usage
+impl core::cmp::Eq for bitrouter_sdk::language_model::types::Usage
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::types::Usage
+pub fn bitrouter_sdk::language_model::types::Usage::eq(&self, &bitrouter_sdk::language_model::types::Usage) -> bool
+impl core::default::Default for bitrouter_sdk::language_model::types::Usage
+pub fn bitrouter_sdk::language_model::types::Usage::default() -> bitrouter_sdk::language_model::types::Usage
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::Usage
+pub fn bitrouter_sdk::language_model::types::Usage::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::types::Usage
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::types::Usage
+pub fn bitrouter_sdk::language_model::types::Usage::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::types::Usage
+pub fn bitrouter_sdk::language_model::types::Usage::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::Usage
+impl core::marker::Send for bitrouter_sdk::language_model::types::Usage
+impl core::marker::Sync for bitrouter_sdk::language_model::types::Usage
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::Usage
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::Usage
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::Usage
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::Usage
+pub type bitrouter_sdk::language_model::types::ProviderMetadata = alloc::collections::btree::map::BTreeMap<alloc::string::String, serde_json::value::Value>
+pub enum bitrouter_sdk::language_model::ApiProtocol
+pub bitrouter_sdk::language_model::ApiProtocol::ChatCompletions
+pub bitrouter_sdk::language_model::ApiProtocol::Custom(alloc::string::String)
+pub bitrouter_sdk::language_model::ApiProtocol::GenerateContent
+pub bitrouter_sdk::language_model::ApiProtocol::Messages
+pub bitrouter_sdk::language_model::ApiProtocol::Responses
+impl bitrouter_sdk::language_model::types::ApiProtocol
+pub fn bitrouter_sdk::language_model::types::ApiProtocol::as_str(&self) -> &str
+impl core::clone::Clone for bitrouter_sdk::language_model::types::ApiProtocol
+pub fn bitrouter_sdk::language_model::types::ApiProtocol::clone(&self) -> bitrouter_sdk::language_model::types::ApiProtocol
+impl core::cmp::Eq for bitrouter_sdk::language_model::types::ApiProtocol
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::types::ApiProtocol
+pub fn bitrouter_sdk::language_model::types::ApiProtocol::eq(&self, &bitrouter_sdk::language_model::types::ApiProtocol) -> bool
+impl core::convert::From<bitrouter_sdk::language_model::types::ApiProtocol> for bitrouter_sdk::language_model::types::ProtocolList
+pub fn bitrouter_sdk::language_model::types::ProtocolList::from(bitrouter_sdk::language_model::types::ApiProtocol) -> Self
+impl core::default::Default for bitrouter_sdk::language_model::types::ApiProtocol
+pub fn bitrouter_sdk::language_model::types::ApiProtocol::default() -> bitrouter_sdk::language_model::types::ApiProtocol
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::ApiProtocol
+pub fn bitrouter_sdk::language_model::types::ApiProtocol::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitrouter_sdk::language_model::types::ApiProtocol
+pub fn bitrouter_sdk::language_model::types::ApiProtocol::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for bitrouter_sdk::language_model::types::ApiProtocol
+pub fn bitrouter_sdk::language_model::types::ApiProtocol::hash<__H: core::hash::Hasher>(&self, &mut __H)
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::types::ApiProtocol
+impl schemars::JsonSchema for bitrouter_sdk::language_model::types::ApiProtocol
+pub fn bitrouter_sdk::language_model::types::ApiProtocol::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::language_model::types::ApiProtocol::schema_name() -> alloc::borrow::Cow<'static, str>
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::types::ApiProtocol
+pub fn bitrouter_sdk::language_model::types::ApiProtocol::serialize<S: serde_core::ser::Serializer>(&self, S) -> core::result::Result<<S as serde_core::ser::Serializer>::Ok, <S as serde_core::ser::Serializer>::Error>
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::types::ApiProtocol
+pub fn bitrouter_sdk::language_model::types::ApiProtocol::deserialize<D: serde_core::de::Deserializer<'de>>(D) -> core::result::Result<Self, <D as serde_core::de::Deserializer>::Error>
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::ApiProtocol
+impl core::marker::Send for bitrouter_sdk::language_model::types::ApiProtocol
+impl core::marker::Sync for bitrouter_sdk::language_model::types::ApiProtocol
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::ApiProtocol
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::ApiProtocol
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::ApiProtocol
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::ApiProtocol
+pub enum bitrouter_sdk::language_model::Capability
+pub bitrouter_sdk::language_model::Capability::AudioInput
+pub bitrouter_sdk::language_model::Capability::AudioOutput
+pub bitrouter_sdk::language_model::Capability::FileInput
+pub bitrouter_sdk::language_model::Capability::ImageInput
+pub bitrouter_sdk::language_model::Capability::ImageOutput
+pub bitrouter_sdk::language_model::Capability::Logprobs
+pub bitrouter_sdk::language_model::Capability::Reasoning
+pub bitrouter_sdk::language_model::Capability::StructuredOutputs
+pub bitrouter_sdk::language_model::Capability::Tools
+pub bitrouter_sdk::language_model::Capability::VideoInput
+pub bitrouter_sdk::language_model::Capability::WebSearch
+impl bitrouter_sdk::language_model::types::Capability
+pub fn bitrouter_sdk::language_model::types::Capability::as_str(&self) -> &'static str
+impl core::clone::Clone for bitrouter_sdk::language_model::types::Capability
+pub fn bitrouter_sdk::language_model::types::Capability::clone(&self) -> bitrouter_sdk::language_model::types::Capability
+impl core::cmp::Eq for bitrouter_sdk::language_model::types::Capability
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::types::Capability
+pub fn bitrouter_sdk::language_model::types::Capability::eq(&self, &bitrouter_sdk::language_model::types::Capability) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::Capability
+pub fn bitrouter_sdk::language_model::types::Capability::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for bitrouter_sdk::language_model::types::Capability
+pub fn bitrouter_sdk::language_model::types::Capability::hash<__H: core::hash::Hasher>(&self, &mut __H)
+impl core::marker::Copy for bitrouter_sdk::language_model::types::Capability
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::types::Capability
+impl schemars::JsonSchema for bitrouter_sdk::language_model::types::Capability
+pub fn bitrouter_sdk::language_model::types::Capability::inline_schema() -> bool
+pub fn bitrouter_sdk::language_model::types::Capability::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::language_model::types::Capability::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::language_model::types::Capability::schema_name() -> alloc::borrow::Cow<'static, str>
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::types::Capability
+pub fn bitrouter_sdk::language_model::types::Capability::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::types::Capability
+pub fn bitrouter_sdk::language_model::types::Capability::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::Capability
+impl core::marker::Send for bitrouter_sdk::language_model::types::Capability
+impl core::marker::Sync for bitrouter_sdk::language_model::types::Capability
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::Capability
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::Capability
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::Capability
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::Capability
+pub enum bitrouter_sdk::language_model::Content
+pub bitrouter_sdk::language_model::Content::File
+pub bitrouter_sdk::language_model::Content::File::data: bitrouter_sdk::language_model::types::DataContent
+pub bitrouter_sdk::language_model::Content::File::filename: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::Content::File::media_type: alloc::string::String
+pub bitrouter_sdk::language_model::Content::File::provider_metadata: bitrouter_sdk::language_model::types::ProviderMetadata
+pub bitrouter_sdk::language_model::Content::Reasoning
+pub bitrouter_sdk::language_model::Content::Reasoning::provider_metadata: bitrouter_sdk::language_model::types::ProviderMetadata
+pub bitrouter_sdk::language_model::Content::Reasoning::text: alloc::string::String
+pub bitrouter_sdk::language_model::Content::Source
+pub bitrouter_sdk::language_model::Content::Source::provider_metadata: bitrouter_sdk::language_model::types::ProviderMetadata
+pub bitrouter_sdk::language_model::Content::Source::source: bitrouter_sdk::language_model::types::Source
+pub bitrouter_sdk::language_model::Content::Text
+pub bitrouter_sdk::language_model::Content::Text::provider_metadata: bitrouter_sdk::language_model::types::ProviderMetadata
+pub bitrouter_sdk::language_model::Content::Text::text: alloc::string::String
+pub bitrouter_sdk::language_model::Content::ToolApprovalRequest
+pub bitrouter_sdk::language_model::Content::ToolApprovalRequest::approval_id: alloc::string::String
+pub bitrouter_sdk::language_model::Content::ToolApprovalRequest::provider_metadata: bitrouter_sdk::language_model::types::ProviderMetadata
+pub bitrouter_sdk::language_model::Content::ToolApprovalRequest::tool_call_id: alloc::string::String
+pub bitrouter_sdk::language_model::Content::ToolApprovalResponse
+pub bitrouter_sdk::language_model::Content::ToolApprovalResponse::approval_id: alloc::string::String
+pub bitrouter_sdk::language_model::Content::ToolApprovalResponse::approved: bool
+pub bitrouter_sdk::language_model::Content::ToolApprovalResponse::provider_metadata: bitrouter_sdk::language_model::types::ProviderMetadata
+pub bitrouter_sdk::language_model::Content::ToolApprovalResponse::reason: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::Content::ToolCall
+pub bitrouter_sdk::language_model::Content::ToolCall::arguments: alloc::string::String
+pub bitrouter_sdk::language_model::Content::ToolCall::dynamic: bool
+pub bitrouter_sdk::language_model::Content::ToolCall::id: alloc::string::String
+pub bitrouter_sdk::language_model::Content::ToolCall::name: alloc::string::String
+pub bitrouter_sdk::language_model::Content::ToolCall::provider_executed: bool
+pub bitrouter_sdk::language_model::Content::ToolCall::provider_metadata: bitrouter_sdk::language_model::types::ProviderMetadata
+pub bitrouter_sdk::language_model::Content::ToolResult
+pub bitrouter_sdk::language_model::Content::ToolResult::call_id: alloc::string::String
+pub bitrouter_sdk::language_model::Content::ToolResult::dynamic: bool
+pub bitrouter_sdk::language_model::Content::ToolResult::output: bitrouter_sdk::language_model::types::ToolResultOutput
+pub bitrouter_sdk::language_model::Content::ToolResult::provider_metadata: bitrouter_sdk::language_model::types::ProviderMetadata
+pub bitrouter_sdk::language_model::Content::ToolResult::tool_name: core::option::Option<alloc::string::String>
+impl core::clone::Clone for bitrouter_sdk::language_model::types::Content
+pub fn bitrouter_sdk::language_model::types::Content::clone(&self) -> bitrouter_sdk::language_model::types::Content
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::types::Content
+pub fn bitrouter_sdk::language_model::types::Content::eq(&self, &bitrouter_sdk::language_model::types::Content) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::Content
+pub fn bitrouter_sdk::language_model::types::Content::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::types::Content
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::types::Content
+pub fn bitrouter_sdk::language_model::types::Content::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::types::Content
+pub fn bitrouter_sdk::language_model::types::Content::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::Content
+impl core::marker::Send for bitrouter_sdk::language_model::types::Content
+impl core::marker::Sync for bitrouter_sdk::language_model::types::Content
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::Content
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::Content
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::Content
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::Content
+pub enum bitrouter_sdk::language_model::DataContent
+pub bitrouter_sdk::language_model::DataContent::Base64
+pub bitrouter_sdk::language_model::DataContent::Base64::data: alloc::string::String
+pub bitrouter_sdk::language_model::DataContent::Url
+pub bitrouter_sdk::language_model::DataContent::Url::url: alloc::string::String
+impl bitrouter_sdk::language_model::types::DataContent
+pub fn bitrouter_sdk::language_model::types::DataContent::from_url(&str) -> (core::option::Option<alloc::string::String>, bitrouter_sdk::language_model::types::DataContent)
+pub fn bitrouter_sdk::language_model::types::DataContent::to_url(&self, &str) -> alloc::string::String
+impl core::clone::Clone for bitrouter_sdk::language_model::types::DataContent
+pub fn bitrouter_sdk::language_model::types::DataContent::clone(&self) -> bitrouter_sdk::language_model::types::DataContent
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::types::DataContent
+pub fn bitrouter_sdk::language_model::types::DataContent::eq(&self, &bitrouter_sdk::language_model::types::DataContent) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::DataContent
+pub fn bitrouter_sdk::language_model::types::DataContent::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::types::DataContent
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::types::DataContent
+pub fn bitrouter_sdk::language_model::types::DataContent::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::types::DataContent
+pub fn bitrouter_sdk::language_model::types::DataContent::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::DataContent
+impl core::marker::Send for bitrouter_sdk::language_model::types::DataContent
+impl core::marker::Sync for bitrouter_sdk::language_model::types::DataContent
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::DataContent
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::DataContent
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::DataContent
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::DataContent
+pub enum bitrouter_sdk::language_model::DenyReason
+pub bitrouter_sdk::language_model::DenyReason::BadRequest(alloc::string::String)
+pub bitrouter_sdk::language_model::DenyReason::Custom(u16, alloc::string::String)
+pub bitrouter_sdk::language_model::DenyReason::Forbidden(alloc::string::String)
+pub bitrouter_sdk::language_model::DenyReason::GuardrailViolation(alloc::string::String)
+pub bitrouter_sdk::language_model::DenyReason::PaymentRequired(alloc::string::String)
+pub bitrouter_sdk::language_model::DenyReason::RateLimited
+pub bitrouter_sdk::language_model::DenyReason::RateLimited::retry_after: core::option::Option<u64>
+pub bitrouter_sdk::language_model::DenyReason::Unauthorized(alloc::string::String)
+impl core::convert::From<bitrouter_sdk::language_model::hooks::DenyReason> for bitrouter_sdk::error::BitrouterError
+pub fn bitrouter_sdk::error::BitrouterError::from(bitrouter_sdk::language_model::hooks::DenyReason) -> Self
+impl core::fmt::Debug for bitrouter_sdk::language_model::hooks::DenyReason
+pub fn bitrouter_sdk::language_model::hooks::DenyReason::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::language_model::hooks::DenyReason
+impl core::marker::Send for bitrouter_sdk::language_model::hooks::DenyReason
+impl core::marker::Sync for bitrouter_sdk::language_model::hooks::DenyReason
+impl core::marker::Unpin for bitrouter_sdk::language_model::hooks::DenyReason
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::hooks::DenyReason
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::hooks::DenyReason
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::hooks::DenyReason
+pub enum bitrouter_sdk::language_model::FallbackDecision
+pub bitrouter_sdk::language_model::FallbackDecision::Fail(bitrouter_sdk::error::BitrouterError)
+pub bitrouter_sdk::language_model::FallbackDecision::TryNext
+impl core::fmt::Debug for bitrouter_sdk::language_model::hooks::FallbackDecision
+pub fn bitrouter_sdk::language_model::hooks::FallbackDecision::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::language_model::hooks::FallbackDecision
+impl core::marker::Send for bitrouter_sdk::language_model::hooks::FallbackDecision
+impl core::marker::Sync for bitrouter_sdk::language_model::hooks::FallbackDecision
+impl core::marker::Unpin for bitrouter_sdk::language_model::hooks::FallbackDecision
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::hooks::FallbackDecision
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::hooks::FallbackDecision
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::hooks::FallbackDecision
+pub enum bitrouter_sdk::language_model::FinishReason
+pub bitrouter_sdk::language_model::FinishReason::ContentFilter
+pub bitrouter_sdk::language_model::FinishReason::Error(alloc::string::String)
+pub bitrouter_sdk::language_model::FinishReason::Length
+pub bitrouter_sdk::language_model::FinishReason::Other(alloc::string::String)
+pub bitrouter_sdk::language_model::FinishReason::Stop
+pub bitrouter_sdk::language_model::FinishReason::ToolCalls
+impl core::clone::Clone for bitrouter_sdk::language_model::types::FinishReason
+pub fn bitrouter_sdk::language_model::types::FinishReason::clone(&self) -> bitrouter_sdk::language_model::types::FinishReason
+impl core::cmp::Eq for bitrouter_sdk::language_model::types::FinishReason
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::types::FinishReason
+pub fn bitrouter_sdk::language_model::types::FinishReason::eq(&self, &bitrouter_sdk::language_model::types::FinishReason) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::FinishReason
+pub fn bitrouter_sdk::language_model::types::FinishReason::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::types::FinishReason
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::types::FinishReason
+pub fn bitrouter_sdk::language_model::types::FinishReason::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::types::FinishReason
+pub fn bitrouter_sdk::language_model::types::FinishReason::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::FinishReason
+impl core::marker::Send for bitrouter_sdk::language_model::types::FinishReason
+impl core::marker::Sync for bitrouter_sdk::language_model::types::FinishReason
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::FinishReason
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::FinishReason
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::FinishReason
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::FinishReason
+pub enum bitrouter_sdk::language_model::HookDecision
+pub bitrouter_sdk::language_model::HookDecision::Allow
+pub bitrouter_sdk::language_model::HookDecision::Deny(bitrouter_sdk::language_model::hooks::DenyReason)
+impl core::fmt::Debug for bitrouter_sdk::language_model::hooks::HookDecision
+pub fn bitrouter_sdk::language_model::hooks::HookDecision::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::language_model::hooks::HookDecision
+impl core::marker::Send for bitrouter_sdk::language_model::hooks::HookDecision
+impl core::marker::Sync for bitrouter_sdk::language_model::hooks::HookDecision
+impl core::marker::Unpin for bitrouter_sdk::language_model::hooks::HookDecision
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::hooks::HookDecision
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::hooks::HookDecision
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::hooks::HookDecision
+pub enum bitrouter_sdk::language_model::HopOutcome<'a>
+pub bitrouter_sdk::language_model::HopOutcome::Failed(&'a bitrouter_sdk::error::BitrouterError)
+pub bitrouter_sdk::language_model::HopOutcome::Generated(&'a bitrouter_sdk::language_model::types::ExecutionResult)
+pub bitrouter_sdk::language_model::HopOutcome::StreamStarted
+impl<'a> core::clone::Clone for bitrouter_sdk::language_model::hooks::HopOutcome<'a>
+pub fn bitrouter_sdk::language_model::hooks::HopOutcome<'a>::clone(&self) -> bitrouter_sdk::language_model::hooks::HopOutcome<'a>
+impl<'a> core::fmt::Debug for bitrouter_sdk::language_model::hooks::HopOutcome<'a>
+pub fn bitrouter_sdk::language_model::hooks::HopOutcome<'a>::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<'a> core::marker::Copy for bitrouter_sdk::language_model::hooks::HopOutcome<'a>
+impl<'a> core::marker::Freeze for bitrouter_sdk::language_model::hooks::HopOutcome<'a>
+impl<'a> core::marker::Send for bitrouter_sdk::language_model::hooks::HopOutcome<'a>
+impl<'a> core::marker::Sync for bitrouter_sdk::language_model::hooks::HopOutcome<'a>
+impl<'a> core::marker::Unpin for bitrouter_sdk::language_model::hooks::HopOutcome<'a>
+impl<'a> core::marker::UnsafeUnpin for bitrouter_sdk::language_model::hooks::HopOutcome<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::hooks::HopOutcome<'a>
+impl<'a> core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::hooks::HopOutcome<'a>
+pub enum bitrouter_sdk::language_model::MockResponse
+pub bitrouter_sdk::language_model::MockResponse::Error(bitrouter_sdk::error::BitrouterError)
+pub bitrouter_sdk::language_model::MockResponse::Generate(bitrouter_sdk::language_model::types::GenerateResult)
+pub bitrouter_sdk::language_model::MockResponse::Stream(alloc::vec::Vec<bitrouter_sdk::language_model::types::StreamPart>)
+impl core::marker::Freeze for bitrouter_sdk::language_model::executor::MockResponse
+impl core::marker::Send for bitrouter_sdk::language_model::executor::MockResponse
+impl core::marker::Sync for bitrouter_sdk::language_model::executor::MockResponse
+impl core::marker::Unpin for bitrouter_sdk::language_model::executor::MockResponse
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::executor::MockResponse
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::executor::MockResponse
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::executor::MockResponse
+pub enum bitrouter_sdk::language_model::Phase
+pub bitrouter_sdk::language_model::Phase::Execution
+pub bitrouter_sdk::language_model::Phase::PreRequest
+pub bitrouter_sdk::language_model::Phase::Route
+pub bitrouter_sdk::language_model::Phase::Settlement
+impl core::clone::Clone for bitrouter_sdk::language_model::hooks::Phase
+pub fn bitrouter_sdk::language_model::hooks::Phase::clone(&self) -> bitrouter_sdk::language_model::hooks::Phase
+impl core::cmp::Eq for bitrouter_sdk::language_model::hooks::Phase
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::hooks::Phase
+pub fn bitrouter_sdk::language_model::hooks::Phase::eq(&self, &bitrouter_sdk::language_model::hooks::Phase) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::hooks::Phase
+pub fn bitrouter_sdk::language_model::hooks::Phase::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for bitrouter_sdk::language_model::hooks::Phase
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::hooks::Phase
+impl core::marker::Freeze for bitrouter_sdk::language_model::hooks::Phase
+impl core::marker::Send for bitrouter_sdk::language_model::hooks::Phase
+impl core::marker::Sync for bitrouter_sdk::language_model::hooks::Phase
+impl core::marker::Unpin for bitrouter_sdk::language_model::hooks::Phase
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::hooks::Phase
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::hooks::Phase
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::hooks::Phase
+pub enum bitrouter_sdk::language_model::RequestOutcome
+pub bitrouter_sdk::language_model::RequestOutcome::ClientDisconnected
+pub bitrouter_sdk::language_model::RequestOutcome::Completed
+pub bitrouter_sdk::language_model::RequestOutcome::Failed(bitrouter_sdk::error::BitrouterError)
+impl core::fmt::Debug for bitrouter_sdk::language_model::hooks::RequestOutcome
+pub fn bitrouter_sdk::language_model::hooks::RequestOutcome::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::language_model::hooks::RequestOutcome
+impl core::marker::Send for bitrouter_sdk::language_model::hooks::RequestOutcome
+impl core::marker::Sync for bitrouter_sdk::language_model::hooks::RequestOutcome
+impl core::marker::Unpin for bitrouter_sdk::language_model::hooks::RequestOutcome
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::hooks::RequestOutcome
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::hooks::RequestOutcome
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::hooks::RequestOutcome
+pub enum bitrouter_sdk::language_model::Role
+pub bitrouter_sdk::language_model::Role::Assistant
+pub bitrouter_sdk::language_model::Role::System
+pub bitrouter_sdk::language_model::Role::Tool
+pub bitrouter_sdk::language_model::Role::User
+impl core::clone::Clone for bitrouter_sdk::language_model::types::Role
+pub fn bitrouter_sdk::language_model::types::Role::clone(&self) -> bitrouter_sdk::language_model::types::Role
+impl core::cmp::Eq for bitrouter_sdk::language_model::types::Role
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::types::Role
+pub fn bitrouter_sdk::language_model::types::Role::eq(&self, &bitrouter_sdk::language_model::types::Role) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::Role
+pub fn bitrouter_sdk::language_model::types::Role::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for bitrouter_sdk::language_model::types::Role
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::types::Role
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::types::Role
+pub fn bitrouter_sdk::language_model::types::Role::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::types::Role
+pub fn bitrouter_sdk::language_model::types::Role::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::Role
+impl core::marker::Send for bitrouter_sdk::language_model::types::Role
+impl core::marker::Sync for bitrouter_sdk::language_model::types::Role
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::Role
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::Role
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::Role
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::Role
+#[non_exhaustive] pub enum bitrouter_sdk::language_model::ServerToolKind
+pub bitrouter_sdk::language_model::ServerToolKind::Provider
+pub bitrouter_sdk::language_model::ServerToolKind::Router
+impl core::clone::Clone for bitrouter_sdk::language_model::types::ServerToolKind
+pub fn bitrouter_sdk::language_model::types::ServerToolKind::clone(&self) -> bitrouter_sdk::language_model::types::ServerToolKind
+impl core::cmp::Eq for bitrouter_sdk::language_model::types::ServerToolKind
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::types::ServerToolKind
+pub fn bitrouter_sdk::language_model::types::ServerToolKind::eq(&self, &bitrouter_sdk::language_model::types::ServerToolKind) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::ServerToolKind
+pub fn bitrouter_sdk::language_model::types::ServerToolKind::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for bitrouter_sdk::language_model::types::ServerToolKind
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::types::ServerToolKind
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::types::ServerToolKind
+pub fn bitrouter_sdk::language_model::types::ServerToolKind::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::types::ServerToolKind
+pub fn bitrouter_sdk::language_model::types::ServerToolKind::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::ServerToolKind
+impl core::marker::Send for bitrouter_sdk::language_model::types::ServerToolKind
+impl core::marker::Sync for bitrouter_sdk::language_model::types::ServerToolKind
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::ServerToolKind
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::ServerToolKind
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::ServerToolKind
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::ServerToolKind
+#[non_exhaustive] pub enum bitrouter_sdk::language_model::ServerToolStatus
+pub bitrouter_sdk::language_model::ServerToolStatus::Denied
+pub bitrouter_sdk::language_model::ServerToolStatus::Error
+pub bitrouter_sdk::language_model::ServerToolStatus::Ok
+pub bitrouter_sdk::language_model::ServerToolStatus::Timeout
+impl core::clone::Clone for bitrouter_sdk::language_model::types::ServerToolStatus
+pub fn bitrouter_sdk::language_model::types::ServerToolStatus::clone(&self) -> bitrouter_sdk::language_model::types::ServerToolStatus
+impl core::cmp::Eq for bitrouter_sdk::language_model::types::ServerToolStatus
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::types::ServerToolStatus
+pub fn bitrouter_sdk::language_model::types::ServerToolStatus::eq(&self, &bitrouter_sdk::language_model::types::ServerToolStatus) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::ServerToolStatus
+pub fn bitrouter_sdk::language_model::types::ServerToolStatus::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for bitrouter_sdk::language_model::types::ServerToolStatus
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::types::ServerToolStatus
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::types::ServerToolStatus
+pub fn bitrouter_sdk::language_model::types::ServerToolStatus::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::types::ServerToolStatus
+pub fn bitrouter_sdk::language_model::types::ServerToolStatus::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::ServerToolStatus
+impl core::marker::Send for bitrouter_sdk::language_model::types::ServerToolStatus
+impl core::marker::Sync for bitrouter_sdk::language_model::types::ServerToolStatus
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::ServerToolStatus
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::ServerToolStatus
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::ServerToolStatus
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::ServerToolStatus
+pub enum bitrouter_sdk::language_model::SortOrder
+pub bitrouter_sdk::language_model::SortOrder::Alphabetical
+pub bitrouter_sdk::language_model::SortOrder::Cost
+pub bitrouter_sdk::language_model::SortOrder::Latency
+impl core::clone::Clone for bitrouter_sdk::language_model::routing::SortOrder
+pub fn bitrouter_sdk::language_model::routing::SortOrder::clone(&self) -> bitrouter_sdk::language_model::routing::SortOrder
+impl core::cmp::Eq for bitrouter_sdk::language_model::routing::SortOrder
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::routing::SortOrder
+pub fn bitrouter_sdk::language_model::routing::SortOrder::eq(&self, &bitrouter_sdk::language_model::routing::SortOrder) -> bool
+impl core::default::Default for bitrouter_sdk::language_model::routing::SortOrder
+pub fn bitrouter_sdk::language_model::routing::SortOrder::default() -> bitrouter_sdk::language_model::routing::SortOrder
+impl core::fmt::Debug for bitrouter_sdk::language_model::routing::SortOrder
+pub fn bitrouter_sdk::language_model::routing::SortOrder::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for bitrouter_sdk::language_model::routing::SortOrder
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::routing::SortOrder
+impl schemars::JsonSchema for bitrouter_sdk::language_model::routing::SortOrder
+pub fn bitrouter_sdk::language_model::routing::SortOrder::inline_schema() -> bool
+pub fn bitrouter_sdk::language_model::routing::SortOrder::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::language_model::routing::SortOrder::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::language_model::routing::SortOrder::schema_name() -> alloc::borrow::Cow<'static, str>
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::routing::SortOrder
+pub fn bitrouter_sdk::language_model::routing::SortOrder::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::routing::SortOrder
+pub fn bitrouter_sdk::language_model::routing::SortOrder::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::routing::SortOrder
+impl core::marker::Send for bitrouter_sdk::language_model::routing::SortOrder
+impl core::marker::Sync for bitrouter_sdk::language_model::routing::SortOrder
+impl core::marker::Unpin for bitrouter_sdk::language_model::routing::SortOrder
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::routing::SortOrder
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::routing::SortOrder
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::routing::SortOrder
+pub enum bitrouter_sdk::language_model::Source
+pub bitrouter_sdk::language_model::Source::Document
+pub bitrouter_sdk::language_model::Source::Document::filename: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::Source::Document::id: alloc::string::String
+pub bitrouter_sdk::language_model::Source::Document::media_type: alloc::string::String
+pub bitrouter_sdk::language_model::Source::Document::title: alloc::string::String
+pub bitrouter_sdk::language_model::Source::Url
+pub bitrouter_sdk::language_model::Source::Url::id: alloc::string::String
+pub bitrouter_sdk::language_model::Source::Url::title: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::Source::Url::url: alloc::string::String
+impl bitrouter_sdk::language_model::types::Source
+pub fn bitrouter_sdk::language_model::types::Source::synthesize_id(&str, usize) -> alloc::string::String
+impl core::clone::Clone for bitrouter_sdk::language_model::types::Source
+pub fn bitrouter_sdk::language_model::types::Source::clone(&self) -> bitrouter_sdk::language_model::types::Source
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::types::Source
+pub fn bitrouter_sdk::language_model::types::Source::eq(&self, &bitrouter_sdk::language_model::types::Source) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::Source
+pub fn bitrouter_sdk::language_model::types::Source::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::types::Source
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::types::Source
+pub fn bitrouter_sdk::language_model::types::Source::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::types::Source
+pub fn bitrouter_sdk::language_model::types::Source::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::Source
+impl core::marker::Send for bitrouter_sdk::language_model::types::Source
+impl core::marker::Sync for bitrouter_sdk::language_model::types::Source
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::Source
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::Source
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::Source
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::Source
+pub enum bitrouter_sdk::language_model::SseFrame
+pub bitrouter_sdk::language_model::SseFrame::Comment(alloc::string::String)
+pub bitrouter_sdk::language_model::SseFrame::Event
+pub bitrouter_sdk::language_model::SseFrame::Event::data: alloc::string::String
+pub bitrouter_sdk::language_model::SseFrame::Event::event: core::option::Option<alloc::string::String>
+impl bitrouter_sdk::language_model::stream::SseFrame
+pub fn bitrouter_sdk::language_model::stream::SseFrame::to_wire(&self) -> alloc::string::String
+impl core::clone::Clone for bitrouter_sdk::language_model::stream::SseFrame
+pub fn bitrouter_sdk::language_model::stream::SseFrame::clone(&self) -> bitrouter_sdk::language_model::stream::SseFrame
+impl core::cmp::Eq for bitrouter_sdk::language_model::stream::SseFrame
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::stream::SseFrame
+pub fn bitrouter_sdk::language_model::stream::SseFrame::eq(&self, &bitrouter_sdk::language_model::stream::SseFrame) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::stream::SseFrame
+pub fn bitrouter_sdk::language_model::stream::SseFrame::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::stream::SseFrame
+impl core::marker::Freeze for bitrouter_sdk::language_model::stream::SseFrame
+impl core::marker::Send for bitrouter_sdk::language_model::stream::SseFrame
+impl core::marker::Sync for bitrouter_sdk::language_model::stream::SseFrame
+impl core::marker::Unpin for bitrouter_sdk::language_model::stream::SseFrame
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::stream::SseFrame
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::stream::SseFrame
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::stream::SseFrame
+pub enum bitrouter_sdk::language_model::StreamAction
+pub bitrouter_sdk::language_model::StreamAction::Abort(bitrouter_sdk::error::BitrouterError)
+pub bitrouter_sdk::language_model::StreamAction::Drop
+pub bitrouter_sdk::language_model::StreamAction::Pass
+pub bitrouter_sdk::language_model::StreamAction::Replace(alloc::vec::Vec<bitrouter_sdk::language_model::types::StreamPart>)
+impl core::fmt::Debug for bitrouter_sdk::language_model::stream::StreamAction
+pub fn bitrouter_sdk::language_model::stream::StreamAction::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::language_model::stream::StreamAction
+impl core::marker::Send for bitrouter_sdk::language_model::stream::StreamAction
+impl core::marker::Sync for bitrouter_sdk::language_model::stream::StreamAction
+impl core::marker::Unpin for bitrouter_sdk::language_model::stream::StreamAction
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::stream::StreamAction
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::stream::StreamAction
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::stream::StreamAction
+pub enum bitrouter_sdk::language_model::StreamHopOutcome<'a>
+pub bitrouter_sdk::language_model::StreamHopOutcome::Completed
+pub bitrouter_sdk::language_model::StreamHopOutcome::Dropped
+pub bitrouter_sdk::language_model::StreamHopOutcome::Failed(&'a bitrouter_sdk::error::BitrouterError)
+impl<'a> core::clone::Clone for bitrouter_sdk::language_model::hooks::StreamHopOutcome<'a>
+pub fn bitrouter_sdk::language_model::hooks::StreamHopOutcome<'a>::clone(&self) -> bitrouter_sdk::language_model::hooks::StreamHopOutcome<'a>
+impl<'a> core::fmt::Debug for bitrouter_sdk::language_model::hooks::StreamHopOutcome<'a>
+pub fn bitrouter_sdk::language_model::hooks::StreamHopOutcome<'a>::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl<'a> core::marker::Copy for bitrouter_sdk::language_model::hooks::StreamHopOutcome<'a>
+impl<'a> core::marker::Freeze for bitrouter_sdk::language_model::hooks::StreamHopOutcome<'a>
+impl<'a> core::marker::Send for bitrouter_sdk::language_model::hooks::StreamHopOutcome<'a>
+impl<'a> core::marker::Sync for bitrouter_sdk::language_model::hooks::StreamHopOutcome<'a>
+impl<'a> core::marker::Unpin for bitrouter_sdk::language_model::hooks::StreamHopOutcome<'a>
+impl<'a> core::marker::UnsafeUnpin for bitrouter_sdk::language_model::hooks::StreamHopOutcome<'a>
+impl<'a> core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::hooks::StreamHopOutcome<'a>
+impl<'a> core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::hooks::StreamHopOutcome<'a>
+pub enum bitrouter_sdk::language_model::StreamOutcome
+pub bitrouter_sdk::language_model::StreamOutcome::Aborted(bitrouter_sdk::error::BitrouterError)
+pub bitrouter_sdk::language_model::StreamOutcome::ClientDisconnected
+pub bitrouter_sdk::language_model::StreamOutcome::Completed
+pub bitrouter_sdk::language_model::StreamOutcome::UpstreamError(bitrouter_sdk::error::BitrouterError)
+impl core::clone::Clone for bitrouter_sdk::language_model::stream::StreamOutcome
+pub fn bitrouter_sdk::language_model::stream::StreamOutcome::clone(&self) -> bitrouter_sdk::language_model::stream::StreamOutcome
+impl core::fmt::Debug for bitrouter_sdk::language_model::stream::StreamOutcome
+pub fn bitrouter_sdk::language_model::stream::StreamOutcome::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::language_model::stream::StreamOutcome
+impl core::marker::Send for bitrouter_sdk::language_model::stream::StreamOutcome
+impl core::marker::Sync for bitrouter_sdk::language_model::stream::StreamOutcome
+impl core::marker::Unpin for bitrouter_sdk::language_model::stream::StreamOutcome
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::stream::StreamOutcome
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::stream::StreamOutcome
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::stream::StreamOutcome
+pub enum bitrouter_sdk::language_model::StreamPart
+pub bitrouter_sdk::language_model::StreamPart::File
+pub bitrouter_sdk::language_model::StreamPart::File::data: bitrouter_sdk::language_model::types::DataContent
+pub bitrouter_sdk::language_model::StreamPart::File::media_type: alloc::string::String
+pub bitrouter_sdk::language_model::StreamPart::Finish
+pub bitrouter_sdk::language_model::StreamPart::Finish::reason: bitrouter_sdk::language_model::types::FinishReason
+pub bitrouter_sdk::language_model::StreamPart::ReasoningDelta
+pub bitrouter_sdk::language_model::StreamPart::ReasoningDelta::text: alloc::string::String
+pub bitrouter_sdk::language_model::StreamPart::ReasoningEnd
+pub bitrouter_sdk::language_model::StreamPart::ReasoningEnd::id: alloc::string::String
+pub bitrouter_sdk::language_model::StreamPart::ReasoningEnd::signature: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::StreamPart::ReasoningStart
+pub bitrouter_sdk::language_model::StreamPart::ReasoningStart::id: alloc::string::String
+pub bitrouter_sdk::language_model::StreamPart::ResponseCompleted
+pub bitrouter_sdk::language_model::StreamPart::ResponseCompleted::id: alloc::string::String
+pub bitrouter_sdk::language_model::StreamPart::ResponseCompleted::source_protocol: bitrouter_sdk::language_model::types::ApiProtocol
+pub bitrouter_sdk::language_model::StreamPart::ResponseCompleted::status: alloc::string::String
+pub bitrouter_sdk::language_model::StreamPart::ResponseCompleted::usage: core::option::Option<bitrouter_sdk::language_model::types::Usage>
+pub bitrouter_sdk::language_model::StreamPart::ResponseStarted
+pub bitrouter_sdk::language_model::StreamPart::ResponseStarted::id: alloc::string::String
+pub bitrouter_sdk::language_model::StreamPart::ResponseStarted::source_protocol: bitrouter_sdk::language_model::types::ApiProtocol
+pub bitrouter_sdk::language_model::StreamPart::ServerToolCall
+pub bitrouter_sdk::language_model::StreamPart::ServerToolCall::arguments: alloc::string::String
+pub bitrouter_sdk::language_model::StreamPart::ServerToolCall::dynamic: bool
+pub bitrouter_sdk::language_model::StreamPart::ServerToolCall::id: alloc::string::String
+pub bitrouter_sdk::language_model::StreamPart::ServerToolCall::name: alloc::string::String
+pub bitrouter_sdk::language_model::StreamPart::ServerToolCall::server_name: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::StreamPart::ServerToolResult
+pub bitrouter_sdk::language_model::StreamPart::ServerToolResult::call_id: alloc::string::String
+pub bitrouter_sdk::language_model::StreamPart::ServerToolResult::dynamic: bool
+pub bitrouter_sdk::language_model::StreamPart::ServerToolResult::output: bitrouter_sdk::language_model::types::ToolResultOutput
+pub bitrouter_sdk::language_model::StreamPart::ServerToolResult::tool_name: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::StreamPart::Source
+pub bitrouter_sdk::language_model::StreamPart::Source::source: bitrouter_sdk::language_model::types::Source
+pub bitrouter_sdk::language_model::StreamPart::TextDelta
+pub bitrouter_sdk::language_model::StreamPart::TextDelta::text: alloc::string::String
+pub bitrouter_sdk::language_model::StreamPart::TextEnd
+pub bitrouter_sdk::language_model::StreamPart::TextEnd::id: alloc::string::String
+pub bitrouter_sdk::language_model::StreamPart::TextStart
+pub bitrouter_sdk::language_model::StreamPart::TextStart::id: alloc::string::String
+pub bitrouter_sdk::language_model::StreamPart::ToolCallDelta
+pub bitrouter_sdk::language_model::StreamPart::ToolCallDelta::arguments: alloc::string::String
+pub bitrouter_sdk::language_model::StreamPart::ToolCallDelta::id: alloc::string::String
+pub bitrouter_sdk::language_model::StreamPart::ToolCallDelta::name: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::StreamPart::Usage
+pub bitrouter_sdk::language_model::StreamPart::Usage::usage: bitrouter_sdk::language_model::types::Usage
+impl bitrouter_sdk::language_model::types::StreamPart
+pub fn bitrouter_sdk::language_model::types::StreamPart::is_terminal(&self) -> bool
+impl core::clone::Clone for bitrouter_sdk::language_model::types::StreamPart
+pub fn bitrouter_sdk::language_model::types::StreamPart::clone(&self) -> bitrouter_sdk::language_model::types::StreamPart
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::types::StreamPart
+pub fn bitrouter_sdk::language_model::types::StreamPart::eq(&self, &bitrouter_sdk::language_model::types::StreamPart) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::StreamPart
+pub fn bitrouter_sdk::language_model::types::StreamPart::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::types::StreamPart
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::types::StreamPart
+pub fn bitrouter_sdk::language_model::types::StreamPart::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::types::StreamPart
+pub fn bitrouter_sdk::language_model::types::StreamPart::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::StreamPart
+impl core::marker::Send for bitrouter_sdk::language_model::types::StreamPart
+impl core::marker::Sync for bitrouter_sdk::language_model::types::StreamPart
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::StreamPart
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::StreamPart
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::StreamPart
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::StreamPart
+pub enum bitrouter_sdk::language_model::Tool
+pub bitrouter_sdk::language_model::Tool::Function
+pub bitrouter_sdk::language_model::Tool::Function::description: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::Tool::Function::name: alloc::string::String
+pub bitrouter_sdk::language_model::Tool::Function::parameters: serde_json::value::Value
+pub bitrouter_sdk::language_model::Tool::Function::provider_metadata: bitrouter_sdk::language_model::types::ProviderMetadata
+pub bitrouter_sdk::language_model::Tool::Function::strict: core::option::Option<bool>
+pub bitrouter_sdk::language_model::Tool::ProviderDefined
+pub bitrouter_sdk::language_model::Tool::ProviderDefined::args: serde_json::value::Value
+pub bitrouter_sdk::language_model::Tool::ProviderDefined::id: alloc::string::String
+pub bitrouter_sdk::language_model::Tool::ProviderDefined::name: alloc::string::String
+pub bitrouter_sdk::language_model::Tool::ProviderDefined::provider_metadata: bitrouter_sdk::language_model::types::ProviderMetadata
+impl bitrouter_sdk::language_model::types::Tool
+pub fn bitrouter_sdk::language_model::types::Tool::name(&self) -> &str
+impl core::clone::Clone for bitrouter_sdk::language_model::types::Tool
+pub fn bitrouter_sdk::language_model::types::Tool::clone(&self) -> bitrouter_sdk::language_model::types::Tool
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::types::Tool
+pub fn bitrouter_sdk::language_model::types::Tool::eq(&self, &bitrouter_sdk::language_model::types::Tool) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::Tool
+pub fn bitrouter_sdk::language_model::types::Tool::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::types::Tool
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::types::Tool
+pub fn bitrouter_sdk::language_model::types::Tool::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::types::Tool
+pub fn bitrouter_sdk::language_model::types::Tool::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::Tool
+impl core::marker::Send for bitrouter_sdk::language_model::types::Tool
+impl core::marker::Sync for bitrouter_sdk::language_model::types::Tool
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::Tool
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::Tool
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::Tool
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::Tool
+pub enum bitrouter_sdk::language_model::ToolChoice
+pub bitrouter_sdk::language_model::ToolChoice::Auto
+pub bitrouter_sdk::language_model::ToolChoice::None
+pub bitrouter_sdk::language_model::ToolChoice::Required
+pub bitrouter_sdk::language_model::ToolChoice::Tool
+pub bitrouter_sdk::language_model::ToolChoice::Tool::name: alloc::string::String
+impl core::clone::Clone for bitrouter_sdk::language_model::types::ToolChoice
+pub fn bitrouter_sdk::language_model::types::ToolChoice::clone(&self) -> bitrouter_sdk::language_model::types::ToolChoice
+impl core::cmp::Eq for bitrouter_sdk::language_model::types::ToolChoice
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::types::ToolChoice
+pub fn bitrouter_sdk::language_model::types::ToolChoice::eq(&self, &bitrouter_sdk::language_model::types::ToolChoice) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::ToolChoice
+pub fn bitrouter_sdk::language_model::types::ToolChoice::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::types::ToolChoice
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::types::ToolChoice
+pub fn bitrouter_sdk::language_model::types::ToolChoice::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::types::ToolChoice
+pub fn bitrouter_sdk::language_model::types::ToolChoice::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::ToolChoice
+impl core::marker::Send for bitrouter_sdk::language_model::types::ToolChoice
+impl core::marker::Sync for bitrouter_sdk::language_model::types::ToolChoice
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::ToolChoice
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::ToolChoice
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::ToolChoice
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::ToolChoice
+pub enum bitrouter_sdk::language_model::ToolResultContentPart
+pub bitrouter_sdk::language_model::ToolResultContentPart::FileId
+pub bitrouter_sdk::language_model::ToolResultContentPart::FileId::id: alloc::string::String
+pub bitrouter_sdk::language_model::ToolResultContentPart::FileId::media_type: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::ToolResultContentPart::Media
+pub bitrouter_sdk::language_model::ToolResultContentPart::Media::data: bitrouter_sdk::language_model::types::DataContent
+pub bitrouter_sdk::language_model::ToolResultContentPart::Media::media_type: alloc::string::String
+pub bitrouter_sdk::language_model::ToolResultContentPart::Text
+pub bitrouter_sdk::language_model::ToolResultContentPart::Text::text: alloc::string::String
+impl core::clone::Clone for bitrouter_sdk::language_model::types::ToolResultContentPart
+pub fn bitrouter_sdk::language_model::types::ToolResultContentPart::clone(&self) -> bitrouter_sdk::language_model::types::ToolResultContentPart
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::types::ToolResultContentPart
+pub fn bitrouter_sdk::language_model::types::ToolResultContentPart::eq(&self, &bitrouter_sdk::language_model::types::ToolResultContentPart) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::ToolResultContentPart
+pub fn bitrouter_sdk::language_model::types::ToolResultContentPart::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::types::ToolResultContentPart
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::types::ToolResultContentPart
+pub fn bitrouter_sdk::language_model::types::ToolResultContentPart::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::types::ToolResultContentPart
+pub fn bitrouter_sdk::language_model::types::ToolResultContentPart::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::ToolResultContentPart
+impl core::marker::Send for bitrouter_sdk::language_model::types::ToolResultContentPart
+impl core::marker::Sync for bitrouter_sdk::language_model::types::ToolResultContentPart
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::ToolResultContentPart
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::ToolResultContentPart
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::ToolResultContentPart
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::ToolResultContentPart
+pub enum bitrouter_sdk::language_model::ToolResultOutput
+pub bitrouter_sdk::language_model::ToolResultOutput::Content
+pub bitrouter_sdk::language_model::ToolResultOutput::Content::value: alloc::vec::Vec<bitrouter_sdk::language_model::types::ToolResultContentPart>
+pub bitrouter_sdk::language_model::ToolResultOutput::ErrorJson
+pub bitrouter_sdk::language_model::ToolResultOutput::ErrorJson::value: serde_json::value::Value
+pub bitrouter_sdk::language_model::ToolResultOutput::ErrorText
+pub bitrouter_sdk::language_model::ToolResultOutput::ErrorText::value: alloc::string::String
+pub bitrouter_sdk::language_model::ToolResultOutput::ExecutionDenied
+pub bitrouter_sdk::language_model::ToolResultOutput::ExecutionDenied::reason: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::ToolResultOutput::Json
+pub bitrouter_sdk::language_model::ToolResultOutput::Json::value: serde_json::value::Value
+pub bitrouter_sdk::language_model::ToolResultOutput::Text
+pub bitrouter_sdk::language_model::ToolResultOutput::Text::value: alloc::string::String
+impl bitrouter_sdk::language_model::types::ToolResultOutput
+pub fn bitrouter_sdk::language_model::types::ToolResultOutput::from_untyped_value(&serde_json::value::Value) -> Self
+pub fn bitrouter_sdk::language_model::types::ToolResultOutput::is_error(&self) -> bool
+pub fn bitrouter_sdk::language_model::types::ToolResultOutput::to_provider_string(&self) -> alloc::string::String
+impl core::clone::Clone for bitrouter_sdk::language_model::types::ToolResultOutput
+pub fn bitrouter_sdk::language_model::types::ToolResultOutput::clone(&self) -> bitrouter_sdk::language_model::types::ToolResultOutput
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::types::ToolResultOutput
+pub fn bitrouter_sdk::language_model::types::ToolResultOutput::eq(&self, &bitrouter_sdk::language_model::types::ToolResultOutput) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::ToolResultOutput
+pub fn bitrouter_sdk::language_model::types::ToolResultOutput::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::types::ToolResultOutput
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::types::ToolResultOutput
+pub fn bitrouter_sdk::language_model::types::ToolResultOutput::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::types::ToolResultOutput
+pub fn bitrouter_sdk::language_model::types::ToolResultOutput::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::ToolResultOutput
+impl core::marker::Send for bitrouter_sdk::language_model::types::ToolResultOutput
+impl core::marker::Sync for bitrouter_sdk::language_model::types::ToolResultOutput
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::ToolResultOutput
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::ToolResultOutput
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::ToolResultOutput
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::ToolResultOutput
+pub enum bitrouter_sdk::language_model::UsageNormalizationError
+pub bitrouter_sdk::language_model::UsageNormalizationError::InputBucketsOverlap
+pub bitrouter_sdk::language_model::UsageNormalizationError::OutputBucketsOverlap
+impl core::clone::Clone for bitrouter_sdk::language_model::types::UsageNormalizationError
+pub fn bitrouter_sdk::language_model::types::UsageNormalizationError::clone(&self) -> bitrouter_sdk::language_model::types::UsageNormalizationError
+impl core::cmp::Eq for bitrouter_sdk::language_model::types::UsageNormalizationError
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::types::UsageNormalizationError
+pub fn bitrouter_sdk::language_model::types::UsageNormalizationError::eq(&self, &bitrouter_sdk::language_model::types::UsageNormalizationError) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::UsageNormalizationError
+pub fn bitrouter_sdk::language_model::types::UsageNormalizationError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for bitrouter_sdk::language_model::types::UsageNormalizationError
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::types::UsageNormalizationError
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::UsageNormalizationError
+impl core::marker::Send for bitrouter_sdk::language_model::types::UsageNormalizationError
+impl core::marker::Sync for bitrouter_sdk::language_model::types::UsageNormalizationError
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::UsageNormalizationError
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::UsageNormalizationError
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::UsageNormalizationError
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::UsageNormalizationError
+pub enum bitrouter_sdk::language_model::UsageOrigin
+pub bitrouter_sdk::language_model::UsageOrigin::AuthoritativeReceipt
+pub bitrouter_sdk::language_model::UsageOrigin::Estimated
+pub bitrouter_sdk::language_model::UsageOrigin::ProviderReported
+pub bitrouter_sdk::language_model::UsageOrigin::Unknown
+impl bitrouter_sdk::language_model::types::UsageOrigin
+pub fn bitrouter_sdk::language_model::types::UsageOrigin::as_str(self) -> &'static str
+impl core::clone::Clone for bitrouter_sdk::language_model::types::UsageOrigin
+pub fn bitrouter_sdk::language_model::types::UsageOrigin::clone(&self) -> bitrouter_sdk::language_model::types::UsageOrigin
+impl core::cmp::Eq for bitrouter_sdk::language_model::types::UsageOrigin
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::types::UsageOrigin
+pub fn bitrouter_sdk::language_model::types::UsageOrigin::eq(&self, &bitrouter_sdk::language_model::types::UsageOrigin) -> bool
+impl core::default::Default for bitrouter_sdk::language_model::types::UsageOrigin
+pub fn bitrouter_sdk::language_model::types::UsageOrigin::default() -> bitrouter_sdk::language_model::types::UsageOrigin
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::UsageOrigin
+pub fn bitrouter_sdk::language_model::types::UsageOrigin::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for bitrouter_sdk::language_model::types::UsageOrigin
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::types::UsageOrigin
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::types::UsageOrigin
+pub fn bitrouter_sdk::language_model::types::UsageOrigin::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::types::UsageOrigin
+pub fn bitrouter_sdk::language_model::types::UsageOrigin::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::UsageOrigin
+impl core::marker::Send for bitrouter_sdk::language_model::types::UsageOrigin
+impl core::marker::Sync for bitrouter_sdk::language_model::types::UsageOrigin
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::UsageOrigin
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::UsageOrigin
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::UsageOrigin
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::UsageOrigin
+pub struct bitrouter_sdk::language_model::AuthAppliers
+impl bitrouter_sdk::language_model::auth::AuthAppliers
+pub async fn bitrouter_sdk::language_model::auth::AuthAppliers::continuation_authority(&self, &bitrouter_sdk::language_model::types::RoutingTarget) -> bitrouter_sdk::error::Result<core::option::Option<bitrouter_sdk::language_model::auth::CredentialAuthority>>
+pub async fn bitrouter_sdk::language_model::auth::AuthAppliers::continuation_authority_proof(&self, &bitrouter_sdk::language_model::types::RoutingTarget) -> bitrouter_sdk::error::Result<core::option::Option<bitrouter_sdk::language_model::auth::ContinuationAuthority>>
+pub fn bitrouter_sdk::language_model::auth::AuthAppliers::is_empty(&self) -> bool
+pub fn bitrouter_sdk::language_model::auth::AuthAppliers::lookup(&self, &str) -> core::option::Option<&alloc::sync::Arc<dyn bitrouter_sdk::language_model::auth::AuthApplier>>
+pub fn bitrouter_sdk::language_model::auth::AuthAppliers::new() -> Self
+pub fn bitrouter_sdk::language_model::auth::AuthAppliers::register(&mut self, impl core::convert::Into<alloc::string::String>, alloc::sync::Arc<dyn bitrouter_sdk::language_model::auth::AuthApplier>)
+pub fn bitrouter_sdk::language_model::auth::AuthAppliers::with(self, impl core::convert::Into<alloc::string::String>, alloc::sync::Arc<dyn bitrouter_sdk::language_model::auth::AuthApplier>) -> Self
+impl core::clone::Clone for bitrouter_sdk::language_model::auth::AuthAppliers
+pub fn bitrouter_sdk::language_model::auth::AuthAppliers::clone(&self) -> bitrouter_sdk::language_model::auth::AuthAppliers
+impl core::default::Default for bitrouter_sdk::language_model::auth::AuthAppliers
+pub fn bitrouter_sdk::language_model::auth::AuthAppliers::default() -> bitrouter_sdk::language_model::auth::AuthAppliers
+impl core::marker::Freeze for bitrouter_sdk::language_model::auth::AuthAppliers
+impl core::marker::Send for bitrouter_sdk::language_model::auth::AuthAppliers
+impl core::marker::Sync for bitrouter_sdk::language_model::auth::AuthAppliers
+impl core::marker::Unpin for bitrouter_sdk::language_model::auth::AuthAppliers
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::auth::AuthAppliers
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::auth::AuthAppliers
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::auth::AuthAppliers
+pub struct bitrouter_sdk::language_model::DefaultFallbackPolicy
+impl bitrouter_sdk::language_model::routing::FallbackPolicy for bitrouter_sdk::language_model::routing::DefaultFallbackPolicy
+pub fn bitrouter_sdk::language_model::routing::DefaultFallbackPolicy::classify(&self, &bitrouter_sdk::error::BitrouterError, &bitrouter_sdk::language_model::types::RoutingTarget) -> bitrouter_sdk::language_model::hooks::FallbackDecision
+impl core::clone::Clone for bitrouter_sdk::language_model::routing::DefaultFallbackPolicy
+pub fn bitrouter_sdk::language_model::routing::DefaultFallbackPolicy::clone(&self) -> bitrouter_sdk::language_model::routing::DefaultFallbackPolicy
+impl core::default::Default for bitrouter_sdk::language_model::routing::DefaultFallbackPolicy
+pub fn bitrouter_sdk::language_model::routing::DefaultFallbackPolicy::default() -> bitrouter_sdk::language_model::routing::DefaultFallbackPolicy
+impl core::fmt::Debug for bitrouter_sdk::language_model::routing::DefaultFallbackPolicy
+pub fn bitrouter_sdk::language_model::routing::DefaultFallbackPolicy::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for bitrouter_sdk::language_model::routing::DefaultFallbackPolicy
+impl core::marker::Freeze for bitrouter_sdk::language_model::routing::DefaultFallbackPolicy
+impl core::marker::Send for bitrouter_sdk::language_model::routing::DefaultFallbackPolicy
+impl core::marker::Sync for bitrouter_sdk::language_model::routing::DefaultFallbackPolicy
+impl core::marker::Unpin for bitrouter_sdk::language_model::routing::DefaultFallbackPolicy
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::routing::DefaultFallbackPolicy
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::routing::DefaultFallbackPolicy
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::routing::DefaultFallbackPolicy
+pub struct bitrouter_sdk::language_model::DispatchExecutor
+impl bitrouter_sdk::language_model::executor::DispatchExecutor
+pub fn bitrouter_sdk::language_model::executor::DispatchExecutor::new(alloc::sync::Arc<dyn bitrouter_sdk::language_model::executor::Executor>) -> Self
+pub fn bitrouter_sdk::language_model::executor::DispatchExecutor::register(&mut self, bitrouter_sdk::language_model::types::ApiProtocol, alloc::sync::Arc<dyn bitrouter_sdk::language_model::executor::Executor>)
+pub fn bitrouter_sdk::language_model::executor::DispatchExecutor::with(self, bitrouter_sdk::language_model::types::ApiProtocol, alloc::sync::Arc<dyn bitrouter_sdk::language_model::executor::Executor>) -> Self
+impl bitrouter_sdk::language_model::executor::Executor for bitrouter_sdk::language_model::executor::DispatchExecutor
+pub fn bitrouter_sdk::language_model::executor::DispatchExecutor::execute<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::types::RoutingTarget, &'life2 bitrouter_sdk::language_model::types::Prompt, &'life3 bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::ExecutionResult>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub fn bitrouter_sdk::language_model::executor::DispatchExecutor::execute_stream<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::types::RoutingTarget, &'life2 bitrouter_sdk::language_model::types::Prompt, &'life3 bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::executor::StreamPartStream>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+impl core::marker::Freeze for bitrouter_sdk::language_model::executor::DispatchExecutor
+impl core::marker::Send for bitrouter_sdk::language_model::executor::DispatchExecutor
+impl core::marker::Sync for bitrouter_sdk::language_model::executor::DispatchExecutor
+impl core::marker::Unpin for bitrouter_sdk::language_model::executor::DispatchExecutor
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::executor::DispatchExecutor
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::executor::DispatchExecutor
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::executor::DispatchExecutor
+pub struct bitrouter_sdk::language_model::ExecutionResult
+pub bitrouter_sdk::language_model::ExecutionResult::account_label: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::ExecutionResult::model_id: alloc::string::String
+pub bitrouter_sdk::language_model::ExecutionResult::provider_id: alloc::string::String
+pub bitrouter_sdk::language_model::ExecutionResult::request_duration_ms: u64
+pub bitrouter_sdk::language_model::ExecutionResult::result: bitrouter_sdk::language_model::types::GenerateResult
+pub bitrouter_sdk::language_model::ExecutionResult::server_tool_calls: alloc::vec::Vec<bitrouter_sdk::language_model::types::ServerToolCall>
+pub bitrouter_sdk::language_model::ExecutionResult::upstream_duration_ms: core::option::Option<u64>
+impl core::clone::Clone for bitrouter_sdk::language_model::types::ExecutionResult
+pub fn bitrouter_sdk::language_model::types::ExecutionResult::clone(&self) -> bitrouter_sdk::language_model::types::ExecutionResult
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::ExecutionResult
+pub fn bitrouter_sdk::language_model::types::ExecutionResult::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::ExecutionResult
+impl core::marker::Send for bitrouter_sdk::language_model::types::ExecutionResult
+impl core::marker::Sync for bitrouter_sdk::language_model::types::ExecutionResult
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::ExecutionResult
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::ExecutionResult
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::ExecutionResult
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::ExecutionResult
+pub struct bitrouter_sdk::language_model::GenerateResult
+pub bitrouter_sdk::language_model::GenerateResult::content: alloc::vec::Vec<bitrouter_sdk::language_model::types::Content>
+pub bitrouter_sdk::language_model::GenerateResult::finish_reason: core::option::Option<bitrouter_sdk::language_model::types::FinishReason>
+pub bitrouter_sdk::language_model::GenerateResult::provider_metadata: bitrouter_sdk::language_model::types::ProviderMetadata
+pub bitrouter_sdk::language_model::GenerateResult::response_id: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::GenerateResult::stop_details: core::option::Option<bitrouter_sdk::language_model::types::StopDetails>
+pub bitrouter_sdk::language_model::GenerateResult::usage: core::option::Option<bitrouter_sdk::language_model::types::Usage>
+impl core::clone::Clone for bitrouter_sdk::language_model::types::GenerateResult
+pub fn bitrouter_sdk::language_model::types::GenerateResult::clone(&self) -> bitrouter_sdk::language_model::types::GenerateResult
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::types::GenerateResult
+pub fn bitrouter_sdk::language_model::types::GenerateResult::eq(&self, &bitrouter_sdk::language_model::types::GenerateResult) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::GenerateResult
+pub fn bitrouter_sdk::language_model::types::GenerateResult::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::types::GenerateResult
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::types::GenerateResult
+pub fn bitrouter_sdk::language_model::types::GenerateResult::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::types::GenerateResult
+pub fn bitrouter_sdk::language_model::types::GenerateResult::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::GenerateResult
+impl core::marker::Send for bitrouter_sdk::language_model::types::GenerateResult
+impl core::marker::Sync for bitrouter_sdk::language_model::types::GenerateResult
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::GenerateResult
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::GenerateResult
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::GenerateResult
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::GenerateResult
+pub struct bitrouter_sdk::language_model::GenerationParams
+pub bitrouter_sdk::language_model::GenerationParams::chat_stream_options: core::option::Option<bitrouter_sdk::language_model::types::ChatStreamOptions>
+pub bitrouter_sdk::language_model::GenerationParams::chat_token_limit_field: core::option::Option<bitrouter_sdk::language_model::types::ChatTokenLimitField>
+pub bitrouter_sdk::language_model::GenerationParams::extra: std::collections::hash::map::HashMap<alloc::string::String, serde_json::value::Value>
+pub bitrouter_sdk::language_model::GenerationParams::extra_protocol: core::option::Option<bitrouter_sdk::language_model::types::ApiProtocol>
+pub bitrouter_sdk::language_model::GenerationParams::frequency_penalty: core::option::Option<f64>
+pub bitrouter_sdk::language_model::GenerationParams::max_tokens: core::option::Option<u32>
+pub bitrouter_sdk::language_model::GenerationParams::parallel_tool_calls: core::option::Option<bool>
+pub bitrouter_sdk::language_model::GenerationParams::presence_penalty: core::option::Option<f64>
+pub bitrouter_sdk::language_model::GenerationParams::reasoning_effort: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::GenerationParams::response_modalities: alloc::vec::Vec<bitrouter_sdk::language_model::types::Modality>
+pub bitrouter_sdk::language_model::GenerationParams::seed: core::option::Option<i64>
+pub bitrouter_sdk::language_model::GenerationParams::stop: alloc::vec::Vec<alloc::string::String>
+pub bitrouter_sdk::language_model::GenerationParams::store: core::option::Option<bool>
+pub bitrouter_sdk::language_model::GenerationParams::supplemental_extra: std::collections::hash::map::HashMap<alloc::string::String, serde_json::value::Value>
+pub bitrouter_sdk::language_model::GenerationParams::temperature: core::option::Option<f64>
+pub bitrouter_sdk::language_model::GenerationParams::top_k: core::option::Option<u32>
+pub bitrouter_sdk::language_model::GenerationParams::top_p: core::option::Option<f64>
+impl bitrouter_sdk::language_model::types::GenerationParams
+pub fn bitrouter_sdk::language_model::types::GenerationParams::extra_value_for_protocol(&self, &bitrouter_sdk::language_model::types::ApiProtocol, &str) -> core::option::Option<&serde_json::value::Value>
+pub fn bitrouter_sdk::language_model::types::GenerationParams::extras_for_protocol<'a>(&'a self, &'a bitrouter_sdk::language_model::types::ApiProtocol) -> impl core::iter::traits::iterator::Iterator<Item = (&'a alloc::string::String, &'a serde_json::value::Value)> + 'a
+impl core::clone::Clone for bitrouter_sdk::language_model::types::GenerationParams
+pub fn bitrouter_sdk::language_model::types::GenerationParams::clone(&self) -> bitrouter_sdk::language_model::types::GenerationParams
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::types::GenerationParams
+pub fn bitrouter_sdk::language_model::types::GenerationParams::eq(&self, &bitrouter_sdk::language_model::types::GenerationParams) -> bool
+impl core::default::Default for bitrouter_sdk::language_model::types::GenerationParams
+pub fn bitrouter_sdk::language_model::types::GenerationParams::default() -> bitrouter_sdk::language_model::types::GenerationParams
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::GenerationParams
+pub fn bitrouter_sdk::language_model::types::GenerationParams::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::types::GenerationParams
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::types::GenerationParams
+pub fn bitrouter_sdk::language_model::types::GenerationParams::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::types::GenerationParams
+pub fn bitrouter_sdk::language_model::types::GenerationParams::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::GenerationParams
+impl core::marker::Send for bitrouter_sdk::language_model::types::GenerationParams
+impl core::marker::Sync for bitrouter_sdk::language_model::types::GenerationParams
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::GenerationParams
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::GenerationParams
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::GenerationParams
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::GenerationParams
+pub struct bitrouter_sdk::language_model::HttpExecutor
+impl bitrouter_sdk::language_model::executor::HttpExecutor
+pub fn bitrouter_sdk::language_model::executor::HttpExecutor::new(bitrouter_sdk::language_model::executor::HttpTimeouts) -> bitrouter_sdk::error::Result<Self>
+pub fn bitrouter_sdk::language_model::executor::HttpExecutor::reload_provider_timeouts(&self, bitrouter_sdk::language_model::executor::HttpTimeouts, std::collections::hash::map::HashMap<alloc::string::String, bitrouter_sdk::language_model::executor::HttpTimeouts>) -> bitrouter_sdk::error::Result<()>
+pub fn bitrouter_sdk::language_model::executor::HttpExecutor::with_defaults() -> bitrouter_sdk::error::Result<Self>
+pub fn bitrouter_sdk::language_model::executor::HttpExecutor::with_dispatch(bitrouter_sdk::language_model::executor::HttpTimeouts, bitrouter_sdk::language_model::protocol::OutboundDispatch) -> bitrouter_sdk::error::Result<Self>
+pub fn bitrouter_sdk::language_model::executor::HttpExecutor::with_dispatch_and_auth(bitrouter_sdk::language_model::executor::HttpTimeouts, bitrouter_sdk::language_model::protocol::OutboundDispatch, bitrouter_sdk::language_model::auth::AuthAppliers) -> bitrouter_sdk::error::Result<Self>
+pub fn bitrouter_sdk::language_model::executor::HttpExecutor::with_provider_timeouts(bitrouter_sdk::language_model::executor::HttpTimeouts, std::collections::hash::map::HashMap<alloc::string::String, bitrouter_sdk::language_model::executor::HttpTimeouts>, bitrouter_sdk::language_model::protocol::OutboundDispatch, bitrouter_sdk::language_model::auth::AuthAppliers) -> bitrouter_sdk::error::Result<Self>
+impl bitrouter_sdk::language_model::executor::Executor for bitrouter_sdk::language_model::executor::HttpExecutor
+pub fn bitrouter_sdk::language_model::executor::HttpExecutor::execute<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::types::RoutingTarget, &'life2 bitrouter_sdk::language_model::types::Prompt, &'life3 bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::ExecutionResult>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub fn bitrouter_sdk::language_model::executor::HttpExecutor::execute_stream<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::types::RoutingTarget, &'life2 bitrouter_sdk::language_model::types::Prompt, &'life3 bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::executor::StreamPartStream>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+impl !core::marker::Freeze for bitrouter_sdk::language_model::executor::HttpExecutor
+impl core::marker::Send for bitrouter_sdk::language_model::executor::HttpExecutor
+impl core::marker::Sync for bitrouter_sdk::language_model::executor::HttpExecutor
+impl core::marker::Unpin for bitrouter_sdk::language_model::executor::HttpExecutor
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::executor::HttpExecutor
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::executor::HttpExecutor
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::executor::HttpExecutor
+pub struct bitrouter_sdk::language_model::HttpTimeouts
+pub bitrouter_sdk::language_model::HttpTimeouts::connect: core::time::Duration
+pub bitrouter_sdk::language_model::HttpTimeouts::pool_idle: core::time::Duration
+pub bitrouter_sdk::language_model::HttpTimeouts::read: core::time::Duration
+pub bitrouter_sdk::language_model::HttpTimeouts::tcp_keepalive: core::time::Duration
+pub bitrouter_sdk::language_model::HttpTimeouts::total: core::option::Option<core::time::Duration>
+impl core::clone::Clone for bitrouter_sdk::language_model::executor::HttpTimeouts
+pub fn bitrouter_sdk::language_model::executor::HttpTimeouts::clone(&self) -> bitrouter_sdk::language_model::executor::HttpTimeouts
+impl core::cmp::Eq for bitrouter_sdk::language_model::executor::HttpTimeouts
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::executor::HttpTimeouts
+pub fn bitrouter_sdk::language_model::executor::HttpTimeouts::eq(&self, &bitrouter_sdk::language_model::executor::HttpTimeouts) -> bool
+impl core::default::Default for bitrouter_sdk::language_model::executor::HttpTimeouts
+pub fn bitrouter_sdk::language_model::executor::HttpTimeouts::default() -> Self
+impl core::fmt::Debug for bitrouter_sdk::language_model::executor::HttpTimeouts
+pub fn bitrouter_sdk::language_model::executor::HttpTimeouts::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::executor::HttpTimeouts
+impl core::marker::Freeze for bitrouter_sdk::language_model::executor::HttpTimeouts
+impl core::marker::Send for bitrouter_sdk::language_model::executor::HttpTimeouts
+impl core::marker::Sync for bitrouter_sdk::language_model::executor::HttpTimeouts
+impl core::marker::Unpin for bitrouter_sdk::language_model::executor::HttpTimeouts
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::executor::HttpTimeouts
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::executor::HttpTimeouts
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::executor::HttpTimeouts
+pub struct bitrouter_sdk::language_model::Message
+pub bitrouter_sdk::language_model::Message::content: alloc::vec::Vec<bitrouter_sdk::language_model::types::Content>
+pub bitrouter_sdk::language_model::Message::role: bitrouter_sdk::language_model::types::Role
+impl bitrouter_sdk::language_model::types::Message
+pub fn bitrouter_sdk::language_model::types::Message::text(bitrouter_sdk::language_model::types::Role, impl core::convert::Into<alloc::string::String>) -> Self
+impl core::clone::Clone for bitrouter_sdk::language_model::types::Message
+pub fn bitrouter_sdk::language_model::types::Message::clone(&self) -> bitrouter_sdk::language_model::types::Message
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::types::Message
+pub fn bitrouter_sdk::language_model::types::Message::eq(&self, &bitrouter_sdk::language_model::types::Message) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::Message
+pub fn bitrouter_sdk::language_model::types::Message::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::types::Message
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::types::Message
+pub fn bitrouter_sdk::language_model::types::Message::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::types::Message
+pub fn bitrouter_sdk::language_model::types::Message::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::Message
+impl core::marker::Send for bitrouter_sdk::language_model::types::Message
+impl core::marker::Sync for bitrouter_sdk::language_model::types::Message
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::Message
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::Message
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::Message
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::Message
+pub struct bitrouter_sdk::language_model::MockExecutor
+impl bitrouter_sdk::language_model::executor::MockExecutor
+pub fn bitrouter_sdk::language_model::executor::MockExecutor::always_text(impl core::convert::Into<alloc::string::String>) -> Self
+pub fn bitrouter_sdk::language_model::executor::MockExecutor::new(alloc::vec::Vec<bitrouter_sdk::language_model::executor::MockResponse>) -> Self
+impl bitrouter_sdk::language_model::executor::Executor for bitrouter_sdk::language_model::executor::MockExecutor
+pub fn bitrouter_sdk::language_model::executor::MockExecutor::execute<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::types::RoutingTarget, &'life2 bitrouter_sdk::language_model::types::Prompt, &'life3 bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::ExecutionResult>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub fn bitrouter_sdk::language_model::executor::MockExecutor::execute_stream<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::types::RoutingTarget, &'life2 bitrouter_sdk::language_model::types::Prompt, &'life3 bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::executor::StreamPartStream>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+impl !core::marker::Freeze for bitrouter_sdk::language_model::executor::MockExecutor
+impl core::marker::Send for bitrouter_sdk::language_model::executor::MockExecutor
+impl core::marker::Sync for bitrouter_sdk::language_model::executor::MockExecutor
+impl core::marker::Unpin for bitrouter_sdk::language_model::executor::MockExecutor
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::executor::MockExecutor
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::executor::MockExecutor
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::executor::MockExecutor
+pub struct bitrouter_sdk::language_model::ModelInfo
+pub bitrouter_sdk::language_model::ModelInfo::id: alloc::string::String
+pub bitrouter_sdk::language_model::ModelInfo::providers: alloc::vec::Vec<alloc::string::String>
+impl core::clone::Clone for bitrouter_sdk::language_model::routing::ModelInfo
+pub fn bitrouter_sdk::language_model::routing::ModelInfo::clone(&self) -> bitrouter_sdk::language_model::routing::ModelInfo
+impl core::fmt::Debug for bitrouter_sdk::language_model::routing::ModelInfo
+pub fn bitrouter_sdk::language_model::routing::ModelInfo::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::routing::ModelInfo
+pub fn bitrouter_sdk::language_model::routing::ModelInfo::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::routing::ModelInfo
+pub fn bitrouter_sdk::language_model::routing::ModelInfo::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::routing::ModelInfo
+impl core::marker::Send for bitrouter_sdk::language_model::routing::ModelInfo
+impl core::marker::Sync for bitrouter_sdk::language_model::routing::ModelInfo
+impl core::marker::Unpin for bitrouter_sdk::language_model::routing::ModelInfo
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::routing::ModelInfo
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::routing::ModelInfo
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::routing::ModelInfo
+pub struct bitrouter_sdk::language_model::ModelResolution
+pub bitrouter_sdk::language_model::ModelResolution::clean_model: alloc::string::String
+pub bitrouter_sdk::language_model::ModelResolution::overrides: bitrouter_sdk::language_model::routing::PromptOverrides
+pub bitrouter_sdk::language_model::ModelResolution::policy: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::ModelResolution::prefs: bitrouter_sdk::language_model::routing::RoutingPrefs
+pub bitrouter_sdk::language_model::ModelResolution::variant: core::option::Option<alloc::string::String>
+impl bitrouter_sdk::language_model::routing::ModelResolution
+pub fn bitrouter_sdk::language_model::routing::ModelResolution::passthrough(&str) -> Self
+impl core::clone::Clone for bitrouter_sdk::language_model::routing::ModelResolution
+pub fn bitrouter_sdk::language_model::routing::ModelResolution::clone(&self) -> bitrouter_sdk::language_model::routing::ModelResolution
+impl core::fmt::Debug for bitrouter_sdk::language_model::routing::ModelResolution
+pub fn bitrouter_sdk::language_model::routing::ModelResolution::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::language_model::routing::ModelResolution
+impl core::marker::Send for bitrouter_sdk::language_model::routing::ModelResolution
+impl core::marker::Sync for bitrouter_sdk::language_model::routing::ModelResolution
+impl core::marker::Unpin for bitrouter_sdk::language_model::routing::ModelResolution
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::routing::ModelResolution
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::routing::ModelResolution
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::routing::ModelResolution
+pub struct bitrouter_sdk::language_model::NormalizedUsage
+pub bitrouter_sdk::language_model::NormalizedUsage::cache_read_tokens: u64
+pub bitrouter_sdk::language_model::NormalizedUsage::cache_write_tokens: u64
+pub bitrouter_sdk::language_model::NormalizedUsage::output_tokens: u64
+pub bitrouter_sdk::language_model::NormalizedUsage::reasoning_tokens: u64
+pub bitrouter_sdk::language_model::NormalizedUsage::uncached_input_tokens: u64
+impl core::clone::Clone for bitrouter_sdk::language_model::types::NormalizedUsage
+pub fn bitrouter_sdk::language_model::types::NormalizedUsage::clone(&self) -> bitrouter_sdk::language_model::types::NormalizedUsage
+impl core::cmp::Eq for bitrouter_sdk::language_model::types::NormalizedUsage
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::types::NormalizedUsage
+pub fn bitrouter_sdk::language_model::types::NormalizedUsage::eq(&self, &bitrouter_sdk::language_model::types::NormalizedUsage) -> bool
+impl core::default::Default for bitrouter_sdk::language_model::types::NormalizedUsage
+pub fn bitrouter_sdk::language_model::types::NormalizedUsage::default() -> bitrouter_sdk::language_model::types::NormalizedUsage
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::NormalizedUsage
+pub fn bitrouter_sdk::language_model::types::NormalizedUsage::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for bitrouter_sdk::language_model::types::NormalizedUsage
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::types::NormalizedUsage
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::types::NormalizedUsage
+pub fn bitrouter_sdk::language_model::types::NormalizedUsage::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::types::NormalizedUsage
+pub fn bitrouter_sdk::language_model::types::NormalizedUsage::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::NormalizedUsage
+impl core::marker::Send for bitrouter_sdk::language_model::types::NormalizedUsage
+impl core::marker::Sync for bitrouter_sdk::language_model::types::NormalizedUsage
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::NormalizedUsage
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::NormalizedUsage
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::NormalizedUsage
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::NormalizedUsage
+pub struct bitrouter_sdk::language_model::OutboundDispatch
+impl bitrouter_sdk::language_model::protocol::OutboundDispatch
+pub fn bitrouter_sdk::language_model::protocol::OutboundDispatch::builtin() -> Self
+pub fn bitrouter_sdk::language_model::protocol::OutboundDispatch::empty() -> Self
+pub fn bitrouter_sdk::language_model::protocol::OutboundDispatch::lookup(&self, &bitrouter_sdk::language_model::types::ApiProtocol) -> core::option::Option<bitrouter_sdk::language_model::protocol::DispatchHandle<'_>>
+pub fn bitrouter_sdk::language_model::protocol::OutboundDispatch::register(&mut self, alloc::sync::Arc<dyn bitrouter_sdk::language_model::protocol::OutboundAdapter>, alloc::sync::Arc<dyn bitrouter_sdk::language_model::protocol::Transport>)
+impl core::default::Default for bitrouter_sdk::language_model::protocol::OutboundDispatch
+pub fn bitrouter_sdk::language_model::protocol::OutboundDispatch::default() -> Self
+impl core::marker::Freeze for bitrouter_sdk::language_model::protocol::OutboundDispatch
+impl core::marker::Send for bitrouter_sdk::language_model::protocol::OutboundDispatch
+impl core::marker::Sync for bitrouter_sdk::language_model::protocol::OutboundDispatch
+impl core::marker::Unpin for bitrouter_sdk::language_model::protocol::OutboundDispatch
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::protocol::OutboundDispatch
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::protocol::OutboundDispatch
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::protocol::OutboundDispatch
+pub struct bitrouter_sdk::language_model::Pipeline
+impl bitrouter_sdk::language_model::pipeline::Pipeline
+pub async fn bitrouter_sdk::language_model::pipeline::Pipeline::drain_pending_settlements(&self) -> usize
+pub async fn bitrouter_sdk::language_model::pipeline::Pipeline::drain_required_pending_settlements(&self) -> bitrouter_sdk::error::Result<usize>
+pub async fn bitrouter_sdk::language_model::pipeline::Pipeline::execute(&self, bitrouter_sdk::language_model::types::PipelineRequest) -> bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::PipelineResponse>
+pub async fn bitrouter_sdk::language_model::pipeline::Pipeline::execute_detached(alloc::sync::Arc<Self>, bitrouter_sdk::language_model::types::PipelineRequest) -> bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::PipelineResponse>
+pub async fn bitrouter_sdk::language_model::pipeline::Pipeline::execute_stream(alloc::sync::Arc<Self>, bitrouter_sdk::language_model::types::PipelineRequest) -> bitrouter_sdk::error::Result<core::pin::Pin<alloc::boxed::Box<(dyn futures_core::stream::Stream<Item = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::StreamPart>> + core::marker::Send)>>>
+pub fn bitrouter_sdk::language_model::pipeline::Pipeline::keepalive_interval(&self) -> core::time::Duration
+pub fn bitrouter_sdk::language_model::pipeline::Pipeline::routing_table(&self) -> &alloc::sync::Arc<dyn bitrouter_sdk::language_model::routing::RoutingTable>
+impl core::marker::Freeze for bitrouter_sdk::language_model::pipeline::Pipeline
+impl core::marker::Send for bitrouter_sdk::language_model::pipeline::Pipeline
+impl core::marker::Sync for bitrouter_sdk::language_model::pipeline::Pipeline
+impl core::marker::Unpin for bitrouter_sdk::language_model::pipeline::Pipeline
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::pipeline::Pipeline
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::pipeline::Pipeline
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::pipeline::Pipeline
+pub struct bitrouter_sdk::language_model::PipelineBuilder
+impl bitrouter_sdk::language_model::builder::PipelineBuilder
+pub fn bitrouter_sdk::language_model::builder::PipelineBuilder::build(self) -> bitrouter_sdk::error::Result<bitrouter_sdk::language_model::pipeline::Pipeline>
+pub fn bitrouter_sdk::language_model::builder::PipelineBuilder::execution_hook(&mut self, impl bitrouter_sdk::language_model::hooks::ExecutionHook + 'static) -> &mut Self
+pub fn bitrouter_sdk::language_model::builder::PipelineBuilder::executor(&mut self, alloc::sync::Arc<dyn bitrouter_sdk::language_model::executor::Executor>) -> &mut Self
+pub fn bitrouter_sdk::language_model::builder::PipelineBuilder::fallback_backoff(&mut self, impl core::iter::traits::collect::IntoIterator<Item = core::time::Duration>) -> &mut Self
+pub fn bitrouter_sdk::language_model::builder::PipelineBuilder::fallback_policy(&mut self, alloc::sync::Arc<dyn bitrouter_sdk::language_model::routing::FallbackPolicy>) -> &mut Self
+pub fn bitrouter_sdk::language_model::builder::PipelineBuilder::is_configured(&self) -> bool
+pub fn bitrouter_sdk::language_model::builder::PipelineBuilder::keepalive_interval(&mut self, core::time::Duration) -> &mut Self
+pub fn bitrouter_sdk::language_model::builder::PipelineBuilder::model_selector(&mut self, alloc::sync::Arc<dyn bitrouter_sdk::language_model::routing::ModelSelector>) -> &mut Self
+pub fn bitrouter_sdk::language_model::builder::PipelineBuilder::new() -> Self
+pub fn bitrouter_sdk::language_model::builder::PipelineBuilder::observe_hook(&mut self, impl bitrouter_sdk::language_model::hooks::ObserveHook + 'static) -> &mut Self
+pub fn bitrouter_sdk::language_model::builder::PipelineBuilder::pre_request_hook(&mut self, impl bitrouter_sdk::language_model::hooks::PreRequestHook + 'static) -> &mut Self
+pub fn bitrouter_sdk::language_model::builder::PipelineBuilder::required_finalizer(&mut self, impl bitrouter_sdk::language_model::settlement::RequiredFinalizer + 'static) -> &mut Self
+pub fn bitrouter_sdk::language_model::builder::PipelineBuilder::route_hook(&mut self, impl bitrouter_sdk::language_model::hooks::RouteHook + 'static) -> &mut Self
+pub fn bitrouter_sdk::language_model::builder::PipelineBuilder::routing_table(&mut self, alloc::sync::Arc<dyn bitrouter_sdk::language_model::routing::RoutingTable>) -> &mut Self
+pub fn bitrouter_sdk::language_model::builder::PipelineBuilder::server_tool_loop(&mut self, alloc::sync::Arc<bitrouter_sdk::language_model::server_tools::loop_controller::ServerToolLoop>) -> &mut Self
+pub fn bitrouter_sdk::language_model::builder::PipelineBuilder::settlement_recorder(&mut self, impl bitrouter_sdk::language_model::settlement::SettlementRecorder + 'static) -> &mut Self
+pub fn bitrouter_sdk::language_model::builder::PipelineBuilder::stream_hook(&mut self, impl bitrouter_sdk::language_model::hooks::StreamHook + 'static) -> &mut Self
+impl core::default::Default for bitrouter_sdk::language_model::builder::PipelineBuilder
+pub fn bitrouter_sdk::language_model::builder::PipelineBuilder::default() -> Self
+impl core::marker::Freeze for bitrouter_sdk::language_model::builder::PipelineBuilder
+impl core::marker::Send for bitrouter_sdk::language_model::builder::PipelineBuilder
+impl core::marker::Sync for bitrouter_sdk::language_model::builder::PipelineBuilder
+impl core::marker::Unpin for bitrouter_sdk::language_model::builder::PipelineBuilder
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::builder::PipelineBuilder
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::builder::PipelineBuilder
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::builder::PipelineBuilder
+pub struct bitrouter_sdk::language_model::PipelineContext
+pub bitrouter_sdk::language_model::PipelineContext::execution_result: core::option::Option<bitrouter_sdk::language_model::types::ExecutionResult>
+pub bitrouter_sdk::language_model::PipelineContext::route_chain: core::option::Option<alloc::vec::Vec<bitrouter_sdk::language_model::types::RoutingTarget>>
+impl bitrouter_sdk::language_model::context::PipelineContext
+pub fn bitrouter_sdk::language_model::context::PipelineContext::absorb_settlement(&mut self, bitrouter_sdk::language_model::settlement::SettlementContext)
+pub fn bitrouter_sdk::language_model::context::PipelineContext::absorb_stream(&mut self, bitrouter_sdk::language_model::context::StreamContext)
+pub fn bitrouter_sdk::language_model::context::PipelineContext::apply_preset_overrides(&mut self, &bitrouter_sdk::language_model::routing::PromptOverrides)
+pub fn bitrouter_sdk::language_model::context::PipelineContext::caller(&self) -> &bitrouter_sdk::caller::CallerContext
+pub fn bitrouter_sdk::language_model::context::PipelineContext::emit<E: bitrouter_sdk::event::PipelineEvent>(&mut self, E)
+pub fn bitrouter_sdk::language_model::context::PipelineContext::events(&self) -> &bitrouter_sdk::event::EventBus
+pub fn bitrouter_sdk::language_model::context::PipelineContext::extension<T: core::marker::Send + core::marker::Sync + 'static>(&self) -> core::option::Option<alloc::sync::Arc<T>>
+pub fn bitrouter_sdk::language_model::context::PipelineContext::first_token_timing(&self) -> core::option::Option<bitrouter_sdk::language_model::timing::FirstTokenTiming>
+pub fn bitrouter_sdk::language_model::context::PipelineContext::generation_duration_ms(&self) -> core::option::Option<u64>
+pub fn bitrouter_sdk::language_model::context::PipelineContext::get_event<E: bitrouter_sdk::event::PipelineEvent>(&self) -> core::option::Option<&E>
+pub fn bitrouter_sdk::language_model::context::PipelineContext::get_events<E: bitrouter_sdk::event::PipelineEvent>(&self) -> alloc::vec::Vec<&E>
+pub fn bitrouter_sdk::language_model::context::PipelineContext::get_metadata(&self, &bitrouter_sdk::plugin::PluginId) -> core::option::Option<&serde_json::value::Value>
+pub fn bitrouter_sdk::language_model::context::PipelineContext::has_event<E: bitrouter_sdk::event::PipelineEvent>(&self) -> bool
+pub fn bitrouter_sdk::language_model::context::PipelineContext::headers(&self) -> &http::header::map::HeaderMap
+pub fn bitrouter_sdk::language_model::context::PipelineContext::inbound_protocol(&self) -> core::option::Option<bitrouter_sdk::language_model::types::ApiProtocol>
+pub fn bitrouter_sdk::language_model::context::PipelineContext::insert_extension<T: core::marker::Send + core::marker::Sync + 'static>(&mut self, alloc::sync::Arc<T>)
+pub fn bitrouter_sdk::language_model::context::PipelineContext::into_response(self) -> bitrouter_sdk::language_model::types::PipelineResponse
+pub fn bitrouter_sdk::language_model::context::PipelineContext::metadata(&self) -> &std::collections::hash::map::HashMap<bitrouter_sdk::plugin::PluginId, serde_json::value::Value>
+pub fn bitrouter_sdk::language_model::context::PipelineContext::model(&self) -> &str
+pub fn bitrouter_sdk::language_model::context::PipelineContext::new(bitrouter_sdk::language_model::types::PipelineRequest) -> Self
+pub fn bitrouter_sdk::language_model::context::PipelineContext::prompt(&self) -> &bitrouter_sdk::language_model::types::Prompt
+pub fn bitrouter_sdk::language_model::context::PipelineContext::request_duration_ms(&self) -> u64
+pub fn bitrouter_sdk::language_model::context::PipelineContext::request_id(&self) -> &str
+pub fn bitrouter_sdk::language_model::context::PipelineContext::serving_target(&self) -> core::option::Option<bitrouter_sdk::language_model::types::RoutingTarget>
+pub fn bitrouter_sdk::language_model::context::PipelineContext::set_caller(&mut self, bitrouter_sdk::caller::CallerContext)
+pub fn bitrouter_sdk::language_model::context::PipelineContext::set_metadata(&mut self, &bitrouter_sdk::plugin::PluginId, serde_json::value::Value)
+pub fn bitrouter_sdk::language_model::context::PipelineContext::set_model(&mut self, impl core::convert::Into<alloc::string::String>)
+pub fn bitrouter_sdk::language_model::context::PipelineContext::set_outbound_trace_headers(&self, http::header::map::HeaderMap)
+pub fn bitrouter_sdk::language_model::context::PipelineContext::settlement_context(&mut self) -> bitrouter_sdk::language_model::settlement::SettlementContext
+pub fn bitrouter_sdk::language_model::context::PipelineContext::stream_context(&self) -> bitrouter_sdk::language_model::context::StreamContext
+pub fn bitrouter_sdk::language_model::context::PipelineContext::take_outbound_trace_headers(&self) -> core::option::Option<http::header::map::HeaderMap>
+impl !core::marker::Freeze for bitrouter_sdk::language_model::context::PipelineContext
+impl core::marker::Send for bitrouter_sdk::language_model::context::PipelineContext
+impl core::marker::Sync for bitrouter_sdk::language_model::context::PipelineContext
+impl core::marker::Unpin for bitrouter_sdk::language_model::context::PipelineContext
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::context::PipelineContext
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::context::PipelineContext
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::context::PipelineContext
+pub struct bitrouter_sdk::language_model::PipelineRequest
+pub bitrouter_sdk::language_model::PipelineRequest::caller: bitrouter_sdk::caller::CallerContext
+pub bitrouter_sdk::language_model::PipelineRequest::headers: http::header::map::HeaderMap
+pub bitrouter_sdk::language_model::PipelineRequest::inbound_protocol: core::option::Option<bitrouter_sdk::language_model::types::ApiProtocol>
+pub bitrouter_sdk::language_model::PipelineRequest::model: alloc::string::String
+pub bitrouter_sdk::language_model::PipelineRequest::prompt: bitrouter_sdk::language_model::types::Prompt
+pub bitrouter_sdk::language_model::PipelineRequest::request_id: alloc::string::String
+impl bitrouter_sdk::language_model::types::PipelineRequest
+pub fn bitrouter_sdk::language_model::types::PipelineRequest::new(impl core::convert::Into<alloc::string::String>, bitrouter_sdk::caller::CallerContext, bitrouter_sdk::language_model::types::Prompt) -> Self
+impl core::clone::Clone for bitrouter_sdk::language_model::types::PipelineRequest
+pub fn bitrouter_sdk::language_model::types::PipelineRequest::clone(&self) -> bitrouter_sdk::language_model::types::PipelineRequest
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::PipelineRequest
+pub fn bitrouter_sdk::language_model::types::PipelineRequest::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::PipelineRequest
+impl core::marker::Send for bitrouter_sdk::language_model::types::PipelineRequest
+impl core::marker::Sync for bitrouter_sdk::language_model::types::PipelineRequest
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::PipelineRequest
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::PipelineRequest
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::PipelineRequest
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::PipelineRequest
+pub struct bitrouter_sdk::language_model::PipelineResponse
+pub bitrouter_sdk::language_model::PipelineResponse::request_id: alloc::string::String
+pub bitrouter_sdk::language_model::PipelineResponse::result: bitrouter_sdk::language_model::types::GenerateResult
+impl core::clone::Clone for bitrouter_sdk::language_model::types::PipelineResponse
+pub fn bitrouter_sdk::language_model::types::PipelineResponse::clone(&self) -> bitrouter_sdk::language_model::types::PipelineResponse
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::PipelineResponse
+pub fn bitrouter_sdk::language_model::types::PipelineResponse::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::PipelineResponse
+impl core::marker::Send for bitrouter_sdk::language_model::types::PipelineResponse
+impl core::marker::Sync for bitrouter_sdk::language_model::types::PipelineResponse
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::PipelineResponse
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::PipelineResponse
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::PipelineResponse
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::PipelineResponse
+pub struct bitrouter_sdk::language_model::Prompt
+pub bitrouter_sdk::language_model::Prompt::messages: alloc::vec::Vec<bitrouter_sdk::language_model::types::Message>
+pub bitrouter_sdk::language_model::Prompt::model: alloc::string::String
+pub bitrouter_sdk::language_model::Prompt::params: bitrouter_sdk::language_model::types::GenerationParams
+pub bitrouter_sdk::language_model::Prompt::response_format: core::option::Option<bitrouter_sdk::language_model::types::ResponseFormat>
+pub bitrouter_sdk::language_model::Prompt::stream: bool
+pub bitrouter_sdk::language_model::Prompt::system: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::Prompt::system_provider_metadata: bitrouter_sdk::language_model::types::ProviderMetadata
+pub bitrouter_sdk::language_model::Prompt::tool_choice: core::option::Option<bitrouter_sdk::language_model::types::ToolChoice>
+pub bitrouter_sdk::language_model::Prompt::tools: alloc::vec::Vec<bitrouter_sdk::language_model::types::Tool>
+impl bitrouter_sdk::language_model::types::Prompt
+pub fn bitrouter_sdk::language_model::types::Prompt::required_capabilities(&self) -> alloc::vec::Vec<bitrouter_sdk::language_model::types::Capability>
+impl core::clone::Clone for bitrouter_sdk::language_model::types::Prompt
+pub fn bitrouter_sdk::language_model::types::Prompt::clone(&self) -> bitrouter_sdk::language_model::types::Prompt
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::types::Prompt
+pub fn bitrouter_sdk::language_model::types::Prompt::eq(&self, &bitrouter_sdk::language_model::types::Prompt) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::Prompt
+pub fn bitrouter_sdk::language_model::types::Prompt::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::types::Prompt
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::types::Prompt
+pub fn bitrouter_sdk::language_model::types::Prompt::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::types::Prompt
+pub fn bitrouter_sdk::language_model::types::Prompt::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::Prompt
+impl core::marker::Send for bitrouter_sdk::language_model::types::Prompt
+impl core::marker::Sync for bitrouter_sdk::language_model::types::Prompt
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::Prompt
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::Prompt
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::Prompt
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::Prompt
+pub struct bitrouter_sdk::language_model::RoutingPrefs
+pub bitrouter_sdk::language_model::RoutingPrefs::ignore: alloc::vec::Vec<alloc::string::String>
+pub bitrouter_sdk::language_model::RoutingPrefs::inbound_protocol: core::option::Option<bitrouter_sdk::language_model::types::ApiProtocol>
+pub bitrouter_sdk::language_model::RoutingPrefs::only: alloc::vec::Vec<alloc::string::String>
+pub bitrouter_sdk::language_model::RoutingPrefs::require_capabilities: alloc::vec::Vec<bitrouter_sdk::language_model::types::Capability>
+pub bitrouter_sdk::language_model::RoutingPrefs::require_tags: alloc::vec::Vec<alloc::string::String>
+pub bitrouter_sdk::language_model::RoutingPrefs::sort: bitrouter_sdk::language_model::routing::SortOrder
+impl core::clone::Clone for bitrouter_sdk::language_model::routing::RoutingPrefs
+pub fn bitrouter_sdk::language_model::routing::RoutingPrefs::clone(&self) -> bitrouter_sdk::language_model::routing::RoutingPrefs
+impl core::default::Default for bitrouter_sdk::language_model::routing::RoutingPrefs
+pub fn bitrouter_sdk::language_model::routing::RoutingPrefs::default() -> bitrouter_sdk::language_model::routing::RoutingPrefs
+impl core::fmt::Debug for bitrouter_sdk::language_model::routing::RoutingPrefs
+pub fn bitrouter_sdk::language_model::routing::RoutingPrefs::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::language_model::routing::RoutingPrefs
+impl core::marker::Send for bitrouter_sdk::language_model::routing::RoutingPrefs
+impl core::marker::Sync for bitrouter_sdk::language_model::routing::RoutingPrefs
+impl core::marker::Unpin for bitrouter_sdk::language_model::routing::RoutingPrefs
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::routing::RoutingPrefs
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::routing::RoutingPrefs
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::routing::RoutingPrefs
+pub struct bitrouter_sdk::language_model::RoutingTarget
+pub bitrouter_sdk::language_model::RoutingTarget::account_label: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::RoutingTarget::api_base: alloc::string::String
+pub bitrouter_sdk::language_model::RoutingTarget::api_base_override: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::RoutingTarget::api_key: alloc::string::String
+pub bitrouter_sdk::language_model::RoutingTarget::api_key_override: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::RoutingTarget::api_protocol: bitrouter_sdk::language_model::types::ApiProtocol
+pub bitrouter_sdk::language_model::RoutingTarget::auth_scheme: bitrouter_sdk::language_model::types::AuthScheme
+pub bitrouter_sdk::language_model::RoutingTarget::chat_supports_store: core::option::Option<bool>
+pub bitrouter_sdk::language_model::RoutingTarget::chat_supports_stream_options: core::option::Option<bool>
+pub bitrouter_sdk::language_model::RoutingTarget::chat_token_limit_field: core::option::Option<bitrouter_sdk::language_model::types::ChatTokenLimitField>
+pub bitrouter_sdk::language_model::RoutingTarget::provider_name: alloc::string::String
+pub bitrouter_sdk::language_model::RoutingTarget::service_id: alloc::string::String
+impl bitrouter_sdk::language_model::types::RoutingTarget
+pub fn bitrouter_sdk::language_model::types::RoutingTarget::effective_api_base(&self) -> &str
+pub fn bitrouter_sdk::language_model::types::RoutingTarget::effective_api_key(&self) -> &str
+impl core::clone::Clone for bitrouter_sdk::language_model::types::RoutingTarget
+pub fn bitrouter_sdk::language_model::types::RoutingTarget::clone(&self) -> bitrouter_sdk::language_model::types::RoutingTarget
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::RoutingTarget
+pub fn bitrouter_sdk::language_model::types::RoutingTarget::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::RoutingTarget
+impl core::marker::Send for bitrouter_sdk::language_model::types::RoutingTarget
+impl core::marker::Sync for bitrouter_sdk::language_model::types::RoutingTarget
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::RoutingTarget
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::RoutingTarget
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::RoutingTarget
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::RoutingTarget
+pub struct bitrouter_sdk::language_model::ServerToolCall
+pub bitrouter_sdk::language_model::ServerToolCall::call_id: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::ServerToolCall::kind: bitrouter_sdk::language_model::types::ServerToolKind
+pub bitrouter_sdk::language_model::ServerToolCall::name: alloc::string::String
+pub bitrouter_sdk::language_model::ServerToolCall::result_count: u32
+pub bitrouter_sdk::language_model::ServerToolCall::status: bitrouter_sdk::language_model::types::ServerToolStatus
+impl core::clone::Clone for bitrouter_sdk::language_model::types::ServerToolCall
+pub fn bitrouter_sdk::language_model::types::ServerToolCall::clone(&self) -> bitrouter_sdk::language_model::types::ServerToolCall
+impl core::cmp::Eq for bitrouter_sdk::language_model::types::ServerToolCall
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::types::ServerToolCall
+pub fn bitrouter_sdk::language_model::types::ServerToolCall::eq(&self, &bitrouter_sdk::language_model::types::ServerToolCall) -> bool
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::ServerToolCall
+pub fn bitrouter_sdk::language_model::types::ServerToolCall::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::types::ServerToolCall
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::types::ServerToolCall
+pub fn bitrouter_sdk::language_model::types::ServerToolCall::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::types::ServerToolCall
+pub fn bitrouter_sdk::language_model::types::ServerToolCall::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::ServerToolCall
+impl core::marker::Send for bitrouter_sdk::language_model::types::ServerToolCall
+impl core::marker::Sync for bitrouter_sdk::language_model::types::ServerToolCall
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::ServerToolCall
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::ServerToolCall
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::ServerToolCall
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::ServerToolCall
+pub struct bitrouter_sdk::language_model::SettlementContext
+pub bitrouter_sdk::language_model::SettlementContext::account_label: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::language_model::SettlementContext::cache_read_tokens: u64
+pub bitrouter_sdk::language_model::SettlementContext::cache_write_tokens: u64
+pub bitrouter_sdk::language_model::SettlementContext::caller: bitrouter_sdk::caller::CallerContext
+pub bitrouter_sdk::language_model::SettlementContext::completion_tokens: u64
+pub bitrouter_sdk::language_model::SettlementContext::error: core::option::Option<bitrouter_sdk::error::BitrouterError>
+pub bitrouter_sdk::language_model::SettlementContext::events: bitrouter_sdk::event::EventBus
+pub bitrouter_sdk::language_model::SettlementContext::finish_reason: core::option::Option<bitrouter_sdk::language_model::types::FinishReason>
+pub bitrouter_sdk::language_model::SettlementContext::first_token_kind: core::option::Option<bitrouter_sdk::language_model::timing::FirstTokenKind>
+pub bitrouter_sdk::language_model::SettlementContext::generation_duration_ms: core::option::Option<u64>
+pub bitrouter_sdk::language_model::SettlementContext::media_input_count: u64
+pub bitrouter_sdk::language_model::SettlementContext::media_output_count: u64
+pub bitrouter_sdk::language_model::SettlementContext::model_id: alloc::string::String
+pub bitrouter_sdk::language_model::SettlementContext::prompt_tokens: u64
+pub bitrouter_sdk::language_model::SettlementContext::provider_id: alloc::string::String
+pub bitrouter_sdk::language_model::SettlementContext::raw_usage: core::option::Option<serde_json::value::Value>
+pub bitrouter_sdk::language_model::SettlementContext::reasoning_tokens: u64
+pub bitrouter_sdk::language_model::SettlementContext::request_duration_ms: u64
+pub bitrouter_sdk::language_model::SettlementContext::request_id: alloc::string::String
+pub bitrouter_sdk::language_model::SettlementContext::server_tool_calls: alloc::vec::Vec<bitrouter_sdk::language_model::types::ServerToolCall>
+pub bitrouter_sdk::language_model::SettlementContext::streamed: bool
+pub bitrouter_sdk::language_model::SettlementContext::target: core::option::Option<bitrouter_sdk::language_model::types::RoutingTarget>
+pub bitrouter_sdk::language_model::SettlementContext::ttft_ms: core::option::Option<u64>
+pub bitrouter_sdk::language_model::SettlementContext::upstream_duration_ms: core::option::Option<u64>
+pub bitrouter_sdk::language_model::SettlementContext::usage_origin: bitrouter_sdk::language_model::types::UsageOrigin
+pub bitrouter_sdk::language_model::SettlementContext::web_search_count: u64
+impl bitrouter_sdk::language_model::settlement::SettlementContext
+pub fn bitrouter_sdk::language_model::settlement::SettlementContext::emit<E: bitrouter_sdk::event::PipelineEvent>(&mut self, E)
+pub fn bitrouter_sdk::language_model::settlement::SettlementContext::get_event<E: bitrouter_sdk::event::PipelineEvent>(&self) -> core::option::Option<&E>
+pub fn bitrouter_sdk::language_model::settlement::SettlementContext::get_events<E: bitrouter_sdk::event::PipelineEvent>(&self) -> alloc::vec::Vec<&E>
+pub fn bitrouter_sdk::language_model::settlement::SettlementContext::has_event<E: bitrouter_sdk::event::PipelineEvent>(&self) -> bool
+impl core::marker::Freeze for bitrouter_sdk::language_model::settlement::SettlementContext
+impl core::marker::Send for bitrouter_sdk::language_model::settlement::SettlementContext
+impl core::marker::Sync for bitrouter_sdk::language_model::settlement::SettlementContext
+impl core::marker::Unpin for bitrouter_sdk::language_model::settlement::SettlementContext
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::settlement::SettlementContext
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::settlement::SettlementContext
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::settlement::SettlementContext
+pub struct bitrouter_sdk::language_model::SseEvent
+pub bitrouter_sdk::language_model::SseEvent::data: alloc::string::String
+pub bitrouter_sdk::language_model::SseEvent::event: core::option::Option<alloc::string::String>
+impl core::clone::Clone for bitrouter_sdk::language_model::protocol::SseEvent
+pub fn bitrouter_sdk::language_model::protocol::SseEvent::clone(&self) -> bitrouter_sdk::language_model::protocol::SseEvent
+impl core::default::Default for bitrouter_sdk::language_model::protocol::SseEvent
+pub fn bitrouter_sdk::language_model::protocol::SseEvent::default() -> bitrouter_sdk::language_model::protocol::SseEvent
+impl core::fmt::Debug for bitrouter_sdk::language_model::protocol::SseEvent
+pub fn bitrouter_sdk::language_model::protocol::SseEvent::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::language_model::protocol::SseEvent
+impl core::marker::Send for bitrouter_sdk::language_model::protocol::SseEvent
+impl core::marker::Sync for bitrouter_sdk::language_model::protocol::SseEvent
+impl core::marker::Unpin for bitrouter_sdk::language_model::protocol::SseEvent
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::protocol::SseEvent
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::protocol::SseEvent
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::protocol::SseEvent
+pub struct bitrouter_sdk::language_model::SseKeepaliveStream<S>
+impl<S> bitrouter_sdk::language_model::stream::SseKeepaliveStream<S>
+pub fn bitrouter_sdk::language_model::stream::SseKeepaliveStream<S>::new(S, core::time::Duration) -> Self
+impl<'__pin, S> core::marker::Unpin for bitrouter_sdk::language_model::stream::SseKeepaliveStream<S> where pin_project_lite::__private::PinnedFieldsOf<__Origin<'__pin, S>>: core::marker::Unpin
+impl<S> futures_core::stream::Stream for bitrouter_sdk::language_model::stream::SseKeepaliveStream<S> where S: futures_core::stream::Stream<Item = bitrouter_sdk::language_model::stream::SseFrame>
+pub type bitrouter_sdk::language_model::stream::SseKeepaliveStream<S>::Item = bitrouter_sdk::language_model::stream::SseFrame
+pub fn bitrouter_sdk::language_model::stream::SseKeepaliveStream<S>::poll_next(core::pin::Pin<&mut Self>, &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<core::option::Option<Self::Item>>
+impl<S> !core::marker::Freeze for bitrouter_sdk::language_model::stream::SseKeepaliveStream<S>
+impl<S> core::marker::Send for bitrouter_sdk::language_model::stream::SseKeepaliveStream<S> where S: core::marker::Send
+impl<S> core::marker::Sync for bitrouter_sdk::language_model::stream::SseKeepaliveStream<S> where S: core::marker::Sync
+impl<S> !core::marker::UnsafeUnpin for bitrouter_sdk::language_model::stream::SseKeepaliveStream<S>
+impl<S> !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::stream::SseKeepaliveStream<S>
+impl<S> !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::stream::SseKeepaliveStream<S>
+pub struct bitrouter_sdk::language_model::StaticRoutingTable
+impl bitrouter_sdk::language_model::routing::StaticRoutingTable
+pub fn bitrouter_sdk::language_model::routing::StaticRoutingTable::insert(&self, impl core::convert::Into<alloc::string::String>, alloc::vec::Vec<bitrouter_sdk::language_model::types::RoutingTarget>)
+pub fn bitrouter_sdk::language_model::routing::StaticRoutingTable::new() -> Self
+impl bitrouter_sdk::language_model::routing::RoutingTable for bitrouter_sdk::language_model::routing::StaticRoutingTable
+pub fn bitrouter_sdk::language_model::routing::StaticRoutingTable::list_models(&self) -> alloc::vec::Vec<bitrouter_sdk::language_model::routing::ModelInfo>
+pub fn bitrouter_sdk::language_model::routing::StaticRoutingTable::model_info(&self, &str) -> core::option::Option<bitrouter_sdk::language_model::routing::ModelInfo>
+pub fn bitrouter_sdk::language_model::routing::StaticRoutingTable::preset_overrides<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 str) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::routing::PromptOverrides>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::routing::StaticRoutingTable::reload<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<()>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn bitrouter_sdk::language_model::routing::StaticRoutingTable::resolve_model<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 str) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::routing::ModelResolution>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::routing::StaticRoutingTable::route_chain<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 str, &'life2 bitrouter_sdk::language_model::routing::RoutingPrefs, &'life3 bitrouter_sdk::caller::CallerContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<alloc::vec::Vec<bitrouter_sdk::language_model::types::RoutingTarget>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub fn bitrouter_sdk::language_model::routing::StaticRoutingTable::route_resolved<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 str, &'life2 bitrouter_sdk::language_model::routing::RoutingPrefs, &'life3 bitrouter_sdk::caller::CallerContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<alloc::vec::Vec<bitrouter_sdk::language_model::types::RoutingTarget>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+impl core::default::Default for bitrouter_sdk::language_model::routing::StaticRoutingTable
+pub fn bitrouter_sdk::language_model::routing::StaticRoutingTable::default() -> Self
+impl !core::marker::Freeze for bitrouter_sdk::language_model::routing::StaticRoutingTable
+impl core::marker::Send for bitrouter_sdk::language_model::routing::StaticRoutingTable
+impl core::marker::Sync for bitrouter_sdk::language_model::routing::StaticRoutingTable
+impl core::marker::Unpin for bitrouter_sdk::language_model::routing::StaticRoutingTable
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::routing::StaticRoutingTable
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::routing::StaticRoutingTable
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::routing::StaticRoutingTable
+pub struct bitrouter_sdk::language_model::StreamContext
+pub bitrouter_sdk::language_model::StreamContext::accumulated_usage: bitrouter_sdk::language_model::stream::UsageAccumulator
+pub bitrouter_sdk::language_model::StreamContext::caller: bitrouter_sdk::caller::CallerContext
+pub bitrouter_sdk::language_model::StreamContext::final_usage: core::option::Option<bitrouter_sdk::language_model::types::Usage>
+pub bitrouter_sdk::language_model::StreamContext::parts_emitted: u64
+pub bitrouter_sdk::language_model::StreamContext::request_id: alloc::string::String
+pub bitrouter_sdk::language_model::StreamContext::target: core::option::Option<bitrouter_sdk::language_model::types::RoutingTarget>
+impl bitrouter_sdk::language_model::context::StreamContext
+pub fn bitrouter_sdk::language_model::context::StreamContext::emit<E: bitrouter_sdk::event::PipelineEvent>(&mut self, E)
+pub fn bitrouter_sdk::language_model::context::StreamContext::extension<T: core::marker::Send + core::marker::Sync + 'static>(&self) -> core::option::Option<alloc::sync::Arc<T>>
+pub fn bitrouter_sdk::language_model::context::StreamContext::finish_reason(&self) -> core::option::Option<&bitrouter_sdk::language_model::types::FinishReason>
+pub fn bitrouter_sdk::language_model::context::StreamContext::first_token_timing(&self) -> core::option::Option<bitrouter_sdk::language_model::timing::FirstTokenTiming>
+pub fn bitrouter_sdk::language_model::context::StreamContext::generation_duration_ms(&self) -> core::option::Option<u64>
+pub fn bitrouter_sdk::language_model::context::StreamContext::get_event<E: bitrouter_sdk::event::PipelineEvent>(&self) -> core::option::Option<&E>
+pub fn bitrouter_sdk::language_model::context::StreamContext::get_metadata(&self, &bitrouter_sdk::plugin::PluginId) -> core::option::Option<&serde_json::value::Value>
+pub fn bitrouter_sdk::language_model::context::StreamContext::has_event<E: bitrouter_sdk::event::PipelineEvent>(&self) -> bool
+pub fn bitrouter_sdk::language_model::context::StreamContext::set_metadata(&mut self, &bitrouter_sdk::plugin::PluginId, serde_json::value::Value)
+impl core::marker::Freeze for bitrouter_sdk::language_model::context::StreamContext
+impl core::marker::Send for bitrouter_sdk::language_model::context::StreamContext
+impl core::marker::Sync for bitrouter_sdk::language_model::context::StreamContext
+impl core::marker::Unpin for bitrouter_sdk::language_model::context::StreamContext
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::context::StreamContext
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::context::StreamContext
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::context::StreamContext
+pub struct bitrouter_sdk::language_model::StreamInterest(_)
+impl bitrouter_sdk::language_model::stream::StreamInterest
+pub const fn bitrouter_sdk::language_model::stream::StreamInterest::all() -> Self
+pub fn bitrouter_sdk::language_model::stream::StreamInterest::is_empty(&self) -> bool
+pub fn bitrouter_sdk::language_model::stream::StreamInterest::matches(&self, &bitrouter_sdk::language_model::types::StreamPart) -> bool
+pub const fn bitrouter_sdk::language_model::stream::StreamInterest::none() -> Self
+pub const fn bitrouter_sdk::language_model::stream::StreamInterest::with_finish(self) -> Self
+pub const fn bitrouter_sdk::language_model::stream::StreamInterest::with_reasoning_delta(self) -> Self
+pub const fn bitrouter_sdk::language_model::stream::StreamInterest::with_response_started(self) -> Self
+pub const fn bitrouter_sdk::language_model::stream::StreamInterest::with_text_delta(self) -> Self
+pub const fn bitrouter_sdk::language_model::stream::StreamInterest::with_tool_call_delta(self) -> Self
+pub const fn bitrouter_sdk::language_model::stream::StreamInterest::with_usage(self) -> Self
+impl core::clone::Clone for bitrouter_sdk::language_model::stream::StreamInterest
+pub fn bitrouter_sdk::language_model::stream::StreamInterest::clone(&self) -> bitrouter_sdk::language_model::stream::StreamInterest
+impl core::cmp::Eq for bitrouter_sdk::language_model::stream::StreamInterest
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::stream::StreamInterest
+pub fn bitrouter_sdk::language_model::stream::StreamInterest::eq(&self, &bitrouter_sdk::language_model::stream::StreamInterest) -> bool
+impl core::default::Default for bitrouter_sdk::language_model::stream::StreamInterest
+pub fn bitrouter_sdk::language_model::stream::StreamInterest::default() -> bitrouter_sdk::language_model::stream::StreamInterest
+impl core::fmt::Debug for bitrouter_sdk::language_model::stream::StreamInterest
+pub fn bitrouter_sdk::language_model::stream::StreamInterest::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for bitrouter_sdk::language_model::stream::StreamInterest
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::stream::StreamInterest
+impl core::marker::Freeze for bitrouter_sdk::language_model::stream::StreamInterest
+impl core::marker::Send for bitrouter_sdk::language_model::stream::StreamInterest
+impl core::marker::Sync for bitrouter_sdk::language_model::stream::StreamInterest
+impl core::marker::Unpin for bitrouter_sdk::language_model::stream::StreamInterest
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::stream::StreamInterest
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::stream::StreamInterest
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::stream::StreamInterest
+pub struct bitrouter_sdk::language_model::StreamProcessor
+impl bitrouter_sdk::language_model::stream::StreamProcessor
+pub fn bitrouter_sdk::language_model::stream::StreamProcessor::context(&self) -> &bitrouter_sdk::language_model::context::StreamContext
+pub async fn bitrouter_sdk::language_model::stream::StreamProcessor::finish(&mut self, bitrouter_sdk::language_model::stream::StreamOutcome) -> &bitrouter_sdk::language_model::context::StreamContext
+pub fn bitrouter_sdk::language_model::stream::StreamProcessor::into_context(self) -> bitrouter_sdk::language_model::context::StreamContext
+pub fn bitrouter_sdk::language_model::stream::StreamProcessor::new(alloc::vec::Vec<alloc::sync::Arc<dyn bitrouter_sdk::language_model::hooks::StreamHook>>, alloc::vec::Vec<alloc::sync::Arc<dyn bitrouter_sdk::language_model::hooks::ObserveHook>>, bitrouter_sdk::language_model::context::StreamContext) -> Self
+pub async fn bitrouter_sdk::language_model::stream::StreamProcessor::process_part(&mut self, bitrouter_sdk::language_model::types::StreamPart) -> bitrouter_sdk::error::Result<alloc::vec::Vec<bitrouter_sdk::language_model::types::StreamPart>>
+impl core::marker::Freeze for bitrouter_sdk::language_model::stream::StreamProcessor
+impl core::marker::Send for bitrouter_sdk::language_model::stream::StreamProcessor
+impl core::marker::Sync for bitrouter_sdk::language_model::stream::StreamProcessor
+impl core::marker::Unpin for bitrouter_sdk::language_model::stream::StreamProcessor
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::stream::StreamProcessor
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::stream::StreamProcessor
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::stream::StreamProcessor
+pub struct bitrouter_sdk::language_model::Usage
+pub bitrouter_sdk::language_model::Usage::cache_read_tokens: u64
+pub bitrouter_sdk::language_model::Usage::cache_write_tokens: u64
+pub bitrouter_sdk::language_model::Usage::completion_tokens: u64
+pub bitrouter_sdk::language_model::Usage::origin: bitrouter_sdk::language_model::types::UsageOrigin
+pub bitrouter_sdk::language_model::Usage::prompt_tokens: u64
+pub bitrouter_sdk::language_model::Usage::raw: core::option::Option<alloc::boxed::Box<serde_json::value::Value>>
+pub bitrouter_sdk::language_model::Usage::reasoning_tokens: u64
+pub bitrouter_sdk::language_model::Usage::web_search_count: u64
+impl bitrouter_sdk::language_model::types::Usage
+pub fn bitrouter_sdk::language_model::types::Usage::normalized_buckets(&self) -> core::result::Result<bitrouter_sdk::language_model::types::NormalizedUsage, bitrouter_sdk::language_model::types::UsageNormalizationError>
+pub fn bitrouter_sdk::language_model::types::Usage::total(&self) -> u64
+impl core::clone::Clone for bitrouter_sdk::language_model::types::Usage
+pub fn bitrouter_sdk::language_model::types::Usage::clone(&self) -> bitrouter_sdk::language_model::types::Usage
+impl core::cmp::Eq for bitrouter_sdk::language_model::types::Usage
+impl core::cmp::PartialEq for bitrouter_sdk::language_model::types::Usage
+pub fn bitrouter_sdk::language_model::types::Usage::eq(&self, &bitrouter_sdk::language_model::types::Usage) -> bool
+impl core::default::Default for bitrouter_sdk::language_model::types::Usage
+pub fn bitrouter_sdk::language_model::types::Usage::default() -> bitrouter_sdk::language_model::types::Usage
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::Usage
+pub fn bitrouter_sdk::language_model::types::Usage::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::language_model::types::Usage
+impl serde_core::ser::Serialize for bitrouter_sdk::language_model::types::Usage
+pub fn bitrouter_sdk::language_model::types::Usage::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::language_model::types::Usage
+pub fn bitrouter_sdk::language_model::types::Usage::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::Usage
+impl core::marker::Send for bitrouter_sdk::language_model::types::Usage
+impl core::marker::Sync for bitrouter_sdk::language_model::types::Usage
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::Usage
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::Usage
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::Usage
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::Usage
+pub struct bitrouter_sdk::language_model::UsageAccumulator
+impl bitrouter_sdk::language_model::stream::UsageAccumulator
+pub fn bitrouter_sdk::language_model::stream::UsageAccumulator::estimated_output_tokens(&self) -> u64
+pub fn bitrouter_sdk::language_model::stream::UsageAccumulator::estimated_prompt_tokens(&self) -> u64
+pub fn bitrouter_sdk::language_model::stream::UsageAccumulator::finalized(&self) -> core::option::Option<bitrouter_sdk::language_model::types::Usage>
+pub fn bitrouter_sdk::language_model::stream::UsageAccumulator::observe(&mut self, &bitrouter_sdk::language_model::types::StreamPart)
+pub fn bitrouter_sdk::language_model::stream::UsageAccumulator::with_prompt_chars(u64) -> Self
+impl core::clone::Clone for bitrouter_sdk::language_model::stream::UsageAccumulator
+pub fn bitrouter_sdk::language_model::stream::UsageAccumulator::clone(&self) -> bitrouter_sdk::language_model::stream::UsageAccumulator
+impl core::default::Default for bitrouter_sdk::language_model::stream::UsageAccumulator
+pub fn bitrouter_sdk::language_model::stream::UsageAccumulator::default() -> bitrouter_sdk::language_model::stream::UsageAccumulator
+impl core::fmt::Debug for bitrouter_sdk::language_model::stream::UsageAccumulator
+pub fn bitrouter_sdk::language_model::stream::UsageAccumulator::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::language_model::stream::UsageAccumulator
+impl core::marker::Send for bitrouter_sdk::language_model::stream::UsageAccumulator
+impl core::marker::Sync for bitrouter_sdk::language_model::stream::UsageAccumulator
+impl core::marker::Unpin for bitrouter_sdk::language_model::stream::UsageAccumulator
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::stream::UsageAccumulator
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::stream::UsageAccumulator
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::stream::UsageAccumulator
+pub const bitrouter_sdk::language_model::DEFAULT_KEEPALIVE: core::time::Duration
+pub trait bitrouter_sdk::language_model::AuthApplier: core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::language_model::AuthApplier::apply<'life0, 'life1, 'async_trait>(&'life0 self, reqwest::async_impl::request::Request, &'life1 bitrouter_sdk::language_model::types::RoutingTarget) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<reqwest::async_impl::request::Request>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::AuthApplier::apply_with_authority<'life0, 'life1, 'async_trait>(&'life0 self, reqwest::async_impl::request::Request, &'life1 bitrouter_sdk::language_model::types::RoutingTarget) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::auth::AppliedAuth>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::AuthApplier::continuation_authority<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::types::RoutingTarget) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<core::option::Option<bitrouter_sdk::language_model::auth::CredentialAuthority>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::AuthApplier::continuation_authority_proof<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::types::RoutingTarget) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<core::option::Option<bitrouter_sdk::language_model::auth::ContinuationAuthority>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::AuthApplier::prepare_body<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 mut serde_json::value::Value, &'life2 bitrouter_sdk::language_model::types::RoutingTarget) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<()>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub fn bitrouter_sdk::language_model::AuthApplier::refresh_after_unauthorized<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::types::RoutingTarget, core::option::Option<&'life2 http::header::value::HeaderValue>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bool>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub trait bitrouter_sdk::language_model::ExecutionHook: core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::language_model::ExecutionHook::on_failure<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::context::PipelineContext, &'life2 bitrouter_sdk::error::BitrouterError) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::language_model::hooks::FallbackDecision> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub fn bitrouter_sdk::language_model::ExecutionHook::on_success<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::context::PipelineContext, &'life2 bitrouter_sdk::language_model::types::ExecutionResult) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<()>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub trait bitrouter_sdk::language_model::Executor: core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::language_model::Executor::execute<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::types::RoutingTarget, &'life2 bitrouter_sdk::language_model::types::Prompt, &'life3 bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::ExecutionResult>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub fn bitrouter_sdk::language_model::Executor::execute_stream<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::types::RoutingTarget, &'life2 bitrouter_sdk::language_model::types::Prompt, &'life3 bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::executor::StreamPartStream>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+impl bitrouter_sdk::language_model::executor::Executor for bitrouter_sdk::language_model::executor::DispatchExecutor
+pub fn bitrouter_sdk::language_model::executor::DispatchExecutor::execute<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::types::RoutingTarget, &'life2 bitrouter_sdk::language_model::types::Prompt, &'life3 bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::ExecutionResult>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub fn bitrouter_sdk::language_model::executor::DispatchExecutor::execute_stream<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::types::RoutingTarget, &'life2 bitrouter_sdk::language_model::types::Prompt, &'life3 bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::executor::StreamPartStream>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+impl bitrouter_sdk::language_model::executor::Executor for bitrouter_sdk::language_model::executor::HttpExecutor
+pub fn bitrouter_sdk::language_model::executor::HttpExecutor::execute<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::types::RoutingTarget, &'life2 bitrouter_sdk::language_model::types::Prompt, &'life3 bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::ExecutionResult>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub fn bitrouter_sdk::language_model::executor::HttpExecutor::execute_stream<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::types::RoutingTarget, &'life2 bitrouter_sdk::language_model::types::Prompt, &'life3 bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::executor::StreamPartStream>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+impl bitrouter_sdk::language_model::executor::Executor for bitrouter_sdk::language_model::executor::MockExecutor
+pub fn bitrouter_sdk::language_model::executor::MockExecutor::execute<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::types::RoutingTarget, &'life2 bitrouter_sdk::language_model::types::Prompt, &'life3 bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::ExecutionResult>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub fn bitrouter_sdk::language_model::executor::MockExecutor::execute_stream<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::types::RoutingTarget, &'life2 bitrouter_sdk::language_model::types::Prompt, &'life3 bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::executor::StreamPartStream>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub trait bitrouter_sdk::language_model::FallbackPolicy: core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::language_model::FallbackPolicy::classify(&self, &bitrouter_sdk::error::BitrouterError, &bitrouter_sdk::language_model::types::RoutingTarget) -> bitrouter_sdk::language_model::hooks::FallbackDecision
+impl bitrouter_sdk::language_model::routing::FallbackPolicy for bitrouter_sdk::language_model::routing::DefaultFallbackPolicy
+pub fn bitrouter_sdk::language_model::routing::DefaultFallbackPolicy::classify(&self, &bitrouter_sdk::error::BitrouterError, &bitrouter_sdk::language_model::types::RoutingTarget) -> bitrouter_sdk::language_model::hooks::FallbackDecision
+pub trait bitrouter_sdk::language_model::InboundAdapter: core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::language_model::InboundAdapter::parse_request(&self, serde_json::value::Value) -> bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::Prompt>
+pub fn bitrouter_sdk::language_model::InboundAdapter::protocol(&self) -> bitrouter_sdk::language_model::types::ApiProtocol
+pub fn bitrouter_sdk::language_model::InboundAdapter::render_response(&self, &bitrouter_sdk::language_model::types::GenerateResult, &bitrouter_sdk::language_model::types::Prompt, &str) -> bitrouter_sdk::error::Result<serde_json::value::Value>
+pub fn bitrouter_sdk::language_model::InboundAdapter::stream_encoder(&self, &str, &str) -> alloc::boxed::Box<dyn bitrouter_sdk::language_model::protocol::StreamEncoder>
+impl bitrouter_sdk::language_model::protocol::InboundAdapter for bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsAdapter
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsAdapter::parse_request(&self, serde_json::value::Value) -> bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::Prompt>
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsAdapter::protocol(&self) -> bitrouter_sdk::language_model::types::ApiProtocol
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsAdapter::render_response(&self, &bitrouter_sdk::language_model::types::GenerateResult, &bitrouter_sdk::language_model::types::Prompt, &str) -> bitrouter_sdk::error::Result<serde_json::value::Value>
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsAdapter::stream_encoder(&self, &str, &str) -> alloc::boxed::Box<dyn bitrouter_sdk::language_model::protocol::StreamEncoder>
+impl bitrouter_sdk::language_model::protocol::InboundAdapter for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentAdapter
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentAdapter::parse_request(&self, serde_json::value::Value) -> bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::Prompt>
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentAdapter::protocol(&self) -> bitrouter_sdk::language_model::types::ApiProtocol
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentAdapter::render_response(&self, &bitrouter_sdk::language_model::types::GenerateResult, &bitrouter_sdk::language_model::types::Prompt, &str) -> bitrouter_sdk::error::Result<serde_json::value::Value>
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentAdapter::stream_encoder(&self, &str, &str) -> alloc::boxed::Box<dyn bitrouter_sdk::language_model::protocol::StreamEncoder>
+impl bitrouter_sdk::language_model::protocol::InboundAdapter for bitrouter_sdk::language_model::protocol::messages::MessagesAdapter
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesAdapter::parse_request(&self, serde_json::value::Value) -> bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::Prompt>
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesAdapter::protocol(&self) -> bitrouter_sdk::language_model::types::ApiProtocol
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesAdapter::render_response(&self, &bitrouter_sdk::language_model::types::GenerateResult, &bitrouter_sdk::language_model::types::Prompt, &str) -> bitrouter_sdk::error::Result<serde_json::value::Value>
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesAdapter::stream_encoder(&self, &str, &str) -> alloc::boxed::Box<dyn bitrouter_sdk::language_model::protocol::StreamEncoder>
+impl bitrouter_sdk::language_model::protocol::InboundAdapter for bitrouter_sdk::language_model::protocol::responses::ResponsesAdapter
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesAdapter::parse_request(&self, serde_json::value::Value) -> bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::Prompt>
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesAdapter::protocol(&self) -> bitrouter_sdk::language_model::types::ApiProtocol
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesAdapter::render_response(&self, &bitrouter_sdk::language_model::types::GenerateResult, &bitrouter_sdk::language_model::types::Prompt, &str) -> bitrouter_sdk::error::Result<serde_json::value::Value>
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesAdapter::stream_encoder(&self, &str, &str) -> alloc::boxed::Box<dyn bitrouter_sdk::language_model::protocol::StreamEncoder>
+pub trait bitrouter_sdk::language_model::ModelSelector: core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::language_model::ModelSelector::select_variant<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 str, core::option::Option<&'life2 str>, &'life3 mut bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<()>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub trait bitrouter_sdk::language_model::ObserveHook: core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::language_model::ObserveHook::after_phase<'life0, 'life1, 'async_trait>(&'life0 self, bitrouter_sdk::language_model::hooks::Phase, &'life1 bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = ()> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::ObserveHook::on_hop_end<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::context::PipelineContext, &'life2 bitrouter_sdk::language_model::types::RoutingTarget, bitrouter_sdk::language_model::hooks::HopOutcome<'life3>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = ()> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub fn bitrouter_sdk::language_model::ObserveHook::on_hop_start<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::context::PipelineContext, &'life2 bitrouter_sdk::language_model::types::RoutingTarget) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = ()> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub fn bitrouter_sdk::language_model::ObserveHook::on_request_end<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::context::PipelineContext, &'life2 bitrouter_sdk::language_model::hooks::RequestOutcome) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = ()> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub fn bitrouter_sdk::language_model::ObserveHook::on_request_start<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = ()> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::ObserveHook::on_stream_hop_end(&self, &str, &bitrouter_sdk::language_model::types::RoutingTarget, bitrouter_sdk::language_model::hooks::StreamHopOutcome<'_>, u64)
+pub fn bitrouter_sdk::language_model::ObserveHook::on_stream_part<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::context::StreamContext, &'life2 bitrouter_sdk::language_model::types::StreamPart) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = ()> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub fn bitrouter_sdk::language_model::ObserveHook::stream_interest(&self) -> bitrouter_sdk::language_model::stream::StreamInterest
+impl bitrouter_sdk::language_model::hooks::ObserveHook for bitrouter_sdk::otel::OtelExporter
+pub fn bitrouter_sdk::otel::OtelExporter::after_phase<'life0, 'life1, 'async_trait>(&'life0 self, bitrouter_sdk::language_model::hooks::Phase, &'life1 bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = ()> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::otel::OtelExporter::on_hop_end<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::context::PipelineContext, &'life2 bitrouter_sdk::language_model::types::RoutingTarget, bitrouter_sdk::language_model::hooks::HopOutcome<'life3>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = ()> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub fn bitrouter_sdk::otel::OtelExporter::on_hop_start<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::context::PipelineContext, &'life2 bitrouter_sdk::language_model::types::RoutingTarget) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = ()> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub fn bitrouter_sdk::otel::OtelExporter::on_request_end<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::context::PipelineContext, &'life2 bitrouter_sdk::language_model::hooks::RequestOutcome) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = ()> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub fn bitrouter_sdk::otel::OtelExporter::on_request_start<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = ()> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::otel::OtelExporter::on_stream_hop_end(&self, &str, &bitrouter_sdk::language_model::types::RoutingTarget, bitrouter_sdk::language_model::hooks::StreamHopOutcome<'_>, u64)
+pub fn bitrouter_sdk::otel::OtelExporter::on_stream_part<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::context::StreamContext, &'life2 bitrouter_sdk::language_model::types::StreamPart) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = ()> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub fn bitrouter_sdk::otel::OtelExporter::stream_interest(&self) -> bitrouter_sdk::language_model::stream::StreamInterest
+impl bitrouter_sdk::language_model::hooks::ObserveHook for bitrouter_sdk::otel::OtelObserveHook
+pub fn bitrouter_sdk::otel::OtelObserveHook::after_phase<'life0, 'life1, 'async_trait>(&'life0 self, bitrouter_sdk::language_model::hooks::Phase, &'life1 bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = ()> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::otel::OtelObserveHook::on_hop_end<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::context::PipelineContext, &'life2 bitrouter_sdk::language_model::types::RoutingTarget, bitrouter_sdk::language_model::hooks::HopOutcome<'life3>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = ()> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub fn bitrouter_sdk::otel::OtelObserveHook::on_hop_start<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::context::PipelineContext, &'life2 bitrouter_sdk::language_model::types::RoutingTarget) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = ()> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub fn bitrouter_sdk::otel::OtelObserveHook::on_request_end<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::context::PipelineContext, &'life2 bitrouter_sdk::language_model::hooks::RequestOutcome) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = ()> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub fn bitrouter_sdk::otel::OtelObserveHook::on_request_start<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = ()> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::otel::OtelObserveHook::on_stream_hop_end(&self, &str, &bitrouter_sdk::language_model::types::RoutingTarget, bitrouter_sdk::language_model::hooks::StreamHopOutcome<'_>, u64)
+pub fn bitrouter_sdk::otel::OtelObserveHook::on_stream_part<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::context::StreamContext, &'life2 bitrouter_sdk::language_model::types::StreamPart) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = ()> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub fn bitrouter_sdk::otel::OtelObserveHook::stream_interest(&self) -> bitrouter_sdk::language_model::stream::StreamInterest
+pub trait bitrouter_sdk::language_model::OutboundAdapter: core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::language_model::OutboundAdapter::parse_response(&self, serde_json::value::Value) -> bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::GenerateResult>
+pub fn bitrouter_sdk::language_model::OutboundAdapter::protocol(&self) -> bitrouter_sdk::language_model::types::ApiProtocol
+pub fn bitrouter_sdk::language_model::OutboundAdapter::render_request(&self, &bitrouter_sdk::language_model::types::Prompt) -> bitrouter_sdk::error::Result<serde_json::value::Value>
+pub fn bitrouter_sdk::language_model::OutboundAdapter::render_request_for_target(&self, &bitrouter_sdk::language_model::types::Prompt, &bitrouter_sdk::language_model::types::RoutingTarget) -> bitrouter_sdk::error::Result<serde_json::value::Value>
+pub fn bitrouter_sdk::language_model::OutboundAdapter::stream_decoder(&self) -> alloc::boxed::Box<dyn bitrouter_sdk::language_model::protocol::StreamDecoder>
+pub fn bitrouter_sdk::language_model::OutboundAdapter::supports_response_format(&self) -> bool
+impl bitrouter_sdk::language_model::protocol::OutboundAdapter for bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsAdapter
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsAdapter::parse_response(&self, serde_json::value::Value) -> bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::GenerateResult>
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsAdapter::protocol(&self) -> bitrouter_sdk::language_model::types::ApiProtocol
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsAdapter::render_request(&self, &bitrouter_sdk::language_model::types::Prompt) -> bitrouter_sdk::error::Result<serde_json::value::Value>
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsAdapter::render_request_for_target(&self, &bitrouter_sdk::language_model::types::Prompt, &bitrouter_sdk::language_model::types::RoutingTarget) -> bitrouter_sdk::error::Result<serde_json::value::Value>
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsAdapter::stream_decoder(&self) -> alloc::boxed::Box<dyn bitrouter_sdk::language_model::protocol::StreamDecoder>
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsAdapter::supports_response_format(&self) -> bool
+impl bitrouter_sdk::language_model::protocol::OutboundAdapter for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentAdapter
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentAdapter::parse_response(&self, serde_json::value::Value) -> bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::GenerateResult>
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentAdapter::protocol(&self) -> bitrouter_sdk::language_model::types::ApiProtocol
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentAdapter::render_request(&self, &bitrouter_sdk::language_model::types::Prompt) -> bitrouter_sdk::error::Result<serde_json::value::Value>
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentAdapter::render_request_for_target(&self, &bitrouter_sdk::language_model::types::Prompt, &bitrouter_sdk::language_model::types::RoutingTarget) -> bitrouter_sdk::error::Result<serde_json::value::Value>
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentAdapter::stream_decoder(&self) -> alloc::boxed::Box<dyn bitrouter_sdk::language_model::protocol::StreamDecoder>
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentAdapter::supports_response_format(&self) -> bool
+impl bitrouter_sdk::language_model::protocol::OutboundAdapter for bitrouter_sdk::language_model::protocol::messages::MessagesAdapter
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesAdapter::parse_response(&self, serde_json::value::Value) -> bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::GenerateResult>
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesAdapter::protocol(&self) -> bitrouter_sdk::language_model::types::ApiProtocol
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesAdapter::render_request(&self, &bitrouter_sdk::language_model::types::Prompt) -> bitrouter_sdk::error::Result<serde_json::value::Value>
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesAdapter::render_request_for_target(&self, &bitrouter_sdk::language_model::types::Prompt, &bitrouter_sdk::language_model::types::RoutingTarget) -> bitrouter_sdk::error::Result<serde_json::value::Value>
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesAdapter::stream_decoder(&self) -> alloc::boxed::Box<dyn bitrouter_sdk::language_model::protocol::StreamDecoder>
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesAdapter::supports_response_format(&self) -> bool
+impl bitrouter_sdk::language_model::protocol::OutboundAdapter for bitrouter_sdk::language_model::protocol::responses::ResponsesAdapter
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesAdapter::parse_response(&self, serde_json::value::Value) -> bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::GenerateResult>
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesAdapter::protocol(&self) -> bitrouter_sdk::language_model::types::ApiProtocol
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesAdapter::render_request(&self, &bitrouter_sdk::language_model::types::Prompt) -> bitrouter_sdk::error::Result<serde_json::value::Value>
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesAdapter::render_request_for_target(&self, &bitrouter_sdk::language_model::types::Prompt, &bitrouter_sdk::language_model::types::RoutingTarget) -> bitrouter_sdk::error::Result<serde_json::value::Value>
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesAdapter::stream_decoder(&self) -> alloc::boxed::Box<dyn bitrouter_sdk::language_model::protocol::StreamDecoder>
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesAdapter::supports_response_format(&self) -> bool
+pub trait bitrouter_sdk::language_model::PreRequestHook: core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::language_model::PreRequestHook::check<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 mut bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::hooks::HookDecision>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+impl bitrouter_sdk::language_model::hooks::PreRequestHook for bitrouter_sdk::language_model::server_tools::declarations::ServerToolDeclarationsHook
+pub fn bitrouter_sdk::language_model::server_tools::declarations::ServerToolDeclarationsHook::check<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 mut bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::hooks::HookDecision>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub trait bitrouter_sdk::language_model::RouteHook: core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::language_model::RouteHook::resolve<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 mut alloc::vec::Vec<bitrouter_sdk::language_model::types::RoutingTarget>, &'life2 mut bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<()>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub trait bitrouter_sdk::language_model::RoutingTable: core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::language_model::RoutingTable::list_models(&self) -> alloc::vec::Vec<bitrouter_sdk::language_model::routing::ModelInfo>
+pub fn bitrouter_sdk::language_model::RoutingTable::model_info(&self, &str) -> core::option::Option<bitrouter_sdk::language_model::routing::ModelInfo>
+pub fn bitrouter_sdk::language_model::RoutingTable::preset_overrides<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 str) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::routing::PromptOverrides>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::RoutingTable::reload<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<()>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn bitrouter_sdk::language_model::RoutingTable::resolve_model<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 str) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::routing::ModelResolution>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::RoutingTable::route_chain<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 str, &'life2 bitrouter_sdk::language_model::routing::RoutingPrefs, &'life3 bitrouter_sdk::caller::CallerContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<alloc::vec::Vec<bitrouter_sdk::language_model::types::RoutingTarget>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub fn bitrouter_sdk::language_model::RoutingTable::route_resolved<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 str, &'life2 bitrouter_sdk::language_model::routing::RoutingPrefs, &'life3 bitrouter_sdk::caller::CallerContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<alloc::vec::Vec<bitrouter_sdk::language_model::types::RoutingTarget>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+impl bitrouter_sdk::language_model::routing::RoutingTable for bitrouter_sdk::config::routing_table::ConfigRoutingTable
+pub fn bitrouter_sdk::config::routing_table::ConfigRoutingTable::list_models(&self) -> alloc::vec::Vec<bitrouter_sdk::language_model::routing::ModelInfo>
+pub fn bitrouter_sdk::config::routing_table::ConfigRoutingTable::model_info(&self, &str) -> core::option::Option<bitrouter_sdk::language_model::routing::ModelInfo>
+pub fn bitrouter_sdk::config::routing_table::ConfigRoutingTable::preset_overrides<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 str) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::routing::PromptOverrides>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::config::routing_table::ConfigRoutingTable::reload<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<()>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn bitrouter_sdk::config::routing_table::ConfigRoutingTable::resolve_model<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 str) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::routing::ModelResolution>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::config::routing_table::ConfigRoutingTable::route_chain<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 str, &'life2 bitrouter_sdk::language_model::routing::RoutingPrefs, &'life3 bitrouter_sdk::caller::CallerContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<alloc::vec::Vec<bitrouter_sdk::language_model::types::RoutingTarget>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub fn bitrouter_sdk::config::routing_table::ConfigRoutingTable::route_resolved<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 str, &'life2 bitrouter_sdk::language_model::routing::RoutingPrefs, &'life3 bitrouter_sdk::caller::CallerContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<alloc::vec::Vec<bitrouter_sdk::language_model::types::RoutingTarget>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+impl bitrouter_sdk::language_model::routing::RoutingTable for bitrouter_sdk::language_model::routing::StaticRoutingTable
+pub fn bitrouter_sdk::language_model::routing::StaticRoutingTable::list_models(&self) -> alloc::vec::Vec<bitrouter_sdk::language_model::routing::ModelInfo>
+pub fn bitrouter_sdk::language_model::routing::StaticRoutingTable::model_info(&self, &str) -> core::option::Option<bitrouter_sdk::language_model::routing::ModelInfo>
+pub fn bitrouter_sdk::language_model::routing::StaticRoutingTable::preset_overrides<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 str) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::routing::PromptOverrides>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::routing::StaticRoutingTable::reload<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<()>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn bitrouter_sdk::language_model::routing::StaticRoutingTable::resolve_model<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 str) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::routing::ModelResolution>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::routing::StaticRoutingTable::route_chain<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 str, &'life2 bitrouter_sdk::language_model::routing::RoutingPrefs, &'life3 bitrouter_sdk::caller::CallerContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<alloc::vec::Vec<bitrouter_sdk::language_model::types::RoutingTarget>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub fn bitrouter_sdk::language_model::routing::StaticRoutingTable::route_resolved<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 str, &'life2 bitrouter_sdk::language_model::routing::RoutingPrefs, &'life3 bitrouter_sdk::caller::CallerContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<alloc::vec::Vec<bitrouter_sdk::language_model::types::RoutingTarget>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub trait bitrouter_sdk::language_model::SettlementRecorder: core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::language_model::SettlementRecorder::record<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 mut bitrouter_sdk::language_model::settlement::SettlementContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<()>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub trait bitrouter_sdk::language_model::StreamDecoder: core::marker::Send
+pub fn bitrouter_sdk::language_model::StreamDecoder::decode(&mut self, &bitrouter_sdk::language_model::protocol::SseEvent) -> bitrouter_sdk::error::Result<alloc::vec::Vec<bitrouter_sdk::language_model::types::StreamPart>>
+pub fn bitrouter_sdk::language_model::StreamDecoder::finish(&mut self) -> bitrouter_sdk::error::Result<alloc::vec::Vec<bitrouter_sdk::language_model::types::StreamPart>>
+pub trait bitrouter_sdk::language_model::StreamEncoder: core::marker::Send
+pub fn bitrouter_sdk::language_model::StreamEncoder::encode(&mut self, &bitrouter_sdk::language_model::types::StreamPart) -> bitrouter_sdk::error::Result<alloc::vec::Vec<bitrouter_sdk::language_model::stream::SseFrame>>
+pub fn bitrouter_sdk::language_model::StreamEncoder::encode_bitrouter_error(&mut self, &bitrouter_sdk::error::BitrouterError) -> alloc::vec::Vec<bitrouter_sdk::language_model::stream::SseFrame>
+pub fn bitrouter_sdk::language_model::StreamEncoder::encode_error(&mut self, &str) -> alloc::vec::Vec<bitrouter_sdk::language_model::stream::SseFrame>
+pub fn bitrouter_sdk::language_model::StreamEncoder::finish(&mut self) -> bitrouter_sdk::error::Result<alloc::vec::Vec<bitrouter_sdk::language_model::stream::SseFrame>>
+pub trait bitrouter_sdk::language_model::StreamHook: core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::language_model::StreamHook::interest(&self) -> bitrouter_sdk::language_model::stream::StreamInterest
+pub fn bitrouter_sdk::language_model::StreamHook::on_part<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 mut bitrouter_sdk::language_model::context::StreamContext, bitrouter_sdk::language_model::types::StreamPart) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::stream::StreamAction>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::StreamHook::on_stream_end<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 mut bitrouter_sdk::language_model::context::StreamContext, &'life2 bitrouter_sdk::language_model::stream::StreamOutcome) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<()>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub trait bitrouter_sdk::language_model::Transport: core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::language_model::Transport::authorise<'life0, 'life1, 'async_trait>(&'life0 self, reqwest::async_impl::request::Request, &'life1 bitrouter_sdk::language_model::types::RoutingTarget) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<reqwest::async_impl::request::Request>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::Transport::endpoint_url(&self, &bitrouter_sdk::language_model::types::RoutingTarget, bool) -> alloc::string::String
+pub fn bitrouter_sdk::language_model::Transport::protocol(&self) -> bitrouter_sdk::language_model::types::ApiProtocol
+impl bitrouter_sdk::language_model::protocol::Transport for bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsTransport
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsTransport::authorise<'life0, 'life1, 'async_trait>(&'life0 self, reqwest::async_impl::request::Request, &'life1 bitrouter_sdk::language_model::types::RoutingTarget) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<reqwest::async_impl::request::Request>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsTransport::endpoint_url(&self, &bitrouter_sdk::language_model::types::RoutingTarget, bool) -> alloc::string::String
+pub fn bitrouter_sdk::language_model::protocol::chat_completions::ChatCompletionsTransport::protocol(&self) -> bitrouter_sdk::language_model::types::ApiProtocol
+impl bitrouter_sdk::language_model::protocol::Transport for bitrouter_sdk::language_model::protocol::generate_content::GenerateContentTransport
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentTransport::authorise<'life0, 'life1, 'async_trait>(&'life0 self, reqwest::async_impl::request::Request, &'life1 bitrouter_sdk::language_model::types::RoutingTarget) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<reqwest::async_impl::request::Request>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentTransport::endpoint_url(&self, &bitrouter_sdk::language_model::types::RoutingTarget, bool) -> alloc::string::String
+pub fn bitrouter_sdk::language_model::protocol::generate_content::GenerateContentTransport::protocol(&self) -> bitrouter_sdk::language_model::types::ApiProtocol
+impl bitrouter_sdk::language_model::protocol::Transport for bitrouter_sdk::language_model::protocol::messages::MessagesTransport
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesTransport::authorise<'life0, 'life1, 'async_trait>(&'life0 self, reqwest::async_impl::request::Request, &'life1 bitrouter_sdk::language_model::types::RoutingTarget) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<reqwest::async_impl::request::Request>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesTransport::endpoint_url(&self, &bitrouter_sdk::language_model::types::RoutingTarget, bool) -> alloc::string::String
+pub fn bitrouter_sdk::language_model::protocol::messages::MessagesTransport::protocol(&self) -> bitrouter_sdk::language_model::types::ApiProtocol
+impl bitrouter_sdk::language_model::protocol::Transport for bitrouter_sdk::language_model::protocol::responses::ResponsesTransport
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesTransport::authorise<'life0, 'life1, 'async_trait>(&'life0 self, reqwest::async_impl::request::Request, &'life1 bitrouter_sdk::language_model::types::RoutingTarget) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<reqwest::async_impl::request::Request>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesTransport::endpoint_url(&self, &bitrouter_sdk::language_model::types::RoutingTarget, bool) -> alloc::string::String
+pub fn bitrouter_sdk::language_model::protocol::responses::ResponsesTransport::protocol(&self) -> bitrouter_sdk::language_model::types::ApiProtocol
+pub fn bitrouter_sdk::language_model::inbound_adapter_for(&bitrouter_sdk::language_model::types::ApiProtocol) -> core::option::Option<alloc::boxed::Box<dyn bitrouter_sdk::language_model::protocol::InboundAdapter>>
+pub fn bitrouter_sdk::language_model::sanitize_model_name(&str) -> alloc::string::String
+pub type bitrouter_sdk::language_model::ProviderMetadata = alloc::collections::btree::map::BTreeMap<alloc::string::String, serde_json::value::Value>
+pub type bitrouter_sdk::language_model::StreamPartStream = core::pin::Pin<alloc::boxed::Box<(dyn futures_core::stream::Stream<Item = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::types::StreamPart>> + core::marker::Send)>>
+pub mod bitrouter_sdk::mcp
+pub mod bitrouter_sdk::mcp::aggregating_executor
+pub struct bitrouter_sdk::mcp::aggregating_executor::AggregatingExecutor<E: bitrouter_sdk::mcp::Executor>
+impl<E: bitrouter_sdk::mcp::Executor> bitrouter_sdk::mcp::aggregating_executor::AggregatingExecutor<E>
+pub fn bitrouter_sdk::mcp::aggregating_executor::AggregatingExecutor<E>::new(alloc::sync::Arc<E>) -> Self
+impl<E: bitrouter_sdk::mcp::Executor + 'static> bitrouter_sdk::mcp::Executor for bitrouter_sdk::mcp::aggregating_executor::AggregatingExecutor<E>
+pub fn bitrouter_sdk::mcp::aggregating_executor::AggregatingExecutor<E>::execute<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::mcp::McpTarget, &'life2 bitrouter_sdk::mcp::McpRequest) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::mcp::McpResponse>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub fn bitrouter_sdk::mcp::aggregating_executor::AggregatingExecutor<E>::execute_streaming<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::mcp::McpTarget, &'life2 bitrouter_sdk::mcp::McpRequest) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<futures_core::stream::BoxStream<'static, bitrouter_sdk::error::Result<bitrouter_sdk::mcp::McpStreamPart>>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+impl<E> core::marker::Freeze for bitrouter_sdk::mcp::aggregating_executor::AggregatingExecutor<E>
+impl<E> core::marker::Send for bitrouter_sdk::mcp::aggregating_executor::AggregatingExecutor<E>
+impl<E> core::marker::Sync for bitrouter_sdk::mcp::aggregating_executor::AggregatingExecutor<E>
+impl<E> core::marker::Unpin for bitrouter_sdk::mcp::aggregating_executor::AggregatingExecutor<E>
+impl<E> core::marker::UnsafeUnpin for bitrouter_sdk::mcp::aggregating_executor::AggregatingExecutor<E>
+impl<E> core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::mcp::aggregating_executor::AggregatingExecutor<E> where E: core::panic::unwind_safe::RefUnwindSafe
+impl<E> core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::mcp::aggregating_executor::AggregatingExecutor<E> where E: core::panic::unwind_safe::RefUnwindSafe
+pub mod bitrouter_sdk::mcp::caching_executor
+pub struct bitrouter_sdk::mcp::caching_executor::CacheTtls
+pub bitrouter_sdk::mcp::caching_executor::CacheTtls::max_entries_per_server: usize
+pub bitrouter_sdk::mcp::caching_executor::CacheTtls::prompts_list: core::time::Duration
+pub bitrouter_sdk::mcp::caching_executor::CacheTtls::resources_list: core::time::Duration
+pub bitrouter_sdk::mcp::caching_executor::CacheTtls::resources_templates_list: core::time::Duration
+pub bitrouter_sdk::mcp::caching_executor::CacheTtls::skills_list: core::time::Duration
+pub bitrouter_sdk::mcp::caching_executor::CacheTtls::tools_list: core::time::Duration
+impl core::clone::Clone for bitrouter_sdk::mcp::caching_executor::CacheTtls
+pub fn bitrouter_sdk::mcp::caching_executor::CacheTtls::clone(&self) -> bitrouter_sdk::mcp::caching_executor::CacheTtls
+impl core::convert::From<&bitrouter_sdk::config::McpCacheConfig> for bitrouter_sdk::mcp::caching_executor::CacheTtls
+pub fn bitrouter_sdk::mcp::caching_executor::CacheTtls::from(&bitrouter_sdk::config::McpCacheConfig) -> Self
+impl core::default::Default for bitrouter_sdk::mcp::caching_executor::CacheTtls
+pub fn bitrouter_sdk::mcp::caching_executor::CacheTtls::default() -> Self
+impl core::fmt::Debug for bitrouter_sdk::mcp::caching_executor::CacheTtls
+pub fn bitrouter_sdk::mcp::caching_executor::CacheTtls::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::mcp::caching_executor::CacheTtls
+impl core::marker::Send for bitrouter_sdk::mcp::caching_executor::CacheTtls
+impl core::marker::Sync for bitrouter_sdk::mcp::caching_executor::CacheTtls
+impl core::marker::Unpin for bitrouter_sdk::mcp::caching_executor::CacheTtls
+impl core::marker::UnsafeUnpin for bitrouter_sdk::mcp::caching_executor::CacheTtls
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::mcp::caching_executor::CacheTtls
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::mcp::caching_executor::CacheTtls
+pub struct bitrouter_sdk::mcp::caching_executor::CachingExecutor<E: bitrouter_sdk::mcp::Executor>
+impl<E: bitrouter_sdk::mcp::Executor + 'static> bitrouter_sdk::mcp::caching_executor::CachingExecutor<E>
+pub fn bitrouter_sdk::mcp::caching_executor::CachingExecutor<E>::new(alloc::sync::Arc<E>, bitrouter_sdk::mcp::caching_executor::CacheTtls) -> Self
+pub fn bitrouter_sdk::mcp::caching_executor::CachingExecutor<E>::with_invalidation(self, tokio::sync::broadcast::Receiver<bitrouter_sdk::mcp::InvalidationEvent>) -> Self
+impl<E: bitrouter_sdk::mcp::Executor + 'static> bitrouter_sdk::mcp::Executor for bitrouter_sdk::mcp::caching_executor::CachingExecutor<E>
+pub fn bitrouter_sdk::mcp::caching_executor::CachingExecutor<E>::execute<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::mcp::McpTarget, &'life2 bitrouter_sdk::mcp::McpRequest) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::mcp::McpResponse>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub fn bitrouter_sdk::mcp::caching_executor::CachingExecutor<E>::execute_streaming<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::mcp::McpTarget, &'life2 bitrouter_sdk::mcp::McpRequest) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<futures_core::stream::BoxStream<'static, bitrouter_sdk::error::Result<bitrouter_sdk::mcp::McpStreamPart>>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+impl<E: bitrouter_sdk::mcp::Executor> core::ops::drop::Drop for bitrouter_sdk::mcp::caching_executor::CachingExecutor<E>
+pub fn bitrouter_sdk::mcp::caching_executor::CachingExecutor<E>::drop(&mut self)
+impl<E> core::marker::Freeze for bitrouter_sdk::mcp::caching_executor::CachingExecutor<E>
+impl<E> core::marker::Send for bitrouter_sdk::mcp::caching_executor::CachingExecutor<E>
+impl<E> core::marker::Sync for bitrouter_sdk::mcp::caching_executor::CachingExecutor<E>
+impl<E> core::marker::Unpin for bitrouter_sdk::mcp::caching_executor::CachingExecutor<E>
+impl<E> core::marker::UnsafeUnpin for bitrouter_sdk::mcp::caching_executor::CachingExecutor<E>
+impl<E> core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::mcp::caching_executor::CachingExecutor<E> where E: core::panic::unwind_safe::RefUnwindSafe
+impl<E> core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::mcp::caching_executor::CachingExecutor<E> where E: core::panic::unwind_safe::RefUnwindSafe
+pub const bitrouter_sdk::mcp::caching_executor::DEFAULT_MAX_ENTRIES_PER_SERVER: usize
+pub mod bitrouter_sdk::mcp::config_routing
+pub struct bitrouter_sdk::mcp::config_routing::ConfigMcpRoutingTable
+impl bitrouter_sdk::mcp::config_routing::ConfigMcpRoutingTable
+pub fn bitrouter_sdk::mcp::config_routing::ConfigMcpRoutingTable::from_configs<I>(I) -> bitrouter_sdk::error::Result<Self> where I: core::iter::traits::collect::IntoIterator<Item = (alloc::string::String, bitrouter_sdk::mcp::transport::McpServerConfig, bitrouter_sdk::mcp::config_routing::McpServerAggregateConfig)>
+pub fn bitrouter_sdk::mcp::config_routing::ConfigMcpRoutingTable::is_empty(&self) -> bool
+impl bitrouter_sdk::mcp::RoutingTable for bitrouter_sdk::mcp::config_routing::ConfigMcpRoutingTable
+pub fn bitrouter_sdk::mcp::config_routing::ConfigMcpRoutingTable::resolve<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::mcp::ServerSelector, &'life2 bitrouter_sdk::caller::CallerContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::mcp::McpTarget>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+impl core::clone::Clone for bitrouter_sdk::mcp::config_routing::ConfigMcpRoutingTable
+pub fn bitrouter_sdk::mcp::config_routing::ConfigMcpRoutingTable::clone(&self) -> bitrouter_sdk::mcp::config_routing::ConfigMcpRoutingTable
+impl core::default::Default for bitrouter_sdk::mcp::config_routing::ConfigMcpRoutingTable
+pub fn bitrouter_sdk::mcp::config_routing::ConfigMcpRoutingTable::default() -> bitrouter_sdk::mcp::config_routing::ConfigMcpRoutingTable
+impl core::fmt::Debug for bitrouter_sdk::mcp::config_routing::ConfigMcpRoutingTable
+pub fn bitrouter_sdk::mcp::config_routing::ConfigMcpRoutingTable::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::mcp::config_routing::ConfigMcpRoutingTable
+impl core::marker::Send for bitrouter_sdk::mcp::config_routing::ConfigMcpRoutingTable
+impl core::marker::Sync for bitrouter_sdk::mcp::config_routing::ConfigMcpRoutingTable
+impl core::marker::Unpin for bitrouter_sdk::mcp::config_routing::ConfigMcpRoutingTable
+impl core::marker::UnsafeUnpin for bitrouter_sdk::mcp::config_routing::ConfigMcpRoutingTable
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::mcp::config_routing::ConfigMcpRoutingTable
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::mcp::config_routing::ConfigMcpRoutingTable
+pub struct bitrouter_sdk::mcp::config_routing::McpServerAggregateConfig
+pub bitrouter_sdk::mcp::config_routing::McpServerAggregateConfig::aggregate: bool
+pub bitrouter_sdk::mcp::config_routing::McpServerAggregateConfig::tool_prefix: alloc::string::String
+impl bitrouter_sdk::mcp::config_routing::McpServerAggregateConfig
+pub fn bitrouter_sdk::mcp::config_routing::McpServerAggregateConfig::default_for(&str) -> Self
+impl core::clone::Clone for bitrouter_sdk::mcp::config_routing::McpServerAggregateConfig
+pub fn bitrouter_sdk::mcp::config_routing::McpServerAggregateConfig::clone(&self) -> bitrouter_sdk::mcp::config_routing::McpServerAggregateConfig
+impl core::fmt::Debug for bitrouter_sdk::mcp::config_routing::McpServerAggregateConfig
+pub fn bitrouter_sdk::mcp::config_routing::McpServerAggregateConfig::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::mcp::config_routing::McpServerAggregateConfig
+impl core::marker::Send for bitrouter_sdk::mcp::config_routing::McpServerAggregateConfig
+impl core::marker::Sync for bitrouter_sdk::mcp::config_routing::McpServerAggregateConfig
+impl core::marker::Unpin for bitrouter_sdk::mcp::config_routing::McpServerAggregateConfig
+impl core::marker::UnsafeUnpin for bitrouter_sdk::mcp::config_routing::McpServerAggregateConfig
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::mcp::config_routing::McpServerAggregateConfig
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::mcp::config_routing::McpServerAggregateConfig
+pub mod bitrouter_sdk::mcp::rmcp_executor
+pub struct bitrouter_sdk::mcp::rmcp_executor::RmcpExecutor
+impl bitrouter_sdk::mcp::rmcp_executor::RmcpExecutor
+pub async fn bitrouter_sdk::mcp::rmcp_executor::RmcpExecutor::evict(&self, &str) -> bool
+pub fn bitrouter_sdk::mcp::rmcp_executor::RmcpExecutor::invalidation_receiver(&self) -> tokio::sync::broadcast::Receiver<bitrouter_sdk::mcp::InvalidationEvent>
+pub fn bitrouter_sdk::mcp::rmcp_executor::RmcpExecutor::new() -> Self
+pub fn bitrouter_sdk::mcp::rmcp_executor::RmcpExecutor::with_protocol_version(self, rmcp::model::ProtocolVersion) -> Self
+impl bitrouter_sdk::mcp::Executor for bitrouter_sdk::mcp::rmcp_executor::RmcpExecutor
+pub fn bitrouter_sdk::mcp::rmcp_executor::RmcpExecutor::execute<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::mcp::McpTarget, &'life2 bitrouter_sdk::mcp::McpRequest) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::mcp::McpResponse>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub fn bitrouter_sdk::mcp::rmcp_executor::RmcpExecutor::execute_streaming<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::mcp::McpTarget, &'life2 bitrouter_sdk::mcp::McpRequest) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<futures_core::stream::BoxStream<'static, bitrouter_sdk::error::Result<bitrouter_sdk::mcp::McpStreamPart>>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+impl core::default::Default for bitrouter_sdk::mcp::rmcp_executor::RmcpExecutor
+pub fn bitrouter_sdk::mcp::rmcp_executor::RmcpExecutor::default() -> Self
+impl !core::marker::Freeze for bitrouter_sdk::mcp::rmcp_executor::RmcpExecutor
+impl core::marker::Send for bitrouter_sdk::mcp::rmcp_executor::RmcpExecutor
+impl core::marker::Sync for bitrouter_sdk::mcp::rmcp_executor::RmcpExecutor
+impl core::marker::Unpin for bitrouter_sdk::mcp::rmcp_executor::RmcpExecutor
+impl core::marker::UnsafeUnpin for bitrouter_sdk::mcp::rmcp_executor::RmcpExecutor
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::mcp::rmcp_executor::RmcpExecutor
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::mcp::rmcp_executor::RmcpExecutor
+pub const bitrouter_sdk::mcp::rmcp_executor::RELAYED_EXTENSION_METHODS: &[&str]
+pub mod bitrouter_sdk::mcp::skills
+pub struct bitrouter_sdk::mcp::skills::GetSkillParams
+pub bitrouter_sdk::mcp::skills::GetSkillParams::uri: alloc::string::String
+impl core::clone::Clone for bitrouter_sdk::mcp::skills::GetSkillParams
+pub fn bitrouter_sdk::mcp::skills::GetSkillParams::clone(&self) -> bitrouter_sdk::mcp::skills::GetSkillParams
+impl core::cmp::Eq for bitrouter_sdk::mcp::skills::GetSkillParams
+impl core::cmp::PartialEq for bitrouter_sdk::mcp::skills::GetSkillParams
+pub fn bitrouter_sdk::mcp::skills::GetSkillParams::eq(&self, &bitrouter_sdk::mcp::skills::GetSkillParams) -> bool
+impl core::fmt::Debug for bitrouter_sdk::mcp::skills::GetSkillParams
+pub fn bitrouter_sdk::mcp::skills::GetSkillParams::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::mcp::skills::GetSkillParams
+impl serde_core::ser::Serialize for bitrouter_sdk::mcp::skills::GetSkillParams
+pub fn bitrouter_sdk::mcp::skills::GetSkillParams::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::mcp::skills::GetSkillParams
+pub fn bitrouter_sdk::mcp::skills::GetSkillParams::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::mcp::skills::GetSkillParams
+impl core::marker::Send for bitrouter_sdk::mcp::skills::GetSkillParams
+impl core::marker::Sync for bitrouter_sdk::mcp::skills::GetSkillParams
+impl core::marker::Unpin for bitrouter_sdk::mcp::skills::GetSkillParams
+impl core::marker::UnsafeUnpin for bitrouter_sdk::mcp::skills::GetSkillParams
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::mcp::skills::GetSkillParams
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::mcp::skills::GetSkillParams
+pub struct bitrouter_sdk::mcp::skills::GetSkillResult
+pub bitrouter_sdk::mcp::skills::GetSkillResult::skill: bitrouter_sdk::mcp::skills::SkillEntry
+impl core::clone::Clone for bitrouter_sdk::mcp::skills::GetSkillResult
+pub fn bitrouter_sdk::mcp::skills::GetSkillResult::clone(&self) -> bitrouter_sdk::mcp::skills::GetSkillResult
+impl core::cmp::Eq for bitrouter_sdk::mcp::skills::GetSkillResult
+impl core::cmp::PartialEq for bitrouter_sdk::mcp::skills::GetSkillResult
+pub fn bitrouter_sdk::mcp::skills::GetSkillResult::eq(&self, &bitrouter_sdk::mcp::skills::GetSkillResult) -> bool
+impl core::fmt::Debug for bitrouter_sdk::mcp::skills::GetSkillResult
+pub fn bitrouter_sdk::mcp::skills::GetSkillResult::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::mcp::skills::GetSkillResult
+impl serde_core::ser::Serialize for bitrouter_sdk::mcp::skills::GetSkillResult
+pub fn bitrouter_sdk::mcp::skills::GetSkillResult::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::mcp::skills::GetSkillResult
+pub fn bitrouter_sdk::mcp::skills::GetSkillResult::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::mcp::skills::GetSkillResult
+impl core::marker::Send for bitrouter_sdk::mcp::skills::GetSkillResult
+impl core::marker::Sync for bitrouter_sdk::mcp::skills::GetSkillResult
+impl core::marker::Unpin for bitrouter_sdk::mcp::skills::GetSkillResult
+impl core::marker::UnsafeUnpin for bitrouter_sdk::mcp::skills::GetSkillResult
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::mcp::skills::GetSkillResult
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::mcp::skills::GetSkillResult
+pub struct bitrouter_sdk::mcp::skills::ListSkillsResult
+pub bitrouter_sdk::mcp::skills::ListSkillsResult::skills: alloc::vec::Vec<bitrouter_sdk::mcp::skills::SkillEntry>
+impl core::clone::Clone for bitrouter_sdk::mcp::skills::ListSkillsResult
+pub fn bitrouter_sdk::mcp::skills::ListSkillsResult::clone(&self) -> bitrouter_sdk::mcp::skills::ListSkillsResult
+impl core::cmp::Eq for bitrouter_sdk::mcp::skills::ListSkillsResult
+impl core::cmp::PartialEq for bitrouter_sdk::mcp::skills::ListSkillsResult
+pub fn bitrouter_sdk::mcp::skills::ListSkillsResult::eq(&self, &bitrouter_sdk::mcp::skills::ListSkillsResult) -> bool
+impl core::fmt::Debug for bitrouter_sdk::mcp::skills::ListSkillsResult
+pub fn bitrouter_sdk::mcp::skills::ListSkillsResult::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::mcp::skills::ListSkillsResult
+impl serde_core::ser::Serialize for bitrouter_sdk::mcp::skills::ListSkillsResult
+pub fn bitrouter_sdk::mcp::skills::ListSkillsResult::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::mcp::skills::ListSkillsResult
+pub fn bitrouter_sdk::mcp::skills::ListSkillsResult::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::mcp::skills::ListSkillsResult
+impl core::marker::Send for bitrouter_sdk::mcp::skills::ListSkillsResult
+impl core::marker::Sync for bitrouter_sdk::mcp::skills::ListSkillsResult
+impl core::marker::Unpin for bitrouter_sdk::mcp::skills::ListSkillsResult
+impl core::marker::UnsafeUnpin for bitrouter_sdk::mcp::skills::ListSkillsResult
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::mcp::skills::ListSkillsResult
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::mcp::skills::ListSkillsResult
+pub struct bitrouter_sdk::mcp::skills::SkillEntry
+pub bitrouter_sdk::mcp::skills::SkillEntry::extra: serde_json::map::Map<alloc::string::String, serde_json::value::Value>
+pub bitrouter_sdk::mcp::skills::SkillEntry::frontmatter: serde_json::map::Map<alloc::string::String, serde_json::value::Value>
+pub bitrouter_sdk::mcp::skills::SkillEntry::resources: core::option::Option<alloc::vec::Vec<bitrouter_sdk::mcp::skills::SkillResource>>
+pub bitrouter_sdk::mcp::skills::SkillEntry::uri: alloc::string::String
+impl core::clone::Clone for bitrouter_sdk::mcp::skills::SkillEntry
+pub fn bitrouter_sdk::mcp::skills::SkillEntry::clone(&self) -> bitrouter_sdk::mcp::skills::SkillEntry
+impl core::cmp::Eq for bitrouter_sdk::mcp::skills::SkillEntry
+impl core::cmp::PartialEq for bitrouter_sdk::mcp::skills::SkillEntry
+pub fn bitrouter_sdk::mcp::skills::SkillEntry::eq(&self, &bitrouter_sdk::mcp::skills::SkillEntry) -> bool
+impl core::fmt::Debug for bitrouter_sdk::mcp::skills::SkillEntry
+pub fn bitrouter_sdk::mcp::skills::SkillEntry::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::mcp::skills::SkillEntry
+impl serde_core::ser::Serialize for bitrouter_sdk::mcp::skills::SkillEntry
+pub fn bitrouter_sdk::mcp::skills::SkillEntry::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::mcp::skills::SkillEntry
+pub fn bitrouter_sdk::mcp::skills::SkillEntry::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::mcp::skills::SkillEntry
+impl core::marker::Send for bitrouter_sdk::mcp::skills::SkillEntry
+impl core::marker::Sync for bitrouter_sdk::mcp::skills::SkillEntry
+impl core::marker::Unpin for bitrouter_sdk::mcp::skills::SkillEntry
+impl core::marker::UnsafeUnpin for bitrouter_sdk::mcp::skills::SkillEntry
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::mcp::skills::SkillEntry
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::mcp::skills::SkillEntry
+pub struct bitrouter_sdk::mcp::skills::SkillResource
+pub bitrouter_sdk::mcp::skills::SkillResource::digest: alloc::string::String
+pub bitrouter_sdk::mcp::skills::SkillResource::uri: alloc::string::String
+impl core::clone::Clone for bitrouter_sdk::mcp::skills::SkillResource
+pub fn bitrouter_sdk::mcp::skills::SkillResource::clone(&self) -> bitrouter_sdk::mcp::skills::SkillResource
+impl core::cmp::Eq for bitrouter_sdk::mcp::skills::SkillResource
+impl core::cmp::PartialEq for bitrouter_sdk::mcp::skills::SkillResource
+pub fn bitrouter_sdk::mcp::skills::SkillResource::eq(&self, &bitrouter_sdk::mcp::skills::SkillResource) -> bool
+impl core::fmt::Debug for bitrouter_sdk::mcp::skills::SkillResource
+pub fn bitrouter_sdk::mcp::skills::SkillResource::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::mcp::skills::SkillResource
+impl serde_core::ser::Serialize for bitrouter_sdk::mcp::skills::SkillResource
+pub fn bitrouter_sdk::mcp::skills::SkillResource::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::mcp::skills::SkillResource
+pub fn bitrouter_sdk::mcp::skills::SkillResource::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::mcp::skills::SkillResource
+impl core::marker::Send for bitrouter_sdk::mcp::skills::SkillResource
+impl core::marker::Sync for bitrouter_sdk::mcp::skills::SkillResource
+impl core::marker::Unpin for bitrouter_sdk::mcp::skills::SkillResource
+impl core::marker::UnsafeUnpin for bitrouter_sdk::mcp::skills::SkillResource
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::mcp::skills::SkillResource
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::mcp::skills::SkillResource
+pub const bitrouter_sdk::mcp::skills::RESOURCES_DIRECTORY_READ_METHOD: &str
+pub const bitrouter_sdk::mcp::skills::SKILLS_EXTENSION_ID: &str
+pub const bitrouter_sdk::mcp::skills::SKILLS_GET_METHOD: &str
+pub const bitrouter_sdk::mcp::skills::SKILLS_LIST_METHOD: &str
+pub const bitrouter_sdk::mcp::skills::SKILL_SCHEME: &str
+pub fn bitrouter_sdk::mcp::skills::namespace_entry(&str, &serde_json::value::Value) -> core::option::Option<serde_json::value::Value>
+pub fn bitrouter_sdk::mcp::skills::namespace_uri(&str, &str) -> core::option::Option<alloc::string::String>
+pub fn bitrouter_sdk::mcp::skills::strip_label(&str, &str) -> core::option::Option<alloc::string::String>
+pub mod bitrouter_sdk::mcp::transport
+pub enum bitrouter_sdk::mcp::transport::McpConfigError
+pub bitrouter_sdk::mcp::transport::McpConfigError::EmptyHttpUrl
+pub bitrouter_sdk::mcp::transport::McpConfigError::EmptyHttpUrl::name: alloc::string::String
+pub bitrouter_sdk::mcp::transport::McpConfigError::EmptyStdioCommand
+pub bitrouter_sdk::mcp::transport::McpConfigError::EmptyStdioCommand::name: alloc::string::String
+pub bitrouter_sdk::mcp::transport::McpConfigError::InvalidName
+pub bitrouter_sdk::mcp::transport::McpConfigError::InvalidName::name: alloc::string::String
+pub bitrouter_sdk::mcp::transport::McpConfigError::InvalidName::reason: alloc::string::String
+pub bitrouter_sdk::mcp::transport::McpConfigError::UnsafeHttpUrl
+pub bitrouter_sdk::mcp::transport::McpConfigError::UnsafeHttpUrl::name: alloc::string::String
+pub bitrouter_sdk::mcp::transport::McpConfigError::UnsafeHttpUrl::reason: alloc::string::String
+impl core::cmp::Eq for bitrouter_sdk::mcp::transport::McpConfigError
+impl core::cmp::PartialEq for bitrouter_sdk::mcp::transport::McpConfigError
+pub fn bitrouter_sdk::mcp::transport::McpConfigError::eq(&self, &bitrouter_sdk::mcp::transport::McpConfigError) -> bool
+impl core::error::Error for bitrouter_sdk::mcp::transport::McpConfigError
+impl core::fmt::Debug for bitrouter_sdk::mcp::transport::McpConfigError
+pub fn bitrouter_sdk::mcp::transport::McpConfigError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitrouter_sdk::mcp::transport::McpConfigError
+pub fn bitrouter_sdk::mcp::transport::McpConfigError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::mcp::transport::McpConfigError
+impl core::marker::Freeze for bitrouter_sdk::mcp::transport::McpConfigError
+impl core::marker::Send for bitrouter_sdk::mcp::transport::McpConfigError
+impl core::marker::Sync for bitrouter_sdk::mcp::transport::McpConfigError
+impl core::marker::Unpin for bitrouter_sdk::mcp::transport::McpConfigError
+impl core::marker::UnsafeUnpin for bitrouter_sdk::mcp::transport::McpConfigError
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::mcp::transport::McpConfigError
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::mcp::transport::McpConfigError
+pub enum bitrouter_sdk::mcp::transport::McpTransport
+pub bitrouter_sdk::mcp::transport::McpTransport::Http
+pub bitrouter_sdk::mcp::transport::McpTransport::Http::headers: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+pub bitrouter_sdk::mcp::transport::McpTransport::Http::url: alloc::string::String
+pub bitrouter_sdk::mcp::transport::McpTransport::Stdio
+pub bitrouter_sdk::mcp::transport::McpTransport::Stdio::args: alloc::vec::Vec<alloc::string::String>
+pub bitrouter_sdk::mcp::transport::McpTransport::Stdio::command: alloc::string::String
+pub bitrouter_sdk::mcp::transport::McpTransport::Stdio::env: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+impl core::clone::Clone for bitrouter_sdk::mcp::transport::McpTransport
+pub fn bitrouter_sdk::mcp::transport::McpTransport::clone(&self) -> bitrouter_sdk::mcp::transport::McpTransport
+impl core::cmp::Eq for bitrouter_sdk::mcp::transport::McpTransport
+impl core::cmp::PartialEq for bitrouter_sdk::mcp::transport::McpTransport
+pub fn bitrouter_sdk::mcp::transport::McpTransport::eq(&self, &bitrouter_sdk::mcp::transport::McpTransport) -> bool
+impl core::fmt::Debug for bitrouter_sdk::mcp::transport::McpTransport
+pub fn bitrouter_sdk::mcp::transport::McpTransport::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for bitrouter_sdk::mcp::transport::McpTransport
+impl schemars::JsonSchema for bitrouter_sdk::mcp::transport::McpTransport
+pub fn bitrouter_sdk::mcp::transport::McpTransport::inline_schema() -> bool
+pub fn bitrouter_sdk::mcp::transport::McpTransport::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::mcp::transport::McpTransport::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::mcp::transport::McpTransport::schema_name() -> alloc::borrow::Cow<'static, str>
+impl serde_core::ser::Serialize for bitrouter_sdk::mcp::transport::McpTransport
+pub fn bitrouter_sdk::mcp::transport::McpTransport::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::mcp::transport::McpTransport
+pub fn bitrouter_sdk::mcp::transport::McpTransport::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::mcp::transport::McpTransport
+impl core::marker::Send for bitrouter_sdk::mcp::transport::McpTransport
+impl core::marker::Sync for bitrouter_sdk::mcp::transport::McpTransport
+impl core::marker::Unpin for bitrouter_sdk::mcp::transport::McpTransport
+impl core::marker::UnsafeUnpin for bitrouter_sdk::mcp::transport::McpTransport
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::mcp::transport::McpTransport
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::mcp::transport::McpTransport
+pub struct bitrouter_sdk::mcp::transport::McpServerConfig
+pub bitrouter_sdk::mcp::transport::McpServerConfig::aggregate: bool
+pub bitrouter_sdk::mcp::transport::McpServerConfig::name: alloc::string::String
+pub bitrouter_sdk::mcp::transport::McpServerConfig::tool_prefix: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::mcp::transport::McpServerConfig::transport: bitrouter_sdk::mcp::transport::McpTransport
+impl bitrouter_sdk::mcp::transport::McpServerConfig
+pub fn bitrouter_sdk::mcp::transport::McpServerConfig::validate(&self) -> core::result::Result<(), bitrouter_sdk::mcp::transport::McpConfigError>
+impl bitrouter_sdk::mcp::transport::McpServerConfig
+pub fn bitrouter_sdk::mcp::transport::McpServerConfig::with_defaults(impl core::convert::Into<alloc::string::String>, bitrouter_sdk::mcp::transport::McpTransport) -> Self
+impl core::clone::Clone for bitrouter_sdk::mcp::transport::McpServerConfig
+pub fn bitrouter_sdk::mcp::transport::McpServerConfig::clone(&self) -> bitrouter_sdk::mcp::transport::McpServerConfig
+impl core::fmt::Debug for bitrouter_sdk::mcp::transport::McpServerConfig
+pub fn bitrouter_sdk::mcp::transport::McpServerConfig::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl schemars::JsonSchema for bitrouter_sdk::mcp::transport::McpServerConfig
+pub fn bitrouter_sdk::mcp::transport::McpServerConfig::inline_schema() -> bool
+pub fn bitrouter_sdk::mcp::transport::McpServerConfig::json_schema(&mut schemars::generate::SchemaGenerator) -> schemars::schema::Schema
+pub fn bitrouter_sdk::mcp::transport::McpServerConfig::schema_id() -> alloc::borrow::Cow<'static, str>
+pub fn bitrouter_sdk::mcp::transport::McpServerConfig::schema_name() -> alloc::borrow::Cow<'static, str>
+impl serde_core::ser::Serialize for bitrouter_sdk::mcp::transport::McpServerConfig
+pub fn bitrouter_sdk::mcp::transport::McpServerConfig::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::mcp::transport::McpServerConfig
+pub fn bitrouter_sdk::mcp::transport::McpServerConfig::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::mcp::transport::McpServerConfig
+impl core::marker::Send for bitrouter_sdk::mcp::transport::McpServerConfig
+impl core::marker::Sync for bitrouter_sdk::mcp::transport::McpServerConfig
+impl core::marker::Unpin for bitrouter_sdk::mcp::transport::McpServerConfig
+impl core::marker::UnsafeUnpin for bitrouter_sdk::mcp::transport::McpServerConfig
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::mcp::transport::McpServerConfig
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::mcp::transport::McpServerConfig
+pub enum bitrouter_sdk::mcp::InvalidationKind
+pub bitrouter_sdk::mcp::InvalidationKind::PromptsListChanged
+pub bitrouter_sdk::mcp::InvalidationKind::Reinitialized
+pub bitrouter_sdk::mcp::InvalidationKind::ResourcesListChanged
+pub bitrouter_sdk::mcp::InvalidationKind::ToolsListChanged
+impl core::clone::Clone for bitrouter_sdk::mcp::InvalidationKind
+pub fn bitrouter_sdk::mcp::InvalidationKind::clone(&self) -> bitrouter_sdk::mcp::InvalidationKind
+impl core::cmp::Eq for bitrouter_sdk::mcp::InvalidationKind
+impl core::cmp::PartialEq for bitrouter_sdk::mcp::InvalidationKind
+pub fn bitrouter_sdk::mcp::InvalidationKind::eq(&self, &bitrouter_sdk::mcp::InvalidationKind) -> bool
+impl core::fmt::Debug for bitrouter_sdk::mcp::InvalidationKind
+pub fn bitrouter_sdk::mcp::InvalidationKind::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for bitrouter_sdk::mcp::InvalidationKind
+impl core::marker::StructuralPartialEq for bitrouter_sdk::mcp::InvalidationKind
+impl core::marker::Freeze for bitrouter_sdk::mcp::InvalidationKind
+impl core::marker::Send for bitrouter_sdk::mcp::InvalidationKind
+impl core::marker::Sync for bitrouter_sdk::mcp::InvalidationKind
+impl core::marker::Unpin for bitrouter_sdk::mcp::InvalidationKind
+impl core::marker::UnsafeUnpin for bitrouter_sdk::mcp::InvalidationKind
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::mcp::InvalidationKind
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::mcp::InvalidationKind
+pub enum bitrouter_sdk::mcp::McpStreamPart
+pub bitrouter_sdk::mcp::McpStreamPart::Final(bitrouter_sdk::mcp::McpResponse)
+pub bitrouter_sdk::mcp::McpStreamPart::Notification
+pub bitrouter_sdk::mcp::McpStreamPart::Notification::method: alloc::string::String
+pub bitrouter_sdk::mcp::McpStreamPart::Notification::params: serde_json::value::Value
+impl core::clone::Clone for bitrouter_sdk::mcp::McpStreamPart
+pub fn bitrouter_sdk::mcp::McpStreamPart::clone(&self) -> bitrouter_sdk::mcp::McpStreamPart
+impl core::fmt::Debug for bitrouter_sdk::mcp::McpStreamPart
+pub fn bitrouter_sdk::mcp::McpStreamPart::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::mcp::McpStreamPart
+impl core::marker::Send for bitrouter_sdk::mcp::McpStreamPart
+impl core::marker::Sync for bitrouter_sdk::mcp::McpStreamPart
+impl core::marker::Unpin for bitrouter_sdk::mcp::McpStreamPart
+impl core::marker::UnsafeUnpin for bitrouter_sdk::mcp::McpStreamPart
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::mcp::McpStreamPart
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::mcp::McpStreamPart
+pub enum bitrouter_sdk::mcp::McpTarget
+pub bitrouter_sdk::mcp::McpTarget::Aggregate
+pub bitrouter_sdk::mcp::McpTarget::Aggregate::members: alloc::vec::Vec<bitrouter_sdk::mcp::AggregateMember>
+pub bitrouter_sdk::mcp::McpTarget::Direct
+pub bitrouter_sdk::mcp::McpTarget::Direct::server_name: alloc::string::String
+pub bitrouter_sdk::mcp::McpTarget::Direct::transport: bitrouter_sdk::mcp::transport::McpTransport
+impl core::clone::Clone for bitrouter_sdk::mcp::McpTarget
+pub fn bitrouter_sdk::mcp::McpTarget::clone(&self) -> bitrouter_sdk::mcp::McpTarget
+impl core::fmt::Debug for bitrouter_sdk::mcp::McpTarget
+pub fn bitrouter_sdk::mcp::McpTarget::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::mcp::McpTarget
+impl core::marker::Send for bitrouter_sdk::mcp::McpTarget
+impl core::marker::Sync for bitrouter_sdk::mcp::McpTarget
+impl core::marker::Unpin for bitrouter_sdk::mcp::McpTarget
+impl core::marker::UnsafeUnpin for bitrouter_sdk::mcp::McpTarget
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::mcp::McpTarget
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::mcp::McpTarget
+pub enum bitrouter_sdk::mcp::ServerSelector
+pub bitrouter_sdk::mcp::ServerSelector::Aggregate
+pub bitrouter_sdk::mcp::ServerSelector::Direct(alloc::string::String)
+impl core::clone::Clone for bitrouter_sdk::mcp::ServerSelector
+pub fn bitrouter_sdk::mcp::ServerSelector::clone(&self) -> bitrouter_sdk::mcp::ServerSelector
+impl core::fmt::Debug for bitrouter_sdk::mcp::ServerSelector
+pub fn bitrouter_sdk::mcp::ServerSelector::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::mcp::ServerSelector
+impl core::marker::Send for bitrouter_sdk::mcp::ServerSelector
+impl core::marker::Sync for bitrouter_sdk::mcp::ServerSelector
+impl core::marker::Unpin for bitrouter_sdk::mcp::ServerSelector
+impl core::marker::UnsafeUnpin for bitrouter_sdk::mcp::ServerSelector
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::mcp::ServerSelector
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::mcp::ServerSelector
+pub struct bitrouter_sdk::mcp::AggregateMember
+pub bitrouter_sdk::mcp::AggregateMember::server_name: alloc::string::String
+pub bitrouter_sdk::mcp::AggregateMember::tool_prefix: alloc::string::String
+pub bitrouter_sdk::mcp::AggregateMember::transport: bitrouter_sdk::mcp::transport::McpTransport
+impl core::clone::Clone for bitrouter_sdk::mcp::AggregateMember
+pub fn bitrouter_sdk::mcp::AggregateMember::clone(&self) -> bitrouter_sdk::mcp::AggregateMember
+impl core::fmt::Debug for bitrouter_sdk::mcp::AggregateMember
+pub fn bitrouter_sdk::mcp::AggregateMember::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::mcp::AggregateMember
+impl core::marker::Send for bitrouter_sdk::mcp::AggregateMember
+impl core::marker::Sync for bitrouter_sdk::mcp::AggregateMember
+impl core::marker::Unpin for bitrouter_sdk::mcp::AggregateMember
+impl core::marker::UnsafeUnpin for bitrouter_sdk::mcp::AggregateMember
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::mcp::AggregateMember
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::mcp::AggregateMember
+pub struct bitrouter_sdk::mcp::InvalidationEvent
+pub bitrouter_sdk::mcp::InvalidationEvent::kind: bitrouter_sdk::mcp::InvalidationKind
+pub bitrouter_sdk::mcp::InvalidationEvent::server_name: alloc::string::String
+impl core::clone::Clone for bitrouter_sdk::mcp::InvalidationEvent
+pub fn bitrouter_sdk::mcp::InvalidationEvent::clone(&self) -> bitrouter_sdk::mcp::InvalidationEvent
+impl core::fmt::Debug for bitrouter_sdk::mcp::InvalidationEvent
+pub fn bitrouter_sdk::mcp::InvalidationEvent::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::mcp::InvalidationEvent
+impl core::marker::Send for bitrouter_sdk::mcp::InvalidationEvent
+impl core::marker::Sync for bitrouter_sdk::mcp::InvalidationEvent
+impl core::marker::Unpin for bitrouter_sdk::mcp::InvalidationEvent
+impl core::marker::UnsafeUnpin for bitrouter_sdk::mcp::InvalidationEvent
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::mcp::InvalidationEvent
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::mcp::InvalidationEvent
+pub struct bitrouter_sdk::mcp::McpContext
+pub bitrouter_sdk::mcp::McpContext::target: core::option::Option<bitrouter_sdk::mcp::McpTarget>
+impl bitrouter_sdk::mcp::McpContext
+pub fn bitrouter_sdk::mcp::McpContext::caller(&self) -> &bitrouter_sdk::caller::CallerContext
+pub fn bitrouter_sdk::mcp::McpContext::emit<E: bitrouter_sdk::event::PipelineEvent>(&mut self, E)
+pub fn bitrouter_sdk::mcp::McpContext::has_event<E: bitrouter_sdk::event::PipelineEvent>(&self) -> bool
+pub fn bitrouter_sdk::mcp::McpContext::headers(&self) -> &http::header::map::HeaderMap
+pub fn bitrouter_sdk::mcp::McpContext::new(bitrouter_sdk::mcp::McpRequest) -> Self
+pub fn bitrouter_sdk::mcp::McpContext::request(&self) -> &bitrouter_sdk::mcp::McpRequest
+pub fn bitrouter_sdk::mcp::McpContext::set_caller(&mut self, bitrouter_sdk::caller::CallerContext)
+impl core::marker::Freeze for bitrouter_sdk::mcp::McpContext
+impl core::marker::Send for bitrouter_sdk::mcp::McpContext
+impl core::marker::Sync for bitrouter_sdk::mcp::McpContext
+impl core::marker::Unpin for bitrouter_sdk::mcp::McpContext
+impl core::marker::UnsafeUnpin for bitrouter_sdk::mcp::McpContext
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::mcp::McpContext
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::mcp::McpContext
+pub struct bitrouter_sdk::mcp::McpRequest
+pub bitrouter_sdk::mcp::McpRequest::caller: bitrouter_sdk::caller::CallerContext
+pub bitrouter_sdk::mcp::McpRequest::headers: http::header::map::HeaderMap
+pub bitrouter_sdk::mcp::McpRequest::method: alloc::string::String
+pub bitrouter_sdk::mcp::McpRequest::params: serde_json::value::Value
+pub bitrouter_sdk::mcp::McpRequest::request_id: alloc::string::String
+pub bitrouter_sdk::mcp::McpRequest::selector: bitrouter_sdk::mcp::ServerSelector
+impl bitrouter_sdk::mcp::McpRequest
+pub fn bitrouter_sdk::mcp::McpRequest::aggregate(impl core::convert::Into<alloc::string::String>, serde_json::value::Value, bitrouter_sdk::caller::CallerContext) -> Self
+pub fn bitrouter_sdk::mcp::McpRequest::direct(impl core::convert::Into<alloc::string::String>, impl core::convert::Into<alloc::string::String>, serde_json::value::Value, bitrouter_sdk::caller::CallerContext) -> Self
+pub fn bitrouter_sdk::mcp::McpRequest::with_headers(self, http::header::map::HeaderMap) -> Self
+impl core::clone::Clone for bitrouter_sdk::mcp::McpRequest
+pub fn bitrouter_sdk::mcp::McpRequest::clone(&self) -> bitrouter_sdk::mcp::McpRequest
+impl core::fmt::Debug for bitrouter_sdk::mcp::McpRequest
+pub fn bitrouter_sdk::mcp::McpRequest::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::mcp::McpRequest
+impl core::marker::Send for bitrouter_sdk::mcp::McpRequest
+impl core::marker::Sync for bitrouter_sdk::mcp::McpRequest
+impl core::marker::Unpin for bitrouter_sdk::mcp::McpRequest
+impl core::marker::UnsafeUnpin for bitrouter_sdk::mcp::McpRequest
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::mcp::McpRequest
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::mcp::McpRequest
+pub struct bitrouter_sdk::mcp::McpResponse
+pub bitrouter_sdk::mcp::McpResponse::request_id: alloc::string::String
+pub bitrouter_sdk::mcp::McpResponse::result: serde_json::value::Value
+impl core::clone::Clone for bitrouter_sdk::mcp::McpResponse
+pub fn bitrouter_sdk::mcp::McpResponse::clone(&self) -> bitrouter_sdk::mcp::McpResponse
+impl core::fmt::Debug for bitrouter_sdk::mcp::McpResponse
+pub fn bitrouter_sdk::mcp::McpResponse::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::mcp::McpResponse
+impl core::marker::Send for bitrouter_sdk::mcp::McpResponse
+impl core::marker::Sync for bitrouter_sdk::mcp::McpResponse
+impl core::marker::Unpin for bitrouter_sdk::mcp::McpResponse
+impl core::marker::UnsafeUnpin for bitrouter_sdk::mcp::McpResponse
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::mcp::McpResponse
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::mcp::McpResponse
+pub struct bitrouter_sdk::mcp::Pipeline
+impl bitrouter_sdk::mcp::Pipeline
+pub async fn bitrouter_sdk::mcp::Pipeline::execute(&self, bitrouter_sdk::mcp::McpRequest) -> bitrouter_sdk::error::Result<bitrouter_sdk::mcp::McpResponse>
+pub async fn bitrouter_sdk::mcp::Pipeline::execute_streaming(&self, bitrouter_sdk::mcp::McpRequest) -> bitrouter_sdk::error::Result<futures_core::stream::BoxStream<'static, bitrouter_sdk::error::Result<bitrouter_sdk::mcp::McpStreamPart>>>
+impl core::marker::Freeze for bitrouter_sdk::mcp::Pipeline
+impl core::marker::Send for bitrouter_sdk::mcp::Pipeline
+impl core::marker::Sync for bitrouter_sdk::mcp::Pipeline
+impl core::marker::Unpin for bitrouter_sdk::mcp::Pipeline
+impl core::marker::UnsafeUnpin for bitrouter_sdk::mcp::Pipeline
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::mcp::Pipeline
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::mcp::Pipeline
+pub struct bitrouter_sdk::mcp::PipelineBuilder
+impl bitrouter_sdk::mcp::PipelineBuilder
+pub fn bitrouter_sdk::mcp::PipelineBuilder::build(self) -> bitrouter_sdk::error::Result<bitrouter_sdk::mcp::Pipeline>
+pub fn bitrouter_sdk::mcp::PipelineBuilder::execution_hook(&mut self, impl bitrouter_sdk::mcp::ExecutionHook + 'static) -> &mut Self
+pub fn bitrouter_sdk::mcp::PipelineBuilder::executor(&mut self, alloc::sync::Arc<dyn bitrouter_sdk::mcp::Executor>) -> &mut Self
+pub fn bitrouter_sdk::mcp::PipelineBuilder::is_configured(&self) -> bool
+pub fn bitrouter_sdk::mcp::PipelineBuilder::new() -> Self
+pub fn bitrouter_sdk::mcp::PipelineBuilder::pre_request_hook(&mut self, impl bitrouter_sdk::mcp::PreRequestHook + 'static) -> &mut Self
+pub fn bitrouter_sdk::mcp::PipelineBuilder::route_hook(&mut self, impl bitrouter_sdk::mcp::RouteHook + 'static) -> &mut Self
+pub fn bitrouter_sdk::mcp::PipelineBuilder::routing_table(&mut self, alloc::sync::Arc<dyn bitrouter_sdk::mcp::RoutingTable>) -> &mut Self
+impl core::default::Default for bitrouter_sdk::mcp::PipelineBuilder
+pub fn bitrouter_sdk::mcp::PipelineBuilder::default() -> bitrouter_sdk::mcp::PipelineBuilder
+impl core::marker::Freeze for bitrouter_sdk::mcp::PipelineBuilder
+impl core::marker::Send for bitrouter_sdk::mcp::PipelineBuilder
+impl core::marker::Sync for bitrouter_sdk::mcp::PipelineBuilder
+impl core::marker::Unpin for bitrouter_sdk::mcp::PipelineBuilder
+impl core::marker::UnsafeUnpin for bitrouter_sdk::mcp::PipelineBuilder
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::mcp::PipelineBuilder
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::mcp::PipelineBuilder
+pub trait bitrouter_sdk::mcp::ExecutionHook: core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::mcp::ExecutionHook::on_success<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::mcp::McpContext, &'life2 bitrouter_sdk::mcp::McpResponse) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<()>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub trait bitrouter_sdk::mcp::Executor: core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::mcp::Executor::execute<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::mcp::McpTarget, &'life2 bitrouter_sdk::mcp::McpRequest) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::mcp::McpResponse>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub fn bitrouter_sdk::mcp::Executor::execute_streaming<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::mcp::McpTarget, &'life2 bitrouter_sdk::mcp::McpRequest) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<futures_core::stream::BoxStream<'static, bitrouter_sdk::error::Result<bitrouter_sdk::mcp::McpStreamPart>>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+impl bitrouter_sdk::mcp::Executor for bitrouter_sdk::mcp::rmcp_executor::RmcpExecutor
+pub fn bitrouter_sdk::mcp::rmcp_executor::RmcpExecutor::execute<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::mcp::McpTarget, &'life2 bitrouter_sdk::mcp::McpRequest) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::mcp::McpResponse>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub fn bitrouter_sdk::mcp::rmcp_executor::RmcpExecutor::execute_streaming<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::mcp::McpTarget, &'life2 bitrouter_sdk::mcp::McpRequest) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<futures_core::stream::BoxStream<'static, bitrouter_sdk::error::Result<bitrouter_sdk::mcp::McpStreamPart>>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+impl<E: bitrouter_sdk::mcp::Executor + 'static> bitrouter_sdk::mcp::Executor for bitrouter_sdk::mcp::aggregating_executor::AggregatingExecutor<E>
+pub fn bitrouter_sdk::mcp::aggregating_executor::AggregatingExecutor<E>::execute<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::mcp::McpTarget, &'life2 bitrouter_sdk::mcp::McpRequest) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::mcp::McpResponse>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub fn bitrouter_sdk::mcp::aggregating_executor::AggregatingExecutor<E>::execute_streaming<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::mcp::McpTarget, &'life2 bitrouter_sdk::mcp::McpRequest) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<futures_core::stream::BoxStream<'static, bitrouter_sdk::error::Result<bitrouter_sdk::mcp::McpStreamPart>>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+impl<E: bitrouter_sdk::mcp::Executor + 'static> bitrouter_sdk::mcp::Executor for bitrouter_sdk::mcp::caching_executor::CachingExecutor<E>
+pub fn bitrouter_sdk::mcp::caching_executor::CachingExecutor<E>::execute<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::mcp::McpTarget, &'life2 bitrouter_sdk::mcp::McpRequest) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::mcp::McpResponse>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub fn bitrouter_sdk::mcp::caching_executor::CachingExecutor<E>::execute_streaming<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::mcp::McpTarget, &'life2 bitrouter_sdk::mcp::McpRequest) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<futures_core::stream::BoxStream<'static, bitrouter_sdk::error::Result<bitrouter_sdk::mcp::McpStreamPart>>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub trait bitrouter_sdk::mcp::PreRequestHook: core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::mcp::PreRequestHook::check<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 mut bitrouter_sdk::mcp::McpContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::hooks::HookDecision>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub trait bitrouter_sdk::mcp::RouteHook: core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::mcp::RouteHook::resolve<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 mut bitrouter_sdk::mcp::McpTarget, &'life2 mut bitrouter_sdk::mcp::McpContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<()>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub trait bitrouter_sdk::mcp::RoutingTable: core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::mcp::RoutingTable::resolve<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::mcp::ServerSelector, &'life2 bitrouter_sdk::caller::CallerContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::mcp::McpTarget>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+impl bitrouter_sdk::mcp::RoutingTable for bitrouter_sdk::mcp::config_routing::ConfigMcpRoutingTable
+pub fn bitrouter_sdk::mcp::config_routing::ConfigMcpRoutingTable::resolve<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::mcp::ServerSelector, &'life2 bitrouter_sdk::caller::CallerContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::mcp::McpTarget>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub fn bitrouter_sdk::mcp::upstream_protocol_version(bitrouter_sdk::config::McpUpstreamProtocol) -> rmcp::model::ProtocolVersion
+pub mod bitrouter_sdk::metrics
+pub trait bitrouter_sdk::metrics::MetricsRenderer: core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::metrics::MetricsRenderer::content_type(&self) -> &'static str
+pub fn bitrouter_sdk::metrics::MetricsRenderer::render(&self) -> alloc::string::String
+pub mod bitrouter_sdk::otel
+pub mod bitrouter_sdk::otel::acp
+pub struct bitrouter_sdk::otel::acp::AcpSpanRecorder
+impl bitrouter_sdk::otel::acp::AcpSpanRecorder
+pub fn bitrouter_sdk::otel::acp::AcpSpanRecorder::new(&bitrouter_sdk::otel::OtelExporter, impl core::convert::Into<alloc::string::String>, impl core::convert::Into<alloc::string::String>) -> Self
+pub fn bitrouter_sdk::otel::acp::AcpSpanRecorder::tool_finished(&self, &str, bool, core::option::Option<&str>)
+pub fn bitrouter_sdk::otel::acp::AcpSpanRecorder::tool_started(&self, impl core::convert::Into<alloc::string::String>, impl core::convert::Into<alloc::string::String>)
+pub fn bitrouter_sdk::otel::acp::AcpSpanRecorder::turn_completed(&self, &bitrouter_sdk::otel::acp::TurnRecord)
+impl !core::marker::Freeze for bitrouter_sdk::otel::acp::AcpSpanRecorder
+impl core::marker::Send for bitrouter_sdk::otel::acp::AcpSpanRecorder
+impl core::marker::Sync for bitrouter_sdk::otel::acp::AcpSpanRecorder
+impl core::marker::Unpin for bitrouter_sdk::otel::acp::AcpSpanRecorder
+impl core::marker::UnsafeUnpin for bitrouter_sdk::otel::acp::AcpSpanRecorder
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::otel::acp::AcpSpanRecorder
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::otel::acp::AcpSpanRecorder
+pub struct bitrouter_sdk::otel::acp::TurnRecord
+pub bitrouter_sdk::otel::acp::TurnRecord::context_size: core::option::Option<u64>
+pub bitrouter_sdk::otel::acp::TurnRecord::context_used: core::option::Option<u64>
+pub bitrouter_sdk::otel::acp::TurnRecord::latency: core::time::Duration
+pub bitrouter_sdk::otel::acp::TurnRecord::stop_reason: alloc::string::String
+impl core::clone::Clone for bitrouter_sdk::otel::acp::TurnRecord
+pub fn bitrouter_sdk::otel::acp::TurnRecord::clone(&self) -> bitrouter_sdk::otel::acp::TurnRecord
+impl core::fmt::Debug for bitrouter_sdk::otel::acp::TurnRecord
+pub fn bitrouter_sdk::otel::acp::TurnRecord::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::otel::acp::TurnRecord
+impl core::marker::Send for bitrouter_sdk::otel::acp::TurnRecord
+impl core::marker::Sync for bitrouter_sdk::otel::acp::TurnRecord
+impl core::marker::Unpin for bitrouter_sdk::otel::acp::TurnRecord
+impl core::marker::UnsafeUnpin for bitrouter_sdk::otel::acp::TurnRecord
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::otel::acp::TurnRecord
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::otel::acp::TurnRecord
+pub mod bitrouter_sdk::otel::http_layer
+pub fn bitrouter_sdk::otel::http_layer::router_wrapper() -> impl core::ops::function::Fn(axum::routing::Router) -> axum::routing::Router + core::marker::Send + core::marker::Sync + 'static
+pub mod bitrouter_sdk::otel::subscriber
+pub fn bitrouter_sdk::otel::subscriber::tracing_subscriber_layer<S>(&bitrouter_sdk::otel::OtelExporter) -> impl tracing_subscriber::layer::Layer<S> where S: tracing_core::subscriber::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>
+pub enum bitrouter_sdk::otel::ContentCaptureMode
+pub bitrouter_sdk::otel::ContentCaptureMode::Full
+pub bitrouter_sdk::otel::ContentCaptureMode::Off
+impl core::clone::Clone for bitrouter_sdk::otel::ContentCaptureMode
+pub fn bitrouter_sdk::otel::ContentCaptureMode::clone(&self) -> bitrouter_sdk::otel::ContentCaptureMode
+impl core::cmp::Eq for bitrouter_sdk::otel::ContentCaptureMode
+impl core::cmp::PartialEq for bitrouter_sdk::otel::ContentCaptureMode
+pub fn bitrouter_sdk::otel::ContentCaptureMode::eq(&self, &bitrouter_sdk::otel::ContentCaptureMode) -> bool
+impl core::default::Default for bitrouter_sdk::otel::ContentCaptureMode
+pub fn bitrouter_sdk::otel::ContentCaptureMode::default() -> bitrouter_sdk::otel::ContentCaptureMode
+impl core::fmt::Debug for bitrouter_sdk::otel::ContentCaptureMode
+pub fn bitrouter_sdk::otel::ContentCaptureMode::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for bitrouter_sdk::otel::ContentCaptureMode
+impl core::marker::StructuralPartialEq for bitrouter_sdk::otel::ContentCaptureMode
+impl serde_core::ser::Serialize for bitrouter_sdk::otel::ContentCaptureMode
+pub fn bitrouter_sdk::otel::ContentCaptureMode::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::otel::ContentCaptureMode
+pub fn bitrouter_sdk::otel::ContentCaptureMode::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::otel::ContentCaptureMode
+impl core::marker::Send for bitrouter_sdk::otel::ContentCaptureMode
+impl core::marker::Sync for bitrouter_sdk::otel::ContentCaptureMode
+impl core::marker::Unpin for bitrouter_sdk::otel::ContentCaptureMode
+impl core::marker::UnsafeUnpin for bitrouter_sdk::otel::ContentCaptureMode
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::otel::ContentCaptureMode
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::otel::ContentCaptureMode
+pub enum bitrouter_sdk::otel::SamplerKind
+pub bitrouter_sdk::otel::SamplerKind::AlwaysOff
+pub bitrouter_sdk::otel::SamplerKind::AlwaysOn
+pub bitrouter_sdk::otel::SamplerKind::ParentBasedAlwaysOff
+pub bitrouter_sdk::otel::SamplerKind::ParentBasedAlwaysOn
+pub bitrouter_sdk::otel::SamplerKind::ParentBasedTraceIdRatio
+pub bitrouter_sdk::otel::SamplerKind::TraceIdRatio
+impl core::clone::Clone for bitrouter_sdk::otel::SamplerKind
+pub fn bitrouter_sdk::otel::SamplerKind::clone(&self) -> bitrouter_sdk::otel::SamplerKind
+impl core::cmp::Eq for bitrouter_sdk::otel::SamplerKind
+impl core::cmp::PartialEq for bitrouter_sdk::otel::SamplerKind
+pub fn bitrouter_sdk::otel::SamplerKind::eq(&self, &bitrouter_sdk::otel::SamplerKind) -> bool
+impl core::fmt::Debug for bitrouter_sdk::otel::SamplerKind
+pub fn bitrouter_sdk::otel::SamplerKind::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for bitrouter_sdk::otel::SamplerKind
+impl core::marker::StructuralPartialEq for bitrouter_sdk::otel::SamplerKind
+impl serde_core::ser::Serialize for bitrouter_sdk::otel::SamplerKind
+pub fn bitrouter_sdk::otel::SamplerKind::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::otel::SamplerKind
+pub fn bitrouter_sdk::otel::SamplerKind::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::otel::SamplerKind
+impl core::marker::Send for bitrouter_sdk::otel::SamplerKind
+impl core::marker::Sync for bitrouter_sdk::otel::SamplerKind
+impl core::marker::Unpin for bitrouter_sdk::otel::SamplerKind
+impl core::marker::UnsafeUnpin for bitrouter_sdk::otel::SamplerKind
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::otel::SamplerKind
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::otel::SamplerKind
+pub struct bitrouter_sdk::otel::BatchConfig
+pub bitrouter_sdk::otel::BatchConfig::flush_ms: u64
+pub bitrouter_sdk::otel::BatchConfig::max_queue_size: usize
+impl core::clone::Clone for bitrouter_sdk::otel::BatchConfig
+pub fn bitrouter_sdk::otel::BatchConfig::clone(&self) -> bitrouter_sdk::otel::BatchConfig
+impl core::default::Default for bitrouter_sdk::otel::BatchConfig
+pub fn bitrouter_sdk::otel::BatchConfig::default() -> Self
+impl core::fmt::Debug for bitrouter_sdk::otel::BatchConfig
+pub fn bitrouter_sdk::otel::BatchConfig::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl serde_core::ser::Serialize for bitrouter_sdk::otel::BatchConfig
+pub fn bitrouter_sdk::otel::BatchConfig::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::otel::BatchConfig where bitrouter_sdk::otel::BatchConfig: core::default::Default
+pub fn bitrouter_sdk::otel::BatchConfig::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::otel::BatchConfig
+impl core::marker::Send for bitrouter_sdk::otel::BatchConfig
+impl core::marker::Sync for bitrouter_sdk::otel::BatchConfig
+impl core::marker::Unpin for bitrouter_sdk::otel::BatchConfig
+impl core::marker::UnsafeUnpin for bitrouter_sdk::otel::BatchConfig
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::otel::BatchConfig
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::otel::BatchConfig
+pub struct bitrouter_sdk::otel::CardinalityLimiter
+impl bitrouter_sdk::otel::CardinalityLimiter
+pub fn bitrouter_sdk::otel::CardinalityLimiter::cap(&self, &str) -> alloc::string::String
+pub fn bitrouter_sdk::otel::CardinalityLimiter::cardinality(&self) -> usize
+pub fn bitrouter_sdk::otel::CardinalityLimiter::new(usize) -> Self
+impl !core::marker::Freeze for bitrouter_sdk::otel::CardinalityLimiter
+impl core::marker::Send for bitrouter_sdk::otel::CardinalityLimiter
+impl core::marker::Sync for bitrouter_sdk::otel::CardinalityLimiter
+impl core::marker::Unpin for bitrouter_sdk::otel::CardinalityLimiter
+impl core::marker::UnsafeUnpin for bitrouter_sdk::otel::CardinalityLimiter
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::otel::CardinalityLimiter
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::otel::CardinalityLimiter
+pub struct bitrouter_sdk::otel::MetricsConfig
+pub bitrouter_sdk::otel::MetricsConfig::api_key_id_cap: usize
+pub bitrouter_sdk::otel::MetricsConfig::enabled: bool
+pub bitrouter_sdk::otel::MetricsConfig::export_interval_ms: u64
+pub bitrouter_sdk::otel::MetricsConfig::user_id_cap: usize
+impl core::clone::Clone for bitrouter_sdk::otel::MetricsConfig
+pub fn bitrouter_sdk::otel::MetricsConfig::clone(&self) -> bitrouter_sdk::otel::MetricsConfig
+impl core::default::Default for bitrouter_sdk::otel::MetricsConfig
+pub fn bitrouter_sdk::otel::MetricsConfig::default() -> Self
+impl core::fmt::Debug for bitrouter_sdk::otel::MetricsConfig
+pub fn bitrouter_sdk::otel::MetricsConfig::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl serde_core::ser::Serialize for bitrouter_sdk::otel::MetricsConfig
+pub fn bitrouter_sdk::otel::MetricsConfig::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::otel::MetricsConfig where bitrouter_sdk::otel::MetricsConfig: core::default::Default
+pub fn bitrouter_sdk::otel::MetricsConfig::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::otel::MetricsConfig
+impl core::marker::Send for bitrouter_sdk::otel::MetricsConfig
+impl core::marker::Sync for bitrouter_sdk::otel::MetricsConfig
+impl core::marker::Unpin for bitrouter_sdk::otel::MetricsConfig
+impl core::marker::UnsafeUnpin for bitrouter_sdk::otel::MetricsConfig
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::otel::MetricsConfig
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::otel::MetricsConfig
+pub struct bitrouter_sdk::otel::OtelConfig
+pub bitrouter_sdk::otel::OtelConfig::bearer_token: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::otel::OtelConfig::content_attr_max_bytes: usize
+pub bitrouter_sdk::otel::OtelConfig::content_capture: bitrouter_sdk::otel::ContentCaptureMode
+pub bitrouter_sdk::otel::OtelConfig::endpoint: alloc::string::String
+pub bitrouter_sdk::otel::OtelConfig::headers: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+pub bitrouter_sdk::otel::OtelConfig::metrics: bitrouter_sdk::otel::MetricsConfig
+pub bitrouter_sdk::otel::OtelConfig::resource_attributes: std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+pub bitrouter_sdk::otel::OtelConfig::sampler: bitrouter_sdk::otel::SamplerKind
+pub bitrouter_sdk::otel::OtelConfig::sampler_arg: core::option::Option<f64>
+pub bitrouter_sdk::otel::OtelConfig::service_name: alloc::string::String
+pub bitrouter_sdk::otel::OtelConfig::traces: bitrouter_sdk::otel::TraceConfig
+impl bitrouter_sdk::otel::OtelConfig
+pub fn bitrouter_sdk::otel::OtelConfig::effective_headers(&self) -> std::collections::hash::map::HashMap<alloc::string::String, alloc::string::String>
+impl bitrouter_sdk::otel::OtelConfig
+pub fn bitrouter_sdk::otel::OtelConfig::with_env_from<F>(self, F) -> Self where F: core::ops::function::Fn(&str) -> core::option::Option<alloc::string::String>
+pub fn bitrouter_sdk::otel::OtelConfig::with_env_overrides(self) -> Self
+impl core::clone::Clone for bitrouter_sdk::otel::OtelConfig
+pub fn bitrouter_sdk::otel::OtelConfig::clone(&self) -> bitrouter_sdk::otel::OtelConfig
+impl core::default::Default for bitrouter_sdk::otel::OtelConfig
+pub fn bitrouter_sdk::otel::OtelConfig::default() -> Self
+impl core::fmt::Debug for bitrouter_sdk::otel::OtelConfig
+pub fn bitrouter_sdk::otel::OtelConfig::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl serde_core::ser::Serialize for bitrouter_sdk::otel::OtelConfig
+pub fn bitrouter_sdk::otel::OtelConfig::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::otel::OtelConfig where bitrouter_sdk::otel::OtelConfig: core::default::Default
+pub fn bitrouter_sdk::otel::OtelConfig::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::otel::OtelConfig
+impl core::marker::Send for bitrouter_sdk::otel::OtelConfig
+impl core::marker::Sync for bitrouter_sdk::otel::OtelConfig
+impl core::marker::Unpin for bitrouter_sdk::otel::OtelConfig
+impl core::marker::UnsafeUnpin for bitrouter_sdk::otel::OtelConfig
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::otel::OtelConfig
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::otel::OtelConfig
+pub struct bitrouter_sdk::otel::OtelExporter
+impl bitrouter_sdk::otel::OtelExporter
+pub fn bitrouter_sdk::otel::OtelExporter::new(bitrouter_sdk::otel::OtelConfig, core::option::Option<alloc::sync::Arc<dyn bitrouter_sdk::otel::TelemetryBearer>>) -> core::result::Result<Self, alloc::boxed::Box<dyn core::error::Error>>
+pub fn bitrouter_sdk::otel::OtelExporter::shutdown(&self)
+pub fn bitrouter_sdk::otel::OtelExporter::status(&self) -> bitrouter_sdk::otel::OtelStatus
+impl bitrouter_sdk::language_model::hooks::ObserveHook for bitrouter_sdk::otel::OtelExporter
+pub fn bitrouter_sdk::otel::OtelExporter::after_phase<'life0, 'life1, 'async_trait>(&'life0 self, bitrouter_sdk::language_model::hooks::Phase, &'life1 bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = ()> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::otel::OtelExporter::on_hop_end<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::context::PipelineContext, &'life2 bitrouter_sdk::language_model::types::RoutingTarget, bitrouter_sdk::language_model::hooks::HopOutcome<'life3>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = ()> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub fn bitrouter_sdk::otel::OtelExporter::on_hop_start<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::context::PipelineContext, &'life2 bitrouter_sdk::language_model::types::RoutingTarget) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = ()> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub fn bitrouter_sdk::otel::OtelExporter::on_request_end<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::context::PipelineContext, &'life2 bitrouter_sdk::language_model::hooks::RequestOutcome) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = ()> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub fn bitrouter_sdk::otel::OtelExporter::on_request_start<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = ()> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::otel::OtelExporter::on_stream_hop_end(&self, &str, &bitrouter_sdk::language_model::types::RoutingTarget, bitrouter_sdk::language_model::hooks::StreamHopOutcome<'_>, u64)
+pub fn bitrouter_sdk::otel::OtelExporter::on_stream_part<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::context::StreamContext, &'life2 bitrouter_sdk::language_model::types::StreamPart) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = ()> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub fn bitrouter_sdk::otel::OtelExporter::stream_interest(&self) -> bitrouter_sdk::language_model::stream::StreamInterest
+impl !core::marker::Freeze for bitrouter_sdk::otel::OtelExporter
+impl core::marker::Send for bitrouter_sdk::otel::OtelExporter
+impl core::marker::Sync for bitrouter_sdk::otel::OtelExporter
+impl core::marker::Unpin for bitrouter_sdk::otel::OtelExporter
+impl core::marker::UnsafeUnpin for bitrouter_sdk::otel::OtelExporter
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::otel::OtelExporter
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::otel::OtelExporter
+pub struct bitrouter_sdk::otel::OtelObserveHook(_)
+impl bitrouter_sdk::otel::OtelObserveHook
+pub fn bitrouter_sdk::otel::OtelObserveHook::new(alloc::sync::Arc<bitrouter_sdk::otel::OtelExporter>) -> Self
+impl bitrouter_sdk::language_model::hooks::ObserveHook for bitrouter_sdk::otel::OtelObserveHook
+pub fn bitrouter_sdk::otel::OtelObserveHook::after_phase<'life0, 'life1, 'async_trait>(&'life0 self, bitrouter_sdk::language_model::hooks::Phase, &'life1 bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = ()> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::otel::OtelObserveHook::on_hop_end<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::context::PipelineContext, &'life2 bitrouter_sdk::language_model::types::RoutingTarget, bitrouter_sdk::language_model::hooks::HopOutcome<'life3>) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = ()> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub fn bitrouter_sdk::otel::OtelObserveHook::on_hop_start<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::context::PipelineContext, &'life2 bitrouter_sdk::language_model::types::RoutingTarget) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = ()> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub fn bitrouter_sdk::otel::OtelObserveHook::on_request_end<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::context::PipelineContext, &'life2 bitrouter_sdk::language_model::hooks::RequestOutcome) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = ()> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub fn bitrouter_sdk::otel::OtelObserveHook::on_request_start<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = ()> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::otel::OtelObserveHook::on_stream_hop_end(&self, &str, &bitrouter_sdk::language_model::types::RoutingTarget, bitrouter_sdk::language_model::hooks::StreamHopOutcome<'_>, u64)
+pub fn bitrouter_sdk::otel::OtelObserveHook::on_stream_part<'life0, 'life1, 'life2, 'async_trait>(&'life0 self, &'life1 bitrouter_sdk::language_model::context::StreamContext, &'life2 bitrouter_sdk::language_model::types::StreamPart) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = ()> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait
+pub fn bitrouter_sdk::otel::OtelObserveHook::stream_interest(&self) -> bitrouter_sdk::language_model::stream::StreamInterest
+impl core::marker::Freeze for bitrouter_sdk::otel::OtelObserveHook
+impl core::marker::Send for bitrouter_sdk::otel::OtelObserveHook
+impl core::marker::Sync for bitrouter_sdk::otel::OtelObserveHook
+impl core::marker::Unpin for bitrouter_sdk::otel::OtelObserveHook
+impl core::marker::UnsafeUnpin for bitrouter_sdk::otel::OtelObserveHook
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::otel::OtelObserveHook
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::otel::OtelObserveHook
+pub struct bitrouter_sdk::otel::OtelStatus
+pub bitrouter_sdk::otel::OtelStatus::active_spans: usize
+pub bitrouter_sdk::otel::OtelStatus::api_key_cap: usize
+pub bitrouter_sdk::otel::OtelStatus::api_key_count: usize
+pub bitrouter_sdk::otel::OtelStatus::compiled_in: bool
+pub bitrouter_sdk::otel::OtelStatus::endpoint: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::otel::OtelStatus::exporter_wired: bool
+pub bitrouter_sdk::otel::OtelStatus::header_count: usize
+pub bitrouter_sdk::otel::OtelStatus::metrics_enabled: bool
+pub bitrouter_sdk::otel::OtelStatus::resource_attribute_count: usize
+pub bitrouter_sdk::otel::OtelStatus::sampler: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::otel::OtelStatus::sampler_arg: core::option::Option<f64>
+pub bitrouter_sdk::otel::OtelStatus::service_name: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::otel::OtelStatus::user_id_cap: usize
+pub bitrouter_sdk::otel::OtelStatus::user_id_count: usize
+impl core::clone::Clone for bitrouter_sdk::otel::OtelStatus
+pub fn bitrouter_sdk::otel::OtelStatus::clone(&self) -> bitrouter_sdk::otel::OtelStatus
+impl core::fmt::Debug for bitrouter_sdk::otel::OtelStatus
+pub fn bitrouter_sdk::otel::OtelStatus::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl serde_core::ser::Serialize for bitrouter_sdk::otel::OtelStatus
+pub fn bitrouter_sdk::otel::OtelStatus::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::otel::OtelStatus
+pub fn bitrouter_sdk::otel::OtelStatus::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::otel::OtelStatus
+impl core::marker::Send for bitrouter_sdk::otel::OtelStatus
+impl core::marker::Sync for bitrouter_sdk::otel::OtelStatus
+impl core::marker::Unpin for bitrouter_sdk::otel::OtelStatus
+impl core::marker::UnsafeUnpin for bitrouter_sdk::otel::OtelStatus
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::otel::OtelStatus
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::otel::OtelStatus
+pub struct bitrouter_sdk::otel::SpanAttributes(pub serde_json::map::Map<alloc::string::String, serde_json::value::Value>)
+impl bitrouter_sdk::event::PipelineEvent for bitrouter_sdk::otel::SpanAttributes
+pub fn bitrouter_sdk::otel::SpanAttributes::event_name(&self) -> &'static str
+impl core::clone::Clone for bitrouter_sdk::otel::SpanAttributes
+pub fn bitrouter_sdk::otel::SpanAttributes::clone(&self) -> bitrouter_sdk::otel::SpanAttributes
+impl core::fmt::Debug for bitrouter_sdk::otel::SpanAttributes
+pub fn bitrouter_sdk::otel::SpanAttributes::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl serde_core::ser::Serialize for bitrouter_sdk::otel::SpanAttributes
+pub fn bitrouter_sdk::otel::SpanAttributes::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl core::marker::Freeze for bitrouter_sdk::otel::SpanAttributes
+impl core::marker::Send for bitrouter_sdk::otel::SpanAttributes
+impl core::marker::Sync for bitrouter_sdk::otel::SpanAttributes
+impl core::marker::Unpin for bitrouter_sdk::otel::SpanAttributes
+impl core::marker::UnsafeUnpin for bitrouter_sdk::otel::SpanAttributes
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::otel::SpanAttributes
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::otel::SpanAttributes
+pub struct bitrouter_sdk::otel::TraceConfig
+pub bitrouter_sdk::otel::TraceConfig::batch: bitrouter_sdk::otel::BatchConfig
+impl core::clone::Clone for bitrouter_sdk::otel::TraceConfig
+pub fn bitrouter_sdk::otel::TraceConfig::clone(&self) -> bitrouter_sdk::otel::TraceConfig
+impl core::default::Default for bitrouter_sdk::otel::TraceConfig
+pub fn bitrouter_sdk::otel::TraceConfig::default() -> bitrouter_sdk::otel::TraceConfig
+impl core::fmt::Debug for bitrouter_sdk::otel::TraceConfig
+pub fn bitrouter_sdk::otel::TraceConfig::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl serde_core::ser::Serialize for bitrouter_sdk::otel::TraceConfig
+pub fn bitrouter_sdk::otel::TraceConfig::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::otel::TraceConfig where bitrouter_sdk::otel::TraceConfig: core::default::Default
+pub fn bitrouter_sdk::otel::TraceConfig::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::otel::TraceConfig
+impl core::marker::Send for bitrouter_sdk::otel::TraceConfig
+impl core::marker::Sync for bitrouter_sdk::otel::TraceConfig
+impl core::marker::Unpin for bitrouter_sdk::otel::TraceConfig
+impl core::marker::UnsafeUnpin for bitrouter_sdk::otel::TraceConfig
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::otel::TraceConfig
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::otel::TraceConfig
+pub const bitrouter_sdk::otel::DEFAULT_CONTENT_ATTR_MAX_BYTES: usize
+pub trait bitrouter_sdk::otel::TelemetryBearer: core::fmt::Debug + core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::otel::TelemetryBearer::bearer<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = core::option::Option<alloc::string::String>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub mod bitrouter_sdk::plugin
+pub enum bitrouter_sdk::plugin::MigrationContent
+pub bitrouter_sdk::plugin::MigrationContent::Sql(alloc::string::String)
+impl core::fmt::Debug for bitrouter_sdk::plugin::MigrationContent
+pub fn bitrouter_sdk::plugin::MigrationContent::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::plugin::MigrationContent
+impl core::marker::Send for bitrouter_sdk::plugin::MigrationContent
+impl core::marker::Sync for bitrouter_sdk::plugin::MigrationContent
+impl core::marker::Unpin for bitrouter_sdk::plugin::MigrationContent
+impl core::marker::UnsafeUnpin for bitrouter_sdk::plugin::MigrationContent
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::plugin::MigrationContent
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::plugin::MigrationContent
+pub struct bitrouter_sdk::plugin::MigrationItem
+pub bitrouter_sdk::plugin::MigrationItem::content: bitrouter_sdk::plugin::MigrationContent
+pub bitrouter_sdk::plugin::MigrationItem::tables: alloc::vec::Vec<alloc::string::String>
+pub bitrouter_sdk::plugin::MigrationItem::version: i64
+impl bitrouter_sdk::plugin::MigrationItem
+pub fn bitrouter_sdk::plugin::MigrationItem::sql(i64, alloc::vec::Vec<alloc::string::String>, impl core::convert::Into<alloc::string::String>) -> Self
+impl core::fmt::Debug for bitrouter_sdk::plugin::MigrationItem
+pub fn bitrouter_sdk::plugin::MigrationItem::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::plugin::MigrationItem
+impl core::marker::Send for bitrouter_sdk::plugin::MigrationItem
+impl core::marker::Sync for bitrouter_sdk::plugin::MigrationItem
+impl core::marker::Unpin for bitrouter_sdk::plugin::MigrationItem
+impl core::marker::UnsafeUnpin for bitrouter_sdk::plugin::MigrationItem
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::plugin::MigrationItem
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::plugin::MigrationItem
+pub struct bitrouter_sdk::plugin::PluginId(_)
+impl bitrouter_sdk::plugin::PluginId
+pub fn bitrouter_sdk::plugin::PluginId::as_str(&self) -> &str
+pub fn bitrouter_sdk::plugin::PluginId::new(impl core::convert::Into<alloc::string::String>) -> Self
+impl core::clone::Clone for bitrouter_sdk::plugin::PluginId
+pub fn bitrouter_sdk::plugin::PluginId::clone(&self) -> bitrouter_sdk::plugin::PluginId
+impl core::cmp::Eq for bitrouter_sdk::plugin::PluginId
+impl core::cmp::PartialEq for bitrouter_sdk::plugin::PluginId
+pub fn bitrouter_sdk::plugin::PluginId::eq(&self, &bitrouter_sdk::plugin::PluginId) -> bool
+impl core::convert::From<&str> for bitrouter_sdk::plugin::PluginId
+pub fn bitrouter_sdk::plugin::PluginId::from(&str) -> Self
+impl core::convert::From<alloc::string::String> for bitrouter_sdk::plugin::PluginId
+pub fn bitrouter_sdk::plugin::PluginId::from(alloc::string::String) -> Self
+impl core::fmt::Debug for bitrouter_sdk::plugin::PluginId
+pub fn bitrouter_sdk::plugin::PluginId::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitrouter_sdk::plugin::PluginId
+pub fn bitrouter_sdk::plugin::PluginId::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for bitrouter_sdk::plugin::PluginId
+pub fn bitrouter_sdk::plugin::PluginId::hash<__H: core::hash::Hasher>(&self, &mut __H)
+impl core::marker::StructuralPartialEq for bitrouter_sdk::plugin::PluginId
+impl core::marker::Freeze for bitrouter_sdk::plugin::PluginId
+impl core::marker::Send for bitrouter_sdk::plugin::PluginId
+impl core::marker::Sync for bitrouter_sdk::plugin::PluginId
+impl core::marker::Unpin for bitrouter_sdk::plugin::PluginId
+impl core::marker::UnsafeUnpin for bitrouter_sdk::plugin::PluginId
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::plugin::PluginId
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::plugin::PluginId
+pub mod bitrouter_sdk::server
+pub struct bitrouter_sdk::server::AppState
+pub bitrouter_sdk::server::AppState::language_model: alloc::sync::Arc<bitrouter_sdk::language_model::pipeline::Pipeline>
+pub bitrouter_sdk::server::AppState::mcp: core::option::Option<alloc::sync::Arc<bitrouter_sdk::mcp::Pipeline>>
+pub bitrouter_sdk::server::AppState::metrics_renderer: core::option::Option<alloc::sync::Arc<dyn bitrouter_sdk::metrics::MetricsRenderer>>
+pub bitrouter_sdk::server::AppState::prompt_transforms: alloc::vec::Vec<alloc::sync::Arc<dyn bitrouter_sdk::app::PromptTransform>>
+pub bitrouter_sdk::server::AppState::skip_auth: bool
+impl core::clone::Clone for bitrouter_sdk::server::AppState
+pub fn bitrouter_sdk::server::AppState::clone(&self) -> bitrouter_sdk::server::AppState
+impl core::marker::Freeze for bitrouter_sdk::server::AppState
+impl core::marker::Send for bitrouter_sdk::server::AppState
+impl core::marker::Sync for bitrouter_sdk::server::AppState
+impl core::marker::Unpin for bitrouter_sdk::server::AppState
+impl core::marker::UnsafeUnpin for bitrouter_sdk::server::AppState
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::server::AppState
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::server::AppState
+pub struct bitrouter_sdk::server::RouterOptions
+pub bitrouter_sdk::server::RouterOptions::mcp_aggregate_route: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::server::RouterOptions::omit_v1_models: bool
+pub bitrouter_sdk::server::RouterOptions::router_wrapper: core::option::Option<bitrouter_sdk::server::RouterWrapper>
+impl bitrouter_sdk::server::RouterOptions
+pub fn bitrouter_sdk::server::RouterOptions::with_router_wrapper<F>(self, F) -> Self where F: core::ops::function::Fn(axum::routing::Router) -> axum::routing::Router + core::marker::Send + core::marker::Sync + 'static
+impl core::clone::Clone for bitrouter_sdk::server::RouterOptions
+pub fn bitrouter_sdk::server::RouterOptions::clone(&self) -> bitrouter_sdk::server::RouterOptions
+impl core::default::Default for bitrouter_sdk::server::RouterOptions
+pub fn bitrouter_sdk::server::RouterOptions::default() -> bitrouter_sdk::server::RouterOptions
+impl core::marker::Freeze for bitrouter_sdk::server::RouterOptions
+impl core::marker::Send for bitrouter_sdk::server::RouterOptions
+impl core::marker::Sync for bitrouter_sdk::server::RouterOptions
+impl core::marker::Unpin for bitrouter_sdk::server::RouterOptions
+impl core::marker::UnsafeUnpin for bitrouter_sdk::server::RouterOptions
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::server::RouterOptions
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::server::RouterOptions
+pub fn bitrouter_sdk::server::build_router(bitrouter_sdk::server::AppState) -> axum::routing::Router
+pub fn bitrouter_sdk::server::build_router_with_options(bitrouter_sdk::server::AppState, bitrouter_sdk::server::RouterOptions) -> axum::routing::Router
+pub type bitrouter_sdk::server::RouterWrapper = alloc::sync::Arc<(dyn core::ops::function::Fn(axum::routing::Router) -> axum::routing::Router + core::marker::Send + core::marker::Sync)>
+pub mod bitrouter_sdk::url_validator
+pub fn bitrouter_sdk::url_validator::validate_upstream_url(&str) -> bitrouter_sdk::error::Result<()>
+pub enum bitrouter_sdk::BitrouterError
+pub bitrouter_sdk::BitrouterError::BadRequest
+pub bitrouter_sdk::BitrouterError::BadRequest::message: alloc::string::String
+pub bitrouter_sdk::BitrouterError::Forbidden(alloc::string::String)
+pub bitrouter_sdk::BitrouterError::Internal(alloc::string::String)
+pub bitrouter_sdk::BitrouterError::NotFound(alloc::string::String)
+pub bitrouter_sdk::BitrouterError::PaymentRequired(alloc::string::String)
+pub bitrouter_sdk::BitrouterError::RateLimited
+pub bitrouter_sdk::BitrouterError::RateLimited::retry_after: core::option::Option<u64>
+pub bitrouter_sdk::BitrouterError::Unauthorized(alloc::string::String)
+pub bitrouter_sdk::BitrouterError::Upstream
+pub bitrouter_sdk::BitrouterError::Upstream::message: alloc::string::String
+pub bitrouter_sdk::BitrouterError::Upstream::status: u16
+pub bitrouter_sdk::BitrouterError::UpstreamAuth
+pub bitrouter_sdk::BitrouterError::UpstreamAuth::required_scope: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::BitrouterError::UpstreamAuth::status: u16
+pub bitrouter_sdk::BitrouterError::UpstreamAuth::www_authenticate: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::BitrouterError::UpstreamBadRequest
+pub bitrouter_sdk::BitrouterError::UpstreamBadRequest::error: serde_json::value::Value
+pub bitrouter_sdk::BitrouterError::UpstreamInvalidResponse
+pub bitrouter_sdk::BitrouterError::UpstreamInvalidResponse::message: alloc::string::String
+pub bitrouter_sdk::BitrouterError::UpstreamPaymentRequired
+pub bitrouter_sdk::BitrouterError::UpstreamPaymentRequired::detail: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::BitrouterError::UpstreamPolicyViolation
+pub bitrouter_sdk::BitrouterError::UpstreamPolicyViolation::message: alloc::string::String
+pub bitrouter_sdk::BitrouterError::UpstreamRateLimited
+pub bitrouter_sdk::BitrouterError::UpstreamRateLimited::detail: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::BitrouterError::UpstreamRateLimited::retry_after: core::option::Option<u64>
+pub bitrouter_sdk::BitrouterError::UpstreamTimeout
+pub bitrouter_sdk::BitrouterError::UpstreamUnavailable
+impl bitrouter_sdk::error::BitrouterError
+pub fn bitrouter_sdk::error::BitrouterError::bad_request(impl core::fmt::Display) -> Self
+pub fn bitrouter_sdk::error::BitrouterError::error_code(&self) -> &'static str
+pub fn bitrouter_sdk::error::BitrouterError::error_type(&self) -> &'static str
+pub fn bitrouter_sdk::error::BitrouterError::internal(impl core::fmt::Display) -> Self
+pub fn bitrouter_sdk::error::BitrouterError::kind(&self) -> bitrouter_sdk::error::ErrorKind
+pub fn bitrouter_sdk::error::BitrouterError::public_message(&self) -> alloc::string::String
+pub fn bitrouter_sdk::error::BitrouterError::status(&self) -> u16
+pub fn bitrouter_sdk::error::BitrouterError::to_envelope(&self) -> bitrouter_sdk::error::ErrorEnvelope
+pub fn bitrouter_sdk::error::BitrouterError::upstream_detail(&self) -> core::option::Option<&str>
+impl axum_core::response::into_response::IntoResponse for bitrouter_sdk::error::BitrouterError
+pub fn bitrouter_sdk::error::BitrouterError::into_response(self) -> axum_core::response::Response
+impl core::clone::Clone for bitrouter_sdk::error::BitrouterError
+pub fn bitrouter_sdk::error::BitrouterError::clone(&self) -> bitrouter_sdk::error::BitrouterError
+impl core::convert::From<bitrouter_sdk::language_model::hooks::DenyReason> for bitrouter_sdk::error::BitrouterError
+pub fn bitrouter_sdk::error::BitrouterError::from(bitrouter_sdk::language_model::hooks::DenyReason) -> Self
+impl core::error::Error for bitrouter_sdk::error::BitrouterError
+impl core::fmt::Debug for bitrouter_sdk::error::BitrouterError
+pub fn bitrouter_sdk::error::BitrouterError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitrouter_sdk::error::BitrouterError
+pub fn bitrouter_sdk::error::BitrouterError::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::error::BitrouterError
+impl core::marker::Send for bitrouter_sdk::error::BitrouterError
+impl core::marker::Sync for bitrouter_sdk::error::BitrouterError
+impl core::marker::Unpin for bitrouter_sdk::error::BitrouterError
+impl core::marker::UnsafeUnpin for bitrouter_sdk::error::BitrouterError
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::error::BitrouterError
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::error::BitrouterError
+pub enum bitrouter_sdk::HookDecision
+pub bitrouter_sdk::HookDecision::Allow
+pub bitrouter_sdk::HookDecision::Deny(bitrouter_sdk::language_model::hooks::DenyReason)
+impl core::fmt::Debug for bitrouter_sdk::language_model::hooks::HookDecision
+pub fn bitrouter_sdk::language_model::hooks::HookDecision::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::language_model::hooks::HookDecision
+impl core::marker::Send for bitrouter_sdk::language_model::hooks::HookDecision
+impl core::marker::Sync for bitrouter_sdk::language_model::hooks::HookDecision
+impl core::marker::Unpin for bitrouter_sdk::language_model::hooks::HookDecision
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::hooks::HookDecision
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::hooks::HookDecision
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::hooks::HookDecision
+pub enum bitrouter_sdk::MigrationContent
+pub bitrouter_sdk::MigrationContent::Sql(alloc::string::String)
+impl core::fmt::Debug for bitrouter_sdk::plugin::MigrationContent
+pub fn bitrouter_sdk::plugin::MigrationContent::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::plugin::MigrationContent
+impl core::marker::Send for bitrouter_sdk::plugin::MigrationContent
+impl core::marker::Sync for bitrouter_sdk::plugin::MigrationContent
+impl core::marker::Unpin for bitrouter_sdk::plugin::MigrationContent
+impl core::marker::UnsafeUnpin for bitrouter_sdk::plugin::MigrationContent
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::plugin::MigrationContent
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::plugin::MigrationContent
+pub struct bitrouter_sdk::App
+impl bitrouter_sdk::app::App
+pub fn bitrouter_sdk::app::App::builder() -> bitrouter_sdk::app::AppBuilder
+pub fn bitrouter_sdk::app::App::language_model(&self) -> core::option::Option<&alloc::sync::Arc<bitrouter_sdk::language_model::pipeline::Pipeline>>
+pub fn bitrouter_sdk::app::App::mcp(&self) -> core::option::Option<&alloc::sync::Arc<bitrouter_sdk::mcp::Pipeline>>
+pub fn bitrouter_sdk::app::App::mcp_aggregate_route(&self) -> core::option::Option<&str>
+pub fn bitrouter_sdk::app::App::metrics_renderer(&self) -> core::option::Option<&alloc::sync::Arc<dyn bitrouter_sdk::metrics::MetricsRenderer>>
+pub fn bitrouter_sdk::app::App::migrations(&self) -> &[bitrouter_sdk::plugin::MigrationItem]
+pub fn bitrouter_sdk::app::App::prompt_transforms(&self) -> &[alloc::sync::Arc<dyn bitrouter_sdk::app::PromptTransform>]
+pub fn bitrouter_sdk::app::App::skip_auth(&self) -> bool
+impl bitrouter_sdk::app::App
+pub async fn bitrouter_sdk::app::App::serve(&self, &str) -> bitrouter_sdk::error::Result<()>
+pub async fn bitrouter_sdk::app::App::serve_with_router_wrapper<F>(&self, &str, F) -> bitrouter_sdk::error::Result<()> where F: core::ops::function::Fn(axum::routing::Router) -> axum::routing::Router + core::marker::Send + core::marker::Sync + 'static
+pub async fn bitrouter_sdk::app::App::serve_with_router_wrapper_and_shutdown<F, S>(&self, &str, F, S) -> bitrouter_sdk::error::Result<()> where F: core::ops::function::Fn(axum::routing::Router) -> axum::routing::Router + core::marker::Send + core::marker::Sync + 'static, S: core::future::future::Future<Output = ()> + core::marker::Send + 'static
+pub async fn bitrouter_sdk::app::App::serve_with_shutdown<S>(&self, &str, S) -> bitrouter_sdk::error::Result<()> where S: core::future::future::Future<Output = ()> + core::marker::Send + 'static
+impl core::marker::Freeze for bitrouter_sdk::app::App
+impl core::marker::Send for bitrouter_sdk::app::App
+impl core::marker::Sync for bitrouter_sdk::app::App
+impl core::marker::Unpin for bitrouter_sdk::app::App
+impl core::marker::UnsafeUnpin for bitrouter_sdk::app::App
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::app::App
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::app::App
+pub struct bitrouter_sdk::AppBuilder
+impl bitrouter_sdk::app::AppBuilder
+pub fn bitrouter_sdk::app::AppBuilder::add_migrations(&mut self, impl core::iter::traits::collect::IntoIterator<Item = bitrouter_sdk::plugin::MigrationItem>)
+pub fn bitrouter_sdk::app::AppBuilder::build(self) -> bitrouter_sdk::error::Result<bitrouter_sdk::app::App>
+pub fn bitrouter_sdk::app::AppBuilder::language_model<F>(self, F) -> Self where F: core::ops::function::FnOnce(&mut bitrouter_sdk::language_model::builder::PipelineBuilder)
+pub fn bitrouter_sdk::app::AppBuilder::language_model_builder(&mut self) -> &mut bitrouter_sdk::language_model::builder::PipelineBuilder
+pub fn bitrouter_sdk::app::AppBuilder::mcp<F>(self, F) -> Self where F: core::ops::function::FnOnce(&mut bitrouter_sdk::mcp::PipelineBuilder)
+pub fn bitrouter_sdk::app::AppBuilder::mcp_aggregate_route(self, impl core::convert::Into<alloc::string::String>) -> Self
+pub fn bitrouter_sdk::app::AppBuilder::metrics_renderer(self, alloc::sync::Arc<dyn bitrouter_sdk::metrics::MetricsRenderer>) -> Self
+pub fn bitrouter_sdk::app::AppBuilder::new() -> Self
+pub fn bitrouter_sdk::app::AppBuilder::plugin(self, impl bitrouter_sdk::app::Plugin) -> Self
+pub fn bitrouter_sdk::app::AppBuilder::prompt_transform(self, alloc::sync::Arc<dyn bitrouter_sdk::app::PromptTransform>) -> Self
+pub fn bitrouter_sdk::app::AppBuilder::skip_auth(self, bool) -> Self
+impl core::default::Default for bitrouter_sdk::app::AppBuilder
+pub fn bitrouter_sdk::app::AppBuilder::default() -> Self
+impl core::marker::Freeze for bitrouter_sdk::app::AppBuilder
+impl core::marker::Send for bitrouter_sdk::app::AppBuilder
+impl core::marker::Sync for bitrouter_sdk::app::AppBuilder
+impl core::marker::Unpin for bitrouter_sdk::app::AppBuilder
+impl core::marker::UnsafeUnpin for bitrouter_sdk::app::AppBuilder
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::app::AppBuilder
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::app::AppBuilder
+pub struct bitrouter_sdk::CallerContext
+impl bitrouter_sdk::caller::CallerContext
+pub fn bitrouter_sdk::caller::CallerContext::anonymous() -> Self
+pub fn bitrouter_sdk::caller::CallerContext::api_key_id(&self) -> &str
+pub fn bitrouter_sdk::caller::CallerContext::is_anonymous(&self) -> bool
+pub fn bitrouter_sdk::caller::CallerContext::is_local(&self) -> bool
+pub fn bitrouter_sdk::caller::CallerContext::launch_id(&self) -> core::option::Option<&str>
+pub fn bitrouter_sdk::caller::CallerContext::local() -> Self
+pub fn bitrouter_sdk::caller::CallerContext::local_launch(impl core::convert::Into<alloc::string::String>) -> Self
+pub fn bitrouter_sdk::caller::CallerContext::new(impl core::convert::Into<alloc::string::String>, impl core::convert::Into<alloc::string::String>) -> Self
+pub fn bitrouter_sdk::caller::CallerContext::user_id(&self) -> &str
+impl core::clone::Clone for bitrouter_sdk::caller::CallerContext
+pub fn bitrouter_sdk::caller::CallerContext::clone(&self) -> bitrouter_sdk::caller::CallerContext
+impl core::fmt::Debug for bitrouter_sdk::caller::CallerContext
+pub fn bitrouter_sdk::caller::CallerContext::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl serde_core::ser::Serialize for bitrouter_sdk::caller::CallerContext
+pub fn bitrouter_sdk::caller::CallerContext::serialize<__S>(&self, __S) -> core::result::Result<<__S as serde_core::ser::Serializer>::Ok, <__S as serde_core::ser::Serializer>::Error> where __S: serde_core::ser::Serializer
+impl<'de> serde_core::de::Deserialize<'de> for bitrouter_sdk::caller::CallerContext
+pub fn bitrouter_sdk::caller::CallerContext::deserialize<__D>(__D) -> core::result::Result<Self, <__D as serde_core::de::Deserializer>::Error> where __D: serde_core::de::Deserializer<'de>
+impl core::marker::Freeze for bitrouter_sdk::caller::CallerContext
+impl core::marker::Send for bitrouter_sdk::caller::CallerContext
+impl core::marker::Sync for bitrouter_sdk::caller::CallerContext
+impl core::marker::Unpin for bitrouter_sdk::caller::CallerContext
+impl core::marker::UnsafeUnpin for bitrouter_sdk::caller::CallerContext
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::caller::CallerContext
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::caller::CallerContext
+pub struct bitrouter_sdk::EventBus
+impl bitrouter_sdk::event::EventBus
+pub fn bitrouter_sdk::event::EventBus::dump_json(&self) -> serde_json::value::Value
+pub fn bitrouter_sdk::event::EventBus::emit<E: bitrouter_sdk::event::PipelineEvent>(&mut self, E)
+pub fn bitrouter_sdk::event::EventBus::get<E: bitrouter_sdk::event::PipelineEvent>(&self) -> core::option::Option<&E>
+pub fn bitrouter_sdk::event::EventBus::get_all<E: bitrouter_sdk::event::PipelineEvent>(&self) -> alloc::vec::Vec<&E>
+pub fn bitrouter_sdk::event::EventBus::has<E: bitrouter_sdk::event::PipelineEvent>(&self) -> bool
+pub fn bitrouter_sdk::event::EventBus::is_empty(&self) -> bool
+pub fn bitrouter_sdk::event::EventBus::len(&self) -> usize
+pub fn bitrouter_sdk::event::EventBus::merge_from(&mut self, bitrouter_sdk::event::EventBus)
+pub fn bitrouter_sdk::event::EventBus::new() -> Self
+impl core::clone::Clone for bitrouter_sdk::event::EventBus
+pub fn bitrouter_sdk::event::EventBus::clone(&self) -> bitrouter_sdk::event::EventBus
+impl core::default::Default for bitrouter_sdk::event::EventBus
+pub fn bitrouter_sdk::event::EventBus::default() -> bitrouter_sdk::event::EventBus
+impl core::marker::Freeze for bitrouter_sdk::event::EventBus
+impl core::marker::Send for bitrouter_sdk::event::EventBus
+impl core::marker::Sync for bitrouter_sdk::event::EventBus
+impl core::marker::Unpin for bitrouter_sdk::event::EventBus
+impl core::marker::UnsafeUnpin for bitrouter_sdk::event::EventBus
+impl !core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::event::EventBus
+impl !core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::event::EventBus
+pub struct bitrouter_sdk::MigrationItem
+pub bitrouter_sdk::MigrationItem::content: bitrouter_sdk::plugin::MigrationContent
+pub bitrouter_sdk::MigrationItem::tables: alloc::vec::Vec<alloc::string::String>
+pub bitrouter_sdk::MigrationItem::version: i64
+impl bitrouter_sdk::plugin::MigrationItem
+pub fn bitrouter_sdk::plugin::MigrationItem::sql(i64, alloc::vec::Vec<alloc::string::String>, impl core::convert::Into<alloc::string::String>) -> Self
+impl core::fmt::Debug for bitrouter_sdk::plugin::MigrationItem
+pub fn bitrouter_sdk::plugin::MigrationItem::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::plugin::MigrationItem
+impl core::marker::Send for bitrouter_sdk::plugin::MigrationItem
+impl core::marker::Sync for bitrouter_sdk::plugin::MigrationItem
+impl core::marker::Unpin for bitrouter_sdk::plugin::MigrationItem
+impl core::marker::UnsafeUnpin for bitrouter_sdk::plugin::MigrationItem
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::plugin::MigrationItem
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::plugin::MigrationItem
+pub struct bitrouter_sdk::PluginId(_)
+impl bitrouter_sdk::plugin::PluginId
+pub fn bitrouter_sdk::plugin::PluginId::as_str(&self) -> &str
+pub fn bitrouter_sdk::plugin::PluginId::new(impl core::convert::Into<alloc::string::String>) -> Self
+impl core::clone::Clone for bitrouter_sdk::plugin::PluginId
+pub fn bitrouter_sdk::plugin::PluginId::clone(&self) -> bitrouter_sdk::plugin::PluginId
+impl core::cmp::Eq for bitrouter_sdk::plugin::PluginId
+impl core::cmp::PartialEq for bitrouter_sdk::plugin::PluginId
+pub fn bitrouter_sdk::plugin::PluginId::eq(&self, &bitrouter_sdk::plugin::PluginId) -> bool
+impl core::convert::From<&str> for bitrouter_sdk::plugin::PluginId
+pub fn bitrouter_sdk::plugin::PluginId::from(&str) -> Self
+impl core::convert::From<alloc::string::String> for bitrouter_sdk::plugin::PluginId
+pub fn bitrouter_sdk::plugin::PluginId::from(alloc::string::String) -> Self
+impl core::fmt::Debug for bitrouter_sdk::plugin::PluginId
+pub fn bitrouter_sdk::plugin::PluginId::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for bitrouter_sdk::plugin::PluginId
+pub fn bitrouter_sdk::plugin::PluginId::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for bitrouter_sdk::plugin::PluginId
+pub fn bitrouter_sdk::plugin::PluginId::hash<__H: core::hash::Hasher>(&self, &mut __H)
+impl core::marker::StructuralPartialEq for bitrouter_sdk::plugin::PluginId
+impl core::marker::Freeze for bitrouter_sdk::plugin::PluginId
+impl core::marker::Send for bitrouter_sdk::plugin::PluginId
+impl core::marker::Sync for bitrouter_sdk::plugin::PluginId
+impl core::marker::Unpin for bitrouter_sdk::plugin::PluginId
+impl core::marker::UnsafeUnpin for bitrouter_sdk::plugin::PluginId
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::plugin::PluginId
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::plugin::PluginId
+pub struct bitrouter_sdk::RoutingTarget
+pub bitrouter_sdk::RoutingTarget::account_label: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::RoutingTarget::api_base: alloc::string::String
+pub bitrouter_sdk::RoutingTarget::api_base_override: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::RoutingTarget::api_key: alloc::string::String
+pub bitrouter_sdk::RoutingTarget::api_key_override: core::option::Option<alloc::string::String>
+pub bitrouter_sdk::RoutingTarget::api_protocol: bitrouter_sdk::language_model::types::ApiProtocol
+pub bitrouter_sdk::RoutingTarget::auth_scheme: bitrouter_sdk::language_model::types::AuthScheme
+pub bitrouter_sdk::RoutingTarget::chat_supports_store: core::option::Option<bool>
+pub bitrouter_sdk::RoutingTarget::chat_supports_stream_options: core::option::Option<bool>
+pub bitrouter_sdk::RoutingTarget::chat_token_limit_field: core::option::Option<bitrouter_sdk::language_model::types::ChatTokenLimitField>
+pub bitrouter_sdk::RoutingTarget::provider_name: alloc::string::String
+pub bitrouter_sdk::RoutingTarget::service_id: alloc::string::String
+impl bitrouter_sdk::language_model::types::RoutingTarget
+pub fn bitrouter_sdk::language_model::types::RoutingTarget::effective_api_base(&self) -> &str
+pub fn bitrouter_sdk::language_model::types::RoutingTarget::effective_api_key(&self) -> &str
+impl core::clone::Clone for bitrouter_sdk::language_model::types::RoutingTarget
+pub fn bitrouter_sdk::language_model::types::RoutingTarget::clone(&self) -> bitrouter_sdk::language_model::types::RoutingTarget
+impl core::fmt::Debug for bitrouter_sdk::language_model::types::RoutingTarget
+pub fn bitrouter_sdk::language_model::types::RoutingTarget::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Freeze for bitrouter_sdk::language_model::types::RoutingTarget
+impl core::marker::Send for bitrouter_sdk::language_model::types::RoutingTarget
+impl core::marker::Sync for bitrouter_sdk::language_model::types::RoutingTarget
+impl core::marker::Unpin for bitrouter_sdk::language_model::types::RoutingTarget
+impl core::marker::UnsafeUnpin for bitrouter_sdk::language_model::types::RoutingTarget
+impl core::panic::unwind_safe::RefUnwindSafe for bitrouter_sdk::language_model::types::RoutingTarget
+impl core::panic::unwind_safe::UnwindSafe for bitrouter_sdk::language_model::types::RoutingTarget
+pub const bitrouter_sdk::OTEL_ENABLED: bool
+pub trait bitrouter_sdk::FallbackPolicy: core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::FallbackPolicy::classify(&self, &bitrouter_sdk::error::BitrouterError, &bitrouter_sdk::language_model::types::RoutingTarget) -> bitrouter_sdk::language_model::hooks::FallbackDecision
+impl bitrouter_sdk::language_model::routing::FallbackPolicy for bitrouter_sdk::language_model::routing::DefaultFallbackPolicy
+pub fn bitrouter_sdk::language_model::routing::DefaultFallbackPolicy::classify(&self, &bitrouter_sdk::error::BitrouterError, &bitrouter_sdk::language_model::types::RoutingTarget) -> bitrouter_sdk::language_model::hooks::FallbackDecision
+pub trait bitrouter_sdk::MetricsRenderer: core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::MetricsRenderer::content_type(&self) -> &'static str
+pub fn bitrouter_sdk::MetricsRenderer::render(&self) -> alloc::string::String
+pub trait bitrouter_sdk::PipelineEvent: serde_core::ser::Serialize + core::any::Any + core::marker::Send + core::marker::Sync + 'static
+pub fn bitrouter_sdk::PipelineEvent::event_name(&self) -> &'static str
+impl bitrouter_sdk::event::PipelineEvent for bitrouter_sdk::otel::SpanAttributes
+pub fn bitrouter_sdk::otel::SpanAttributes::event_name(&self) -> &'static str
+pub trait bitrouter_sdk::Plugin
+pub fn bitrouter_sdk::Plugin::id(&self) -> &bitrouter_sdk::plugin::PluginId
+pub fn bitrouter_sdk::Plugin::install(&self, &mut bitrouter_sdk::app::AppBuilder)
+pub fn bitrouter_sdk::Plugin::migrations(&self) -> alloc::vec::Vec<bitrouter_sdk::plugin::MigrationItem>
+pub trait bitrouter_sdk::PreRequestHook: core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::PreRequestHook::check<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 mut bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::hooks::HookDecision>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+impl bitrouter_sdk::language_model::hooks::PreRequestHook for bitrouter_sdk::language_model::server_tools::declarations::ServerToolDeclarationsHook
+pub fn bitrouter_sdk::language_model::server_tools::declarations::ServerToolDeclarationsHook::check<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 mut bitrouter_sdk::language_model::context::PipelineContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::hooks::HookDecision>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub trait bitrouter_sdk::PromptTransform: core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::PromptTransform::apply(&self, &mut bitrouter_sdk::language_model::types::Prompt)
+pub fn bitrouter_sdk::PromptTransform::apply_with_headers(&self, &mut bitrouter_sdk::language_model::types::Prompt, &http::header::map::HeaderMap)
+impl bitrouter_sdk::app::PromptTransform for bitrouter_sdk::language_model::server_tools::fusion::alias::FusionAliasConfig
+pub fn bitrouter_sdk::language_model::server_tools::fusion::alias::FusionAliasConfig::apply(&self, &mut bitrouter_sdk::language_model::types::Prompt)
+pub fn bitrouter_sdk::language_model::server_tools::fusion::alias::FusionAliasConfig::apply_with_headers(&self, &mut bitrouter_sdk::language_model::types::Prompt, &http::header::map::HeaderMap)
+pub trait bitrouter_sdk::RoutingTable: core::marker::Send + core::marker::Sync
+pub fn bitrouter_sdk::RoutingTable::list_models(&self) -> alloc::vec::Vec<bitrouter_sdk::language_model::routing::ModelInfo>
+pub fn bitrouter_sdk::RoutingTable::model_info(&self, &str) -> core::option::Option<bitrouter_sdk::language_model::routing::ModelInfo>
+pub fn bitrouter_sdk::RoutingTable::preset_overrides<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 str) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::routing::PromptOverrides>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::RoutingTable::reload<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<()>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn bitrouter_sdk::RoutingTable::resolve_model<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 str) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::routing::ModelResolution>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::RoutingTable::route_chain<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 str, &'life2 bitrouter_sdk::language_model::routing::RoutingPrefs, &'life3 bitrouter_sdk::caller::CallerContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<alloc::vec::Vec<bitrouter_sdk::language_model::types::RoutingTarget>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub fn bitrouter_sdk::RoutingTable::route_resolved<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 str, &'life2 bitrouter_sdk::language_model::routing::RoutingPrefs, &'life3 bitrouter_sdk::caller::CallerContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<alloc::vec::Vec<bitrouter_sdk::language_model::types::RoutingTarget>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+impl bitrouter_sdk::language_model::routing::RoutingTable for bitrouter_sdk::config::routing_table::ConfigRoutingTable
+pub fn bitrouter_sdk::config::routing_table::ConfigRoutingTable::list_models(&self) -> alloc::vec::Vec<bitrouter_sdk::language_model::routing::ModelInfo>
+pub fn bitrouter_sdk::config::routing_table::ConfigRoutingTable::model_info(&self, &str) -> core::option::Option<bitrouter_sdk::language_model::routing::ModelInfo>
+pub fn bitrouter_sdk::config::routing_table::ConfigRoutingTable::preset_overrides<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 str) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::routing::PromptOverrides>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::config::routing_table::ConfigRoutingTable::reload<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<()>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn bitrouter_sdk::config::routing_table::ConfigRoutingTable::resolve_model<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 str) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::routing::ModelResolution>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::config::routing_table::ConfigRoutingTable::route_chain<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 str, &'life2 bitrouter_sdk::language_model::routing::RoutingPrefs, &'life3 bitrouter_sdk::caller::CallerContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<alloc::vec::Vec<bitrouter_sdk::language_model::types::RoutingTarget>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub fn bitrouter_sdk::config::routing_table::ConfigRoutingTable::route_resolved<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 str, &'life2 bitrouter_sdk::language_model::routing::RoutingPrefs, &'life3 bitrouter_sdk::caller::CallerContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<alloc::vec::Vec<bitrouter_sdk::language_model::types::RoutingTarget>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+impl bitrouter_sdk::language_model::routing::RoutingTable for bitrouter_sdk::language_model::routing::StaticRoutingTable
+pub fn bitrouter_sdk::language_model::routing::StaticRoutingTable::list_models(&self) -> alloc::vec::Vec<bitrouter_sdk::language_model::routing::ModelInfo>
+pub fn bitrouter_sdk::language_model::routing::StaticRoutingTable::model_info(&self, &str) -> core::option::Option<bitrouter_sdk::language_model::routing::ModelInfo>
+pub fn bitrouter_sdk::language_model::routing::StaticRoutingTable::preset_overrides<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 str) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::routing::PromptOverrides>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::routing::StaticRoutingTable::reload<'life0, 'async_trait>(&'life0 self) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<()>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+pub fn bitrouter_sdk::language_model::routing::StaticRoutingTable::resolve_model<'life0, 'life1, 'async_trait>(&'life0 self, &'life1 str) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<bitrouter_sdk::language_model::routing::ModelResolution>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
+pub fn bitrouter_sdk::language_model::routing::StaticRoutingTable::route_chain<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 str, &'life2 bitrouter_sdk::language_model::routing::RoutingPrefs, &'life3 bitrouter_sdk::caller::CallerContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<alloc::vec::Vec<bitrouter_sdk::language_model::types::RoutingTarget>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub fn bitrouter_sdk::language_model::routing::StaticRoutingTable::route_resolved<'life0, 'life1, 'life2, 'life3, 'async_trait>(&'life0 self, &'life1 str, &'life2 bitrouter_sdk::language_model::routing::RoutingPrefs, &'life3 bitrouter_sdk::caller::CallerContext) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = bitrouter_sdk::error::Result<alloc::vec::Vec<bitrouter_sdk::language_model::types::RoutingTarget>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait, 'life2: 'async_trait, 'life3: 'async_trait
+pub type bitrouter_sdk::Result<T> = core::result::Result<T, bitrouter_sdk::error::BitrouterError>

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -170,4 +170,19 @@ cargo clippy --workspace --all-targets --all-features -- -D warnings
 cargo test --workspace --all-features
 ```
 
-CI additionally runs `doc` (rustdoc under `-D warnings`), `doctest`, `feature-isolation` (the SDK's default tree stays free of axum and the OTel stack, and the two OTLP transports stay isolated), and `msrv` (pinned to Rust 1.93). AI agents should also read [`CLAUDE.md`](../CLAUDE.md).
+CI additionally runs `doc` (rustdoc under `-D warnings`), `doctest`, `feature-isolation` (the SDK's default tree stays free of axum and the OTel stack, and the two OTLP transports stay isolated), `sdk-public-api` (see below), and `msrv` (pinned to Rust 1.93). AI agents should also read [`CLAUDE.md`](../CLAUDE.md).
+
+### The `sdk-public-api` job
+
+`bitrouter-sdk` exports OTLP without making the OpenTelemetry version part of its own semver contract, which only holds while no `opentelemetry*` or `tracing_opentelemetry` type appears in any public SDK signature. The job renders the SDK's entire public surface with [`cargo public-api`](https://github.com/cargo-public-api/cargo-public-api) — one fully-qualified line per public item — greps that rendering for forbidden types, and diffs it against the committed baseline at `crates/bitrouter-sdk/public-api.txt`. The baseline half is the broader guard: any change to the SDK's public API, OTel-related or not, shows up in review as a diff instead of slipping through. Full rationale in [`OTEL_SDK_MIGRATION_SPEC.md`](OTEL_SDK_MIGRATION_SPEC.md).
+
+**If this job fails on your PR**, read which step failed. A forbidden-type or re-export failure is a real design problem — keep the OTel type out of the public signature (make it `pub(crate)`, or return `impl Trait`), do not regenerate around it. A baseline failure means your change moved the SDK's public API; if the printed diff is entirely intended, regenerate:
+
+```sh
+rustup toolchain install nightly-2026-05-05
+cargo install cargo-public-api --locked --version 0.52.0
+cargo +nightly-2026-05-05 public-api \
+  -p bitrouter-sdk --all-features --simplified > crates/bitrouter-sdk/public-api.txt
+```
+
+Both versions are pinned in `crates/bitrouter-sdk/public-api.pins`, which the CI job reads — take them from there rather than from this snippet if the two ever disagree. They are pinned because the baseline is a byte-for-byte diff: rustdoc's JSON format and `cargo public-api`'s rendering each change across releases, so regenerating on a different nightly or a newer tool rewrites the whole file. Run it on Linux or macOS; the SDK has `#[cfg(unix)]` items, so a Windows-generated baseline will not match.

--- a/docs/OTEL_SDK_MIGRATION_SPEC.md
+++ b/docs/OTEL_SDK_MIGRATION_SPEC.md
@@ -1,6 +1,7 @@
 # OTel SDK migration spec
 
-Status: **PR 1 landed.** Tracking issue #808.
+Status: **PR 1 landed; the public-API guard landed on top of it.** Tracking
+issue #808.
 
 Moves the OTLP exporter out of `crates/bitrouter-observe` into
 `crates/bitrouter-sdk` behind an `otel` feature, and deletes the observe
@@ -156,6 +157,29 @@ constraint below covers `opentelemetry*` only.
 `tower-http` is deliberately *not* on this list: `TraceLayer` never leaves
 `router_wrapper`'s closure body, so it stays a private dependency.
 
+Every claim in this section is checked, not asserted. The committed baseline at
+`crates/bitrouter-sdk/public-api.txt` renders that one function as exactly one
+line, and it is the only line in the SDK's whole public surface that mentions
+`tracing` at all:
+
+```
+pub fn bitrouter_sdk::otel::subscriber::tracing_subscriber_layer<S>(&bitrouter_sdk::otel::OtelExporter) -> impl tracing_subscriber::layer::Layer<S> where S: tracing_core::subscriber::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>
+```
+
+Three foreign types, two crates, no `tower_http` anywhere in the baseline —
+the table is complete. The baseline spells the *defining* paths
+(`tracing_subscriber::layer::Layer`, `tracing_core::subscriber::Subscriber`)
+where the table spells the re-export paths callers write; they are the same
+items.
+
+Under `--all-features` the SDK's public surface reaches fifteen foreign crates
+in total — `serde_core`, `schemars`, `serde_json`, `reqwest`,
+`agent_client_protocol_schema`, `futures_core`, `anyhow`, `http`, `axum`,
+`axum_core`, `tokio`, `rmcp`, `pin_project_lite`, `tracing_subscriber`,
+`tracing_core`. Only the last two are in scope for this document; the rest
+predate the OTel move and are listed here so the next reader does not mistake
+the two-crate claim above for a claim about the whole crate.
+
 ## Hard constraint
 
 **No `opentelemetry*` or `tracing_opentelemetry` type may appear in any public
@@ -166,9 +190,62 @@ This is what lets the SDK export OTLP without making the OpenTelemetry version
 part of its own semver contract. `tracer_clone` being `pub(crate)` is the
 load-bearing piece; see the `acp.rs` constraint above.
 
-Enforcement is by inspection today. The machine-checkable gate (a
-public-API-surface diff) needs a nightly toolchain and is deliberately a
-separate future PR.
+### How it is enforced
+
+The `sdk-public-api` CI job. It renders the SDK's whole public surface with
+`cargo public-api -p bitrouter-sdk --all-features --simplified` — one
+fully-qualified line per public item, with rustdoc's own name resolution
+already applied, which is why fields, variant payloads, generic bounds,
+associated types and aliases all collapse into a single grep. It then asserts
+four things about that one artifact:
+
+1. **The listing is real.** Two sentinels (`pub mod bitrouter_sdk::otel`, the
+   `tracing_subscriber_layer` line) must be present. Every other gate is a
+   negative assertion, and an empty or feature-less listing would satisfy them
+   all vacuously.
+2. **Hard gate.** No case-insensitive `opentelemetry` match anywhere in the
+   listing. `tracing_opentelemetry` contains `opentelemetry`, so one pattern
+   covers both crates, and folding case also catches type names like
+   `OpenTelemetryLayer`.
+3. **Re-export gate.** No verbatim `pub use opentelemetry…` /
+   `pub use tracing_opentelemetry…` in `crates/bitrouter-sdk/src/`. See the
+   known gap below for why gate 2 cannot see this on its own.
+4. **Baseline gate.** The rendering must match the committed
+   `crates/bitrouter-sdk/public-api.txt` byte for byte. A grep-only guard sees
+   a forbidden type but never *unintended public API growth*, which is how a
+   public foreign type gets added in the first place; the baseline turns every
+   public-surface change into a reviewable diff.
+
+`--simplified` (omit blanket impls) is load-bearing, not cosmetic.
+`opentelemetry` ships `impl<T> FutureExt for T`, which rustdoc attaches to
+every documented type — without the flag the listing carries 353 lines of
+`impl<T> opentelemetry::context::future_ext::FutureExt for <an SDK type>` that
+this crate never authored, and gate 2 would be permanently red. The flag drops
+them structurally, so no allow-list exists for a genuine leak to hide behind.
+
+Two things are pinned, in `crates/bitrouter-sdk/public-api.pins` — the nightly
+toolchain and the `cargo public-api` version. The baseline is a byte-for-byte
+diff, and rustdoc's JSON format and `cargo public-api`'s rendering each change
+across releases, so an unpinned either would rewrite the whole file on an
+unrelated upgrade and bury the real signal. The pins file sits beside the
+baseline, carries the regeneration command, and is the single source of truth:
+the workflow reads both values out of it rather than repeating them.
+
+### Known gap in gate 2
+
+`cargo public-api` renders a bare re-export under its **local** path. Adding
+`pub use opentelemetry_sdk::trace::SdkTracer;` to `otel/mod.rs` prints
+
+```
+pub use bitrouter_sdk::otel::SdkTracer
+```
+
+— the origin crate appears nowhere in the line, so gate 2 passes. A re-export
+whose *type name* carries "OpenTelemetry" (say `OpenTelemetrySpanExt`) does
+trip it; a neutrally-named one does not. Gate 3 closes the verbatim case at
+the source level. A re-export laundered through a local alias is out of reach
+of any lexical check, and is left to gate 4: the added line still fails the
+baseline diff, and a human has to consciously accept it to regenerate.
 
 ## Frozen: the `bitrouter-observe` config namespace
 


### PR DESCRIPTION
Implements the public-API guard that #810's spec defers to a follow-up. **Stacked on #810** — retarget to `main` once that merges.

Makes this constraint mechanical instead of review-held:

> No `opentelemetry*` or `tracing_opentelemetry` type may appear in any public `bitrouter-sdk` signature.

Inside the SDK those become semver-committed surface, so an upstream rename would become a BitRouter breaking change — on a stack whose own manifest notes the API "churns minor-to-minor".

### How

A new `sdk-public-api` job runs `cargo public-api -p bitrouter-sdk --all-features --simplified` and diffs it against a committed baseline at `crates/bitrouter-sdk/public-api.txt`. Four gates:

1. **Sentinel** — `pub mod bitrouter_sdk::otel` and the `tracing_subscriber_layer` line must be present, so an empty or feature-less listing fails loudly instead of passing the negative gates vacuously.
2. **No OTel in the listing.**
3. **No verbatim `pub use opentelemetry…` in `crates/bitrouter-sdk/src/`** — see below.
4. **Baseline diff**, with the regeneration command in the failure message.

`--simplified` is load-bearing, not cosmetic: without it the listing carries **353** lines of `impl<T> opentelemetry::…::FutureExt for <SDK type>` blanket impls. It drops them structurally, so there is no allow-list for a real leak to hide behind.

### Gate 3 exists because gate 2 has a blind spot

Found by a negative control rather than by reasoning. `cargo public-api` renders a bare re-export under its **local** path:

```rust
pub use opentelemetry_sdk::trace::SdkTracer;   // prints as: pub use bitrouter_sdk::otel::SdkTracer
```

The origin crate appears nowhere and **gate 2 passes**. The neighbouring case that *is* caught (`OpenTelemetrySpanExt`) is caught only because the type's own name contains "OpenTelemetry" — luck, not mechanism.

Gate 3 closes the verbatim form. A re-export laundered through a local alias remains beyond any lexical check; that residual falls to gate 4 and is documented in the spec under "Known gap in gate 2".

### Controls

Both run, both reverted.

- **Positive** — the baseline contains all three genuinely-public foreign types (`tracing_subscriber::layer::Layer`, `tracing_subscriber::registry::LookupSpan`, `tracing_core::subscriber::Subscriber`), on one line.
- **Negative** — flipping `tracer_clone` to `pub` fails gates 2 + 4; adding a neutrally-named re-export fails gates 3 + 4.

### Two pins, not one

`crates/bitrouter-sdk/public-api.pins` carries `toolchain=nightly-2026-05-05` and `tool=cargo-public-api@0.52.0`, and the workflow **reads** both — single source of truth, no drift between file and job.

The tool version matters as much as the toolchain: `cargo public-api`'s rendering changes across releases just like rustdoc JSON, so pinning only nightly would still let a `cargo install` rewrite the whole baseline and bury the signal.

No repo-wide `rust-toolchain.toml` — every other job stays on stable.

### Notes

- `Cargo.toml` gains `exclude = ["public-api.txt", "public-api.pins"]`; the 960 KB baseline is a CI artifact and should not ship in the published crate.
- The spec's public-type table was verified exact. It also now records that under `--all-features` the SDK's public surface reaches **fifteen** foreign crates in total — the "two crates" figure is scoped to `tracing_subscriber_layer`'s signature and was being misread as a whole-crate claim.
- No public-API problem surfaced, so nothing in #810 was changed.

⚠️ The baseline was generated on `aarch64-apple-darwin`; CI renders on `x86_64-unknown-linux-gnu`. The SDK's only platform cfg is `#[cfg(unix)]`, which holds on both, so it should match — but if the first run fails gate 4 with platform-shaped noise, that is the cause and the fix is to commit the Linux-generated listing.
