### PR TITLE
feat(acp): harden v1 controller routing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,8 +16,7 @@ dependencies = [
 [[package]]
 name = "agent-client-protocol"
 version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d87bc7769eba641753ba5dc52f73ec3765d51022c6753bf040967125ddc86a8"
+source = "git+https://github.com/agentclientprotocol/rust-sdk.git?rev=c63610fc38a642f7a73ba2719f403f17d771c345#c63610fc38a642f7a73ba2719f403f17d771c345"
 dependencies = [
  "agent-client-protocol-derive",
  "agent-client-protocol-schema",
@@ -40,8 +39,7 @@ dependencies = [
 [[package]]
 name = "agent-client-protocol-conductor"
 version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76bc4fa6dce4d0c06726a091a134442048204ea6974b38e1d72fd49a6481458e"
+source = "git+https://github.com/agentclientprotocol/rust-sdk.git?rev=c63610fc38a642f7a73ba2719f403f17d771c345#c63610fc38a642f7a73ba2719f403f17d771c345"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-trace-viewer",
@@ -64,8 +62,7 @@ dependencies = [
 [[package]]
 name = "agent-client-protocol-derive"
 version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3abd4080f51e4f24f5042beb7fb7a66ede29a2dc1c2582c329532e1c27264ddc"
+source = "git+https://github.com/agentclientprotocol/rust-sdk.git?rev=c63610fc38a642f7a73ba2719f403f17d771c345#c63610fc38a642f7a73ba2719f403f17d771c345"
 dependencies = [
  "quote",
  "syn 3.0.3",
@@ -73,9 +70,9 @@ dependencies = [
 
 [[package]]
 name = "agent-client-protocol-schema"
-version = "1.5.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5c231915b4ab578c722eca2d1bd7df4d300bfd6cac3b8e9f0d1e3ddc95b187c"
+checksum = "ca98360c7bb8cc97d7acd49e2a8a851c3f7bee6b2f0535036d8ab86b5fcd223d"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -90,8 +87,7 @@ dependencies = [
 [[package]]
 name = "agent-client-protocol-trace-viewer"
 version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "163ed8d901ef7e805e574f6d28e4bbc1cbe98c4ce82abac120833b58b43c306c"
+source = "git+https://github.com/agentclientprotocol/rust-sdk.git?rev=c63610fc38a642f7a73ba2719f403f17d771c345#c63610fc38a642f7a73ba2719f403f17d771c345"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,9 +39,11 @@ bitrouter-observe = { path = "crates/bitrouter-observe", version = "1.0.0-alpha.
 # `libc` would need an `unsafe` block, and `bitrouter-sdk` forbids unsafe code.
 rustix = { version = "1", default-features = false }
 
-# ACP SDK crates
-agent-client-protocol = { version = "=2.0.0", features = ["unstable_session_fork"] }
-agent-client-protocol-conductor = "=2.0.0"
+# ACP SDK crates. The published 2.0.0 runtime pins schema 1.5.0 exactly, while
+# the official SDK revision below consumes schema 1.7.0. Pinning one reviewed
+# revision keeps the runtime and the schema on one ACP v1 type universe.
+agent-client-protocol = { git = "https://github.com/agentclientprotocol/rust-sdk.git", rev = "c63610fc38a642f7a73ba2719f403f17d771c345", features = ["unstable_session_fork"] }
+agent-client-protocol-conductor = { git = "https://github.com/agentclientprotocol/rust-sdk.git", rev = "c63610fc38a642f7a73ba2719f403f17d771c345" }
 # Shared by `bitrouter status --watch` (in the app) and `bitrouter-tui` (the
 # ACP session renderer), so the version lives here rather than in either.
 ratatui = { version = "0.29", features = [
@@ -64,7 +66,7 @@ unicode-width = "0.2"
 # for controller-to-harness endpoint setup. `unstable_session_fork` lets tests
 # exercise the advertised lifecycle method. We deliberately do not enable
 # `unstable_protocol_v2`: this controller retains stable ACP v1 wire semantics.
-agent-client-protocol-schema = { version = "=1.5.0", features = [
+agent-client-protocol-schema = { version = "=1.7.0", features = [
     "unstable_llm_providers",
     "unstable_session_fork",
 ] }

--- a/apps/bitrouter/src/acp_cli.rs
+++ b/apps/bitrouter/src/acp_cli.rs
@@ -207,6 +207,9 @@ pub struct Routed {
     /// One controller process / harness connection correlation id. This is
     /// never an ACP session id and is absent for direct or legacy harnesses.
     pub controller_instance_id: Option<String>,
+    /// Opaque route namespace derived from the ordinary API credential, or
+    /// `local` under `skip_auth`. It is not a bearer credential.
+    pub api_principal: Option<String>,
     /// The one process-scoped endpoint plan used for both launch fallback and
     /// post-initialize ACP provider configuration.
     pub endpoint_plan: Option<crate::harness::HarnessEndpointPlan>,
@@ -228,35 +231,7 @@ pub async fn apply_routing(
     opts: &RoutingOptions,
 ) -> std::result::Result<Routed, RoutingError> {
     let cloud_credentials = crate::cloud::StandaloneCloudCredentials::new();
-    apply_routing_with_cloud_credentials(
-        source,
-        config,
-        agent_id,
-        opts,
-        &cloud_credentials,
-        RoutingCredentialMode::UserOrLaunch,
-    )
-    .await
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum RoutingCredentialMode {
-    UserOrLaunch,
-    ControllerIssuedLocal,
-}
-
-fn user_key_required(
-    target_is_local: bool,
-    daemon_requires_key: bool,
-    uses_maintained_adapter: bool,
-    implicit_local_target: bool,
-    mode: RoutingCredentialMode,
-) -> bool {
-    daemon_requires_key
-        && !(target_is_local
-            && uses_maintained_adapter
-            && implicit_local_target
-            && mode == RoutingCredentialMode::ControllerIssuedLocal)
+    apply_routing_with_cloud_credentials(source, config, agent_id, opts, &cloud_credentials).await
 }
 
 async fn apply_routing_with_cloud_credentials(
@@ -265,7 +240,6 @@ async fn apply_routing_with_cloud_credentials(
     agent_id: &str,
     opts: &RoutingOptions,
     cloud_credentials: &crate::cloud::StandaloneCloudCredentials,
-    credential_mode: RoutingCredentialMode,
 ) -> std::result::Result<Routed, RoutingError> {
     // A catalog-known id needs no `agents:` entry — synthesize its invocation.
     if !config.agents.contains_key(agent_id)
@@ -360,13 +334,6 @@ async fn apply_routing_with_cloud_credentials(
     };
     // A remote daemon's `skip_auth` is unknowable here, so require a key.
     let require_key = !target_is_local || !config.server.skip_auth;
-    let require_user_key = user_key_required(
-        target_is_local,
-        require_key,
-        uses_maintained_adapter,
-        opts.base_url.is_none(),
-        credential_mode,
-    );
 
     // A harness whose credential isn't Bearer (gemini's `x-goog-api-key`) is
     // rejected by the daemon's auth hook under `skip_auth: false` — warn
@@ -393,11 +360,16 @@ async fn apply_routing_with_cloud_credentials(
     // metering store has nothing to group by and cost can only be reported
     // daemon-wide.
     let supplied = explicit_key.or(stored_cloud_key);
-    if supplied.is_none() && require_user_key {
+    if supplied.is_none() && require_key {
         return Err(RoutingError::AuthRequired { via: base_url });
     }
     let auth = crate::spawn::resolve_launch_token(supplied, None);
     let launch_id = crate::spawn::is_launch_token(&auth).then(|| auth.clone());
+    let api_principal = if target_is_local && config.server.skip_auth {
+        "local".to_string()
+    } else {
+        crate::auth::keys::hash_key(&auth)
+    };
 
     // Daemon liveness: auto-start a local daemon, then probe. Fail fast if the
     // daemon is still unreachable (a routed sub-agent without one is
@@ -453,6 +425,7 @@ async fn apply_routing_with_cloud_credentials(
         via: Some(base_url),
         launch_id,
         controller_instance_id: endpoint_plan.as_ref().map(|_| controller_instance_id),
+        api_principal: endpoint_plan.as_ref().map(|_| api_principal),
         endpoint_plan,
     })
 }
@@ -721,13 +694,19 @@ fn controller_endpoint(
 
 struct DaemonRouteControl {
     socket_path: PathBuf,
+    api_principal: String,
     controller_instance_id: String,
 }
 
 impl DaemonRouteControl {
-    fn new(socket_path: PathBuf, controller_instance_id: impl Into<String>) -> Self {
+    fn new(
+        socket_path: PathBuf,
+        api_principal: impl Into<String>,
+        controller_instance_id: impl Into<String>,
+    ) -> Self {
         Self {
             socket_path,
+            api_principal: api_principal.into(),
             controller_instance_id: controller_instance_id.into(),
         }
     }
@@ -764,6 +743,7 @@ impl AcpRouteControl for DaemonRouteControl {
         session_id: &str,
     ) -> std::result::Result<RouteControlState, RouteControlError> {
         self.route_state(crate::daemon::DaemonCommand::AcpRouteList {
+            api_principal: self.api_principal.clone(),
             controller_instance_id: self.controller_instance_id.clone(),
             session_id: session_id.to_string(),
         })
@@ -776,6 +756,7 @@ impl AcpRouteControl for DaemonRouteControl {
         route: &str,
     ) -> std::result::Result<RouteControlState, RouteControlError> {
         self.route_state(crate::daemon::DaemonCommand::AcpRouteSet {
+            api_principal: self.api_principal.clone(),
             controller_instance_id: self.controller_instance_id.clone(),
             session_id: session_id.to_string(),
             route: route.to_string(),
@@ -788,6 +769,7 @@ impl AcpRouteControl for DaemonRouteControl {
         session_id: &str,
     ) -> std::result::Result<RouteControlState, RouteControlError> {
         self.route_state(crate::daemon::DaemonCommand::AcpRouteReset {
+            api_principal: self.api_principal.clone(),
             controller_instance_id: self.controller_instance_id.clone(),
             session_id: session_id.to_string(),
         })
@@ -801,7 +783,8 @@ impl AcpRouteControl for DaemonRouteControl {
     async fn disconnected(&self) -> std::result::Result<(), RouteControlError> {
         match crate::daemon::send_command(
             &self.socket_path,
-            &crate::daemon::DaemonCommand::AcpControllerRevoke {
+            &crate::daemon::DaemonCommand::AcpControllerCleanup {
+                api_principal: self.api_principal.clone(),
                 controller_instance_id: self.controller_instance_id.clone(),
             },
         )
@@ -812,10 +795,10 @@ impl AcpRouteControl for DaemonRouteControl {
                 Err(RouteControlError::unavailable(message))
             }
             Ok(other) => Err(RouteControlError::unavailable(format!(
-                "daemon returned an unexpected revoke response: {other:?}"
+                "daemon returned an unexpected cleanup response: {other:?}"
             ))),
             Err(error) => Err(RouteControlError::unavailable(format!(
-                "daemon controller revoke is unavailable: {error}"
+                "daemon controller cleanup is unavailable: {error}"
             ))),
         }
     }
@@ -843,13 +826,12 @@ pub async fn serve(ctx: SpawnContext<'_>) -> Result<()> {
     // Returned, not `exit(1)`: a caller that never sees a value cannot render
     // one, and the shutdown path below is skipped either way because nothing
     // has been launched yet. `run_acp` renders it to stderr.
-    let mut routed = apply_routing_with_cloud_credentials(
+    let routed = apply_routing_with_cloud_credentials(
         source,
         &mut config,
         agent_id,
         &routing,
         &cloud_credentials,
-        RoutingCredentialMode::ControllerIssuedLocal,
     )
     .await
     .map_err(anyhow::Error::new)?;
@@ -860,65 +842,22 @@ pub async fn serve(ctx: SpawnContext<'_>) -> Result<()> {
         .validate()
         .with_context(|| format!("invalid ACP agent '{agent_id}'"))?;
     let mut route_control: Option<Arc<dyn AcpRouteControl>> = None;
-    if let (Some(endpoint), Some(controller_instance_id)) = (
-        routed.endpoint_plan.clone(),
+    if let (Some(_endpoint), Some(controller_instance_id), Some(api_principal)) = (
+        routed.endpoint_plan.as_ref(),
         routed.controller_instance_id.clone(),
+        routed.api_principal.clone(),
     ) {
         if routing.base_url.is_none() {
             let socket_path = crate::daemon::socket_path_for(source, &config);
-            let issued = crate::daemon::send_command(
-                &socket_path,
-                &crate::daemon::DaemonCommand::AcpControllerIssue {
-                    controller_instance_id: controller_instance_id.clone(),
-                },
-            )
-            .await
-            .context("requesting a local ACP controller credential")?;
-            let credential = match issued {
-                crate::daemon::DaemonResponse::AcpControllerCredential {
-                    controller_instance_id: confirmed,
-                    credential,
-                    ..
-                } if confirmed == controller_instance_id => credential,
-                crate::daemon::DaemonResponse::Error { message } => {
-                    return Err(anyhow::anyhow!("ACP controller binding failed: {message}"));
-                }
-                other => {
-                    return Err(anyhow::anyhow!(
-                        "daemon returned an unexpected ACP credential response: {other:?}"
-                    ));
-                }
-            };
-            let endpoint = endpoint.controller_credential(credential.as_str());
-            let overlay = match endpoint.fallback_overlay() {
-                Ok(overlay) => overlay,
-                Err(error) => {
-                    let _ = crate::daemon::send_command(
-                        &socket_path,
-                        &crate::daemon::DaemonCommand::AcpControllerRevoke {
-                            controller_instance_id: controller_instance_id.clone(),
-                        },
-                    )
-                    .await;
-                    return Err(error.context("rendering controller-authenticated fallback"));
-                }
-            };
-            if let Some(entry) = config.agents.get_mut(agent_id) {
-                let AcpTransport::Stdio { args, env, .. } = &mut entry.transport;
-                for (name, value) in overlay.env {
-                    env.insert(name, value);
-                }
-                args.extend(overlay.args);
-            }
-            routed.endpoint_plan = Some(endpoint);
             route_control = Some(Arc::new(DaemonRouteControl::new(
                 socket_path,
+                api_principal,
                 controller_instance_id,
             )));
         } else {
             eprintln!(
                 "note: _bitrouter/route/* is unavailable with an explicit --base-url; \
-                 the remote model endpoint remains usable without trusted session leases"
+                 the remote model endpoint remains usable without session route control"
             );
         }
     }
@@ -980,7 +919,6 @@ pub async fn chat(ctx: SpawnContext<'_>) -> Result<()> {
         agent_id,
         &routing,
         &cloud_credentials,
-        RoutingCredentialMode::UserOrLaunch,
     )
     .await
     .map_err(anyhow::Error::new)?;
@@ -1087,7 +1025,6 @@ where
         agent_id,
         &routing,
         &cloud_credentials,
-        RoutingCredentialMode::UserOrLaunch,
     )
     .await
     {
@@ -1789,53 +1726,7 @@ pub(crate) fn catalog_from_config(config: &Config) -> Result<ConfigAcpRoutingTab
 
 #[cfg(test)]
 mod controller_tests {
-    use super::{RoutingCredentialMode, controller_identity, user_key_required};
-
-    #[test]
-    fn local_maintained_controller_bootstraps_without_a_user_key() {
-        assert!(!user_key_required(
-            true,
-            true,
-            true,
-            true,
-            RoutingCredentialMode::ControllerIssuedLocal,
-        ));
-        assert!(user_key_required(
-            false,
-            true,
-            true,
-            true,
-            RoutingCredentialMode::ControllerIssuedLocal,
-        ));
-        assert!(user_key_required(
-            true,
-            true,
-            false,
-            true,
-            RoutingCredentialMode::ControllerIssuedLocal,
-        ));
-        assert!(user_key_required(
-            true,
-            true,
-            true,
-            false,
-            RoutingCredentialMode::ControllerIssuedLocal,
-        ));
-        assert!(user_key_required(
-            true,
-            true,
-            true,
-            true,
-            RoutingCredentialMode::UserOrLaunch,
-        ));
-        assert!(!user_key_required(
-            true,
-            false,
-            true,
-            true,
-            RoutingCredentialMode::UserOrLaunch,
-        ));
-    }
+    use super::controller_identity;
 
     #[test]
     fn direct_maintained_adapter_keeps_exact_identity() {

--- a/apps/bitrouter/src/acp_runtime.rs
+++ b/apps/bitrouter/src/acp_runtime.rs
@@ -1,79 +1,24 @@
-//! Authenticated, ephemeral ACP controller runtime state.
+//! Ephemeral ACP session-route state.
 
 use std::collections::HashMap;
 use std::sync::RwLock;
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
-use sha2::{Digest, Sha256};
 
-/// Prefix of credentials accepted only for authenticated ACP controllers.
-pub const CONTROLLER_CREDENTIAL_PREFIX: &str = "brac_";
-
-/// One short-lived controller credential returned over the owner-only daemon
-/// control socket. Its `Debug` implementation never exposes the token.
-#[derive(Clone)]
-pub struct ControllerCredentialGrant {
-    controller_instance_id: String,
-    token: String,
-    expires_at: DateTime<Utc>,
-}
-
-impl ControllerCredentialGrant {
-    /// Plaintext bearer token. Callers must keep it inside harness endpoint
-    /// configuration and must not log it.
-    pub fn token(&self) -> &str {
-        &self.token
-    }
-
-    /// Controller identity bound to this credential.
-    pub fn controller_instance_id(&self) -> &str {
-        &self.controller_instance_id
-    }
-
-    /// Expiry of this credential and every lease it owns.
-    pub fn expires_at(&self) -> DateTime<Utc> {
-        self.expires_at
-    }
-}
-
-impl std::fmt::Debug for ControllerCredentialGrant {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter
-            .debug_struct("ControllerCredentialGrant")
-            .field("controller_instance_id", &self.controller_instance_id)
-            .field("token", &"[REDACTED]")
-            .field("expires_at", &self.expires_at)
-            .finish()
-    }
-}
-
-/// Authenticated controller principal established from a credential.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ControllerPrincipal {
-    controller_instance_id: String,
-    expires_at: DateTime<Utc>,
-}
-
-impl ControllerPrincipal {
-    /// Credential-bound controller identity.
-    pub fn controller_instance_id(&self) -> &str {
-        &self.controller_instance_id
-    }
-
-    /// Credential expiry.
-    pub fn expires_at(&self) -> DateTime<Utc> {
-        self.expires_at
-    }
-}
+/// Default lifetime of one route lease. Explicit close/delete/disconnect
+/// cleanup normally removes leases first; the TTL bounds crash leftovers.
+pub const DEFAULT_ROUTE_LEASE_TTL: Duration = Duration::from_secs(12 * 60 * 60);
 
 /// One effective session route lease.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RouteLease {
     lease_id: String,
+    api_principal: String,
     controller_instance_id: String,
     session_id: String,
     route: String,
+    expires_at: DateTime<Utc>,
 }
 
 impl RouteLease {
@@ -82,7 +27,12 @@ impl RouteLease {
         &self.lease_id
     }
 
-    /// Owning controller.
+    /// Opaque API principal that owns the route namespace.
+    pub fn api_principal(&self) -> &str {
+        &self.api_principal
+    }
+
+    /// Declared controller namespace.
     pub fn controller_instance_id(&self) -> &str {
         &self.controller_instance_id
     }
@@ -92,135 +42,93 @@ impl RouteLease {
         &self.session_id
     }
 
-    /// BitRouter route selector installed by the manager.
+    /// BitRouter route selector installed by the controller.
     pub fn route(&self) -> &str {
         &self.route
     }
+
+    /// Independent expiry of this route lease.
+    pub fn expires_at(&self) -> DateTime<Utc> {
+        self.expires_at
+    }
 }
 
-#[derive(Clone)]
-struct CredentialEntry {
-    controller_instance_id: String,
-    expires_at: DateTime<Utc>,
-}
+type RouteKey = (String, String, String);
 
 #[derive(Default)]
 struct RuntimeState {
-    credentials: HashMap<String, CredentialEntry>,
-    leases: HashMap<(String, String), RouteLease>,
+    leases: HashMap<RouteKey, RouteLease>,
 }
 
-/// Daemon-owned controller credentials and session route leases.
+/// Daemon-owned, in-memory ACP route leases.
 ///
-/// Everything is deliberately in memory: revocation, expiry, daemon restart,
-/// or controller disconnect removes authority without touching harness-owned
-/// session data.
-#[derive(Default)]
+/// Authentication remains the normal model/API-key concern. Controller and
+/// session values are declared namespace claims within that API principal;
+/// this runtime does not issue credentials or attest those claims.
 pub struct AcpRuntime {
     state: RwLock<RuntimeState>,
+    lease_ttl: Duration,
+}
+
+impl Default for AcpRuntime {
+    fn default() -> Self {
+        Self::with_lease_ttl(DEFAULT_ROUTE_LEASE_TTL)
+    }
 }
 
 impl AcpRuntime {
-    /// Construct an empty runtime.
+    /// Construct an empty runtime with the production lease TTL.
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// Issue a short-lived credential for one controller instance.
-    pub fn issue_controller(
-        &self,
-        controller_instance_id: &str,
-        ttl: Duration,
-    ) -> Result<ControllerCredentialGrant, String> {
-        let controller_instance_id = controller_instance_id.trim();
-        if controller_instance_id.is_empty() {
-            return Err("controller instance id must not be empty".to_string());
+    /// Construct an empty runtime with an explicit lease TTL.
+    ///
+    /// This is public so embeddings can choose a shorter crash-recovery bound;
+    /// it does not change request authentication semantics.
+    pub fn with_lease_ttl(lease_ttl: Duration) -> Self {
+        Self {
+            state: RwLock::new(RuntimeState::default()),
+            lease_ttl,
         }
-        let ttl = chrono::Duration::from_std(ttl)
-            .map_err(|error| format!("controller credential ttl is out of range: {error}"))?;
-        let now = Utc::now();
-        let expires_at = now + ttl;
-        let mut state = self.write_state();
-        cleanup_expired(&mut state, now);
-        if state.credentials.values().any(|entry| {
-            entry.controller_instance_id == controller_instance_id && entry.expires_at > now
-        }) {
-            return Err(format!(
-                "controller instance '{controller_instance_id}' already has a live credential"
-            ));
-        }
-        let token = format!(
-            "{CONTROLLER_CREDENTIAL_PREFIX}{}{}",
-            uuid::Uuid::new_v4().simple(),
-            uuid::Uuid::new_v4().simple()
-        );
-        state.credentials.insert(
-            credential_hash(&token),
-            CredentialEntry {
-                controller_instance_id: controller_instance_id.to_string(),
-                expires_at,
-            },
-        );
-        Ok(ControllerCredentialGrant {
-            controller_instance_id: controller_instance_id.to_string(),
-            token,
-            expires_at,
-        })
     }
 
-    /// Authenticate a presented controller bearer. Expired credentials and
-    /// their leases are removed before lookup.
-    pub fn authenticate(&self, token: &str) -> Option<ControllerPrincipal> {
-        if !token.starts_with(CONTROLLER_CREDENTIAL_PREFIX) {
-            return None;
-        }
-        let mut state = self.write_state();
-        cleanup_expired(&mut state, Utc::now());
-        state
-            .credentials
-            .get(&credential_hash(token))
-            .map(|entry| ControllerPrincipal {
-                controller_instance_id: entry.controller_instance_id.clone(),
-                expires_at: entry.expires_at,
-            })
-    }
-
-    /// Revoke a controller credential and all of its route leases.
-    pub fn revoke_controller(&self, controller_instance_id: &str) {
-        let mut state = self.write_state();
-        state
-            .credentials
-            .retain(|_, entry| entry.controller_instance_id != controller_instance_id);
-        state
-            .leases
-            .retain(|(controller, _), _| controller != controller_instance_id);
-    }
-
-    /// Create or replace one controller/session route lease.
+    /// Create or replace one API-principal/controller/session route lease.
     pub fn set_route(
         &self,
+        api_principal: &str,
         controller_instance_id: &str,
         session_id: &str,
         route: &str,
     ) -> Result<RouteLease, String> {
+        let api_principal = api_principal.trim();
+        let controller_instance_id = controller_instance_id.trim();
         let session_id = session_id.trim();
         let route = route.trim();
-        if session_id.is_empty() || route.is_empty() {
-            return Err("session id and route must not be empty".to_string());
+        if api_principal.is_empty()
+            || controller_instance_id.is_empty()
+            || session_id.is_empty()
+            || route.is_empty()
+        {
+            return Err(
+                "API principal, controller id, session id, and route must not be empty".to_string(),
+            );
         }
-        let mut state = self.write_state();
-        cleanup_expired(&mut state, Utc::now());
-        if !controller_is_active(&state, controller_instance_id) {
-            return Err("controller credential is not active".to_string());
-        }
+        let ttl = chrono::Duration::from_std(self.lease_ttl)
+            .map_err(|error| format!("route lease ttl is out of range: {error}"))?;
+        let now = Utc::now();
         let lease = RouteLease {
             lease_id: format!("brlease_{}", uuid::Uuid::new_v4().simple()),
+            api_principal: api_principal.to_string(),
             controller_instance_id: controller_instance_id.to_string(),
             session_id: session_id.to_string(),
             route: route.to_string(),
+            expires_at: now + ttl,
         };
+        let mut state = self.write_state();
+        cleanup_expired(&mut state, now);
         state.leases.insert(
-            (controller_instance_id.to_string(), session_id.to_string()),
+            route_key(api_principal, controller_instance_id, session_id),
             lease.clone(),
         );
         Ok(lease)
@@ -229,51 +137,58 @@ impl AcpRuntime {
     /// Remove one route lease. Returns the removed lease when present.
     pub fn reset_route(
         &self,
+        api_principal: &str,
         controller_instance_id: &str,
         session_id: &str,
     ) -> Option<RouteLease> {
-        self.write_state()
-            .leases
-            .remove(&(controller_instance_id.to_string(), session_id.to_string()))
+        let mut state = self.write_state();
+        cleanup_expired(&mut state, Utc::now());
+        state.leases.remove(&route_key(
+            api_principal,
+            controller_instance_id,
+            session_id,
+        ))
     }
 
-    /// Resolve the first matching session candidate for an authenticated
-    /// controller. Candidate order expresses exact-child before root fallback.
+    /// Remove every lease in one API-principal/controller namespace.
+    pub fn remove_controller(&self, api_principal: &str, controller_instance_id: &str) {
+        let mut state = self.write_state();
+        cleanup_expired(&mut state, Utc::now());
+        state.leases.retain(|(principal, controller, _), _| {
+            principal != api_principal || controller != controller_instance_id
+        });
+    }
+
+    /// Resolve the first matching session candidate. Candidate order expresses
+    /// exact-child before root fallback.
     pub fn resolve_route(
         &self,
+        api_principal: &str,
         controller_instance_id: &str,
         session_candidates: &[&str],
     ) -> Option<RouteLease> {
         let mut state = self.write_state();
         cleanup_expired(&mut state, Utc::now());
-        if !controller_is_active(&state, controller_instance_id) {
-            return None;
-        }
         session_candidates.iter().find_map(|session_id| {
             state
                 .leases
-                .get(&(
-                    controller_instance_id.to_string(),
-                    (*session_id).to_string(),
+                .get(&route_key(
+                    api_principal,
+                    controller_instance_id,
+                    session_id,
                 ))
                 .cloned()
         })
     }
 
-    /// Read the exact lease for one controller/session pair.
+    /// Read the exact lease for one principal/controller/session tuple.
     pub fn current_route(
         &self,
+        api_principal: &str,
         controller_instance_id: &str,
         session_id: &str,
     ) -> Option<RouteLease> {
-        self.resolve_route(controller_instance_id, &[session_id])
-    }
-
-    /// Whether the daemon still recognizes an unexpired controller binding.
-    pub fn is_controller_active(&self, controller_instance_id: &str) -> bool {
-        let mut state = self.write_state();
-        cleanup_expired(&mut state, Utc::now());
-        controller_is_active(&state, controller_instance_id)
+        self.resolve_route(api_principal, controller_instance_id, &[session_id])
     }
 
     fn write_state(&self) -> std::sync::RwLockWriteGuard<'_, RuntimeState> {
@@ -284,33 +199,16 @@ impl AcpRuntime {
     }
 }
 
-fn credential_hash(token: &str) -> String {
-    hex::encode(Sha256::digest(token.as_bytes()))
-}
-
-fn controller_is_active(state: &RuntimeState, controller_instance_id: &str) -> bool {
-    state
-        .credentials
-        .values()
-        .any(|entry| entry.controller_instance_id == controller_instance_id)
+fn route_key(api_principal: &str, controller_instance_id: &str, session_id: &str) -> RouteKey {
+    (
+        api_principal.to_string(),
+        controller_instance_id.to_string(),
+        session_id.to_string(),
+    )
 }
 
 fn cleanup_expired(state: &mut RuntimeState, now: DateTime<Utc>) {
-    let expired = state
-        .credentials
-        .values()
-        .filter(|entry| entry.expires_at <= now)
-        .map(|entry| entry.controller_instance_id.clone())
-        .collect::<std::collections::HashSet<_>>();
-    if expired.is_empty() {
-        return;
-    }
-    state
-        .credentials
-        .retain(|_, entry| !expired.contains(&entry.controller_instance_id));
-    state
-        .leases
-        .retain(|(controller, _), _| !expired.contains(controller));
+    state.leases.retain(|_, lease| lease.expires_at > now);
 }
 
 #[cfg(test)]
@@ -320,97 +218,124 @@ mod tests {
     use super::AcpRuntime;
 
     #[test]
-    fn controller_credentials_authenticate_and_revoke_without_debug_leakage() {
+    fn route_leases_are_isolated_by_api_principal_and_controller_claim() {
         let runtime = AcpRuntime::new();
-        let grant = runtime
-            .issue_controller("brc_alpha", Duration::from_secs(60))
-            .expect("controller credential is issued");
+        runtime
+            .set_route(
+                "principal-a",
+                "controller-a",
+                "root",
+                "anthropic:claude-sonnet",
+            )
+            .expect("principal a lease");
+        runtime
+            .set_route("principal-a", "controller-b", "root", "openai:gpt-5")
+            .expect("controller b lease");
+        runtime
+            .set_route("principal-b", "controller-a", "root", "google:gemini-3")
+            .expect("principal b lease");
 
-        assert!(grant.token().starts_with("brac_"));
-        assert!(!format!("{grant:?}").contains(grant.token()));
         assert_eq!(
             runtime
-                .authenticate(grant.token())
-                .expect("credential authenticates")
-                .controller_instance_id(),
-            "brc_alpha"
+                .current_route("principal-a", "controller-a", "root")
+                .expect("principal a controller a route")
+                .route(),
+            "anthropic:claude-sonnet"
         );
-
-        runtime.revoke_controller("brc_alpha");
-        assert!(runtime.authenticate(grant.token()).is_none());
+        assert_eq!(
+            runtime
+                .current_route("principal-a", "controller-b", "root")
+                .expect("principal a controller b route")
+                .route(),
+            "openai:gpt-5"
+        );
+        assert_eq!(
+            runtime
+                .current_route("principal-b", "controller-a", "root")
+                .expect("principal b controller a route")
+                .route(),
+            "google:gemini-3"
+        );
+        assert!(
+            runtime
+                .current_route("principal-b", "controller-b", "root")
+                .is_none()
+        );
     }
 
     #[test]
-    fn route_leases_are_isolated_and_follow_ordered_native_candidates() {
+    fn routes_follow_ordered_native_candidates_and_cleanup_one_controller() {
         let runtime = AcpRuntime::new();
-        let alpha = runtime
-            .issue_controller("brc_alpha", Duration::from_secs(60))
-            .expect("alpha credential");
-        let beta = runtime
-            .issue_controller("brc_beta", Duration::from_secs(60))
-            .expect("beta credential");
         runtime
-            .set_route("brc_alpha", "root", "anthropic:claude-sonnet")
-            .expect("alpha lease");
+            .set_route("principal", "controller", "root", "anthropic:claude-sonnet")
+            .expect("root lease");
         runtime
-            .set_route("brc_alpha", "child", "openai:gpt-5")
+            .set_route("principal", "controller", "child", "openai:gpt-5")
             .expect("child lease");
         runtime
-            .set_route("brc_beta", "root", "google:gemini-3")
-            .expect("beta lease");
+            .set_route("principal", "other", "root", "google:gemini-3")
+            .expect("other controller lease");
 
         let exact = runtime
-            .resolve_route("brc_alpha", &["child", "root"])
+            .resolve_route("principal", "controller", &["child", "root"])
             .expect("exact child lease");
         assert_eq!(exact.matched_session_id(), "child");
         assert_eq!(exact.route(), "openai:gpt-5");
 
-        runtime.reset_route("brc_alpha", "child");
-        let inherited = runtime
-            .resolve_route("brc_alpha", &["child", "root"])
-            .expect("root fallback lease");
-        assert_eq!(inherited.matched_session_id(), "root");
-        assert_eq!(inherited.route(), "anthropic:claude-sonnet");
+        runtime.reset_route("principal", "controller", "child");
         assert_eq!(
             runtime
-                .resolve_route("brc_beta", &["root"])
-                .expect("beta route")
+                .resolve_route("principal", "controller", &["child", "root"])
+                .expect("root fallback")
                 .route(),
-            "google:gemini-3"
+            "anthropic:claude-sonnet"
         );
 
-        runtime.revoke_controller("brc_alpha");
-        assert!(runtime.resolve_route("brc_alpha", &["root"]).is_none());
-        assert!(runtime.authenticate(alpha.token()).is_none());
-        assert!(runtime.authenticate(beta.token()).is_some());
-        assert!(runtime.resolve_route("brc_beta", &["root"]).is_some());
-    }
-
-    #[test]
-    fn expired_controller_credentials_remove_owned_leases() {
-        let runtime = AcpRuntime::new();
-        let grant = runtime
-            .issue_controller("brc_expired", Duration::ZERO)
-            .expect("credential is issued before expiry cleanup");
-        runtime
-            .set_route("brc_expired", "session", "openai:gpt-5")
-            .expect_err("an already-expired controller cannot create a lease");
-
-        assert!(runtime.authenticate(grant.token()).is_none());
-        assert!(runtime.resolve_route("brc_expired", &["session"]).is_none());
-    }
-
-    #[test]
-    fn duplicate_live_controller_identity_is_rejected() {
-        let runtime = AcpRuntime::new();
-        let _grant = runtime
-            .issue_controller("brc_same", Duration::from_secs(60))
-            .expect("first controller");
-
+        runtime.remove_controller("principal", "controller");
         assert!(
             runtime
-                .issue_controller("brc_same", Duration::from_secs(60))
-                .is_err()
+                .current_route("principal", "controller", "root")
+                .is_none()
+        );
+        assert!(
+            runtime
+                .current_route("principal", "other", "root")
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn route_lease_expiry_is_independent_per_lease() {
+        let runtime = AcpRuntime::with_lease_ttl(Duration::ZERO);
+        let lease = runtime
+            .set_route("principal", "controller", "session", "openai:gpt-5")
+            .expect("lease can be installed");
+        assert_eq!(lease.api_principal(), "principal");
+        assert_eq!(lease.controller_instance_id(), "controller");
+        assert!(
+            runtime
+                .current_route("principal", "controller", "session")
+                .is_none(),
+            "zero-TTL lease is removed on the next lookup"
+        );
+    }
+
+    #[test]
+    fn same_principal_can_deliberately_reuse_an_exact_claim_namespace() {
+        let runtime = AcpRuntime::new();
+        runtime
+            .set_route("shared", "controller", "session", "first")
+            .expect("first lease");
+        runtime
+            .set_route("shared", "controller", "session", "second")
+            .expect("replacement lease");
+
+        assert_eq!(
+            runtime
+                .current_route("shared", "controller", "session")
+                .expect("shared namespace route")
+                .route(),
+            "second"
         );
     }
 }

--- a/apps/bitrouter/src/assemble.rs
+++ b/apps/bitrouter/src/assemble.rs
@@ -79,7 +79,7 @@ pub struct Assembled {
     pub app: App,
     /// The shared database connection.
     pub db: DatabaseConnection,
-    /// In-memory authenticated ACP controller credentials and route leases.
+    /// In-memory API-principal-scoped ACP route leases.
     pub acp_runtime: Arc<AcpRuntime>,
     /// The policy store wired into the language_model pipeline. Held by the
     /// caller (the daemon) so `bitrouter reload` / SIGHUP can call
@@ -612,7 +612,6 @@ pub async fn build_app_with_path(
     let eval_store_for_recorder = eval_service.store().clone();
     let pricing_for_eval = pricing.clone();
     let db_for_hooks = db.clone();
-    let acp_runtime_for_hooks = Arc::clone(&acp_runtime);
     let acp_runtime_for_session = Arc::clone(&acp_runtime);
     let app = App::builder()
         .skip_auth(config.server.skip_auth)
@@ -641,14 +640,11 @@ pub async fn build_app_with_path(
             }
             // Stage 1, in order: auth → request-session normalization →
             // continuation → policy. Session normalization may apply a
-            // credential-bound route lease before Stage 2 model selection;
+            // API-principal-scoped route lease before Stage 2 model selection;
             // explicit routes and provider continuations retain precedence.
             // The guardrail plugin appends its hooks after this closure (see
             // `.plugin(...)` below), preserving the policy → guardrail order.
-            lm.pre_request_hook(AuthHook::with_acp_runtime(
-                db_for_hooks.clone(),
-                acp_runtime_for_hooks,
-            ));
+            lm.pre_request_hook(AuthHook::new(db_for_hooks.clone()));
             lm.pre_request_hook(SessionContextHook::new(acp_runtime_for_session));
             lm.pre_request_hook(continuation_for_pre_request);
             lm.pre_request_hook(PolicyHook::new(

--- a/apps/bitrouter/src/auth/events.rs
+++ b/apps/bitrouter/src/auth/events.rs
@@ -26,19 +26,18 @@ impl PipelineEvent for Authenticated {
     }
 }
 
-/// A short-lived controller credential was authenticated. Claimed transport
-/// headers are intentionally absent; session normalization compares them to
-/// this credential-bound identity later.
+/// Opaque route namespace derived from the ordinary API credential.
+///
+/// This value is internal correlation state, not a second credential. The
+/// public API-key id remains on [`Authenticated`] and the request caller.
 #[derive(Debug, Clone, Serialize)]
-pub struct ControllerAuthenticated {
-    /// Credential-bound controller identity.
-    pub controller_instance_id: String,
-    /// RFC3339 credential expiry.
-    pub expires_at: String,
+pub struct ApiPrincipalEstablished {
+    /// Stable per-credential route namespace.
+    pub route_scope_id: String,
 }
 
-impl PipelineEvent for ControllerAuthenticated {
+impl PipelineEvent for ApiPrincipalEstablished {
     fn event_name(&self) -> &'static str {
-        "auth.acp_controller_authenticated"
+        "auth.api_principal_established"
     }
 }

--- a/apps/bitrouter/src/auth/hook.rs
+++ b/apps/bitrouter/src/auth/hook.rs
@@ -25,8 +25,6 @@
 //! virtual key. Multi-tenant operators set `skip_auth: false` (the SDK
 //! default) to get real validation.
 
-use std::sync::Arc;
-
 use async_trait::async_trait;
 use chrono::Utc;
 use sea_orm::DatabaseConnection;
@@ -36,9 +34,8 @@ use bitrouter_sdk::language_model::{DenyReason, HookDecision, PipelineContext, P
 use bitrouter_sdk::{PluginId, Result};
 use http::HeaderMap;
 
-use crate::acp_runtime::AcpRuntime;
 use crate::auth::db::{self, ApiKeyRecord};
-use crate::auth::events::{Authenticated, ControllerAuthenticated};
+use crate::auth::events::{ApiPrincipalEstablished, Authenticated};
 use crate::auth::keys;
 
 /// The auth module id, used as the `PipelineContext` metadata key. The
@@ -54,26 +51,13 @@ pub fn plugin_id() -> PluginId {
 /// establishes identity.
 pub struct AuthHook {
     db: DatabaseConnection,
-    acp_runtime: Option<Arc<AcpRuntime>>,
 }
 
 impl AuthHook {
     /// Build an `AuthHook` over a database connection. The database must
     /// already carry this module's tables (`crate::db::run_migrations`).
     pub fn new(db: DatabaseConnection) -> Self {
-        Self {
-            db,
-            acp_runtime: None,
-        }
-    }
-
-    /// Build an auth hook that also recognizes daemon-issued ACP controller
-    /// credentials before the local skip-auth compatibility branch.
-    pub fn with_acp_runtime(db: DatabaseConnection, acp_runtime: Arc<AcpRuntime>) -> Self {
-        Self {
-            db,
-            acp_runtime: Some(acp_runtime),
-        }
+        Self { db }
     }
 
     /// Extract a presented API-key credential from the request headers.
@@ -113,36 +97,6 @@ pub(crate) fn credential_from_headers(headers: &HeaderMap) -> Option<String> {
 impl PreRequestHook for AuthHook {
     async fn check(&self, ctx: &mut PipelineContext) -> Result<HookDecision> {
         let credential = Self::extract_credential(ctx);
-        if let (Some(runtime), Some(credential)) = (&self.acp_runtime, credential.as_deref())
-            && let Some(principal) = runtime.authenticate(credential)
-        {
-            let controller_instance_id = principal.controller_instance_id().to_string();
-            ctx.set_caller(CallerContext::new_scoped(
-                "acp-controller",
-                "acp-controller",
-                controller_instance_id.clone(),
-            ));
-            ctx.set_metadata(
-                &plugin_id(),
-                serde_json::json!({
-                    "api_key_id": "acp-controller",
-                    "user_id": "acp-controller",
-                    "policy_id": null,
-                    "controller_instance_id": controller_instance_id,
-                }),
-            );
-            ctx.emit(Authenticated {
-                api_key_id: "acp-controller".to_string(),
-                user_id: "acp-controller".to_string(),
-                policy_id: None,
-            });
-            ctx.emit(ControllerAuthenticated {
-                controller_instance_id,
-                expires_at: principal.expires_at().to_rfc3339(),
-            });
-            return Ok(HookDecision::Allow);
-        }
-
         // `skip_auth=true` on the SDK side synthesises a local caller
         // for *every* inbound request — admit immediately regardless of
         // any presented header. Validating a stray `Authorization`
@@ -202,6 +156,9 @@ impl PreRequestHook for AuthHook {
             api_key_id: record.id,
             user_id: record.user_id,
             policy_id: record.policy_id,
+        });
+        ctx.emit(ApiPrincipalEstablished {
+            route_scope_id: hash,
         });
         Ok(HookDecision::Allow)
     }

--- a/apps/bitrouter/src/auth/tests.rs
+++ b/apps/bitrouter/src/auth/tests.rs
@@ -11,10 +11,8 @@ use bitrouter_sdk::language_model::{
     Prompt, Role,
 };
 
-use crate::acp_runtime::AcpRuntime;
 use crate::auth::db::{self, NewApiKey};
-use crate::auth::events::Authenticated;
-use crate::auth::events::ControllerAuthenticated;
+use crate::auth::events::{ApiPrincipalEstablished, Authenticated};
 use crate::auth::hook::AuthHook;
 use crate::auth::keys;
 
@@ -89,39 +87,18 @@ async fn valid_key_authenticates_and_emits_event() {
     let event = ctx.get_event::<Authenticated>().expect("event emitted");
     assert_eq!(event.api_key_id, key_id);
     assert_eq!(event.policy_id.as_deref(), Some("pol_default"));
-}
-
-#[tokio::test]
-async fn controller_credential_authenticates_before_skip_auth_short_circuit() {
-    let pool = pool().await;
-    let runtime = std::sync::Arc::new(AcpRuntime::new());
-    let grant = runtime
-        .issue_controller("brc_auth", std::time::Duration::from_secs(60))
-        .expect("controller credential");
-    let hook = AuthHook::with_acp_runtime(pool, runtime);
-    let mut ctx = ctx_with(CallerContext::local(), Some(grant.token()));
-
-    assert!(matches!(
-        hook.check(&mut ctx).await.unwrap(),
-        HookDecision::Allow
-    ));
-    assert!(!ctx.caller().is_local());
-    assert_eq!(ctx.caller().api_key_id(), "acp-controller");
-    assert_eq!(ctx.caller().user_id(), "acp-controller");
-    assert_eq!(ctx.caller().security_scope_id(), "brc_auth");
     assert_eq!(
-        ctx.get_event::<ControllerAuthenticated>()
-            .expect("controller event")
-            .controller_instance_id,
-        "brc_auth"
+        ctx.get_event::<ApiPrincipalEstablished>()
+            .expect("route principal event")
+            .route_scope_id,
+        keys::hash_key(&secret)
     );
 }
 
 #[tokio::test]
-async fn copied_controller_header_without_valid_credential_stays_untrusted() {
+async fn skip_auth_keeps_declared_controller_headers_on_the_local_principal() {
     let pool = pool().await;
-    let runtime = std::sync::Arc::new(AcpRuntime::new());
-    let hook = AuthHook::with_acp_runtime(pool, runtime);
+    let hook = AuthHook::new(pool);
     let mut request = PipelineRequest::new("m", CallerContext::local(), prompt());
     request
         .headers
@@ -136,7 +113,7 @@ async fn copied_controller_header_without_valid_credential_stays_untrusted() {
         HookDecision::Allow
     ));
     assert!(ctx.caller().is_local());
-    assert!(ctx.get_event::<ControllerAuthenticated>().is_none());
+    assert!(ctx.get_event::<ApiPrincipalEstablished>().is_none());
 }
 
 #[tokio::test]

--- a/apps/bitrouter/src/continuation.rs
+++ b/apps/bitrouter/src/continuation.rs
@@ -2080,11 +2080,7 @@ impl PreRequestHook for ContinuationRuntime {
         }
         let resolution = self
             .registry
-            .resolve(
-                ctx.caller().security_scope_id(),
-                &previous_response_id,
-                Utc::now(),
-            )
+            .resolve(ctx.caller().user_id(), &previous_response_id, Utc::now())
             .await
             .map_err(|error| {
                 BitrouterError::internal(format!(
@@ -2224,11 +2220,7 @@ impl RouteHook for ContinuationRuntime {
             ContinuationResolution::Active(prepared.active.clone())
         } else {
             self.registry
-                .resolve(
-                    ctx.caller().security_scope_id(),
-                    &previous_response_id,
-                    Utc::now(),
-                )
+                .resolve(ctx.caller().user_id(), &previous_response_id, Utc::now())
                 .await
                 .map_err(|error| {
                     BitrouterError::internal(format!(
@@ -2343,7 +2335,7 @@ impl ContinuationRuntime {
         let now = Utc::now();
         self.registry
             .bind_pending(
-                ctx.caller.security_scope_id(),
+                ctx.caller.user_id(),
                 &public_continuation_id,
                 ContinuationBinding {
                     provider_response_id,

--- a/apps/bitrouter/src/daemon.rs
+++ b/apps/bitrouter/src/daemon.rs
@@ -24,9 +24,6 @@ use bitrouter_sdk::language_model::RoutingPrefs;
 
 use crate::acp_runtime::AcpRuntime;
 
-const ACP_CONTROLLER_CREDENTIAL_TTL: std::time::Duration =
-    std::time::Duration::from_secs(12 * 60 * 60);
-
 /// Anything the daemon's `Reload` command (and SIGHUP) should re-read. The
 /// runtime reloader fans out to every reloadable subsystem — routing table,
 /// policy store, … — atomically per subsystem. A failure in one is reported
@@ -95,26 +92,27 @@ pub enum DaemonCommand {
         #[serde(default)]
         provider_id: Option<String>,
     },
-    /// Mint a short-lived controller credential over the owner-only socket.
-    AcpControllerIssue {
-        /// Controller process identity that owns the credential and leases.
-        controller_instance_id: String,
-    },
-    /// Revoke one controller credential and every lease it owns.
-    AcpControllerRevoke {
-        /// Credential-bound controller process identity.
+    /// Remove every route lease in one principal/controller namespace.
+    AcpControllerCleanup {
+        /// Opaque principal derived from the normal API credential, or local.
+        api_principal: String,
+        /// Caller-declared controller process identity.
         controller_instance_id: String,
     },
     /// Query routes and exact lease state for one native session.
     AcpRouteList {
-        /// Credential-bound controller process identity.
+        /// Opaque principal derived from the normal API credential, or local.
+        api_principal: String,
+        /// Caller-declared controller process identity.
         controller_instance_id: String,
         /// Harness-native ACP session identity.
         session_id: String,
     },
     /// Install or replace one native-session route lease.
     AcpRouteSet {
-        /// Credential-bound controller process identity.
+        /// Opaque principal derived from the normal API credential, or local.
+        api_principal: String,
+        /// Caller-declared controller process identity.
         controller_instance_id: String,
         /// Harness-native ACP session identity.
         session_id: String,
@@ -123,29 +121,13 @@ pub enum DaemonCommand {
     },
     /// Remove one native-session route lease.
     AcpRouteReset {
-        /// Credential-bound controller process identity.
+        /// Opaque principal derived from the normal API credential, or local.
+        api_principal: String,
+        /// Caller-declared controller process identity.
         controller_instance_id: String,
         /// Harness-native ACP session identity.
         session_id: String,
     },
-}
-
-/// Controller bearer transported only over the owner-only local daemon IPC.
-#[derive(Clone, Serialize, Deserialize)]
-#[serde(transparent)]
-pub struct ControllerCredential(String);
-
-impl ControllerCredential {
-    /// Borrow the credential for harness endpoint configuration.
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-}
-
-impl std::fmt::Debug for ControllerCredential {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter.write_str("[REDACTED]")
-    }
 }
 
 /// One resolved hop of a route chain.
@@ -183,15 +165,6 @@ pub enum DaemonResponse {
     ObserveStatus {
         /// The serialized exporter state.
         payload: ObserveStatusPayload,
-    },
-    /// Newly-issued controller credential and binding metadata.
-    AcpControllerCredential {
-        /// Credential-bound controller process identity.
-        controller_instance_id: String,
-        /// Redacted-on-debug bearer for the harness model endpoint.
-        credential: ControllerCredential,
-        /// RFC 3339 expiry timestamp.
-        expires_at: String,
     },
     /// Daemon-confirmed route state for one native ACP session.
     AcpRouteState {
@@ -444,8 +417,8 @@ pub async fn run_control_socket(
     .await
 }
 
-/// Run the control listener with the same authenticated ACP runtime used by
-/// the model request pipeline.
+/// Run the control listener with the same ACP route runtime used by the model
+/// request pipeline.
 pub async fn run_control_socket_with_acp_runtime(
     socket_path: PathBuf,
     app: Arc<App>,
@@ -618,39 +591,29 @@ async fn dispatch(
                 }
             }
         }
-        DaemonCommand::AcpControllerIssue {
-            controller_instance_id,
-        } => match acp_runtime
-            .issue_controller(&controller_instance_id, ACP_CONTROLLER_CREDENTIAL_TTL)
-        {
-            Ok(grant) => DaemonResponse::AcpControllerCredential {
-                controller_instance_id: grant.controller_instance_id().to_string(),
-                credential: ControllerCredential(grant.token().to_string()),
-                expires_at: grant.expires_at().to_rfc3339(),
-            },
-            Err(message) => DaemonResponse::Error { message },
-        },
-        DaemonCommand::AcpControllerRevoke {
+        DaemonCommand::AcpControllerCleanup {
+            api_principal,
             controller_instance_id,
         } => {
-            acp_runtime.revoke_controller(&controller_instance_id);
+            acp_runtime.remove_controller(&api_principal, &controller_instance_id);
             DaemonResponse::Ok
         }
         DaemonCommand::AcpRouteList {
+            api_principal,
             controller_instance_id,
             session_id,
         } => {
-            if !acp_runtime.is_controller_active(&controller_instance_id) {
+            if api_principal.trim().is_empty()
+                || controller_instance_id.trim().is_empty()
+                || session_id.trim().is_empty()
+            {
                 DaemonResponse::Error {
-                    message: "controller credential is not active".to_string(),
-                }
-            } else if session_id.trim().is_empty() {
-                DaemonResponse::Error {
-                    message: "session id must not be empty".to_string(),
+                    message: "API principal, controller id, and session id must not be empty"
+                        .to_string(),
                 }
             } else {
                 let current = acp_runtime
-                    .current_route(&controller_instance_id, &session_id)
+                    .current_route(&api_principal, &controller_instance_id, &session_id)
                     .map(|lease| lease.route().to_string());
                 DaemonResponse::AcpRouteState {
                     available: route_suggestions(app),
@@ -665,6 +628,7 @@ async fn dispatch(
             }
         }
         DaemonCommand::AcpRouteSet {
+            api_principal,
             controller_instance_id,
             session_id,
             route,
@@ -674,14 +638,15 @@ async fn dispatch(
                     message: "no language_model pipeline configured".to_string(),
                 };
             };
-            if !acp_runtime.is_controller_active(&controller_instance_id) {
+            if api_principal.trim().is_empty()
+                || controller_instance_id.trim().is_empty()
+                || session_id.trim().is_empty()
+                || route.trim().is_empty()
+            {
                 return DaemonResponse::Error {
-                    message: "controller credential is not active".to_string(),
-                };
-            }
-            if session_id.trim().is_empty() || route.trim().is_empty() {
-                return DaemonResponse::Error {
-                    message: "session id and route must not be empty".to_string(),
+                    message:
+                        "API principal, controller id, session id, and route must not be empty"
+                            .to_string(),
                 };
             }
             if let Err(error) = pipeline
@@ -693,7 +658,12 @@ async fn dispatch(
                     message: format!("route is not available: {error}"),
                 };
             }
-            match acp_runtime.set_route(&controller_instance_id, &session_id, &route) {
+            match acp_runtime.set_route(
+                &api_principal,
+                &controller_instance_id,
+                &session_id,
+                &route,
+            ) {
                 Ok(lease) => DaemonResponse::AcpRouteState {
                     available: route_suggestions(app),
                     current: Some(lease.route().to_string()),
@@ -703,19 +673,20 @@ async fn dispatch(
             }
         }
         DaemonCommand::AcpRouteReset {
+            api_principal,
             controller_instance_id,
             session_id,
         } => {
-            if !acp_runtime.is_controller_active(&controller_instance_id) {
+            if api_principal.trim().is_empty()
+                || controller_instance_id.trim().is_empty()
+                || session_id.trim().is_empty()
+            {
                 DaemonResponse::Error {
-                    message: "controller credential is not active".to_string(),
-                }
-            } else if session_id.trim().is_empty() {
-                DaemonResponse::Error {
-                    message: "session id must not be empty".to_string(),
+                    message: "API principal, controller id, and session id must not be empty"
+                        .to_string(),
                 }
             } else {
-                acp_runtime.reset_route(&controller_instance_id, &session_id);
+                acp_runtime.reset_route(&api_principal, &controller_instance_id, &session_id);
                 DaemonResponse::AcpRouteState {
                     available: route_suggestions(app),
                     current: None,

--- a/apps/bitrouter/src/harness.rs
+++ b/apps/bitrouter/src/harness.rs
@@ -210,16 +210,6 @@ impl std::fmt::Debug for HarnessEndpointPlan {
 }
 
 impl HarnessEndpointPlan {
-    /// Replace only the gateway bearer with a daemon-issued controller
-    /// credential. Static controller and harness headers remain unchanged.
-    #[must_use]
-    pub fn controller_credential(mut self, credential: &str) -> Self {
-        self.auth = credential.to_string();
-        self.headers
-            .insert("authorization".to_string(), format!("Bearer {credential}"));
-        self
-    }
-
     /// Render the documented process-environment fallback for this exact
     /// adapter version. No routing configuration is added to adapter argv.
     pub fn fallback_overlay(&self) -> anyhow::Result<RoutingOverlay> {
@@ -1419,30 +1409,6 @@ mod tests {
         let debug = format!("{plan:?}");
         assert!(!debug.contains("brk_secret"), "credential leaked: {debug}");
         assert!(debug.contains("[REDACTED]"));
-        Ok(())
-    }
-
-    #[test]
-    fn controller_credential_updates_provider_and_fallback_auth() -> anyhow::Result<()> {
-        let harness = by_id("claude-acp").ok_or_else(|| anyhow::anyhow!("claude-acp missing"))?;
-        let plan = harness
-            .endpoint_plan("http://127.0.0.1:4356", "old", None, "brc_test")
-            .ok_or_else(|| anyhow::anyhow!("Claude endpoint plan missing"))?
-            .controller_credential("brac_new");
-
-        assert_eq!(
-            plan.headers.get("authorization").map(String::as_str),
-            Some("Bearer brac_new")
-        );
-        let env = plan
-            .fallback_overlay()?
-            .env
-            .into_iter()
-            .collect::<std::collections::HashMap<_, _>>();
-        assert_eq!(
-            env.get("ANTHROPIC_AUTH_TOKEN").map(String::as_str),
-            Some("brac_new")
-        );
         Ok(())
     }
 

--- a/apps/bitrouter/src/metering/db.rs
+++ b/apps/bitrouter/src/metering/db.rs
@@ -39,9 +39,9 @@ pub enum ReconciliationStatus {
 pub struct MeteringSessionIdentity {
     /// Recognized harness.
     pub agent_harness: Option<String>,
-    /// Credential-bound controller identity.
+    /// Caller-declared controller correlation.
     pub controller_instance_id: Option<String>,
-    /// Trusted ACP session binding.
+    /// Caller-declared ACP session correlation.
     pub acp_session_id: Option<String>,
     /// Native root session.
     pub native_root_session_id: Option<String>,

--- a/apps/bitrouter/src/metering/entities/requests.rs
+++ b/apps/bitrouter/src/metering/entities/requests.rs
@@ -18,9 +18,9 @@ pub struct Model {
     pub launch_id: Option<String>,
     /// Recognized agent harness for this request.
     pub agent_harness: Option<String>,
-    /// Credential-bound ACP controller identity.
+    /// Caller-declared ACP controller correlation.
     pub controller_instance_id: Option<String>,
-    /// Trusted ACP session binding.
+    /// Caller-declared ACP session correlation.
     pub acp_session_id: Option<String>,
     /// Native harness root-session identity.
     pub native_root_session_id: Option<String>,

--- a/apps/bitrouter/src/metering/recorder.rs
+++ b/apps/bitrouter/src/metering/recorder.rs
@@ -189,7 +189,7 @@ impl SettlementRecorder for MeteringRecorder {
             .as_ref()
             .filter(|event| {
                 event.attributed
-                    || event.authenticated_controller_instance_id.is_some()
+                    || event.claimed_controller_instance_id.is_some()
                     || event.harness.is_some()
             })
             .map(|event| {
@@ -201,7 +201,7 @@ impl SettlementRecorder for MeteringRecorder {
                 Ok::<MeteringSessionIdentity, bitrouter_sdk::BitrouterError>(
                     MeteringSessionIdentity {
                         agent_harness: event.harness.clone(),
-                        controller_instance_id: event.authenticated_controller_instance_id.clone(),
+                        controller_instance_id: event.claimed_controller_instance_id.clone(),
                         acp_session_id: event.acp_session_id.clone(),
                         native_root_session_id: event.native_root_session_id.clone(),
                         native_agent_thread_id: event.native_agent_thread_id.clone(),
@@ -297,10 +297,14 @@ fn session_span_attributes(
         ),
     ]);
     for (name, value) in [
+        (
+            "bitrouter.acp.api_principal_id",
+            Some(&event.api_principal_id),
+        ),
         ("bitrouter.agent.harness", event.harness.as_ref()),
         (
             "bitrouter.acp.controller_instance_id",
-            event.authenticated_controller_instance_id.as_ref(),
+            event.claimed_controller_instance_id.as_ref(),
         ),
         ("bitrouter.acp.session_id", event.acp_session_id.as_ref()),
         (

--- a/apps/bitrouter/src/metering/tests.rs
+++ b/apps/bitrouter/src/metering/tests.rs
@@ -90,9 +90,9 @@ async fn recorder_correlates_normalized_acp_identity_without_prompt_content() ->
     attributed.request_id = "router-acp-request".to_string();
     attributed.emit(SessionIdentityObserved {
         router_request_id: attributed.request_id.clone(),
-        origin: RequestOrigin::AuthenticatedAcpController,
+        origin: RequestOrigin::AcpHarnessRequest,
+        api_principal_id: "key-acp".to_string(),
         harness: Some("codex".to_string()),
-        authenticated_controller_instance_id: Some("brc_metering".to_string()),
         claimed_controller_instance_id: Some("brc_metering".to_string()),
         acp_session_id: Some("acp-session".to_string()),
         native_root_session_id: Some("codex-root".to_string()),
@@ -105,7 +105,7 @@ async fn recorder_correlates_normalized_acp_identity_without_prompt_content() ->
             transport: "header".to_string(),
             field: "thread-id".to_string(),
             source: "codex".to_string(),
-            trusted_for_route: true,
+            used_for_route_match: true,
             value_representation: "raw".to_string(),
             value: Some("codex-thread".to_string()),
         }],
@@ -151,6 +151,7 @@ async fn recorder_correlates_normalized_acp_identity_without_prompt_content() ->
     );
     let identity_json = row.try_get::<String>("", "session_identity_json")?;
     assert!(identity_json.contains("thread-id"));
+    assert!(identity_json.contains("key-acp"));
     for forbidden in ["prompt", "messages", "authorization", "cookie"] {
         assert!(!identity_json.to_ascii_lowercase().contains(forbidden));
     }
@@ -174,6 +175,18 @@ async fn recorder_correlates_normalized_acp_identity_without_prompt_content() ->
     let span = attributed
         .get_event::<bitrouter_observe::otel::SpanAttributes>()
         .expect("session span attributes");
+    assert_eq!(
+        span.0
+            .get("bitrouter.acp.api_principal_id")
+            .and_then(serde_json::Value::as_str),
+        Some("key-acp")
+    );
+    assert_eq!(
+        span.0
+            .get("bitrouter.acp.controller_instance_id")
+            .and_then(serde_json::Value::as_str),
+        Some("brc_metering")
+    );
     assert_eq!(
         span.0
             .get("bitrouter.agent.thread_id")

--- a/apps/bitrouter/src/session_identity.rs
+++ b/apps/bitrouter/src/session_identity.rs
@@ -1,4 +1,4 @@
-//! Authenticated ACP/native request-session normalization.
+//! ACP/native request-session normalization.
 
 use std::sync::Arc;
 
@@ -8,7 +8,7 @@ use bitrouter_sdk::language_model::{ApiProtocol, HookDecision, PipelineContext, 
 use serde::Serialize;
 
 use crate::acp_runtime::AcpRuntime;
-use crate::auth::events::ControllerAuthenticated;
+use crate::auth::events::ApiPrincipalEstablished;
 use crate::workflow_state::extractors::{ExtractorInput, parse_compatibility_harness};
 use crate::workflow_state::ir::ProtocolKind;
 use crate::workflow_state::session::resolve_session_signal;
@@ -37,15 +37,15 @@ const EVIDENCE_HEADERS: &[&str] = &[
     "x-bitrouter-inbound-protocol",
 ];
 
-/// Whether request identity came from the legacy model API path or a
-/// credential-bound ACP controller.
+/// Whether request identity came from the legacy model API path or declared
+/// ACP harness correlation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum RequestOrigin {
-    /// No authenticated controller credential was present.
+    /// No controller claim was present.
     PureModelApi,
-    /// The daemon authenticated a controller-scoped credential.
-    AuthenticatedAcpController,
+    /// The request declared an ACP controller namespace.
+    AcpHarnessRequest,
 }
 
 /// Source-independent native agent identity observed on the model request.
@@ -72,8 +72,8 @@ pub struct IdentityEvidence {
     pub field: String,
     /// Signal family (`bitrouter`, `claude_code`, `codex`, or `legacy`).
     pub source: String,
-    /// Whether this evidence may participate in authenticated lease lookup.
-    pub trusted_for_route: bool,
+    /// Whether this exact evidence value participated in route lookup.
+    pub used_for_route_match: bool,
     /// `raw`, `stable_digest`, or `presence_only`.
     pub value_representation: String,
     /// Value when the reviewed representation permits it.
@@ -111,13 +111,13 @@ pub struct RouteLeaseObservation {
 /// Full request-scoped normalized session context.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct RequestSessionContext {
-    /// Trust origin.
+    /// Attribution origin.
     pub origin: RequestOrigin,
-    /// Credential-bound controller identity.
-    pub authenticated_controller_instance_id: Option<String>,
-    /// Untrusted static controller header, retained separately.
+    /// Non-secret public API-key identity, or `local` under `skip_auth`.
+    pub api_principal_id: String,
+    /// Caller-declared static controller header.
     pub claimed_controller_instance_id: Option<String>,
-    /// Dynamic ACP session header only after a trusted controller binding.
+    /// Caller-declared dynamic ACP session header.
     pub acp_session_id: Option<String>,
     /// Native Claude/Codex identity.
     pub native: NativeSessionIdentity,
@@ -138,15 +138,15 @@ pub struct RequestSessionContext {
 pub struct SessionIdentityObserved {
     /// Router request id joining trace, route, and metering artifacts.
     pub router_request_id: String,
-    /// Trust origin.
+    /// Attribution origin.
     pub origin: RequestOrigin,
+    /// Non-secret public API-key identity, or `local` under `skip_auth`.
+    pub api_principal_id: String,
     /// Recognized harness.
     pub harness: Option<String>,
-    /// Credential-bound controller identity.
-    pub authenticated_controller_instance_id: Option<String>,
-    /// Untrusted claimed controller identity.
+    /// Caller-declared controller identity.
     pub claimed_controller_instance_id: Option<String>,
-    /// Trusted ACP session binding.
+    /// Caller-declared ACP session identity.
     pub acp_session_id: Option<String>,
     /// Native root session.
     pub native_root_session_id: Option<String>,
@@ -180,8 +180,8 @@ impl PipelineEvent for SessionIdentityObserved {
     }
 }
 
-/// Post-auth hook that normalizes identity and applies an authenticated route
-/// lease without changing legacy pure API behavior.
+/// Post-auth hook that normalizes identity and applies an API-principal-scoped
+/// route lease without changing legacy pure API behavior.
 pub struct SessionContextHook {
     runtime: Arc<AcpRuntime>,
 }
@@ -196,50 +196,23 @@ impl SessionContextHook {
 #[async_trait]
 impl PreRequestHook for SessionContextHook {
     async fn check(&self, ctx: &mut PipelineContext) -> bitrouter_sdk::Result<HookDecision> {
-        let authenticated_controller = ctx
-            .get_event::<ControllerAuthenticated>()
-            .map(|event| event.controller_instance_id.clone());
-        let origin = if authenticated_controller.is_some() {
-            RequestOrigin::AuthenticatedAcpController
+        let api_principal_id = ctx.caller().api_key_id().to_string();
+        let route_principal = if ctx.caller().is_local() {
+            "local".to_string()
+        } else {
+            ctx.get_event::<ApiPrincipalEstablished>()
+                .map(|event| event.route_scope_id.clone())
+                .unwrap_or_else(|| api_principal_id.clone())
+        };
+        let claimed_controller = header_value(ctx, "x-bitrouter-controller-id");
+        let origin = if claimed_controller.is_some() {
+            RequestOrigin::AcpHarnessRequest
         } else {
             RequestOrigin::PureModelApi
         };
-        let claimed_controller = header_value(ctx, "x-bitrouter-controller-id");
-        let dynamic_acp_session = header_value(ctx, "x-bitrouter-acp-session-id");
+        let acp_session_id = header_value(ctx, "x-bitrouter-acp-session-id");
         let mut conflicts = Vec::new();
-        let controller_claim_matches = match (
-            authenticated_controller.as_deref(),
-            claimed_controller.as_deref(),
-        ) {
-            (Some(authenticated), Some(claimed)) if authenticated == claimed => true,
-            (Some(authenticated), Some(claimed)) => {
-                conflicts.push(IdentityConflict {
-                    field: "header.x-bitrouter-controller-id".to_string(),
-                    expected: Some(authenticated.to_string()),
-                    observed: Some(claimed.to_string()),
-                    resolution: "credential_binding_wins".to_string(),
-                });
-                false
-            }
-            _ => false,
-        };
-        let acp_session_id = dynamic_acp_session
-            .clone()
-            .filter(|_| controller_claim_matches);
-        if dynamic_acp_session.is_some() && acp_session_id.is_none() {
-            conflicts.push(IdentityConflict {
-                field: "header.x-bitrouter-acp-session-id".to_string(),
-                expected: authenticated_controller.clone(),
-                observed: dynamic_acp_session.clone(),
-                resolution: "ignored_without_matching_controller_binding".to_string(),
-            });
-        }
-
-        let mut evidence = header_evidence(
-            ctx,
-            authenticated_controller.is_some(),
-            acp_session_id.is_some(),
-        );
+        let mut evidence = header_evidence(ctx);
         let raw_body = canonical_extra_body(ctx);
         let protocol_kind = protocol_kind(ctx.inbound_protocol());
         let harness_hint = header_value(ctx, "x-bitrouter-harness")
@@ -256,7 +229,7 @@ impl PreRequestHook for SessionContextHook {
                 transport: "derived".to_string(),
                 field: legacy_evidence.value,
                 source: "legacy".to_string(),
-                trusted_for_route: false,
+                used_for_route_match: false,
                 value_representation: "presence_only".to_string(),
                 value: None,
             });
@@ -273,13 +246,6 @@ impl PreRequestHook for SessionContextHook {
         }
 
         let mut native = extract_native(ctx, &mut evidence, &mut conflicts);
-        if authenticated_controller.is_none() {
-            // Native evidence remains observable for pure API callers, but no
-            // field can be promoted to controller route authority.
-            for item in &mut evidence {
-                item.trusted_for_route = false;
-            }
-        }
         if let (Some(dynamic), Some(root)) =
             (acp_session_id.as_deref(), native.root_session_id.as_deref())
             && dynamic != root
@@ -292,7 +258,7 @@ impl PreRequestHook for SessionContextHook {
             });
         }
 
-        let route_lease = authenticated_controller.as_deref().and_then(|controller| {
+        let route_lease = claimed_controller.as_deref().and_then(|controller| {
             let mut candidates = Vec::new();
             push_unique(&mut candidates, acp_session_id.as_deref());
             match native.harness.as_deref() {
@@ -305,9 +271,10 @@ impl PreRequestHook for SessionContextHook {
                 }
                 _ => {}
             }
+            mark_route_evidence(&mut evidence, &native, acp_session_id.as_deref());
             let candidate_refs = candidates.iter().map(String::as_str).collect::<Vec<_>>();
             self.runtime
-                .resolve_route(controller, &candidate_refs)
+                .resolve_route(&route_principal, controller, &candidate_refs)
                 .map(|lease| {
                     let (applied, reason) = if api_continuation_id.is_some() {
                         (false, "continuation_precedence")
@@ -329,7 +296,7 @@ impl PreRequestHook for SessionContextHook {
 
         let normalized = RequestSessionContext {
             origin,
-            authenticated_controller_instance_id: authenticated_controller,
+            api_principal_id,
             claimed_controller_instance_id: claimed_controller,
             acp_session_id,
             native: std::mem::take(&mut native),
@@ -358,8 +325,8 @@ fn event_from_context(
     SessionIdentityObserved {
         router_request_id: router_request_id.to_string(),
         origin: context.origin,
+        api_principal_id: context.api_principal_id.clone(),
         harness: context.native.harness.clone(),
-        authenticated_controller_instance_id: context.authenticated_controller_instance_id.clone(),
         claimed_controller_instance_id: context.claimed_controller_instance_id.clone(),
         acp_session_id: context.acp_session_id.clone(),
         native_root_session_id: context.native.root_session_id.clone(),
@@ -388,34 +355,66 @@ fn event_from_context(
     }
 }
 
-fn header_evidence(
-    ctx: &PipelineContext,
-    authenticated: bool,
-    dynamic_acp_trusted: bool,
-) -> Vec<IdentityEvidence> {
+fn header_evidence(ctx: &PipelineContext) -> Vec<IdentityEvidence> {
     EVIDENCE_HEADERS
         .iter()
         .filter_map(|name| {
             let value = header_value(ctx, name)?;
-            let (source, trusted_for_route) = match *name {
-                "x-bitrouter-acp-session-id" => ("bitrouter", dynamic_acp_trusted),
-                "x-claude-code-session-id" => ("claude_code", authenticated),
-                "session-id" | "thread-id" => ("codex", authenticated),
-                name if name.starts_with("x-claude-code-") => ("claude_code", false),
-                "x-codex-turn-metadata" => ("codex", false),
-                _ => ("bitrouter", false),
+            let source = match *name {
+                "x-bitrouter-acp-session-id" => "bitrouter",
+                "x-claude-code-session-id" => "claude_code",
+                "session-id" | "thread-id" => "codex",
+                name if name.starts_with("x-claude-code-") => "claude_code",
+                "x-codex-turn-metadata" => "codex",
+                _ => "bitrouter",
             };
             let compound = *name == "x-codex-turn-metadata";
             Some(IdentityEvidence {
                 transport: "header".to_string(),
                 field: (*name).to_string(),
                 source: source.to_string(),
-                trusted_for_route,
+                used_for_route_match: false,
                 value_representation: if compound { "presence_only" } else { "raw" }.to_string(),
                 value: (!compound).then_some(value),
             })
         })
         .collect()
+}
+
+fn mark_route_evidence(
+    evidence: &mut [IdentityEvidence],
+    native: &NativeSessionIdentity,
+    acp_session_id: Option<&str>,
+) {
+    for item in evidence {
+        let selected_native = match item.field.as_str() {
+            "x-claude-code-session-id" | "metadata.user_id.session_id"
+                if native.harness.as_deref() == Some("claude_code") =>
+            {
+                native.root_session_id.as_deref()
+            }
+            "session-id" | "client_metadata.session_id"
+                if native.harness.as_deref() == Some("codex") =>
+            {
+                native.root_session_id.as_deref()
+            }
+            "thread-id" | "client_metadata.thread_id"
+                if native.harness.as_deref() == Some("codex") =>
+            {
+                native.agent_thread_id.as_deref()
+            }
+            _ => None,
+        };
+        item.used_for_route_match = match item.field.as_str() {
+            "x-bitrouter-controller-id" => {
+                acp_session_id.is_some()
+                    || native.root_session_id.is_some()
+                    || native.agent_thread_id.is_some()
+            }
+            "x-bitrouter-acp-session-id" => item.value.as_deref() == acp_session_id,
+            _ => selected_native.is_some() && item.value.as_deref() == selected_native,
+        };
+    }
 }
 
 fn extract_native(
@@ -593,13 +592,13 @@ fn body_evidence(
     field: &str,
     source: &str,
     value: String,
-    trusted_for_route: bool,
+    used_for_route_match: bool,
 ) -> IdentityEvidence {
     IdentityEvidence {
         transport: "body".to_string(),
         field: field.to_string(),
         source: source.to_string(),
-        trusted_for_route,
+        used_for_route_match,
         value_representation: "raw".to_string(),
         value: Some(value),
     }
@@ -726,28 +725,26 @@ fn push_unique(values: &mut Vec<String>, candidate: Option<&str>) {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeSet;
-    use std::sync::Arc;
-    use std::time::Duration;
-
     use bitrouter_sdk::caller::CallerContext;
     use bitrouter_sdk::language_model::{
         ApiProtocol, GenerationParams, HookDecision, Message, PipelineContext, PipelineRequest,
         PreRequestHook, Prompt, Role,
     };
+    use std::collections::BTreeSet;
+    use std::sync::Arc;
 
     use super::{
         RequestOrigin, RequestSessionContext, SessionContextHook, SessionIdentityObserved,
     };
     use crate::acp_runtime::AcpRuntime;
-    use crate::auth::events::ControllerAuthenticated;
+    use crate::auth::events::ApiPrincipalEstablished;
 
     fn context(
         model: &str,
         protocol: ApiProtocol,
         headers: &[(&str, &str)],
         extra: serde_json::Map<String, serde_json::Value>,
-        authenticated_controller: Option<&str>,
+        route_principal: Option<&str>,
     ) -> PipelineContext {
         let prompt = Prompt {
             model: model.to_string(),
@@ -764,7 +761,12 @@ mod tests {
             tool_choice: None,
             stream: false,
         };
-        let mut request = PipelineRequest::new(model, CallerContext::local(), prompt);
+        let caller = if route_principal.is_some() {
+            CallerContext::new("test-key", "test-user")
+        } else {
+            CallerContext::local()
+        };
+        let mut request = PipelineRequest::new(model, caller, prompt);
         request.request_id = "router-request-1".to_string();
         request.inbound_protocol = Some(protocol);
         for (name, value) in headers {
@@ -774,10 +776,9 @@ mod tests {
             );
         }
         let mut context = PipelineContext::new(request);
-        if let Some(controller_instance_id) = authenticated_controller {
-            context.emit(ControllerAuthenticated {
-                controller_instance_id: controller_instance_id.to_string(),
-                expires_at: "2026-09-02T12:00:00Z".to_string(),
+        if let Some(route_principal) = route_principal {
+            context.emit(ApiPrincipalEstablished {
+                route_scope_id: route_principal.to_string(),
             });
         }
         context
@@ -820,19 +821,22 @@ mod tests {
             normalized.legacy_workflow_session_id.as_deref(),
             Some("legacy-session")
         );
-        assert!(normalized.authenticated_controller_instance_id.is_none());
+        assert_eq!(normalized.api_principal_id, "local");
+        assert!(normalized.claimed_controller_instance_id.is_none());
         assert!(normalized.acp_session_id.is_none());
         assert_eq!(context.model(), "gpt-5");
     }
 
     #[tokio::test]
-    async fn authenticated_claude_identity_applies_the_matching_session_lease() {
+    async fn declared_claude_identity_applies_the_matching_session_lease() {
         let runtime = Arc::new(AcpRuntime::new());
-        let _grant = runtime
-            .issue_controller("brc_claude", Duration::from_secs(60))
-            .expect("controller");
         runtime
-            .set_route("brc_claude", "claude-root", "anthropic:claude-opus")
+            .set_route(
+                "principal",
+                "brc_claude",
+                "claude-root",
+                "anthropic:claude-opus",
+            )
             .expect("route");
         let mut context = context(
             "claude-sonnet",
@@ -844,7 +848,7 @@ mod tests {
                 ("x-claude-code-parent-agent-id", "claude-parent"),
             ],
             serde_json::Map::new(),
-            Some("brc_claude"),
+            Some("principal"),
         );
 
         let normalized = observe(runtime, &mut context).await;
@@ -882,14 +886,11 @@ mod tests {
     #[tokio::test]
     async fn codex_exact_thread_lease_wins_before_root_fallback_and_parses_turn_lineage() {
         let runtime = Arc::new(AcpRuntime::new());
-        let _grant = runtime
-            .issue_controller("brc_codex", Duration::from_secs(60))
-            .expect("controller");
         runtime
-            .set_route("brc_codex", "codex-root", "openai:gpt-5")
+            .set_route("principal", "brc_codex", "codex-root", "openai:gpt-5")
             .expect("root route");
         runtime
-            .set_route("brc_codex", "codex-child", "openai:gpt-5.5")
+            .set_route("principal", "brc_codex", "codex-child", "openai:gpt-5.5")
             .expect("child route");
         let mut extra = serde_json::Map::new();
         extra.insert(
@@ -913,7 +914,7 @@ mod tests {
                 ),
             ],
             extra,
-            Some("brc_codex"),
+            Some("principal"),
         );
 
         let normalized = observe(runtime, &mut context).await;
@@ -936,49 +937,78 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn mismatched_claimed_controller_cannot_authorize_dynamic_session_header() {
+    async fn a_distinct_api_principal_cannot_activate_the_same_declared_claims() {
         let runtime = Arc::new(AcpRuntime::new());
-        let _grant = runtime
-            .issue_controller("brc_real", Duration::from_secs(60))
-            .expect("controller");
         runtime
-            .set_route("brc_real", "forged-session", "attacker:model")
-            .expect("forged candidate route");
-        runtime
-            .set_route("brc_real", "native-session", "safe:model")
-            .expect("native route");
+            .set_route(
+                "principal-owner",
+                "brc_shared",
+                "shared-session",
+                "owner:model",
+            )
+            .expect("owner route");
         let mut context = context(
             "logical-model",
             ApiProtocol::Messages,
             &[
-                ("x-bitrouter-controller-id", "brc_other"),
-                ("x-bitrouter-acp-session-id", "forged-session"),
-                ("x-claude-code-session-id", "native-session"),
+                ("x-bitrouter-controller-id", "brc_shared"),
+                ("x-bitrouter-acp-session-id", "shared-session"),
             ],
             serde_json::Map::new(),
-            Some("brc_real"),
+            Some("principal-other"),
         );
 
         let normalized = observe(runtime, &mut context).await;
 
-        assert!(normalized.acp_session_id.is_none());
-        assert_eq!(context.model(), "safe:model");
-        assert!(
-            normalized
-                .conflicts
-                .iter()
-                .any(|conflict| { conflict.field == "header.x-bitrouter-controller-id" })
+        assert_eq!(normalized.origin, RequestOrigin::AcpHarnessRequest);
+        assert_eq!(normalized.acp_session_id.as_deref(), Some("shared-session"));
+        assert_eq!(context.model(), "logical-model");
+        assert!(normalized.route_lease.is_none());
+    }
+
+    #[tokio::test]
+    async fn skip_auth_uses_the_shared_local_route_principal() {
+        let runtime = Arc::new(AcpRuntime::new());
+        runtime
+            .set_route("local", "brc_local", "local-session", "local:model")
+            .expect("local route");
+        let mut context = context(
+            "logical-model",
+            ApiProtocol::Messages,
+            &[
+                ("x-bitrouter-controller-id", "brc_local"),
+                ("x-bitrouter-acp-session-id", "local-session"),
+            ],
+            serde_json::Map::new(),
+            None,
         );
+
+        let normalized = observe(runtime, &mut context).await;
+
+        assert_eq!(normalized.api_principal_id, "local");
+        assert_eq!(context.model(), "local:model");
+        assert_eq!(
+            normalized
+                .route_lease
+                .as_ref()
+                .map(|lease| lease.matched_session_id.as_str()),
+            Some("local-session")
+        );
+        for field in ["x-bitrouter-controller-id", "x-bitrouter-acp-session-id"] {
+            assert!(
+                normalized
+                    .evidence
+                    .iter()
+                    .any(|evidence| { evidence.field == field && evidence.used_for_route_match })
+            );
+        }
     }
 
     #[tokio::test]
     async fn explicit_caller_routes_and_continuations_are_stronger_than_a_lease() {
         let runtime = Arc::new(AcpRuntime::new());
-        let _grant = runtime
-            .issue_controller("brc_precedence", Duration::from_secs(60))
-            .expect("controller");
         runtime
-            .set_route("brc_precedence", "root", "lease:model")
+            .set_route("principal", "brc_precedence", "root", "lease:model")
             .expect("route");
 
         for model in ["explicit:model", "@careful", "bitrouter/auto"] {
@@ -990,7 +1020,7 @@ mod tests {
                     ("session-id", "root"),
                 ],
                 serde_json::Map::new(),
-                Some("brc_precedence"),
+                Some("principal"),
             );
             let normalized = observe(Arc::clone(&runtime), &mut context).await;
             assert_eq!(context.model(), model);
@@ -1023,7 +1053,7 @@ mod tests {
                 ("session-id", "root"),
             ],
             extra,
-            Some("brc_precedence"),
+            Some("principal"),
         );
         let normalized = observe(runtime, &mut continuation).await;
         assert_eq!(continuation.model(), "logical-model");
@@ -1076,6 +1106,10 @@ mod tests {
             "thread-id",
             "x-codex-turn-metadata",
             "x-session-id",
+            "anthropic-beta",
+            "user-agent",
+            "x-bitrouter-harness",
+            "x-bitrouter-inbound-protocol",
         ];
         let mut request_headers = expected
             .iter()

--- a/apps/bitrouter/tests/daemon.rs
+++ b/apps/bitrouter/tests/daemon.rs
@@ -179,7 +179,7 @@ async fn status_route_and_stop_roundtrip_over_the_control_socket() {
 }
 
 #[tokio::test]
-async fn authenticated_acp_route_state_roundtrips_over_the_control_socket() {
+async fn api_principal_scoped_acp_routes_roundtrip_over_the_control_socket() {
     let dir = tempdir("acp-route");
     let cfg_path = write_config(&dir, "sqlite::memory:").await;
     let cfg = config::load(&cfg_path).await.unwrap();
@@ -198,36 +198,10 @@ async fn authenticated_acp_route_state_roundtrips_over_the_control_socket() {
     ));
     wait_until_ready(&socket).await;
 
-    let issued = daemon::send_command(
-        &socket,
-        &DaemonCommand::AcpControllerIssue {
-            controller_instance_id: "brc_test".to_string(),
-        },
-    )
-    .await
-    .unwrap();
-    let credential = match issued {
-        DaemonResponse::AcpControllerCredential {
-            controller_instance_id,
-            credential,
-            ..
-        } => {
-            assert_eq!(controller_instance_id, "brc_test");
-            credential
-        }
-        other => panic!("expected ACP credential, got {other:?}"),
-    };
-    assert_eq!(
-        runtime
-            .authenticate(credential.as_str())
-            .unwrap()
-            .controller_instance_id(),
-        "brc_test"
-    );
-
     let set = daemon::send_command(
         &socket,
         &DaemonCommand::AcpRouteSet {
+            api_principal: "principal-a".to_string(),
             controller_instance_id: "brc_test".to_string(),
             session_id: "native-session".to_string(),
             route: "gpt-5".to_string(),
@@ -251,6 +225,7 @@ async fn authenticated_acp_route_state_roundtrips_over_the_control_socket() {
     let invalid = daemon::send_command(
         &socket,
         &DaemonCommand::AcpRouteSet {
+            api_principal: "principal-a".to_string(),
             controller_instance_id: "brc_test".to_string(),
             session_id: "native-session".to_string(),
             route: "missing-model".to_string(),
@@ -261,7 +236,7 @@ async fn authenticated_acp_route_state_roundtrips_over_the_control_socket() {
     assert!(matches!(invalid, DaemonResponse::Error { .. }));
     assert_eq!(
         runtime
-            .current_route("brc_test", "native-session")
+            .current_route("principal-a", "brc_test", "native-session")
             .unwrap()
             .route(),
         "gpt-5"
@@ -270,17 +245,26 @@ async fn authenticated_acp_route_state_roundtrips_over_the_control_socket() {
     let other = daemon::send_command(
         &socket,
         &DaemonCommand::AcpRouteList {
-            controller_instance_id: "brc_other".to_string(),
+            api_principal: "principal-b".to_string(),
+            controller_instance_id: "brc_test".to_string(),
             session_id: "native-session".to_string(),
         },
     )
     .await
     .unwrap();
-    assert!(matches!(other, DaemonResponse::Error { .. }));
+    assert!(matches!(
+        other,
+        DaemonResponse::AcpRouteState {
+            current: None,
+            scope,
+            ..
+        } if scope == "default"
+    ));
 
     let reset = daemon::send_command(
         &socket,
         &DaemonCommand::AcpRouteReset {
+            api_principal: "principal-a".to_string(),
             controller_instance_id: "brc_test".to_string(),
             session_id: "native-session".to_string(),
         },
@@ -296,10 +280,34 @@ async fn authenticated_acp_route_state_roundtrips_over_the_control_socket() {
         } if scope == "default"
     ));
 
+    let cleanup_target = daemon::send_command(
+        &socket,
+        &DaemonCommand::AcpRouteSet {
+            api_principal: "principal-a".to_string(),
+            controller_instance_id: "brc_test".to_string(),
+            session_id: "cleanup-target".to_string(),
+            route: "gpt-5".to_string(),
+        },
+    )
+    .await
+    .unwrap();
+    assert!(matches!(
+        cleanup_target,
+        DaemonResponse::AcpRouteState {
+            current: Some(_),
+            scope,
+            ..
+        } if scope == "session"
+    ));
+    runtime
+        .set_route("principal-a", "brc_other", "cleanup-target", "shared")
+        .unwrap();
+
     assert!(matches!(
         daemon::send_command(
             &socket,
-            &DaemonCommand::AcpControllerRevoke {
+            &DaemonCommand::AcpControllerCleanup {
+                api_principal: "principal-a".to_string(),
                 controller_instance_id: "brc_test".to_string(),
             },
         )
@@ -307,7 +315,18 @@ async fn authenticated_acp_route_state_roundtrips_over_the_control_socket() {
         .unwrap(),
         DaemonResponse::Ok
     ));
-    assert!(runtime.authenticate(credential.as_str()).is_none());
+    assert!(
+        runtime
+            .current_route("principal-a", "brc_test", "cleanup-target")
+            .is_none()
+    );
+    assert_eq!(
+        runtime
+            .current_route("principal-a", "brc_other", "cleanup-target")
+            .unwrap()
+            .route(),
+        "shared"
+    );
 
     let _ = daemon::send_command(&socket, &DaemonCommand::Stop).await;
     server.await.unwrap().unwrap();

--- a/crates/bitrouter-sdk/src/acp/controller.rs
+++ b/crates/bitrouter-sdk/src/acp/controller.rs
@@ -17,10 +17,9 @@ use agent_client_protocol::{
 use agent_client_protocol_conductor::{ConductorImpl, ProxiesAndAgent};
 use async_trait::async_trait;
 
-// agent-client-protocol-schema 1.5 exposes the unstable provider payloads,
-// while agent-client-protocol 2.0 does not yet attach its JSON-RPC traits to
-// them. Transparent local wrappers supply only that missing method binding;
-// the request and response bodies remain the official typed schema values.
+// Provider configuration remains an unstable internal extension. Transparent
+// local wrappers supply its method binding; request and response bodies remain
+// the official typed schema values.
 #[derive(
     Debug, Clone, serde::Serialize, serde::Deserialize, agent_client_protocol::JsonRpcRequest,
 )]
@@ -184,7 +183,7 @@ pub struct RouteControlError {
 }
 
 impl RouteControlError {
-    /// The daemon or trusted controller binding is unavailable.
+    /// The configured route-control backend is unavailable.
     pub fn unavailable(message: impl Into<String>) -> Self {
         Self {
             code: "route_control_unavailable",
@@ -229,7 +228,7 @@ pub trait RouteControl: Send + Sync {
     async fn reset(&self, session_id: &str) -> Result<RouteControlState, RouteControlError>;
     /// Remove route state after the harness accepted close/delete.
     async fn session_closed(&self, session_id: &str) -> Result<(), RouteControlError>;
-    /// Revoke controller-owned authority and leases after disconnect.
+    /// Remove this controller connection's route leases after disconnect.
     async fn disconnected(&self) -> Result<(), RouteControlError>;
 }
 
@@ -657,7 +656,7 @@ impl ConnectTo<Conductor> for ControllerProxy {
 
 fn route_control_unavailable() -> agent_client_protocol::Error {
     agent_client_protocol::Error::method_not_found()
-        .data("BitRouter route control requires a trusted local daemon binding")
+        .data("BitRouter route control is unavailable on this controller connection")
 }
 
 fn initialization_incomplete() -> agent_client_protocol::Error {
@@ -820,26 +819,36 @@ impl HandleDispatchFrom<Conductor> for ForwardMessages {
 #[cfg(test)]
 mod tests {
     use std::collections::{BTreeMap, HashMap};
+    use std::path::PathBuf;
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
 
     use agent_client_protocol::schema::ProtocolVersion;
     use agent_client_protocol::schema::v1::{
-        AgentCapabilities, CancelNotification, ClientCapabilities, CloseSessionRequest,
-        CloseSessionResponse, ContentBlock, ContentChunk, DeleteSessionRequest,
-        DeleteSessionResponse, FileSystemCapabilities, ForkSessionRequest, ForkSessionResponse,
-        Implementation, InitializeRequest, InitializeResponse, ListProvidersResponse,
-        ListSessionsRequest, ListSessionsResponse, LlmProtocol, LoadSessionRequest,
-        LoadSessionResponse, Meta, NewSessionRequest, NewSessionResponse, PermissionOption,
-        PermissionOptionKind, PromptRequest, PromptResponse, ProviderCurrentConfig, ProviderInfo,
-        ProvidersCapabilities, ReadTextFileRequest, ReadTextFileResponse, RequestPermissionOutcome,
-        RequestPermissionRequest, RequestPermissionResponse, ResumeSessionRequest,
-        ResumeSessionResponse, SelectedPermissionOutcome, SessionCapabilities,
-        SessionCloseCapabilities, SessionDeleteCapabilities, SessionForkCapabilities, SessionId,
-        SessionInfo, SessionListCapabilities, SessionNotification, SessionResumeCapabilities,
-        SessionUpdate, SetProviderRequest, SetProviderResponse, SetSessionConfigOptionRequest,
-        SetSessionConfigOptionResponse, StopReason, TextContent, ToolCallUpdate,
-        ToolCallUpdateFields,
+        AgentAuthCapabilities, AgentCapabilities, AuthCapabilities, AuthMethod, AuthMethodAgent,
+        AuthenticateRequest, AuthenticateResponse, CancelNotification, ClientCapabilities,
+        CloseSessionRequest, CloseSessionResponse, ContentBlock, ContentChunk,
+        CreateElicitationRequest, CreateElicitationResponse, CreateTerminalRequest,
+        CreateTerminalResponse, DeleteSessionRequest, DeleteSessionResponse, ElicitationAction,
+        ElicitationCapabilities, ElicitationFormCapabilities, ElicitationFormMode,
+        ElicitationSchema, ElicitationSessionScope, FileSystemCapabilities, ForkSessionRequest,
+        ForkSessionResponse, Implementation, InitializeRequest, InitializeResponse,
+        KillTerminalRequest, KillTerminalResponse, ListProvidersResponse, ListSessionsRequest,
+        ListSessionsResponse, LlmProtocol, LoadSessionRequest, LoadSessionResponse,
+        LogoutCapabilities, LogoutRequest, LogoutResponse, Meta, NewSessionRequest,
+        NewSessionResponse, PermissionOption, PermissionOptionKind, PromptRequest, PromptResponse,
+        ProviderCurrentConfig, ProviderInfo, ProvidersCapabilities, ReadTextFileRequest,
+        ReadTextFileResponse, ReleaseTerminalRequest, ReleaseTerminalResponse,
+        RequestPermissionOutcome, RequestPermissionRequest, RequestPermissionResponse,
+        ResumeSessionRequest, ResumeSessionResponse, SelectedPermissionOutcome,
+        SessionCapabilities, SessionCloseCapabilities, SessionDeleteCapabilities,
+        SessionForkCapabilities, SessionId, SessionInfo, SessionListCapabilities,
+        SessionNotification, SessionResumeCapabilities, SessionUpdate, SetProviderRequest,
+        SetProviderResponse, SetSessionConfigOptionRequest, SetSessionConfigOptionResponse,
+        SetSessionModeRequest, SetSessionModeResponse, StopReason, TerminalExitStatus,
+        TerminalOutputRequest, TerminalOutputResponse, TextContent, ToolCallUpdate,
+        ToolCallUpdateFields, WaitForTerminalExitRequest, WaitForTerminalExitResponse,
+        WriteTextFileRequest, WriteTextFileResponse,
     };
     use agent_client_protocol::{Agent, Client, ConnectTo, ConnectionTo, JsonRpcResponse};
     use tokio::io::duplex;
@@ -995,6 +1004,9 @@ mod tests {
         initialize: Mutex<Option<InitializeRequest>>,
         permission_completed: AtomicBool,
         read_completed: AtomicBool,
+        write_completed: AtomicBool,
+        terminal_completed: AtomicBool,
+        elicitation_completed: AtomicBool,
         extension_completed: AtomicBool,
     }
 
@@ -1161,6 +1173,177 @@ mod tests {
                                 Ordering::SeqCst,
                             );
 
+                            let write = receive(
+                                connection.send_request(
+                                    WriteTextFileRequest::new(
+                                        request.session_id.clone(),
+                                        "/workspace/native.txt",
+                                        "harness-file",
+                                    )
+                                    .meta(Meta::from_iter([(
+                                        "harness.write".to_string(),
+                                        serde_json::json!({"opaque": true}),
+                                    )])),
+                                ),
+                            )
+                            .await;
+                            let write = match write {
+                                Ok(write) => write,
+                                Err(error) => return responder.respond_with_error(error),
+                            };
+                            state.write_completed.store(
+                                write
+                                    .meta
+                                    .as_ref()
+                                    .is_some_and(|meta| meta.contains_key("manager.write")),
+                                Ordering::SeqCst,
+                            );
+
+                            let terminal = receive(
+                                connection.send_request(
+                                    CreateTerminalRequest::new(
+                                        request.session_id.clone(),
+                                        "native-command",
+                                    )
+                                    .args(vec!["--opaque".to_string()])
+                                    .meta(Meta::from_iter([(
+                                        "harness.terminal".to_string(),
+                                        serde_json::json!({"phase": "create"}),
+                                    )])),
+                                ),
+                            )
+                            .await;
+                            let terminal = match terminal {
+                                Ok(terminal) => terminal,
+                                Err(error) => return responder.respond_with_error(error),
+                            };
+                            let terminal_id = terminal.terminal_id.clone();
+                            let create_preserved = terminal
+                                .meta
+                                .as_ref()
+                                .is_some_and(|meta| meta.contains_key("manager.terminal.create"));
+                            let output = receive(
+                                connection.send_request(
+                                    TerminalOutputRequest::new(
+                                        request.session_id.clone(),
+                                        terminal_id.clone(),
+                                    )
+                                    .meta(Meta::from_iter([(
+                                        "harness.terminal".to_string(),
+                                        serde_json::json!({"phase": "output"}),
+                                    )])),
+                                ),
+                            )
+                            .await;
+                            let output = match output {
+                                Ok(output) => output,
+                                Err(error) => return responder.respond_with_error(error),
+                            };
+                            let wait = receive(
+                                connection.send_request(
+                                    WaitForTerminalExitRequest::new(
+                                        request.session_id.clone(),
+                                        terminal_id.clone(),
+                                    )
+                                    .meta(Meta::from_iter([(
+                                        "harness.terminal".to_string(),
+                                        serde_json::json!({"phase": "wait"}),
+                                    )])),
+                                ),
+                            )
+                            .await;
+                            let wait = match wait {
+                                Ok(wait) => wait,
+                                Err(error) => return responder.respond_with_error(error),
+                            };
+                            let killed = receive(
+                                connection.send_request(
+                                    KillTerminalRequest::new(
+                                        request.session_id.clone(),
+                                        terminal_id.clone(),
+                                    )
+                                    .meta(Meta::from_iter([(
+                                        "harness.terminal".to_string(),
+                                        serde_json::json!({"phase": "kill"}),
+                                    )])),
+                                ),
+                            )
+                            .await;
+                            let killed = match killed {
+                                Ok(killed) => killed,
+                                Err(error) => return responder.respond_with_error(error),
+                            };
+                            let released = receive(
+                                connection.send_request(
+                                    ReleaseTerminalRequest::new(
+                                        request.session_id.clone(),
+                                        terminal_id,
+                                    )
+                                    .meta(Meta::from_iter([(
+                                        "harness.terminal".to_string(),
+                                        serde_json::json!({"phase": "release"}),
+                                    )])),
+                                ),
+                            )
+                            .await;
+                            let released = match released {
+                                Ok(released) => released,
+                                Err(error) => return responder.respond_with_error(error),
+                            };
+                            state.terminal_completed.store(
+                                create_preserved
+                                    && output.output == "manager-output"
+                                    && output
+                                        .exit_status
+                                        .as_ref()
+                                        .and_then(|status| status.exit_code)
+                                        == Some(0)
+                                    && output.meta.as_ref().is_some_and(|meta| {
+                                        meta.contains_key("manager.terminal.output")
+                                    })
+                                    && wait.exit_status.exit_code == Some(0)
+                                    && wait.meta.as_ref().is_some_and(|meta| {
+                                        meta.contains_key("manager.terminal.wait")
+                                    })
+                                    && killed.meta.as_ref().is_some_and(|meta| {
+                                        meta.contains_key("manager.terminal.kill")
+                                    })
+                                    && released.meta.as_ref().is_some_and(|meta| {
+                                        meta.contains_key("manager.terminal.release")
+                                    }),
+                                Ordering::SeqCst,
+                            );
+
+                            let elicitation = receive(
+                                connection.send_request(
+                                    CreateElicitationRequest::new(
+                                        ElicitationFormMode::new(
+                                            ElicitationSessionScope::new(
+                                                request.session_id.clone(),
+                                            ),
+                                            ElicitationSchema::new().string("answer", true),
+                                        ),
+                                        "Choose an answer",
+                                    )
+                                    .meta(Meta::from_iter([(
+                                        "harness.elicitation".to_string(),
+                                        serde_json::json!({"opaque": true}),
+                                    )])),
+                                ),
+                            )
+                            .await;
+                            let elicitation = match elicitation {
+                                Ok(elicitation) => elicitation,
+                                Err(error) => return responder.respond_with_error(error),
+                            };
+                            state.elicitation_completed.store(
+                                matches!(elicitation.action, ElicitationAction::Decline)
+                                    && elicitation.meta.as_ref().is_some_and(|meta| {
+                                        meta.contains_key("manager.elicitation")
+                                    }),
+                                Ordering::SeqCst,
+                            );
+
                             let extension = receive(connection.send_request(
                                 HarnessExtensionRequest(serde_json::json!({
                                     "sessionId": request.session_id,
@@ -1214,39 +1397,85 @@ mod tests {
             let delete_state = Arc::clone(&self.state);
             let fork_state = Arc::clone(&self.state);
             let config_state = Arc::clone(&self.state);
+            let mode_state = Arc::clone(&self.state);
+            let auth_state = Arc::clone(&self.state);
+            let logout_state = Arc::clone(&self.state);
             Agent
                 .builder()
                 .name("transparent-agent")
                 .on_receive_request(
                     async move |request: InitializeRequest, responder, _connection| {
                         responder.respond(
-                            InitializeResponse::new(request.protocol_version).agent_capabilities(
-                                AgentCapabilities::new()
-                                    .load_session(true)
-                                    .session_capabilities(
-                                        SessionCapabilities::new()
-                                            .list(SessionListCapabilities::new())
-                                            .delete(SessionDeleteCapabilities::new())
-                                            .fork(SessionForkCapabilities::new())
-                                            .resume(SessionResumeCapabilities::new())
-                                            .close(SessionCloseCapabilities::new()),
+                            InitializeResponse::new(request.protocol_version)
+                                .agent_capabilities(
+                                    AgentCapabilities::new()
+                                        .load_session(true)
+                                        .auth(
+                                            AgentAuthCapabilities::new()
+                                                .logout(LogoutCapabilities::new()),
+                                        )
+                                        .session_capabilities(
+                                            SessionCapabilities::new()
+                                                .list(SessionListCapabilities::new())
+                                                .delete(SessionDeleteCapabilities::new())
+                                                .fork(SessionForkCapabilities::new())
+                                                .resume(SessionResumeCapabilities::new())
+                                                .close(SessionCloseCapabilities::new()),
+                                        ),
+                                )
+                                .auth_methods(vec![AuthMethod::Agent(
+                                    AuthMethodAgent::new("native-auth", "Native auth").meta(
+                                        Meta::from_iter([(
+                                            "harness.authMethod".to_string(),
+                                            serde_json::json!(true),
+                                        )]),
                                     ),
-                            ),
+                                )]),
                         )
                     },
                     agent_client_protocol::on_receive_request!(),
                 )
                 .on_receive_request(
-                    async move |_request: NewSessionRequest, responder, _connection| {
+                    async move |request: NewSessionRequest, responder, _connection| {
                         let index = new_state.next_session.fetch_add(1, Ordering::SeqCst);
                         let session_id = if index == 0 { "native-a" } else { "native-b" };
                         record(&new_state.requests, format!("new:{session_id}"));
+                        record(
+                            &new_state.requests,
+                            format!(
+                                "new-input:{}:{}",
+                                request.cwd.display(),
+                                request
+                                    .additional_directories
+                                    .iter()
+                                    .map(|path| path.display().to_string())
+                                    .collect::<Vec<_>>()
+                                    .join(",")
+                            ),
+                        );
                         responder.respond(NewSessionResponse::new(session_id).meta(
                             Meta::from_iter([(
                                 "harness.response".to_string(),
                                 serde_json::json!(session_id),
                             )]),
                         ))
+                    },
+                    agent_client_protocol::on_receive_request!(),
+                )
+                .on_receive_request(
+                    async move |request: AuthenticateRequest, responder, _connection| {
+                        record(
+                            &auth_state.requests,
+                            format!("authenticate:{}", request.method_id.0),
+                        );
+                        responder.respond(AuthenticateResponse::new().meta(request.meta))
+                    },
+                    agent_client_protocol::on_receive_request!(),
+                )
+                .on_receive_request(
+                    async move |request: LogoutRequest, responder, _connection| {
+                        record(&logout_state.requests, "logout".to_string());
+                        responder.respond(LogoutResponse::new().meta(request.meta))
                     },
                     agent_client_protocol::on_receive_request!(),
                 )
@@ -1369,6 +1598,16 @@ mod tests {
                         responder.respond(
                             SetSessionConfigOptionResponse::new(Vec::new()).meta(request.meta),
                         )
+                    },
+                    agent_client_protocol::on_receive_request!(),
+                )
+                .on_receive_request(
+                    async move |request: SetSessionModeRequest, responder, _connection| {
+                        record(
+                            &mode_state.requests,
+                            format!("mode:{}:{}", request.session_id.0, request.mode_id.0),
+                        );
+                        responder.respond(SetSessionModeResponse::new().meta(request.meta))
                     },
                     agent_client_protocol::on_receive_request!(),
                 )
@@ -1615,6 +1854,22 @@ mod tests {
                     )]);
                     let capabilities = ClientCapabilities::new()
                         .terminal(true)
+                        .auth(
+                            AuthCapabilities::new()
+                                .terminal(true)
+                                .meta(Meta::from_iter([(
+                                    "client.auth".to_string(),
+                                    serde_json::json!({"terminal": "opaque"}),
+                                )])),
+                        )
+                        .elicitation(
+                            ElicitationCapabilities::new()
+                                .form(ElicitationFormCapabilities::new())
+                                .meta(Meta::from_iter([(
+                                    "client.elicitation".to_string(),
+                                    serde_json::json!({"form": "opaque"}),
+                                )])),
+                        )
                         .meta(capability_meta.clone());
                     let response = receive(
                         connection.send_request(
@@ -1687,6 +1942,32 @@ mod tests {
         };
         assert_eq!(requests.len(), 1, "initialize must reach the harness once");
         assert!(requests[0].client_capabilities.terminal);
+        assert!(requests[0].client_capabilities.auth.terminal);
+        assert_eq!(
+            requests[0]
+                .client_capabilities
+                .auth
+                .meta
+                .as_ref()
+                .and_then(|meta| meta.get("client.auth")),
+            Some(&serde_json::json!({"terminal": "opaque"}))
+        );
+        assert!(
+            requests[0]
+                .client_capabilities
+                .elicitation
+                .as_ref()
+                .is_some_and(ElicitationCapabilities::supports_form)
+        );
+        assert_eq!(
+            requests[0]
+                .client_capabilities
+                .elicitation
+                .as_ref()
+                .and_then(|elicitation| elicitation.meta.as_ref())
+                .and_then(|meta| meta.get("client.elicitation")),
+            Some(&serde_json::json!({"form": "opaque"}))
+        );
         assert_eq!(
             requests[0]
                 .client_capabilities
@@ -2061,11 +2342,39 @@ mod tests {
             .connect_with(
                 manager_transport,
                 async |connection: ConnectionTo<Agent>| {
-                    receive(connection.send_request(InitializeRequest::new(ProtocolVersion::V1)))
-                        .await?;
-                    let native_a =
-                        receive(connection.send_request(NewSessionRequest::new("/workspace")))
-                            .await?;
+                    let initialized = receive(
+                        connection.send_request(InitializeRequest::new(ProtocolVersion::V1)),
+                    )
+                    .await?;
+                    assert_eq!(initialized.auth_methods.len(), 1);
+                    assert_eq!(initialized.auth_methods[0].id().0.as_ref(), "native-auth");
+                    assert!(
+                        initialized.auth_methods[0]
+                            .meta()
+                            .is_some_and(|meta| meta.contains_key("harness.authMethod"))
+                    );
+                    assert!(initialized.agent_capabilities.auth.logout.is_some());
+                    let auth_meta = Meta::from_iter([(
+                        "manager.auth".to_string(),
+                        serde_json::json!({"opaque": true}),
+                    )]);
+                    let authenticated = receive(connection.send_request(
+                        AuthenticateRequest::new("native-auth").meta(auth_meta.clone()),
+                    ))
+                    .await?;
+                    assert_eq!(authenticated.meta, Some(auth_meta.clone()));
+                    let logged_out = receive(
+                        connection.send_request(LogoutRequest::new().meta(auth_meta.clone())),
+                    )
+                    .await?;
+                    assert_eq!(logged_out.meta, Some(auth_meta));
+                    let native_a = receive(
+                        connection.send_request(
+                            NewSessionRequest::new("/workspace")
+                                .additional_directories(vec![PathBuf::from("/workspace-extra")]),
+                        ),
+                    )
+                    .await?;
                     let native_b =
                         receive(connection.send_request(NewSessionRequest::new("/workspace")))
                             .await?;
@@ -2174,7 +2483,15 @@ mod tests {
                         ),
                     )
                     .await?;
-                    assert_eq!(configured.meta, Some(request_meta));
+                    assert_eq!(configured.meta, Some(request_meta.clone()));
+                    let mode = receive(
+                        connection.send_request(
+                            SetSessionModeRequest::new("never-observed-mode", "review")
+                                .meta(request_meta.clone()),
+                        ),
+                    )
+                    .await?;
+                    assert_eq!(mode.meta, Some(request_meta));
 
                     let error =
                         receive(connection.send_request(DeleteSessionRequest::new("reject-me")))
@@ -2196,6 +2513,9 @@ mod tests {
             Err(poisoned) => poisoned.into_inner().clone(),
         };
         for expected in [
+            "authenticate:native-auth",
+            "logout",
+            "new-input:/workspace:/workspace-extra",
             "prompt:native-a",
             "prompt:native-b",
             "list:harness-cursor",
@@ -2205,6 +2525,7 @@ mod tests {
             "delete:never-observed-delete",
             "fork:never-observed-fork",
             "config:never-observed-config",
+            "mode:never-observed-mode:review",
             "delete:reject-me",
         ] {
             assert!(requests.iter().any(|request| request == expected));
@@ -2310,6 +2631,147 @@ mod tests {
                 agent_client_protocol::on_receive_request!(),
             )
             .on_receive_request(
+                async move |request: WriteTextFileRequest, responder, _connection| {
+                    if request.path.to_string_lossy() != "/workspace/native.txt"
+                        || request.content != "harness-file"
+                        || request
+                            .meta
+                            .as_ref()
+                            .is_none_or(|meta| !meta.contains_key("harness.write"))
+                    {
+                        return responder.respond_with_error(
+                            agent_client_protocol::Error::invalid_params()
+                                .data(serde_json::json!("write request was changed")),
+                        );
+                    }
+                    responder.respond(WriteTextFileResponse::new().meta(Meta::from_iter([(
+                        "manager.write".to_string(),
+                        serde_json::json!(["preserved"]),
+                    )])))
+                },
+                agent_client_protocol::on_receive_request!(),
+            )
+            .on_receive_request(
+                async move |request: CreateTerminalRequest, responder, _connection| {
+                    if request.command != "native-command"
+                        || request.args != ["--opaque"]
+                        || request
+                            .meta
+                            .as_ref()
+                            .is_none_or(|meta| !meta.contains_key("harness.terminal"))
+                    {
+                        return responder.respond_with_error(
+                            agent_client_protocol::Error::invalid_params()
+                                .data(serde_json::json!("terminal create was changed")),
+                        );
+                    }
+                    responder.respond(CreateTerminalResponse::new("manager-terminal").meta(
+                        Meta::from_iter([(
+                            "manager.terminal.create".to_string(),
+                            serde_json::json!(true),
+                        )]),
+                    ))
+                },
+                agent_client_protocol::on_receive_request!(),
+            )
+            .on_receive_request(
+                async move |request: TerminalOutputRequest, responder, _connection| {
+                    if request.terminal_id.0.as_ref() != "manager-terminal" {
+                        return responder.respond_with_error(
+                            agent_client_protocol::Error::invalid_params()
+                                .data(serde_json::json!("terminal output id was changed")),
+                        );
+                    }
+                    responder.respond(
+                        TerminalOutputResponse::new("manager-output", false)
+                            .exit_status(TerminalExitStatus::new().exit_code(0))
+                            .meta(Meta::from_iter([(
+                                "manager.terminal.output".to_string(),
+                                serde_json::json!(true),
+                            )])),
+                    )
+                },
+                agent_client_protocol::on_receive_request!(),
+            )
+            .on_receive_request(
+                async move |request: WaitForTerminalExitRequest, responder, _connection| {
+                    if request.terminal_id.0.as_ref() != "manager-terminal" {
+                        return responder.respond_with_error(
+                            agent_client_protocol::Error::invalid_params()
+                                .data(serde_json::json!("terminal wait id was changed")),
+                        );
+                    }
+                    responder.respond(
+                        WaitForTerminalExitResponse::new(TerminalExitStatus::new().exit_code(0))
+                            .meta(Meta::from_iter([(
+                                "manager.terminal.wait".to_string(),
+                                serde_json::json!(true),
+                            )])),
+                    )
+                },
+                agent_client_protocol::on_receive_request!(),
+            )
+            .on_receive_request(
+                async move |request: KillTerminalRequest, responder, _connection| {
+                    if request.terminal_id.0.as_ref() != "manager-terminal" {
+                        return responder.respond_with_error(
+                            agent_client_protocol::Error::invalid_params()
+                                .data(serde_json::json!("terminal kill id was changed")),
+                        );
+                    }
+                    responder.respond(KillTerminalResponse::new().meta(Meta::from_iter([(
+                        "manager.terminal.kill".to_string(),
+                        serde_json::json!(true),
+                    )])))
+                },
+                agent_client_protocol::on_receive_request!(),
+            )
+            .on_receive_request(
+                async move |request: ReleaseTerminalRequest, responder, _connection| {
+                    if request.terminal_id.0.as_ref() != "manager-terminal" {
+                        return responder.respond_with_error(
+                            agent_client_protocol::Error::invalid_params()
+                                .data(serde_json::json!("terminal release id was changed")),
+                        );
+                    }
+                    responder.respond(ReleaseTerminalResponse::new().meta(Meta::from_iter([(
+                        "manager.terminal.release".to_string(),
+                        serde_json::json!(true),
+                    )])))
+                },
+                agent_client_protocol::on_receive_request!(),
+            )
+            .on_receive_request(
+                async move |request: CreateElicitationRequest, responder, _connection| {
+                    let schema_preserved = matches!(
+                        &request.mode,
+                        agent_client_protocol::schema::v1::ElicitationMode::Form(form)
+                            if form.requested_schema.properties.contains_key("answer")
+                    );
+                    if !schema_preserved
+                        || request.message != "Choose an answer"
+                        || request
+                            .meta
+                            .as_ref()
+                            .is_none_or(|meta| !meta.contains_key("harness.elicitation"))
+                    {
+                        return responder.respond_with_error(
+                            agent_client_protocol::Error::invalid_params()
+                                .data(serde_json::json!("elicitation request was changed")),
+                        );
+                    }
+                    responder.respond(
+                        CreateElicitationResponse::new(ElicitationAction::Decline).meta(
+                            Meta::from_iter([(
+                                "manager.elicitation".to_string(),
+                                serde_json::json!(true),
+                            )]),
+                        ),
+                    )
+                },
+                agent_client_protocol::on_receive_request!(),
+            )
+            .on_receive_request(
                 async move |request: HarnessExtensionRequest, responder, _connection| {
                     responder.respond(HarnessExtensionResponse(serde_json::json!({
                         "managerEcho": request.0,
@@ -2326,8 +2788,14 @@ mod tests {
                         connection.send_request(
                             InitializeRequest::new(ProtocolVersion::V1).client_capabilities(
                                 ClientCapabilities::new()
-                                    .fs(FileSystemCapabilities::new().read_text_file(true))
-                                    .terminal(true),
+                                    .fs(FileSystemCapabilities::new()
+                                        .read_text_file(true)
+                                        .write_text_file(true))
+                                    .terminal(true)
+                                    .elicitation(
+                                        ElicitationCapabilities::new()
+                                            .form(ElicitationFormCapabilities::new()),
+                                    ),
                             ),
                         ),
                     )
@@ -2379,9 +2847,20 @@ mod tests {
         }
         .ok_or_else(|| anyhow::anyhow!("harness did not receive initialize"))?;
         assert!(initialize.client_capabilities.fs.read_text_file);
+        assert!(initialize.client_capabilities.fs.write_text_file);
         assert!(initialize.client_capabilities.terminal);
+        assert!(
+            initialize
+                .client_capabilities
+                .elicitation
+                .as_ref()
+                .is_some_and(ElicitationCapabilities::supports_form)
+        );
         assert!(state.permission_completed.load(Ordering::SeqCst));
         assert!(state.read_completed.load(Ordering::SeqCst));
+        assert!(state.write_completed.load(Ordering::SeqCst));
+        assert!(state.terminal_completed.load(Ordering::SeqCst));
+        assert!(state.elicitation_completed.load(Ordering::SeqCst));
         assert!(state.extension_completed.load(Ordering::SeqCst));
         Ok(())
     }

--- a/crates/bitrouter-sdk/src/caller.rs
+++ b/crates/bitrouter-sdk/src/caller.rs
@@ -29,10 +29,6 @@ pub struct CallerContext {
     /// minted the credential it arrived with. See [`launch_tag`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
     launch_id: Option<String>,
-    /// Private authorization/continuation scope when it must be narrower than
-    /// the low-cardinality user exposed to metering and aggregate telemetry.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    security_scope_id: Option<String>,
 }
 
 /// Prefix of the opaque per-launch attribution token `bitrouter launch` mints
@@ -73,22 +69,6 @@ impl CallerContext {
             user_id: user_id.into(),
             local: false,
             launch_id: None,
-            security_scope_id: None,
-        }
-    }
-
-    /// Construct an authenticated caller with a private ownership scope.
-    pub fn new_scoped(
-        api_key_id: impl Into<String>,
-        user_id: impl Into<String>,
-        security_scope_id: impl Into<String>,
-    ) -> Self {
-        Self {
-            api_key_id: api_key_id.into(),
-            user_id: user_id.into(),
-            local: false,
-            launch_id: None,
-            security_scope_id: Some(security_scope_id.into()),
         }
     }
 
@@ -99,7 +79,6 @@ impl CallerContext {
             user_id: "local".to_string(),
             local: true,
             launch_id: None,
-            security_scope_id: None,
         }
     }
 
@@ -128,7 +107,6 @@ impl CallerContext {
             user_id: "anonymous".to_string(),
             local: false,
             launch_id: None,
-            security_scope_id: None,
         }
     }
 
@@ -155,12 +133,6 @@ impl CallerContext {
     /// The `bitrouter launch` session this request belongs to, if any.
     pub fn launch_id(&self) -> Option<&str> {
         self.launch_id.as_deref()
-    }
-
-    /// Security ownership scope used by durable continuation state. Ordinary
-    /// callers retain their existing user-id scope.
-    pub fn security_scope_id(&self) -> &str {
-        self.security_scope_id.as_deref().unwrap_or(&self.user_id)
     }
 }
 
@@ -210,18 +182,5 @@ mod tests {
         assert!(tagged.is_local(), "still an unauthenticated local caller");
         assert_eq!(tagged.launch_id(), Some("brl_abc"));
         assert_eq!(plain.launch_id(), None);
-    }
-
-    #[test]
-    fn scoped_callers_keep_public_identity_separate_from_private_ownership() {
-        let caller = CallerContext::new_scoped("acp-controller", "acp-controller", "brc_one");
-
-        assert_eq!(caller.api_key_id(), "acp-controller");
-        assert_eq!(caller.user_id(), "acp-controller");
-        assert_eq!(caller.security_scope_id(), "brc_one");
-        assert_eq!(
-            CallerContext::new("key", "user").security_scope_id(),
-            "user"
-        );
     }
 }

--- a/docs/ACP_CONTROLLER_PHASE3_PLAN.md
+++ b/docs/ACP_CONTROLLER_PHASE3_PLAN.md
@@ -1,0 +1,164 @@
+# ACP controller Phase 3 execution plan
+
+Status: **implementation complete; PR validation pending** · Date: 2026-09-02
+
+This plan is derived from [`ACP_CONTROLLER_SPEC.md`](ACP_CONTROLLER_SPEC.md).
+It records the already-delivered Phase 2 baseline without pretending to be a
+historical pre-implementation artifact, then defines the executable Phase 3
+work and completion gates.
+
+## Phase 2 completion ledger
+
+Phase 2 was implemented and merged by
+[`feat(acp): add controller identity and session routing` (#852)](https://github.com/bitrouter/bitrouter/pull/852)
+at commit `d3920084`. The merged change supplied the implementation plan through
+the Phase 2 sections of the controller spec and delivered:
+
+- controller and native Claude/Codex request identity;
+- in-memory session route leases and `_bitrouter/route/*`;
+- controller, session, trace, OpenTelemetry, and metering correlation;
+- provider setup and native ACP lifecycle contract coverage; and
+- workspace verification on Linux, macOS, and Windows.
+
+The PR reports 2,891 passing nextest tests, clippy, formatting, rustdoc, and a
+final Critical/Important review with no remaining findings. A Phase 3 audit of
+the merged design found one intentional correction: the `brac_*` credential
+does not attest caller-declared controller or session headers and duplicates
+the existing API-key boundary. The current spec supersedes it. No separate
+Phase 2 implementation will be created.
+
+## Phase 3 outcome
+
+The controller remains an ACP v1 harness process. Model calls use the normal
+BitRouter API key, or the deliberately open local principal under
+`skip_auth`. Route state is ephemeral and keyed by the same API principal plus
+declared controller/session claims. The controller forwards the stable v1
+surface supported by its pinned Rust SDK without taking ownership of harness
+session data.
+
+Hosted HTTP route control and TUI migration remain Phase 4 and Phase 5. Phase 3
+does not introduce a shared ACP service daemon, session database, transcript
+store, or claim-attestation mechanism.
+
+## Task 1 — remove the duplicate controller credential
+
+- Delete controller credential issue, authentication, expiry, revoke, and
+  `ControllerAuthenticated` event paths.
+- Keep ordinary `brvk_*` validation as the only authenticated model-request
+  path; preserve the existing early local allow for `skip_auth`.
+- Keep the endpoint plan's ordinary API key/launch placeholder instead of
+  replacing it after process launch.
+- Remove credential-only SDK/application APIs and their tests.
+
+Completion: no `brac_*` value can be issued or accepted, normal API auth tests
+and the `skip_auth` truth table pass, and secrets remain redacted.
+
+## Task 2 — API-principal route leases
+
+- Derive an opaque route principal from the ordinary virtual key on both the
+  controller and model-request paths; use the singleton `local` principal for
+  `skip_auth`.
+- Key leases by `(api_principal, declared_controller_id, session_id)`.
+- Give every lease an independent TTL and remove it on reset, successful
+  close/delete, controller disconnect, expiry, or daemon restart.
+- Keep route control on the owner-only local daemon socket in this phase. The
+  socket transports route mutations but does not mint a second credential.
+- Prove that distinct API principals cannot cross namespaces, equal session
+  IDs under distinct controller IDs do not collide, and deliberate reuse of
+  exact claims under one principal is accepted.
+
+Completion: runtime, daemon, controller bridge, and integration tests cover
+namespace isolation, precedence, cleanup, and expiry.
+
+## Task 3 — declared session identity and observability
+
+- Replace authenticated/trusted controller terminology with declared claim and
+  route-match terminology in request context, events, capture, spans, and
+  metering plumbing.
+- Classify the ACP origin from the declared controller marker and parse
+  recognized harness/native evidence independently for attribution; never
+  describe either as authentication or attestation.
+- Preserve the pure model API compatibility projection and continuation
+  precedence unchanged.
+- Record every reviewed ACP, Claude, and Codex identity header and whether the
+  signal participated in route matching. Exclude authorization, cookies, and
+  credentials.
+
+Completion: pure API fixtures remain unchanged; declared ACP and native
+signals join request, route, trace, and settlement artifacts without secret
+material or high-cardinality metric labels.
+
+## Task 4 — pin a coherent ACP v1 Rust SDK line
+
+The crates.io runtime `agent-client-protocol` 2.0.0 pins schema 1.5.0 exactly,
+while schema 1.7.0 is the current Rust schema release. Therefore changing only
+the direct schema dependency would create two incompatible type universes and
+is not an upgrade.
+
+- Pin `agent-client-protocol` and its conductor to one reviewed official Rust
+  SDK revision that consumes schema 1.7.0, and pin the direct schema dependency
+  to the same version.
+- Keep `ProtocolVersion::V1` and `schema::v1`; do not enable protocol v2.
+- Record the exact upstream revision in the dependency and spec.
+- Keep `session/fork` behind its explicit unstable feature; provider setup
+  remains an internal, version-pinned extension.
+
+Completion: one schema version exists in `Cargo.lock`, the controller compiles
+against a coherent official SDK revision, and ACP v2 remains disabled.
+
+## Task 5 — v1 forwarding contracts
+
+Extend the fake-harness protocol suite to prove bidirectional preservation for:
+
+- initialize capabilities and `_meta`, including terminal auth and
+  elicitation;
+- authenticate and logout;
+- filesystem read and write;
+- terminal create, output, wait, kill, and release;
+- permission callbacks and elicitation callbacks;
+- cancellation;
+- session modes, configuration options, and additional directories; and
+- lifecycle calls and unknown namespaced JSON-RPC extensions.
+
+Typed initialize fields and ACP `_meta` must survive decode/forward/re-encode.
+Arbitrary unknown top-level initialize fields are not promised by the typed
+upstream SDK and must not be advertised as preserved. Unknown namespaced RPC
+methods continue to use the raw dispatch forwarding path.
+
+Completion: contract tests exercise each negotiated surface and verify native
+session IDs plus `_meta` round-trip unchanged.
+
+## Task 6 — documentation, review, and release gates
+
+- Correct CLI/help wording so one controller connection is not described as
+  one ACP session.
+- Update `skills/bitrouter/` for changed auth and harness wiring.
+- Run focused tests while implementing, then:
+  - `cargo nextest run --all-features`;
+  - `cargo clippy --workspace --all-features --tests -- -D warnings`;
+  - `cargo fmt -- --check`; and
+  - `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps`.
+- Review the final diff for correctness, secret handling, compatibility,
+  unnecessary abstraction, and scope creep; fix all Critical and Important
+  findings and rerun affected gates.
+- Commit conventionally, push the branch, open a Phase 3 PR, and verify its CI.
+
+Completion: the PR contains implementation, tests, spec/skill updates, review
+evidence, and successful CI, with hosted control and TUI work left explicit.
+
+## Implementation evidence
+
+- The runtime, conductor, and schema form one ACP v1 type universe at official
+  Rust SDK revision `c63610fc38a642f7a73ba2719f403f17d771c345` and schema
+  1.7.0; `unstable_protocol_v2` is not enabled.
+- No production path issues, accepts, authenticates, renews, or revokes a
+  `brac_*` credential. Normal virtual-key authentication and the explicit
+  `skip_auth` local principal remain the only request boundaries.
+- Focused controller, routing, authentication, daemon, metering, and ACP CLI
+  contract suites pass.
+- The final local tree passes 2,888 nextest tests with 11 skipped, workspace
+  clippy with warnings denied, formatting, rustdoc with warnings denied, and
+  `git diff --check`.
+- Final Critical/Important review found no remaining correctness, secret
+  handling, compatibility, or scope findings. Hosted HTTP route control and
+  the TUI remain Phase 4 and Phase 5 respectively.

--- a/docs/ACP_CONTROLLER_PHASE3_PLAN.md
+++ b/docs/ACP_CONTROLLER_PHASE3_PLAN.md
@@ -1,6 +1,6 @@
 # ACP controller Phase 3 execution plan
 
-Status: **implementation complete; PR validation pending** · Date: 2026-09-02
+Status: **completed** · Date: 2026-09-02
 
 This plan is derived from [`ACP_CONTROLLER_SPEC.md`](ACP_CONTROLLER_SPEC.md).
 It records the already-delivered Phase 2 baseline without pretending to be a
@@ -162,3 +162,6 @@ evidence, and successful CI, with hosted control and TUI work left explicit.
 - Final Critical/Important review found no remaining correctness, secret
   handling, compatibility, or scope findings. Hosted HTTP route control and
   the TUI remain Phase 4 and Phase 5 respectively.
+- Pull request [#853](https://github.com/bitrouter/bitrouter/pull/853) passed
+  Linux, macOS, Windows, clippy, rustdoc, MSRV, integration, repository,
+  packaging, and CodeQL validation.

--- a/docs/ACP_CONTROLLER_SPEC.md
+++ b/docs/ACP_CONTROLLER_SPEC.md
@@ -1,17 +1,21 @@
 # Spec: the ACP controller runtime
 
-Status: **Phase 2 controller core implemented; next iterations specified** · Date: 2026-09-02
+Status: **Phase 3 stable-v1 controller implemented; next iterations specified** · Date: 2026-09-02
 
 Implementation note: Phase 0 pins stable ACP v1 wire semantics and maintained
 Claude/Codex adapters behind one endpoint plan. Phase 1 ships the manager-first
 connection controller used by `acp serve`, including provider setup gating,
-native lifecycle forwarding, callbacks, and extension fidelity. Phase 2 now
-ships daemon-issued controller credentials, authenticated Claude/Codex
-request-session normalization, ephemeral native-session route leases,
-`_bitrouter/route/*`, `SessionIdentityObserved`, controlled capture/replay,
-span attributes, and nullable metering correlation. The remaining roadmap is
-stable-v1 compatibility hardening, trusted hosted-Core route control, migration
-of the single-user-session TUI, pre-connection harness selection, and release
+native lifecycle forwarding, callbacks, and extension fidelity. Phase 2 ships
+Claude/Codex request-session normalization, ephemeral native-session route
+leases, `_bitrouter/route/*`, `SessionIdentityObserved`, controlled
+capture/replay, span attributes, and nullable metering correlation. Phase 3
+removes the former daemon-issued `brac_*` controller credential: normal
+BitRouter API authentication is the only authentication boundary, while
+controller/session headers are explicitly caller-declared routing and
+observability signals. It also pins one coherent Rust SDK/schema line and adds
+stable-v1 forwarding contracts. The remaining roadmap includes
+API-key-authenticated hosted-Core route control, migration of the
+single-user-session TUI, pre-connection harness selection, and release
 hardening.
 
 This document defines the core runtime beneath BitRouter's ACP-facing products.
@@ -109,8 +113,8 @@ shared ACP daemon.
 
 - The **manager plane** controls sessions and renders updates.
 - The **harness plane** owns agent behavior and session data.
-- The **model plane** routes and meters model requests using native session
-  evidence plus authenticated controller correlation.
+- The **model plane** routes and meters model requests using the normal API
+  principal plus declared controller and native-session evidence.
 
 The controller connects these planes without collapsing their ownership.
 
@@ -183,10 +187,11 @@ following names explicitly.
 | `agent_thread_id` | harness | harness-defined | Child agent or thread identity within the root session |
 | `parent_agent_thread_id` | harness | harness-defined | Native lineage when supplied |
 | `turn_id` | harness | harness-defined | Native turn identity when supplied |
+| `api_principal` | BitRouter Core | one API-authentication scope | Stable non-secret identity derived from a validated API key, or the singleton local caller when `skip_auth: true`; scopes route state but does not attest request headers |
 | `legacy_workflow_session_id` | BitRouter/caller | one inferred workflow | Existing `x-bitrouter-workflow-session`, adapter hint, or prompt-hash result used by pure model API traffic |
 | `api_continuation_id` | provider/BitRouter continuation service | one provider-side continuation chain | Responses `previous_response_id`; constrains provider state and is not an agent session ID |
 | `router_request_id` | BitRouter | one model request | BitRouter ingress and metering correlation |
-| `route_lease_id` | BitRouter | one live controller/session override | Authorizes and cleans up an ephemeral route override |
+| `route_lease_id` | BitRouter | one live controller/session override | Identifies and cleans up an ephemeral route override; it is not a credential |
 
 ### 4.1 Identity invariants
 
@@ -197,10 +202,11 @@ following names explicitly.
    current controller process has not seen it before. The harness, not an
    in-memory BitRouter map, decides whether it exists.
 4. `controller_instance_id` must never be placed in the ACP `sessionId` field.
-5. For authenticated ACP traffic, native request evidence wins over legacy
-   compatibility headers. Pure model API traffic retains the existing legacy
-   precedence in §10.2. Conflicts are diagnostic events, not a reason to erase
-   either signal.
+5. For traffic classified as coming from an ACP harness, native request
+   evidence wins over legacy compatibility headers. This classification is an
+   attribution decision, not authentication or attestation. Pure model API
+   traffic retains the existing legacy precedence in §10.2. Conflicts are
+   diagnostic events, not a reason to erase either signal.
 6. Missing identity never causes BitRouter to fabricate a confident session.
    The request uses the default route and is marked unattributed.
 7. Raw native IDs may exist in request scope and live controller memory.
@@ -233,7 +239,7 @@ of them into a universal session key.
 | Mechanism | Current key and precedence | Current effect | Controller treatment |
 |---|---|---|---|
 | Legacy workflow identity | `x-bitrouter-workflow-session`, then a detected adapter's body hint, then a low-confidence first-user-message hash | Structured workflow identity, trace/capture joins, and context analysis | Keep unchanged as the pure model API compatibility projection |
-| Local launch route override | `launch_id` parsed from a `Bearer brl_*` launch token | Rewrites the provider for one local launch before normal policy routing | Do not reuse; it is process attribution for the local `skip_auth` path, not an authenticated ACP session lease |
+| Local launch route override | `launch_id` parsed from a `Bearer brl_*` launch token | Rewrites the provider for one local launch before normal policy routing | Do not treat it as authentication; it is process attribution for the local `skip_auth` path, not an API principal |
 | Responses continuation | `previous_response_id` resolved by the continuation subsystem | Binds server-side provider state to the original provider, model, account, and caller | Keep separate and stronger than any ACP route preference |
 
 Ordinary workflow identity does not participate in the static predictive route
@@ -282,18 +288,26 @@ These are review gates, not preferences.
 - Standard `providers/*` is not advertised manager-side as a synonym for
   BitRouter's internal provider catalog.
 
-### 5.5 Authenticated routing scope
+### 5.5 API-authenticated, claim-scoped routing
 
-- Raw `x-bitrouter-controller-id` and `x-bitrouter-acp-session-id` headers are
-  correlation evidence, not authorization.
-- The harness uses a controller-scoped BitRouter credential. BitRouter Core
-  derives the trusted controller identity from that credential and checks any
-  claimed header against it, whether authority was issued through the local
-  control socket or the hosted HTTPS control surface.
-- A session override is keyed by authenticated controller identity plus the
-  opaque ACP session ID. Model ingress matches source-specific native identity
-  candidates to that ID. Two independently launched user sessions cannot
-  change each other's routes.
+- BitRouter uses the existing API key or virtual key as its only authentication
+  boundary. Model calls and HTTP route-control calls use the same normal API
+  authentication path and resolve to the same non-secret `api_principal`.
+- `server.skip_auth: true` applies consistently to both model and route-control
+  endpoints. It resolves requests to the singleton local caller and does not
+  retain a hidden second authentication requirement for routing.
+- Raw `x-bitrouter-controller-id`, `x-bitrouter-acp-session-id`, and
+  harness-native session headers are caller-declared correlation and route
+  lookup inputs. They are not cryptographic proof of a controller, harness, or
+  session, and BitRouter does not claim to prevent a caller from forging them.
+- A session override is keyed by `api_principal`, the declared
+  `controller_instance_id`, and the opaque ACP/native session ID. This prevents
+  accidental and cross-principal collisions without pretending to attest the
+  claims. Holders of the same API key share one security principal and can
+  deliberately reuse each other's claimed identifiers; that is an accepted
+  boundary. Under `skip_auth`, all callers share the local principal.
+- Controllers generate high-entropy instance IDs to make accidental collision
+  negligible. Randomness is namespacing, not authorization.
 
 ### 5.6 The controller has no TUI dependency
 
@@ -353,7 +367,7 @@ The application owns BitRouter-specific policy:
 - the harness catalog and pinned adapter versions;
 - per-harness launch fallback configuration;
 - post-initialize `providers/set` configuration;
-- controller credentials and static metadata headers;
+- normal API credentials and static metadata headers;
 - `_bitrouter/route/*` request handling;
 - local or hosted route-lease installation and removal;
 - Claude/Codex native identity extraction at HTTP ingress; and
@@ -384,8 +398,10 @@ behavior is a later product iteration over the same interface.
 
 The required sequence is:
 
-1. The app resolves an explicit harness and creates a
-   `controller_instance_id` plus a controller-scoped BitRouter credential.
+1. The app resolves an explicit harness, creates a high-entropy
+   `controller_instance_id`, and resolves the normal BitRouter API key accepted
+   by the target Core. Under `skip_auth`, a non-secret launch token or adapter
+   placeholder may still be supplied when the harness requires a value.
 2. The app builds one `HarnessEndpointPlan` containing the BitRouter base URL,
    logical model, authentication, and static headers.
 3. The app launches the pinned adapter with the plan's harness-specific
@@ -427,7 +443,8 @@ information for troubleshooting and UI labels.
 On manager disconnect or controller shutdown:
 
 1. cancel or finish in-flight local forwarding according to ACP semantics;
-2. remove every BitRouter route lease owned by the controller;
+2. remove every BitRouter route lease owned by the API-principal/controller
+   tuple;
 3. terminate the child adapter according to the existing process policy; and
 4. discard the ephemeral live-session index.
 
@@ -506,26 +523,27 @@ HarnessEndpointPlan
   base_url             BitRouter model endpoint
   protocol             Anthropic Messages or OpenAI Responses
   logical_model        model or BitRouter preset presented to the harness
-  controller_credential short-lived credential bound to the controller
+  api_key              existing BitRouter API/virtual key when auth is enabled
   static_headers
     x-bitrouter-controller-id
     x-bitrouter-harness
 ```
 
-The credential is passed through the adapter's secret-bearing configuration
-field or environment variable. It is never returned from `providers/list`,
-included in `_meta`, printed in logs, or rendered by the TUI.
+The API key is passed through the adapter's secret-bearing configuration field
+or environment variable. It is never returned from `providers/list`, included
+in `_meta`, printed in logs, or rendered by the TUI. No second controller
+credential is minted or exchanged.
 
 `x-bitrouter-controller-id` and `x-bitrouter-harness` improve diagnostics, but
-the daemon trusts the credential binding rather than those caller-controlled
-strings.
+remain caller-controlled strings. Core uses them as namespacing and attribution
+claims within the normal API principal, not as authenticated facts.
 
 ### 9.2 Preferred path: harness-side `providers/set`
 
 When the initialized harness advertises the provider capability, the
 controller calls `providers/set` after initialization and before any
 `session/new`, `load`, or `resume`. The configured provider points to BitRouter,
-uses the required wire protocol, carries the controller credential and static
+uses the required wire protocol, carries the normal API key and static
 headers, and is process-scoped.
 
 The controller verifies the effective non-secret URL/protocol/model through
@@ -582,27 +600,32 @@ platform constraints require a different version, the compatibility change
 must record the package version and upstream commit used by its conformance
 tests and rerun endpoint, session, capability, and identity smokes.
 
-### 9.6 Trusted local binding and hosted-Core gap
+### 9.6 One API authentication boundary and the hosted-Core gap
 
-`acp serve` obtains a short-lived `brac_*` controller credential only from the
-owner-only control socket of the locally resolved daemon. That credential is
-used by both provider configuration and the launch fallback, and is revoked
-with all controller-owned leases when the controller exits normally.
+The Phase 2 local `acp serve` path obtained a short-lived `brac_*` controller
+credential from the owner-only daemon socket. Phase 3 removes that dedicated
+credential path. It did not attest session-header contents and is not part of
+the target protocol.
 
-An explicit `--base-url` continues to support model endpoint configuration,
-but the implemented path has no access to that endpoint's owner-only control
-plane. The controller therefore does not advertise `_bitrouter/route/*` for
-that path and model requests are handled as ordinary model API traffic. Native
-Claude/Codex session evidence remains observable, while the static controller
-claim remains untrusted for lease authority. A user API key or
-launch-attribution token is never promoted to controller authority.
+The target path uses the same API key for model requests and route-control
+requests. Core derives `api_principal` from its existing authentication
+middleware; the controller and session headers remain declared values inside
+that scope. If `skip_auth: true`, both request classes use the same local
+principal and no extra routing credential is required.
 
-The next hosted-Core iteration adds an authenticated HTTPS control surface for
-short-lived controller credential issue, renewal, revocation, and
-session-route list/set/reset. The existing `RouteControl` boundary receives an
-HTTPS implementation; no local ACP service daemon is introduced. Hosted and
-local implementations must enforce the same controller/session isolation,
-lease expiry, cleanup, and observability contract.
+An explicit `--base-url` already supports model endpoint configuration, but
+the implemented path does not yet expose a matching HTTP route-control
+surface. Until that gap is closed, the controller does not advertise
+`_bitrouter/route/*` for the remote path. Native Claude/Codex session evidence
+and static controller claims remain observable.
+
+The next hosted-Core iteration adds an HTTP(S) session-route list/set/reset
+surface protected by Core's existing API authentication middleware. Local and
+hosted Core use the same API and `skip_auth` semantics; no credential issue,
+renewal, revocation, or exchange endpoint is introduced. Route leases retain
+their own TTL and explicit cleanup so controller crashes do not leave permanent
+state. The existing `RouteControl` boundary receives an HTTP implementation;
+no local ACP service daemon is introduced.
 
 ## 10. Native identity at BitRouter model ingress
 
@@ -614,9 +637,10 @@ collapsing them into the current single `SessionSignal.key`:
 
 ```text
 RequestSessionContext
-  origin: PureModelApi | AuthenticatedAcpController
-  authenticated_controller_instance_id?
-  acp_session_id?                 # populated only after a trusted binding
+  origin: PureModelApi | AcpHarnessRequest
+  api_principal                   # API-key identity or local under skip_auth
+  claimed_controller_instance_id?
+  declared_acp_session_id?
   native:
     harness?
     root_session_id?
@@ -653,19 +677,21 @@ not parsed as Claude identity without Claude recognition, and a Responses
 `previous_response_id` remains continuation evidence rather than route
 authority.
 
-For `AuthenticatedAcpController`, the analysis projection uses:
+For `AcpHarnessRequest`, the analysis projection uses:
 
-1. a credential-bound, dynamically supplied `x-bitrouter-acp-session-id` when
-   an adapter can provide one;
+1. a dynamically supplied `x-bitrouter-acp-session-id` when an adapter can
+   provide one;
 2. Claude or Codex native request identity;
 3. the existing `x-bitrouter-workflow-session` compatibility signal;
 4. existing adapter body hints; and
 5. the low-confidence prompt hash.
 
-The route-lease projection is intentionally narrower. It accepts only a
-credential-bound ACP session ID or source-specific native session candidates.
-Legacy headers, user-agent detection, `previous_response_id`, and prompt hashes
-may improve analysis but cannot authorize a session route override.
+The route-lease projection is intentionally narrower. Within the request's
+normal `api_principal`, it accepts only the declared ACP session ID or
+source-specific native session candidates together with the declared
+controller instance ID. Legacy headers, user-agent detection,
+`previous_response_id`, and prompt hashes may improve analysis but do not form
+a route key.
 
 All evidence is retained. Resolving the ACP projection does not overwrite the
 legacy workflow projection, and conflicting evidence produces diagnostics.
@@ -706,20 +732,25 @@ native identity projection.
 ### 10.5 Conflict behavior
 
 If two native fields conflict, the extractor follows the source-specific
-precedence above, attaches a structured diagnostic, and avoids using the lower
-authority value for route scope. A private BitRouter harness header can help
+precedence above, attaches a structured diagnostic, and avoids using the
+lower-specificity value for route scope. This precedence improves deterministic
+routing and attribution; it does not make the selected value authentic. A
+private BitRouter harness header can help
 select an extractor only when no stronger native evidence identifies one; that
 harness-selector hint cannot replace a native session ID.
 
 ### 10.6 Pipeline carriers
 
-Identity normalization runs after authentication, because raw controller and
-ACP session headers are not trusted inputs. A `SessionContextHook` writes:
+Identity normalization runs after normal API authentication so route lookup can
+use the resolved `api_principal`. The ordering does not authenticate raw
+controller, ACP, or harness-native session headers. A `SessionContextHook`
+writes:
 
 - a typed request extension containing the full normalized context for route
   resolution and stream hooks; and
 - one redaction-safe `SessionIdentityObserved` event containing the transport
-  evidence, normalized correlation fields, trust decisions, and conflicts
+  evidence, normalized correlation fields, route-eligibility decisions, and
+  conflicts
   required by trace, replay, route-decision, and settlement recorders.
 
 Request extensions do not flow directly into settlement in the current
@@ -778,23 +809,23 @@ Managers discover this extension from
 `initialize._meta["bitrouter.dev/controller"].routeControl`. An available v1
 surface reports `version: "1"`, the three method names above, and
 `scope: "session"`. An absent or `null` value means that this controller has no
-trusted route-control binding; callers must hide or disable the route surface.
+working route-control backend; callers must hide or disable the route surface.
 Calling an unavailable extension returns JSON-RPC method-not-found rather than
 silently falling back to a different authority.
 
 ### 11.3 Route key and descendant behavior
 
-The trusted route-lease key is:
+The route-lease key is:
 
 ```text
-(authenticated_controller_instance_id, acp_session_id)
+(api_principal, claimed_controller_instance_id, acp_or_native_session_id)
 ```
 
 BitRouter Core does not require the HTTP client to send a field literally named
 `acp_session_id`. When an adapter can emit a dynamic
-`x-bitrouter-acp-session-id`, Core validates it against the authenticated
-controller binding and tries it first. Otherwise, or if it does not match a
-lease, the native extractor produces ordered lookup candidates:
+`x-bitrouter-acp-session-id`, Core tries it first inside the API-principal and
+claimed-controller namespace. Otherwise, or if it does not match a lease, the
+native extractor produces ordered lookup candidates:
 
 | Harness | Route lookup candidates |
 |---|---|
@@ -814,11 +845,14 @@ The manager can install the route immediately after `session/new`, `load`, or
 experimental fork when advertised. The first prompt therefore does not race
 route installation.
 
-If a model request has authenticated controller identity but neither a trusted
-dynamic ACP session ID nor native root session identity, no session override
-applies. The default router policy runs and telemetry marks the request
-unattributed. If it has a claimed ACP/native ID but an invalid controller
-credential, it cannot access another controller's lease.
+If a model request has no declared controller instance ID, or neither a
+declared dynamic ACP session ID nor native root session identity, no session
+override applies. The default router policy runs and telemetry marks the
+request unattributed. With API authentication enabled, an invalid or missing
+API key is rejected by the normal API path before route lookup. With
+`skip_auth: true`, the same claims are usable within the shared local principal.
+BitRouter deliberately does not attempt to detect a caller that forges those
+claims.
 
 ### 11.4 Lease lifetime
 
@@ -827,7 +861,8 @@ A route override is an ephemeral `route_lease`:
 - created or replaced by `_bitrouter/route/set`;
 - removed by `reset`;
 - removed after successful `session/close` or `session/delete`;
-- removed when the controller disconnects or its credential expires; and
+- removed when the controller disconnects or its independent lease TTL
+  expires; and
 - not restored automatically by harness `session/resume` after a new
   controller process starts.
 
@@ -853,13 +888,13 @@ standard meaning, but it requires a separate security review.
 ### 11.6 Pipeline integration and precedence
 
 The current launch-token override and policy-table transform run at ingress,
-before `AuthHook`. Trusted ACP routing cannot reuse that seam because controller
-authority has not been established there. The compatible control flow is:
+before `AuthHook`. ACP route lookup cannot reuse that seam because the normal
+API principal has not been established there. The compatible control flow is:
 
 ```text
 parse + existing ingress transforms
   -> AuthHook
-  -> SessionContextHook + authenticated route-lease lookup
+  -> SessionContextHook + API-principal-scoped route-lease lookup
   -> Responses continuation resolution
   -> policy composition
   -> route resolution
@@ -872,7 +907,7 @@ applies this precedence:
 ```text
 Responses continuation pin
   > original explicit caller route or preset
-  > authenticated ACP session route lease
+  > matching ACP session route lease
   > existing policy-table/default result
 ```
 
@@ -883,7 +918,7 @@ final authority when `previous_response_id` pins provider-side state, so an ACP
 preference can never move a continuation to a different provider, model,
 account, or caller.
 
-Expressed by pipeline responsibility, the new authenticated portion is:
+Expressed by pipeline responsibility, the new route-scoped portion is:
 
 ```text
 AuthHook
@@ -894,10 +929,10 @@ AuthHook
   -> route resolution
 ```
 
-This hook order changes only `AuthenticatedAcpController` requests with a
-matching route lease. Pure model API traffic and authenticated ACP requests
-without a matching native-session lease continue through the existing policy
-path unchanged.
+This hook order changes only requests whose API principal and declared
+controller/native-session claims match a route lease. Existing pure model API
+fixtures and ACP-attributed requests without a matching native-session lease
+continue through the existing policy path unchanged.
 
 ## 12. Session flows
 
@@ -938,7 +973,8 @@ Manager        Controller        Harness             BitRouter Core
    |-------------->| prompt(id)     |                       |
    |               |--------------->| model HTTP            |
    |               |                |---------------------->|
-   |               |                | controller credential |
+   |               |                | normal API key        |
+   |               |                | declared controller id|
    |               |                | native session fields |
    |               |                |                       | resolve lease
    |               |                |<----------------------|
@@ -948,14 +984,14 @@ Manager        Controller        Harness             BitRouter Core
 No controller-generated per-session header is required in this flow. Static
 controller correlation comes from endpoint configuration; session identity
 comes from the harness's native model client. An adapter that can correctly
-emit a dynamic, credential-bound `x-bitrouter-acp-session-id` may do so, but the
+emit a dynamic `x-bitrouter-acp-session-id` may do so, but the
 Claude and Codex baseline does not depend on it.
 
 ### 12.4 Close, delete, and disconnect
 
 The controller removes local route state only after the harness accepts close
 or delete. A failed harness operation leaves the route lease in place until an
-explicit reset, controller teardown, or credential expiry.
+explicit reset, controller teardown, or lease expiry.
 
 An ACP connection drop removes controller-owned leases but does not translate
 to harness `session/delete` or erase harness data.
@@ -975,7 +1011,7 @@ control that only changed local display state.
 | Harness session method fails | Preserve harness ACP error and native ID; do not mutate local catalog |
 | Manager requests unsupported method | Protocol-defined unsupported/method-not-found response |
 | Route lease installation fails | `_bitrouter/route/set` fails; `current` remains backend-confirmed state |
-| Trusted ACP/native model identity missing | Use default route; emit unattributed diagnostic; never fabricate ID |
+| Declared ACP/native model identity missing | Use default route; emit unattributed diagnostic; never fabricate ID |
 | Native identity conflict | Use source-specific native precedence and emit conflict diagnostic |
 | BitRouter Core or route-control backend unavailable | Model request or route mutation fails through its normal path; controller surfaces the relevant sanitized error |
 | Adapter exits | Fail in-flight operations, remove route leases, retain harness-owned session files untouched |
@@ -986,22 +1022,31 @@ headers, and full provider configuration payloads are redacted at the source.
 
 ## 14. Security and privacy
 
-1. Controller credentials are short-lived, least-privilege, and bound to one
-   controller instance. Reusing a user's upstream model credential as the
-   controller credential is forbidden.
-2. BitRouter Core authenticates route-control commands and model requests.
-   Header strings alone do not grant access to a route lease; an untrusted pure
-   API caller cannot activate ACP mode by copying controller or session
-   headers.
-3. Provider configuration responses expose only non-secret effective fields.
-4. Session IDs are treated as opaque identifiers. They are not placed in error
+1. BitRouter's existing API key or virtual key is the only authentication
+   boundary for both model and HTTP route-control requests. No ACP-specific
+   credential is issued, exchanged, renewed, or revoked.
+2. `server.skip_auth: true` deliberately admits both request classes as the
+   local principal. Operators who select that mode are not given a misleading
+   secondary routing-authentication boundary.
+3. Controller, ACP session, and harness-native session headers are assertions
+   made by the caller. BitRouter uses them for attribution and route matching
+   but does not attest them or claim to prevent forgery.
+4. API-principal scoping prevents a caller authenticated as one key from
+   colliding with route state owned by another key. It does not stop two
+   processes sharing one API key from impersonating each other's claimed
+   controller/session namespace. Under `skip_auth`, all callers intentionally
+   share that authority.
+5. High-entropy controller IDs reduce accidental collisions only. They are not
+   secrets and must never be described as authorization tokens.
+6. Provider configuration responses expose only non-secret effective fields.
+7. Session IDs are treated as opaque identifiers. They are not placed in error
    messages that may be sent to an unrelated manager connection.
-5. The controller never reads harness session-storage directories merely to
+8. The controller never reads harness session-storage directories merely to
    populate UI or router state.
-6. Existing request tracing may associate metering with normalized agent
+9. Existing request tracing may associate metering with normalized agent
    identity, but it must not reinterpret that telemetry as a resumable session
    store.
-7. Custom base URLs and headers follow the existing BitRouter configuration
+10. Custom base URLs and headers follow the existing BitRouter configuration
    trust model. Any future remote controller transport requires a separate
    authentication and threat-model review.
 
@@ -1012,9 +1057,9 @@ Every model request produces one `SessionIdentityObserved` event, including an
 explicit unattributed event when no session signal is present. Model-plane
 trace, route, usage, and settlement artifacts join exactly through
 `router_request_id`. Controller ACP events correlate at session scope through
-the authenticated controller ID and ACP/native identity, and at turn scope
-only when the harness exposes a native turn ID. None of these events is a
-replacement session record.
+the API principal, declared controller ID, and ACP/native identity, and at turn
+scope only when the harness exposes a native turn ID. None of these events is
+a replacement session record.
 
 ### 15.1 Required evidence inventory
 
@@ -1025,7 +1070,7 @@ the normalized event records which exact field supplied each semantic value.
 | Source | Transport evidence | Normalized purpose |
 |---|---|---|
 | Request correlation | `x-bitrouter-request-id` | Join trace, route decision, usage, and settlement artifacts for one model request |
-| ACP controller | `x-bitrouter-controller-id`, `x-bitrouter-acp-session-id` | Record claimed controller/session identity separately from authenticated controller identity and trusted ACP binding |
+| ACP controller | `x-bitrouter-controller-id`, `x-bitrouter-acp-session-id` | Record declared controller/session identity and whether each value participated in route matching; do not label either value authenticated or trusted |
 | Existing BitRouter workflow | `x-bitrouter-workflow-session`, `x-bitrouter-parent-session-id`, `x-bitrouter-agent-session-id`, `x-bitrouter-agent-role`, `x-bitrouter-context-epoch`, `x-bitrouter-context-transition`, `x-bitrouter-session-fingerprint` | Preserve the legacy workflow projection, lineage, role, and compaction context |
 | Claude Code | `x-claude-code-session-id`, `x-claude-code-agent-id`, `x-claude-code-parent-agent-id` | Root Claude session and child-agent lineage |
 | Codex | `session-id`, `thread-id`, `x-codex-turn-metadata` | Root Codex session, exact thread, parent/subagent lineage, and turn identity |
@@ -1034,8 +1079,9 @@ the normalized event records which exact field supplied each semantic value.
 | API continuation | Responses `previous_response_id` | Correlate provider-side continuation while keeping it distinct from agent session identity |
 
 Harness recognition fields such as `anthropic-beta`, `user-agent`,
-`x-bitrouter-harness`, and the trusted inbound protocol remain observable as
-adapter-selection evidence, but they do not become session IDs.
+`x-bitrouter-harness`, and the inbound protocol remain observable as
+adapter-selection evidence, but they do not become session IDs or authenticated
+harness claims.
 
 ### 15.2 Normalized event contract
 
@@ -1046,9 +1092,9 @@ SessionIdentityObserved
   router_request_id
   origin
   harness
-  authenticated_controller_instance_id?
+  api_principal_id?               # non-secret stable identity/digest
   claimed_controller_instance_id?
-  acp_session_id?                 # only after trusted binding
+  declared_acp_session_id?
   native_root_session_id?
   native_agent_thread_id?
   native_parent_agent_thread_id?
@@ -1059,7 +1105,7 @@ SessionIdentityObserved
     transport: header | body | derived
     field
     source
-    trusted_for_route
+    used_for_route_match
     value?
     value_representation: raw | stable_digest | presence_only
   conflicts[]
@@ -1072,12 +1118,12 @@ Every identifier-valued field in a persisted event is logically an
 `IdentityValue { value, representation }`; the abbreviated schema above shows
 semantic names rather than implying that every sink receives a raw value.
 
-The event preserves both the claimed controller header and the authenticated
-controller identity so spoofing or configuration drift is visible without
-granting the claim authority. It preserves all competing session evidence;
-the selected projection does not erase lower-precedence inputs. Structured
-events contain only recognized fields from compound values such as
-`x-codex-turn-metadata` and `client_metadata`, never an unbounded metadata blob.
+The event preserves the normal API principal separately from every declared
+controller/session value, without implying that the principal attests those
+values. It preserves all competing session evidence; the selected projection
+does not erase lower-precedence inputs. Structured events contain only
+recognized fields from compound values such as `x-codex-turn-metadata` and
+`client_metadata`, never an unbounded metadata blob.
 
 ### 15.3 Required sinks and joins
 
@@ -1087,10 +1133,10 @@ field names and representation policy where their scope overlaps.
 
 | Sink | Required behavior |
 |---|---|
-| Structured trace/log spans | Attach request/controller/harness identity, normalized session lineage, evidence source/trust, attribution status, conflicts, effective route, scope, and lease outcome |
+| Structured trace/log spans | Attach request/API-principal/controller/harness correlation, normalized session lineage, evidence source and route use, attribution status, conflicts, effective route, scope, and lease outcome |
 | Controlled ingress capture and replay | In explicit replay-capable mode, preserve every privacy-reviewed header in §15.1 plus recognized body evidence with the exact values required to rerun extraction; replay must produce the same normalized event and route-attribution result as online ingestion |
 | Policy and route-decision records | Persist the normalized identity reference, matched lease key, precedence outcome, and unattributed/conflict reason |
-| Metering/settlement | Join by `router_request_id`; persist nullable harness, authenticated controller, ACP session, native root/thread/parent/turn, route-lease, and redaction-reviewed normalized-event fields; ordinary requests keep these fields null |
+| Metering/settlement | Join by `router_request_id`; persist nullable harness, API principal reference, declared controller/ACP session, native root/thread/parent/turn, route-lease, and redaction-reviewed normalized-event fields; ordinary requests keep these fields null |
 | Aggregate metrics | Count attributed/unattributed requests, evidence source, conflicts, and lease outcomes using low-cardinality enums only |
 | Controller lifecycle logs | Record adapter/version, endpoint configuration mode, ACP method, native ID presence, capability decision, process exit, and lease cleanup outcome |
 
@@ -1102,8 +1148,8 @@ and may report unknown rather than daemon-wide data as if it were session data.
 
 ### 15.4 Privacy, retention, and cardinality
 
-- `Authorization`, proxy authorization, cookies, provider API keys, controller
-  credentials, and full provider configuration never enter observability.
+- `Authorization`, proxy authorization, cookies, provider/API keys, and full
+  provider configuration never enter observability.
 - Session identifiers are sensitive correlation data. A controlled trace may
   retain raw values under the existing explicit capture and retention policy.
   Replay-capable captures require those exact allowlisted identity values. A
@@ -1137,20 +1183,21 @@ blob.
 
 ### 16.1 ACP SDK
 
-The workspace uses `agent-client-protocol` 2.0.0 as its Rust runtime and the
-stable v1 schema exposed by `agent-client-protocol-schema` 1.5.0. The runtime
-crate's major version does **not** select ACP v2 wire semantics: initialization
-requires `ProtocolVersion::V1`, controller types come from `schema::v1`, and
-the namespaced BitRouter route methods are v1-compatible extensions. ACP v2
-wire types remain out of scope.
+The workspace pins the official Rust SDK runtime and conductor at revision
+`c63610fc38a642f7a73ba2719f403f17d771c345` and uses
+`agent-client-protocol-schema` 1.7.0 throughout. The runtime crates retain
+their 2.0.0 crate versions, but that major version does **not** select ACP v2
+wire semantics: initialization requires `ProtocolVersion::V1`, controller
+types come from `schema::v1`, and the namespaced BitRouter route methods are
+v1-compatible extensions. ACP v2 wire types remain out of scope.
 
-The schema pin is now a compatibility gap. The upstream stable schema is
-1.21.0 as of 2026-09-02 and includes stable fields such as terminal
-authentication and elicitation that the 1.5.0 typed initialize path cannot
-represent. The next iteration upgrades the stable-v1 schema/runtime pair and
-proves that initialization preserves current and unknown capability fields
-losslessly. Generic forwarding after initialization is not sufficient if
-decode/re-encode already removed a field during the handshake.
+This exact revision resolves the compatibility gap in the published crates.io
+runtime, which pins Rust schema 1.5.0 exactly. Upgrading only the direct schema
+dependency would create two incompatible type universes. The lockfile now has
+one schema 1.7.0 type universe, and contract tests prove that typed terminal
+authentication and elicitation capabilities plus ACP `_meta` survive the
+initialize handshake. Generic forwarding after initialization remains
+insufficient if decode/re-encode removes a typed field during that handshake.
 
 ### 16.2 Existing one-shot `Session`
 
@@ -1220,9 +1267,11 @@ Before Phases 0–2, the relay had these limitations:
 The implemented controller path replaces those limitations for `acp serve`:
 manager-first initialization and native lifecycle forwarding live in
 `acp/controller.rs`; maintained adapter endpoint plans use exact pins;
-manager-side provider aliases are rejected; authenticated controller/session
-normalization and route leases run after `AuthHook`; and trace, spans, and
-metering consume the normalized identity event. The legacy one-shot engine and
+manager-side provider aliases are rejected; controller/session normalization
+and route leases run after `AuthHook`; and trace, spans, and metering consume
+the normalized identity event. The local path now uses the normal API
+principal, or the deliberately shared `local` principal under `skip_auth`, and
+does not mint a second controller credential. The legacy one-shot engine and
 pure model API projection intentionally remain available and behaviorally
 separate.
 
@@ -1236,14 +1285,14 @@ loaded and no real upstream model request was made.
 
 The implementation is divided along these boundaries:
 
-| Area | Current files | Phase 2 status |
+| Area | Current files | Phase 3 status |
 |---|---|---|
-| Controller lifecycle and capabilities | `crates/bitrouter-sdk/src/acp/controller.rs` | Implemented: manager-first stable-v1 controller, native-ID lifecycle forwarding, callbacks, and lifecycle-gated cleanup; stable-schema refresh remains |
-| Harness configuration | `apps/bitrouter/src/harness.rs`, `acp_cli.rs` | Implemented for maintained Claude/Codex pins with one provider/fallback endpoint plan and local controller credential |
-| Route extensions | `crates/bitrouter-sdk/src/acp/controller.rs`, `apps/bitrouter/src/acp_cli.rs`, `daemon.rs`, `acp_runtime.rs` | Implemented: typed `_bitrouter/route/*`, daemon-confirmed mutations, controller/session isolation, expiry/revoke/close/delete cleanup |
+| Controller lifecycle and capabilities | `crates/bitrouter-sdk/src/acp/controller.rs` | Implemented: manager-first stable-v1 controller, native-ID lifecycle forwarding, stable auth/elicitation/filesystem/terminal callbacks, and lifecycle-gated cleanup on schema 1.7.0 |
+| Harness configuration | `apps/bitrouter/src/harness.rs`, `acp_cli.rs` | Implemented: maintained Claude/Codex pins and one provider/fallback endpoint plan using the normal API key or `skip_auth` local principal |
+| Route extensions | `crates/bitrouter-sdk/src/acp/controller.rs`, `apps/bitrouter/src/acp_cli.rs`, `daemon.rs`, `acp_runtime.rs` | Implemented locally: typed `_bitrouter/route/*`, daemon-confirmed mutations, and independent leases keyed by `(api_principal, controller claim, session claim)` |
 | Request session normalization | `apps/bitrouter/src/session_identity.rs`, hook assembly | Implemented after auth; legacy pure API projection remains separate and unchanged |
 | Session observability | `session_identity.rs`, `workflow_state/real_trace.rs`, `metering`, OTel exporter | Implemented: reviewed headers, typed event, span attributes, nullable metering correlation, no identifier metric labels |
-| Hosted route control | Core HTTP control surface plus an app-owned `RouteControl` backend | Not implemented: explicit remote `--base-url` routes model traffic but has no trusted controller credential or session lease |
+| Hosted route control | Core HTTP control surface plus an app-owned `RouteControl` backend | Not implemented: explicit remote `--base-url` routes model traffic but has no normal-API-authenticated session-route surface |
 | TUI migration | `crates/bitrouter-tui`, `apps/bitrouter/src/chat` | Not part of Phase 2; product work keeps one user session bound to one selected harness and native session |
 | Harness selector | TUI/launcher policy above controller creation | Not implemented: selection occurs before connection creation and never changes the harness behind an active session |
 
@@ -1266,12 +1315,14 @@ dependency from the controller.
 - the §15.1 evidence inventory accepts every BitRouter, Claude, and Codex
   identity header, emits its exact source name, and excludes authorization,
   cookies, credentials, and unknown compound metadata;
-- `SessionIdentityObserved` distinguishes claimed headers from authenticated
-  controller/session bindings and retains conflicts without changing route
-  authority;
-- route keys derived from authenticated controller plus native root session;
-- raw ACP/controller headers without controller authentication cannot produce
-  a route-lease key;
+- `SessionIdentityObserved` distinguishes the normal API principal from every
+  declared controller/session value and retains conflicts without labeling a
+  claim trusted;
+- route keys derived from API principal plus declared controller and native
+  root session;
+- API-authenticated requests cannot cross API-principal route namespaces;
+- under `skip_auth`, declared ACP/controller headers can produce a route key in
+  the shared local namespace, as explicitly documented;
 - secret redaction from provider responses, logs, and errors; and
 - route-lease cleanup state transitions.
 
@@ -1295,15 +1346,19 @@ Drive raw JSON-RPC over stdio and prove:
 
 - Start two independent controllers/user sessions, install different routes,
   and prove their model requests resolve independently.
-- Give those controllers equal-looking native session IDs and prove the
-  controller credential prevents collision.
+- Give those controllers equal-looking native session IDs and prove distinct
+  high-entropy controller IDs prevent accidental collision, including when the
+  normal API key is shared.
 - Prove Claude child agents and Codex child threads inherit the root route.
 - Prove an unattributed request uses the default route and cannot claim a
   session override.
-- Prove pure model API requests and authenticated ACP requests without a
+- Prove pure model API requests and ACP-attributed requests without a
   matching lease retain the existing policy result.
-- Prove a forged `x-bitrouter-controller-id` or
-  `x-bitrouter-acp-session-id` cannot activate another controller's lease.
+- Prove distinct API principals cannot activate each other's leases even when
+  they copy the same controller/session claims.
+- Prove a caller using the same API principal can deliberately reuse an exact
+  controller/session claim and document that this is accepted rather than
+  reported as spoofing resistance.
 - Prove Responses continuation keeps its original provider/model/account even
   when an ACP route preference points elsewhere.
 - Prove `_bitrouter/route/set` reports success only after authoritative
@@ -1327,10 +1382,11 @@ For each pinned Claude and Codex adapter, use a local capture server and dummy
 credentials to prove without touching the user's harness home:
 
 - the configured request reaches the BitRouter URL;
-- the controller credential and static headers arrive;
+- the normal API-key value or `skip_auth` adapter placeholder and static
+  headers arrive;
 - native session/root/thread/agent/turn fields arrive as documented;
 - every observed BitRouter/Claude/Codex identity field produces the expected
-  normalized observability evidence and source/trust annotation;
+  normalized observability evidence and source/route-use annotation;
 - `session/new`, list, load, and resume work when advertised;
 - provider configuration or its documented fallback is the path actually used;
   and
@@ -1359,8 +1415,9 @@ when all of the following are true:
 3. A fresh controller can list/load/resume a harness-native session without a
    BitRouter session database.
 4. Capability-dependent methods appear only when the complete path works.
-5. Claude and Codex model requests reach BitRouter with authenticated controller
-   correlation and native root session identity.
+5. Claude and Codex model requests reach BitRouter with the normal API
+   principal, declared controller correlation, and native root session
+   identity.
 6. Two independently launched user sessions select different BitRouter routes
    without cross-talk, including when their native IDs are equal-looking.
 7. Standard ACP `providers/*` is used for harness endpoint configuration, not
@@ -1384,8 +1441,9 @@ when all of the following are true:
     request join through one `router_request_id` and agree on session identity.
 16. No aggregate metric uses a session, thread, turn, request, or controller ID
     as a label.
-17. An explicit hosted `--base-url` can obtain controller-scoped authority and
-    use `_bitrouter/route/*` through HTTPS without a local ACP service daemon.
+17. An explicit hosted `--base-url` can use the same normal API key for model
+    and `_bitrouter/route/*` requests through HTTPS, without a local ACP service
+    daemon or a controller-credential exchange.
 18. A BitRouter-aware launcher can choose Claude or Codex before creating the
     controller connection, records the selection reason, and never changes the
     harness behind the active native session.
@@ -1414,10 +1472,10 @@ These phases define scope boundaries, not an executable task plan.
 - remain protocol-transparent without making same-connection multiplexing a
   BitRouter product feature.
 
-### Phase 2 — identity and route isolation (core implemented)
+### Phase 2 — identity and route scoping (implemented)
 
-- inject authenticated controller configuration;
-- add the authenticated request-session hook and parse Claude/Codex native
+- inject declared controller configuration and the Core's normal API key;
+- add the API-principal-scoped request-session hook and parse Claude/Codex native
   request identity without replacing the legacy pure API projection;
 - introduce session route leases and `_bitrouter/route/*`;
 - emit `SessionIdentityObserved`, preserve the full §15.1 evidence inventory
@@ -1428,12 +1486,18 @@ These phases define scope boundaries, not an executable task plan.
 - publish the controller interface needed for a separate TUI migration without
   adding TUI code to the controller change.
 
-### Phase 3 — stable-v1 compatibility hardening (next, P0)
+### Phase 3 — stable-v1 compatibility hardening (implemented)
 
-- upgrade the stable-v1 schema/runtime pair from the current 1.5.0 schema pin
-  to the current upstream stable line;
-- make initialize capability forwarding lossless, including terminal
-  authentication, elicitation, and unknown forward-compatible fields;
+- remove `brac_*`, controller credential issue/revoke/authentication events,
+  and credential-bound session trust decisions;
+- key route state by the normal API principal plus declared controller/session
+  values, and preserve the explicitly open behavior of `skip_auth`;
+- pin the stable-v1 schema/runtime/conductor set from the current crates.io
+  1.5.0 schema combination to one reviewed official Rust SDK revision using
+  schema 1.7.0;
+- make typed initialize capability and ACP `_meta` forwarding lossless,
+  including terminal authentication and elicitation; arbitrary unknown
+  top-level initialize fields remain outside the typed SDK contract;
 - cover authenticate/logout, filesystem read/write, terminal lifecycle,
   permission, elicitation, cancellation, modes/configuration, and additional
   directories with protocol contract tests;
@@ -1444,13 +1508,13 @@ These phases define scope boundaries, not an executable task plan.
 
 ### Phase 4 — hosted-Core route control (P0/P1)
 
-- add an authenticated HTTPS control surface for short-lived controller
-  credential issue, renewal, and revocation;
-- implement HTTPS `RouteControl` list/set/reset with the same lease isolation,
-  expiry, close/delete/disconnect cleanup, and error semantics as the local
-  path;
-- retain native session evidence for observability while separating an
-  untrusted static controller claim from controller-scoped authority; and
+- add an HTTP(S) `RouteControl` list/set/reset surface that uses the same normal
+  API-key middleware and `skip_auth` behavior as model inference;
+- use an independent route-lease TTL plus explicit
+  close/delete/disconnect cleanup, without issuing or renewing a controller
+  credential;
+- retain declared controller and native-session evidence for routing and
+  observability without labeling it authenticated or attested; and
 - prove that pure model API session parsing and routing are unchanged.
 
 This phase does not introduce a local ACP service daemon. BitRouter Core stays
@@ -1492,10 +1556,11 @@ virtual multi-harness ACP Agent and does not rewrite native session IDs.
 
 - validate third-party ACP v1 managers against the fixed-harness controller;
 - automate adapter fixture refresh and capability-drift reporting;
-- exercise harness crashes, Core disconnects, controller expiry, resume
+- exercise harness crashes, Core disconnects, lease expiry, resume
   failures, and lease cleanup failures;
-- verify header-spoofing resistance, cross-user lease isolation, redaction, and
-  bounded metric cardinality; and
+- verify the documented same-principal claim-forgery behavior,
+  cross-API-principal lease isolation, redaction, and bounded metric
+  cardinality; and
 - publish operator diagnostics and release gates for the controller, hosted
   Core, and TUI paths.
 
@@ -1506,11 +1571,11 @@ virtual multi-harness ACP Agent and does not rewrite native session IDs.
 | Stable-v1 schema pin lags upstream | Initialize drops capabilities that later forwarding cannot recover | Current stable schema pin, lossless initialize tests, and versioned conformance fixtures |
 | ACP provider configuration changes while Draft | Adapter upgrades break automatic endpoint setup | Feature detection, exact adapter pins, one canonical endpoint plan, tested fallbacks |
 | Adapter capabilities differ or drift | UI exposes controls that fail | Honest runtime composition plus adapter conformance fixtures |
-| Hosted controller authority is confused with a user API key | Forged claims or over-broad credentials activate session routes | Dedicated short-lived controller credentials and identical local/HTTPS lease checks |
+| An API key is shared by mutually untrusted processes, or `skip_auth` is enabled | One process can reuse another process's declared controller/session values and affect its route | Treat the API key/local mode as the explicit security boundary, recommend separate keys for separate trust domains, generate high-entropy controller IDs for accidental isolation, and make no anti-forgery claim |
 | Native request metadata changes | Session route or analysis loses attribution | Source-specific extractors, multiple evidence levels, conflict diagnostics, default-route fallback |
 | Each observability sink reparses identity independently | Trace, route, replay, and metering disagree about one request | One `SessionIdentityObserved` contract, `router_request_id` joins, and online/replay equivalence tests |
 | Raw session IDs become metric labels | Unbounded cardinality and sensitive identifier exposure | Stable transformed IDs only in approved trace/event stores; metrics use bounded attribution enums |
-| Route state is keyed only by process/launch | One user session changes another | Authenticated `(controller, root session)` lease key and independent-controller isolation tests |
+| Route state is keyed only by process/launch | One user session changes another accidentally | `(api_principal, declared controller, root session)` lease key and independent-controller isolation tests |
 | Controller becomes another session database | Native resume diverges from BitRouter state | Hard no-storage invariant and restart/load acceptance test |
 | TUI requirements leak into protocol core | Controller becomes hard to embed/test | SDK/TUI dependency boundary and headless acceptance gate |
 | Harness selector changes an active session's harness | Native context, tools, and identifiers become invalid | Select before connection/session creation and make the binding immutable after success |
@@ -1572,6 +1637,18 @@ first prompt. Deferring selection until `session/prompt` would require a
 wrapper-owned provisional ID and durable mapping. The BitRouter TUI instead
 collects the initial task first, selects the harness, opens the connection, and
 only then creates or restores the native session.
+
+### 22.9 Add a dedicated ACP controller credential or session attestation layer
+
+Rejected because a bearer credential held by the harness can identify the
+credential holder but cannot prove that controller, ACP session, or native
+session headers emitted by that holder are truthful. The previous `brac_*`
+design added a second issue/renew/revoke path and complicated hosted Core while
+providing no harness attestation. BitRouter instead uses its existing API key as
+the sole authentication boundary, scopes route state by that API principal,
+and treats all session/controller values as declared inputs. Operators needing
+isolation between mutually untrusted callers must give them different API keys;
+`skip_auth` explicitly provides no such isolation.
 
 ## 23. Authoritative references
 

--- a/docs/ACP_CONTROLLER_SPEC.md
+++ b/docs/ACP_CONTROLLER_SPEC.md
@@ -1,18 +1,18 @@
 # Spec: the ACP controller runtime
 
-Status: **Phase 2 controller core implemented; Phase 3 product surfaces proposed** · Date: 2026-09-02
+Status: **Phase 2 controller core implemented; next iterations specified** · Date: 2026-09-02
 
 Implementation note: Phase 0 pins stable ACP v1 wire semantics and maintained
 Claude/Codex adapters behind one endpoint plan. Phase 1 ships the manager-first
 connection controller used by `acp serve`, including provider setup gating,
-native multi-session lifecycle forwarding, callbacks, and extension fidelity.
-Phase 2 now ships daemon-issued controller credentials, authenticated
-Claude/Codex request-session normalization, ephemeral native-session route
-leases, `_bitrouter/route/*`, `SessionIdentityObserved`, controlled
-capture/replay, span attributes, and nullable metering correlation. The
-existing single-session engine remains the implementation of `acp prompt` and
-`chat`. TUI migration and automatic harness selection are deliberately outside
-this phase and this implementation change.
+native lifecycle forwarding, callbacks, and extension fidelity. Phase 2 now
+ships daemon-issued controller credentials, authenticated Claude/Codex
+request-session normalization, ephemeral native-session route leases,
+`_bitrouter/route/*`, `SessionIdentityObserved`, controlled capture/replay,
+span attributes, and nullable metering correlation. The remaining roadmap is
+stable-v1 compatibility hardening, trusted hosted-Core route control, migration
+of the single-user-session TUI, pre-connection harness selection, and release
+hardening.
 
 This document defines the core runtime beneath BitRouter's ACP-facing products.
 It is authoritative for session ownership, controller topology, capability
@@ -22,11 +22,16 @@ existing pure model API session heuristics and Responses continuation state.
 
 It supersedes the following decisions in [`ACP_TUI_SPEC.md`](ACP_TUI_SPEC.md):
 
-- the single-session product boundary in §§2, 8.3, 11, and 12;
 - the use of standard ACP `providers/*` methods for BitRouter's internal route
   selection in §§6 and 10; and
 - the assumption that one `Session` relay per manager connection is the right
   long-term ACP architecture in §5.
+
+It retains and sharpens that document's single-user-session product boundary:
+one TUI user session selects one harness and one harness-native session. The
+TUI may recreate its ACP connection to resume that session, but neither
+same-connection multi-session UX nor concurrently open TUI sessions is a
+roadmap goal.
 
 It does **not** supersede the shipped renderer, inline terminal behavior,
 permission UI, cost presentation, or the `chat` command. Those become clients
@@ -41,11 +46,17 @@ BitRouter will own the **ACP control plane**, not the agent's conversation
 state.
 
 One BitRouter ACP controller instance launches and controls one agent harness
-process. That connection may carry multiple harness-native sessions. The
-controller configures the harness to send model traffic through BitRouter,
-forwards the harness's ACP session lifecycle without replacing its identifiers,
-and attaches enough controller and native-agent identity to model requests for
-the router to attribute and isolate them accurately.
+process over one ACP connection. For a BitRouter TUI user session, that
+connection is bound to one harness-native session. The controller configures
+the harness to send model traffic through BitRouter, forwards the harness's ACP
+session lifecycle without replacing its identifiers, and attaches enough
+controller and native-agent identity to model requests for the router to
+attribute and isolate them accurately.
+
+The controller remains a protocol-transparent ACP v1 Agent and does not need
+to reject a generic manager that sends more than one `session/new` on the same
+connection. That protocol compatibility is not a BitRouter product surface,
+process-sharing strategy, TUI requirement, or acceptance criterion.
 
 The harness remains the only authority for:
 
@@ -90,6 +101,12 @@ TUI / IDE / CLI  -- ACP -->  BitRouter ACP Controller  -- ACP -->  Harness
                                            route + meter
 ```
 
+Physically, stable ACP v1 uses a client-launched local stdio wrapper process;
+that wrapper launches one selected local harness process. BitRouter Core is a
+separate HTTP(S) service and may run locally or in a hosted deployment. Local
+auto-start is a CLI convenience, not an architectural dependency and not a
+shared ACP daemon.
+
 - The **manager plane** controls sessions and renders updates.
 - The **harness plane** owns agent behavior and session data.
 - The **model plane** routes and meters model requests using native session
@@ -105,7 +122,8 @@ The controller connects these planes without collapsing their ownership.
    authentication, and static controller headers.
 2. Preserve harness-native ACP session IDs end to end.
 3. Forward all capability-gated ACP v1 session operations supported by the
-   harness, including multiple concurrent sessions on one connection.
+   harness without turning same-connection session multiplexing into a product
+   requirement.
 4. Negotiate capabilities honestly between the manager, controller, and
    harness instead of initializing the harness with empty client capabilities.
 5. Extract Claude and Codex native session, thread, agent, parent, and turn
@@ -121,15 +139,25 @@ The controller connects these planes without collapsing their ownership.
    model API.
 10. Make every BitRouter-added and harness-native session signal observable
     through one privacy-reviewed, replayable correlation contract.
+11. Allow a BitRouter-aware launcher or TUI to select a harness before opening
+    the controller connection, then keep that harness binding fixed for the
+    lifetime of the user session.
 
 ### 3.2 Non-goals
 
 - A BitRouter transcript store, session database, or session-file editor.
 - A cross-harness session catalog. A controller instance exposes the sessions
-  known to its one harness; a future harness supervisor may aggregate several
-  controllers without taking ownership of their sessions.
-- Automatic harness selection. Agent/harness routing is a separate policy and
-  evaluation problem layered above this controller.
+  known to its one harness; BitRouter does not merge catalogs from several
+  harnesses.
+- Same-connection multi-harness routing, virtual ACP session IDs, or a wrapper
+  that changes the harness behind an active session.
+- TUI multi-open or product-level multiplexing of several user sessions over
+  one ACP connection. Generic protocol pass-through may continue to tolerate
+  multiple native sessions, but no product behavior depends on it.
+- Cross-harness session migration or transcript conversion.
+- A unified local ACP service daemon. Each routed harness remains an ordinary
+  local ACP v1 process; BitRouter Core is the independently reachable HTTP(S)
+  service.
 - ACP v2 wire semantics.
 - A network ACP transport. Stdio remains the v1 transport; a future transport
   must not change the controller's ownership rules.
@@ -148,6 +176,7 @@ following names explicitly.
 
 | Name | Owner | Lifetime | Meaning |
 |---|---|---|---|
+| `tui_user_session` | BitRouter TUI | one interactive user experience | UI scope fixed to one selected harness and one harness-native session; not a transcript or ACP session authority |
 | `controller_instance_id` | BitRouter | one harness process / ACP connection | Correlates traffic with the controller that configured the harness |
 | `acp_session_id` | harness | harness-defined | Opaque ID returned by ACP and used for every session method |
 | `root_session_id` | harness | harness-defined | Root conversation identity observed on model HTTP traffic |
@@ -177,6 +206,10 @@ following names explicitly.
 7. Raw native IDs may exist in request scope and live controller memory.
    Existing metering and trace retention policy governs any diagnostic copy;
    the controller itself introduces no persistent session store.
+8. `tui_user_session` is not placed on the ACP wire as a replacement ID. Its
+   operational locator is the selected harness plus the opaque native
+   `acp_session_id`; reconnecting may replace `controller_instance_id` without
+   changing either of those identities.
 
 ### 4.2 Current harness mappings
 
@@ -253,13 +286,14 @@ These are review gates, not preferences.
 
 - Raw `x-bitrouter-controller-id` and `x-bitrouter-acp-session-id` headers are
   correlation evidence, not authorization.
-- The harness uses a controller-scoped BitRouter credential. The daemon derives
-  the trusted controller identity from that credential and checks any claimed
-  header against it.
+- The harness uses a controller-scoped BitRouter credential. BitRouter Core
+  derives the trusted controller identity from that credential and checks any
+  claimed header against it, whether authority was issued through the local
+  control socket or the hosted HTTPS control surface.
 - A session override is keyed by authenticated controller identity plus the
   opaque ACP session ID. Model ingress matches source-specific native identity
-  candidates to that ID. Two controllers or two sessions cannot change each
-  other's routes.
+  candidates to that ID. Two independently launched user sessions cannot
+  change each other's routes.
 
 ### 5.6 The controller has no TUI dependency
 
@@ -280,7 +314,7 @@ The SDK owns protocol-correct, harness-independent behavior:
 - harness process transport and the harness-side ACP connection;
 - manager-side ACP serving;
 - initialization sequencing and capability composition;
-- multi-session request/notification forwarding;
+- transparent native-session request/notification forwarding;
 - in-flight prompt and cancellation correlation;
 - permission, elicitation, filesystem, terminal, and other client callbacks
   when supported by both sides;
@@ -321,7 +355,7 @@ The application owns BitRouter-specific policy:
 - post-initialize `providers/set` configuration;
 - controller credentials and static metadata headers;
 - `_bitrouter/route/*` request handling;
-- daemon route-lease installation and removal;
+- local or hosted route-lease installation and removal;
 - Claude/Codex native identity extraction at HTTP ingress; and
 - router-measured usage updates.
 
@@ -330,13 +364,19 @@ No ACP framing or session forwarding belongs in the TUI.
 
 ### 6.3 `bitrouter-tui`: optional manager client
 
-The existing TUI remains a standalone ACP client. It may add session listing,
-loading, resuming, closing, and deleting only by calling the corresponding ACP
-methods and honoring advertised capabilities. It must not read harness homes or
-invent a separate session model.
+The TUI remains a standalone ACP client. One TUI user session selects one
+harness, opens one current controller connection, and creates or restores one
+harness-native session. Reconnecting may replace the transport process, but it
+does not change the selected harness or native session identity.
 
-The first controller version does not require a session browser in the TUI.
-Headless protocol conformance is the acceptance gate.
+The TUI may list sessions from that selected harness so the user can choose a
+native session to load or resume. It may close or delete only by calling the
+corresponding ACP method and honoring advertised capabilities. It must not
+read harness homes, aggregate cross-harness catalogs, invent a separate session
+model, or expose multi-open as a product goal.
+
+Headless protocol conformance remains the controller acceptance gate; TUI
+behavior is a later product iteration over the same interface.
 
 ## 7. Controller lifecycle
 
@@ -415,7 +455,7 @@ A field is never copied merely because both schemas contain the same name. Its
 requests, responses, notifications, cancellation, and error behavior must all
 be forwardable before it is advertised.
 
-### 8.2 Stable session methods
+### 8.2 ACP v1 session methods
 
 | ACP operation | Controller behavior |
 |---|---|
@@ -427,12 +467,13 @@ be forwardable before it is advertised.
 | `session/cancel` | Forward by native ID, including for a session first observed before controller restart |
 | `session/close` | Forward; remove BitRouter live state and route lease only after harness success |
 | `session/delete` | Forward; remove BitRouter live state and route lease only after harness success |
-| `session/fork` | Forward when advertised and return the new native ID unchanged; the fork may receive its own route lease |
 | `session/set_config_option` | Forward when advertised; do not mirror harness configuration locally |
 
-`session/list`, `load`, `resume`, `close`, `delete`, `fork`, and configuration
-methods are capability-gated. The controller does not emulate a missing
-harness capability with partial local state.
+`session/list`, `load`, `resume`, `close`, `delete`, and configuration methods
+are capability-gated. The controller does not emulate a missing harness
+capability with partial local state. `session/fork` may be forwarded as a
+version-gated experimental capability, but it is not part of the stable-v1
+product baseline or acceptance criteria.
 
 ### 8.3 Agent-to-client callbacks and updates
 
@@ -541,7 +582,7 @@ platform constraints require a different version, the compatibility change
 must record the package version and upstream commit used by its conformance
 tests and rerun endpoint, session, capability, and identity smokes.
 
-### 9.6 Trusted local binding and remote limitation
+### 9.6 Trusted local binding and hosted-Core gap
 
 `acp serve` obtains a short-lived `brac_*` controller credential only from the
 owner-only control socket of the locally resolved daemon. That credential is
@@ -549,11 +590,19 @@ used by both provider configuration and the launch fallback, and is revoked
 with all controller-owned leases when the controller exits normally.
 
 An explicit `--base-url` continues to support model endpoint configuration,
-but this phase does not assume access to that endpoint's owner-only control
+but the implemented path has no access to that endpoint's owner-only control
 plane. The controller therefore does not advertise `_bitrouter/route/*` for
-that path and model requests are handled as ordinary model API traffic unless
-the remote deployment supplies a separately reviewed trusted binding. A user
-API key or launch-attribution token is never promoted to controller authority.
+that path and model requests are handled as ordinary model API traffic. Native
+Claude/Codex session evidence remains observable, while the static controller
+claim remains untrusted for lease authority. A user API key or
+launch-attribution token is never promoted to controller authority.
+
+The next hosted-Core iteration adds an authenticated HTTPS control surface for
+short-lived controller credential issue, renewal, revocation, and
+session-route list/set/reset. The existing `RouteControl` boundary receives an
+HTTPS implementation; no local ACP service daemon is introduced. Hosted and
+local implementations must enforce the same controller/session isolation,
+lease expiry, cleanup, and observability contract.
 
 ## 10. Native identity at BitRouter model ingress
 
@@ -620,11 +669,12 @@ may improve analysis but cannot authorize a session route override.
 
 All evidence is retained. Resolving the ACP projection does not overwrite the
 legacy workflow projection, and conflicting evidence produces diagnostics.
-A static controller header identifies the controller process; it cannot carry
-a different ACP session ID for every request when one harness process runs
-concurrent sessions. Claude and Codex therefore use their native request
+A static controller header identifies the controller process; it is not a
+dynamic ACP session binding even when the product uses only one native session
+on that connection. Claude and Codex therefore use their native request
 headers as the primary per-session signal. The dynamic ACP header is supported
-for adapters that can emit it correctly, but it is not required.
+for adapters that can emit it correctly, but it is not required and must never
+be synthesized as a process-wide constant.
 
 ### 10.3 Claude precedence
 
@@ -714,14 +764,15 @@ _bitrouter/route/reset
 model, or explicit provider/model where allowed by router policy. Credentials
 never cross this surface.
 
-`available` is the live daemon's logical-model suggestion list for a picker;
+`available` is the authoritative route-control backend's logical-model
+suggestion list for a picker;
 it is intentionally not an exhaustive grammar. Presets and permitted explicit
 provider/model routes remain valid free-form `set` inputs and are confirmed by
-the daemon before success.
+the backend before success.
 
-The controller acknowledges `set` only after the daemon confirms that the
-route lease is installed. `list` reports the effective route from the daemon,
-not a controller-local optimistic value.
+The controller acknowledges `set` only after the backend confirms that the
+route lease is installed. `list` reports the backend's effective route, not a
+controller-local optimistic value.
 
 Managers discover this extension from
 `initialize._meta["bitrouter.dev/controller"].routeControl`. An available v1
@@ -733,15 +784,15 @@ silently falling back to a different authority.
 
 ### 11.3 Route key and descendant behavior
 
-The trusted daemon key is:
+The trusted route-lease key is:
 
 ```text
 (authenticated_controller_instance_id, acp_session_id)
 ```
 
-The daemon does not require the HTTP client to send a field literally named
+BitRouter Core does not require the HTTP client to send a field literally named
 `acp_session_id`. When an adapter can emit a dynamic
-`x-bitrouter-acp-session-id`, the daemon validates it against the authenticated
+`x-bitrouter-acp-session-id`, Core validates it against the authenticated
 controller binding and tries it first. Otherwise, or if it does not match a
 lease, the native extractor produces ordered lookup candidates:
 
@@ -751,15 +802,17 @@ lease, the native extractor produces ordered lookup candidates:
 | Codex | `thread-id`, then `session-id` |
 
 For a root Codex session, both values normally match the ACP thread ID. For an
-ACP fork, the new `thread-id` can match its own route lease before falling back
-to the root `session-id`. For a subagent thread that is not separately exposed
-as an ACP session, no exact lease exists and the root session lease is
-inherited. Claude child agents inherit the lease selected by the Claude session
-ID. Explicit per-subagent route controls are out of scope for v1.
+experimental ACP fork, the new `thread-id` can match its own route lease before
+falling back to the root `session-id`. For a subagent thread that is not
+separately exposed as an ACP session, no exact lease exists and the root
+session lease is inherited. Claude child agents inherit the lease selected by
+the Claude session ID. Explicit per-subagent route controls are out of scope
+for v1.
 
-The manager can install the route immediately after `session/new`, `load`,
-`resume`, or `fork` returns because it already has the native ID. The first
-prompt therefore does not race route installation.
+The manager can install the route immediately after `session/new`, `load`, or
+`resume` returns because it already has the native ID. The same applies to an
+experimental fork when advertised. The first prompt therefore does not race
+route installation.
 
 If a model request has authenticated controller identity but neither a trusted
 dynamic ACP session ID nor native root session identity, no session override
@@ -789,11 +842,13 @@ The Phase 2 controller does not advertise or accept manager-side
 the only controller route namespace, and its availability is advertised under
 initialize response `_meta["bitrouter.dev/controller"].routeControl`.
 
-The shipped single-session TUI keeps its existing local route surface until a
-separate Phase 3 migration. That compatibility code is not part of the
-connection controller and does not weaken the controller namespace. A future
-explicit endpoint-administration mode may expose standard `providers/*` with
-its standard meaning, but it requires a separate security review.
+The shipped single-user-session TUI keeps its existing local route surface
+until its product migration. The migrated TUI selects one harness, opens one
+current controller connection, and controls one native session through
+`_bitrouter/route/*`. That compatibility code is not part of the connection
+controller and does not weaken the controller namespace. A future explicit
+endpoint-administration mode may expose standard `providers/*` with its
+standard meaning, but it requires a separate security review.
 
 ### 11.6 Pipeline integration and precedence
 
@@ -849,7 +904,7 @@ path unchanged.
 ### 12.1 New session
 
 ```text
-Manager                  Controller                 Harness          Daemon
+Manager                  Controller                 Harness     Route backend
    | session/new             |                         |                |
    |------------------------>| session/new             |                |
    |                         |------------------------>|                |
@@ -857,9 +912,10 @@ Manager                  Controller                 Harness          Daemon
    |<------------------------| same native id          |                |
 ```
 
-No daemon registration or BitRouter session record is created here. The
+No BitRouter session record is created here. The
 manager may immediately use the returned opaque native ID with a route-control
-method; that method creates the ephemeral lease only after daemon confirmation.
+method; that method creates the ephemeral lease only after backend
+confirmation.
 
 ### 12.2 List, load, and resume
 
@@ -918,10 +974,10 @@ control that only changed local display state.
 | Effective provider mismatches endpoint plan | Fail initialize when verification is available |
 | Harness session method fails | Preserve harness ACP error and native ID; do not mutate local catalog |
 | Manager requests unsupported method | Protocol-defined unsupported/method-not-found response |
-| Route lease installation fails | `_bitrouter/route/set` fails; `current` remains daemon-confirmed state |
+| Route lease installation fails | `_bitrouter/route/set` fails; `current` remains backend-confirmed state |
 | Trusted ACP/native model identity missing | Use default route; emit unattributed diagnostic; never fabricate ID |
 | Native identity conflict | Use source-specific native precedence and emit conflict diagnostic |
-| Daemon unavailable | Model request fails through the normal provider path; controller surfaces relevant harness error/update |
+| BitRouter Core or route-control backend unavailable | Model request or route mutation fails through its normal path; controller surfaces the relevant sanitized error |
 | Adapter exits | Fail in-flight operations, remove route leases, retain harness-owned session files untouched |
 
 Agent stderr and BitRouter controller diagnostics continue to use the existing
@@ -933,9 +989,10 @@ headers, and full provider configuration payloads are redacted at the source.
 1. Controller credentials are short-lived, least-privilege, and bound to one
    controller instance. Reusing a user's upstream model credential as the
    controller credential is forbidden.
-2. The daemon authenticates route-control commands and model requests. Header
-   strings alone do not grant access to a route lease; an untrusted pure API
-   caller cannot activate ACP mode by copying controller or session headers.
+2. BitRouter Core authenticates route-control commands and model requests.
+   Header strings alone do not grant access to a route lease; an untrusted pure
+   API caller cannot activate ACP mode by copying controller or session
+   headers.
 3. Provider configuration responses expose only non-secret effective fields.
 4. Session IDs are treated as opaque identifiers. They are not placed in error
    messages that may be sent to an unrelated manager connection.
@@ -1087,20 +1144,29 @@ requires `ProtocolVersion::V1`, controller types come from `schema::v1`, and
 the namespaced BitRouter route methods are v1-compatible extensions. ACP v2
 wire types remain out of scope.
 
-### 16.2 Existing one-session `Session`
+The schema pin is now a compatibility gap. The upstream stable schema is
+1.21.0 as of 2026-09-02 and includes stable fields such as terminal
+authentication and elicitation that the 1.5.0 typed initialize path cannot
+represent. The next iteration upgrades the stable-v1 schema/runtime pair and
+proves that initialization preserves current and unknown capability fields
+losslessly. Generic forwarding after initialization is not sufficient if
+decode/re-encode already removed a field during the handshake.
+
+### 16.2 Existing one-shot `Session`
 
 The `record_id`-based `Session` path remains for `acp prompt` and `chat`. It is
 not used by `acp serve` and is not a compatibility layer around native IDs.
-The connection-level controller transparently serves multiple harness-native
-sessions; the one-shot engine retains its own local queue, recording, and TUI
-semantics until Phase 3 chooses whether to migrate those products.
+The connection-level controller transparently forwards native session methods;
+the one-shot engine retains its own local queue, recording, and TUI semantics
+until the single-user-session TUI migration replaces that path.
 
 ### 16.3 Existing commands
 
 - `bitrouter acp serve --agent <harness>` is the headless stdio entry point for
-  the multi-session controller; its explicit harness selection remains.
+  one fixed-harness controller connection; its explicit harness selection
+  remains.
 - `bitrouter chat <harness>` remains on the existing single-session engine in
-  Phase 2; TUI/controller convergence is separate Phase 3 product work.
+  Phase 2; TUI/controller convergence is separate product work.
 - Direct `bitrouter launch` remains the harness-owned native UX and is
   unaffected.
 - No TUI command is required to prove controller correctness.
@@ -1135,7 +1201,7 @@ Before Phases 0–2, the relay had these limitations:
   `providers/list` and `providers/set` as BitRouter route controls and scopes
   the daemon override with a launch ID. The behavior works for the shipped
   one-session TUI but has the wrong protocol meaning and process-level scope
-  for a multi-session controller.
+  for a native-session controller.
 - The legacy
   [Claude extractor](../apps/bitrouter/src/workflow_state/extractors/claude_code.rs)
   does not consume `x-claude-code-*` identity headers, and the
@@ -1152,7 +1218,7 @@ Before Phases 0–2, the relay had these limitations:
   trace sanitization omitted the native Claude/Codex identity headers.
 
 The implemented controller path replaces those limitations for `acp serve`:
-manager-first initialization and native multi-session forwarding live in
+manager-first initialization and native lifecycle forwarding live in
 `acp/controller.rs`; maintained adapter endpoint plans use exact pins;
 manager-side provider aliases are rejected; authenticated controller/session
 normalization and route leases run after `AuthHook`; and trace, spans, and
@@ -1172,12 +1238,14 @@ The implementation is divided along these boundaries:
 
 | Area | Current files | Phase 2 status |
 |---|---|---|
-| Controller lifecycle and capabilities | `crates/bitrouter-sdk/src/acp/controller.rs` | Implemented: manager-first stable-v1 controller, native IDs, multi-session forwarding, callbacks, and lifecycle-gated cleanup |
+| Controller lifecycle and capabilities | `crates/bitrouter-sdk/src/acp/controller.rs` | Implemented: manager-first stable-v1 controller, native-ID lifecycle forwarding, callbacks, and lifecycle-gated cleanup; stable-schema refresh remains |
 | Harness configuration | `apps/bitrouter/src/harness.rs`, `acp_cli.rs` | Implemented for maintained Claude/Codex pins with one provider/fallback endpoint plan and local controller credential |
 | Route extensions | `crates/bitrouter-sdk/src/acp/controller.rs`, `apps/bitrouter/src/acp_cli.rs`, `daemon.rs`, `acp_runtime.rs` | Implemented: typed `_bitrouter/route/*`, daemon-confirmed mutations, controller/session isolation, expiry/revoke/close/delete cleanup |
 | Request session normalization | `apps/bitrouter/src/session_identity.rs`, hook assembly | Implemented after auth; legacy pure API projection remains separate and unchanged |
 | Session observability | `session_identity.rs`, `workflow_state/real_trace.rs`, `metering`, OTel exporter | Implemented: reviewed headers, typed event, span attributes, nullable metering correlation, no identifier metric labels |
-| TUI migration | `crates/bitrouter-tui`, `apps/bitrouter/src/chat` | Not part of Phase 2; coworker-facing interface contract is delivered separately and product work remains Phase 3 |
+| Hosted route control | Core HTTP control surface plus an app-owned `RouteControl` backend | Not implemented: explicit remote `--base-url` routes model traffic but has no trusted controller credential or session lease |
+| TUI migration | `crates/bitrouter-tui`, `apps/bitrouter/src/chat` | Not part of Phase 2; product work keeps one user session bound to one selected harness and native session |
+| Harness selector | TUI/launcher policy above controller creation | Not implemented: selection occurs before connection creation and never changes the harness behind an active session |
 
 The implementation must not create an app dependency from the SDK or a TUI
 dependency from the controller.
@@ -1214,18 +1282,20 @@ Drive raw JSON-RPC over stdio and prove:
 1. manager initialize capabilities affect harness initialize capabilities;
 2. manager-facing capabilities are an honest composition;
 3. `providers/set` runs after initialize and before the first session method;
-4. two sessions can prompt concurrently on one harness connection;
-5. list/load/resume/fork/close/delete are forwarded and preserve native IDs;
+4. list/load/resume/close/delete are forwarded and preserve native IDs;
+5. an experimental fork is forwarded only when version-gated and advertised;
 6. replay updates from load reach the manager unchanged;
-7. unknown update variants and `_meta` survive forwarding;
-8. permission/callback behavior matches negotiated capabilities; and
+7. unknown update variants, `_meta`, and initialize capabilities survive
+   forwarding;
+8. authentication, permission, elicitation, filesystem, terminal, and
+   cancellation behavior matches negotiated capabilities; and
 9. controller disconnect removes route leases without issuing session delete.
 
 ### 18.3 Router integration tests
 
-- Start two native sessions under one controller, install different routes,
+- Start two independent controllers/user sessions, install different routes,
   and prove their model requests resolve independently.
-- Start two controllers with equal-looking native session IDs and prove the
+- Give those controllers equal-looking native session IDs and prove the
   controller credential prevents collision.
 - Prove Claude child agents and Codex child threads inherit the root route.
 - Prove an unattributed request uses the default route and cannot claim a
@@ -1236,7 +1306,8 @@ Drive raw JSON-RPC over stdio and prove:
   `x-bitrouter-acp-session-id` cannot activate another controller's lease.
 - Prove Responses continuation keeps its original provider/model/account even
   when an ACP route preference points elsewhere.
-- Prove `_bitrouter/route/set` reports success only after daemon installation.
+- Prove `_bitrouter/route/set` reports success only after authoritative
+  route-control backend installation.
 - Prove session close/delete/disconnect removes only the intended lease.
 - Capture and replay Claude/Codex native identity and prove the normalized
   online and replayed contexts agree.
@@ -1261,7 +1332,6 @@ credentials to prove without touching the user's harness home:
 - every observed BitRouter/Claude/Codex identity field produces the expected
   normalized observability evidence and source/trust annotation;
 - `session/new`, list, load, and resume work when advertised;
-- two sessions work in one adapter process;
 - provider configuration or its documented fallback is the path actually used;
   and
 - no real upstream token is spent.
@@ -1280,23 +1350,25 @@ The implementation plan must finish with:
 
 ## 19. Acceptance criteria
 
-The full controller product is complete when all of the following are true.
-Items other than the explicitly Phase 3 TUI criterion define the Phase 2 core
-acceptance boundary:
+The completed controller core plus the next product iterations are accepted
+when all of the following are true:
 
-1. A generic headless ACP manager can initialize BitRouter and create two
-   concurrent sessions against one pinned Claude or Codex adapter process.
+1. A generic headless ACP manager can initialize BitRouter and create or
+   restore a native session against one pinned Claude or Codex adapter process.
 2. Every manager-visible session ID is exactly the harness-returned ID.
 3. A fresh controller can list/load/resume a harness-native session without a
    BitRouter session database.
 4. Capability-dependent methods appear only when the complete path works.
 5. Claude and Codex model requests reach BitRouter with authenticated controller
    correlation and native root session identity.
-6. Two sessions select different BitRouter routes without cross-talk.
+6. Two independently launched user sessions select different BitRouter routes
+   without cross-talk, including when their native IDs are equal-looking.
 7. Standard ACP `providers/*` is used for harness endpoint configuration, not
    advertised as BitRouter route selection.
-8. **Phase 3:** the TUI can perform its existing prompt, permission, cost, and
-   route actions solely through ACP plus `_bitrouter/route/*`.
+8. The TUI binds one user session to one selected harness and one native
+   session, and performs prompt, permission, filesystem, terminal, elicitation,
+   authentication, cost, and route actions through ACP plus
+   `_bitrouter/route/*`.
 9. Restarting or disconnecting the controller loses only ephemeral BitRouter
    route state; harness-native sessions remain governed by the harness.
 10. No test or production path reads, copies, or mutates native session files.
@@ -1312,7 +1384,12 @@ acceptance boundary:
     request join through one `router_request_id` and agree on session identity.
 16. No aggregate metric uses a session, thread, turn, request, or controller ID
     as a label.
-17. Full workspace verification passes on the final tree.
+17. An explicit hosted `--base-url` can obtain controller-scoped authority and
+    use `_bitrouter/route/*` through HTTPS without a local ACP service daemon.
+18. A BitRouter-aware launcher can choose Claude or Codex before creating the
+    controller connection, records the selection reason, and never changes the
+    harness behind the active native session.
+19. Full workspace verification passes on the final tree.
 
 ## 20. Delivery phases
 
@@ -1334,7 +1411,8 @@ These phases define scope boundaries, not an executable task plan.
 - compose capabilities manager-first;
 - preserve native IDs;
 - forward the complete capability-gated session lifecycle; and
-- support multiple sessions per connection.
+- remain protocol-transparent without making same-connection multiplexing a
+  BitRouter product feature.
 
 ### Phase 2 — identity and route isolation (core implemented)
 
@@ -1350,31 +1428,92 @@ These phases define scope boundaries, not an executable task plan.
 - publish the controller interface needed for a separate TUI migration without
   adding TUI code to the controller change.
 
-### Phase 3 — product surfaces (proposed)
+### Phase 3 — stable-v1 compatibility hardening (next, P0)
 
-- migrate the existing TUI route picker from its local manager-side
-  `providers/*` compatibility surface to `_bitrouter/route/*`;
-- add harness-native session browsing and lifecycle controls to the TUI if the
-  product requires them;
-- improve controller diagnostics and recovery UX; and
-- validate third-party ACP managers against the same controller surface.
+- upgrade the stable-v1 schema/runtime pair from the current 1.5.0 schema pin
+  to the current upstream stable line;
+- make initialize capability forwarding lossless, including terminal
+  authentication, elicitation, and unknown forward-compatible fields;
+- cover authenticate/logout, filesystem read/write, terminal lifecycle,
+  permission, elicitation, cancellation, modes/configuration, and additional
+  directories with protocol contract tests;
+- treat `session/fork` only as a version-gated experimental capability;
+- rerun pinned Claude/Codex lifecycle, capability, endpoint, and native-header
+  conformance; and
+- correct CLI/help text that describes one connection as one ACP session.
 
-Automatic harness selection is a later, separate design. It consumes explicit
-harness capabilities and evaluation evidence; it does not change session
-ownership or the controller contract.
+### Phase 4 — hosted-Core route control (P0/P1)
+
+- add an authenticated HTTPS control surface for short-lived controller
+  credential issue, renewal, and revocation;
+- implement HTTPS `RouteControl` list/set/reset with the same lease isolation,
+  expiry, close/delete/disconnect cleanup, and error semantics as the local
+  path;
+- retain native session evidence for observability while separating an
+  untrusted static controller claim from controller-scoped authority; and
+- prove that pure model API session parsing and routing are unchanged.
+
+This phase does not introduce a local ACP service daemon. BitRouter Core stays
+an independently deployed HTTP(S) service and each ACP wrapper stays an
+ordinary local process.
+
+### Phase 5 — single-user-session TUI (P1)
+
+- select one harness before opening the controller connection;
+- create one native session or list/load/resume one native session belonging to
+  that selected harness;
+- migrate the route picker from manager-side `providers/*` compatibility to
+  `_bitrouter/route/*`;
+- implement permission, filesystem, terminal, elicitation, terminal-auth,
+  modes/configuration, commands, plan/tool updates, usage, cost scope, and
+  diagnostics through ACP; and
+- preserve the hard no-transcript, no-shadow-catalog boundary.
+
+TUI multi-open and product-level reuse of one connection for several user
+sessions are not goals in this or a later scheduled phase.
+
+### Phase 6 — pre-connection harness selector (P2)
+
+- begin with explicit Claude/Codex selection;
+- maintain versioned capability, authentication-readiness, provider/model, and
+  health evidence for selectable harnesses;
+- let the TUI collect the initial task before connection creation, then select
+  a harness using task requirements, repository evidence, cost, latency,
+  availability, and offline evaluation results;
+- emit candidates, constraints, the selected harness, reasons, and fallback
+  outcomes as structured observability;
+- permit fallback only before `session/new`, `load`, or `resume` succeeds; and
+- keep the selected harness immutable for the active user session.
+
+This selector is a launcher/TUI policy above controller creation. It is not a
+virtual multi-harness ACP Agent and does not rewrite native session IDs.
+
+### Phase 7 — interoperability and release hardening (P2)
+
+- validate third-party ACP v1 managers against the fixed-harness controller;
+- automate adapter fixture refresh and capability-drift reporting;
+- exercise harness crashes, Core disconnects, controller expiry, resume
+  failures, and lease cleanup failures;
+- verify header-spoofing resistance, cross-user lease isolation, redaction, and
+  bounded metric cardinality; and
+- publish operator diagnostics and release gates for the controller, hosted
+  Core, and TUI paths.
 
 ## 21. Risks and mitigations
 
 | Risk | Consequence | Mitigation |
 |---|---|---|
+| Stable-v1 schema pin lags upstream | Initialize drops capabilities that later forwarding cannot recover | Current stable schema pin, lossless initialize tests, and versioned conformance fixtures |
 | ACP provider configuration changes while Draft | Adapter upgrades break automatic endpoint setup | Feature detection, exact adapter pins, one canonical endpoint plan, tested fallbacks |
 | Adapter capabilities differ or drift | UI exposes controls that fail | Honest runtime composition plus adapter conformance fixtures |
+| Hosted controller authority is confused with a user API key | Forged claims or over-broad credentials activate session routes | Dedicated short-lived controller credentials and identical local/HTTPS lease checks |
 | Native request metadata changes | Session route or analysis loses attribution | Source-specific extractors, multiple evidence levels, conflict diagnostics, default-route fallback |
 | Each observability sink reparses identity independently | Trace, route, replay, and metering disagree about one request | One `SessionIdentityObserved` contract, `router_request_id` joins, and online/replay equivalence tests |
 | Raw session IDs become metric labels | Unbounded cardinality and sensitive identifier exposure | Stable transformed IDs only in approved trace/event stores; metrics use bounded attribution enums |
-| Route state is keyed only by process/launch | One session changes another | Authenticated `(controller, root session)` lease key and two-session tests |
+| Route state is keyed only by process/launch | One user session changes another | Authenticated `(controller, root session)` lease key and independent-controller isolation tests |
 | Controller becomes another session database | Native resume diverges from BitRouter state | Hard no-storage invariant and restart/load acceptance test |
 | TUI requirements leak into protocol core | Controller becomes hard to embed/test | SDK/TUI dependency boundary and headless acceptance gate |
+| Harness selector changes an active session's harness | Native context, tools, and identifiers become invalid | Select before connection/session creation and make the binding immutable after success |
 | Exact Claude turn correlation is unavailable | ACP prompt cannot be tied to one HTTP call with certainty | Treat session correlation as sufficient for v1; add adapter extension only if a measured use case requires turn-level precision |
 
 ## 22. Rejected alternatives
@@ -1403,12 +1542,13 @@ Rejected because ACP metadata forwarding does not guarantee propagation into a
 harness's model HTTP request. Native Claude/Codex request identity is both more
 accurate and already available.
 
-### 22.5 One harness process per session
+### 22.5 Same-connection product multiplexing
 
-Rejected as the controller architecture because ACP permits multiple sessions
-per connection and both target adapters implement multi-session lifecycle
-operations. Process-per-session may remain a diagnostic fallback, not the
-default or public ownership model.
+Rejected from the product roadmap. The controller remains transparent if a
+generic ACP manager uses several native sessions, but BitRouter does not build
+TUI multi-open, connection pooling, virtual session IDs, or multi-harness
+routing on top of that fact. One TUI user session uses one selected harness and
+one native session over its current controller connection.
 
 ### 22.6 Build the session manager in the TUI first
 
@@ -1416,12 +1556,35 @@ Rejected because it would encode protocol and storage assumptions in a
 presentation layer. The TUI can only be a faithful session UI after the
 controller transparently exposes harness-native lifecycle operations.
 
+### 22.7 Add a unified local ACP service daemon
+
+Rejected because stable ACP v1 uses a client-launched stdio Agent process and
+the wrapper has no session data that requires a shared local service. BitRouter
+Core may be local or hosted over HTTP(S); that deployment choice does not
+change the local ACP process shape. A supervisor would require a separate
+future need such as background work or multi-client attachment, neither of
+which is in this roadmap.
+
+### 22.8 Select the harness after creating the ACP session
+
+Rejected because `session/new` must return the native session ID before the
+first prompt. Deferring selection until `session/prompt` would require a
+wrapper-owned provisional ID and durable mapping. The BitRouter TUI instead
+collects the initial task first, selects the harness, opens the connection, and
+only then creates or restores the native session.
+
 ## 23. Authoritative references
 
 - [ACP architecture](https://agentclientprotocol.com/get-started/architecture)
+- [ACP transports](https://agentclientprotocol.com/protocol/v1/transports)
 - [ACP initialization](https://agentclientprotocol.com/protocol/v1/initialization)
+- [ACP authentication](https://agentclientprotocol.com/protocol/v1/authentication)
 - [ACP session setup and lifecycle](https://agentclientprotocol.com/protocol/v1/session-setup)
 - [ACP session listing](https://agentclientprotocol.com/protocol/v1/session-list)
+- [ACP elicitation](https://agentclientprotocol.com/protocol/v1/elicitation)
+- [ACP filesystem](https://agentclientprotocol.com/protocol/v1/file-system)
+- [ACP terminals](https://agentclientprotocol.com/protocol/v1/terminals)
+- [ACP schema releases](https://github.com/agentclientprotocol/agent-client-protocol/releases)
 - [ACP extensibility and metadata](https://agentclientprotocol.com/protocol/v1/extensibility)
 - [ACP metadata propagation RFD](https://agentclientprotocol.com/rfds/meta-propagation)
 - [ACP custom LLM endpoint RFD](https://agentclientprotocol.com/rfds/custom-llm-endpoint)

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -292,7 +292,7 @@ bitrouter acp serve --agent <id> [-c <path>]
 bitrouter acp prompt --agent <id> [-c <path>] <text>
 ```
 
-Runs one configured ACP agent session. `serve` exposes a vanilla ACP Agent over stdio until the manager disconnects. `prompt` launches one session, sends one prompt, and streams self-describing NDJSON updates to stdout. Session records live under `.bitrouter/sessions/`. `acp serve|prompt` are stable aliases of `bitrouter spawn <agent> --serve|-p` (below) and, like it, attempt to route the agent's model calls through the daemon when the headless adapter supports redirection (`--direct` opts out).
+Runs a configured ACP agent. `serve` exposes a vanilla ACP Agent over stdio until the manager disconnects; one controller connection can carry multiple harness-native sessions. `prompt` launches one local session, sends one prompt, and streams self-describing NDJSON updates to stdout. Only the one-shot path writes session records under `.bitrouter/sessions/`. `acp serve|prompt` are stable aliases of `bitrouter spawn <agent> --serve|-p` (below) and, like it, attempt to route the agent's model calls through the daemon when the headless adapter supports redirection (`--direct` opts out).
 
 ### `bitrouter chat`
 

--- a/skills/bitrouter/SKILL.md
+++ b/skills/bitrouter/SKILL.md
@@ -167,7 +167,7 @@ sessions on one connection. BitRouter does not own their IDs, transcripts, or
 storage. This is stable ACP v1. A manager can use the capability-gated
 `_bitrouter/route/list|set|reset` extension for ephemeral native-session route
 leases when initialize metadata advertises route control; an explicit remote
-`--base-url` does not currently provide that trusted binding. Read
+`--base-url` does not currently provide that route-control backend. Read
 `references/sessions.md` before reasoning about this surface.
 
 ### 6. Verify

--- a/skills/bitrouter/references/cli.md
+++ b/skills/bitrouter/references/cli.md
@@ -156,11 +156,11 @@ Two ACP execution modes share launch routing but not session ownership. `acp ser
 `_meta["bitrouter.dev/controller"].routeControl`. They operate on opaque native
 `sessionId` values and create daemon-confirmed ephemeral leases; manager-side
 `providers/*` remains unavailable. `--direct` and explicit remote `--base-url`
-connections do not advertise route control because they have no trusted local
-daemon binding. `route/list.available` is a logical-model suggestion list;
+connections do not advertise route control because hosted HTTP route control
+is not implemented yet. `route/list.available` is a logical-model suggestion list;
 presets and permitted explicit routes remain validated free-form `set` inputs.
 
-**Observability and turns**: `acp serve` forwards the harness's session/cancel and session/update wire unchanged; it does not synthesize local per-session usage or timeout behavior. Authenticated routed model calls normalize BitRouter's static controller/harness headers and the harness's native Claude/Codex identity into controlled capture/replay, request spans, route decisions, and nullable metering correlation. Authorization, cookies, and controller credentials remain excluded. `acp prompt` and `chat` retain the local `record_id`, OTel spans, FIFO queue, cooperative cancellation, and `--turn-timeout` behavior.
+**Observability and turns**: `acp serve` forwards the harness's session/cancel and session/update wire unchanged; it does not synthesize local per-session usage or timeout behavior. Routed model calls normalize the caller-declared BitRouter controller/harness headers and the harness's native Claude/Codex identity into controlled capture/replay, request spans, route decisions, and nullable metering correlation. The normal API/virtual key is the only authentication boundary; authorization, cookies, and credentials remain excluded from observability. `acp prompt` and `chat` retain the local `record_id`, OTel spans, FIFO queue, cooperative cancellation, and `--turn-timeout` behavior.
 
 **NDJSON format** (for `acp prompt` / `spawn -p`): the **first** line is a `session` correlation line — `{"type":"session","record_id":"…","agent":"…","via":"http://127.0.0.1:4356"}` (`via` is `null` when `--direct`) — for joining the session to daemon cost/metering. Each update line is then a self-describing JSON object with a `type` field (snake_case): `message_chunk`, `thought_chunk`, `tool_call`, `tool_call_update`, `usage` (context-window occupancy: `used`, `size`, optional `cost`). The terminal line is `{"type":"result","stop_reason":"end_turn"}` (ACP wire spelling). In `--no-wait` mode only `{"type":"submitted"}` follows the session line. A fail-fast routing failure emits a single `{"type":"error","code":"daemon_unreachable"|"auth_required","via":…,"hint":…}` line instead, before any session is created.
 

--- a/skills/bitrouter/references/sessions.md
+++ b/skills/bitrouter/references/sessions.md
@@ -48,7 +48,7 @@ harness endpoint from controller to harness; it is not a manager-side
 BitRouter route picker. The connection uses stable ACP v1 wire semantics; the
 Rust runtime crate's major version is not an ACP wire-version selector.
 
-When the controller has a trusted local daemon binding, initialize metadata
+When the controller has a local daemon route-control backend, initialize metadata
 advertises `_meta["bitrouter.dev/controller"].routeControl` with
 `version: "1"`, `scope: "session"`, and these methods:
 
@@ -113,23 +113,26 @@ to opt out, `--model` to pin the logical model, `--base-url` to select a daemon,
 and `--no-start` to disable local daemon auto-start. Routing/auth failures occur
 before the ACP handshake.
 
-Local routing obtains a short-lived `brac_*` controller credential through the
-owner-only daemon control socket. That credential binds model requests and
-route leases to one controller instance. An explicit `--base-url` can still
+When API authentication is enabled, local routing uses the normal BitRouter
+API/virtual key for both model requests and the route principal. Under
+`skip_auth: true`, both use the deliberately shared `local` principal. The
+owner-only daemon socket carries route mutations but does not mint or validate
+a second controller credential. An explicit remote `--base-url` can still
 configure the harness's model endpoint, but does not advertise route controls
-because it has no reviewed trusted control binding. User API keys are never
-promoted into controller credentials.
+until hosted HTTP route control exists.
 
 The model-router ingress continues to preserve ordinary model API session
-parsing. Authenticated routed adapter requests normalize the static BitRouter
+parsing. Routed adapter requests normalize caller-declared BitRouter
 controller/harness headers together with Claude or Codex native
 session/thread/agent/turn evidence. Session routes are ephemeral leases keyed
-by authenticated controller plus native session. An explicit caller route or
-preset and a Responses continuation pin remain stronger than a lease.
+by API principal, declared controller, and native session. These headers are
+correlation and routing claims, not authenticated facts; processes sharing one
+API key can deliberately reuse them. An explicit caller route or preset and a
+Responses continuation pin remain stronger than a lease.
 
 Close/delete removes a lease only after the harness operation succeeds;
-disconnect, credential expiry, reset, and controller revocation also clean it
-up. None of these operations changes harness session storage. The normalized
+disconnect, lease expiry, reset, daemon restart, and controller cleanup also
+remove it. None of these operations changes harness session storage. The normalized
 identity event joins controlled capture/replay, spans, route decisions, and
 nullable metering columns by `router_request_id`; authorization, cookies, and
 credentials are excluded, and raw identifiers are never aggregate metric


### PR DESCRIPTION
## Summary

- remove the daemon-issued ACP controller credential and scope route leases by the normal API principal plus declared controller/session claims
- pin the official Rust ACP SDK at `c63610fc38a642f7a73ba2719f403f17d771c345` with schema 1.7.0 while retaining ACP v1 wire semantics
- add stable-v1 forwarding contracts for auth, filesystem, terminal, elicitation, cancellation, session configuration, lifecycle, extensions, and `_meta`
- carry declared ACP and native Claude/Codex identity into request context, traces, and metering without treating headers as attested
- update the controller spec, Phase 3 execution plan, CLI docs, and BitRouter skill references

Phase 2 was already delivered by #852. Hosted HTTP route control and TUI migration remain Phase 4 and Phase 5.

## Testing

- `cargo nextest run --all-features` — 2,888 passed, 11 skipped
- `cargo clippy --workspace --all-features --tests -- -D warnings`
- `cargo fmt -- --check`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps`
- focused ACP controller, auth, route-runtime, daemon, metering, and CLI integration suites
- `git diff --check`

## Review

Final local Critical/Important review is clean. The review covered API-principal isolation, `skip_auth`, credential leakage, observability semantics, pure model API compatibility, route precedence, lifecycle cleanup, and scope creep.