### PR TITLE
ci: tell the harness plugins about a release too

### DIFF
--- a/.github/workflows/notify-release.yml
+++ b/.github/workflows/notify-release.yml
@@ -1,14 +1,23 @@
-# Notify the bitrouter-docs site the moment a release is published.
-# Fires a repository_dispatch (event_type: bitrouter-release) that the docs
-# repo's sync-changelog.yml + on-bitrouter-release.yml already listen for —
-# turning "changelog synced by the daily cron" into "synced within seconds of
-# the release". The docs side fetches the release body itself from this public
-# repo, so the payload only carries the tag (+ product, for forward-compat with
-# bitrouter-cloud).
+# Notify the downstream repositories the moment a release is published.
 #
-# Reuses the existing DOCS_DISPATCH_TOKEN secret (the same fine-grained PAT that
-# notify-docs.yml uses to dispatch on bitrouter/bitrouter-docs).
-name: Notify docs of release
+# Two audiences, one event:
+#
+#   - bitrouter-docs, whose sync-changelog.yml + on-bitrouter-release.yml turn
+#     "changelog synced by the daily cron" into "synced within seconds".
+#   - the three harness plugins, whose on-bitrouter-release.yml checks whether
+#     a gateway release moved anything they depend on. Each of them also polls
+#     weekly, so this dispatch is the fast path and not the only one — if a
+#     token expires, they notice on their own schedule rather than silently
+#     falling behind.
+#
+# Both payloads carry only the tag; each side fetches the release body itself
+# from this public repository. `product` is there for forward-compatibility
+# with bitrouter-cloud.
+#
+# Two tokens, not one. DOCS_DISPATCH_TOKEN reaches bitrouter-docs and
+# PLUGIN_DISPATCH_TOKEN reaches the plugins, each scoped to only the
+# repositories it needs, so neither pipeline's compromise reaches the other's.
+name: Notify downstream of release
 on:
   release:
     types: [published]   # fires for stable AND prereleases
@@ -16,12 +25,39 @@ permissions: {}
 jobs:
   dispatch:
     runs-on: ubuntu-latest
+    strategy:
+      # Every downstream is told, even when one of them is unreachable —
+      # a revoked token for the docs should not cost the plugins their
+      # notification.
+      fail-fast: false
+      matrix:
+        include:
+          - repo: bitrouter/bitrouter-docs
+            token_name: DOCS_DISPATCH_TOKEN
+          - repo: bitrouter/bitrouter-dsh
+            token_name: PLUGIN_DISPATCH_TOKEN
+          - repo: bitrouter/bitrouter-pi
+            token_name: PLUGIN_DISPATCH_TOKEN
+          - repo: bitrouter/bitrouter-opencode
+            token_name: PLUGIN_DISPATCH_TOKEN
+    name: ${{ matrix.repo }}
     steps:
-      - name: Dispatch bitrouter-release to bitrouter-docs
+      - name: Dispatch bitrouter-release
+        env:
+          TOKEN: ${{ secrets[matrix.token_name] }}
+          REPO: ${{ matrix.repo }}
+          TAG: ${{ github.event.release.tag_name }}
         run: |
+          set -euo pipefail
+          if [ -z "${TOKEN:-}" ]; then
+            echo "::warning::${{ matrix.token_name }} is not set — ${REPO} was not notified of ${TAG}."
+            echo "It polls on its own schedule, so this delays the check rather than losing it."
+            exit 0
+          fi
           curl -fsSL -X POST \
-            -H "Authorization: Bearer ${{ secrets.DOCS_DISPATCH_TOKEN }}" \
+            -H "Authorization: Bearer $TOKEN" \
             -H "Accept: application/vnd.github+json" \
-            https://api.github.com/repos/bitrouter/bitrouter-docs/dispatches \
-            -d "$(jq -n --arg tag '${{ github.event.release.tag_name }}' \
+            "https://api.github.com/repos/${REPO}/dispatches" \
+            -d "$(jq -n --arg tag "$TAG" \
                   '{event_type:"bitrouter-release", client_payload:{tag:$tag, product:"oss"}}')"
+          echo "notified ${REPO} of ${TAG}"


### PR DESCRIPTION
The docs already learn about a release within seconds of it being published.
The three harness plugins — [bitrouter-dsh][dsh], [bitrouter-pi][pi],
[bitrouter-opencode][oc] — each watch this repository for the same reason, and
until now each learned about it whenever its weekly poll came round.

They keep that poll. It's what notices when a dispatch never arrived, which is
the failure a fast path cannot report on itself. This makes the notification
fast; it doesn't make it load-bearing.

Every downstream is notified even when one is unreachable, and a missing token
is a warning rather than a job failure. A revoked docs token shouldn't cost the
plugins their notification, and in neither case is the work lost — the receiver
polls.

**Two tokens, not one.** `DOCS_DISPATCH_TOKEN` reaches `bitrouter-docs` and a
new `PLUGIN_DISPATCH_TOKEN` reaches the plugins, each scoped to only the
repositories it needs, so a compromise of one pipeline doesn't reach the other.

## Needs before it does anything

`PLUGIN_DISPATCH_TOKEN` — a fine-grained PAT, owner `bitrouter`, repository
access limited to the three plugin repos, permission **Contents: read and
write** (that's what `repository_dispatch` requires). Until it's set, the three
new matrix legs warn and exit 0; the docs leg is unaffected.

The receiving side is
[bitrouter-dsh#8](https://github.com/bitrouter/bitrouter-dsh/pull/8),
[bitrouter-pi#9](https://github.com/bitrouter/bitrouter-pi/pull/9),
[bitrouter-opencode#8](https://github.com/bitrouter/bitrouter-opencode/pull/8).
Merging this first is harmless — the dispatch simply finds nothing listening
yet.

[dsh]: https://github.com/bitrouter/bitrouter-dsh
[pi]: https://github.com/bitrouter/bitrouter-pi
[oc]: https://github.com/bitrouter/bitrouter-opencode