### PR TITLE
feat(registry): add Tencent DeepSeek V4 revisions

### DIFF
--- a/dist/registry/models.json
+++ b/dist/registry/models.json
@@ -2195,6 +2195,30 @@
           },
           "provider": "qianfan",
           "provider_model_id": "deepseek-v4-flash-0731"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.014,
+              "no_cache": 0.44
+            },
+            "output_tokens": {
+              "text": 1.32
+            }
+          },
+          "provider": "tencent",
+          "provider_model_id": "deepseek-v4-flash-0731",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
         }
       ],
       "release_date": "2026-07-31"
@@ -2579,6 +2603,30 @@
           },
           "provider": "openrouter",
           "provider_model_id": "deepseek/deepseek-v4-pro-0813"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.044,
+              "no_cache": 1.32
+            },
+            "output_tokens": {
+              "text": 3.96
+            }
+          },
+          "provider": "tencent",
+          "provider_model_id": "deepseek-v4-pro-0813",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
         }
       ],
       "release_date": "2026-08-13"

--- a/dist/registry/providers.json
+++ b/dist/registry/providers.json
@@ -8745,6 +8745,54 @@
           ],
           "capabilities": [
             "reasoning",
+            "tools"
+          ],
+          "id": "deepseek/deepseek-v4-flash-0731",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.014,
+              "no_cache": 0.44
+            },
+            "output_tokens": {
+              "text": 1.32
+            }
+          },
+          "provider_model_id": "deepseek-v4-flash-0731",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "deepseek/deepseek-v4-pro-0813",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.044,
+              "no_cache": 1.32
+            },
+            "output_tokens": {
+              "text": 3.96
+            }
+          },
+          "provider_model_id": "deepseek-v4-pro-0813",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
             "structured_outputs",
             "tools"
           ],

--- a/registry/providers/tencent.yaml
+++ b/registry/providers/tencent.yaml
@@ -56,6 +56,30 @@ models:
     capabilities:
       - reasoning
       - tools
+  # TokenHub bills these dated GA models at peak/off-peak rates. The registry
+  # is static, so publish the peak rates to avoid underestimating route cost.
+  - id: deepseek/deepseek-v4-flash-0731
+    provider_model_id: deepseek-v4-flash-0731
+    pricing:
+      input_tokens:
+        no_cache: 0.44
+        cache_read: 0.014
+      output_tokens:
+        text: 1.32
+    capabilities:
+      - reasoning
+      - tools
+  - id: deepseek/deepseek-v4-pro-0813
+    provider_model_id: deepseek-v4-pro-0813
+    pricing:
+      input_tokens:
+        no_cache: 1.32
+        cache_read: 0.044
+      output_tokens:
+        text: 3.96
+    capabilities:
+      - reasoning
+      - tools
   - id: z-ai/glm-5
     provider_model_id: glm-5
     pricing:


### PR DESCRIPTION
## Summary

- add Tencent TokenHub routes for `deepseek/deepseek-v4-flash-0731` and `deepseek/deepseek-v4-pro-0813`
- use the exact Tencent-hosted model IDs rather than Vendor Direct aliases
- preserve the existing generic `deepseek-v4-flash` and `deepseek-v4-pro` routes unchanged
- regenerate `dist/registry/models.json` and `dist/registry/providers.json`

## Pricing

Tencent applies peak/off-peak pricing to these dated GA models. Because the registry currently supports static prices, this PR records the conservative peak rates:

| Model | Input | Cache read | Output |
| --- | ---: | ---: | ---: |
| Flash 0731 | $0.44 | $0.014 | $1.32 |
| Pro 0813 | $1.32 | $0.044 | $3.96 |

All prices are USD per 1M tokens.

## Verification

- `cargo run -p dist-helper -- registry validate`
- `cargo run -p dist-helper -- registry build`
- `cargo run -p dist-helper -- check`
- live TokenHub Chat Completions smoke requests returned HTTP 200 for both exact provider model IDs

## Sources

- Tencent model list: https://intl.cloud.tencent.com/ind/document/product/1300/78934
- Tencent model pricing: https://intl.cloud.tencent.com/ind/document/product/1300/78937