### PR TITLE
docs: harden Harbor EC2 network preflight

### DIFF
--- a/apps/bitrouter/tests/agent_trace_generalization.rs
+++ b/apps/bitrouter/tests/agent_trace_generalization.rs
@@ -842,7 +842,7 @@ async fn native_literal_histories_receive_exact_template_decisions() {
 
     let traces = capture.records();
     assert_eq!(traces.len(), 16);
-    for pair in traces.chunks_exact(4) {
+    for pair in traces.as_chunks::<4>().0 {
         assert_eq!(pair[0].harness, HarnessId::Terminus2);
         assert_eq!(pair[1].harness, HarnessId::Terminus2);
         assert_eq!(pair[2].harness, HarnessId::ClaudeCode);
@@ -872,7 +872,7 @@ async fn native_literal_histories_receive_exact_template_decisions() {
         (root_key, root_tier),
     ) in scenarios
         .iter()
-        .zip(decisions.chunks_exact(4))
+        .zip(decisions.as_chunks::<4>().0)
         .zip(root_expectations)
     {
         for root in [&pair[0], &pair[2]] {

--- a/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
@@ -239,7 +239,7 @@ fn decode_digest(value: &str) -> Option<[u8; 32]> {
         return None;
     }
     let mut digest = [0_u8; 32];
-    for (index, pair) in encoded.chunks_exact(2).enumerate() {
+    for (index, pair) in encoded.as_chunks::<2>().0.iter().enumerate() {
         let high = decode_hex_nibble(pair[0])?;
         let low = decode_hex_nibble(pair[1])?;
         digest[index] = (high << 4) | low;

--- a/skills/run-bitrouter-benchmark/SKILL.md
+++ b/skills/run-bitrouter-benchmark/SKILL.md
@@ -29,10 +29,11 @@ and stop. Do not infer an unspecified choice from local state:
 
 If the user chooses a new custom config, ask one follow-up for the entry
 preset/model, reachable provider/model targets, fallback, and credential source
-names. Do not ask AWS questions when no deployment is needed. Do not require a
-baseline when the user only wants one routed score. Treat `any` as permission
-for that named choice only; never default a different missing choice. Ask all
-remaining Stage 1 choices together.
+names. Do not require a baseline when the user only wants one routed score. Do
+not ask AWS questions when neither BitRouter AWS deployment nor a Harbor
+AWS/EC2 environment is selected. Treat `any` as permission for that named
+choice only; never default a different missing choice. Ask all remaining Stage
+1 choices together.
 
 ## 2. Inspect before asking again
 
@@ -47,7 +48,8 @@ Inspect without external mutation:
 - BitRouter endpoint provenance and health metadata where available;
 - selected config source and every provider/model/fallback reachable from its
   entry route, plus broader exposure from inherited defaults or credentials;
-- AWS profile or assume-role name only if AWS deployment was selected.
+- AWS profile or assume-role name only if BitRouter AWS deployment or a Harbor
+  AWS/EC2 environment was selected.
 
 Use read-only host discovery first. A command absent from `PATH` is unresolved,
 not proof that the software is uninstalled. After discovery, batch all access
@@ -93,14 +95,17 @@ Present one compact plan containing:
 - bounded agent-specific smoke payload, maximum requests, expected cost, the
   whole benchmark's provider-spend estimate or ceiling, and retained artifacts;
 - installs, service/config/secret-store changes, plus AWS account/principal,
-  region, resources, and cost only when applicable;
+  region, resources, cost, and—when Harbor uses EC2—the resolved controller-to-
+  sandbox address/SSH path, bootstrap egress, proposed temporary rule
+  specifications and stopping condition, and cleanup only when applicable;
 - output path and upload destination, visibility, and data sensitivity.
 
 Require one explicit confirmation before installation, service start,
 secret-store write, paid provider request, AWS mutation, benchmark launch, or
 upload. Reconfirm provider/model targets even when they came from existing
 config. Read [agents.md](references/agents.md) for agent protocol and smoke
-checks; read [aws.md](references/aws.md) only when operating on AWS.
+checks; read [aws.md](references/aws.md) when operating BitRouter or a Harbor
+EC2 environment on AWS.
 
 ## 4. Prepare the route
 
@@ -159,6 +164,6 @@ job-isolated BitRouter evidence and an explicit join.
 | Read | When |
 |---|---|
 | [agents.md](references/agents.md) | Configure or smoke Codex, Claude Code, Terminus 2, or another Harbor agent |
-| [aws.md](references/aws.md) | Operate BitRouter OSS on AWS or select IAM boundaries |
+| [aws.md](references/aws.md) | Operate BitRouter OSS or a Harbor EC2 environment on AWS, or select IAM boundaries |
 | [harbor.md](references/harbor.md) | Discover/run/resume Harbor jobs and set attempts or concurrency |
 | [publishing.md](references/publishing.md) | Preserve evidence, upload to Hub, submit officially, or make route claims |

--- a/skills/run-bitrouter-benchmark/references/aws.md
+++ b/skills/run-bitrouter-benchmark/references/aws.md
@@ -49,6 +49,40 @@ explicitly require one.
 If Harbor uses local Docker or another environment while BitRouter runs on AWS,
 do not request Harbor EC2 permissions.
 
+## Prove both SSH paths
+
+When Harbor runs from an EC2 controller, treat these as two independent paths:
+
+1. **Operator to controller.** Determine the source address from the actual SSH
+   transport. An HTTP or SOCKS proxy's observed egress is not proof of the
+   direct TCP source, and mobile or consumer networks may change it.
+2. **Controller to sandbox.** Determine the address Harbor actually selects for
+   SSH and the source address AWS will see on that path. Do not reuse the
+   operator's CIDR for this rule.
+
+Choose the sandbox address mode from observed network facts:
+
+| Harbor SSH target | Sandbox bootstrap egress | Required SSH proof |
+|---|---|---|
+| Public IP | Public IPv4 assignment plus an Internet Gateway route | A security-group reference to the controller does not authorize traffic sent to the sandbox public IP. Use a confirmed, temporary controller public-egress `/32` rule and prove controller-to-sandbox SSH. |
+| Private IP | NAT, required VPC endpoints, or an image that needs no external bootstrap downloads | A controller security-group reference can be used when both private interfaces and VPC routing permit it; prove private SSH and every bootstrap dependency. |
+
+Do not assume public and private address-selection flags from another Harbor
+version. Read the pinned backend as described in [harbor.md](harbor.md). Record
+every temporary rule ID, exact source, purpose/run tag, and creation time, then
+revoke and independently re-query each rule during cleanup.
+
+Temporary SSH rules are not governed by the deployment cleanup preference.
+Always revoke and independently re-query them at the confirmed stopping point
+and on failure or abort, even when the human retains instances, volumes, or
+other deployment resources.
+
+Prefer a stable bastion, VPN, SSM, or another approved stable operator path when
+the operator's address drifts. Never widen SSH ingress silently. If the human
+explicitly authorizes a broader emergency rule, treat it as a time-bounded
+deviation: state the exposure, preserve its exact rule ID, and revoke it at the
+confirmed stopping point.
+
 ## Operate in this order
 
 1. **Inspect.** Confirm STS identity, region, quota, existing resources, and
@@ -68,10 +102,14 @@ do not request Harbor EC2 permissions.
    TLS, BitRouter inbound authentication, and the narrow confirmed source CIDR.
    Never expose an unauthenticated starter config.
 7. **Validate.** Check service health and run the confirmed agent-specific
-   smoke from the same network path Harbor will use.
+   smoke from the same network path Harbor will use. For Harbor EC2, first run
+   one disposable canary that proves instance launch, selected SSH address,
+   authentication, sandbox bootstrap, agent/model reachability, and normal
+   instance/volume cleanup before starting the scored job.
 8. **Operate.** Monitor availability and spend without changing the frozen
    route config during a job.
-9. **Clean up.** On request, remove only recorded resources created for this
+9. **Clean up.** Always revoke and re-query recorded temporary access rules.
+   On request, remove only the other recorded resources created for this
    deployment. Re-query by exact IDs/tags and report retained resources and
    continuing cost.
 

--- a/skills/run-bitrouter-benchmark/references/harbor.md
+++ b/skills/run-bitrouter-benchmark/references/harbor.md
@@ -29,6 +29,27 @@ and include it in the resolved plan. Do not assume a package manager, virtual
 environment, path, or container runtime; do not install or upgrade silently.
 Record the effective Harbor version, launcher, and agent version with the job.
 
+### Validate the installed EC2 backend
+
+When the selected environment is EC2, inspect the pinned installation rather
+than relying on flags or constructors from another Harbor release:
+
+- confirm the EC2 environment dependency set imports successfully before
+  launch (for example, the installed AWS SDK dependency); do not assume that a
+  base Harbor install includes its EC2 extras;
+- inspect the installed run help, environment schema, and—when necessary—the
+  backend signature or source to learn its supported address-selection fields;
+- do not invent `ssh_use_private_ip` or another compatibility option merely
+  because it exists in a different version; some releases expose only a setting
+  such as `use_public_ip`;
+- confirm the address Harbor will SSH to, public-IP assignment, SSH key/user,
+  security groups, bootstrap behavior, timeouts, deletion behavior, and volume
+  cleanup from the installed contract.
+
+Read [aws.md](aws.md) for the public/private SSH-path and bootstrap-egress
+matrix. These checks are read-only discovery; include any required install or
+network correction in the resolved plan before mutation.
+
 Inspect the dataset/repository documentation and task metadata before forming a
 command. A benchmark-owned `job.yaml` or equivalent official config wins over
 generic flags: preserve its dataset revision, verifier/judges, agent constraints,
@@ -71,9 +92,12 @@ examples or uploadable manifests.
 Before the scored job:
 
 1. validate the benchmark-owned config or ad hoc command;
-2. run the confirmed bounded agent/protocol smoke;
-3. confirm a fresh output path and expected trial count;
-4. launch exactly the resolved Harbor job.
+2. for EC2, run one disposable canary through Harbor's native backend and prove
+   instance launch, the selected SSH address, authentication, Docker or other
+   sandbox bootstrap, one bounded agent/model call, and instance/volume cleanup;
+3. run any remaining confirmed bounded agent/protocol smoke;
+4. confirm a fresh output path and expected trial count;
+5. launch exactly the resolved Harbor job.
 
 Preserve all completed and failed trials. For a compatible incomplete job, use
 the installed `harbor job resume -p <JOB_DIR>` interface. Do not delete failures,


### PR DESCRIPTION
## Summary

- distinguish operator-to-controller SSH from controller-to-sandbox SSH and make proxy/direct source discovery explicit
- document pinned Harbor EC2 dependency and backend-contract inspection, including public/private address and bootstrap-egress decisions
- require a disposable Harbor-native EC2 canary and mandatory temporary security-group rule cleanup by recorded ID
- keep current Rust 1.98 CI green with three behavior-preserving fixed-chunk iteration updates

## Scope

- benchmark skill documentation plus mechanical Rust 1.98 Clippy compatibility fixes in two existing Rust files
- no Terminal-Bench-specific logic, benchmark Python, credentials, provider configuration, or single-run data
- no Superpowers planning documents in the OSS worktree

## Verification

- independent pre-edit and post-edit behavioral scenarios
- independent merge review of the skill changes and Rust compatibility updates
- skill-creator quick validator
- agentskills validator
- cargo test --all-features
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo fmt --all -- --check
- RUSTDOCFLAGS=-D warnings cargo doc --workspace --all-features --no-deps
- cargo run -p dist-helper -- check
- cargo +1.98.0 clippy --workspace --all-features --tests -- -D warnings
- cargo +1.93.0 check -p bitrouter-sdk --all-features
- cargo +1.93.0 test -p bitrouter --test agent_trace_generalization --all-features
- cargo test -p bitrouter-sdk --all-features assistant_turn_commitment_tests
