### PR TITLE
fix(tui): draw only the routes a keystroke can reach

### DIFF
--- a/crates/bitrouter-tui/src/machine.rs
+++ b/crates/bitrouter-tui/src/machine.rs
@@ -481,14 +481,41 @@ fn routing_key(state: &mut State, picker: Picker, event: &Event) -> Vec<Effect> 
             Effect::Paint(Trigger::Key),
         ];
     }
-    if let KeyCode::Char(c) = key.code
-        && let Some(route) = picker.choose(c)
-    {
-        // A route to *attempt*. Only what the daemon confirms is in force.
-        return vec![Effect::Modal(None), Effect::SetRoute(route)];
+    // A digit selects; anything else printable narrows the list. Model ids do
+    // contain digits, so filtering by one is lost — but `glm-4.7` is still
+    // reachable by typing `glm` and then picking the number beside it, and the
+    // alternative is a keystroke whose meaning depends on how many routes the
+    // daemon happened to return.
+    let mut picker = picker;
+    match key.code {
+        KeyCode::Char(c) if c.is_ascii_digit() => {
+            if let Some(route) = picker.choose(c) {
+                // A route to *attempt*. Only what the daemon confirms is in
+                // force.
+                return vec![Effect::Modal(None), Effect::SetRoute(route)];
+            }
+            // A number nothing is drawn beside chooses nothing, rather than
+            // wrapping around to whatever happens to be at that index.
+            state.phase = Phase::Routing(picker);
+            Vec::new()
+        }
+        KeyCode::Char(c) => {
+            picker.filter(c);
+            let row = picker.render();
+            state.phase = Phase::Routing(picker);
+            vec![Effect::Modal(Some(row)), Effect::Paint(Trigger::Key)]
+        }
+        KeyCode::Backspace => {
+            picker.unfilter();
+            let row = picker.render();
+            state.phase = Phase::Routing(picker);
+            vec![Effect::Modal(Some(row)), Effect::Paint(Trigger::Key)]
+        }
+        _ => {
+            state.phase = Phase::Routing(picker);
+            Vec::new()
+        }
     }
-    state.phase = Phase::Routing(picker);
-    Vec::new()
 }
 
 /// The agent asked for permission.
@@ -802,7 +829,8 @@ mod tests {
             ("turn", press(KeyCode::Enter), &[], "turn"),
             ("answering", press(KeyCode::Enter), &[], "answering"),
             ("routing", press(KeyCode::Enter), &[], "routing"),
-            // Any other printable key: types it / ignored / nothing / nothing.
+            // Any other printable key: types it / ignored / nothing /
+            // narrows the route list.
             (
                 "idle",
                 press(KeyCode::Char('x')),
@@ -811,7 +839,29 @@ mod tests {
             ),
             ("turn", press(KeyCode::Char('x')), &[], "turn"),
             ("answering", press(KeyCode::Char('x')), &[], "answering"),
-            ("routing", press(KeyCode::Char('x')), &[], "routing"),
+            (
+                "routing",
+                press(KeyCode::Char('x')),
+                &["modal", "paint"],
+                "routing",
+            ),
+            // Backspace: the picker is the only phase that reads it as its
+            // own, widening the filter again rather than editing a line that
+            // is not on screen.
+            (
+                "idle",
+                press(KeyCode::Backspace),
+                &["echo", "paint"],
+                "idle",
+            ),
+            ("turn", press(KeyCode::Backspace), &[], "turn"),
+            ("answering", press(KeyCode::Backspace), &[], "answering"),
+            (
+                "routing",
+                press(KeyCode::Backspace),
+                &["modal", "paint"],
+                "routing",
+            ),
         ];
 
         for (phase, event, expected, after) in table {

--- a/crates/bitrouter-tui/src/picker.rs
+++ b/crates/bitrouter-tui/src/picker.rs
@@ -25,10 +25,22 @@
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 
-/// The routes on offer, and which one is in force.
+/// At most this many routes are drawn at once.
+///
+/// Not a layout choice — it is the number a single keystroke can address.
+/// [`Picker::choose`] reads one digit, so ten or more numbered entries would
+/// label options the input cannot reach, and this module's whole rule is that a
+/// control which cannot act is worse than an absent one. The list is narrowed
+/// by typing instead; see [`Picker::filter`].
+const SHORTLIST: usize = 9;
+
+/// The routes on offer, which one is in force, and what the reader has typed
+/// to narrow them.
 #[derive(Debug, Clone)]
 pub struct Picker {
     entries: Vec<Entry>,
+    /// Substring the reader is narrowing by. Empty until they type.
+    filter: String,
 }
 
 /// One route, as the picker shows it.
@@ -52,6 +64,7 @@ impl Picker {
             return None;
         }
         Some(Self {
+            filter: String::new(),
             entries: routes
                 .iter()
                 .map(|route| Entry {
@@ -64,7 +77,40 @@ impl Picker {
         })
     }
 
+    /// The routes currently on offer: those matching the filter, capped at
+    /// what a digit can address.
+    fn shortlist(&self) -> impl Iterator<Item = &Entry> {
+        self.entries
+            .iter()
+            .filter(|entry| entry.route.contains(&self.filter))
+            .take(SHORTLIST)
+    }
+
+    /// How many matches the shortlist could not show.
+    fn hidden(&self) -> usize {
+        self.entries
+            .iter()
+            .filter(|entry| entry.route.contains(&self.filter))
+            .count()
+            .saturating_sub(SHORTLIST)
+    }
+
+    /// Narrow the list by one typed character.
+    pub fn filter(&mut self, key: char) {
+        self.filter.push(key);
+    }
+
+    /// Widen it again by one.
+    pub fn unfilter(&mut self) {
+        self.filter.pop();
+    }
+
     /// The picker as it appears in the live area.
+    ///
+    /// Every numbered entry drawn here is one [`Picker::choose`] accepts, and
+    /// anything the shortlist could not fit is reported as a count rather than
+    /// drawn unreachably. A filter that matches nothing says so instead of
+    /// showing an empty row that looks like a broken control.
     pub fn render(&self) -> Line<'static> {
         let mut spans = vec![Span::styled(
             "route: ",
@@ -72,7 +118,15 @@ impl Picker {
                 .fg(Color::Cyan)
                 .add_modifier(Modifier::BOLD),
         )];
-        for (index, entry) in self.entries.iter().enumerate() {
+        if !self.filter.is_empty() {
+            spans.push(Span::styled(
+                format!("/{} ", self.filter),
+                Style::default().fg(Color::Yellow),
+            ));
+        }
+        let mut shown = 0;
+        for (index, entry) in self.shortlist().enumerate() {
+            shown += 1;
             spans.push(Span::styled(
                 format!("[{}]", index + 1),
                 Style::default().add_modifier(Modifier::BOLD),
@@ -85,6 +139,19 @@ impl Picker {
                 Style::default()
             };
             spans.push(Span::styled(format!("{} ", entry.route), style));
+        }
+        if shown == 0 {
+            spans.push(Span::styled(
+                "nothing matches ",
+                Style::default().fg(Color::Yellow),
+            ));
+        }
+        let hidden = self.hidden();
+        if hidden > 0 {
+            spans.push(Span::styled(
+                format!("+{hidden} more, type to narrow "),
+                Style::default().add_modifier(Modifier::DIM),
+            ));
         }
         spans.push(Span::styled(
             "[esc] keep",
@@ -99,7 +166,9 @@ impl Picker {
     /// module docs. An unoffered key selects nothing.
     pub fn choose(&self, key: char) -> Option<String> {
         let index = key.to_digit(10)?.checked_sub(1)? as usize;
-        self.entries.get(index).map(|entry| entry.route.clone())
+        // Into the shortlist, never the whole list: the reader picks by the
+        // number they can see, and what they can see is what is offered.
+        self.shortlist().nth(index).map(|entry| entry.route.clone())
     }
 }
 
@@ -180,6 +249,83 @@ mod tests {
         let rendered = text(&picker.render());
         assert!(rendered.contains("[1]@balanced"), "{rendered:?}");
         assert!(rendered.contains("[2]openai:gpt-5"), "{rendered:?}");
+    }
+
+    /// Fifty-eight routes, as a live daemon actually returns.
+    fn many() -> Vec<String> {
+        (1..=58).map(|n| format!("vendor/model-{n:02}")).collect()
+    }
+
+    /// The property this module exists for: nothing is drawn that a keystroke
+    /// cannot reach.
+    ///
+    /// A daemon's `available` list is its whole logical model catalogue — it
+    /// was returning 58 — while `choose` reads one digit. Numbering all of them
+    /// labelled 49 options the input could never select, which is precisely the
+    /// dead control this module refuses to draw.
+    #[test]
+    fn every_numbered_route_is_one_a_keystroke_can_reach() {
+        let picker = Picker::open(true, &many(), None).expect("routes");
+        let drawn = text(&picker.render());
+
+        for n in 1..=SHORTLIST {
+            assert!(drawn.contains(&format!("[{n}]")), "{n} is offered: {drawn}");
+            assert!(
+                picker
+                    .choose(char::from_digit(n as u32, 10).expect("digit"))
+                    .is_some(),
+                "and selectable"
+            );
+        }
+        assert!(
+            !drawn.contains(&format!("[{}]", SHORTLIST + 1)),
+            "nothing beyond a single digit is numbered: {drawn}"
+        );
+    }
+
+    /// What the shortlist cannot show is reported as a count, not hidden and
+    /// not drawn unreachably.
+    #[test]
+    fn the_routes_that_did_not_fit_are_counted() {
+        let picker = Picker::open(true, &many(), None).expect("routes");
+        assert!(
+            text(&picker.render()).contains("+49 more"),
+            "58 routes, 9 shown"
+        );
+    }
+
+    /// Typing narrows, and the numbers follow what is on screen rather than
+    /// the position a route held in the daemon's list.
+    #[test]
+    fn filtering_renumbers_what_is_left() {
+        let mut picker = Picker::open(true, &many(), None).expect("routes");
+        for key in "model-4".chars() {
+            picker.filter(key);
+        }
+        let drawn = text(&picker.render());
+        assert!(drawn.contains("/model-4"), "the filter is shown: {drawn}");
+        // `model-40`..`model-49` match — `model-04` does not, the digits are
+        // the wrong way round. Ten match, nine fit.
+        assert_eq!(picker.choose('1').as_deref(), Some("vendor/model-40"));
+        assert!(drawn.contains("+1 more"), "{drawn}");
+
+        // And widening again restores the unfiltered head.
+        for _ in 0.."model-4".len() {
+            picker.unfilter();
+        }
+        assert_eq!(picker.choose('1').as_deref(), Some("vendor/model-01"));
+    }
+
+    /// A filter matching nothing says so, rather than drawing an empty row
+    /// that looks like a control which stopped working.
+    #[test]
+    fn a_filter_matching_nothing_says_so() {
+        let mut picker = Picker::open(true, &many(), None).expect("routes");
+        for key in "zzz".chars() {
+            picker.filter(key);
+        }
+        assert!(text(&picker.render()).contains("nothing matches"));
+        assert!(picker.choose('1').is_none(), "and selects nothing");
     }
 
     /// A key outside the offered range selects nothing rather than wrapping.


### PR DESCRIPTION
`_bitrouter/route/list` returns the daemon's whole logical model list — 58 on a live one — and the picker numbered every entry. `Picker::choose` reads a **single digit**, so `[10]`…`[58]` were labels for options the input could never select.

That is the one thing `picker.rs`'s own charter forbids:

> A control that cannot act is worse than an absent one, because absence is legible and a dead control is a lie.

49 dead controls, drawn as though they were live.

## Why it appeared now

The limitation predates route control. It was survivable under `providers/*`, which returned a handful of providers — nine was plenty. `_bitrouter/route/*` returns the model catalogue, and the labels started promising something the input could not deliver.

Every unit test passed against the broken version, because the fixtures had two routes. It took driving a real terminal against a real daemon to see it.

## The fix

The picker draws at most **nine** — the number a digit can address — and narrows by typing:

```
route: [1]anthropic/claude-fable-5 … [9]anthropic/claude-sonnet-5 +49 more, type to narrow [esc] keep
route: /glm [1]z-ai/glm-4.7 [2]z-ai/glm-5 [3]z-ai/glm-5.1 … [6]z-ai/glm-5.3-flash [esc] keep
```

Digits select from what is on screen; every other printable key filters; backspace widens. What the shortlist cannot fit is reported as a count rather than drawn unreachably, and a filter matching nothing says so instead of leaving an empty row that reads as a broken control.

**The trade-off, stated:** model ids contain digits, so filtering *by* one is lost — you cannot type `4.7`. `glm-4.7` is reached by typing `glm` and picking the number beside it. The alternative, multi-digit entry, makes a keystroke's meaning depend on how many routes the daemon happened to return, which is worse in a one-row control.

## Tests

`every_numbered_route_is_one_a_keystroke_can_reach` builds 58 routes and asserts the property directly — drawn implies selectable — rather than pinning a rendering. Plus the count of what did not fit, renumbering under a filter, and the empty-match case.

The key table (`the_key_table_is_one_table`) caught the behaviour change on its own and failed until the two new cells were recorded: a printable key and backspace now do something in `Routing` and nothing anywhere they did nothing before.

## Verified live

Driven in a terminal against a daemon with 58 models: nine shown with `+49 more`, `glm` narrowing to six, `[2]` selecting `z-ai/glm-5` by its visible position. The daemon then refused that route, and the picker reported the refusal rather than claiming success — `set` first, report only what is confirmed, which is the module's other rule working.

That refusal is a separate bug, filed as #854: `route/list` offers models `route/set` will not accept. This PR does not change it — the picker still offers whatever `available` contains, it just no longer offers more than it can act on.

2898 tests pass; clippy `--tests -D warnings`, rustdoc `-D warnings`, dist and fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
