### PR TITLE
feat(registry): add latest GLM and Qwen models

### DIFF
--- a/dist/registry/models.json
+++ b/dist/registry/models.json
@@ -6795,6 +6795,241 @@
       "release_date": "2026-06-01"
     },
     {
+      "description": "Open-weight text MoE with 2.4T total parameters and 95B active parameters for coding, research, and agentic workflows.",
+      "family": "qwen3.8",
+      "id": "qwen/qwen3.8-2.4t-a95b",
+      "input_modalities": [
+        "text"
+      ],
+      "max_input_tokens": 1000000,
+      "max_output_tokens": 131072,
+      "name": "Qwen: Qwen3.8 2.4T-A95B",
+      "open_weights": true,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.17,
+              "cache_write": 2.5,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 6.0
+            }
+          },
+          "provider": "alibaba",
+          "provider_model_id": "qwen3.8-2.4t-a95b",
+          "rate_limits": {
+            "requests_per_minute": 60
+          },
+          "reasoning_effort": {
+            "default": "xhigh",
+            "levels": [
+              "low",
+              "medium",
+              "xhigh"
+            ]
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.167,
+              "cache_write": 2.083,
+              "no_cache": 1.667
+            },
+            "output_tokens": {
+              "text": 5.0
+            }
+          },
+          "provider": "alibaba_cn",
+          "provider_model_id": "qwen3.8-2.4t-a95b",
+          "rate_limits": {
+            "requests_per_minute": 60
+          },
+          "reasoning_effort": {
+            "default": "xhigh",
+            "levels": [
+              "low",
+              "medium",
+              "xhigh"
+            ]
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.25,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 6.0
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "qwen/qwen3.8-2.4t-a95b",
+          "reasoning_effort": {
+            "default": "xhigh",
+            "levels": [
+              "low",
+              "medium",
+              "xhigh"
+            ]
+          }
+        }
+      ],
+      "release_date": "2026-08-12"
+    },
+    {
+      "description": "Open-weight dense native vision-language model for coding, professional work, and long-running agent tasks.",
+      "family": "qwen3.8",
+      "id": "qwen/qwen3.8-27b",
+      "input_modalities": [
+        "text",
+        "image",
+        "video"
+      ],
+      "max_input_tokens": 1000000,
+      "max_output_tokens": 131072,
+      "name": "Qwen: Qwen3.8 27B",
+      "open_weights": true,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.05,
+              "cache_write": 0.625,
+              "no_cache": 0.5
+            },
+            "output_tokens": {
+              "text": 3.0
+            }
+          },
+          "provider": "alibaba",
+          "provider_model_id": "qwen3.8-27b",
+          "rate_limits": {
+            "requests_per_minute": 60
+          },
+          "reasoning_effort": {
+            "default": "xhigh",
+            "levels": [
+              "low",
+              "medium",
+              "xhigh"
+            ]
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.042,
+              "cache_write": 0.521,
+              "no_cache": 0.417
+            },
+            "output_tokens": {
+              "text": 1.667
+            }
+          },
+          "provider": "alibaba_cn",
+          "provider_model_id": "qwen3.8-27b",
+          "rate_limits": {
+            "requests_per_minute": 60
+          },
+          "reasoning_effort": {
+            "default": "xhigh",
+            "levels": [
+              "low",
+              "medium",
+              "xhigh"
+            ]
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.085,
+              "cache_write": 0.53125,
+              "no_cache": 0.425
+            },
+            "output_tokens": {
+              "text": 2.55
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "qwen/qwen3.8-27b",
+          "reasoning_effort": {
+            "default": "xhigh",
+            "levels": [
+              "low",
+              "medium",
+              "xhigh"
+            ]
+          }
+        }
+      ],
+      "release_date": "2026-08-14"
+    },
+    {
       "description": "2.4T-parameter multimodal MoE flagship for coding, professional work, and long-horizon agentic workflows.",
       "family": "qwen3.8",
       "id": "qwen/qwen3.8-max",
@@ -8950,6 +9185,168 @@
         }
       ],
       "release_date": "2026-06-13"
+    },
+    {
+      "description": "Z.ai flagship reasoning model for complex software engineering and long-horizon agent tasks.",
+      "family": "glm",
+      "id": "z-ai/glm-5.3",
+      "input_modalities": [
+        "text"
+      ],
+      "max_input_tokens": 1000000,
+      "max_output_tokens": 131072,
+      "name": "Zhipu: GLM-5.3",
+      "open_weights": false,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.26,
+              "no_cache": 1.4
+            },
+            "output_tokens": {
+              "text": 4.4
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "z-ai/glm-5.3",
+          "reasoning_effort": {
+            "default": "max",
+            "levels": [
+              "low",
+              "high",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.26,
+              "no_cache": 1.4
+            },
+            "output_tokens": {
+              "text": 4.4
+            }
+          },
+          "provider": "zai",
+          "provider_model_id": "glm-5.3",
+          "rate_limits": {
+            "requests_per_minute": 60
+          },
+          "reasoning_effort": {
+            "default": "max",
+            "levels": [
+              "low",
+              "high",
+              "max"
+            ]
+          }
+        }
+      ],
+      "release_date": "2026-08-14"
+    },
+    {
+      "description": "Open-weight native multimodal MoE for efficient coding, professional work, and long-horizon agent tasks.",
+      "family": "glm",
+      "id": "z-ai/glm-5.3-flash",
+      "input_modalities": [
+        "text",
+        "image",
+        "video"
+      ],
+      "max_input_tokens": 1000000,
+      "max_output_tokens": 131072,
+      "name": "Zhipu: GLM-5.3 Flash",
+      "open_weights": true,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.015,
+              "no_cache": 0.075
+            },
+            "output_tokens": {
+              "text": 0.25
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "z-ai/glm-5.3-flash",
+          "reasoning_effort": {
+            "default": "max",
+            "levels": [
+              "low",
+              "high",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.015,
+              "no_cache": 0.075
+            },
+            "output_tokens": {
+              "text": 0.25
+            }
+          },
+          "provider": "zai",
+          "provider_model_id": "glm-5.3-flash",
+          "rate_limits": {
+            "requests_per_minute": 60
+          },
+          "reasoning_effort": {
+            "default": "max",
+            "levels": [
+              "low",
+              "high",
+              "max"
+            ]
+          }
+        }
+      ],
+      "release_date": "2026-08-26"
     }
   ]
 }

--- a/dist/registry/providers.json
+++ b/dist/registry/providers.json
@@ -28,6 +28,74 @@
             "anthropic"
           ],
           "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "qwen/qwen3.8-2.4t-a95b",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.17,
+              "cache_write": 2.5,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 6.0
+            }
+          },
+          "provider_model_id": "qwen3.8-2.4t-a95b",
+          "rate_limits": {
+            "requests_per_minute": 60
+          },
+          "reasoning_effort": {
+            "default": "xhigh",
+            "levels": [
+              "low",
+              "medium",
+              "xhigh"
+            ]
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "qwen/qwen3.8-27b",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.05,
+              "cache_write": 0.625,
+              "no_cache": 0.5
+            },
+            "output_tokens": {
+              "text": 3.0
+            }
+          },
+          "provider_model_id": "qwen3.8-27b",
+          "rate_limits": {
+            "requests_per_minute": 60
+          },
+          "reasoning_effort": {
+            "default": "xhigh",
+            "levels": [
+              "low",
+              "medium",
+              "xhigh"
+            ]
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
             "tools"
           ],
           "id": "qwen/qwen3.8-max",
@@ -322,6 +390,74 @@
         "terms_of_service_url": "https://help.aliyun.com/zh/model-studio/related-agreements"
       },
       "models": [
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "qwen/qwen3.8-2.4t-a95b",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.167,
+              "cache_write": 2.083,
+              "no_cache": 1.667
+            },
+            "output_tokens": {
+              "text": 5.0
+            }
+          },
+          "provider_model_id": "qwen3.8-2.4t-a95b",
+          "rate_limits": {
+            "requests_per_minute": 60
+          },
+          "reasoning_effort": {
+            "default": "xhigh",
+            "levels": [
+              "low",
+              "medium",
+              "xhigh"
+            ]
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "qwen/qwen3.8-27b",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.042,
+              "cache_write": 0.521,
+              "no_cache": 0.417
+            },
+            "output_tokens": {
+              "text": 1.667
+            }
+          },
+          "provider_model_id": "qwen3.8-27b",
+          "rate_limits": {
+            "requests_per_minute": 60
+          },
+          "reasoning_effort": {
+            "default": "xhigh",
+            "levels": [
+              "low",
+              "medium",
+              "xhigh"
+            ]
+          }
+        },
         {
           "api_protocol": [
             "openai",
@@ -6492,6 +6628,66 @@
             "responses",
             "anthropic"
           ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "z-ai/glm-5.3",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.26,
+              "no_cache": 1.4
+            },
+            "output_tokens": {
+              "text": 4.4
+            }
+          },
+          "provider_model_id": "z-ai/glm-5.3",
+          "reasoning_effort": {
+            "default": "max",
+            "levels": [
+              "low",
+              "high",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "z-ai/glm-5.3-flash",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.015,
+              "no_cache": 0.075
+            },
+            "output_tokens": {
+              "text": 0.25
+            }
+          },
+          "provider_model_id": "z-ai/glm-5.3-flash",
+          "reasoning_effort": {
+            "default": "max",
+            "levels": [
+              "low",
+              "high",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
           "id": "openai/gpt-oss-120b",
           "pricing": {
             "input_tokens": {
@@ -6747,6 +6943,67 @@
             }
           },
           "provider_model_id": "qwen/qwen3.7-max"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "qwen/qwen3.8-2.4t-a95b",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.25,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 6.0
+            }
+          },
+          "provider_model_id": "qwen/qwen3.8-2.4t-a95b",
+          "reasoning_effort": {
+            "default": "xhigh",
+            "levels": [
+              "low",
+              "medium",
+              "xhigh"
+            ]
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "qwen/qwen3.8-27b",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.085,
+              "cache_write": 0.53125,
+              "no_cache": 0.425
+            },
+            "output_tokens": {
+              "text": 2.55
+            }
+          },
+          "provider_model_id": "qwen/qwen3.8-27b",
+          "reasoning_effort": {
+            "default": "xhigh",
+            "levels": [
+              "low",
+              "medium",
+              "xhigh"
+            ]
+          }
         },
         {
           "api_protocol": [
@@ -9756,6 +10013,70 @@
         "terms_of_service_url": "https://docs.z.ai/legal-agreement/terms-of-use"
       },
       "models": [
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "z-ai/glm-5.3",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.26,
+              "no_cache": 1.4
+            },
+            "output_tokens": {
+              "text": 4.4
+            }
+          },
+          "provider_model_id": "glm-5.3",
+          "rate_limits": {
+            "requests_per_minute": 60
+          },
+          "reasoning_effort": {
+            "default": "max",
+            "levels": [
+              "low",
+              "high",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "z-ai/glm-5.3-flash",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.015,
+              "no_cache": 0.075
+            },
+            "output_tokens": {
+              "text": 0.25
+            }
+          },
+          "provider_model_id": "glm-5.3-flash",
+          "rate_limits": {
+            "requests_per_minute": 60
+          },
+          "reasoning_effort": {
+            "default": "max",
+            "levels": [
+              "low",
+              "high",
+              "max"
+            ]
+          }
+        },
         {
           "api_protocol": [
             "openai",

--- a/registry/models/qwen.yaml
+++ b/registry/models/qwen.yaml
@@ -74,6 +74,34 @@
   release_date: 2026-06-10
   open_weights: false
   family: qwen3.7
+# Official model: https://www.qwencloud.com/models/qwen3.8-2.4t-a95b
+- id: qwen/qwen3.8-2.4t-a95b
+  name: 'Qwen: Qwen3.8 2.4T-A95B'
+  description: Open-weight text MoE with 2.4T total parameters and 95B active parameters for coding, research, and agentic workflows.
+  input_modalities:
+  - text
+  output_modalities:
+  - text
+  max_input_tokens: 1000000
+  max_output_tokens: 131072
+  release_date: 2026-08-12
+  open_weights: true
+  family: qwen3.8
+# Official model: https://www.qwencloud.com/models/qwen3.8-27b
+- id: qwen/qwen3.8-27b
+  name: 'Qwen: Qwen3.8 27B'
+  description: Open-weight dense native vision-language model for coding, professional work, and long-running agent tasks.
+  input_modalities:
+  - text
+  - image
+  - video
+  output_modalities:
+  - text
+  max_input_tokens: 1000000
+  max_output_tokens: 131072
+  release_date: 2026-08-14
+  open_weights: true
+  family: qwen3.8
 # Official model: https://www.qwencloud.com/models/qwen3.8-max
 - id: qwen/qwen3.8-max
   name: 'Qwen: Qwen3.8 Max'

--- a/registry/models/z-ai.yaml
+++ b/registry/models/z-ai.yaml
@@ -1,3 +1,29 @@
+- id: z-ai/glm-5.3
+  name: 'Zhipu: GLM-5.3'
+  description: Z.ai flagship reasoning model for complex software engineering and long-horizon agent tasks.
+  input_modalities:
+  - text
+  output_modalities:
+  - text
+  max_input_tokens: 1000000
+  max_output_tokens: 131072
+  release_date: 2026-08-14
+  open_weights: false
+  family: glm
+- id: z-ai/glm-5.3-flash
+  name: 'Zhipu: GLM-5.3 Flash'
+  description: Open-weight native multimodal MoE for efficient coding, professional work, and long-horizon agent tasks.
+  input_modalities:
+  - text
+  - image
+  - video
+  output_modalities:
+  - text
+  max_input_tokens: 1000000
+  max_output_tokens: 131072
+  release_date: 2026-08-26
+  open_weights: true
+  family: glm
 - id: z-ai/glm-5.1
   name: 'Zhipu: GLM-5.1'
   input_modalities:

--- a/registry/providers/alibaba.yaml
+++ b/registry/providers/alibaba.yaml
@@ -20,6 +20,34 @@ rate_limits:
   - "*":
       requests_per_minute: 60
 models:
+  # Official pricing: https://www.qwencloud.com/models/qwen3.8-2.4t-a95b
+  - id: qwen/qwen3.8-2.4t-a95b
+    provider_model_id: qwen3.8-2.4t-a95b
+    reasoning_effort:
+      levels: [low, medium, xhigh]
+      default: xhigh
+    pricing:
+      input_tokens:
+        no_cache: 2
+        cache_read: 0.17
+        cache_write: 2.5
+      output_tokens:
+        text: 6
+    capabilities: [reasoning, tools]
+  # Official pricing: https://www.qwencloud.com/models/qwen3.8-27b
+  - id: qwen/qwen3.8-27b
+    provider_model_id: qwen3.8-27b
+    reasoning_effort:
+      levels: [low, medium, xhigh]
+      default: xhigh
+    pricing:
+      input_tokens:
+        no_cache: 0.5
+        cache_read: 0.05
+        cache_write: 0.625
+      output_tokens:
+        text: 3
+    capabilities: [reasoning, tools]
   # Official pricing: https://www.qwencloud.com/models/qwen3.8-max
   # Official function-calling docs: https://docs.qwencloud.com/developer-guides/text-generation/function-calling
   - id: qwen/qwen3.8-max

--- a/registry/providers/alibaba_cn.yaml
+++ b/registry/providers/alibaba_cn.yaml
@@ -19,6 +19,36 @@ rate_limits:
       requests_per_minute: 60
 models:
   # CNY 12/1.2/15/36 converted at ~7.2 CNY/USD.
+  # Official pricing: https://help.aliyun.com/zh/model-studio/model-pricing
+  - id: qwen/qwen3.8-2.4t-a95b
+    provider_model_id: qwen3.8-2.4t-a95b
+    reasoning_effort:
+      levels: [low, medium, xhigh]
+      default: xhigh
+    pricing:
+      input_tokens:
+        no_cache: 1.667
+        cache_read: 0.167
+        cache_write: 2.083
+      output_tokens:
+        text: 5
+    capabilities: [reasoning, tools]
+  # CNY 3/0.3/3.75/12 converted at ~7.2 CNY/USD.
+  # Official pricing: https://help.aliyun.com/zh/model-studio/qwen3-8-27b
+  - id: qwen/qwen3.8-27b
+    provider_model_id: qwen3.8-27b
+    reasoning_effort:
+      levels: [low, medium, xhigh]
+      default: xhigh
+    pricing:
+      input_tokens:
+        no_cache: 0.417
+        cache_read: 0.042
+        cache_write: 0.521
+      output_tokens:
+        text: 1.667
+    capabilities: [reasoning, tools]
+  # CNY 12/1.2/15/36 converted at ~7.2 CNY/USD.
   # Sources: https://help.aliyun.com/zh/model-studio/model-pricing
   # and https://help.aliyun.com/zh/model-studio/context-cache
   # Official function-calling docs: https://docs.qwencloud.com/developer-guides/text-generation/function-calling

--- a/registry/providers/openrouter.yaml
+++ b/registry/providers/openrouter.yaml
@@ -116,6 +116,31 @@ models:
         cache_read: 0.2
       output_tokens:
         text: 2.55
+  # OpenRouter catalog: https://openrouter.ai/api/v1/models
+  - id: z-ai/glm-5.3
+    provider_model_id: z-ai/glm-5.3
+    reasoning_effort:
+      levels: [low, high, max]
+      default: max
+    pricing:
+      input_tokens:
+        no_cache: 1.4
+        cache_read: 0.26
+      output_tokens:
+        text: 4.4
+    capabilities: [reasoning, tools]
+  - id: z-ai/glm-5.3-flash
+    provider_model_id: z-ai/glm-5.3-flash
+    reasoning_effort:
+      levels: [low, high, max]
+      default: max
+    pricing:
+      input_tokens:
+        no_cache: 0.075
+        cache_read: 0.015
+      output_tokens:
+        text: 0.25
+    capabilities: [reasoning, tools]
   - id: openai/gpt-oss-120b
     provider_model_id: openai/gpt-oss-120b
     pricing:
@@ -237,6 +262,32 @@ models:
         cache_write: 1.84375
       output_tokens:
         text: 4.425
+  # OpenRouter catalog: https://openrouter.ai/api/v1/models
+  - id: qwen/qwen3.8-2.4t-a95b
+    provider_model_id: qwen/qwen3.8-2.4t-a95b
+    reasoning_effort:
+      levels: [low, medium, xhigh]
+      default: xhigh
+    pricing:
+      input_tokens:
+        no_cache: 2
+        cache_read: 0.25
+      output_tokens:
+        text: 6
+    capabilities: [reasoning, tools]
+  - id: qwen/qwen3.8-27b
+    provider_model_id: qwen/qwen3.8-27b
+    reasoning_effort:
+      levels: [low, medium, xhigh]
+      default: xhigh
+    pricing:
+      input_tokens:
+        no_cache: 0.425
+        cache_read: 0.085
+        cache_write: 0.53125
+      output_tokens:
+        text: 2.55
+    capabilities: [reasoning, tools]
   # OpenRouter tool support catalog: https://openrouter.ai/api/v1/models
   - id: qwen/qwen3.8-max
     provider_model_id: qwen/qwen3.8-max

--- a/registry/providers/zai.yaml
+++ b/registry/providers/zai.yaml
@@ -11,6 +11,38 @@ rate_limits:
   - "*":
       requests_per_minute: 60
 models:
+  # Official model: https://docs.z.ai/guides/llm/glm-5.3
+  # Official pricing: https://docs.z.ai/guides/overview/pricing
+  - id: z-ai/glm-5.3
+    provider_model_id: glm-5.3
+    reasoning_effort:
+      levels: [low, high, max]
+      default: max
+    pricing:
+      input_tokens:
+        no_cache: 1.4
+        cache_read: 0.26
+      output_tokens:
+        text: 4.4
+    capabilities:
+      - reasoning
+      - tools
+  # Official model: https://docs.z.ai/guides/vlm/glm-5.3-flash
+  # The 50% launch pricing expires at 24:00 UTC+8 on 2026-09-09.
+  - id: z-ai/glm-5.3-flash
+    provider_model_id: glm-5.3-flash
+    reasoning_effort:
+      levels: [low, high, max]
+      default: max
+    pricing:
+      input_tokens:
+        no_cache: 0.075
+        cache_read: 0.015
+      output_tokens:
+        text: 0.25
+    capabilities:
+      - reasoning
+      - tools
   - id: z-ai/glm-5.1
     provider_model_id: glm-5.1
     pricing:


### PR DESCRIPTION
## Summary

- add `z-ai/glm-5.3` and `z-ai/glm-5.3-flash` to the canonical catalog, Z.ai, and OpenRouter
- add `qwen/qwen3.8-2.4t-a95b` and `qwen/qwen3.8-27b` to the canonical catalog, Alibaba international/China, and OpenRouter
- record verified modalities, context/output limits, reasoning-effort levels, provider model IDs, and per-token pricing
- rebuild the committed runtime registry artifacts

## Sources

- https://docs.z.ai/guides/llm/glm-5.3
- https://docs.z.ai/guides/vlm/glm-5.3-flash
- https://docs.z.ai/guides/overview/pricing
- https://www.qwencloud.com/models/qwen3.8-2.4t-a95b
- https://www.qwencloud.com/models/qwen3.8-27b
- https://openrouter.ai/api/v1/models

## Validation

- `cargo run -p dist-helper -- registry validate`
- `cargo run -p dist-helper -- registry build`
- `cargo run -p dist-helper -- check`
- `git diff --check`

Registry-only change; repository policy explicitly excludes catalog-entry-specific Rust tests.