### PR TITLE
feat(registry): add August official models

### DIFF
--- a/dist/registry/models.json
+++ b/dist/registry/models.json
@@ -2008,30 +2008,6 @@
           "provider_model_id": "deepseek/deepseek-v4-pro"
         },
         {
-          "api_protocol": [
-            "openai",
-            "anthropic"
-          ],
-          "capabilities": [
-            "reasoning",
-            "tools"
-          ],
-          "pricing": {
-            "input_tokens": {
-              "cache_read": 0.003625,
-              "no_cache": 0.435
-            },
-            "output_tokens": {
-              "text": 0.87
-            }
-          },
-          "provider": "deepseek",
-          "provider_model_id": "deepseek-v4-pro",
-          "rate_limits": {
-            "requests_per_minute": 60
-          }
-        },
-        {
           "api_protocol": "openai",
           "pricing": {
             "input_tokens": {
@@ -2256,6 +2232,49 @@
         }
       ],
       "release_date": "2026-04-24"
+    },
+    {
+      "description": "Generally available DeepSeek V4 Pro release for advanced reasoning, coding, and agentic workloads.",
+      "family": "deepseek-thinking",
+      "id": "deepseek/deepseek-v4-pro-0813",
+      "input_modalities": [
+        "text"
+      ],
+      "max_input_tokens": 1000000,
+      "max_output_tokens": 384000,
+      "name": "DeepSeek: DeepSeek V4 Pro 0813",
+      "open_weights": false,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.003625,
+              "no_cache": 0.435
+            },
+            "output_tokens": {
+              "text": 0.87
+            }
+          },
+          "provider": "deepseek",
+          "provider_model_id": "deepseek-v4-pro",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        }
+      ],
+      "release_date": "2026-08-13"
     },
     {
       "family": "gemini-flash-lite",
@@ -2556,6 +2575,52 @@
         }
       ],
       "release_date": "2026-05-19"
+    },
+    {
+      "description": "Efficient multimodal Gemini model for coding, agentic planning, and high-throughput workloads.",
+      "family": "gemini-flash",
+      "id": "google/gemini-3.6-flash",
+      "input_modalities": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "knowledge_cutoff": "2026-03",
+      "max_input_tokens": 1048576,
+      "max_output_tokens": 65536,
+      "name": "Google: Gemini 3.6 Flash",
+      "open_weights": false,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": [
+            "google",
+            "openai"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.15,
+              "no_cache": 1.5
+            },
+            "output_tokens": {
+              "text": 7.5
+            }
+          },
+          "provider": "google",
+          "provider_model_id": "gemini-3.6-flash",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        }
+      ],
+      "release_date": "2026-07-21"
     },
     {
       "description": "Google Gemma 4 31B — open-weight instruction-tuned vision-language model.",
@@ -7121,6 +7186,49 @@
         }
       ],
       "release_date": "2026-07-08"
+    },
+    {
+      "description": "xAI flagship for coding, reasoning, knowledge work, and agentic tool use.",
+      "family": "grok",
+      "id": "x-ai/grok-4.6",
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "knowledge_cutoff": "2026-02",
+      "max_input_tokens": 500000,
+      "name": "xAI: Grok 4.6",
+      "open_weights": false,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": [
+            "responses",
+            "openai"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 6.0
+            }
+          },
+          "provider": "xai",
+          "provider_model_id": "grok-4.6",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        }
+      ],
+      "release_date": "2026-08-12"
     },
     {
       "family": "grok",

--- a/dist/registry/providers.json
+++ b/dist/registry/providers.json
@@ -3477,13 +3477,14 @@
         {
           "api_protocol": [
             "openai",
+            "responses",
             "anthropic"
           ],
           "capabilities": [
             "reasoning",
             "tools"
           ],
-          "id": "deepseek/deepseek-v4-pro",
+          "id": "deepseek/deepseek-v4-pro-0813",
           "pricing": {
             "input_tokens": {
               "cache_read": 0.003625,
@@ -3956,6 +3957,30 @@
             }
           },
           "provider_model_id": "gemini-3.5-flash",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "google",
+            "openai"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "google/gemini-3.6-flash",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.15,
+              "no_cache": 1.5
+            },
+            "output_tokens": {
+              "text": 7.5
+            }
+          },
+          "provider_model_id": "gemini-3.6-flash",
           "rate_limits": {
             "requests_per_minute": 60
           }
@@ -8998,6 +9023,30 @@
         "terms_of_service_url": "https://x.ai/legal/terms-of-service"
       },
       "models": [
+        {
+          "api_protocol": [
+            "responses",
+            "openai"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "x-ai/grok-4.6",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 6.0
+            }
+          },
+          "provider_model_id": "grok-4.6",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
         {
           "api_protocol": [
             "responses",

--- a/docs/NEW_MODELS_2026_08_13_SPEC.md
+++ b/docs/NEW_MODELS_2026_08_13_SPEC.md
@@ -1,0 +1,156 @@
+# DeepSeek V4 Pro 0813, Grok 4.6, and Gemini 3.6 Flash Registry Design
+
+## Goal
+
+Publish three verified models in the BitRouter OSS curated registry using the
+canonical IDs exposed by OpenRouter:
+
+- `deepseek/deepseek-v4-pro-0813`
+- `x-ai/grok-4.6`
+- `google/gemini-3.6-flash`
+
+Only the three first-party model-provider entries are in scope. OpenRouter,
+BitRouter Cloud, and every other gateway or third-party provider remain
+unchanged.
+
+## Evidence and live verification
+
+OpenRouter's public `GET /api/v1/models` catalog exposes all three canonical
+IDs. First-party documentation and live APIs establish the upstream mappings
+and model facts:
+
+- DeepSeek's official pricing page identifies the current
+  `deepseek-v4-pro` API alias as model version `DeepSeek-V4-Pro-0813`, with a
+  1M-token context window, 384K maximum output, tool calling, Responses API,
+  Anthropic API, and the published token prices.
+- xAI's authenticated model endpoint exposes `grok-4.6`, a 500,000-token
+  text-and-image model, with the base and long-context token prices.
+- Google's authenticated model endpoint exposes `gemini-3.6-flash`, its input
+  and output limits, and its supported generation methods. Google's changelog
+  records the model as generally available on 2026-07-21, and its pricing page
+  publishes the token rates.
+
+The live checks used API keys injected from the Railway `production`
+environment. Their output was restricted to model metadata, response model
+versions, and usage; no credential value was printed or persisted. Minimal
+generation requests succeeded against all three first-party APIs.
+
+## Canonical models
+
+### DeepSeek V4 Pro 0813
+
+Add `deepseek/deepseek-v4-pro-0813` as a distinct canonical model. Preserve the
+existing `deepseek/deepseek-v4-pro` entry as the earlier April revision so the
+two releases are never conflated.
+
+Record:
+
+- name `DeepSeek: DeepSeek V4 Pro 0813`;
+- description identifying it as the generally available V4 Pro release;
+- text input and text output;
+- 1,000,000 maximum input tokens and 384,000 maximum output tokens;
+- release date `2026-08-13`;
+- proprietary/unpublished weights (`open_weights: false`);
+- family `deepseek-thinking`.
+
+The release date follows DeepSeek's official `0813` model-version label; the
+documentation does not yet carry a separate release-note entry for this update.
+Do not infer a knowledge cutoff because neither DeepSeek nor OpenRouter
+currently publishes one for this revision.
+
+### Grok 4.6
+
+Add `x-ai/grok-4.6` with:
+
+- name `xAI: Grok 4.6`;
+- a concise description of its coding, reasoning, and agentic positioning;
+- text and image input with text output;
+- 500,000 maximum input tokens;
+- release date `2026-08-12`;
+- February 2026 knowledge cutoff;
+- proprietary weights and family `grok`.
+
+Omit a maximum-output field because xAI's first-party model metadata does not
+publish a separate output limit.
+
+### Gemini 3.6 Flash
+
+Add `google/gemini-3.6-flash` with:
+
+- name `Google: Gemini 3.6 Flash`;
+- a concise description of its efficient multimodal agentic positioning;
+- text, image, audio, and video input with text output;
+- 1,048,576 maximum input tokens and 65,536 maximum output tokens;
+- release date `2026-07-21` and March 2026 knowledge cutoff;
+- proprietary weights and family `gemini-flash`.
+
+The registry has no `file` or `pdf` modality convention, so document inputs are
+represented through the supported media modalities rather than a new modality
+token.
+
+## First-party provider mappings
+
+### DeepSeek
+
+Move the existing upstream alias `deepseek-v4-pro` from the April canonical ID
+to `deepseek/deepseek-v4-pro-0813`. This mirrors the established V4 Flash 0731
+pattern: the first-party alias advances in place while the old canonical model
+remains available through providers that still explicitly identify it.
+
+The mapping supports OpenAI Chat Completions, Responses, and Anthropic
+protocols; advertises reasoning and tools; and uses the official prices per 1M
+tokens:
+
+- input cache miss: USD 0.435;
+- input cache hit: USD 0.003625;
+- output: USD 0.87.
+
+### xAI
+
+Map `x-ai/grok-4.6` to upstream `grok-4.6`, advertise reasoning and tools, and
+record the official base prices per 1M tokens:
+
+- input: USD 2.00;
+- cached input: USD 0.50;
+- output: USD 6.00.
+
+xAI doubles all three rates at 200,000 tokens and above. The current registry
+pricing schema cannot represent context tiers, so retain the provider file's
+existing family-level comment and store the base tier, consistent with the
+other Grok 4 mappings.
+
+### Google Gemini API
+
+Map `google/gemini-3.6-flash` to upstream `gemini-3.6-flash`, advertise
+reasoning and tools, and record the official prices per 1M tokens:
+
+- input: USD 1.50;
+- cached input: USD 0.15;
+- output, including thinking tokens: USD 7.50.
+
+## Generated artifacts and verification
+
+Rebuild and commit `dist/registry/models.json` and
+`dist/registry/providers.json`. Because this change is confined to registry
+data, repository policy explicitly says not to add model-specific Rust tests.
+Verify with:
+
+```sh
+cargo run -p dist-helper -- registry validate
+cargo run -p dist-helper -- registry build
+cargo run -p dist-helper -- check
+```
+
+Inspect the generated JSON to confirm that all three canonical entries exist,
+that only the three first-party providers gained or moved mappings, and that
+the old DeepSeek canonical entry remains present.
+
+## Non-goals
+
+- Do not modify OpenRouter, BitRouter Cloud, Vertex AI, opencode, or any other
+  non-first-party provider mapping.
+- Do not run a BitRouter Cloud end-to-end request.
+- Do not repoint third-party `deepseek-v4-pro` aliases without explicit evidence
+  that those providers advanced to the 0813 revision.
+- Do not remove or rewrite the earlier unversioned DeepSeek canonical model.
+- Do not add unrelated registry sync or Rust source changes.

--- a/registry/models/deepseek.yaml
+++ b/registry/models/deepseek.yaml
@@ -50,3 +50,16 @@
   knowledge_cutoff: 2025-05
   open_weights: true
   family: deepseek-thinking
+# Official model version and limits: https://api-docs.deepseek.com/quick_start/pricing
+- id: deepseek/deepseek-v4-pro-0813
+  name: 'DeepSeek: DeepSeek V4 Pro 0813'
+  description: Generally available DeepSeek V4 Pro release for advanced reasoning, coding, and agentic workloads.
+  input_modalities:
+  - text
+  output_modalities:
+  - text
+  max_input_tokens: 1000000
+  max_output_tokens: 384000
+  release_date: 2026-08-13
+  open_weights: false
+  family: deepseek-thinking

--- a/registry/models/google.yaml
+++ b/registry/models/google.yaml
@@ -38,6 +38,23 @@
   knowledge_cutoff: 2025-01
   open_weights: false
   family: gemini-flash
+# Official model: https://ai.google.dev/gemini-api/docs/models/gemini-3.6-flash
+- id: google/gemini-3.6-flash
+  name: 'Google: Gemini 3.6 Flash'
+  description: Efficient multimodal Gemini model for coding, agentic planning, and high-throughput workloads.
+  input_modalities:
+  - text
+  - image
+  - audio
+  - video
+  output_modalities:
+  - text
+  max_input_tokens: 1048576
+  max_output_tokens: 65536
+  release_date: 2026-07-21
+  knowledge_cutoff: 2026-03
+  open_weights: false
+  family: gemini-flash
 - id: google/gemma-4-31b
   name: 'Google: Gemma 4 31B'
   description: Google Gemma 4 31B — open-weight instruction-tuned vision-language model.

--- a/registry/models/x-ai.yaml
+++ b/registry/models/x-ai.yaml
@@ -31,6 +31,19 @@
   release_date: 2026-07-08
   open_weights: false
   family: grok
+- id: x-ai/grok-4.6
+  name: 'xAI: Grok 4.6'
+  description: xAI flagship for coding, reasoning, knowledge work, and agentic tool use.
+  input_modalities:
+  - text
+  - image
+  output_modalities:
+  - text
+  max_input_tokens: 500000
+  release_date: 2026-08-12
+  knowledge_cutoff: 2026-02
+  open_weights: false
+  family: grok
 - id: x-ai/grok-4.3
   name: 'xAI: Grok 4.3'
   input_modalities:

--- a/registry/providers/deepseek.yaml
+++ b/registry/providers/deepseek.yaml
@@ -18,8 +18,11 @@ rate_limits:
 # Catalog source: https://models.dev/api.json (provider key `deepseek`, api=https://api.deepseek.com); v3.2 is no longer served first-party.
 # Pricing is per 1M tokens.
 models:
-  - id: deepseek/deepseek-v4-pro
+  # `deepseek-v4-pro` moved in place to the 0813 GA release:
+  # https://api-docs.deepseek.com/quick_start/pricing
+  - id: deepseek/deepseek-v4-pro-0813
     provider_model_id: deepseek-v4-pro
+    api_protocol: [openai, responses, anthropic]
     pricing:
       input_tokens:
         no_cache: 0.435

--- a/registry/providers/google.yaml
+++ b/registry/providers/google.yaml
@@ -38,6 +38,18 @@ models:
     capabilities:
       - reasoning
       - tools
+  # Official pricing: https://ai.google.dev/gemini-api/docs/pricing#gemini-3.6-flash
+  - id: google/gemini-3.6-flash
+    provider_model_id: gemini-3.6-flash
+    pricing:
+      input_tokens:
+        no_cache: 1.5
+        cache_read: 0.15
+      output_tokens:
+        text: 7.5
+    capabilities:
+      - reasoning
+      - tools
   - id: google/gemini-2.5-pro-preview
     provider_model_id: gemini-2.5-pro
     pricing:

--- a/registry/providers/xai.yaml
+++ b/registry/providers/xai.yaml
@@ -15,6 +15,18 @@ rate_limits:
 # Catalog source: https://models.dev/api.json (provider key `xai`); >200k tier on Grok 4 family doubles the base price listed here.
 # Pricing is per 1M tokens.
 models:
+  # Official model and pricing: https://docs.x.ai/developers/models/grok-4.6
+  - id: x-ai/grok-4.6
+    provider_model_id: grok-4.6
+    pricing:
+      input_tokens:
+        no_cache: 2
+        cache_read: 0.5
+      output_tokens:
+        text: 6
+    capabilities:
+      - reasoning
+      - tools
   - id: x-ai/grok-4.5
     provider_model_id: grok-4.5
     # Pricing from the xAI API catalog ($2.00 in / $6.00 out per 1M, $0.50


### PR DESCRIPTION
## Summary

- add canonical registry entries for `deepseek/deepseek-v4-pro-0813`, `x-ai/grok-4.6`, and `google/gemini-3.6-flash`
- move DeepSeek's first-party `deepseek-v4-pro` rolling alias to the new 0813 canonical entry while retaining the earlier `deepseek/deepseek-v4-pro` canonical model
- add mappings only for the DeepSeek, xAI, and Google first-party providers
- rebuild the committed registry JSON artifacts

## Why

OpenRouter now exposes all three canonical model IDs. Their first-party APIs also list and serve the upstream IDs `deepseek-v4-pro`, `grok-4.6`, and `gemini-3.6-flash`, so the OSS registry can publish them without speculative third-party mappings.

## Impact

Consumers of the OSS registry can discover these three models and route BYOK requests to their official providers. OpenRouter, BitRouter, Vertex AI, opencode, and other third-party provider catalogs are intentionally unchanged.

## Validation

- `cargo run -p dist-helper -- registry validate`
- `cargo run -p dist-helper -- registry build`
- `cargo run -p dist-helper -- check`
- audited generated JSON to confirm exactly one first-party mapping per new canonical ID
- confirmed the old DeepSeek canonical entry remains and the `deepseek-v4-pro` first-party alias maps uniquely to the 0813 entry

BitRouter Cloud end-to-end testing was intentionally omitted because the pending cloud-side registry-access change is not published yet.
