### PR TITLE
fix(trajectory): hold continuation starts at episode head

### DIFF
--- a/apps/bitrouter/src/trajectory/store.rs
+++ b/apps/bitrouter/src/trajectory/store.rs
@@ -429,6 +429,7 @@ impl TrajectoryStore {
             }
             None => Vec::new(),
         };
+        let captured_at = episode_monotonic_captured_at(&prior_events, &input.captured_at)?;
         let extends_existing_episode = resolved_episode.is_some();
         let (episode_id, episode_start, sequence) = match resolved_episode {
             Some(episode) => {
@@ -514,7 +515,7 @@ impl TrajectoryStore {
                     })
                     .unwrap_or_default(),
             },
-            captured_at: input.captured_at.clone(),
+            captured_at: captured_at.clone(),
             content_digest: String::new(),
         };
         event.content_digest = event.semantic_digest()?;
@@ -535,7 +536,7 @@ impl TrajectoryStore {
                 &episode_id,
                 sequence,
                 &input.request_id,
-                &input.captured_at,
+                &captured_at,
                 completeness,
             )
             .await?;
@@ -2606,6 +2607,34 @@ async fn event_matches_existing(
     Ok(false)
 }
 
+/// Holds a new request start at the episode head when the wall clock disagrees
+/// with the episode's own ordering.
+///
+/// A start timestamp is `Utc::now()` backdated by the pipeline's monotonic
+/// elapsed time, while the preceding settlement is its start plus a monotonic
+/// duration. The two readings round independently, so a request arriving within
+/// a couple of milliseconds of its predecessor's settlement can carry a start
+/// that precedes the event it follows — which the reducer rejects as a
+/// regression. Settlement already pins itself to the last event for the same
+/// reason; do the same here rather than let a sub-millisecond turnaround fail
+/// the request.
+fn episode_monotonic_captured_at(
+    prior_events: &[TrajectoryEvent],
+    captured_at: &str,
+) -> Result<String> {
+    let Some(head) = prior_events.last() else {
+        return Ok(captured_at.to_owned());
+    };
+    let observed = chrono::DateTime::parse_from_rfc3339(captured_at)
+        .context("parsing trajectory request start timestamp")?;
+    let head_captured_at = chrono::DateTime::parse_from_rfc3339(&head.captured_at)
+        .context("parsing trajectory episode head timestamp")?;
+    if observed < head_captured_at {
+        return Ok(head.captured_at.clone());
+    }
+    Ok(captured_at.to_owned())
+}
+
 fn validate_candidate_history(
     events: &[TrajectoryEvent],
     candidate: &TrajectoryEvent,
@@ -3442,6 +3471,73 @@ mod tests {
             before
         );
         assert!(store.request("owner-a", "request-1").await?.is_none());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn continuation_start_behind_the_episode_head_is_held_at_the_head() -> anyhow::Result<()>
+    {
+        let store = store().await?;
+        seed_started_episode(
+            &store,
+            "owner-a",
+            "episode-1",
+            "request-0",
+            "2026-08-01T00:00:00.010Z",
+        )
+        .await?;
+
+        let route = guarded_route_input("route-1", "guard-1");
+        let mut input = correlate_input("request-1", "unused-new-episode", "start-1", route);
+        input.ancestor_prefix_digests = vec![keyed_digest("key-1", "2")];
+        input.starts_with_prior_turns = true;
+        input.captured_at = "2026-08-01T00:00:00.008Z".into();
+        store.correlate_and_begin("owner-a", input).await?;
+
+        let events = store.events_for_episode("owner-a", "episode-1").await?;
+        let start = events
+            .iter()
+            .find(|event| event.request_id.as_deref() == Some("request-1"))
+            .ok_or_else(|| anyhow::anyhow!("continuation start was not persisted"))?;
+        assert_eq!(start.captured_at, "2026-08-01T00:00:00.010Z");
+        assert_eq!(
+            store
+                .episode("owner-a", "episode-1")
+                .await?
+                .ok_or_else(|| anyhow::anyhow!("episode is missing"))?
+                .last_captured_at,
+            "2026-08-01T00:00:00.010Z"
+        );
+        reduce(&events, &BTreeSet::new())?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn continuation_start_ahead_of_the_episode_head_keeps_its_own_timestamp()
+    -> anyhow::Result<()> {
+        let store = store().await?;
+        seed_started_episode(
+            &store,
+            "owner-a",
+            "episode-1",
+            "request-0",
+            "2026-08-01T00:00:00.010Z",
+        )
+        .await?;
+
+        let route = guarded_route_input("route-1", "guard-1");
+        let mut input = correlate_input("request-1", "unused-new-episode", "start-1", route);
+        input.ancestor_prefix_digests = vec![keyed_digest("key-1", "2")];
+        input.starts_with_prior_turns = true;
+        input.captured_at = "2026-08-01T00:00:00.025Z".into();
+        store.correlate_and_begin("owner-a", input).await?;
+
+        let events = store.events_for_episode("owner-a", "episode-1").await?;
+        let start = events
+            .iter()
+            .find(|event| event.request_id.as_deref() == Some("request-1"))
+            .ok_or_else(|| anyhow::anyhow!("continuation start was not persisted"))?;
+        assert_eq!(start.captured_at, "2026-08-01T00:00:00.025Z");
         Ok(())
     }
 


### PR DESCRIPTION
## Problem

`test (macos-latest)` is red on `main` (run [31894568906](https://github.com/bitrouter/bitrouter/actions/runs/31894568906)), failing one test:

```
FAIL bitrouter::trajectory_progress_control
     hidden_suffix_root_detaches_only_with_the_complete_visible_prefix
streaming Responses request failed: internal error:
  trajectory correlation failed: trajectory event timestamps regress in sequence order
```

## Root cause

This is a real product bug, not a test artifact. Two event timestamps within an episode come from independent clock reads that round in opposite directions:

- **`RequestStarted`** is *backdated*: `Utc::now() - floor_ms(elapsed)` (`policy_lock.rs:2765`) — lands up to 1ms **early**.
- **`RequestSettled`** is *forward-dated*: `start + floor_ms(duration)` (`settlement.rs:216`) — lands up to 1ms **late**.

When a request arrives within ~2ms of its predecessor's settlement, its start timestamp precedes the event it follows. The reducer's monotonicity guard (`health.rs:118`) then rejects the whole request with a 500.

macOS CI just happened to land in that window; any sufficiently fast client can hit it.

## Fix

`settlement_timestamp` already clamps itself with `max(measured, head)` for exactly this reason — the continuation-start path had no equivalent. This adds `episode_monotonic_captured_at`, applied to both the start event and the episode-head reservation so the two cannot diverge.

Notes on safety:
- Event IDs derive from `stable_id(owner, request_id)`, not the timestamp, so clamping does not shift event identities.
- The clamp is a pure function of the persisted prior events, so it stays deterministic across the sequence-reservation and deterministic-start retries.

## Verification

- Two new unit tests in `trajectory::store`, covering the clamped and unclamped directions. I confirmed the behind-the-head test **fails without the fix**, reproducing the exact CI error string (`trajectory event timestamps regress in sequence order`), and passes with it.
- `cargo nextest run --workspace --all-features`: 2758 passed, 11 skipped.
- `cargo clippy --all-features` and `cargo fmt -- --check`: clean.

One caveat: the original flake did not reproduce locally (40/40 passes — the machine is too idle to hit the sub-millisecond window), so CI-level confirmation rests on the mechanism plus the unit test reproducing the identical error, rather than on observing the integration test go red then green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)