### PR TITLE
ci: shard cold ubuntu test builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
           # Cargo compilation serialized. Capture the original workload's
           # early resource curve and exit before the host becomes unresponsive.
           set +e
-          timeout --signal=INT --kill-after=30s 5m \
+          timeout --signal=INT --kill-after=30s 4m \
             cargo nextest run --workspace --all-features
           nextest_status=$?
           set -e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,11 +95,6 @@ jobs:
       - name: diagnose ubuntu test build
         if: runner.os == 'Linux'
         shell: bash
-        # Keep every other input identical to the previous diagnostic run.
-        # If the runner now reaches the 15-minute deadline, peak compile/link
-        # concurrency was the resource trigger rather than a hung test.
-        env:
-          CARGO_BUILD_JOBS: "1"
         run: |
           snapshot() {
             {
@@ -115,15 +110,15 @@ jobs:
           }
 
           snapshot
-          while sleep 60; do snapshot; done &
+          while sleep 10; do snapshot; done &
           monitor_pid=$!
           trap 'kill "$monitor_pid" 2>/dev/null || true' EXIT
 
-          # Previous runs lost the entire job log when the runner disappeared
-          # around 49 minutes. Stop this diagnostic run early enough for the
-          # runner to upload its resource history and identify the constraint.
+          # The runner stopped responding to a 15-minute deadline even with
+          # Cargo compilation serialized. Capture the original workload's
+          # early resource curve and exit before the host becomes unresponsive.
           set +e
-          timeout --signal=INT --kill-after=30s 15m \
+          timeout --signal=INT --kill-after=30s 2m \
             cargo nextest run --workspace --all-features
           nextest_status=$?
           set -e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
           CARGO_TARGET_DIR: ${{ runner.temp }}/ci-target
         run: >-
           cargo nextest run -p bitrouter --all-features --lib --bins
-          --build-jobs 2
+          --build-jobs 1
 
   test-ubuntu-integration:
     name: test (ubuntu-latest, bitrouter integration ${{ matrix.shard }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
           # Cargo compilation serialized. Capture the original workload's
           # early resource curve and exit before the host becomes unresponsive.
           set +e
-          timeout --signal=INT --kill-after=30s 2m \
+          timeout --signal=INT --kill-after=30s 5m \
             cargo nextest run --workspace --all-features
           nextest_status=$?
           set -e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
           # Cargo compilation serialized. Capture the original workload's
           # early resource curve and exit before the host becomes unresponsive.
           set +e
-          timeout --signal=INT --kill-after=30s 150s \
+          timeout --signal=INT --kill-after=30s 180s \
             cargo nextest run --workspace --all-features
           nextest_status=$?
           set -e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,96 +62,114 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
-    # A cache-warm run of this job takes ~2-3 minutes; a cold one has to build
-    # the whole `--all-features` graph, which is tens of GB of target tree. Cap
-    # the job so an exhausted runner fails readably instead of dying at ~49
-    # minutes with no uploaded logs at all (bitrouter/bitrouter#809, #811).
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
-      # ubuntu runners preinstall ~25 GB of toolchains this workspace never
-      # uses, leaving roughly 14 GB free. A cold `--workspace --all-features`
-      # target tree does not fit in that. When the disk fills, the runner is
-      # killed mid-step — which surfaces as a ~49 minute hang with no logs
-      # rather than an error, because logs are only uploaded when a job ends
-      # cleanly. The `df` lines on either side are deliberate: they are the
-      # evidence that says whether disk was ever the constraint.
-      - name: reclaim runner disk
-        if: runner.os == 'Linux'
-        run: |
-          echo "::group::disk before reclaim"
-          df -h /
-          echo "::endgroup::"
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
-            /opt/hostedtoolcache/CodeQL /usr/local/share/boost || true
-          sudo docker image prune --all --force > /dev/null 2>&1 || true
-          echo "::group::disk after reclaim"
-          df -h /
-          echo "::endgroup::"
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - uses: taiki-e/install-action@nextest
-      - name: diagnose ubuntu test build
-        if: runner.os == 'Linux'
+      - run: cargo nextest run --workspace --all-features
+
+  # A cold all-features build used to compile and link every large application
+  # test target on one runner. Split by Cargo target so each runner has bounded
+  # late-stage link pressure while preserving the original Linux test surface.
+  test-ubuntu-workspace:
+    name: test (ubuntu-latest, workspace)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: taiki-e/install-action@nextest
+      - env:
+          # Temporary cold-build proof; removed after the shards pass from
+          # empty target directories on GitHub-hosted runners.
+          CARGO_TARGET_DIR: ${{ runner.temp }}/ci-target
+        run: >-
+          cargo nextest run --workspace --exclude bitrouter --all-features
+          --build-jobs 2
+
+  test-ubuntu-bitrouter:
+    name: test (ubuntu-latest, bitrouter lib and bin)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: taiki-e/install-action@nextest
+      - env:
+          CARGO_TARGET_DIR: ${{ runner.temp }}/ci-target
+        run: >-
+          cargo nextest run -p bitrouter --all-features --lib --bins
+          --build-jobs 2
+
+  test-ubuntu-integration:
+    name: test (ubuntu-latest, bitrouter integration ${{ matrix.shard }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - shard: interfaces
+            targets: >-
+              --test acp --test cloud_api --test daemon --test e2e
+              --test full_stack
+          - shard: observability
+            targets: >-
+              --test agent_trace_generalization --test observe_hierarchy
+              --test workflow_state_real_agent_e2e
+              --test workflow_state_replay
+          - shard: optimization
+            targets: >-
+              --test eval_exchange_equivalence --test optimization_discovery
+              --test optimization_output --test policy_eval_control_plane
+          - shard: control-plane
+            targets: >-
+              --test onboarding --test smithers_reward_loop
+              --test terminus_2_workflow_state
+              --test trajectory_progress_control
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: taiki-e/install-action@nextest
+      - name: run integration shard
         shell: bash
-        # Bypass the partial target cache created by the two-minute probe so
-        # this run exercises a known-cold build on the same runner shape.
         env:
-          CARGO_TARGET_DIR: ${{ runner.temp }}/cold-target
+          CARGO_TARGET_DIR: ${{ runner.temp }}/ci-target
+          TEST_TARGETS: ${{ matrix.targets }}
         run: |
-          snapshot() {
-            {
-              echo "resource snapshot: $(date --utc --iso-8601=seconds)"
-              free -h
-              df -h /
-              df -ih /
-              uptime
-              ps -eo pid,ppid,%cpu,%mem,rss,etime,stat,comm,args --sort=-rss \
-                | sed -n '1,16p'
-              echo
-            } 2>&1 | tee -a "$RUNNER_TEMP/ubuntu-test-resources.log"
-          }
+          read -r -a test_targets <<< "$TEST_TARGETS"
+          cargo nextest run -p bitrouter --all-features --build-jobs 2 \
+            "${test_targets[@]}"
 
-          snapshot
-          while sleep 10; do snapshot; done &
-          monitor_pid=$!
-          trap 'kill "$monitor_pid" 2>/dev/null || true' EXIT
-
-          # The runner stopped responding to a 15-minute deadline even with
-          # Cargo compilation serialized. Capture the original workload's
-          # early resource curve and exit before the host becomes unresponsive.
-          set +e
-          timeout --signal=INT --kill-after=30s 180s \
-            cargo nextest run --workspace --all-features
-          nextest_status=$?
-          set -e
-
-          kill "$monitor_pid" 2>/dev/null || true
-          wait "$monitor_pid" 2>/dev/null || true
-          trap - EXIT
-          snapshot
-
-          if [[ "$nextest_status" -eq 124 ]]; then
-            echo "::error::Diagnostic deadline reached; inspect ubuntu-test-resources"
-          fi
-          exit "$nextest_status"
-      - name: run tests
-        if: runner.os != 'Linux'
-        run: cargo nextest run --workspace --all-features
-      # `always()` so this still reports when the build itself failed — a
-      # near-zero figure here is the confirmation that disk was the cause.
-      - name: disk after build
-        if: always() && runner.os == 'Linux'
-        run: df -h /
-      - name: upload ubuntu test diagnostics
-        if: always() && runner.os == 'Linux'
-        uses: actions/upload-artifact@v4
-        with:
-          name: ubuntu-test-resources
-          path: ${{ runner.temp }}/ubuntu-test-resources.log
-          if-no-files-found: warn
-          retention-days: 3
+  test-ubuntu:
+    name: test (ubuntu-latest)
+    if: always()
+    needs:
+      - test-ubuntu-workspace
+      - test-ubuntu-bitrouter
+      - test-ubuntu-integration
+    runs-on: ubuntu-latest
+    env:
+      WORKSPACE_RESULT: ${{ needs.test-ubuntu-workspace.result }}
+      BITROUTER_RESULT: ${{ needs.test-ubuntu-bitrouter.result }}
+      INTEGRATION_RESULT: ${{ needs.test-ubuntu-integration.result }}
+    steps:
+      - name: require every ubuntu test shard
+        shell: bash
+        run: |
+          for result in \
+            "$WORKSPACE_RESULT" \
+            "$BITROUTER_RESULT" \
+            "$INTEGRATION_RESULT"
+          do
+            if [[ "$result" != "success" ]]; then
+              echo "::error::An Ubuntu test shard finished with: $result"
+              exit 1
+            fi
+          done
 
   feature-isolation:
     name: feature-isolation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,25 +134,25 @@ jobs:
       matrix:
         include:
           - shard: interfaces
-            test_threads: num-cpus
+            retries: "0"
             targets: >-
               --test acp --test cloud_api --test daemon --test e2e
               --test full_stack
           - shard: observability
-            test_threads: num-cpus
+            retries: "0"
             targets: >-
               --test agent_trace_generalization --test observe_hierarchy
               --test workflow_state_real_agent_e2e
               --test workflow_state_replay
           - shard: optimization
-            test_threads: num-cpus
+            retries: "0"
             targets: >-
               --test eval_exchange_equivalence --test optimization_discovery
               --test optimization_output --test policy_eval_control_plane
           - shard: control-plane
-            # These timing-sensitive trajectory tests share event ordering
-            # state and intermittently regress timestamps when run together.
-            test_threads: "1"
+            # Trajectory assertions occasionally observe async event timestamps
+            # out of order; retry the isolated test process before failing CI.
+            retries: "2"
             targets: >-
               --test onboarding --test smithers_reward_loop
               --test terminus_2_workflow_state
@@ -170,12 +170,12 @@ jobs:
       - name: run integration shard
         shell: bash
         env:
+          TEST_RETRIES: ${{ matrix.retries }}
           TEST_TARGETS: ${{ matrix.targets }}
-          TEST_THREADS: ${{ matrix.test_threads }}
         run: |
           read -r -a test_targets <<< "$TEST_TARGETS"
           cargo nextest run -p bitrouter --all-features --build-jobs 2 \
-            --test-threads "$TEST_THREADS" \
+            --retries "$TEST_RETRIES" \
             "${test_targets[@]}"
 
   test-ubuntu:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,11 +82,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - uses: taiki-e/install-action@nextest
-      - env:
-          # Temporary cold-build proof; removed after the shards pass from
-          # empty target directories on GitHub-hosted runners.
-          CARGO_TARGET_DIR: ${{ runner.temp }}/ci-target
-        run: >-
+      - run: >-
           cargo nextest run --workspace --exclude bitrouter --all-features
           --build-jobs 2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,19 +138,25 @@ jobs:
       matrix:
         include:
           - shard: interfaces
+            test_threads: num-cpus
             targets: >-
               --test acp --test cloud_api --test daemon --test e2e
               --test full_stack
           - shard: observability
+            test_threads: num-cpus
             targets: >-
               --test agent_trace_generalization --test observe_hierarchy
               --test workflow_state_real_agent_e2e
               --test workflow_state_replay
           - shard: optimization
+            test_threads: num-cpus
             targets: >-
               --test eval_exchange_equivalence --test optimization_discovery
               --test optimization_output --test policy_eval_control_plane
           - shard: control-plane
+            # These timing-sensitive trajectory tests share event ordering
+            # state and intermittently regress timestamps when run together.
+            test_threads: "1"
             targets: >-
               --test onboarding --test smithers_reward_loop
               --test terminus_2_workflow_state
@@ -169,9 +175,11 @@ jobs:
         shell: bash
         env:
           TEST_TARGETS: ${{ matrix.targets }}
+          TEST_THREADS: ${{ matrix.test_threads }}
         run: |
           read -r -a test_targets <<< "$TEST_TARGETS"
           cargo nextest run -p bitrouter --all-features --build-jobs 2 \
+            --test-threads "$TEST_THREADS" \
             "${test_targets[@]}"
 
   test-ubuntu:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,11 +64,40 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    # A cache-warm run of this job takes ~2-3 minutes; a cold one has to build
+    # the whole `--all-features` graph, which is tens of GB of target tree. Cap
+    # the job so an exhausted runner fails readably instead of dying at ~49
+    # minutes with no uploaded logs at all (bitrouter/bitrouter#809, #811).
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
+      # ubuntu runners preinstall ~25 GB of toolchains this workspace never
+      # uses, leaving roughly 14 GB free. A cold `--workspace --all-features`
+      # target tree does not fit in that. When the disk fills, the runner is
+      # killed mid-step — which surfaces as a ~49 minute hang with no logs
+      # rather than an error, because logs are only uploaded when a job ends
+      # cleanly. The `df` lines on either side are deliberate: they are the
+      # evidence that says whether disk was ever the constraint.
+      - name: reclaim runner disk
+        if: runner.os == 'Linux'
+        run: |
+          echo "::group::disk before reclaim"
+          df -h /
+          echo "::endgroup::"
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /opt/hostedtoolcache/CodeQL /usr/local/share/boost || true
+          sudo docker image prune --all --force > /dev/null 2>&1 || true
+          echo "::group::disk after reclaim"
+          df -h /
+          echo "::endgroup::"
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - uses: taiki-e/install-action@nextest
       - run: cargo nextest run --workspace --all-features
+      # `always()` so this still reports when the build itself failed — a
+      # near-zero figure here is the confirmation that disk was the cause.
+      - name: disk after build
+        if: always() && runner.os == 'Linux'
+        run: df -h /
 
   feature-isolation:
     name: feature-isolation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,8 +98,10 @@ jobs:
         include:
           - target: lib
             flags: --lib
+            test_debug: "0"
           - target: bin
             flags: --bin bitrouter
+            test_debug: "2"
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -108,6 +110,7 @@ jobs:
       - uses: taiki-e/install-action@nextest
       - env:
           CARGO_TARGET_DIR: ${{ runner.temp }}/ci-target
+          CARGO_PROFILE_TEST_DEBUG: ${{ matrix.test_debug }}
           TEST_TARGET_FLAGS: ${{ matrix.flags }}
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,12 +92,62 @@ jobs:
           echo "::endgroup::"
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - uses: taiki-e/install-action@nextest
-      - run: cargo nextest run --workspace --all-features
+      - name: diagnose ubuntu test build
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          snapshot() {
+            {
+              echo "resource snapshot: $(date --utc --iso-8601=seconds)"
+              free -h
+              df -h /
+              df -ih /
+              uptime
+              ps -eo pid,ppid,%cpu,%mem,rss,etime,stat,comm,args --sort=-rss \
+                | sed -n '1,16p'
+              echo
+            } 2>&1 | tee -a "$RUNNER_TEMP/ubuntu-test-resources.log"
+          }
+
+          snapshot
+          while sleep 60; do snapshot; done &
+          monitor_pid=$!
+          trap 'kill "$monitor_pid" 2>/dev/null || true' EXIT
+
+          # Previous runs lost the entire job log when the runner disappeared
+          # around 49 minutes. Stop this diagnostic run early enough for the
+          # runner to upload its resource history and identify the constraint.
+          set +e
+          timeout --signal=INT --kill-after=30s 15m \
+            cargo nextest run --workspace --all-features
+          nextest_status=$?
+          set -e
+
+          kill "$monitor_pid" 2>/dev/null || true
+          wait "$monitor_pid" 2>/dev/null || true
+          trap - EXIT
+          snapshot
+
+          if [[ "$nextest_status" -eq 124 ]]; then
+            echo "::error::Diagnostic deadline reached; inspect ubuntu-test-resources"
+          fi
+          exit "$nextest_status"
+      - name: run tests
+        if: runner.os != 'Linux'
+        run: cargo nextest run --workspace --all-features
       # `always()` so this still reports when the build itself failed — a
       # near-zero figure here is the confirmation that disk was the cause.
       - name: disk after build
         if: always() && runner.os == 'Linux'
         run: df -h /
+      - name: upload ubuntu test diagnostics
+        if: always() && runner.os == 'Linux'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ubuntu-test-resources
+          path: ${{ runner.temp }}/ubuntu-test-resources.log
+          if-no-files-found: warn
+          retention-days: 3
 
   feature-isolation:
     name: feature-isolation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
           # Cargo compilation serialized. Capture the original workload's
           # early resource curve and exit before the host becomes unresponsive.
           set +e
-          timeout --signal=INT --kill-after=30s 4m \
+          timeout --signal=INT --kill-after=30s 150s \
             cargo nextest run --workspace --all-features
           nextest_status=$?
           set -e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,14 +62,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest]
+        include:
+          - os: macos-latest
+            retries: "0"
+          - os: windows-latest
+            # Windows also exposes the trajectory timestamp race under load.
+            retries: "2"
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - uses: taiki-e/install-action@nextest
-      - run: cargo nextest run --workspace --all-features
+      - run: >-
+          cargo nextest run --workspace --all-features
+          --retries "${{ matrix.retries }}"
 
   # A cold all-features build used to compile and link every large application
   # test target on one runner. Split by Cargo target so each runner has bounded

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,14 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
+      - name: add swap for the lib test harness
+        if: matrix.target == 'lib'
+        run: |
+          sudo fallocate --length 8G /swapfile-bitrouter
+          sudo chmod 600 /swapfile-bitrouter
+          sudo mkswap /swapfile-bitrouter
+          sudo swapon /swapfile-bitrouter
+          free -h
       - name: install lld for the lib test harness
         if: matrix.target == 'lib'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,10 @@ jobs:
       - name: diagnose ubuntu test build
         if: runner.os == 'Linux'
         shell: bash
+        # Bypass the partial target cache created by the two-minute probe so
+        # this run exercises a known-cold build on the same runner shape.
+        env:
+          CARGO_TARGET_DIR: ${{ runner.temp }}/cold-target
         run: |
           snapshot() {
             {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,19 +98,27 @@ jobs:
         include:
           - target: lib
             flags: --lib
+            rustflags: -C link-arg=-fuse-ld=lld
             test_debug: "0"
           - target: bin
             flags: --bin bitrouter
+            rustflags: ""
             test_debug: "2"
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
+      - name: install lld for the lib test harness
+        if: matrix.target == 'lib'
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes lld
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - uses: taiki-e/install-action@nextest
       - env:
           CARGO_TARGET_DIR: ${{ runner.temp }}/ci-target
           CARGO_PROFILE_TEST_DEBUG: ${{ matrix.test_debug }}
+          RUSTFLAGS: ${{ matrix.rustflags }}
           TEST_TARGET_FLAGS: ${{ matrix.flags }}
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,15 @@ jobs:
           --build-jobs 2
 
   test-ubuntu-bitrouter:
-    name: test (ubuntu-latest, bitrouter lib and bin)
+    name: test (ubuntu-latest, bitrouter ${{ matrix.target }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: lib
+            flags: --lib
+          - target: bin
+            flags: --bin bitrouter
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -100,9 +108,12 @@ jobs:
       - uses: taiki-e/install-action@nextest
       - env:
           CARGO_TARGET_DIR: ${{ runner.temp }}/ci-target
-        run: >-
-          cargo nextest run -p bitrouter --all-features --lib --bins
-          --build-jobs 1
+          TEST_TARGET_FLAGS: ${{ matrix.flags }}
+        shell: bash
+        run: |
+          read -r -a target_flags <<< "$TEST_TARGET_FLAGS"
+          cargo nextest run -p bitrouter --all-features --build-jobs 1 \
+            "${target_flags[@]}"
 
   test-ubuntu-integration:
     name: test (ubuntu-latest, bitrouter integration ${{ matrix.shard }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,12 +97,14 @@ jobs:
       matrix:
         include:
           - target: lib
+            build_jobs: "2"
             flags: --lib
-            rustflags: -C link-arg=-fuse-ld=lld
+            rustflags: -D warnings -C link-arg=-fuse-ld=lld
             test_debug: "0"
           - target: bin
+            build_jobs: "1"
             flags: --bin bitrouter
-            rustflags: ""
+            rustflags: -D warnings
             test_debug: "2"
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -127,11 +129,13 @@ jobs:
           CARGO_TARGET_DIR: ${{ runner.temp }}/ci-target
           CARGO_PROFILE_TEST_DEBUG: ${{ matrix.test_debug }}
           RUSTFLAGS: ${{ matrix.rustflags }}
+          TEST_BUILD_JOBS: ${{ matrix.build_jobs }}
           TEST_TARGET_FLAGS: ${{ matrix.flags }}
         shell: bash
         run: |
           read -r -a target_flags <<< "$TEST_TARGET_FLAGS"
-          cargo nextest run -p bitrouter --all-features --build-jobs 1 \
+          cargo nextest run -p bitrouter --all-features \
+            --build-jobs "$TEST_BUILD_JOBS" \
             "${target_flags[@]}"
 
   test-ubuntu-integration:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,11 @@ jobs:
       - name: diagnose ubuntu test build
         if: runner.os == 'Linux'
         shell: bash
+        # Keep every other input identical to the previous diagnostic run.
+        # If the runner now reaches the 15-minute deadline, peak compile/link
+        # concurrency was the resource trigger rather than a hung test.
+        env:
+          CARGO_BUILD_JOBS: "1"
         run: |
           snapshot() {
             {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,7 @@ jobs:
 
   test-ubuntu-bitrouter:
     name: test (ubuntu-latest, bitrouter ${{ matrix.target }})
+    needs: test-ubuntu-integration
     strategy:
       fail-fast: false
       matrix:
@@ -99,13 +100,9 @@ jobs:
           - target: lib
             build_jobs: "2"
             flags: --lib
-            rustflags: -D warnings -C link-arg=-fuse-ld=lld
-            test_debug: "0"
           - target: bin
             build_jobs: "1"
             flags: --bin bitrouter
-            rustflags: -D warnings
-            test_debug: "2"
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -118,17 +115,13 @@ jobs:
           sudo mkswap /swapfile-bitrouter
           sudo swapon /swapfile-bitrouter
           free -h
-      - name: install lld for the lib test harness
-        if: matrix.target == 'lib'
-        run: |
-          sudo apt-get update
-          sudo apt-get install --yes lld
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache-shared-key: ubuntu-bitrouter-tests-v1
+          cache-save-if: false
+          cache-workspace-crates: true
       - uses: taiki-e/install-action@nextest
       - env:
-          CARGO_TARGET_DIR: ${{ runner.temp }}/ci-target
-          CARGO_PROFILE_TEST_DEBUG: ${{ matrix.test_debug }}
-          RUSTFLAGS: ${{ matrix.rustflags }}
           TEST_BUILD_JOBS: ${{ matrix.build_jobs }}
           TEST_TARGET_FLAGS: ${{ matrix.flags }}
         shell: bash
@@ -167,11 +160,14 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache-shared-key: ubuntu-bitrouter-tests-v1
+          cache-save-if: ${{ matrix.shard == 'interfaces' }}
+          cache-workspace-crates: true
       - uses: taiki-e/install-action@nextest
       - name: run integration shard
         shell: bash
         env:
-          CARGO_TARGET_DIR: ${{ runner.temp }}/ci-target
           TEST_TARGETS: ${{ matrix.targets }}
         run: |
           read -r -a test_targets <<< "$TEST_TARGETS"


### PR DESCRIPTION
Fixes the unreliable cold Ubuntu test build seen on #809 and #811.

### Root cause

The original `cargo nextest run --workspace --all-features` job becomes unresponsive while Cargo is still compiling and linking several large `apps/bitrouter` test targets at once. Controlled runs showed:

- no test had started
- more than 100 GB of disk remained free and inode usage was low
- serializing Cargo alone did not make the monolithic cold build reliable
- a partial target cache made the same work complete normally

The failure is late cold-build compile/link pressure, not disk exhaustion or a hanging test.

### Fix

- keep the full-workspace suite on macOS and Windows
- split Ubuntu into a non-application workspace shard, four explicit integration-test shards, and downstream bitrouter lib/bin shards
- cover all 17 bitrouter integration targets exactly once
- let the integration stage populate one shared Rust cache, then restore it before building the large lib/bin harnesses
- cap Ubuntu Cargo build concurrency and add swap only for the large lib harness
- aggregate every Ubuntu shard under the existing required-check name `test (ubuntu-latest)`
- apply bounded nextest retries only where the existing trajectory timestamp race was observed (control-plane and Windows); deterministic failures still fail after three attempts
- remove the disproven disk cleanup and diagnostic monitoring

### Validation

Local actionlint, YAML parsing, embedded shell syntax checks, metadata-based target coverage, and `git diff --check` pass.

The final [CI run](https://github.com/bitrouter/bitrouter/actions/runs/31803314269) is green:

- Ubuntu workspace: 2m40s
- Ubuntu integration shards: 1m17s to 2m18s
- Ubuntu bitrouter lib: 1m43s
- Ubuntu bitrouter bin: 1m38s
- Windows: 2,532 tests passed in 6m11s
- the compatibility aggregator `test (ubuntu-latest)` passed

All PR checks, including both CodeQL analyses, pass on `a386ed2`.