### PR TITLE
fix(sdk): stop nonstream continuation after disconnect

### DIFF
--- a/crates/bitrouter-observe/src/otel/exporter.rs
+++ b/crates/bitrouter-observe/src/otel/exporter.rs
@@ -670,6 +670,9 @@ impl ObserveHook for OtelExporter {
                 );
                 hop_span.set_status(Status::error(err.to_string()));
             }
+            HopOutcome::NotDispatched => {
+                hop_span.set_attribute(KeyValue::new("bitrouter.provider_dispatched", false));
+            }
         }
         hop_span.end();
     }

--- a/crates/bitrouter-sdk/src/error.rs
+++ b/crates/bitrouter-sdk/src/error.rs
@@ -129,6 +129,10 @@ pub enum BitrouterError {
     #[error("upstream timeout")]
     UpstreamTimeout,
 
+    /// 499 — the downstream client disconnected before the request completed.
+    #[error("client disconnected")]
+    ClientDisconnected,
+
     /// 503 — the upstream route set is temporarily unavailable.
     #[error("upstream unavailable")]
     UpstreamUnavailable,
@@ -163,6 +167,7 @@ impl BitrouterError {
             Self::UpstreamInvalidResponse { .. } => 502,
             Self::UpstreamAuth { status, .. } => *status,
             Self::UpstreamTimeout => 504,
+            Self::ClientDisconnected => 499,
             Self::UpstreamUnavailable => 503,
             Self::Internal(_) => 500,
         }
@@ -184,6 +189,7 @@ impl BitrouterError {
             Self::Upstream { .. }
             | Self::UpstreamInvalidResponse { .. }
             | Self::UpstreamTimeout => "upstream_error",
+            Self::ClientDisconnected => "client_disconnected",
             Self::UpstreamUnavailable => "upstream_error",
             Self::UpstreamAuth { status: 403, .. } => "permission_error",
             Self::UpstreamAuth { .. } => "authentication_error",
@@ -208,6 +214,7 @@ impl BitrouterError {
             Self::UpstreamInvalidResponse { .. } => "upstream_invalid_response",
             Self::UpstreamAuth { .. } => "upstream_auth_required",
             Self::UpstreamTimeout => "upstream_timeout",
+            Self::ClientDisconnected => "client_disconnected",
             Self::UpstreamUnavailable => "upstream_unavailable",
             Self::Internal(_) => "internal_error",
         }
@@ -256,6 +263,7 @@ impl BitrouterError {
             Self::UpstreamInvalidResponse { .. } => ErrorKind::UpstreamInvalidResponse,
             Self::UpstreamAuth { .. } => ErrorKind::UpstreamAuth,
             Self::UpstreamTimeout => ErrorKind::UpstreamTimeout,
+            Self::ClientDisconnected => ErrorKind::ClientDisconnected,
             Self::UpstreamUnavailable => ErrorKind::UpstreamUnavailable,
             Self::Internal(_) => ErrorKind::Internal,
         }
@@ -288,6 +296,7 @@ impl BitrouterError {
                 format!("upstream auth required ({status})")
             }
             Self::UpstreamTimeout => "upstream timeout".to_string(),
+            Self::ClientDisconnected => "client disconnected".to_string(),
             Self::UpstreamUnavailable => "upstream unavailable".to_string(),
         };
         ErrorEnvelope {
@@ -314,6 +323,7 @@ impl BitrouterError {
             Self::UpstreamInvalidResponse { .. } => {
                 "upstream returned an invalid response".to_string()
             }
+            Self::ClientDisconnected => "client disconnected".to_string(),
             _ => self.to_string(),
         }
     }
@@ -350,6 +360,8 @@ pub enum ErrorKind {
     UpstreamAuth,
     /// 504 — upstream timed out.
     UpstreamTimeout,
+    /// 499 — downstream client disconnected.
+    ClientDisconnected,
     /// 503 — the upstream route set is temporarily unavailable.
     UpstreamUnavailable,
     /// 500 — internal error.
@@ -493,5 +505,16 @@ mod tests {
             .message,
             "upstream error (502): boom"
         );
+    }
+
+    #[test]
+    fn client_disconnected_has_stable_contract() {
+        let error = BitrouterError::ClientDisconnected;
+
+        assert_eq!(error.status(), 499);
+        assert_eq!(error.error_code(), "client_disconnected");
+        assert_eq!(error.kind(), ErrorKind::ClientDisconnected);
+        assert_eq!(error.public_message(), "client disconnected");
+        assert_eq!(error.to_envelope().error.message, "client disconnected");
     }
 }

--- a/crates/bitrouter-sdk/src/language_model/auth.rs
+++ b/crates/bitrouter-sdk/src/language_model/auth.rs
@@ -93,6 +93,7 @@ pub(super) fn normalize_auth_extension_error(
             required_scope: None,
         },
         BitrouterError::UpstreamTimeout => BitrouterError::UpstreamTimeout,
+        BitrouterError::ClientDisconnected => BitrouterError::ClientDisconnected,
         BitrouterError::UpstreamUnavailable => BitrouterError::UpstreamUnavailable,
         BitrouterError::Internal(_) => BitrouterError::Internal(diagnostic.into()),
     }

--- a/crates/bitrouter-sdk/src/language_model/context.rs
+++ b/crates/bitrouter-sdk/src/language_model/context.rs
@@ -9,6 +9,8 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
+use tokio_util::sync::CancellationToken;
+
 use crate::caller::CallerContext;
 use crate::event::{EventBus, PipelineEvent};
 use crate::language_model::auth::ContinuationAuthority;
@@ -41,6 +43,13 @@ static NEXT_DELIVERY_ATTEMPT_ID: AtomicU64 = AtomicU64::new(1);
 #[derive(Clone, Default)]
 struct Extensions {
     map: HashMap<TypeId, Arc<dyn Any + Send + Sync>>,
+}
+
+/// Request-scoped controls shared by server-tool prompt forks.
+#[allow(dead_code)] // Installed at non-stream entry points in the next integration step.
+#[derive(Clone, Default)]
+struct ExecutionControl {
+    client_disconnect: Option<CancellationToken>,
 }
 
 /// A request-local native provider continuation resolved by a route hook.
@@ -196,6 +205,9 @@ pub struct PipelineContext {
     /// is readable from the stream stage.
     extensions: Extensions,
 
+    /// Advisory request-lifetime signals checked at safe non-stream boundaries.
+    execution_control: ExecutionControl,
+
     // ===== typed event bus =====
     events: EventBus,
 
@@ -238,6 +250,7 @@ impl PipelineContext {
             credential_authority: Arc::new(Mutex::new(None)),
             metadata: HashMap::new(),
             extensions: Extensions::default(),
+            execution_control: ExecutionControl::default(),
             events: EventBus::new(),
             outbound_trace_headers: Mutex::new(None),
         }
@@ -272,6 +285,7 @@ impl PipelineContext {
             credential_authority: self.credential_authority.clone(),
             metadata: self.metadata.clone(),
             extensions: self.extensions.clone(),
+            execution_control: self.execution_control.clone(),
             events: self.events.clone(),
             outbound_trace_headers: Mutex::new(None),
         }
@@ -447,6 +461,35 @@ impl PipelineContext {
     /// The canonical request body.
     pub fn prompt(&self) -> &Prompt {
         &self.prompt
+    }
+
+    /// Install the request-scoped client-disconnect signal for non-stream
+    /// continuation checks. Prompt forks retain a clone of this token.
+    #[allow(dead_code)] // Consumed by the non-stream detached execution path.
+    pub(crate) fn install_client_disconnect_token(&mut self, token: CancellationToken) {
+        self.execution_control.client_disconnect = Some(token);
+    }
+
+    /// Whether the downstream client has disconnected from this request.
+    #[allow(dead_code)] // Consumed by fallback and server-tool continuation checks.
+    pub(crate) fn client_disconnected(&self) -> bool {
+        self.execution_control
+            .client_disconnect
+            .as_ref()
+            .is_some_and(CancellationToken::is_cancelled)
+    }
+
+    /// A future that resolves when the downstream client disconnects.
+    ///
+    /// Contexts without an installed signal remain continuable indefinitely.
+    #[allow(dead_code)] // Consumed by cancellable fallback-backoff waits.
+    pub(crate) fn client_disconnected_signal(&self) -> impl std::future::Future<Output = ()> + '_ {
+        async move {
+            match &self.execution_control.client_disconnect {
+                Some(token) => token.cancelled().await,
+                None => std::future::pending().await,
+            }
+        }
     }
 
     /// The inbound wire protocol the request arrived on, if known. Route
@@ -1056,6 +1099,33 @@ mod tests {
             tool_choice: None,
             stream: false,
         }
+    }
+
+    #[tokio::test]
+    async fn disconnect_token_is_shared_by_forked_contexts() {
+        let token = CancellationToken::new();
+        let mut ctx = ctx_from_prompt(empty_prompt());
+        ctx.install_client_disconnect_token(token.clone());
+        let fork = ctx.fork_for_prompt(ctx.prompt().clone());
+
+        token.cancel();
+
+        assert!(ctx.client_disconnected());
+        assert!(fork.client_disconnected());
+    }
+
+    #[tokio::test]
+    async fn disconnect_signal_completes_when_installed_token_is_cancelled() {
+        let token = CancellationToken::new();
+        let mut ctx = ctx_from_prompt(empty_prompt());
+        ctx.install_client_disconnect_token(token.clone());
+        assert!(!ctx.client_disconnected());
+
+        let signal = ctx.client_disconnected_signal();
+        token.cancel();
+        signal.await;
+
+        assert!(ctx.client_disconnected());
     }
 
     #[test]

--- a/crates/bitrouter-sdk/src/language_model/context.rs
+++ b/crates/bitrouter-sdk/src/language_model/context.rs
@@ -469,17 +469,29 @@ impl PipelineContext {
     }
 
     /// Whether the downstream client has disconnected from this request.
-    pub(crate) fn client_disconnected(&self) -> bool {
+    ///
+    /// This read-only predicate is for app-owned pre-dispatch and admission
+    /// boundaries, before provider or tool execution (or any other side
+    /// effect) starts. Never use it to cancel or race an already-started
+    /// provider or tool future; dispatched work and its settlement must finish.
+    pub fn client_disconnected(&self) -> bool {
         self.execution_control
             .client_disconnect
             .as_ref()
             .is_some_and(CancellationToken::is_cancelled)
     }
 
-    /// A future that resolves when the downstream client disconnects.
+    /// Wait until the downstream client disconnects from this request.
     ///
-    /// Contexts without an installed signal remain continuable indefinitely.
-    pub(crate) async fn client_disconnected_signal(&self) {
+    /// This read-only signal is for app-owned pre-dispatch and admission waits,
+    /// so they can wake and re-check before provider, tool, or other side
+    /// effects begin. Never race it against or use it to cancel an
+    /// already-started provider or tool future; dispatched work and its
+    /// settlement must finish.
+    ///
+    /// When the SDK has not installed a detached non-stream disconnect signal,
+    /// this future remains pending indefinitely.
+    pub async fn client_disconnected_signal(&self) {
         match &self.execution_control.client_disconnect {
             Some(token) => token.cancelled().await,
             None => std::future::pending().await,

--- a/crates/bitrouter-sdk/src/language_model/context.rs
+++ b/crates/bitrouter-sdk/src/language_model/context.rs
@@ -483,12 +483,10 @@ impl PipelineContext {
     ///
     /// Contexts without an installed signal remain continuable indefinitely.
     #[allow(dead_code)] // Consumed by cancellable fallback-backoff waits.
-    pub(crate) fn client_disconnected_signal(&self) -> impl std::future::Future<Output = ()> + '_ {
-        async move {
-            match &self.execution_control.client_disconnect {
-                Some(token) => token.cancelled().await,
-                None => std::future::pending().await,
-            }
+    pub(crate) async fn client_disconnected_signal(&self) {
+        match &self.execution_control.client_disconnect {
+            Some(token) => token.cancelled().await,
+            None => std::future::pending().await,
         }
     }
 

--- a/crates/bitrouter-sdk/src/language_model/context.rs
+++ b/crates/bitrouter-sdk/src/language_model/context.rs
@@ -46,7 +46,6 @@ struct Extensions {
 }
 
 /// Request-scoped controls shared by server-tool prompt forks.
-#[allow(dead_code)] // Installed at non-stream entry points in the next integration step.
 #[derive(Clone, Default)]
 struct ExecutionControl {
     client_disconnect: Option<CancellationToken>,
@@ -465,13 +464,11 @@ impl PipelineContext {
 
     /// Install the request-scoped client-disconnect signal for non-stream
     /// continuation checks. Prompt forks retain a clone of this token.
-    #[allow(dead_code)] // Consumed by the non-stream detached execution path.
     pub(crate) fn install_client_disconnect_token(&mut self, token: CancellationToken) {
         self.execution_control.client_disconnect = Some(token);
     }
 
     /// Whether the downstream client has disconnected from this request.
-    #[allow(dead_code)] // Consumed by fallback and server-tool continuation checks.
     pub(crate) fn client_disconnected(&self) -> bool {
         self.execution_control
             .client_disconnect
@@ -482,7 +479,6 @@ impl PipelineContext {
     /// A future that resolves when the downstream client disconnects.
     ///
     /// Contexts without an installed signal remain continuable indefinitely.
-    #[allow(dead_code)] // Consumed by cancellable fallback-backoff waits.
     pub(crate) async fn client_disconnected_signal(&self) {
         match &self.execution_control.client_disconnect {
             Some(token) => token.cancelled().await,

--- a/crates/bitrouter-sdk/src/language_model/executor.rs
+++ b/crates/bitrouter-sdk/src/language_model/executor.rs
@@ -534,9 +534,9 @@ impl UpstreamErrorScrubber {
             BitrouterError::Internal(message) => {
                 BitrouterError::Internal(self.scrub_text(&message))
             }
-            error @ (BitrouterError::UpstreamTimeout | BitrouterError::UpstreamUnavailable) => {
-                error
-            }
+            error @ (BitrouterError::UpstreamTimeout
+            | BitrouterError::ClientDisconnected
+            | BitrouterError::UpstreamUnavailable) => error,
         }
     }
 }

--- a/crates/bitrouter-sdk/src/language_model/hooks.rs
+++ b/crates/bitrouter-sdk/src/language_model/hooks.rs
@@ -164,6 +164,10 @@ pub enum HopOutcome<'a> {
     StreamStarted,
     /// Hop failed before it could complete.
     Failed(&'a BitrouterError),
+    /// Local control stopped the hop after observation began but before the
+    /// provider executor was dispatched. Observers must not treat this as
+    /// provider success, failure, latency, or health evidence.
+    NotDispatched,
 }
 
 /// Terminal outcome of a streaming upstream response body.

--- a/crates/bitrouter-sdk/src/language_model/pipeline.rs
+++ b/crates/bitrouter-sdk/src/language_model/pipeline.rs
@@ -1035,6 +1035,11 @@ impl Pipeline {
                 return Err(BitrouterError::ClientDisconnected);
             }
             self.observe_hop_start(ctx, target).await;
+            if ctx.client_disconnected() {
+                self.observe_hop_end(ctx, target, HopOutcome::NotDispatched)
+                    .await;
+                return Err(BitrouterError::ClientDisconnected);
+            }
             let outcome = self.executor.execute(target, prompt, ctx).await;
             match &outcome {
                 Ok(result) => {

--- a/crates/bitrouter-sdk/src/language_model/pipeline.rs
+++ b/crates/bitrouter-sdk/src/language_model/pipeline.rs
@@ -303,6 +303,10 @@ impl UpstreamTurn for PipelineUpstream<'_> {
             .execute_with_fallback(self.chain, prompt, self.ctx)
             .await
     }
+
+    fn should_continue(&self) -> bool {
+        !self.ctx.client_disconnected()
+    }
 }
 
 /// Drives one upstream **streaming** turn for the server-side tool loop. Each

--- a/crates/bitrouter-sdk/src/language_model/pipeline.rs
+++ b/crates/bitrouter-sdk/src/language_model/pipeline.rs
@@ -10,6 +10,7 @@ use std::{future::Future, mem};
 use async_trait::async_trait;
 use futures::{FutureExt, StreamExt};
 use futures_core::Stream;
+use tokio_util::sync::CancellationToken;
 use tracing::Instrument;
 
 use crate::error::{BitrouterError, Result};
@@ -135,6 +136,28 @@ pub(crate) struct PreparedStreamPart {
 pub(crate) struct PreparedPipelineResponse {
     pub(crate) response: PipelineResponse,
     pub(crate) delivery: DeliveryPermit,
+}
+
+struct DisconnectOnDrop {
+    token: Option<CancellationToken>,
+}
+
+impl DisconnectOnDrop {
+    fn new(token: CancellationToken) -> Self {
+        Self { token: Some(token) }
+    }
+
+    fn disarm(&mut self) {
+        self.token = None;
+    }
+}
+
+impl Drop for DisconnectOnDrop {
+    fn drop(&mut self) {
+        if let Some(token) = self.token.take() {
+            token.cancel();
+        }
+    }
 }
 
 enum DeliveryAuthorizationOutcome {
@@ -467,6 +490,8 @@ impl Pipeline {
         req: PipelineRequest,
     ) -> Result<PreparedPipelineResponse> {
         let pipeline = Arc::clone(&self);
+        let disconnect_token = CancellationToken::new();
+        let execution_token = disconnect_token.clone();
         // `tokio::spawn` does not propagate the current tracing span, so attach
         // it explicitly — otherwise the whole request's logs would detach from
         // the handler's request span / trace context.
@@ -474,7 +499,9 @@ impl Pipeline {
         let (prepared_tx, prepared_rx) = tokio::sync::oneshot::channel();
         self.detached_executions.spawn(
             async move {
-                let result = pipeline.execute_prepared(req).await;
+                let result = pipeline
+                    .execute_prepared_with_control(req, Some(execution_token))
+                    .await;
                 // A dropped handler drops the prepared delivery permit here;
                 // upstream execution and settlement have nevertheless run on
                 // this shutdown-tracked task.
@@ -482,7 +509,10 @@ impl Pipeline {
             }
             .instrument(span),
         );
-        prepared_rx.await.map_err(|error| {
+        let mut disconnect_on_drop = DisconnectOnDrop::new(disconnect_token);
+        let prepared = prepared_rx.await;
+        disconnect_on_drop.disarm();
+        prepared.map_err(|error| {
             BitrouterError::internal(format!(
                 "non-streaming execution task failed to complete: {error}"
             ))
@@ -497,7 +527,18 @@ impl Pipeline {
     }
 
     async fn execute_prepared(&self, req: PipelineRequest) -> Result<PreparedPipelineResponse> {
+        self.execute_prepared_with_control(req, None).await
+    }
+
+    async fn execute_prepared_with_control(
+        &self,
+        req: PipelineRequest,
+        disconnect_token: Option<CancellationToken>,
+    ) -> Result<PreparedPipelineResponse> {
         let mut ctx = PipelineContext::new(req);
+        if let Some(token) = disconnect_token {
+            ctx.install_client_disconnect_token(token);
+        }
         self.observe_start(&ctx).await;
 
         // ---- Stage 1: pre-request checks ----
@@ -598,8 +639,12 @@ impl Pipeline {
                 // Settlement still runs for failed requests (records the error).
                 self.run_settlement(&mut ctx, false, Some(e.clone())).await;
                 self.observe_after(Phase::Settlement, &ctx).await;
-                self.observe_end(&ctx, RequestOutcome::Failed(e.clone()))
-                    .await;
+                let outcome = if matches!(e, BitrouterError::ClientDisconnected) {
+                    RequestOutcome::ClientDisconnected
+                } else {
+                    RequestOutcome::Failed(e.clone())
+                };
+                self.observe_end(&ctx, outcome).await;
                 return Err(e);
             }
         }
@@ -981,7 +1026,10 @@ impl Pipeline {
     ) -> Result<ExecutionResult> {
         let mut errors = Vec::new();
         for (attempt_index, target) in chain.iter().enumerate() {
-            self.wait_before_fallback(attempt_index).await;
+            self.wait_before_fallback(attempt_index, ctx).await?;
+            if ctx.client_disconnected() {
+                return Err(BitrouterError::ClientDisconnected);
+            }
             self.observe_hop_start(ctx, target).await;
             let outcome = self.executor.execute(target, prompt, ctx).await;
             match &outcome {
@@ -1002,19 +1050,24 @@ impl Pipeline {
                     ctx.set_successful_target(target.clone());
                     return Ok(result);
                 }
-                Err(e) => match self.classify_failure(ctx, &e, target).await {
-                    FallbackDecision::TryNext => {
-                        tracing::warn!(
-                            provider = %target.provider_name,
-                            model = %target.service_id,
-                            error = %e,
-                            "upstream route candidate failed"
-                        );
-                        errors.push(e);
-                        continue;
+                Err(e) => {
+                    if ctx.client_disconnected() {
+                        return Err(BitrouterError::ClientDisconnected);
                     }
-                    FallbackDecision::Fail(e) => return Err(e),
-                },
+                    match self.classify_failure(ctx, &e, target).await {
+                        FallbackDecision::TryNext => {
+                            tracing::warn!(
+                                provider = %target.provider_name,
+                                model = %target.service_id,
+                                error = %e,
+                                "upstream route candidate failed"
+                            );
+                            errors.push(e);
+                            continue;
+                        }
+                        FallbackDecision::Fail(e) => return Err(e),
+                    }
+                }
             }
         }
         Err(aggregate_fallback_errors(errors))
@@ -1027,7 +1080,7 @@ impl Pipeline {
     ) -> Result<StreamingExecution> {
         let mut errors = Vec::new();
         for (attempt_index, target) in chain.iter().enumerate() {
-            self.wait_before_fallback(attempt_index).await;
+            self.wait_before_fallback(attempt_index, ctx).await?;
             let provider_started_at = Instant::now();
             self.observe_hop_start(ctx, target).await;
             let outcome = self
@@ -1081,21 +1134,28 @@ impl Pipeline {
         Err(aggregate_fallback_errors(errors))
     }
 
-    async fn wait_before_fallback(&self, attempt_index: usize) {
+    async fn wait_before_fallback(
+        &self,
+        attempt_index: usize,
+        ctx: &PipelineContext,
+    ) -> Result<()> {
         if attempt_index == 0 || self.fallback_backoff.is_empty() {
-            return;
+            return Ok(());
         }
         let schedule_index = (attempt_index - 1).min(self.fallback_backoff.len() - 1);
         let delay = self.fallback_backoff[schedule_index];
         if delay.is_zero() {
-            return;
+            return Ok(());
         }
         tracing::debug!(
             attempt = attempt_index + 1,
             delay_ms = delay.as_millis(),
             "waiting before retryable fallback candidate"
         );
-        tokio::time::sleep(delay).await;
+        tokio::select! {
+            () = tokio::time::sleep(delay) => Ok(()),
+            () = ctx.client_disconnected_signal() => Err(BitrouterError::ClientDisconnected),
+        }
     }
 
     /// Decide fallback after an upstream failure. Any registered execution hook

--- a/crates/bitrouter-sdk/src/language_model/server_tools/loop_controller.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/loop_controller.rs
@@ -789,7 +789,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn server_tool_disconnect_after_provider_result_preserves_usage_without_running_tool() {
+    async fn server_tool_disconnect_after_provider_result_preserves_usage_without_running_tool()
+    -> Result<()> {
         let expected_usage = Usage {
             prompt_tokens: 13,
             completion_tokens: 5,
@@ -812,8 +813,7 @@ mod tests {
 
         let outcome = loop_
             .run_with_provenance(&base_prompt(), &tool_ctx(), &upstream)
-            .await
-            .unwrap();
+            .await?;
 
         assert!(!upstream.should_continue());
         assert_eq!(upstream.calls(), 1);
@@ -824,10 +824,12 @@ mod tests {
             truncation_reason(&outcome.result),
             Some("client_disconnected")
         );
+        Ok(())
     }
 
     #[tokio::test]
-    async fn server_tool_disconnect_during_running_tool_finishes_tool_without_next_upstream_turn() {
+    async fn server_tool_disconnect_during_running_tool_finishes_tool_without_next_upstream_turn()
+    -> Result<()> {
         let started = Arc::new(Notify::new());
         let release = Arc::new(Semaphore::new(0));
         let toolset = Arc::new(CountingToolset::gated(
@@ -851,10 +853,16 @@ mod tests {
         });
         tokio::time::timeout(std::time::Duration::from_secs(1), started.notified())
             .await
-            .unwrap();
+            .map_err(|_| {
+                BitrouterError::Internal(
+                    "timed out waiting for disconnect test tool to start".to_string(),
+                )
+            })?;
         upstream.disconnect();
         release.add_permits(1);
-        let outcome = task.await.unwrap().unwrap();
+        let outcome = task.await.map_err(|error| {
+            BitrouterError::Internal(format!("disconnect test task failed: {error}"))
+        })??;
 
         assert_eq!(toolset.calls(), 1);
         assert_eq!(toolset.finished(), 1);
@@ -864,6 +872,7 @@ mod tests {
             truncation_reason(&outcome.result),
             Some("client_disconnected")
         );
+        Ok(())
     }
 
     #[tokio::test]

--- a/crates/bitrouter-sdk/src/language_model/server_tools/loop_controller.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/loop_controller.rs
@@ -50,6 +50,17 @@ pub(crate) struct ServerToolLoopOutcome {
     pub(crate) provider_terminal_exposed: bool,
 }
 
+enum ToolBatchOutcome {
+    Completed {
+        results: Vec<Content>,
+        had_error: bool,
+    },
+    Interrupted {
+        results: Vec<Content>,
+        had_error: bool,
+    },
+}
+
 impl ServerToolLoop {
     /// Build a loop over `registry`, bounded by `config`, gated by `approval`.
     pub fn new(
@@ -164,7 +175,20 @@ impl ServerToolLoop {
                     provider_terminal_exposed: false,
                 });
             }
-            let mut result = upstream.run(&working).await?;
+            let mut result = match upstream.run(&working).await {
+                Ok(result) => result,
+                Err(BitrouterError::ClientDisconnected) => {
+                    if let Some(mut result) = previous_result.take() {
+                        result.server_tool_calls = std::mem::take(&mut server_calls);
+                        return Ok(ServerToolLoopOutcome {
+                            result: truncate(result, total, had_usage, "client_disconnected"),
+                            provider_terminal_exposed: false,
+                        });
+                    }
+                    return Err(BitrouterError::ClientDisconnected);
+                }
+                Err(error) => return Err(error),
+            };
             if let Some(usage) = &result.result.usage {
                 add_usage(&mut total, usage);
                 had_usage = true;
@@ -200,22 +224,38 @@ impl ServerToolLoop {
                         });
                     }
                     record_provider_calls(&mut server_calls, &result.result.content);
-                    let (tool_results, had_error) = self.execute_calls(&calls, ctx).await;
-                    // v1: status uses the turn's aggregate error flag, not per-call.
-                    // Denied calls and a single failing call among siblings are both
-                    // surfaced as Error/Ok at turn granularity; per-call status
-                    // (including ServerToolStatus::Denied) is a later refinement.
-                    for call in &calls {
-                        server_calls.push(ServerToolCall {
-                            name: call.name.clone(),
-                            kind: ServerToolKind::Router,
-                            call_id: Some(call.id.clone()),
-                            status: if had_error {
-                                ServerToolStatus::Error
-                            } else {
-                                ServerToolStatus::Ok
-                            },
-                            result_count: 0,
+                    let (tool_results, had_error) = match self
+                        .execute_calls(&calls, ctx, upstream)
+                        .await
+                    {
+                        ToolBatchOutcome::Completed { results, had_error } => {
+                            record_router_calls(
+                                &mut server_calls,
+                                &calls,
+                                results.len(),
+                                had_error,
+                            );
+                            (results, had_error)
+                        }
+                        ToolBatchOutcome::Interrupted { results, had_error } => {
+                            record_router_calls(
+                                &mut server_calls,
+                                &calls,
+                                results.len(),
+                                had_error,
+                            );
+                            result.server_tool_calls = std::mem::take(&mut server_calls);
+                            return Ok(ServerToolLoopOutcome {
+                                result: truncate(result, total, had_usage, "client_disconnected"),
+                                provider_terminal_exposed: false,
+                            });
+                        }
+                    };
+                    if !upstream.should_continue() {
+                        result.server_tool_calls = std::mem::take(&mut server_calls);
+                        return Ok(ServerToolLoopOutcome {
+                            result: truncate(result, total, had_usage, "client_disconnected"),
+                            provider_terminal_exposed: false,
                         });
                     }
                     consecutive_errors = if had_error { consecutive_errors + 1 } else { 0 };
@@ -242,7 +282,17 @@ impl ServerToolLoop {
         call: &RouterCall,
         ctx: &ToolContext,
     ) -> (ToolResultOutput, bool) {
-        if !self.approval.allow(call, ctx.caller()).await {
+        let approved = self.approval.allow(call, ctx.caller()).await;
+        self.execute_approved_call(call, ctx, approved).await
+    }
+
+    async fn execute_approved_call(
+        &self,
+        call: &RouterCall,
+        ctx: &ToolContext,
+        approved: bool,
+    ) -> (ToolResultOutput, bool) {
+        if !approved {
             return (
                 ToolResultOutput::ExecutionDenied {
                     reason: Some("denied by approval policy".to_string()),
@@ -280,13 +330,26 @@ impl ServerToolLoop {
         }
     }
 
-    /// Execute each router-owned call, returning the tool-result content blocks
-    /// and whether any call produced an error.
-    async fn execute_calls(&self, calls: &[RouterCall], ctx: &ToolContext) -> (Vec<Content>, bool) {
+    /// Execute each router-owned call without cancelling one that already
+    /// started. The interrupted form retains results for completed calls while
+    /// preventing approval or side effects for every later call.
+    async fn execute_calls(
+        &self,
+        calls: &[RouterCall],
+        ctx: &ToolContext,
+        upstream: &dyn UpstreamTurn,
+    ) -> ToolBatchOutcome {
         let mut results = Vec::with_capacity(calls.len());
         let mut had_error = false;
         for call in calls {
-            let (output, err) = self.call_one(call, ctx).await;
+            if !upstream.should_continue() {
+                return ToolBatchOutcome::Interrupted { results, had_error };
+            }
+            let approved = self.approval.allow(call, ctx.caller()).await;
+            if !upstream.should_continue() {
+                return ToolBatchOutcome::Interrupted { results, had_error };
+            }
+            let (output, err) = self.execute_approved_call(call, ctx, approved).await;
             had_error |= err;
             results.push(Content::ToolResult {
                 call_id: call.id.clone(),
@@ -295,8 +358,11 @@ impl ServerToolLoop {
                 dynamic: false,
                 provider_metadata: ProviderMetadata::new(),
             });
+            if !upstream.should_continue() {
+                return ToolBatchOutcome::Interrupted { results, had_error };
+            }
         }
-        (results, had_error)
+        ToolBatchOutcome::Completed { results, had_error }
     }
 }
 
@@ -403,6 +469,30 @@ fn record_provider_calls(out: &mut Vec<ServerToolCall>, content: &[Content]) {
     }
 }
 
+/// Record only router calls whose execution produced a result before a batch
+/// interruption. Status intentionally retains the historical per-turn
+/// aggregate error semantics.
+fn record_router_calls(
+    out: &mut Vec<ServerToolCall>,
+    calls: &[RouterCall],
+    completed: usize,
+    had_error: bool,
+) {
+    for call in calls.iter().take(completed) {
+        out.push(ServerToolCall {
+            name: call.name.clone(),
+            kind: ServerToolKind::Router,
+            call_id: Some(call.id.clone()),
+            status: if had_error {
+                ServerToolStatus::Error
+            } else {
+                ServerToolStatus::Ok
+            },
+            result_count: 0,
+        });
+    }
+}
+
 /// Finish a bounded loop: replace usage with the accumulated total and set a
 /// truncation finish reason.
 fn truncate(
@@ -422,7 +512,7 @@ fn truncate(
 mod tests {
     use super::*;
     use crate::caller::CallerContext;
-    use crate::language_model::server_tools::approval::AllowAll;
+    use crate::language_model::server_tools::approval::{AllowAll, ApprovalPolicy};
     use crate::language_model::server_tools::toolset::RouterToolset;
     use crate::language_model::types::{GenerateResult, Tool};
     use std::collections::VecDeque;
@@ -624,11 +714,65 @@ mod tests {
         }
     }
 
+    struct LaterDisconnectUpstream {
+        responses: Mutex<VecDeque<Result<ExecutionResult>>>,
+        calls: AtomicUsize,
+    }
+
+    impl LaterDisconnectUpstream {
+        fn new(responses: Vec<Result<ExecutionResult>>) -> Self {
+            Self {
+                responses: Mutex::new(responses.into()),
+                calls: AtomicUsize::new(0),
+            }
+        }
+
+        fn calls(&self) -> usize {
+            self.calls.load(Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait]
+    impl UpstreamTurn for LaterDisconnectUpstream {
+        async fn run(&self, _prompt: &Prompt) -> Result<ExecutionResult> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            let next = match self.responses.lock() {
+                Ok(mut responses) => responses.pop_front(),
+                Err(poisoned) => poisoned.into_inner().pop_front(),
+            };
+            next.unwrap_or_else(|| {
+                Err(BitrouterError::Internal(
+                    "later-disconnect test exhausted upstream turns".to_string(),
+                ))
+            })
+        }
+    }
+
     struct CountingToolset {
         calls: AtomicUsize,
         finished: AtomicUsize,
         started: Option<Arc<Notify>>,
         release: Option<Arc<Semaphore>>,
+        fail: bool,
+    }
+
+    struct GatedApproval {
+        started: Arc<Notify>,
+        release: Arc<Semaphore>,
+    }
+
+    #[async_trait]
+    impl ApprovalPolicy for GatedApproval {
+        async fn allow(&self, _call: &RouterCall, _caller: &CallerContext) -> bool {
+            self.started.notify_one();
+            match self.release.acquire().await {
+                Ok(permit) => {
+                    permit.forget();
+                    true
+                }
+                Err(_) => false,
+            }
+        }
     }
 
     impl CountingToolset {
@@ -638,6 +782,7 @@ mod tests {
                 finished: AtomicUsize::new(0),
                 started: None,
                 release: None,
+                fail: false,
             }
         }
 
@@ -647,6 +792,17 @@ mod tests {
                 finished: AtomicUsize::new(0),
                 started: Some(started),
                 release: Some(release),
+                fail: false,
+            }
+        }
+
+        fn gated_failing(started: Arc<Notify>, release: Arc<Semaphore>) -> Self {
+            Self {
+                calls: AtomicUsize::new(0),
+                finished: AtomicUsize::new(0),
+                started: Some(started),
+                release: Some(release),
+                fail: true,
             }
         }
 
@@ -688,9 +844,15 @@ mod tests {
                 permit.forget();
             }
             self.finished.fetch_add(1, Ordering::SeqCst);
-            Ok(ToolResultOutput::Text {
-                value: "ran search".to_string(),
-            })
+            if self.fail {
+                Err(BitrouterError::Internal(
+                    "disconnect test tool failed".to_string(),
+                ))
+            } else {
+                Ok(ToolResultOutput::Text {
+                    value: "ran search".to_string(),
+                })
+            }
         }
 
         fn owns(&self, name: &str) -> bool {
@@ -699,10 +861,17 @@ mod tests {
     }
 
     fn disconnect_loop_with(toolset: Arc<CountingToolset>) -> ServerToolLoop {
+        disconnect_loop_with_approval(toolset, Arc::new(AllowAll))
+    }
+
+    fn disconnect_loop_with_approval(
+        toolset: Arc<CountingToolset>,
+        approval: Arc<dyn ApprovalPolicy>,
+    ) -> ServerToolLoop {
         ServerToolLoop::new(
             ToolsetRegistry::new(vec![toolset]),
             ServerToolLoopConfig::default(),
-            Arc::new(AllowAll),
+            approval,
         )
     }
 
@@ -764,8 +933,12 @@ mod tests {
     }
 
     fn tool_call(name: &str) -> Content {
+        tool_call_with_id(name, &format!("{name}-1"))
+    }
+
+    fn tool_call_with_id(name: &str, id: &str) -> Content {
         Content::ToolCall {
-            id: format!("{name}-1"),
+            id: id.to_string(),
             name: name.to_string(),
             arguments: "{}".to_string(),
             provider_executed: false,
@@ -867,6 +1040,184 @@ mod tests {
         assert_eq!(toolset.calls(), 1);
         assert_eq!(toolset.finished(), 1);
         assert_eq!(upstream.calls(), 1);
+        assert!(!outcome.provider_terminal_exposed);
+        assert_eq!(
+            truncation_reason(&outcome.result),
+            Some("client_disconnected")
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn server_tool_disconnect_during_approval_starts_no_tool_side_effect() -> Result<()> {
+        let approval_started = Arc::new(Notify::new());
+        let approval_release = Arc::new(Semaphore::new(0));
+        let toolset = Arc::new(CountingToolset::immediate());
+        let loop_ = disconnect_loop_with_approval(
+            Arc::clone(&toolset),
+            Arc::new(GatedApproval {
+                started: Arc::clone(&approval_started),
+                release: Arc::clone(&approval_release),
+            }),
+        );
+        let upstream = Arc::new(DisconnectUpstream::new(
+            vec![
+                exec(vec![tool_call("search")]),
+                exec(vec![text("unexpected later turn")]),
+            ],
+            false,
+        ));
+        let task_upstream = Arc::clone(&upstream);
+
+        let task = tokio::spawn(async move {
+            loop_
+                .run_with_provenance(&base_prompt(), &tool_ctx(), task_upstream.as_ref())
+                .await
+        });
+        tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            approval_started.notified(),
+        )
+        .await
+        .map_err(|_| {
+            BitrouterError::Internal("timed out waiting for disconnect test approval".to_string())
+        })?;
+        upstream.disconnect();
+        approval_release.add_permits(1);
+        let outcome = task.await.map_err(|error| {
+            BitrouterError::Internal(format!("disconnect approval test task failed: {error}"))
+        })??;
+
+        assert_eq!(upstream.calls(), 1);
+        assert_eq!(toolset.calls(), 0);
+        assert!(outcome.result.server_tool_calls.is_empty());
+        assert!(!outcome.provider_terminal_exposed);
+        assert_eq!(
+            truncation_reason(&outcome.result),
+            Some("client_disconnected")
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn server_tool_disconnect_after_first_batch_call_starts_no_later_call() -> Result<()> {
+        let first_started = Arc::new(Notify::new());
+        let first_release = Arc::new(Semaphore::new(0));
+        let toolset = Arc::new(CountingToolset::gated_failing(
+            Arc::clone(&first_started),
+            Arc::clone(&first_release),
+        ));
+        let loop_ = ServerToolLoop::new(
+            ToolsetRegistry::new(vec![toolset.clone()]),
+            ServerToolLoopConfig {
+                max_consecutive_errors: 1,
+                ..Default::default()
+            },
+            Arc::new(AllowAll),
+        );
+        let upstream = Arc::new(DisconnectUpstream::new(
+            vec![
+                exec(vec![
+                    tool_call_with_id("search", "first-call"),
+                    tool_call_with_id("search", "second-call"),
+                ]),
+                exec(vec![text("unexpected later turn")]),
+            ],
+            false,
+        ));
+        let task_upstream = Arc::clone(&upstream);
+
+        let task = tokio::spawn(async move {
+            loop_
+                .run_with_provenance(&base_prompt(), &tool_ctx(), task_upstream.as_ref())
+                .await
+        });
+        tokio::time::timeout(std::time::Duration::from_secs(1), first_started.notified())
+            .await
+            .map_err(|_| {
+                BitrouterError::Internal(
+                    "timed out waiting for first disconnect test tool".to_string(),
+                )
+            })?;
+        upstream.disconnect();
+        first_release.add_permits(2);
+        let outcome = task.await.map_err(|error| {
+            BitrouterError::Internal(format!("disconnect batch test task failed: {error}"))
+        })??;
+
+        assert_eq!(upstream.calls(), 1);
+        assert_eq!(toolset.calls(), 1);
+        assert_eq!(toolset.finished(), 1);
+        assert_eq!(outcome.result.server_tool_calls.len(), 1);
+        assert_eq!(
+            outcome.result.server_tool_calls[0].call_id.as_deref(),
+            Some("first-call")
+        );
+        assert_eq!(
+            outcome.result.server_tool_calls[0].status,
+            ServerToolStatus::Error
+        );
+        assert!(!outcome.provider_terminal_exposed);
+        assert_eq!(
+            truncation_reason(&outcome.result),
+            Some("client_disconnected")
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn later_upstream_disconnect_preserves_prior_usage_and_server_call_evidence() -> Result<()>
+    {
+        let expected_usage = Usage {
+            prompt_tokens: 17,
+            completion_tokens: 6,
+            reasoning_tokens: 2,
+            cache_read_tokens: 4,
+            origin: UsageOrigin::ProviderReported,
+            raw: Some(Box::new(serde_json::json!({
+                "input_tokens": 17,
+                "output_tokens": 6
+            }))),
+            ..Default::default()
+        };
+        let provider_call = Content::ToolCall {
+            id: "provider-call".to_string(),
+            name: "web_search".to_string(),
+            arguments: "{}".to_string(),
+            provider_executed: true,
+            dynamic: false,
+            provider_metadata: ProviderMetadata::new(),
+        };
+        let mut first_result = exec(vec![
+            tool_call_with_id("search", "router-call"),
+            provider_call,
+        ]);
+        first_result.result.usage = Some(expected_usage.clone());
+        let upstream = LaterDisconnectUpstream::new(vec![
+            Ok(first_result),
+            Err(BitrouterError::ClientDisconnected),
+        ]);
+        let toolset = Arc::new(CountingToolset::immediate());
+        let loop_ = disconnect_loop_with(Arc::clone(&toolset));
+
+        let outcome = loop_
+            .run_with_provenance(&base_prompt(), &tool_ctx(), &upstream)
+            .await?;
+
+        assert_eq!(upstream.calls(), 2);
+        assert_eq!(toolset.calls(), 1);
+        assert_eq!(outcome.result.result.usage, Some(expected_usage));
+        assert_eq!(outcome.result.server_tool_calls.len(), 2);
+        assert!(outcome.result.server_tool_calls.iter().any(|call| {
+            call.name == "search"
+                && call.kind == ServerToolKind::Router
+                && call.call_id.as_deref() == Some("router-call")
+        }));
+        assert!(outcome.result.server_tool_calls.iter().any(|call| {
+            call.name == "web_search"
+                && call.kind == ServerToolKind::Provider
+                && call.call_id.as_deref() == Some("provider-call")
+        }));
         assert!(!outcome.provider_terminal_exposed);
         assert_eq!(
             truncation_reason(&outcome.result),

--- a/crates/bitrouter-sdk/src/language_model/server_tools/loop_controller.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/loop_controller.rs
@@ -26,6 +26,12 @@ use crate::language_model::types::{
 pub trait UpstreamTurn: Send + Sync {
     /// Run one upstream turn for `prompt`.
     async fn run(&self, prompt: &Prompt) -> Result<ExecutionResult>;
+
+    /// Whether router-owned continuation work may begin. Implementations that
+    /// do not have request-lifetime control remain continuable by default.
+    fn should_continue(&self) -> bool {
+        true
+    }
 }
 
 /// Drives the server-side tool loop over a [`ToolsetRegistry`].
@@ -146,8 +152,18 @@ impl ServerToolLoop {
         let mut consecutive_errors = 0u32;
         let mut rounds = 0u32;
         let mut server_calls: Vec<ServerToolCall> = Vec::new();
+        let mut previous_result: Option<ExecutionResult> = None;
 
         loop {
+            if !upstream.should_continue()
+                && let Some(mut result) = previous_result.take()
+            {
+                result.server_tool_calls = std::mem::take(&mut server_calls);
+                return Ok(ServerToolLoopOutcome {
+                    result: truncate(result, total, had_usage, "client_disconnected"),
+                    provider_terminal_exposed: false,
+                });
+            }
             let mut result = upstream.run(&working).await?;
             if let Some(usage) = &result.result.usage {
                 add_usage(&mut total, usage);
@@ -167,6 +183,13 @@ impl ServerToolLoop {
                     });
                 }
                 TurnDisposition::Execute(calls) => {
+                    if !upstream.should_continue() {
+                        result.server_tool_calls = std::mem::take(&mut server_calls);
+                        return Ok(ServerToolLoopOutcome {
+                            result: truncate(result, total, had_usage, "client_disconnected"),
+                            provider_terminal_exposed: false,
+                        });
+                    }
                     if rounds >= self.config.max_iterations
                         || start.elapsed() >= self.config.total_budget
                     {
@@ -205,6 +228,7 @@ impl ServerToolLoop {
                             provider_terminal_exposed: false,
                         });
                     }
+                    previous_result = Some(result);
                 }
             }
         }
@@ -402,7 +426,9 @@ mod tests {
     use crate::language_model::server_tools::toolset::RouterToolset;
     use crate::language_model::types::{GenerateResult, Tool};
     use std::collections::VecDeque;
-    use std::sync::Mutex;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::{Mutex, MutexGuard};
+    use tokio::sync::{Notify, Semaphore};
 
     #[test]
     fn aggregated_usage_retains_provenance_and_every_raw_fragment() {
@@ -540,6 +566,146 @@ mod tests {
         }
     }
 
+    /// Replays canned turns while exposing an independently controlled
+    /// continuation signal. A turn may simulate the client disconnecting as
+    /// soon as its provider response has been received.
+    struct DisconnectUpstream {
+        responses: Mutex<VecDeque<ExecutionResult>>,
+        calls: AtomicUsize,
+        continue_: AtomicBool,
+        disconnect_after_run: bool,
+    }
+
+    impl DisconnectUpstream {
+        fn new(responses: Vec<ExecutionResult>, disconnect_after_run: bool) -> Self {
+            Self {
+                responses: Mutex::new(responses.into()),
+                calls: AtomicUsize::new(0),
+                continue_: AtomicBool::new(true),
+                disconnect_after_run,
+            }
+        }
+
+        fn calls(&self) -> usize {
+            self.calls.load(Ordering::SeqCst)
+        }
+
+        fn disconnect(&self) {
+            self.continue_.store(false, Ordering::SeqCst);
+        }
+
+        fn should_continue(&self) -> bool {
+            self.continue_.load(Ordering::SeqCst)
+        }
+
+        fn responses(&self) -> MutexGuard<'_, VecDeque<ExecutionResult>> {
+            match self.responses.lock() {
+                Ok(responses) => responses,
+                Err(poisoned) => poisoned.into_inner(),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl UpstreamTurn for DisconnectUpstream {
+        async fn run(&self, _prompt: &Prompt) -> Result<ExecutionResult> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            let result = self.responses().pop_front().ok_or_else(|| {
+                BitrouterError::Internal("disconnect test exhausted upstream turns".to_string())
+            })?;
+            if self.disconnect_after_run {
+                self.disconnect();
+            }
+            Ok(result)
+        }
+
+        fn should_continue(&self) -> bool {
+            DisconnectUpstream::should_continue(self)
+        }
+    }
+
+    struct CountingToolset {
+        calls: AtomicUsize,
+        finished: AtomicUsize,
+        started: Option<Arc<Notify>>,
+        release: Option<Arc<Semaphore>>,
+    }
+
+    impl CountingToolset {
+        fn immediate() -> Self {
+            Self {
+                calls: AtomicUsize::new(0),
+                finished: AtomicUsize::new(0),
+                started: None,
+                release: None,
+            }
+        }
+
+        fn gated(started: Arc<Notify>, release: Arc<Semaphore>) -> Self {
+            Self {
+                calls: AtomicUsize::new(0),
+                finished: AtomicUsize::new(0),
+                started: Some(started),
+                release: Some(release),
+            }
+        }
+
+        fn calls(&self) -> usize {
+            self.calls.load(Ordering::SeqCst)
+        }
+
+        fn finished(&self) -> usize {
+            self.finished.load(Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait]
+    impl RouterToolset for CountingToolset {
+        async fn list_tools(&self, _ctx: &ToolContext) -> Result<Vec<Tool>> {
+            Ok(vec![Tool::Function {
+                name: "search".to_string(),
+                description: None,
+                parameters: serde_json::json!({ "type": "object" }),
+                strict: None,
+                provider_metadata: ProviderMetadata::new(),
+            }])
+        }
+
+        async fn call_tool(
+            &self,
+            _name: &str,
+            _arguments: &str,
+            _ctx: &ToolContext,
+        ) -> Result<ToolResultOutput> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            if let Some(started) = &self.started {
+                started.notify_one();
+            }
+            if let Some(release) = &self.release {
+                let permit = release.acquire().await.map_err(|_| {
+                    BitrouterError::Internal("disconnect test tool gate closed".to_string())
+                })?;
+                permit.forget();
+            }
+            self.finished.fetch_add(1, Ordering::SeqCst);
+            Ok(ToolResultOutput::Text {
+                value: "ran search".to_string(),
+            })
+        }
+
+        fn owns(&self, name: &str) -> bool {
+            name == "search"
+        }
+    }
+
+    fn disconnect_loop_with(toolset: Arc<CountingToolset>) -> ServerToolLoop {
+        ServerToolLoop::new(
+            ToolsetRegistry::new(vec![toolset]),
+            ServerToolLoopConfig::default(),
+            Arc::new(AllowAll),
+        )
+    }
+
     fn loop_with(names: &[&str], fail: bool, config: ServerToolLoopConfig) -> ServerToolLoop {
         let toolset = Arc::new(MockToolset {
             names: names.iter().map(|s| s.to_string()).collect(),
@@ -613,6 +779,91 @@ mod tests {
             text: s.to_string(),
             provider_metadata: ProviderMetadata::new(),
         }
+    }
+
+    fn truncation_reason(result: &ExecutionResult) -> Option<&str> {
+        match result.result.finish_reason.as_ref() {
+            Some(FinishReason::Other(reason)) => Some(reason.as_str()),
+            _ => None,
+        }
+    }
+
+    #[tokio::test]
+    async fn server_tool_disconnect_after_provider_result_preserves_usage_without_running_tool() {
+        let expected_usage = Usage {
+            prompt_tokens: 13,
+            completion_tokens: 5,
+            cache_read_tokens: 3,
+            origin: UsageOrigin::ProviderReported,
+            raw: Some(Box::new(serde_json::json!({
+                "input_tokens": 13,
+                "output_tokens": 5
+            }))),
+            ..Default::default()
+        };
+        let mut provider_result = exec(vec![tool_call("search")]);
+        provider_result.result.usage = Some(expected_usage.clone());
+        let upstream = DisconnectUpstream::new(
+            vec![provider_result, exec(vec![text("unexpected later turn")])],
+            true,
+        );
+        let toolset = Arc::new(CountingToolset::immediate());
+        let loop_ = disconnect_loop_with(Arc::clone(&toolset));
+
+        let outcome = loop_
+            .run_with_provenance(&base_prompt(), &tool_ctx(), &upstream)
+            .await
+            .unwrap();
+
+        assert!(!upstream.should_continue());
+        assert_eq!(upstream.calls(), 1);
+        assert_eq!(toolset.calls(), 0);
+        assert_eq!(outcome.result.result.usage, Some(expected_usage));
+        assert!(!outcome.provider_terminal_exposed);
+        assert_eq!(
+            truncation_reason(&outcome.result),
+            Some("client_disconnected")
+        );
+    }
+
+    #[tokio::test]
+    async fn server_tool_disconnect_during_running_tool_finishes_tool_without_next_upstream_turn() {
+        let started = Arc::new(Notify::new());
+        let release = Arc::new(Semaphore::new(0));
+        let toolset = Arc::new(CountingToolset::gated(
+            Arc::clone(&started),
+            Arc::clone(&release),
+        ));
+        let loop_ = disconnect_loop_with(Arc::clone(&toolset));
+        let upstream = Arc::new(DisconnectUpstream::new(
+            vec![
+                exec(vec![tool_call("search")]),
+                exec(vec![text("unexpected later turn")]),
+            ],
+            false,
+        ));
+        let task_upstream = Arc::clone(&upstream);
+
+        let task = tokio::spawn(async move {
+            loop_
+                .run_with_provenance(&base_prompt(), &tool_ctx(), task_upstream.as_ref())
+                .await
+        });
+        tokio::time::timeout(std::time::Duration::from_secs(1), started.notified())
+            .await
+            .unwrap();
+        upstream.disconnect();
+        release.add_permits(1);
+        let outcome = task.await.unwrap().unwrap();
+
+        assert_eq!(toolset.calls(), 1);
+        assert_eq!(toolset.finished(), 1);
+        assert_eq!(upstream.calls(), 1);
+        assert!(!outcome.provider_terminal_exposed);
+        assert_eq!(
+            truncation_reason(&outcome.result),
+            Some("client_disconnected")
+        );
     }
 
     #[tokio::test]

--- a/crates/bitrouter-sdk/src/language_model/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/tests.rs
@@ -552,6 +552,7 @@ impl ObserveHook for HopEventRecorder {
             HopOutcome::Generated(_) => "generated",
             HopOutcome::StreamStarted => "stream_started",
             HopOutcome::Failed(_) => "failed",
+            HopOutcome::NotDispatched => "not_dispatched",
         };
         self.0
             .lock()
@@ -3681,6 +3682,88 @@ impl DetachedFallbackExecutor {
     }
 }
 
+struct CountingImmediateExecutor {
+    calls: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl Executor for CountingImmediateExecutor {
+    async fn execute(
+        &self,
+        target: &RoutingTarget,
+        _prompt: &Prompt,
+        _ctx: &PipelineContext,
+    ) -> Result<ExecutionResult> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        Ok(DetachedFallbackExecutor::successful_result(target))
+    }
+
+    async fn execute_stream(
+        &self,
+        _target: &RoutingTarget,
+        _prompt: &Prompt,
+        _ctx: &PipelineContext,
+    ) -> Result<StreamPartStream> {
+        Err(BitrouterError::internal(
+            "CountingImmediateExecutor: streaming not used",
+        ))
+    }
+}
+
+struct GatedHopStartObserver {
+    started: Arc<tokio::sync::Notify>,
+    release: Arc<tokio::sync::Semaphore>,
+    events: Arc<std::sync::Mutex<Vec<&'static str>>>,
+}
+
+impl GatedHopStartObserver {
+    fn record(&self, event: &'static str) {
+        match self.events.lock() {
+            Ok(mut events) => events.push(event),
+            Err(poisoned) => poisoned.into_inner().push(event),
+        }
+    }
+}
+
+#[async_trait]
+impl ObserveHook for GatedHopStartObserver {
+    async fn after_phase(&self, _phase: Phase, _ctx: &PipelineContext) {}
+
+    async fn on_hop_start(&self, _ctx: &PipelineContext, _target: &RoutingTarget) {
+        self.record("hop_start");
+        self.started.notify_one();
+        if let Ok(permit) = self.release.acquire().await {
+            permit.forget();
+        }
+    }
+
+    async fn on_hop_end(
+        &self,
+        _ctx: &PipelineContext,
+        _target: &RoutingTarget,
+        outcome: HopOutcome<'_>,
+    ) {
+        let event = match outcome {
+            HopOutcome::Generated(_) | HopOutcome::StreamStarted | HopOutcome::Failed(_) => {
+                "provider_terminal"
+            }
+            HopOutcome::NotDispatched => "not_dispatched",
+        };
+        self.record(event);
+    }
+
+    async fn on_stream_part(&self, _ctx: &StreamContext, _part: &StreamPart) {}
+
+    async fn on_request_end(&self, _ctx: &PipelineContext, outcome: &RequestOutcome) {
+        let event = match outcome {
+            RequestOutcome::Completed => "request_completed",
+            RequestOutcome::Failed(_) => "request_failed",
+            RequestOutcome::ClientDisconnected => "request_client_disconnected",
+        };
+        self.record(event);
+    }
+}
+
 #[async_trait]
 impl Executor for DetachedFallbackExecutor {
     async fn execute(
@@ -3749,6 +3832,63 @@ impl ObserveHook for LastOutcomeObserver {
     }
 }
 
+struct BackoffNotifyingFallbackPolicy(Arc<tokio::sync::Notify>);
+
+impl FallbackPolicy for BackoffNotifyingFallbackPolicy {
+    fn classify(&self, _error: &BitrouterError, _attempted: &RoutingTarget) -> FallbackDecision {
+        self.0.notify_one();
+        FallbackDecision::TryNext
+    }
+}
+
+#[tokio::test]
+async fn detached_disconnect_during_hop_start_observation_never_dispatches_provider() {
+    let executor_calls = Arc::new(AtomicUsize::new(0));
+    let observer_started = Arc::new(tokio::sync::Notify::new());
+    let observer_release = Arc::new(tokio::sync::Semaphore::new(0));
+    let events = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let pipeline = pipeline_with(
+        routing_table(&["first"]),
+        Arc::new(CountingImmediateExecutor {
+            calls: Arc::clone(&executor_calls),
+        }),
+        |builder| {
+            builder.observe_hook(GatedHopStartObserver {
+                started: Arc::clone(&observer_started),
+                release: Arc::clone(&observer_release),
+                events: Arc::clone(&events),
+            });
+        },
+    );
+
+    let mut caller = Box::pin(pipeline.clone().execute_detached(request()));
+    assert!(
+        futures::poll!(caller.as_mut()).is_pending(),
+        "the hop-start observer remains blocked"
+    );
+    let observer_entered =
+        tokio::time::timeout(Duration::from_secs(1), observer_started.notified()).await;
+    assert!(observer_entered.is_ok(), "the hop-start observer ran");
+
+    drop(caller);
+    observer_release.add_permits(1);
+    let drained = pipeline.drain_pending_settlements().await;
+
+    let recorded = match events.lock() {
+        Ok(events) => events.clone(),
+        Err(poisoned) => poisoned.into_inner().clone(),
+    };
+    assert!(
+        drained >= 1,
+        "the locally aborted detached request was drained"
+    );
+    assert_eq!(executor_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(
+        recorded,
+        vec!["hop_start", "not_dispatched", "request_client_disconnected"]
+    );
+}
+
 fn detached_fallback_fixture() -> (
     Arc<Pipeline>,
     Arc<DetachedFallbackExecutor>,
@@ -3788,6 +3928,61 @@ async fn detached_disconnect_stops_fallback() {
     let drained = pipeline.drain_pending_settlements().await;
 
     assert!(drained >= 1, "the detached request was drained");
+    assert_eq!(executor.first_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(executor.second_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(observer.last_outcome(), Some("client_disconnected"));
+}
+
+#[tokio::test(start_paused = true)]
+async fn detached_disconnect_wakes_nonzero_fallback_backoff_without_dispatching_next_provider() {
+    let executor = Arc::new(DetachedFallbackExecutor {
+        first_started: Arc::new(tokio::sync::Notify::new()),
+        release_first: Arc::new(tokio::sync::Notify::new()),
+        first_calls: Arc::new(AtomicUsize::new(0)),
+        second_calls: Arc::new(AtomicUsize::new(0)),
+    });
+    let fallback_classified = Arc::new(tokio::sync::Notify::new());
+    let observer = LastOutcomeObserver::default();
+    let backoff = Duration::from_secs(30);
+    let pipeline = pipeline_with(
+        routing_table(&["first", "second"]),
+        executor.clone(),
+        |builder| {
+            builder
+                .fallback_policy(Arc::new(BackoffNotifyingFallbackPolicy(Arc::clone(
+                    &fallback_classified,
+                ))))
+                .fallback_backoff([backoff])
+                .observe_hook(observer.clone());
+        },
+    );
+
+    let mut caller = Box::pin(pipeline.clone().execute_detached(request()));
+    assert!(
+        futures::poll!(caller.as_mut()).is_pending(),
+        "the first provider remains in flight"
+    );
+    let first_started =
+        tokio::time::timeout(Duration::from_secs(1), executor.first_started.notified()).await;
+    assert!(first_started.is_ok(), "the first provider started");
+    executor.release_first.notify_one();
+    let classified =
+        tokio::time::timeout(Duration::from_secs(1), fallback_classified.notified()).await;
+    assert!(classified.is_ok(), "the first failure became fallbackable");
+
+    let disconnected_at = tokio::time::Instant::now();
+    drop(caller);
+    let drained = pipeline.drain_pending_settlements().await;
+    let disconnect_latency = tokio::time::Instant::now().duration_since(disconnected_at);
+
+    assert!(
+        drained >= 1,
+        "the backoff-waiting detached request was drained"
+    );
+    assert!(
+        disconnect_latency < Duration::from_secs(1),
+        "disconnect must wake the backoff promptly, not consume {backoff:?}: {disconnect_latency:?}"
+    );
     assert_eq!(executor.first_calls.load(Ordering::SeqCst), 1);
     assert_eq!(executor.second_calls.load(Ordering::SeqCst), 0);
     assert_eq!(observer.last_outcome(), Some("client_disconnected"));

--- a/crates/bitrouter-sdk/src/language_model/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/tests.rs
@@ -3646,11 +3646,181 @@ async fn opaque_nonretryable_auth_failure_stays_fail_fast_in_both_modes() {
 
 // ===== non-streaming client-disconnect billing (OpenRouter parity) =====
 
+struct DetachedFallbackExecutor {
+    first_started: Arc<tokio::sync::Notify>,
+    release_first: Arc<tokio::sync::Notify>,
+    first_calls: Arc<AtomicUsize>,
+    second_calls: Arc<AtomicUsize>,
+}
+
+impl DetachedFallbackExecutor {
+    fn successful_result(target: &RoutingTarget) -> ExecutionResult {
+        ExecutionResult {
+            provider_id: target.provider_name.clone(),
+            model_id: target.service_id.clone(),
+            account_label: target.account_label.clone(),
+            result: GenerateResult {
+                content: vec![Content::Text {
+                    text: "fallback succeeded".into(),
+                    provider_metadata: Default::default(),
+                }],
+                usage: Some(Usage {
+                    prompt_tokens: 2,
+                    completion_tokens: 3,
+                    ..Default::default()
+                }),
+                finish_reason: Some(FinishReason::Stop),
+                response_id: None,
+                stop_details: None,
+                provider_metadata: Default::default(),
+            },
+            request_duration_ms: 1,
+            upstream_duration_ms: Some(1),
+            server_tool_calls: Vec::new(),
+        }
+    }
+}
+
+#[async_trait]
+impl Executor for DetachedFallbackExecutor {
+    async fn execute(
+        &self,
+        target: &RoutingTarget,
+        _prompt: &Prompt,
+        _ctx: &PipelineContext,
+    ) -> Result<ExecutionResult> {
+        match target.provider_name.as_str() {
+            "first" => {
+                self.first_calls.fetch_add(1, Ordering::SeqCst);
+                self.first_started.notify_one();
+                self.release_first.notified().await;
+                Err(BitrouterError::UpstreamUnavailable)
+            }
+            "second" => {
+                self.second_calls.fetch_add(1, Ordering::SeqCst);
+                Ok(Self::successful_result(target))
+            }
+            provider => Err(BitrouterError::internal(format!(
+                "unexpected detached fallback provider: {provider}"
+            ))),
+        }
+    }
+
+    async fn execute_stream(
+        &self,
+        _target: &RoutingTarget,
+        _prompt: &Prompt,
+        _ctx: &PipelineContext,
+    ) -> Result<StreamPartStream> {
+        Err(BitrouterError::internal(
+            "DetachedFallbackExecutor: streaming not used",
+        ))
+    }
+}
+
+#[derive(Clone, Default)]
+struct LastOutcomeObserver(Arc<std::sync::Mutex<Option<&'static str>>>);
+
+impl LastOutcomeObserver {
+    fn last_outcome(&self) -> Option<&'static str> {
+        match self.0.lock() {
+            Ok(outcome) => *outcome,
+            Err(poisoned) => *poisoned.into_inner(),
+        }
+    }
+}
+
+#[async_trait]
+impl ObserveHook for LastOutcomeObserver {
+    async fn after_phase(&self, _phase: Phase, _ctx: &PipelineContext) {}
+
+    async fn on_stream_part(&self, _ctx: &StreamContext, _part: &StreamPart) {}
+
+    async fn on_request_end(&self, _ctx: &PipelineContext, outcome: &RequestOutcome) {
+        let label = match outcome {
+            RequestOutcome::Completed => "completed",
+            RequestOutcome::Failed(_) => "failed",
+            RequestOutcome::ClientDisconnected => "client_disconnected",
+        };
+        match self.0.lock() {
+            Ok(mut last) => *last = Some(label),
+            Err(poisoned) => *poisoned.into_inner() = Some(label),
+        }
+    }
+}
+
+fn detached_fallback_fixture() -> (
+    Arc<Pipeline>,
+    Arc<DetachedFallbackExecutor>,
+    LastOutcomeObserver,
+) {
+    let executor = Arc::new(DetachedFallbackExecutor {
+        first_started: Arc::new(tokio::sync::Notify::new()),
+        release_first: Arc::new(tokio::sync::Notify::new()),
+        first_calls: Arc::new(AtomicUsize::new(0)),
+        second_calls: Arc::new(AtomicUsize::new(0)),
+    });
+    let observer = LastOutcomeObserver::default();
+    let pipeline = pipeline_with(
+        routing_table(&["first", "second"]),
+        executor.clone(),
+        |builder| {
+            builder.observe_hook(observer.clone());
+        },
+    );
+    (pipeline, executor, observer)
+}
+
+#[tokio::test]
+async fn detached_disconnect_stops_fallback() {
+    let (pipeline, executor, observer) = detached_fallback_fixture();
+    let mut caller = Box::pin(pipeline.clone().execute_detached(request()));
+    assert!(
+        futures::poll!(caller.as_mut()).is_pending(),
+        "the first provider remains in flight"
+    );
+    let started =
+        tokio::time::timeout(Duration::from_secs(1), executor.first_started.notified()).await;
+    assert!(started.is_ok(), "the first provider started");
+
+    drop(caller);
+    executor.release_first.notify_one();
+    let drained = pipeline.drain_pending_settlements().await;
+
+    assert!(drained >= 1, "the detached request was drained");
+    assert_eq!(executor.first_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(executor.second_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(observer.last_outcome(), Some("client_disconnected"));
+}
+
+#[tokio::test]
+async fn connected_detached_request_still_falls_back() {
+    let (pipeline, executor, observer) = detached_fallback_fixture();
+    let mut caller = Box::pin(pipeline.clone().execute_detached(request()));
+    assert!(
+        futures::poll!(caller.as_mut()).is_pending(),
+        "the first provider remains in flight"
+    );
+    let started =
+        tokio::time::timeout(Duration::from_secs(1), executor.first_started.notified()).await;
+    assert!(started.is_ok(), "the first provider started");
+
+    executor.release_first.notify_one();
+    let response = caller.await;
+    pipeline.drain_pending_settlements().await;
+
+    assert!(response.is_ok(), "the second provider succeeds");
+    assert_eq!(executor.first_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(executor.second_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(observer.last_outcome(), Some("completed"));
+}
+
 /// An executor whose `execute` blocks on a gate until the test releases it, so
 /// the test can deterministically drop the request future *while the upstream
 /// call is still in flight* — the exact shape of a mid-request client
 /// disconnect.
 struct GatedExecutor {
+    started: Arc<tokio::sync::Notify>,
     gate: Arc<tokio::sync::Notify>,
     usage: (u64, u64),
 }
@@ -3662,6 +3832,7 @@ impl Executor for GatedExecutor {
         _prompt: &Prompt,
         _ctx: &PipelineContext,
     ) -> Result<ExecutionResult> {
+        self.started.notify_one();
         self.gate.notified().await;
         let (prompt_tokens, completion_tokens) = self.usage;
         Ok(ExecutionResult {
@@ -3724,10 +3895,12 @@ async fn nonstream_execute_detached_returns_full_usage_when_connected() {
 #[tokio::test]
 async fn nonstream_disconnect_still_runs_to_completion_and_bills_full() {
     let captured = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let started = Arc::new(tokio::sync::Notify::new());
     let gate = Arc::new(tokio::sync::Notify::new());
     let pipeline = pipeline_with(
         routing_table(&["openai"]),
         Arc::new(GatedExecutor {
+            started: started.clone(),
             gate: gate.clone(),
             usage: (7, 11),
         }),
@@ -3744,6 +3917,8 @@ async fn nonstream_disconnect_still_runs_to_completion_and_bills_full() {
         futures::poll!(fut.as_mut()).is_pending(),
         "detached task spawned but gated; handler future still pending"
     );
+    let provider_started = tokio::time::timeout(Duration::from_secs(1), started.notified()).await;
+    assert!(provider_started.is_ok(), "the provider call is in flight");
     drop(fut); // client disconnected
 
     // The request must still run to completion and settle the real full usage.

--- a/crates/bitrouter-sdk/tests/pipeline_context_disconnect.rs
+++ b/crates/bitrouter-sdk/tests/pipeline_context_disconnect.rs
@@ -1,0 +1,39 @@
+use bitrouter_sdk::caller::CallerContext;
+use bitrouter_sdk::language_model::context::PipelineContext;
+use bitrouter_sdk::language_model::types::{PipelineRequest, Prompt};
+use std::task::Poll;
+
+fn context_without_disconnect_signal() -> PipelineContext {
+    let prompt = Prompt {
+        model: "test-model".to_string(),
+        system: None,
+        system_provider_metadata: Default::default(),
+        messages: Vec::new(),
+        tools: Vec::new(),
+        params: Default::default(),
+        response_format: None,
+        tool_choice: None,
+        stream: false,
+    };
+    PipelineContext::new(PipelineRequest::new(
+        "test-model",
+        CallerContext::local(),
+        prompt,
+    ))
+}
+
+#[test]
+fn public_disconnect_predicate_reports_connected_without_sdk_signal() {
+    let context = context_without_disconnect_signal();
+
+    assert!(!context.client_disconnected());
+}
+
+#[tokio::test]
+async fn public_disconnect_signal_remains_pending_without_sdk_signal() {
+    let context = context_without_disconnect_signal();
+    let signal = context.client_disconnected_signal();
+    tokio::pin!(signal);
+
+    assert!(matches!(futures::poll!(signal.as_mut()), Poll::Pending));
+}


### PR DESCRIPTION
## Summary

Stop detached non-stream execution at request-scoped client-disconnect continuation boundaries. The SDK now reports the stable internal terminal contract as HTTP 499 / `client_disconnected` and classifies its settled request outcome as `ClientDisconnected`.

Expose the same request-scoped state on `PipelineContext` as a read-only synchronous predicate and asynchronous signal for app-owned pre-dispatch/admission waits. Consumers receive neither the underlying cancellation token nor cancellation authority; contexts without an SDK-installed detached non-stream token remain connected and the async signal stays pending.

The final review also closes four late-disconnect races: cancellation while an awaited hop-start observer runs, cancellation during blocking server-tool approval or a multi-call batch, a later upstream disconnect after earlier usage/server-call evidence exists, and cancellation during a nonzero fallback backoff.

## Invariant

An in-flight provider execution or already-started tool side effect is never cancelled. `Executor::execute` remains a direct await and is never raced or polled against the disconnect token. A dispatched provider completes with its real success or failure, and its hop observation and settlement remain authoritative. Likewise, an approved and started tool finishes before continuation stops.

The public `PipelineContext` seam is only for app-owned pre-dispatch/admission boundaries. Its async signal must not be raced against an already-started provider/tool execution or used to cancel any in-flight side effect.

## Safe continuation boundaries

After the downstream client disconnects, the advisory token is checked only at SDK-owned continuation boundaries:

1. Before the first provider dispatch.
2. After an awaited hop-start observer and immediately before executor dispatch.
3. Before and during fallback backoff.
4. After a provider failure and before selecting the next fallback.
5. Before server-tool approval, after approval returns, and after each completed call in a tool batch.
6. After a tool batch and before the next server-tool upstream turn.

If disconnect happens after hop-start observation but before dispatch, the SDK emits a balanced `HopOutcome::NotDispatched` hop end. Observers can classify that as local control flow rather than provider success, failure, latency, or health evidence; the OTel exporter marks `bitrouter.provider_dispatched=false` and leaves the span neutral.

If a later server-tool upstream turn reports `ClientDisconnected`, the last completed result is returned with the `client_disconnected` finish reason while preserving accumulated usage and provider/router server-call evidence. Completed calls in an interrupted batch are also preserved, while unstarted calls never run and disconnect takes precedence over a tool-error terminal.

Streaming behavior is unchanged.

## Verification

- Focused disconnect regression filter — 22 unit tests and 2 external integration tests passed, 0 failed.
- Public seam integration suite — 2 passed, 0 failed; its two RED phases first failed with E0624 while each API was crate-private.
- `cargo fmt --all -- --check` — exit 0.
- `cargo clippy --workspace --all-features --tests -- -D warnings` — exit 0.
- `cargo nextest run --workspace --all-features` — exit 0; 2,862 passed, 11 skipped.
- `cargo check -p bitrouter-sdk --no-default-features` — exit 0.
- `cargo test --doc --workspace --all-features` — exit 0; SDK doctests: 5 passed, 1 ignored.
- `git diff origin/main...HEAD --check` — exit 0.
- `git diff --stat origin/main...HEAD` — 10 files changed; 1,247 insertions, 51 deletions.
- `git status --short` — no tracked or untracked output; ignored implementation report excluded.
- `gh pr checks 850 --watch --interval 10` — terminal success for head `2cdf3f0e9aa663e270f23b7a029cb4ff5a5da7e5`; every non-skipped check passed, with 7 expected workflow skips and 0 failed or pending checks.
