### PR TITLE
docs: sync status and launch docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Point your agent runtime at `http://localhost:4356` and any available provider i
 
 ```bash
 bitrouter start / stop / restart        # daemon lifecycle
-bitrouter status --watch                # live request stream + spend
+bitrouter status --requests             # settled requests + spend
 bitrouter route <model>                 # trace how a model name resolves
 bitrouter key sign --user <id>          # mint a scoped brvk_ API key
 bitrouter cloud keys list               # manage API keys
@@ -233,16 +233,19 @@ actually resolves. Full catalog in [`registry/`](registry/).
 ## Harness integrations
 
 BitRouter runs *under* Claude Code, Codex, and the rest — not instead of them.
-Any agent runtime that speaks OpenAI or Anthropic APIs works with it out of the box — set `OPENAI_BASE_URL=http://localhost:4356/v1` and you're done. For the four harnesses below, `bitrouter launch` does the wiring for you: it starts the harness's own native TUI with its traffic already pointed at the daemon, and never edits the harness's config files.
+Any agent runtime that speaks OpenAI or Anthropic APIs works with it out of the box — set `OPENAI_BASE_URL=http://localhost:4356/v1` for OpenAI-compatible clients or `ANTHROPIC_BASE_URL=http://localhost:4356` for Anthropic-compatible clients. For catalog harnesses with an interactive binary, `bitrouter launch` starts the harness's own native TUI without editing its config files. Routed harnesses start with traffic pointed at the daemon; own-auth harnesses start directly and say so in the startup line.
 
-| Name | Description |
+| Name | Launch behavior |
 | ---- | ----------- |
 | Claude Code | Child env overrides (`ANTHROPIC_BASE_URL`) — see the [LLM gateway guide](https://code.claude.com/docs/en/llm-gateway) for the manual form |
 | OpenAI Codex | One-shot `-c` overrides — see [custom model providers](https://developers.openai.com/codex/config-advanced#custom-model-providers) for the manual form |
 | OpenCode | Synthesized `OPENCODE_CONFIG`; models via [models.dev](https://github.com/anomalyco/models.dev) |
 | Pi-Agent | Synthesized `PI_CODING_AGENT_DIR` — see the [model configuration guide](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/models.md) for the manual form |
+| Hermes | Synthesized `HERMES_HOME` with a loopback `custom` provider |
+| OpenClaw | Synthesized `OPENCLAW_STATE_DIR` plus `OPENCLAW_CONFIG_PATH` |
+| Grok / Antigravity (`agy`) | Own-auth launch: not redirected or metered by `launch`; those sessions remain usable by the daemon as provider capacity |
 
-`launch` supports these four because every promise it makes — routing and gateway injection — has to be re-verified per harness against upstream releases nobody controls. Four is a surface that stays honest.
+Routing and gateway injection are per-harness promises, so the table calls out the maintained mechanisms instead of implying one universal redirect path.
 
 Headless ACP sub-agents use `bitrouter spawn` instead. The full provider and harness catalog lives in [github.com/bitrouter/bitrouter/registry](https://github.com/bitrouter/bitrouter/tree/main/registry).
 

--- a/apps/bitrouter/src/main.rs
+++ b/apps/bitrouter/src/main.rs
@@ -386,17 +386,18 @@ enum Command {
         #[command(subcommand)]
         action: AgentsAction,
     },
-    /// Launch a coding-agent harness as an interactive native-TUI child, with
-    /// its API base URL pointed at the local BitRouter daemon. The human drives
-    /// the harness's own TUI directly (use `bitrouter spawn` for headless ACP
-    /// sub-agents). Follows `cargo run`'s separator convention: bitrouter
-    /// options come before `--`, everything after `--` is forwarded to the
-    /// agent verbatim, e.g. `bitrouter launch -a codex -- --search`.
+    /// Launch a coding-agent harness as an interactive native-TUI child. Routed
+    /// harnesses are pointed at the local BitRouter daemon; own-auth harnesses
+    /// launch directly and are not redirected. The human drives the harness's
+    /// own TUI directly (use `bitrouter spawn` for headless ACP sub-agents).
+    /// Follows `cargo run`'s separator convention: bitrouter options come
+    /// before `--`, everything after `--` is forwarded to the agent verbatim,
+    /// e.g. `bitrouter launch -a codex -- --search`.
     ///
     /// Harnesses that route by env/args (claude, codex) are launched without
-    /// touching any config file. Those that can only be routed by config
-    /// (opencode, pi) get one synthesized under `.bitrouter/launch/` — your
-    /// own agent config is still never modified.
+    /// touching any config file. Those that route by synthesized config
+    /// (opencode, pi, hermes, openclaw) get it under `.bitrouter/launch/` —
+    /// your own agent config is still never modified.
     ///
     /// The agent authenticates to BitRouter with `BITROUTER_API_KEY` when it is
     /// set; otherwise a local placeholder is used (fine under the `skip_auth`
@@ -404,10 +405,12 @@ enum Command {
     /// binary is offered for install via its official native installer; other
     /// harnesses report their own install command instead.
     Launch {
-        /// Which agent harness to launch: `claude`, `codex`, `opencode`, or
-        /// `pi` (catalog ids `claude-acp`, `codex-acp`, `pi-acp` also
-        /// resolve). `hermes`, `openclaw`, `grok`, and `agy` are no longer
-        /// launch-supported — run them directly or via `bitrouter spawn`.
+        /// Which agent harness to launch: any catalog harness with an
+        /// interactive binary (`claude`, `codex`, `opencode`, `pi`, `hermes`,
+        /// `openclaw`, `grok`, or `agy`; catalog ids such as `claude-acp`,
+        /// `codex-acp`, `pi-acp`, and `hermes-acp` also resolve). Own-auth
+        /// harnesses such as `grok` and `agy` launch direct and are not
+        /// redirected.
         #[arg(short, long, value_name = "ID")]
         agent: String,
         /// Pin the harness's model to a daemon-routable id (e.g. the explicit
@@ -423,9 +426,9 @@ enum Command {
         /// → zero-config in-memory defaults.
         #[arg(short, long)]
         config: Option<PathBuf>,
-        /// Override the agent's API base URL instead of deriving it from
-        /// `server.listen` (e.g. when the daemon listens on a non-default
-        /// address or a remote BitRouter).
+        /// Override the BitRouter daemon base URL used by routed harnesses
+        /// instead of deriving it from `server.listen`. Own-auth harnesses are
+        /// not redirected.
         #[arg(long)]
         base_url: Option<String>,
         /// Never offer to install a missing agent — fail with the install

--- a/apps/bitrouter/src/spawn.rs
+++ b/apps/bitrouter/src/spawn.rs
@@ -1,10 +1,11 @@
 //! `bitrouter launch` — launch a coding-agent harness (Claude Code, Codex, …)
-//! as an interactive native-TUI child process with its API base URL pointed at
-//! the local BitRouter daemon. This is the interactive surface; headless
-//! ACP sub-agents are `bitrouter spawn` (see [`crate::acp_cli`]). Both draw
-//! their routing knowledge from the shared [`crate::harness`] catalog.
+//! as an interactive native-TUI child process. Routed harnesses are pointed at
+//! the local BitRouter daemon; own-auth harnesses launch directly. This is the
+//! interactive surface; headless ACP sub-agents are `bitrouter spawn` (see
+//! [`crate::acp_cli`]). Both draw their routing knowledge from the shared
+//! [`crate::harness`] catalog.
 //!
-//! The agent's traffic then routes through BitRouter without ever touching the
+//! Routed agent traffic goes through BitRouter without ever touching the
 //! agent's own config files: instead of mutating `~/.claude/config.json` or
 //! `~/.codex/config.toml` (the
 //! "config takeover" model used by some switcher tools — invasive, needs
@@ -17,6 +18,8 @@
 //! repo's `.bitrouter/launch/` and pointing the harness at it with an env var
 //! — still never touching the user's own config
 //! ([`crate::harness::Harness::launch_overlay`]).
+//! Own-auth harnesses (`grok`, `agy`) are subscription clients the daemon
+//! borrows as providers, so `launch` does not redirect or meter them.
 //!
 //! CLI shape follows `cargo run`'s separator convention so there is no
 //! ambiguity about which flags belong to which program:
@@ -202,8 +205,9 @@ pub struct SpawnOptions {
     /// Arguments forwarded verbatim to the agent binary (everything the
     /// caller put after `--`).
     pub agent_args: Vec<String>,
-    /// Explicit base URL override. When `None` it is derived from the
-    /// daemon's `server.listen`.
+    /// Explicit BitRouter daemon base URL override for routed harnesses. When
+    /// `None` it is derived from the daemon's `server.listen`; own-auth
+    /// harnesses are not redirected.
     pub base_url: Option<String>,
     /// When true, never offer to install a missing agent — error instead.
     /// (Set by `--no-install`, or implied when stdin is not a TTY.)
@@ -329,10 +333,10 @@ pub async fn run(
 }
 
 /// Resolve the base URL from `cfg`, locate the agent binary (offering to
-/// install it if missing and permitted), ensure the local daemon is up
-/// (auto-starting it when down), assemble the routing overlay, and state what
-/// the harness is actually getting (§796) — everything up to, but not
-/// including, the child process.
+/// install it if missing and permitted), ensure the local daemon is up when a
+/// routed harness will use it (auto-starting it when down), assemble the launch
+/// overlay, and state what the harness is actually getting (§796) — everything
+/// up to, but not including, the child process.
 pub async fn prepare<'a>(
     source: &'a crate::paths::ConfigSource,
     cfg: &bitrouter_sdk::config::Config,
@@ -360,10 +364,12 @@ pub async fn prepare<'a>(
     // Locate the binary; prompt-to-install when it's missing.
     let binary = ensure_harness_installed(harness, opts.no_install).await?;
 
-    // Make sure the daemon the agent will talk to is up. For the local daemon
-    // we own (derived base URL + a loopback/wildcard bind), probe its control
-    // socket and auto-start it when down; for an explicit `--base-url` or a
-    // non-local bind we can only warn — we can't start someone else's daemon.
+    // Make sure the daemon a routed harness will talk to is up. For the local
+    // daemon we own (derived base URL + a loopback/wildcard bind), probe its
+    // control socket and auto-start it when down; for an explicit `--base-url`
+    // or a non-local bind we can only warn — we can't start someone else's
+    // daemon. Own-auth harnesses are not redirected, but the probe still gives
+    // a useful daemon-readiness signal for provider borrowing.
     if opts.base_url.is_none() && listen_is_local(&cfg.server.listen) {
         ensure_local_daemon(source, cfg, opts.no_start).await;
     } else {

--- a/apps/bitrouter/src/tui/render.rs
+++ b/apps/bitrouter/src/tui/render.rs
@@ -106,9 +106,8 @@ pub fn footer(snapshot: &Snapshot) -> String {
     line
 }
 
-/// The whole snapshot as plain text — what a redirected or piped
-/// `status --watch` prints once before exiting, so the view stays scriptable
-/// instead of refusing to run without a terminal.
+/// The whole snapshot as plain text — printed identically whether stdout is a
+/// terminal, a pager, a file, or an agent-readable pipe.
 pub fn oneshot(snapshot: &Snapshot) -> String {
     let mut out = String::new();
     out.push_str(&snapshot.state_line());

--- a/apps/bitrouter/src/tui/snapshot.rs
+++ b/apps/bitrouter/src/tui/snapshot.rs
@@ -104,8 +104,8 @@ pub async fn poll(
     // NOTE: which branch ran is *not* recorded, so the bar cannot say whether
     // its figures are the session's or every caller's — the honesty rule
     // `chat`'s cost line keeps (see `crate::chat::cost`) has no equivalent
-    // here yet. Labelling it is a change to what `status --watch` draws, not a
-    // refactor, so it is left to one.
+    // here yet. Labelling it is a change to what the status formatter draws,
+    // not a refactor, so it is left to one.
     if let Some(launch) = launch_id {
         let summary = store
             .spend_summary_for_launch(launch, window)

--- a/docs/ACP_TUI_PLAN.md
+++ b/docs/ACP_TUI_PLAN.md
@@ -5,6 +5,11 @@ Companion to [`ACP_TUI_SPEC.md`](ACP_TUI_SPEC.md). The spec holds the
 completion criteria*. Scope is the spec's **v1 column only** (§12) — every v2
 row is out of scope here.
 
+> **Historical note (2026-08-16):** this plan predates the removal of
+> `status --watch`. Steps that say to leave it untouched describe the state of
+> the implementation when the plan was executed; the current status surface is
+> `bitrouter status --requests`.
+
 Designed to be driven by `/goal`. See §A for the loop protocol and §B for the
 goal conditions to paste.
 
@@ -146,8 +151,10 @@ TUI; ACP v2.
   - Depends on: 1.1
   - Files: `apps/bitrouter/src/tui/{host,pty,term,lifecycle,conformance}.rs`,
     `apps/bitrouter/src/tui/fixtures/`, `scripts/record-vt-fixture.sh`
-  - Do: delete those files and their `mod` declarations in `tui/mod.rs`. Keep
-    `watch.rs`, `render.rs`, `snapshot.rs`, and `run_watch`/`oneshot_text`.
+  - Do: delete those files and their `mod` declarations in `tui/mod.rs`. At the
+    time this plan ran, `watch.rs`, `render.rs`, `snapshot.rs`, and
+    `run_watch`/`oneshot_text` survived; `watch.rs` was later removed with
+    `status --watch`.
   - Done when: those paths do not exist and `tui/mod.rs` declares only the
     surviving modules.
   - Verify: `cargo build -p bitrouter 2>&1 | tail -5`

--- a/docs/ACP_TUI_SPEC.md
+++ b/docs/ACP_TUI_SPEC.md
@@ -2,6 +2,10 @@
 
 Status: **proposed** · Author: Claude (with Spikel) · Date: 2026-08-13
 
+> **Historical note (2026-08-16):** `status --watch` was later removed in favor
+> of `bitrouter status --requests`; references below to it being untouched or
+> authoritative describe the codebase state when this spec was written.
+
 Supersedes the `launch --tui` half of
 [`OBSERVABILITY_TUI_SPEC.md`](OBSERVABILITY_TUI_SPEC.md) (#782) and retires
 [`TUI_FIDELITY_MATRIX.md`](TUI_FIDELITY_MATRIX.md) with it. Leaves
@@ -56,8 +60,8 @@ decision at n=4, and the stale text is still in source in two places.
 They are a deliberate split, and each is coherent alone:
 
 - Want Claude Code's own plan mode, slash commands, and native affordances?
-  `bitrouter launch` — inherited, zero BitRouter terminal code, all nine
-  harnesses.
+  `bitrouter launch` — inherited, zero BitRouter terminal code, all launchable
+  catalog harnesses.
 - Want to swap **agent and model** freely with router-measured cost? The ACP
   TUI.
 
@@ -99,8 +103,8 @@ independent of hosting; only `exec_hosted` goes.
 
 Removed dependencies: `alacritty_terminal`, `portable-pty`, `termwiz`,
 `wezterm-input-types` (`termwiz` alone resolves ~107 crates for three imported
-symbols). `ratatui` and `crossterm` stay — `status --watch` and the new TUI
-both need them.
+symbols). The final tree keeps `crossterm` in the app for terminal I/O and
+`ratatui` behind `crates/bitrouter-tui`; `status --watch` was later removed.
 
 **Supporting evidence, verified.** These are not the reason to delete it, but
 they establish that the code was not load-bearing:
@@ -474,10 +478,10 @@ The honesty problem is solved there too
 > way, instead of showing an empty session forever or, worse, showing the
 > daemon's numbers as if they were the session's.*
 
-That is the fix for the fidelity matrix's defect #1, already written. So:
-**share `snapshot.rs` and `Scope`; keep `watch.rs` and this TUI as separate
-renderers over it.** That yields what merging would actually buy — one data
-layer, consistent numbers, honest attribution — without merging the views.
+That was the proposed fix for the fidelity matrix's defect #1. The final tree
+keeps chat cost scope in `crates/bitrouter-tui::cost::Scope` with the
+BitRouter-specific wire key in `apps/bitrouter/src/chat/cost.rs`; the removed
+`status --watch` view no longer shares a renderer with chat.
 
 **Carry the caveat.** For a subscription harness that ignores the injected
 credential (Claude Code on Max), requests never reach the daemon, so session

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -47,7 +47,8 @@ alone in *serving* is still ACP: `providers/list` renders in the crate because
 is what the protocol does not carry — the `_meta` key naming a cost figure's
 scope (`apps/bitrouter/src/chat/cost.rs`), this process's stdin and signals,
 and anything needing `Config` or the control socket. The check is mechanical:
-`grep -rn "bitrouter/" crates/bitrouter-tui/src` must return nothing.
+`rg -n "bitrouter/costScope|COST_SCOPE_META_KEY" crates/bitrouter-tui/src`
+must return nothing.
 
 Where a control's honesty depends on something ACP does not carry, the crate
 takes it as a **parameter** rather than inferring it — `Picker::open` takes
@@ -179,9 +180,11 @@ Daemon control (`stop` / `restart` / `reload` / `status` / `route`) runs over a 
 
 ### Observability surfaces (`apps/bitrouter/src/tui/`)
 
-One surface, with `render.rs` / `snapshot.rs` as its formatting and data layers:
+One surface remains, with `snapshot.rs` as its data layer and `render.rs` as its formatter:
 
-- `bitrouter status --watch` — the live view (`tui/watch.rs`). Unix-only and gated in exactly one place, `#[cfg(unix)] mod watch;`. Piping it prints a single snapshot and exits, which is the path that stays portable.
+- `bitrouter status --requests` (`-r`) — one plain-text snapshot of settled requests plus daemon-wide spend and request rate. It reads the metering store directly, works with no daemon (`history only`), prints identically when piped, and can be repeated externally with `watch -n1`.
+
+There is no terminal-only status view now. `apps/bitrouter` no longer depends on `ratatui`; `crates/bitrouter-tui` owns drawn terminal UI for ACP chat.
 
 The hosted mode `bitrouter launch --tui` and its VT emulator (`tui/host.rs`, `tui/term.rs`, `tui/pty.rs`, `tui/conformance.rs`, `tui/fixtures/`) are **deleted**, along with the fidelity matrix that gated them and the `alacritty_terminal` / `portable-pty` / `termwiz` / `wezterm-input-types` dependencies. See [`ACP_TUI_SPEC.md`](ACP_TUI_SPEC.md) for the reasoning and for what replaces it — an inline-viewport ACP client rather than a terminal emulator.
 

--- a/docs/OBSERVABILITY_TUI_SPEC.md
+++ b/docs/OBSERVABILITY_TUI_SPEC.md
@@ -14,15 +14,16 @@
 > must say whose spend it is. `status --requests` still does not label its
 > scope; see `crate::chat::cost` for the rule applied properly.
 
-Status: **`status --watch` implemented and authoritative; the `launch --tui`
-half is superseded by [`ACP_TUI_SPEC.md`](ACP_TUI_SPEC.md)** · Author: Claude
-(with Spikel) · Date: 2026-08-10
+Status: **historical; both `status --watch` and `launch --tui` are
+superseded** · Author: Claude (with Spikel) · Date: 2026-08-10
 Issues: #782 (hosted bar) · #797 (live view) · #795 (attribution) · #796 (startup line)
 Supersedes the CLI framing of #782 (`bitrouter top`, `bitrouter tui` deprecation).
 
-> **This spec is half live.** Everything about `bitrouter status --watch` — §1,
-> §§4–8, §10.1, §13.2–13.3 — describes what ships today and remains the
-> authority for that view.
+> **This spec is historical.** Everything about `bitrouter status --watch` — §1,
+> §§4–8, §10.1, §13.2–13.3 — describes the removed ratatui live view. The
+> shipped status implementation is the `Snapshot` data layer rendered by
+> `bitrouter status --requests`; see [`CLI.md`](CLI.md) and
+> [`DEVELOPMENT.md`](DEVELOPMENT.md).
 >
 > Everything about `bitrouter launch --tui` — the hosted mode, the emulator,
 > the PTY host, the pinned status bar, and the fidelity matrix that gated them

--- a/docs/TUI_RENDERER_PLAN.md
+++ b/docs/TUI_RENDERER_PLAN.md
@@ -5,6 +5,13 @@ Companion to [`TUI_RENDERER_SPEC.md`](TUI_RENDERER_SPEC.md). The spec holds the
 criteria*. Scope is the spec's **v1 column only** (§15) — every "later" row is
 out of scope here.
 
+> **Implementation note (2026-08-24):** this plan records an execution plan, not
+> the final mainline boundary. The current tree keeps `ratatui` out of
+> `apps/bitrouter`, keeps `cost.rs` and `picker.rs` in `crates/bitrouter-tui`,
+> deletes `viewport.rs`, and has no `status --watch` / `watch.rs`. Older Phase 4
+> app-only boundary wording is historical and should not be used as current
+> implementation instructions.
+
 Designed to be driven by `/goal`. See §A for the loop protocol and §E for the
 goal strings.
 
@@ -75,8 +82,9 @@ From the spec, restated so this file is usable alone:
 8. **Mode 2026 is emitted unconditionally.** No capability detection (§4.4).
 9. **One owner of stdin, raw mode for the session**, which means we own Ctrl-C
    and Ctrl-D and must supply a single-line editor (§13.1).
-10. **`cost.rs` and `picker.rs` move to `apps/bitrouter` whole**, tests included
-    (§8).
+10. **Final boundary:** `cost.rs` and `picker.rs` stay in
+    `crates/bitrouter-tui`; BitRouter-specific `_meta` keys, metering, control
+    socket, and config access stay in `apps/bitrouter` (§8 update).
 
 ### C.1 Decisions required before Phase 2 starts
 
@@ -101,7 +109,8 @@ These are spec §19 open questions. Phase 1 does not depend on them; Phase 2 doe
   and `ProviderInfo` that way — so the decision is to keep one dependency edge
   rather than add a second to the same crate, which would then have to be held
   in version lockstep and could otherwise compile the app against a different
-  schema than the SDK. Task 4.1 rewrites the moved files' imports; no manifest
+  schema than the SDK. The final boundary keeps renderer imports in
+  `bitrouter-tui` and app wire conversion in `apps/bitrouter`; no manifest
   changes.
 
 ---
@@ -131,8 +140,8 @@ renderer and are worth having even if §19.1 goes the other way.
   - Depends on: 1.1
   - Files: `apps/bitrouter/src/acp_cli.rs`, `apps/bitrouter/src/tui/lifecycle.rs`
   - Do: reuse the existing handle-free `restore()` (`lifecycle.rs:44`) and
-    `install_panic_restore()` (`:56`), and register
-    `ShutdownSignals::install()` (`tui/watch.rs:185`) as a `select!` arm.
+    `install_panic_restore()` (`:56`), and register shutdown-signal handling as
+    a `select!` arm.
     Extend `restore()` to disable raw mode if it does not already. Normal exit,
     panic, and INT/TERM/HUP must all land there.
   - Done when: a test or a documented manual check shows the terminal is out of
@@ -256,7 +265,7 @@ left the old stack intact.
   - Files: `apps/bitrouter/src/acp_cli.rs`
   - Do: replace `Transcript` with `Journal` and `Inline` with the writer.
     Compose the footer (spec §4.5) from cost, route, mode, title and the pending
-    permission — cost still via the crate's `cost.rs`, which moves in 4.1. Drop
+    permission — cost still via the crate's `cost.rs`. Drop
     the turn-end `flush()`. Route `log_tail` to a direct stdout write after
     teardown (spec §10).
   - Done when: `bitrouter chat` renders a session with in-place tool-call
@@ -281,27 +290,31 @@ left the old stack intact.
   - Verify: `cargo nextest run --all-features 2>&1 | tail -15 && cargo clippy --all-features 2>&1 | tail -5 && cargo fmt -- --check`
   - Commit: — (tick only)
 
-### Phase 4 — Moves, new surfaces, and lockstep
+### Phase 4 — Final boundary, new surfaces, and lockstep
 
-- [x] **4.1 Move `cost.rs` to the app, whole**
+- [x] **4.1 Keep the cost surface boundary explicit**
   - Depends on: 3.3, and §C.1's §19.5 decision recorded
-  - Files: `crates/bitrouter-tui/src/cost.rs` → `apps/bitrouter/src/chat/cost.rs`
-  - Do: move the constant, `Scope`, `from_usage`, `render`, `unreported`, and
-    **all five tests**. The crate keeps nothing of it — `from_usage` reads the
-    constant, so the split rev 2 proposed does not compile.
-  - Done when: `crates/bitrouter-tui/src/cost.rs` does not exist and the five
-    tests pass in their new home.
+  - Files: `crates/bitrouter-tui/src/cost.rs`,
+    `apps/bitrouter/src/chat/cost.rs`
+  - Do: keep `Cost` / `Scope` rendering in the TUI crate, keep the
+    BitRouter-specific `_meta` key and wire conversion in the app, and make the
+    caller pass a scope explicitly.
+  - Done when: `crates/bitrouter-tui/src/cost.rs` exists, the app owns
+    `COST_SCOPE_META_KEY`, and cost tests pass in both locations.
   - Verify: `cargo nextest run --all-features cost 2>&1 | tail -10`
-  - Commit: `refactor(tui): move the cost surface to the app`
+  - Commit: `refactor(tui): keep cost scope at the boundary`
 
-- [x] **4.2 Move `picker.rs` to the app, whole**
+- [x] **4.2 Keep the provider picker protocol-shaped**
   - Depends on: 4.1
-  - Files: `crates/bitrouter-tui/src/picker.rs` → `apps/bitrouter/src/chat/picker.rs`
-  - Do: move it as plain app code with **no registry entry** — it is not a
-    `_meta` surface (spec §7). Its five tests move with it.
-  - Done when: `crates/bitrouter-tui/src/picker.rs` does not exist.
+  - Files: `crates/bitrouter-tui/src/picker.rs`,
+    `apps/bitrouter/src/acp_cli.rs`
+  - Do: keep the picker in the TUI crate because it renders ACP
+    `ProviderInfo`; the app decides whether it is available and applies the
+    selected route.
+  - Done when: `crates/bitrouter-tui/src/picker.rs` exists, reads only ACP
+    provider data, and picker tests pass.
   - Verify: `cargo nextest run --all-features picker 2>&1 | tail -10`
-  - Commit: `refactor(tui): move the provider picker to the app`
+  - Commit: `refactor(tui): keep picker on ACP provider data`
 
 - [x] **4.3 Render the five forwarded variants**
   - Depends on: 3.3
@@ -332,11 +345,12 @@ left the old stack intact.
   - Do: normalize the one odd fixture path (`log_tail.rs:81`, `:91`) from
     `/home/u/.bitrouter/logs/session-1.log` to `/tmp/session-1.log`, matching
     the file's other three fixtures. Then run spec §16.5's checks.
-  - Done when: `grep -rn "bitrouter/" crates/bitrouter-tui/src` returns nothing;
-    `cargo tree -p bitrouter-tui` shows no `bitrouter`; `cost.rs`, `picker.rs`,
-    and `viewport.rs` do not exist; and the app-side renderer module references
-    no `Config`, metering, or control socket.
-  - Verify: `grep -rn "bitrouter/" crates/bitrouter-tui/src && echo "FAIL: matches above" || echo "PASS: no matches"`
+  - Done when: `cargo tree -p bitrouter-tui` shows no `bitrouter`;
+    `apps/bitrouter` has no direct `ratatui` dependency; `cost.rs` and
+    `picker.rs` remain in the TUI crate; `viewport.rs` does not exist; and the
+    app owns metering, config, control socket, and BitRouter-specific `_meta`
+    keys.
+  - Verify: `cargo tree -p bitrouter-tui && cargo tree -p bitrouter | rg 'bitrouter-tui|ratatui'`
   - Commit: `test(tui): make the crate boundary check satisfiable`
 
 - [x] **4.6 Lockstep the docs**
@@ -385,7 +399,7 @@ Work through Phase 3 of docs/TUI_RENDERER_PLAN.md following its §A loop protoco
 **Phase 4**
 
 ```
-Work through Phase 4 of docs/TUI_RENDERER_PLAN.md following its §A loop protocol: one task per turn, first unchecked task whose dependencies are met, tick its checkbox and commit. Done when tasks 4.1-4.7 are checked AND the final turn shows `cargo nextest run --all-features`, `cargo clippy --all-features`, and `cargo fmt -- --check` all passing, AND the transcript shows `grep -rn "bitrouter/" crates/bitrouter-tui/src` returning nothing. cost.rs and picker.rs move WHOLE to apps/bitrouter, tests included — do not split them. The picker gets no registry entry; it is not a _meta surface. Before task 4.1, confirm the §19.5 schema-types decision is recorded in §C.1 — if it is not, print BLOCKED and stop. A cancelled turn with an outstanding permission must resolve to deny, never to consent. Never use #[allow], .unwrap, .expect or panic!. Print the full Phase 4 checklist and a `PLAN STATUS:` line every turn, and paste each Verify command's real output — do not summarise it. Stop after 35 turns.
+Work through Phase 4 of docs/TUI_RENDERER_PLAN.md following its §A loop protocol: one task per turn, first unchecked task whose dependencies are met, tick its checkbox and commit. Done when tasks 4.1-4.7 are checked AND the final turn shows `cargo nextest run --all-features`, `cargo clippy --all-features`, and `cargo fmt -- --check` all passing, AND the transcript shows the final crate boundary: `cargo tree -p bitrouter-tui` has no `bitrouter` crate, `apps/bitrouter` has no direct `ratatui` dependency, `cost.rs` and `picker.rs` remain in `crates/bitrouter-tui`, and `viewport.rs` is gone. Before task 4.1, confirm the §19.5 schema-types decision is recorded in §C.1 — if it is not, print BLOCKED and stop. A cancelled turn with an outstanding permission must resolve to deny, never to consent. Never use #[allow], .unwrap, .expect or panic!. Print the full Phase 4 checklist and a `PLAN STATUS:` line every turn, and paste each Verify command's real output — do not summarise it. Stop after 35 turns.
 ```
 
 ---

--- a/docs/TUI_RENDERER_SPEC.md
+++ b/docs/TUI_RENDERER_SPEC.md
@@ -1,6 +1,14 @@
 # Spec: the TUI renderer — a retained journal behind a differential writer
 
-Status: **proposed** · Author: Claude (with Spikel) · Date: 2026-08-14 · Rev 3
+Status: **historical design record; final boundary differs in Phase 4** ·
+Author: Claude (with Spikel) · Date: 2026-08-14 · Rev 3
+
+> **Implementation note (2026-08-24):** the final mainline renderer kept the
+> `ratatui` dependency out of `apps/bitrouter`, kept `cost.rs` and `picker.rs`
+> in `crates/bitrouter-tui`, deleted `viewport.rs`, and later removed
+> `status --watch` / `watch.rs`. References below to moving those two renderers
+> into the app or reusing watcher helpers are retained only as design history
+> unless a later note corrects them.
 
 Companion plan: [`TUI_RENDERER_PLAN.md`](TUI_RENDERER_PLAN.md) — numbered tasks
 and gates, per the house pattern set by
@@ -378,8 +386,7 @@ second.
 - **Preemption:** an immediate render cancels any pending tick render and clears
   the dirty flag, so at most one frame is ever in flight.
 - **Resize** is observed as `crossterm::event::Event::Resize` on §13.1's single
-  stdin owner — the same mechanism `apps/bitrouter/src/tui/watch.rs:158` already
-  uses — and triggers an immediate full redraw.
+  stdin owner and triggers an immediate full redraw.
 
   > **Not yet wired.** Nothing observes `Event::Resize`, so there is no resize
   > trigger and the scheduler carries no variant for one. A resize is still
@@ -475,10 +482,10 @@ with no expressible entries is exactly the dead weight §11 refuses.
 One registry keyed on `ToolKey` remains, with a default renderer for anything
 unregistered. v1 registers three or four.
 
-## 8. Decision 6 — the crate boundary moves to where it was aimed
+## 8. Decision 6 — the crate boundary follows BitRouter-specific knowledge
 
-> **PARTLY SUPERSEDED 2026-08-16.** `picker.rs` moved back into
-> `crates/bitrouter-tui`, and `cost.rs` split rather than staying whole. The
+> **PARTLY SUPERSEDED 2026-08-16.** `picker.rs` remains in
+> `crates/bitrouter-tui`, and `cost.rs` is split rather than app-only. The
 > rule this section states — the boundary is drawn on BitRouter-specific
 > *knowledge*, not on the fact of rendering — is unchanged and is what the
 > reversal applies. What was wrong was the classification, on evidence this
@@ -490,7 +497,7 @@ unregistered. v1 registers three or four.
 >   type was in scope there the whole time. The argument below — *"`providers/*`
 >   is BitRouter's, no generic agent serves it"* — is about who implements the
 >   **server** side, which is not what the charter asks. `Cargo.lock` carries
->   one schema version, so the move was a `git mv` plus one import line.
+>   one schema version, so keeping it in the crate is a boundary correction.
 > - **The "caller composes it" rationale was already satisfied by a parameter.**
 >   `Picker::open(available, …)` takes the capability answer as an argument; the
 >   module's *location* never contributed to it.
@@ -505,9 +512,9 @@ unregistered. v1 registers three or four.
 > (terminal custody was split across the boundary with an ordering contract
 > documented on both sides), and `snapshot.rs`'s `Scope` was deleted — with
 > `as_wire`'s only caller gone it had no reader, and `Snapshot.scope` never had
-> one. **`status --watch` therefore still draws an unlabelled spend figure**,
-> which is the honesty rule below applied to `chat` and not to the bar. Fixing
-> that is a change to what the bar draws, and is not in this amendment.
+> one. The removed `status --watch` view never received that honesty fix; the
+> daemon-wide status formatter is now `status --requests`, separate from this
+> renderer amendment.
 
 `bitrouter-tui`'s doc says it *"must never depend on `bitrouter`"* and that the
 build enforces it. True — but it enforces the boundary against the **crate**,
@@ -516,23 +523,24 @@ not against **BitRouter-specific knowledge**, of which the crate has plenty:
 `bitrouter/costScope`, and `picker.rs` renders `providers/*`, which no generic
 agent serves.
 
-- `crates/bitrouter-tui` keeps the writer, journal, `ToolRenderer`, the registry,
-  and the generic ACP renderers. It knows ACP and nothing else.
-- **`cost.rs` moves whole** to `apps/bitrouter` — constant, `Scope`,
-  `from_usage`, `render`, `unreported`, and all five tests. The split rev 2
-  proposed does not compile: `from_usage` reads the constant, and every test
-  builds fixtures through it (`cost.rs:78`, `:141`).
-- **`picker.rs` moves whole** to `apps/bitrouter` as plain app code with no
-  registry entry, and its five tests move with it.
+- `crates/bitrouter-tui` keeps the writer, journal, `ToolRenderer`, the
+  registry, the generic ACP renderers, `cost.rs`, and `picker.rs`. It may render
+  ACP schema types and caller-supplied scope, but it must not depend on the
+  `bitrouter` crate.
+- **`cost.rs` stays in `crates/bitrouter-tui`**. `Scope` remains a parameter,
+  and the BitRouter-specific `_meta` key that answers it lives in
+  `apps/bitrouter/src/chat/cost.rs`.
+- **`picker.rs` stays in `crates/bitrouter-tui`** because it renders the ACP
+  `ProviderInfo` shape from `providers/list`; the app decides whether the
+  picker is available and applies the selected route.
 
-The app already depends on `ratatui`, so constructing `Line`s there leaks
-nothing new. It does need ACP schema types it does not currently name directly —
-§19.5.
+The app deliberately does not depend on `ratatui`; `apps/bitrouter/Cargo.toml`
+keeps that as a compile-time boundary and routes all drawn terminal UI through
+`crates/bitrouter-tui`.
 
-**A guard, because this moves rendering back where it can reach anything.** The
-moved renderers live in one module that may not reference `Config`, the metering
-store, or the control socket, and take only values already on the ACP wire. §16
-asserts it.
+**Boundary guard.** The rendering crate may not depend on the `bitrouter` crate,
+and any BitRouter-only key, metering store, control socket, or config access
+stays in the app. §16 states the acceptance checks.
 
 **`Capabilities` is deleted, not collapsed.** It is constructed nowhere outside
 its own tests today — the live gate is the app's `can_reroute()`. `providers`
@@ -594,15 +602,16 @@ existing `Prompt::deny()` path, so a cancelled turn never resolves to consent.
   stdout after teardown has restored the terminal**, not through the writer:
   abnormal exit is exactly when `prev`/`anchor` are least trustworthy. **3 tests
   survive as-is; 1 has its fixture normalized** (§16.4).
-- **`cost.rs`** — moves whole to the app (§8). **5 tests move.**
-- **`picker.rs`** — moves whole to the app (§8). **5 tests move.**
+- **`cost.rs`** — stays in the crate (§8). **5 tests survive as-is**; the app
+  owns only the BitRouter-specific wire key and conversion.
+- **`picker.rs`** — stays in the crate (§8). **5 tests survive as-is**.
 - **`viewport.rs`** — **deleted** with its **3 tests**, which assert behaviour of
   the `Inline` type being removed. §16.3 replaces them.
 - **`transcript.rs`** — becomes `journal.rs` plus renderers. Its **8 tests** are
   ported.
 - **`lib.rs`** — `Capabilities` deleted (§8), so its **2 tests** are deleted.
 
-Against the 31 tests passing today: **7 survive as-is, 1 modified, 10 move,
+Against the 31 tests passing today: **17 survive as-is, 1 modified, 0 move,
 8 ported, 3 replaced, 2 deleted.**
 
 ## 11. Decision 9 — no error isolation, no plugin loading, and the trigger
@@ -667,12 +676,12 @@ Session-long raw mode destroys the property
 *"no alternate screen, no lifecycle save/restore, and no panic hook"* — because
 nothing was taken from the terminal. Now something is.
 
-**Reuse what the repo already has.** `apps/bitrouter/src/tui/lifecycle.rs`
-survived Phase 1.2 and provides a handle-free `restore()` (`:44`) plus
-`install_panic_restore()` (`:56`), written so a panic hook or a signal branch can
-call it; `apps/bitrouter/src/tui/watch.rs:185` provides
-`ShutdownSignals::install()` for INT/TERM/HUP. All three exits — normal, panic,
-signal — must call `restore()`, which at minimum disables raw mode.
+**Reuse what the repo already has.** The final tree splits lifecycle by owner:
+`apps/bitrouter/src/tui/lifecycle.rs` owns app-side terminal custody helpers,
+while `crates/bitrouter-tui/src/lifecycle.rs` owns chat restore and panic
+handling. The removed watcher no longer provides signal helpers. All three
+exits — normal, panic, signal — must call restore code that at minimum disables
+raw mode.
 
 ### 13.3 Non-TTY
 
@@ -717,7 +726,7 @@ Proposed for v1, **contingent on §19.1**:
 | `Content` and non-text blocks render, capped (§6) | ✅ | |
 | Hunked diffs with path-naming summary (§6) | ✅ | |
 | One trait + one registry + caller footer (§7) | ✅ | |
-| `cost.rs` and `picker.rs` move to the app (§8) | ✅ | |
+| `cost.rs` and `picker.rs` stay in the TUI crate; app owns BitRouter-specific keys (§8) | ✅ | |
 | Five forwarded variants render (§9) | ✅ | |
 | Key bindings: Esc, Ctrl-C, Ctrl-D, Ctrl-L (§9, §4.6) | ✅ | |
 | Single stdin owner, raw mode, single-line editor (§13.1) | ✅ | |
@@ -752,18 +761,14 @@ Proposed for v1, **contingent on §19.1**:
    renders; `Esc` cancels a turn and auto-denies an outstanding permission;
    `Ctrl-L` forces a redraw; the scheduler coalesces N chunk updates into one
    frame and renders a permission immediately; the non-TTY gate refuses.
-5. **Boundary checks, all satisfiable.**
+5. **Boundary checks, all satisfiable in the final boundary.**
    ```bash
-   grep -rn "bitrouter/" crates/bitrouter-tui/src   # must return nothing
+   cargo tree -p bitrouter-tui          # must not include the bitrouter crate
+   cargo tree -p bitrouter | rg ratatui # ratatui reaches the app only through bitrouter-tui
    ```
-   Today this returns **four** lines, each with a disposition: `cost.rs:11`
-   (module doc) and `cost.rs:31` (the constant) leave with the file (§8);
-   `log_tail.rs:81` and `:91` are fixture paths in one test, normalized to
-   `/tmp/session-1.log` as part of the work. Additionally:
-   `cargo tree -p bitrouter-tui` shows no `bitrouter`;
-   `crates/bitrouter-tui/src/{cost.rs,picker.rs,viewport.rs}` no longer exist;
-   and the app-side renderer module references no `Config`, metering, or control
-   socket (§8's guard).
+   `crates/bitrouter-tui/src/{cost.rs,picker.rs}` exist by design;
+   `viewport.rs` does not. The app owns the BitRouter-specific `_meta` key,
+   metering, control socket, and config access.
 6. Full workspace `cargo nextest run --all-features`, `cargo clippy
    --all-features`, `cargo fmt -- --check` clean — see §13.4 on sequencing.
 
@@ -826,8 +831,8 @@ This spec **does** change user-facing surface.
    ratatui's `scrolling-regions` feature (§4.4) — a workspace manifest change.
    Recommend deferring (§15) and revisiting if users report losing the cost
    readout.
-5. **How does the app name ACP schema types after §8's move?** The moved
-   renderers need `UsageUpdate` and `ProviderInfo`. Either `apps/bitrouter` takes
-   a direct `agent-client-protocol-schema` dependency with
-   `unstable_llm_providers`, or it reaches them via
+5. **How does the app name ACP schema types at the §8 boundary?** The app needs
+   `UsageUpdate` for cost scope conversion and `ProviderInfo` for route
+   management. Either `apps/bitrouter` takes a direct
+   `agent-client-protocol-schema` dependency with `unstable_llm_providers`, or it reaches them via
    `agent_client_protocol::schema::v1::*`. Pick one before task 5 in the plan.


### PR DESCRIPTION
## Summary
- replace current-facing `status --watch` guidance with `status --requests`
- update `launch --agent` docs/help for full interactive catalog support and own-auth harnesses
- mark historical TUI specs/plans where final status, watcher, and renderer crate boundaries diverged

## Verification
- `git diff --check`
- `cargo fmt -- --check`
- `cargo check -p bitrouter`
- `cargo test -p bitrouter spawn::tests::resolve_launch_agent_accepts_every_supported_harness -- --exact`
- `cargo run --quiet -p bitrouter -- launch --help`
- independent reviewer re-check: ready to merge, no blockers

## Notes
- `codex` and `codex-automation` labels are not present in this repo; applied `documentation` and `docs`.
