### PR TITLE
fix(chat): show the session log when a launch fails

### DIFF
--- a/apps/bitrouter/src/acp_cli.rs
+++ b/apps/bitrouter/src/acp_cli.rs
@@ -1150,6 +1150,18 @@ pub async fn serve(ctx: SpawnContext<'_>) -> Result<()> {
 
 // ── chat ──────────────────────────────────────────────────────────────────────
 
+/// Pass a `chat` startup failure through, having shown the session log first.
+///
+/// Only the two `chat` paths use it, and only before their session exists.
+/// Every other ACP verb logs to stderr as well as the file, so its child's
+/// account of a failed launch is already on screen; `chat` suppresses stderr
+/// because its renderer owns the terminal, which is exactly what leaves a
+/// pre-session failure with nothing to show but a closed transport.
+fn show_session_log(error: anyhow::Error) -> anyhow::Error {
+    crate::chat::session::report_failed_launch();
+    error
+}
+
 /// Launch a session for `agent_id` and hand it to the interactive renderer.
 ///
 /// This half is the composition root: it resolves routing, binds the
@@ -1214,12 +1226,15 @@ pub async fn chat(ctx: SpawnContext<'_>) -> Result<()> {
     let mcp_servers = options.mcp_servers.clone();
     let mut session = launch_controlled(&config, agent_id, &routed, options, binding)
         .await
-        .with_context(|| format!("launching acp session for agent '{agent_id}'"))?;
+        .with_context(|| format!("launching acp session for agent '{agent_id}'"))
+        .map_err(show_session_log)?;
     let ids = match session.client.new_session(cwd, mcp_servers).await {
         Ok(ids) => ids,
         Err(error) => {
             session.shutdown().await;
-            return Err(error.context("opening the harness session"));
+            return Err(show_session_log(
+                error.context("opening the harness session"),
+            ));
         }
     };
     let observability =
@@ -1270,12 +1285,15 @@ async fn chat_piped(
     let mcp_servers = options.mcp_servers.clone();
     let mut session = launch_controlled(config, agent_id, routed, options, binding)
         .await
-        .with_context(|| format!("launching acp session for agent '{agent_id}'"))?;
+        .with_context(|| format!("launching acp session for agent '{agent_id}'"))
+        .map_err(show_session_log)?;
     let ids = match session.client.new_session(cwd, mcp_servers).await {
         Ok(ids) => ids,
         Err(error) => {
             session.shutdown().await;
-            return Err(error.context("opening the harness session"));
+            return Err(show_session_log(
+                error.context("opening the harness session"),
+            ));
         }
     };
     let observability =

--- a/apps/bitrouter/src/chat/session.rs
+++ b/apps/bitrouter/src/chat/session.rs
@@ -60,6 +60,23 @@ fn write_session_log_tail(out: &mut impl std::io::Write) -> Result<()> {
     .context("writing the session log tail")
 }
 
+/// Show the end of the session log on **stderr**, for a failure that happened
+/// before there was a view to draw it in.
+///
+/// [`run`] writes the tail to stdout at the end of a session it drew. A launch
+/// that dies during the handshake never gets that far: it returns an error
+/// that `main` renders as this command's stdout envelope, and the reason —
+/// the harness child's own stderr, which `chat` sends to the session file and
+/// nowhere else, because it draws on this terminal — goes unmentioned in a
+/// file the user has no way to guess the name of. Hence stderr: it sits beside
+/// the failure rather than inside the JSON describing it.
+///
+/// The launch error outranks this, so a tail that cannot be written is
+/// dropped rather than replacing the reason the launch failed.
+pub(crate) fn report_failed_launch() {
+    let _ = write_session_log_tail(&mut std::io::stderr());
+}
+
 /// Whether this session's route can be changed from the picker.
 ///
 /// The contract's three-condition gate, asked of what the controller

--- a/docs/TUI_RENDERER_SPEC.md
+++ b/docs/TUI_RENDERER_SPEC.md
@@ -368,6 +368,16 @@ stderr into one per-session file so nothing else writes to this terminal. A
 writer owning more rows makes that more important. **Ctrl-L** forces a full
 redraw for when something writes anyway.
 
+**Before the writer exists, the file is the only record — so a failed launch
+prints its tail.** The rule above is about a terminal the writer owns; a launch
+that dies during the ACP handshake never reaches one. Its error is rendered by
+`main` as the command's stdout envelope, and it names a closed transport — the
+symptom — while the cause is the harness child's own stderr, which by this rule
+went to a file whose name the user has no way to guess. So both `chat` paths
+write the log's tail to **stderr** before returning such a failure, the same
+tail `run` writes to stdout when a session it *did* draw ends badly. No writer
+is drawing at that point, so nothing is scrolled out from under it.
+
 ## 5. Decision 3 — render scheduling
 
 `apply` returning `()` removes the old answer to *who renders, when*. Streamed


### PR DESCRIPTION
## The failure

`bitrouter chat <agent>` against a harness that cannot start reports only the symptom:

```
{
  "error": {
    "kind": "internal",
    "message": "the ACP connection failed: Incoming transport closed: {\n  \"reason\": \"incoming_transport_closed\",\n  \"method\": \"initialize\"\n}",
    "context": ["launching acp session for agent 'codex-acp'"]
  }
}
```

The cause was a child that exited 127 with `sh: codex-acp: command not found` on stderr, and it *was* captured — `forward_agent_stderr` re-emits it under `acp::agent`. It just wasn't reachable: `chat` sends its logs to the per-session file and nowhere else, because its renderer owns the terminal (TUI_RENDERER_SPEC §4.6), and `write_session_log_tail` is only called from `chat::session::run` — i.e. **after** a launch has already succeeded. A launch that dies during the handshake returns through `?` and never names the file holding the answer.

Found while debugging a real `codex-acp` failure: the diagnosis sat in `~/.bitrouter/logs/session-*.log` the whole time.

## The change

Both `chat` paths now write the log's tail to **stderr** before returning a pre-session failure — the same tail `run` writes to stdout when a session it *did* draw ends badly. stderr rather than stdout because the error itself is rendered as this command's stdout envelope, and the tail belongs beside it rather than inside it.

Covers all four pre-session failure points: `launch_controlled` and `new_session`, in `chat` and `chat_piped`. The other ACP verbs are untouched — they log to stderr as well as the file, so their child's account of a failed launch is already on screen.

No writer is drawing at that point, so §4.6's invariant (nothing scrolls the screen out from under the renderer) still holds. The spec records the exception.

## After

Same JSON on stdout; stderr now carries the answer:

```
session log: /Users/…/logs/session-20260904T004544-3443.log
  … INFO connection{name="bitrouter-acp-controller"}: … Proxies spawned proxy_count=1
  … INFO acp::agent: sh: codex-acp: command not found agent=sh
```

## Verification

Reproduced with an agent configured as `sh -c 'echo "sh: codex-acp: command not found" >&2; exit 127'` — the exact original failure — and confirmed on **both** the piped path (`chat_piped`) and a real pty (`chat`).

I also built and then **removed** a `stderr_drained` signal on `AgentProcess` that would have waited for the child's stderr to reach EOF before reading the log, on the theory that the diagnosis races the handshake failure. I could not make that race lose: not in 40 single-line runs with the wait disabled, not with a 20 000-line burst. Pipe backpressure keeps the child from outrunning the reader, and the failure travels five actor hops while the stderr line travels one. Reverted rather than ship SDK surface that can't be justified.

| Check | Result |
|---|---|
| `cargo nextest run --all-features` | 2898 passed, 11 skipped |
| `cargo clippy --all-features --all-targets` | clean |
| `cargo fmt -- --check` | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)