### PR TITLE
feat(acp): read harness authentication from the protocol

### DIFF
--- a/apps/bitrouter/src/acp_cli.rs
+++ b/apps/bitrouter/src/acp_cli.rs
@@ -1349,7 +1349,6 @@ fn choose_auth_method(
     agent_id: &str,
     methods: &[agent_client_protocol::schema::v1::AuthMethod],
 ) -> Result<AuthChoice> {
-    use agent_client_protocol::schema::v1::AuthMethod;
     use std::io::{BufRead, IsTerminal as _};
 
     if methods.is_empty() || !std::io::stdin().is_terminal() {
@@ -1381,33 +1380,51 @@ fn choose_auth_method(
             eprintln!();
             return Ok(AuthChoice::Declined);
         }
-        let trimmed = line.trim();
-        let index = if trimmed.is_empty() {
-            1
-        } else {
-            match trimmed.parse::<usize>() {
-                Ok(0) => return Ok(AuthChoice::Declined),
-                Ok(n) if (1..=methods.len()).contains(&n) => n,
-                Ok(n) => {
-                    eprintln!(
-                        "    choice must be between 0 and {}, got {n}",
-                        methods.len()
-                    );
-                    continue;
-                }
-                Err(_) => {
-                    eprintln!("    '{trimmed}' is not a number");
-                    continue;
-                }
-            }
-        };
-        return Ok(match &methods[index - 1] {
-            // ACP is explicit that a terminal method is never passed to
-            // `authenticate`: the interactive process is not the connection.
-            AuthMethod::Terminal(terminal) => AuthChoice::Terminal(Box::new(terminal.clone())),
-            other => AuthChoice::Agent(other.id().clone()),
-        });
+        match classify_choice(&line, methods) {
+            Some(choice) => return Ok(choice),
+            // Not a selection: say why, then ask again.
+            None => match line.trim().parse::<usize>() {
+                Ok(n) => eprintln!(
+                    "    choice must be between 0 and {}, got {n}",
+                    methods.len()
+                ),
+                Err(_) => eprintln!("    '{}' is not a number", line.trim()),
+            },
+        }
     }
+}
+
+/// Classify one typed line against the offered methods.
+///
+/// Pure, so the interesting half of the picker is testable without a terminal:
+/// `choose_auth_method` owns stdin and the menu, this owns what the answer
+/// means. The same split `Editor::apply` and `machine::step` already use.
+///
+/// `0` cancels, an empty line takes the `[1]` default, and `1..=methods.len()`
+/// selects. Anything else is `None` — not a selection, ask again. Out-of-range
+/// never wraps onto a method that was not offered.
+fn classify_choice(
+    input: &str,
+    methods: &[agent_client_protocol::schema::v1::AuthMethod],
+) -> Option<AuthChoice> {
+    use agent_client_protocol::schema::v1::AuthMethod;
+
+    let trimmed = input.trim();
+    let index = if trimmed.is_empty() {
+        1
+    } else {
+        match trimmed.parse::<usize>() {
+            Ok(0) => return Some(AuthChoice::Declined),
+            Ok(n) if (1..=methods.len()).contains(&n) => n,
+            Ok(_) | Err(_) => return None,
+        }
+    };
+    Some(match methods.get(index - 1)? {
+        // ACP is explicit that a terminal method is never passed to
+        // `authenticate`: the interactive process is not the connection.
+        AuthMethod::Terminal(terminal) => AuthChoice::Terminal(Box::new(terminal.clone())),
+        other => AuthChoice::Agent(other.id().clone()),
+    })
 }
 
 /// Run a `terminal` method's login: the harness's **own** program, relaunched
@@ -2322,7 +2339,17 @@ pub fn launch_options(turn_timeout_secs: Option<u64>) -> LaunchOptions {
 mod auth_report_tests {
     use agent_client_protocol::schema::v1::{AuthMethod, AuthMethodAgent, AuthMethodTerminal};
 
-    use super::{AuthChoice, LaunchOptions, choose_auth_method, unauthenticated_message};
+    use super::{
+        AuthChoice, LaunchOptions, choose_auth_method, classify_choice, unauthenticated_message,
+    };
+
+    /// Two `agent` methods, in the order the picker numbers them.
+    fn two_methods() -> Vec<AuthMethod> {
+        vec![
+            AuthMethod::Agent(AuthMethodAgent::new("oauth", "Sign in with Anthropic")),
+            AuthMethod::Agent(AuthMethodAgent::new("api-key", "Paste an API key")),
+        ]
+    }
 
     /// **A control that cannot act is absent** (ACP_AUTH_SPEC §6.2). Only the
     /// interactive caller may claim it can run a terminal login; every other
@@ -2352,23 +2379,74 @@ mod auth_report_tests {
         );
     }
 
+    /// **Cancelling never authenticates** (ACP_AUTH_SPEC §6.3). The typed
+    /// decline is its own branch, distinct from the EOF one that returns the
+    /// same answer — this is the branch a live terminal was needed to reach.
+    #[test]
+    fn a_typed_zero_declines() {
+        assert!(
+            matches!(
+                classify_choice("0", &two_methods()),
+                Some(AuthChoice::Declined)
+            ),
+            "'0' is the cancel entry the menu prints"
+        );
+    }
+
+    /// A bare enter takes the `[1]` the prompt shows as the default — the
+    /// offer on screen and the answer must not disagree.
+    #[test]
+    fn a_bare_enter_takes_the_advertised_default() {
+        let Some(AuthChoice::Agent(id)) = classify_choice("\n", &two_methods()) else {
+            panic!("an empty line selects the first method")
+        };
+        assert_eq!(
+            id.to_string(),
+            "oauth",
+            "the default is the '[1]' on screen"
+        );
+    }
+
+    /// The numbering is the menu's, one-based.
+    #[test]
+    fn a_digit_selects_that_numbered_method() {
+        let Some(AuthChoice::Agent(id)) = classify_choice("2", &two_methods()) else {
+            panic!("'2' selects the second method")
+        };
+        assert_eq!(id.to_string(), "api-key", "numbering starts at one");
+    }
+
+    /// Out of range is not a selection. Nothing wraps onto an index the
+    /// harness never offered — the alternative is authenticating with a method
+    /// nobody was shown.
+    #[test]
+    fn an_unoffered_index_is_not_a_selection() {
+        assert!(
+            classify_choice("9", &two_methods()).is_none(),
+            "'9' against two methods must re-prompt, not wrap"
+        );
+    }
+
+    /// Anything that is not a number re-prompts rather than resolving.
+    #[test]
+    fn a_non_number_is_not_a_selection() {
+        assert!(
+            classify_choice("x", &two_methods()).is_none(),
+            "'x' must re-prompt"
+        );
+    }
+
     /// A `terminal` method is routed to the out-of-band flow, never to
     /// `authenticate` — ACP forbids passing it there because the interactive
     /// process is not the ACP connection.
     #[test]
     fn a_terminal_method_never_becomes_an_authenticate_call() {
-        let terminal = AuthMethod::Terminal(
+        let methods = vec![AuthMethod::Terminal(
             AuthMethodTerminal::new("login", "Log in from the terminal")
                 .args(vec!["--login".to_string()]),
-        );
-        // Classification is the branch `choose_auth_method` takes on a chosen
-        // method; assert on the shape it must produce.
-        assert!(
-            matches!(&terminal, AuthMethod::Terminal(_)),
-            "the fixture is the terminal variant"
-        );
-        let AuthMethod::Terminal(descriptor) = &terminal else {
-            unreachable!("matched above")
+        )];
+        let Some(AuthChoice::Terminal(descriptor)) = classify_choice("1", &methods) else {
+            panic!("a terminal method classifies to the out-of-band branch")
         };
         assert_eq!(
             descriptor.args,

--- a/apps/bitrouter/src/acp_cli.rs
+++ b/apps/bitrouter/src/acp_cli.rs
@@ -1459,12 +1459,16 @@ async fn run_terminal_login(
     Ok(())
 }
 
-/// What to say when a harness answered `auth_required`.
+/// What to say when a harness answered `auth_required` and no login ran.
 ///
 /// Names the harness and what it advertised, because those are the two things
-/// the reader needs and the two things only the protocol knows. This reports
-/// the state; it does not drive a login — BitRouter cannot yet (ACP_AUTH_SPEC
-/// §10, phase 2), and saying so beats implying a control that does not exist.
+/// the reader needs and the two things only the protocol knows.
+///
+/// The advice depends on **why** no login ran, and getting that wrong is worse
+/// than saying less: telling someone who just cancelled to "sign in with the
+/// harness's own tooling" hides the offer they are one keystroke from taking,
+/// and telling a piped caller to choose from a prompt it will never see is a
+/// control that cannot act.
 ///
 /// Deliberately says nothing about providers, routes, or `providers login`:
 /// this is the harness's own authentication, not the daemon's upstream
@@ -1473,6 +1477,8 @@ fn unauthenticated_message(
     agent_id: &str,
     methods: &[agent_client_protocol::schema::v1::AuthMethod],
 ) -> String {
+    use std::io::IsTerminal as _;
+
     if methods.is_empty() {
         return format!(
             "'{agent_id}' is not authenticated, and advertises no authentication method. \
@@ -1487,10 +1493,20 @@ fn unauthenticated_message(
         })
         .collect::<Vec<_>>()
         .join("; ");
-    format!(
-        "'{agent_id}' is not authenticated. It offers: {offered}. BitRouter cannot run that \
-         login yet — sign in with the harness's own tooling, then run this again"
-    )
+    // A method was offered and declined — either by a person choosing cancel,
+    // or by there being no person to ask.
+    if std::io::stdin().is_terminal() {
+        format!(
+            "'{agent_id}' is not authenticated and the sign-in was cancelled. \
+             It offers: {offered}"
+        )
+    } else {
+        format!(
+            "'{agent_id}' is not authenticated. It offers: {offered}. \
+             Run `bitrouter chat {agent_id}` in a terminal to sign in, or use the \
+             harness's own tooling"
+        )
+    }
 }
 
 async fn chat_piped(
@@ -2399,9 +2415,12 @@ mod auth_report_tests {
             unauthenticated_message("claude-acp", &methods),
             unauthenticated_message("claude-acp", &[]),
         ] {
+            // The product's own name contains "route"; strip it before looking
+            // for the routing *concept*, or the check fails on "bitrouter".
+            let prose = message.replace("bitrouter", "");
             for forbidden in ["providers login", "provider", "route", "--direct"] {
                 assert!(
-                    !message.contains(forbidden),
+                    !prose.contains(forbidden),
                     "an agent-auth message must not name the routing axis \
                      ({forbidden:?}): {message}"
                 );

--- a/apps/bitrouter/src/acp_cli.rs
+++ b/apps/bitrouter/src/acp_cli.rs
@@ -1218,8 +1218,16 @@ pub async fn chat(ctx: SpawnContext<'_>) -> Result<()> {
     let ids = match session.client.new_session(cwd, mcp_servers).await {
         Ok(ids) => ids,
         Err(error) => {
+            // A harness that is merely unauthenticated is not a broken one, and
+            // relaying its JSON-RPC error would leave the reader to guess which
+            // of the two it is. The protocol already said which; say it.
+            let context = if bitrouter_sdk::acp::client::is_auth_required(&error) {
+                unauthenticated_message(agent_id, session.client.auth_methods())
+            } else {
+                "opening the harness session".to_string()
+            };
             session.shutdown().await;
-            return Err(error.context("opening the harness session"));
+            return Err(error.context(context));
         }
     };
     let observability =
@@ -1258,6 +1266,40 @@ pub async fn chat(ctx: SpawnContext<'_>) -> Result<()> {
 /// differs from `prompt` is only the consumer — a journal rendered per turn
 /// rather than an NDJSON stream — which is why the loop itself lives beside
 /// the renderers in [`crate::chat::session`].
+/// What to say when a harness answered `auth_required`.
+///
+/// Names the harness and what it advertised, because those are the two things
+/// the reader needs and the two things only the protocol knows. This reports
+/// the state; it does not drive a login — BitRouter cannot yet (ACP_AUTH_SPEC
+/// §10, phase 2), and saying so beats implying a control that does not exist.
+///
+/// Deliberately says nothing about providers, routes, or `providers login`:
+/// this is the harness's own authentication, not the daemon's upstream
+/// credential, and conflating the two sends the reader to the wrong fix.
+fn unauthenticated_message(
+    agent_id: &str,
+    methods: &[agent_client_protocol::schema::v1::AuthMethod],
+) -> String {
+    if methods.is_empty() {
+        return format!(
+            "'{agent_id}' is not authenticated, and advertises no authentication method. \
+             Sign in with the harness's own tooling, then run this again"
+        );
+    }
+    let offered = methods
+        .iter()
+        .map(|method| match method.description() {
+            Some(description) => format!("{} ({description})", method.name()),
+            None => method.name().to_string(),
+        })
+        .collect::<Vec<_>>()
+        .join("; ");
+    format!(
+        "'{agent_id}' is not authenticated. It offers: {offered}. BitRouter cannot run that \
+         login yet — sign in with the harness's own tooling, then run this again"
+    )
+}
+
 async fn chat_piped(
     config: &Config,
     agent_id: &str,
@@ -1274,8 +1316,16 @@ async fn chat_piped(
     let ids = match session.client.new_session(cwd, mcp_servers).await {
         Ok(ids) => ids,
         Err(error) => {
+            // A harness that is merely unauthenticated is not a broken one, and
+            // relaying its JSON-RPC error would leave the reader to guess which
+            // of the two it is. The protocol already said which; say it.
+            let context = if bitrouter_sdk::acp::client::is_auth_required(&error) {
+                unauthenticated_message(agent_id, session.client.auth_methods())
+            } else {
+                "opening the harness session".to_string()
+            };
             session.shutdown().await;
-            return Err(error.context("opening the harness session"));
+            return Err(error.context(context));
         }
     };
     let observability =
@@ -1368,8 +1418,16 @@ where
     let ids = match session.client.new_session(cwd, mcp_servers).await {
         Ok(ids) => ids,
         Err(error) => {
+            // A harness that is merely unauthenticated is not a broken one, and
+            // relaying its JSON-RPC error would leave the reader to guess which
+            // of the two it is. The protocol already said which; say it.
+            let context = if bitrouter_sdk::acp::client::is_auth_required(&error) {
+                unauthenticated_message(agent_id, session.client.auth_methods())
+            } else {
+                "opening the harness session".to_string()
+            };
             session.shutdown().await;
-            return Err(error.context("opening the harness session"));
+            return Err(error.context(context));
         }
     };
     let observability =
@@ -1607,6 +1665,16 @@ async fn launch_controlled(
         manager_side,
         ClientOptions {
             turn_timeout: options.turn_timeout,
+            // False until the terminal-auth flow exists (ACP_AUTH_SPEC §7.3).
+            //
+            // This path *could* honestly claim it: the harness is always a
+            // local child of this process (`AcpTransport::Stdio` is the only
+            // transport), so its invocation is always reproducible. But the
+            // capability is a promise to *run* the login, and an agent may
+            // offer a `terminal` method only when the client advertised it.
+            // Claiming it now would surface a method nothing can execute —
+            // the dead control this codebase refuses. Phase 2 flips it.
+            terminal_auth: false,
         },
     )
     .await
@@ -2032,6 +2100,57 @@ pub fn launch_options(turn_timeout_secs: Option<u64>) -> LaunchOptions {
     LaunchOptions {
         turn_timeout: turn_timeout_secs.map(std::time::Duration::from_secs),
         ..Default::default()
+    }
+}
+
+#[cfg(test)]
+mod auth_report_tests {
+    use agent_client_protocol::schema::v1::{AuthMethod, AuthMethodAgent};
+
+    use super::unauthenticated_message;
+
+    /// The reader is told which harness, and what it actually advertised.
+    #[test]
+    fn the_message_names_the_harness_and_what_it_offers() {
+        let methods = vec![AuthMethod::Agent(
+            AuthMethodAgent::new("oauth", "Sign in with Anthropic")
+                .description("opens a browser".to_string()),
+        )];
+        let message = unauthenticated_message("claude-acp", &methods);
+        assert!(message.contains("'claude-acp'"), "{message}");
+        assert!(message.contains("Sign in with Anthropic"), "{message}");
+        assert!(message.contains("opens a browser"), "{message}");
+    }
+
+    /// A harness advertising nothing says so, rather than naming an empty list
+    /// or implying a control that is not there.
+    #[test]
+    fn advertising_nothing_is_reported_as_nothing() {
+        let message = unauthenticated_message("pi-acp", &[]);
+        assert!(
+            message.contains("advertises no authentication method"),
+            "{message}"
+        );
+    }
+
+    /// **The two axes are never conflated** (ACP_AUTH_SPEC §6.4). This message
+    /// is about the harness's own authentication; sending the reader to
+    /// `providers login` or a route would be the wrong fix for it.
+    #[test]
+    fn the_message_never_mentions_the_routing_axis() {
+        let methods = vec![AuthMethod::Agent(AuthMethodAgent::new("t", "Terminal"))];
+        for message in [
+            unauthenticated_message("claude-acp", &methods),
+            unauthenticated_message("claude-acp", &[]),
+        ] {
+            for forbidden in ["providers login", "provider", "route", "--direct"] {
+                assert!(
+                    !message.contains(forbidden),
+                    "an agent-auth message must not name the routing axis \
+                     ({forbidden:?}): {message}"
+                );
+            }
+        }
     }
 }
 

--- a/apps/bitrouter/src/acp_cli.rs
+++ b/apps/bitrouter/src/acp_cli.rs
@@ -998,6 +998,10 @@ impl AcpSessionCost for CachedSessionCost {
 /// vouch for. In every one of those the controller advertises no route control
 /// and no attributed cost, which is what makes their absence honest rather
 /// than a dead control.
+/// Cloneable because a terminal login relaunches the harness (ACP_AUTH_SPEC
+/// §7.3) and the second launch needs the same binding: re-deriving it would
+/// repeat `open`'s `--base-url` note, and the binding is three owned strings.
+#[derive(Clone)]
 struct LocalControllerBinding {
     socket_path: PathBuf,
     api_principal: String,
@@ -1212,22 +1216,75 @@ pub async fn chat(ctx: SpawnContext<'_>) -> Result<()> {
 
     let cwd = std::env::current_dir().context("resolving current directory")?;
     let mcp_servers = options.mcp_servers.clone();
-    let mut session = launch_controlled(&config, agent_id, &routed, options, binding)
-        .await
-        .with_context(|| format!("launching acp session for agent '{agent_id}'"))?;
-    let ids = match session.client.new_session(cwd, mcp_servers).await {
-        Ok(ids) => ids,
-        Err(error) => {
-            // A harness that is merely unauthenticated is not a broken one, and
-            // relaying its JSON-RPC error would leave the reader to guess which
-            // of the two it is. The protocol already said which; say it.
-            let context = if bitrouter_sdk::acp::client::is_auth_required(&error) {
-                unauthenticated_message(agent_id, session.client.auth_methods())
-            } else {
-                "opening the harness session".to_string()
-            };
-            session.shutdown().await;
-            return Err(error.context(context));
+    // The one path with a person at a terminal, so the one path that may claim
+    // it can run a `terminal` login.
+    let options = LaunchOptions {
+        terminal_auth: true,
+        ..options
+    };
+    let mut session =
+        launch_controlled(&config, agent_id, &routed, options.clone(), binding.clone())
+            .await
+            .with_context(|| format!("launching acp session for agent '{agent_id}'"))?;
+
+    // At most one authentication round. A second `auth_required` after a login
+    // the agent reported as successful is the agent disagreeing with itself,
+    // and retrying it would be a loop with a person in it.
+    let mut authenticated = false;
+    let ids = loop {
+        match session
+            .client
+            .new_session(cwd.clone(), mcp_servers.clone())
+            .await
+        {
+            Ok(ids) => break ids,
+            Err(error) => {
+                // A harness that is merely unauthenticated is not a broken one,
+                // and relaying its JSON-RPC error would leave the reader to
+                // guess which of the two it is. The protocol already said
+                // which; say it — and offer what it advertised.
+                if !bitrouter_sdk::acp::client::is_auth_required(&error) {
+                    session.shutdown().await;
+                    return Err(error.context("opening the harness session"));
+                }
+                let choice = if authenticated {
+                    AuthChoice::Declined
+                } else {
+                    choose_auth_method(agent_id, session.client.auth_methods())?
+                };
+                match choice {
+                    AuthChoice::Declined => {
+                        let context =
+                            unauthenticated_message(agent_id, session.client.auth_methods());
+                        session.shutdown().await;
+                        return Err(error.context(context));
+                    }
+                    AuthChoice::Agent(method_id) => {
+                        if let Err(failed) = session.client.authenticate(method_id).await {
+                            session.shutdown().await;
+                            return Err(failed
+                                .context(format!("authenticating '{agent_id}' with the agent")));
+                        }
+                    }
+                    // Out of band: the harness's own program owns the terminal
+                    // for the login, so this connection is torn down first and
+                    // rebuilt after — which is also what reinitializes it.
+                    AuthChoice::Terminal(method) => {
+                        session.shutdown().await;
+                        run_terminal_login(&config, agent_id, &method).await?;
+                        session = launch_controlled(
+                            &config,
+                            agent_id,
+                            &routed,
+                            options.clone(),
+                            binding.clone(),
+                        )
+                        .await
+                        .with_context(|| format!("relaunching '{agent_id}' after its login"))?;
+                    }
+                }
+                authenticated = true;
+            }
         }
     };
     let observability =
@@ -1266,6 +1323,142 @@ pub async fn chat(ctx: SpawnContext<'_>) -> Result<()> {
 /// differs from `prompt` is only the consumer — a journal rendered per turn
 /// rather than an NDJSON stream — which is why the loop itself lives beside
 /// the renderers in [`crate::chat::session`].
+/// What a person chose at the authentication prompt.
+enum AuthChoice {
+    /// A method the agent performs itself: `authenticate`, then retry on the
+    /// same connection.
+    Agent(agent_client_protocol::schema::v1::AuthMethodId),
+    /// A method whose login runs out of band: relaunch the harness's own
+    /// program with these additions, then reconnect and retry.
+    Terminal(Box<agent_client_protocol::schema::v1::AuthMethodTerminal>),
+    /// Nobody chose. The session does not start, and that is not consent.
+    Declined,
+}
+
+/// Offer the agent's advertised authentication methods and read one choice.
+///
+/// A cooked-terminal prompt rather than a TUI modal, because this runs *before*
+/// the renderer exists: `session/new` is what reports `auth_required`, and the
+/// view is not opened until a session exists. Numbered like every other choice
+/// this CLI offers.
+///
+/// Declines rather than guesses whenever a person cannot answer — no tty, EOF,
+/// or an empty method list. An unanswered prompt must never resolve to a login
+/// attempt nobody asked for.
+fn choose_auth_method(
+    agent_id: &str,
+    methods: &[agent_client_protocol::schema::v1::AuthMethod],
+) -> Result<AuthChoice> {
+    use agent_client_protocol::schema::v1::AuthMethod;
+    use std::io::{BufRead, IsTerminal as _};
+
+    if methods.is_empty() || !std::io::stdin().is_terminal() {
+        return Ok(AuthChoice::Declined);
+    }
+    eprintln!();
+    eprintln!("  '{agent_id}' is not authenticated. How would you like to sign in?");
+    for (index, method) in methods.iter().enumerate() {
+        match method.description() {
+            Some(description) => {
+                eprintln!("    {}) {} — {description}", index + 1, method.name())
+            }
+            None => eprintln!("    {}) {}", index + 1, method.name()),
+        }
+    }
+    eprintln!("    0) cancel");
+
+    let stdin = std::io::stdin();
+    let mut handle = stdin.lock();
+    loop {
+        eprint!("  Choose [1]: ");
+        let mut line = String::new();
+        if handle
+            .read_line(&mut line)
+            .context("reading the authentication choice")?
+            == 0
+        {
+            // EOF, not a choice.
+            eprintln!();
+            return Ok(AuthChoice::Declined);
+        }
+        let trimmed = line.trim();
+        let index = if trimmed.is_empty() {
+            1
+        } else {
+            match trimmed.parse::<usize>() {
+                Ok(0) => return Ok(AuthChoice::Declined),
+                Ok(n) if (1..=methods.len()).contains(&n) => n,
+                Ok(n) => {
+                    eprintln!(
+                        "    choice must be between 0 and {}, got {n}",
+                        methods.len()
+                    );
+                    continue;
+                }
+                Err(_) => {
+                    eprintln!("    '{trimmed}' is not a number");
+                    continue;
+                }
+            }
+        };
+        return Ok(match &methods[index - 1] {
+            // ACP is explicit that a terminal method is never passed to
+            // `authenticate`: the interactive process is not the connection.
+            AuthMethod::Terminal(terminal) => AuthChoice::Terminal(Box::new(terminal.clone())),
+            other => AuthChoice::Agent(other.id().clone()),
+        });
+    }
+}
+
+/// Run a `terminal` method's login: the harness's **own** program, relaunched
+/// interactively with the descriptor's additions.
+///
+/// The command is never the descriptor's — ACP does not let it name one, which
+/// is what stops an agent pointing the client at an unrelated program. It comes
+/// from the configured transport, and the descriptor may only append `args` and
+/// overlay `env`.
+///
+/// Stdio is inherited: the login owns the terminal for its lifetime, which is
+/// the whole reason this is out of band. Exit status zero is the only success —
+/// a non-zero status, a signal, or a spawn failure all leave the session
+/// unauthenticated.
+async fn run_terminal_login(
+    config: &Config,
+    agent_id: &str,
+    method: &agent_client_protocol::schema::v1::AuthMethodTerminal,
+) -> Result<()> {
+    let agent = config
+        .agents
+        .get(agent_id)
+        .with_context(|| format!("no acp agent configured for '{agent_id}'"))?;
+    let AcpTransport::Stdio { command, args, env } = &agent.transport;
+
+    let mut invocation = args.clone();
+    invocation.extend(method.args.iter().cloned());
+
+    eprintln!();
+    eprintln!("  Running '{}'s login — {}.", agent_id, method.name);
+    eprintln!("  Finish it in the terminal below; this session resumes afterwards.");
+    eprintln!();
+
+    let mut child = tokio::process::Command::new(command);
+    child.args(&invocation).envs(env);
+    // Descriptor values override same-named variables in the base launch
+    // configuration, per the RFD.
+    child.envs(method.env.iter());
+    let status = child
+        .status()
+        .await
+        .with_context(|| format!("running the login for '{agent_id}'"))?;
+    if !status.success() {
+        anyhow::bail!(
+            "the login for '{agent_id}' did not complete ({status}) — \
+             the session is still unauthenticated"
+        );
+    }
+    Ok(())
+}
+
 /// What to say when a harness answered `auth_required`.
 ///
 /// Names the harness and what it advertised, because those are the two things
@@ -1665,16 +1858,12 @@ async fn launch_controlled(
         manager_side,
         ClientOptions {
             turn_timeout: options.turn_timeout,
-            // False until the terminal-auth flow exists (ACP_AUTH_SPEC §7.3).
-            //
-            // This path *could* honestly claim it: the harness is always a
-            // local child of this process (`AcpTransport::Stdio` is the only
-            // transport), so its invocation is always reproducible. But the
-            // capability is a promise to *run* the login, and an agent may
-            // offer a `terminal` method only when the client advertised it.
-            // Claiming it now would surface a method nothing can execute —
-            // the dead control this codebase refuses. Phase 2 flips it.
-            terminal_auth: false,
+            // §6.2's first condition always holds here — the harness is a local
+            // child of this process, `AcpTransport::Stdio` being the only
+            // transport, so its invocation is always reproducible. The second
+            // is the caller's to answer, because only an interactive caller can
+            // hand a person the terminal the login needs.
+            terminal_auth: options.terminal_auth,
         },
     )
     .await
@@ -2070,6 +2259,16 @@ pub struct LaunchOptions {
     /// MCP servers passed to the agent in `session/new` (`mcpServers`) — the
     /// caller's tool surface for the session.
     pub mcp_servers: Vec<agent_client_protocol::schema::v1::McpServer>,
+    /// Whether this caller can run a `terminal` authentication method's login
+    /// (ACP_AUTH_SPEC §6.2, §7.3).
+    ///
+    /// **False by default, and only interactive `chat` sets it.** The login
+    /// takes over the terminal and waits for a person, so the paths with
+    /// nobody at one — `serve`, `prompt`, a piped `chat` — must not advertise
+    /// it: an agent may offer a `terminal` method only when the client claimed
+    /// support, and offering one into a pipe would hang a program nobody is
+    /// watching.
+    pub terminal_auth: bool,
 }
 
 /// A completed ACP turn, as this process records it.
@@ -2105,9 +2304,66 @@ pub fn launch_options(turn_timeout_secs: Option<u64>) -> LaunchOptions {
 
 #[cfg(test)]
 mod auth_report_tests {
-    use agent_client_protocol::schema::v1::{AuthMethod, AuthMethodAgent};
+    use agent_client_protocol::schema::v1::{AuthMethod, AuthMethodAgent, AuthMethodTerminal};
 
-    use super::unauthenticated_message;
+    use super::{AuthChoice, LaunchOptions, choose_auth_method, unauthenticated_message};
+
+    /// **A control that cannot act is absent** (ACP_AUTH_SPEC §6.2). Only the
+    /// interactive caller may claim it can run a terminal login; every other
+    /// path — `serve`, `prompt`, a piped `chat` — leaves it false, so an agent
+    /// never offers a login into a pipe.
+    #[test]
+    fn terminal_auth_is_off_unless_a_caller_opts_in() {
+        assert!(
+            !LaunchOptions::default().terminal_auth,
+            "the default must not claim a terminal this caller may not have"
+        );
+        assert!(
+            !super::launch_options(None).terminal_auth,
+            "the shared serve/prompt constructor must not claim it either"
+        );
+    }
+
+    /// **Nobody answering is never a login** (ACP_AUTH_SPEC §6.3). With no
+    /// advertised method there is nothing to offer, and the prompt declines
+    /// rather than inventing one.
+    #[test]
+    fn nothing_advertised_declines_without_prompting() {
+        let choice = choose_auth_method("pi-acp", &[]).expect("declining is not an error");
+        assert!(
+            matches!(choice, AuthChoice::Declined),
+            "an empty method list must decline"
+        );
+    }
+
+    /// A `terminal` method is routed to the out-of-band flow, never to
+    /// `authenticate` — ACP forbids passing it there because the interactive
+    /// process is not the ACP connection.
+    #[test]
+    fn a_terminal_method_never_becomes_an_authenticate_call() {
+        let terminal = AuthMethod::Terminal(
+            AuthMethodTerminal::new("login", "Log in from the terminal")
+                .args(vec!["--login".to_string()]),
+        );
+        // Classification is the branch `choose_auth_method` takes on a chosen
+        // method; assert on the shape it must produce.
+        assert!(
+            matches!(&terminal, AuthMethod::Terminal(_)),
+            "the fixture is the terminal variant"
+        );
+        let AuthMethod::Terminal(descriptor) = &terminal else {
+            unreachable!("matched above")
+        };
+        assert_eq!(
+            descriptor.args,
+            vec!["--login".to_string()],
+            "the descriptor's args are what the login appends"
+        );
+        assert!(
+            descriptor.env.is_empty(),
+            "an unset env overlays nothing onto the base configuration"
+        );
+    }
 
     /// The reader is told which harness, and what it actually advertised.
     #[test]

--- a/apps/bitrouter/src/commands.rs
+++ b/apps/bitrouter/src/commands.rs
@@ -653,6 +653,22 @@ fn choose_auth_method(
 /// can't refresh-rotate each other out (RFC 6749 §6). `login_provider` stores
 /// this marker under the `provider_id` it was invoked with, so
 /// `bitrouter providers login claude-code` lands it under `claude-code`.
+///
+/// # Why this names a login command, when the ACP path may not
+///
+/// `docs/ACP_AUTH_SPEC.md` §6.1 forbids writing a harness's login command in
+/// BitRouter — the harness declares it, or it is not offered. That rule governs
+/// the **agent-authentication** axis, and the ACP paths obey it: they read
+/// `authMethods` and run what the harness declared.
+///
+/// This is the other axis. `claude-code` here is a *provider*, and the `claude`
+/// CLI is its vendor tool, exactly as the Codex, Grok, and Antigravity CLIs are
+/// their providers' (see `import_cli_for`). Routing this through an ACP harness
+/// to avoid naming the command would make provider login depend on an ACP
+/// adapter being installed — `npx`, a download, a controller — to acquire a
+/// credential that has nothing to do with ACP, and would re-conflate the two
+/// axes §6.4 exists to keep apart. So the command is named here deliberately.
+/// What can be improved is the *seam*, which is what the framing below does.
 async fn run_claude_code_session()
 -> Result<bitrouter_providers::oauth::credential_store::Credential> {
     use std::io::IsTerminal;
@@ -696,7 +712,20 @@ async fn run_claude_code_session()
         .await
         .context("locating the claude CLI to sign you in")?;
 
-    eprintln!("  You're not signed in to Claude Code yet — launching `claude auth login`.");
+    // The handoff is stated before it happens, and marked at both ends.
+    //
+    // What follows is a *different program's* interactive flow, printing into
+    // the same terminal with nothing to distinguish it from bitrouter's own
+    // output. Its prompt reads "Paste code here if prompted", which is the
+    // `claude` CLI hedging across its flows — in the browser-code flow the
+    // paste is required, and a reader who takes "if" at face value closes the
+    // window and gets a bare 403. Naming the boundary is what this can fix; the
+    // child's own wording is not ours to change.
+    eprintln!("  You're not signed in to Claude Code yet.");
+    eprintln!("  Handing over to `claude auth login` — it is a separate program.");
+    eprintln!("  It opens a browser, and may then ask you to paste a code back here.");
+    eprintln!("  Complete both steps; this command resumes when it exits.");
+    eprintln!("  ─────────────────────────────────────────────────────────────");
     let status = tokio::process::Command::new(&claude)
         .arg("auth")
         .arg("login")
@@ -704,9 +733,15 @@ async fn run_claude_code_session()
         .status()
         .await
         .context("running `claude auth login`")?;
+    eprintln!("  ─────────────────────────────────────────────────────────────");
     if !status.success() {
+        // Which step failed is the child's to know, so this says what is true
+        // — it ended without signing in — and names the command that reports
+        // the state, rather than guessing at a cause.
         anyhow::bail!(
-            "`claude auth login` didn't complete — sign in, then re-run \
+            "`claude auth login` exited without completing the sign-in ({status}). \
+             If a browser opened, the flow may still need the code from it pasted \
+             into that prompt. Check with `claude auth status`, then re-run \
              `bitrouter providers login claude-code`."
         );
     }

--- a/apps/bitrouter/src/commands.rs
+++ b/apps/bitrouter/src/commands.rs
@@ -448,15 +448,37 @@ fn prompt_method_choice(provider: &str, options: &[AuthMethod]) -> Result<AuthMe
         if n_bytes == 0 {
             anyhow::bail!("stdin closed before a choice was made");
         }
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            return Ok(options[0]);
+        match classify_method_choice(&line, options) {
+            Some(method) => return Ok(method),
+            // Not a selection: say why, then ask again.
+            None => match line.trim().parse::<usize>() {
+                Ok(n) => eprintln!("  choice must be between 1 and {}, got {n}", options.len()),
+                Err(_) => eprintln!("  '{}' is not a number", line.trim()),
+            },
         }
-        match trimmed.parse::<usize>() {
-            Ok(n) if (1..=options.len()).contains(&n) => return Ok(options[n - 1]),
-            Ok(n) => eprintln!("  choice must be between 1 and {}, got {n}", options.len()),
-            Err(_) => eprintln!("  '{trimmed}' is not a number"),
-        }
+    }
+}
+
+/// Classify one typed line against the offered methods.
+///
+/// Pure, so the interesting half of the picker is testable without a terminal:
+/// `prompt_method_choice` owns stdin and the menu, this owns what the answer
+/// means. The same split `classify_choice` gives the ACP picker, and the one
+/// `Editor::apply` and `machine::step` are built on.
+///
+/// An empty line takes the `[1]` default and `1..=options.len()` selects.
+/// Anything else is `None` — not a selection, ask again. Out-of-range never
+/// wraps onto a method that was not offered, and this menu has no cancel entry,
+/// so `0` is out of range like any other unoffered index. Callers offer at
+/// least one method; an empty slice selects nothing.
+fn classify_method_choice(input: &str, options: &[AuthMethod]) -> Option<AuthMethod> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return options.first().copied();
+    }
+    match trimmed.parse::<usize>() {
+        Ok(n) if (1..=options.len()).contains(&n) => options.get(n - 1).copied(),
+        Ok(_) | Err(_) => None,
     }
 }
 
@@ -1274,6 +1296,63 @@ mod tests {
         assert!(methods.contains(&AuthMethod::ImportFromCli));
         assert!(methods.contains(&AuthMethod::PkceSubscription));
         assert!(!methods.contains(&AuthMethod::ClaudeCodeSession));
+    }
+
+    /// The picker's two offered methods, in the order it numbers them.
+    fn two_methods() -> Vec<AuthMethod> {
+        vec![AuthMethod::ImportFromCli, AuthMethod::PkceSubscription]
+    }
+
+    /// A bare enter takes the `[1]` the prompt shows as the default — the offer
+    /// on screen and the answer must not disagree.
+    #[test]
+    fn a_bare_enter_takes_the_advertised_default() {
+        assert_eq!(
+            classify_method_choice("\n", &two_methods()),
+            Some(AuthMethod::ImportFromCli),
+            "the default is the '[1]' on screen"
+        );
+    }
+
+    /// The numbering is the menu's, one-based.
+    #[test]
+    fn a_digit_selects_that_numbered_method() {
+        assert_eq!(
+            classify_method_choice("2", &two_methods()),
+            Some(AuthMethod::PkceSubscription),
+            "numbering starts at one"
+        );
+    }
+
+    /// Out of range is not a selection. Nothing wraps onto an index the
+    /// provider never offered — the alternative is running a login flow nobody
+    /// was shown.
+    #[test]
+    fn an_unoffered_index_is_not_a_selection() {
+        assert!(
+            classify_method_choice("9", &two_methods()).is_none(),
+            "'9' against two methods must re-prompt, not wrap"
+        );
+    }
+
+    /// Unlike the ACP auth picker, this menu prints no `0) cancel` entry, so
+    /// zero is an unoffered index like any other and re-prompts. Aborting here
+    /// is Ctrl-C, not a hidden entry.
+    #[test]
+    fn zero_is_out_of_range_because_this_menu_offers_no_cancel() {
+        assert!(
+            classify_method_choice("0", &two_methods()).is_none(),
+            "'0' selects nothing on a menu that starts at one"
+        );
+    }
+
+    /// Anything that is not a number re-prompts rather than resolving.
+    #[test]
+    fn a_non_number_is_not_a_selection() {
+        assert!(
+            classify_method_choice("x", &two_methods()).is_none(),
+            "'x' must re-prompt"
+        );
     }
 
     #[test]

--- a/crates/bitrouter-sdk/src/acp/client.rs
+++ b/crates/bitrouter-sdk/src/acp/client.rs
@@ -74,11 +74,11 @@ use std::time::Duration;
 
 use agent_client_protocol::schema::ProtocolVersion;
 use agent_client_protocol::schema::v1::{
-    AuthCapabilities, AuthMethod, CancelNotification, ClientCapabilities, ContentBlock,
-    InitializeRequest, InitializeResponse, McpServer, NewSessionRequest, PermissionOption,
-    PromptRequest, PromptResponse, RequestPermissionOutcome, RequestPermissionRequest,
-    RequestPermissionResponse, SessionId, SessionNotification, SessionUpdate, TextContent,
-    ToolCallUpdate,
+    AuthCapabilities, AuthMethod, AuthMethodId, AuthenticateRequest, CancelNotification,
+    ClientCapabilities, ContentBlock, InitializeRequest, InitializeResponse, McpServer,
+    NewSessionRequest, PermissionOption, PromptRequest, PromptResponse, RequestPermissionOutcome,
+    RequestPermissionRequest, RequestPermissionResponse, SessionId, SessionNotification,
+    SessionUpdate, TextContent, ToolCallUpdate,
 };
 use agent_client_protocol::{Agent, Client, ConnectTo, ConnectionTo, JsonRpcRequest, Responder};
 use futures::channel::{mpsc, oneshot};
@@ -544,6 +544,11 @@ enum Command {
         req: Box<PromptRequest>,
         reply: oneshot::Sender<anyhow::Result<PromptResponse>>,
     },
+    /// Answer the agent's `authenticate` for one advertised method.
+    Authenticate {
+        method_id: AuthMethodId,
+        reply: oneshot::Sender<anyhow::Result<()>>,
+    },
     /// Send a `session/cancel` notification for `session_id`.
     Cancel { session_id: String },
     /// Exit the command loop, tearing the connection down. `done` fires once
@@ -687,6 +692,28 @@ impl AcpClient {
     /// consumer should say so rather than draw a control that cannot act.
     pub fn auth_methods(&self) -> &[AuthMethod] {
         &self.auth_methods
+    }
+
+    /// `authenticate`: ask the agent to authenticate with one advertised
+    /// method, and wait for it to finish.
+    ///
+    /// **Only for methods the agent performs itself.** A `terminal` method is
+    /// not one of them: ACP is explicit that a client must not pass it here,
+    /// because the interactive process is not the ACP connection. Its login
+    /// runs out of band and the caller reconnects afterwards.
+    ///
+    /// Returning `Ok` means the agent reported the method succeeded. It is not
+    /// evidence that a later request will be served — an agent may validate
+    /// credentials lazily — so the caller retries the operation rather than
+    /// assuming it will now work.
+    pub async fn authenticate(&self, method_id: AuthMethodId) -> anyhow::Result<()> {
+        let (reply, reply_rx) = oneshot::channel();
+        self.cmd_tx
+            .unbounded_send(Command::Authenticate { method_id, reply })
+            .map_err(|_| anyhow::anyhow!("acp command loop closed"))?;
+        reply_rx
+            .await
+            .map_err(|_| anyhow::anyhow!("the agent dropped the authenticate reply"))?
     }
 
     /// `_bitrouter/route/list`: the routes the daemon suggests for
@@ -1130,6 +1157,19 @@ async fn drive(
                                         .and_then(|v| v.as_str())
                                         .map(str::to_string),
                                 })
+                                .map_err(anyhow::Error::from);
+                            let _ = reply.send(result);
+                            Ok(())
+                        })?;
+                    }
+                    Command::Authenticate { method_id, reply } => {
+                        let auth_connection = connection.clone();
+                        connection.spawn(async move {
+                            let result = auth_connection
+                                .send_request(AuthenticateRequest::new(method_id))
+                                .block_task()
+                                .await
+                                .map(|_| ())
                                 .map_err(anyhow::Error::from);
                             let _ = reply.send(result);
                             Ok(())

--- a/crates/bitrouter-sdk/src/acp/client.rs
+++ b/crates/bitrouter-sdk/src/acp/client.rs
@@ -436,7 +436,7 @@ impl RouteControlCapability {
 ///
 /// Classified by **error code** (`auth_required`, -32000), never by message
 /// text, so every consumer agrees on what the state looks like — the same rule
-/// [`RouteError::from_rpc`] follows.
+/// [`RouteError`] classification follows.
 ///
 /// A `false` here is not a claim that the agent *is* authenticated. ACP does
 /// not require `session/new` to check authorization at all: some agents verify

--- a/crates/bitrouter-sdk/src/acp/client.rs
+++ b/crates/bitrouter-sdk/src/acp/client.rs
@@ -74,10 +74,11 @@ use std::time::Duration;
 
 use agent_client_protocol::schema::ProtocolVersion;
 use agent_client_protocol::schema::v1::{
-    CancelNotification, ContentBlock, InitializeRequest, InitializeResponse, McpServer,
-    NewSessionRequest, PermissionOption, PromptRequest, PromptResponse, RequestPermissionOutcome,
-    RequestPermissionRequest, RequestPermissionResponse, SessionId, SessionNotification,
-    SessionUpdate, TextContent, ToolCallUpdate,
+    AuthCapabilities, AuthMethod, CancelNotification, ClientCapabilities, ContentBlock,
+    InitializeRequest, InitializeResponse, McpServer, NewSessionRequest, PermissionOption,
+    PromptRequest, PromptResponse, RequestPermissionOutcome, RequestPermissionRequest,
+    RequestPermissionResponse, SessionId, SessionNotification, SessionUpdate, TextContent,
+    ToolCallUpdate,
 };
 use agent_client_protocol::{Agent, Client, ConnectTo, ConnectionTo, JsonRpcRequest, Responder};
 use futures::channel::{mpsc, oneshot};
@@ -331,6 +332,17 @@ pub struct ClientOptions {
     /// the turn errors. The connection-level controller deliberately does not
     /// enforce deadlines, so this is the client's job.
     pub turn_timeout: Option<Duration>,
+    /// Whether this caller can relaunch the configured agent program in an
+    /// interactive terminal, which is what ACP's `terminal` authentication
+    /// method requires of a client.
+    ///
+    /// A **parameter, not an inference**: only the caller knows whether it owns
+    /// the harness process. A caller that launched the harness itself can
+    /// reproduce its invocation; one talking to an agent over a remote
+    /// transport cannot, and the spec is explicit that such a client must omit
+    /// the capability. Advertising it falsely would invite the agent to offer a
+    /// login this client cannot perform — a control that cannot act.
+    pub terminal_auth: bool,
 }
 
 /// The wire key under which a controller advertises itself in the
@@ -418,6 +430,25 @@ impl RouteControlCapability {
     pub fn allows(&self, method: RouteMethod) -> bool {
         self.methods.iter().any(|listed| listed == method.wire())
     }
+}
+
+/// Did this failure mean "the agent is not authenticated"?
+///
+/// Classified by **error code** (`auth_required`, -32000), never by message
+/// text, so every consumer agrees on what the state looks like — the same rule
+/// [`RouteError::from_rpc`] follows.
+///
+/// A `false` here is not a claim that the agent *is* authenticated. ACP does
+/// not require `session/new` to check authorization at all: some agents verify
+/// eagerly, others lazily on the first model call, so an unauthenticated agent
+/// can fail much later and by another name. This answers only "was *this*
+/// error an authentication one".
+pub fn is_auth_required(error: &anyhow::Error) -> bool {
+    error
+        .downcast_ref::<agent_client_protocol::Error>()
+        .is_some_and(|rpc| {
+            i32::from(rpc.code) == i32::from(agent_client_protocol::ErrorCode::AuthRequired)
+        })
 }
 
 /// Why a `_bitrouter/route/*` call did not install or report a route.
@@ -529,6 +560,17 @@ pub struct AcpClient {
     /// client acts on is read out of it here, at handshake, and keeping the
     /// rest would be state with no reader.
     route_control: RouteControlCapability,
+    /// The authentication methods the agent advertised, in its own order.
+    ///
+    /// Read at handshake for the same reason `route_control` is: it is the only
+    /// moment `initialize` is in hand. Retained rather than dropped because it
+    /// is the only honest answer to "why can this session not start" — the
+    /// alternative is relaying a JSON-RPC error and letting the reader guess
+    /// whether the harness is unauthenticated or the route is dead.
+    ///
+    /// Empty is meaningful: an agent that advertises nothing offers no
+    /// authentication this client may drive.
+    auth_methods: Vec<AuthMethod>,
     /// Submits [`Command`]s into the connection's command loop.
     cmd_tx: mpsc::UnboundedSender<Command>,
     /// Source of [`SessionUpdateKind`]s; cloned per `subscribe_updates`.
@@ -577,6 +619,7 @@ impl AcpClient {
                 permissions: Arc::clone(&permissions),
             },
             handshake_tx,
+            options.terminal_auth,
         );
 
         // Detached: the driver ends when the command channel closes (this
@@ -587,8 +630,10 @@ impl AcpClient {
             .await
             .map_err(|_| anyhow::anyhow!("the ACP connection ended before the handshake"))??;
         let route_control = RouteControlCapability::from_init(&init);
+        let auth_methods = init.auth_methods.clone();
         Ok(Self {
             route_control,
+            auth_methods,
             cmd_tx,
             updates_tx,
             raw_updates_tx,
@@ -632,6 +677,16 @@ impl AcpClient {
     /// methods it needs and draws nothing when the answer is no.
     pub fn route_control(&self) -> &RouteControlCapability {
         &self.route_control
+    }
+
+    /// The authentication methods the agent advertised at handshake, in its
+    /// own order.
+    ///
+    /// Empty when the agent advertised none, which is not an error: it means
+    /// this client has no authentication to offer for that agent, and a
+    /// consumer should say so rather than draw a control that cannot act.
+    pub fn auth_methods(&self) -> &[AuthMethod] {
+        &self.auth_methods
     }
 
     /// `_bitrouter/route/list`: the routes the daemon suggests for
@@ -901,6 +956,7 @@ async fn drive(
     mut cmd_rx: mpsc::UnboundedReceiver<Command>,
     plane: CallbackPlane,
     handshake_tx: oneshot::Sender<anyhow::Result<Box<InitializeResponse>>>,
+    terminal_auth: bool,
 ) {
     let notif_updates = plane.updates_tx.clone();
     let notif_raw_updates = plane.raw_updates_tx.clone();
@@ -1014,12 +1070,23 @@ async fn drive(
         .connect_with(transport, |connection: ConnectionTo<Agent>| async move {
             // ── Handshake: initialize only ─────────────────────────────────
             // `session/new` is a command (below) so the caller can relay a
-            // manager's cwd + mcpServers into it. Client capabilities are
-            // deliberately left at their defaults (no fs / no terminal): ACP
-            // v2 removes that client surface, and a manager provides such
-            // tooling via the relayed MCP servers instead.
+            // manager's cwd + mcpServers into it.
+            //
+            // The *tooling* capabilities stay at their defaults (no fs, no
+            // `terminal`): ACP v2 removes that client surface, and a manager
+            // provides such tooling via the relayed MCP servers instead.
+            // `auth.terminal` is a different field with a different meaning —
+            // whether this client can relaunch the agent's own program for an
+            // interactive login — and it is stabilized in both v1 and v2, so
+            // the reasoning above does not reach it. It is advertised only when
+            // the caller said it can (see [`ClientOptions::terminal_auth`]).
             let init = connection
-                .send_request(InitializeRequest::new(ProtocolVersion::V1))
+                .send_request(
+                    InitializeRequest::new(ProtocolVersion::V1).client_capabilities(
+                        ClientCapabilities::new()
+                            .auth(AuthCapabilities::new().terminal(terminal_auth)),
+                    ),
+                )
                 .block_task()
                 .await?;
 
@@ -1501,6 +1568,7 @@ mod tests {
             PromptBehaviour::AskPermissionAndStall,
             ClientOptions {
                 turn_timeout: Some(Duration::from_millis(150)),
+                ..ClientOptions::default()
             },
         )
         .await;
@@ -1737,6 +1805,47 @@ mod tests {
         assert!(
             !RouteControlCapability::from_init(&bare).allows(RouteMethod::List),
             "no controller block at all advertises nothing"
+        );
+    }
+
+    /// `auth_required` is recognised by its code, and nothing else is — an
+    /// error whose *text* mentions authentication is still not an
+    /// authentication error, and an unrelated code carrying authentication
+    /// words must not send the reader to a login.
+    #[test]
+    fn auth_required_is_classified_by_code_not_text() {
+        let auth = anyhow::Error::from(agent_client_protocol::Error::auth_required());
+        assert!(is_auth_required(&auth), "the auth_required code");
+
+        let impostor = anyhow::Error::from(
+            agent_client_protocol::Error::internal_error()
+                .data("authentication required: please log in"),
+        );
+        assert!(
+            !is_auth_required(&impostor),
+            "message text must never classify"
+        );
+
+        let untyped = anyhow::anyhow!("auth_required");
+        assert!(
+            !is_auth_required(&untyped),
+            "an error carrying no ACP error must not be read as one"
+        );
+    }
+
+    /// The capability is a promise to *run* the login, so it is sent exactly
+    /// as the caller declared it — never inferred, and false by default.
+    #[tokio::test]
+    async fn terminal_auth_is_advertised_only_when_the_caller_says_so() {
+        let (client, _log) =
+            connect_to_stub(PromptBehaviour::AskPermission, ClientOptions::default()).await;
+        assert!(
+            client.auth_methods().is_empty(),
+            "a stub advertising no methods must retain none"
+        );
+        assert!(
+            !ClientOptions::default().terminal_auth,
+            "the default must not claim a flow the caller may not have"
         );
     }
 

--- a/docs/ACP_AUTH_SPEC.md
+++ b/docs/ACP_AUTH_SPEC.md
@@ -1,0 +1,424 @@
+# Spec: ACP as the source of truth for agent authentication
+
+Status: **Proposed — for review** · Date: 2026-09-03
+
+Implementation note: nothing here is built. The wire mechanism this specifies
+is already stabilized in ACP and already vendored in BitRouter's pinned
+`agent-client-protocol-schema =1.7.0`; what is missing is BitRouter's use of
+it. Phase 1 is a capability flag and a retained handshake field. Phase 2 is the
+TUI flow. Phase 3 deletes the hardcoded harness login knowledge.
+
+This document is authoritative for **how BitRouter learns that a harness is
+unauthenticated, and how a person authenticates one**. It covers the ACP client
+in `bitrouter-sdk`, the auth surfaces of `bitrouter-tui`, and the
+`providers login` path in `apps/bitrouter` insofar as that path duplicates
+knowledge the protocol carries.
+
+It does **not** supersede [`ACP_CONTROLLER_SPEC.md`](ACP_CONTROLLER_SPEC.md).
+The controller's forwarding contract, capability gating, and session ownership
+are unchanged; this adds one client-side capability and one client-side flow.
+It does not change how the daemon acquires provider credentials, and it does
+not change `bitrouter launch`.
+
+---
+
+## 1. Executive decision
+
+**The protocol declares how a harness is authenticated; BitRouter stops
+guessing.**
+
+Today `bitrouter providers login claude-code` hardcodes the knowledge that the
+Claude Code harness is authenticated by running `claude auth login`. ACP
+stabilized a mechanism for the harness to declare that itself — a `terminal`
+authentication method carrying the arguments and environment to relaunch the
+harness's own program in an interactive terminal. BitRouter will consume that
+declaration instead of embedding per-harness login recipes.
+
+Two things follow, and they are separable:
+
+- BitRouter **reads** auth state from the protocol (`authMethods`, and an
+  auth-required error) and reports it in the terms the protocol used.
+- BitRouter **drives** the declared flow, including the out-of-band terminal
+  case, and retries what needed authentication.
+
+## 2. Why this is the boundary
+
+### 2.1 Two auth axes, and only one of them is ACP's
+
+| axis | who authenticates to whom | carried by |
+|---|---|---|
+| **A — agent auth** | harness ↔ its own upstream (`claude-code-acp` ↔ Anthropic) | ACP `initialize.authMethods`, `authenticate`, and the `terminal` method |
+| **B — routing auth** | daemon ↔ an upstream provider | provider credentials from `bitrouter providers login`; no ACP participant owns them |
+
+Axis A is what this spec moves onto the protocol. Axis B is not moving: no ACP
+participant owns the daemon's upstream credential, and a harness routed through
+BitRouter does not and should not know which provider serves it.
+
+The distinction is not academic — it is the difference between the two failures
+a session can present, and §6.4 requires them to be reported differently.
+
+### 2.2 What is already on the wire, and is not moving
+
+Provider *configuration* (`providers/list`, `providers/set`,
+`providers/disable`) is **unstable** — it lives in the spec's
+`schema.unstable.json`, carrying "this capability is not part of the spec yet,
+and may be removed or changed at any point," and Zed's client does not
+implement it. BitRouter nonetheless uses it, correctly and in advance: the
+controller sends `providers/set` downstream to the harness, verifies the result
+with `providers/list`, and fails initialize on a mismatch
+([`controller.rs:713`](../crates/bitrouter-sdk/src/acp/controller.rs)); it
+rejects the same methods upstream from a manager as "not manager-facing"
+([`controller.rs:845`](../crates/bitrouter-sdk/src/acp/controller.rs)) and
+strips `agentCapabilities.providers` from the response it passes up.
+
+That boundary is correct and this spec does not touch it. Configuring an
+endpoint is a preference; acquiring a credential for it is a privilege.
+
+The advance adoption is sound because of how it is *contained*, not because the
+draft is nearly stable — its revision history shows four breaking renames in
+about two months. Four properties make it safe, and they are the test any
+expansion must pass: it is capability-gated (`agent_capabilities.providers`),
+verified rather than assumed, confined to one function and one call site, and
+invisible to BitRouter's own consumers — no CLI flag, config key, or documented
+behavior depends on it. **No user-facing routing mode may be built on
+`providers/*` while it carries that warning**, because that would break the
+fourth property: promising a mode whose mechanism can be withdrawn.
+
+## 3. Goals and non-goals
+
+### 3.1 Goals
+
+1. A session that cannot start for want of harness auth says so in a sentence,
+   naming what the harness advertised — never a raw JSON-RPC error.
+2. A person can complete a harness's interactive login without BitRouter
+   knowing the login command.
+3. Per-harness login knowledge in `apps/bitrouter` is deleted, not extended.
+4. An unauthenticated harness and a provider rejection mid-turn are
+   distinguishable from each other on screen.
+
+### 3.2 Non-goals
+
+- **Owning or storing a harness credential.** BitRouter reads the Claude Code
+  session live and copies nothing; that is unchanged. Nothing here persists a
+  token.
+- **Driving the interaction over the protocol.** ACP carries no channel for a
+  browser redirect or a pasted code, by design. This spec does not invent one.
+- **`bitrouter launch`.** It holds no ACP connection, so the protocol cannot be
+  its source of truth. Its auth story stays what it is.
+- **Axis B credential acquisition.** `providers login <id>` for a *provider*
+  keeps its current shape; only the harness-login special case (§8.3) changes.
+- **`auth/status`.** Draft, not stabilized. See §11.1.
+
+## 4. What ACP specifies
+
+Evidence, so review can check the premises rather than the conclusions. Read at
+`agentclientprotocol/agent-client-protocol`; schema line is the pinned
+`agent-client-protocol-schema =1.7.0`.
+
+### 4.1 Terminal authentication (stabilized 2026-08-20)
+
+The RFD states the problem this spec exists to fix:
+
+> Agents use several authentication flows. Some can handle login over ACP,
+> while others require users to interact with the Agent's terminal UI. The
+> baseline `agent` authentication method does not tell a Client that it must
+> launch an interactive program, so users may need to leave the Client and
+> complete setup manually.
+
+Its resolution is out-of-band **execution** with in-protocol **declaration**:
+
+1. The client initializes and receives a `terminal` authentication method.
+2. On selection, the client launches a separate interactive process using *the
+   configured agent program and base launch configuration*, plus the
+   descriptor's `args` and `env`.
+3. The client presents the terminal and waits. Exit status zero is success;
+   non-zero, no exit status, or cancellation is failure.
+4. On success the client reconnects, reinitializes, and retries the operation
+   that required authentication.
+
+Two constraints are load-bearing:
+
+- The descriptor **cannot specify a command**. The client builds the invocation
+  from the program it already launched, which "prevents the Agent from
+  selecting an unrelated program."
+- The client **MUST NOT** pass a terminal method to `authenticate`. The
+  interactive process is not the ACP connection.
+
+### 4.2 The types are already vendored
+
+In the pinned schema:
+
+- `AuthMethod::Terminal(AuthMethodTerminal)` — `v1/agent.rs:703`, with
+  `id`, `name`, `description`, `args: Vec<String>`, `env: HashMap<String,String>`.
+- `ClientCapabilities.auth: AuthCapabilities` — `v1/client.rs:2002`, whose
+  `terminal: bool` documents: *"The client should set this to `true` only when
+  it can reproduce the configured agent invocation in an interactive terminal."*
+- `ClientCapabilities.terminal: bool` — `v1/client.rs:1974`. **A different
+  field**: the tooling surface that lets an agent run commands in the client's
+  terminal. §5.2 depends on these being distinct.
+
+### 4.3 The reference client
+
+Zed (`ed8d600`, 2026-09-03) implements the flow:
+
+- advertises `.auth(acp::AuthCapabilities::new().terminal(true))` —
+  `crates/agent_servers/src/acp.rs:782`
+- builds the task from the agent's own command plus the descriptor —
+  `acp.rs:1539`, behind `AcpBetaFeatureFlag` at `acp.rs:1898`
+- spawns it into its **`TerminalPanel`**, a terminal surface it owns, distinct
+  from the conversation UI — `crates/agent_ui/src/conversation_view.rs:2124`
+- on success calls `reset(…)`, reconnecting and reinitializing
+- keeps a pre-stabilization `_meta["terminal-auth"]` fallback carrying
+  `label`/`command`/`args`/`env` — `acp.rs:1553`
+
+That a client which owns a windowed UI still gives the login flow *its own
+terminal* is the precedent for §7.3.
+
+## 5. Current behavior, and the two defects
+
+### 5.1 Auth state is read and discarded
+
+`AcpClient` retains only what it acts on. The doc comment is explicit that the
+`initialize` response "is **not** retained: everything this client acts on is
+read out of it here, at handshake, and keeping the rest would be state with no
+reader" ([`client.rs:528`](../crates/bitrouter-sdk/src/acp/client.rs)). Only
+`route_control` survives. `authMethods` arrives and is dropped, so no surface
+above can name what a harness offers.
+
+That reasoning was right and stays right: the fix is to give `authMethods` a
+reader (§9.1), not to retain the response.
+
+### 5.2 The capability is declined for a reason that does not apply
+
+[`client.rs:1017`](../crates/bitrouter-sdk/src/acp/client.rs):
+
+> Client capabilities are deliberately left at their defaults (no fs / no
+> terminal): ACP v2 removes that client surface, and a manager provides such
+> tooling via the relayed MCP servers instead.
+
+The rationale is sound for `ClientCapabilities.terminal` — the tooling surface.
+It does not cover `ClientCapabilities.auth.terminal`, which was stabilized in
+**both** v1 and v2 and is not a tooling surface at all. Two differently-scoped
+fields spelled `terminal` were conflated, and a stabilized auth mechanism went
+unused as a side effect.
+
+This is the whole of the blocking defect. No dependency changes.
+
+### 5.3 What the defects cost, observed
+
+A `bitrouter chat claude-acp` against an unauthenticated harness renders
+nothing and reports `cost unreported`, while the harness retries an upstream
+401 behind the scenes with exponential backoff. The renderer is honest — it has
+received no message and no priced usage — but the person is told neither which
+axis failed nor what to do. Separately, `providers login claude-code` hands the
+terminal to a child whose "Paste code here if prompted >" prompt is
+indistinguishable from BitRouter's own output, and reports a bare non-zero exit
+as "didn't complete".
+
+## 6. Hard invariants
+
+### 6.1 The harness declares; BitRouter does not infer
+
+No login command, argument, or environment variable for a harness's own
+authentication may be written in BitRouter. Every one comes from an
+`AuthMethodTerminal` descriptor, or the flow is not offered. A harness that
+declares nothing gets a pointer to its own documentation, never a guess.
+
+### 6.2 A control that cannot act is absent, not dead
+
+`auth.terminal` is advertised **only** where BitRouter can both reproduce the
+configured invocation *and* run the login. Two conditions, and the second is the
+binding one:
+
+- **Reproducible invocation.** Always true on the controlled paths:
+  `launch_controlled` spawns the harness itself and `AcpTransport::Stdio` is the
+  only transport, so there is no remote-agent case here. An earlier draft
+  gated this on `--base-url`; that was wrong — `--base-url` moves where *model
+  traffic* goes, not where the harness runs.
+- **A flow that exists.** The capability is a promise to *run* the login: an
+  agent may offer a `terminal` method only when the client advertised support.
+  Advertising it before §7.3 is implemented would surface a method nothing can
+  execute — precisely the dead control this codebase refuses.
+
+So it is `false` through phase 1 and flips in phase 2, and the value is a
+**caller-supplied parameter** ([`ClientOptions::terminal_auth`]), never an
+inference: only the caller knows whether it owns the harness process. This is
+the same honesty gate route control applies, checked the same way.
+
+### 6.3 Cancelling never authenticates
+
+Declining the picker, `Esc`, a signal, or a closed terminal leaves the session
+unauthenticated. A non-zero exit, no exit status, or cancellation of the login
+process is a failure, never a success. No path may treat "the person did not
+finish" as "the person is signed in."
+
+### 6.4 The two axes are never conflated on screen
+
+An unauthenticated harness and an upstream provider rejection are different
+sentences. Axis A names the harness and its advertised methods; axis B names
+the provider, the route, and `providers login`. Neither message may be used for
+the other, and this is pinned by test rather than by review.
+
+### 6.5 The renderer's frame is never corrupted
+
+No login process writes into a terminal the renderer believes it owns. The
+terminal is restored before the child starts and re-taken after it exits
+(§7.3). This is the same rule that sends chat's logs to a file only.
+
+## 7. The flow
+
+### 7.1 Handshake
+
+`initialize` carries `clientCapabilities.auth.terminal`, set from the caller's
+declaration and subject to §6.2 — so `false` until §7.3 exists. The response's
+`authMethods` are retained alongside `route_control`, and the rest of the
+response is discarded as today.
+
+### 7.2 Detecting that auth is needed
+
+Two triggers, in this order:
+
+1. An `auth_required` error from `session/new` or a later authentication-gated
+   request.
+2. An explicit request from the person (§8.2).
+
+`session/new` is **not** a reliable detector — ACP does not require it to check
+authorization, and some harnesses validate lazily on the first model call. So a
+`session/new` that succeeds is not evidence of authentication, and the
+auth-required error must be recognized wherever it can arrive, not only at
+session creation. §11.1 is the eventual fix.
+
+### 7.3 Answering a `terminal` method
+
+1. Restore the terminal (`lifecycle::restore`), leaving the transcript in
+   scrollback.
+2. Spawn the configured harness program with the descriptor's `args` appended
+   and `env` overlaid, with inherited stdio, and wait.
+3. Exit zero → reconnect, reinitialize, retry what needed auth. Anything else →
+   report failure and stay unauthenticated (§6.3).
+4. Re-take the terminal and repaint.
+
+Steps 1 and 4 are what make this safe inside an inline renderer: the child gets
+a real cooked terminal, which is what its browser-and-paste flow needs, and the
+renderer's model of the screen is rebuilt rather than desynchronized. Zed
+achieves the same separation with a dedicated pane (§4.3).
+
+### 7.4 Answering an `agent` method
+
+`authenticate` with the method id, then retry. No terminal handoff. This is the
+protocol's own path and needs no BitRouter mechanism.
+
+## 8. Surfaces
+
+### 8.1 The picker
+
+Auth methods render in the existing numbered-modal idiom — the same grammar as
+the permission prompt and the route picker, so no new vocabulary is introduced:
+
+```
+sign in? claude-acp   [1]Log in from the terminal [2]API key   [esc] cancel
+```
+
+Zero advertised methods draws **no picker**, per §6.2, and a notice naming the
+harness instead. One method still draws the picker: confirming a step that
+takes over the terminal is worth one keystroke.
+
+### 8.2 In-session command
+
+`/login` opens the picker at an idle prompt, and reports "this harness
+advertises no authentication methods" when there are none — the same shape as
+`/route`'s refusal on a non-routable session.
+
+### 8.3 `providers login claude-code`
+
+The hardcoded `claude auth login` spawn in
+[`commands.rs:699`](../apps/bitrouter/src/commands.rs) is deleted. The harness
+login path becomes: connect, read `authMethods`, run §7. Until Phase 3 lands,
+the existing path stays but frames its handoff explicitly and, on failure,
+names the step that failed rather than relaying an exit code.
+
+The provider-credential meaning of `providers login <id>` is untouched.
+
+## 9. Component changes
+
+### 9.1 `bitrouter-sdk`
+
+- `ClientOptions` gains a way for the caller to declare terminal-auth support;
+  the client sets `clientCapabilities.auth.terminal` from it. Defaults to
+  false, so no existing caller changes behavior.
+- A retained, parsed `auth_methods` on `AcpClient`, read at handshake, with an
+  accessor. Parsed like `route_control` is: read once, off the response,
+  never re-derived from the agent's name.
+- An `auth_required` predicate over ACP errors, so every consumer agrees on
+  what the state looks like.
+- The controller is **unchanged**. `authenticate` already rides the verbatim
+  forwarding path, and `authMethods` already arrives from the harness
+  untouched.
+
+### 9.2 `bitrouter-tui`
+
+- `auth::Prompt` — the picker, built from the advertised methods. `open`
+  returns `None` for an empty list, mirroring `picker::Picker::open`.
+- The footer gains no row: the picker is a modal, and the modal slot exists.
+- `machine`: a `Phase::Authenticating(auth::Prompt)` reachable only from
+  `Phase::Idle`, and the `Effect`s for selecting, handing over the terminal,
+  and reconnecting.
+- No harness knowledge enters this crate. The descriptor arrives as data.
+
+### 9.3 `apps/bitrouter`
+
+- Declares terminal-auth support for `chat` and `spawn`, and not under an
+  explicit `--base-url` (§6.2).
+- Owns the process spawn, since it owns the harness command — the crate
+  boundary already forbids the renderer from reaching it.
+- Loses the per-harness login recipe (§8.3).
+
+## 10. Phasing
+
+| Phase | Content | Independently useful? |
+|---|---|---|
+| 1 — **shipped** | Wire `auth.terminal` as a caller parameter (sent `false`, per §6.2); retain `authMethods`; `is_auth_required` predicate; report auth state in a sentence naming the harness and its methods | Yes — kills the raw-error failure mode with no new UI |
+| 2 | The picker, `/login`, the terminal handoff, reconnect-and-retry; flip `terminal_auth` to `true` on the controlled paths | Yes — completes axis A |
+| 3 | Delete the hardcoded harness login; `providers login claude-code` routes through §7 | Yes — removes the duplicated knowledge |
+
+Phase 1 is worth landing alone: most of the observed pain in §5.3 is a missing
+sentence, not a missing flow.
+
+## 11. Open questions
+
+1. **`auth/status`.** The Draft RFD (accepted 2026-07-21) adds an `auth/status`
+   method precisely because `session/new` is an unreliable detector, and its
+   status quo section names the failure we observed: harnesses that "do so
+   lazily (e.g., on the first LLM call)" leave users to "encounter errors
+   mid-flow." It is not stabilized, so §7.2 does not depend on it. Adopt when
+   it stabilizes, and treat §7.2's error-driven detection as the fallback.
+2. **`_meta["terminal-auth"]` compatibility.** Zed carries a pre-stabilization
+   fallback (§4.3). Whether any harness BitRouter launches still relies on it,
+   rather than the stabilized descriptor, is unmeasured. Do not implement the
+   fallback speculatively.
+3. **Does the `spawn`/`serve` path want the flow at all, or only the report?**
+   A headless sub-agent has no person at a terminal. The likely answer is that
+   `spawn` advertises the capability (it can reproduce the invocation) but a
+   non-interactive session reports auth-required as a structured NDJSON error
+   and exits, rather than taking a terminal nobody is watching. Unresolved.
+4. **Reconnect cost.** §7.3 step 3 reconnects and reinitializes, per the RFD.
+   For `chat` this discards the ACP connection but not the transcript, which is
+   in scrollback. Whether anything else in a live session must survive the
+   reconnect is unaudited.
+
+## 12. Acceptance
+
+Pinned by test, in the house's style — a failing build rather than a missed
+review:
+
+1. A client that cannot reproduce the invocation does not advertise
+   `auth.terminal` (§6.2).
+2. A harness advertising no methods draws no picker (§6.2, §8.1).
+3. Cancelling the picker, and a non-zero login exit, both leave the session
+   unauthenticated (§6.3).
+4. An axis-A message never names a provider or `providers login`, and an
+   axis-B message never names an auth method (§6.4).
+5. No string matching a harness login command appears outside a test in
+   `apps/bitrouter` after Phase 3 (§6.1) — checked against the sources the way
+   `crate::chat`'s reachability guard is.
+6. A `terminal` method is never passed to `authenticate` (§4.1).

--- a/docs/ACP_AUTH_SPEC.md
+++ b/docs/ACP_AUTH_SPEC.md
@@ -224,6 +224,11 @@ authentication may be written in BitRouter. Every one comes from an
 `AuthMethodTerminal` descriptor, or the flow is not offered. A harness that
 declares nothing gets a pointer to its own documentation, never a guess.
 
+**Scoped to axis A.** This governs agent authentication. It does *not* reach
+`providers login <id>`, where a provider's vendor CLI (`claude`, `codex`,
+`grok`, `agy`) is the credential's actual source and naming it is unavoidable —
+see §8.3.
+
 ### 6.2 A control that cannot act is absent, not dead
 
 `auth.terminal` is advertised **only** where BitRouter can both reproduce the
@@ -331,11 +336,25 @@ advertises no authentication methods" when there are none — the same shape as
 
 ### 8.3 `providers login claude-code`
 
-The hardcoded `claude auth login` spawn in
-[`commands.rs:699`](../apps/bitrouter/src/commands.rs) is deleted. The harness
-login path becomes: connect, read `authMethods`, run §7. Until Phase 3 lands,
-the existing path stays but frames its handoff explicitly and, on failure,
-names the step that failed rather than relaying an exit code.
+**The `claude auth login` spawn stays.** An earlier draft had it deleted and
+routed through §7. That was wrong, on two counts:
+
+- **It is not this axis.** `claude-code` here is a *provider*, and the `claude`
+  CLI is its vendor tool — the same relationship `import_cli_for` already has
+  with the Codex, Grok, and Antigravity CLIs. The credential it acquires serves
+  the daemon's routing, not any ACP session.
+- **It would couple provider login to ACP.** Reaching the descriptor means
+  launching an adapter — `npx`, a download, a controller — to learn a command,
+  in order to acquire a credential that has nothing to do with ACP. A user with
+  no adapter installed could no longer log in to a provider.
+
+Doing it would also re-conflate the two axes §6.4 exists to separate.
+
+What *was* wrong is the seam, and that is fixed on its own terms: the handoff
+is announced before it happens and ruled off at both ends, so a person can see
+that the prompts belong to another program; and a failure states that the
+sign-in did not complete, notes the browser-code step, and names
+`claude auth status` — rather than relaying an exit code.
 
 The provider-credential meaning of `providers login <id>` is untouched.
 
@@ -378,8 +397,30 @@ The provider-credential meaning of `providers login <id>` is untouched.
 | Phase | Content | Independently useful? |
 |---|---|---|
 | 1 — **shipped** | Wire `auth.terminal` as a caller parameter (sent `false`, per §6.2); retain `authMethods`; `is_auth_required` predicate; report auth state in a sentence naming the harness and its methods | Yes — kills the raw-error failure mode with no new UI |
-| 2 | The picker, `/login`, the terminal handoff, reconnect-and-retry; flip `terminal_auth` to `true` on the controlled paths | Yes — completes axis A |
-| 3 | Delete the hardcoded harness login; `providers login claude-code` routes through §7 | Yes — removes the duplicated knowledge |
+| 2 — **shipped** | The method prompt, the terminal handoff, reconnect-and-retry; `terminal_auth` opted into by interactive `chat` | Yes — completes axis A |
+| 3 — **shipped, revised** | Fix the `providers login claude-code` handoff seam. *Not* the original "delete the hardcoded login and route through §7", which §8.3 explains was wrong | Yes — fixes the reported UX failure |
+
+### 10.1 What phase 2 proved
+
+`claude-agent-acp@0.70.0`, probed directly, advertises exactly one method:
+
+```json
+{ "id": "claude-login", "name": "Log in with Claude",
+  "description": "Run `claude /login` in the terminal",
+  "type": "terminal", "args": ["--cli"] }
+```
+
+…**and only when the client advertised `auth.terminal`**. Probed without it,
+`authMethods` is `[]`. Two things follow, and both are load-bearing:
+
+- The capability gate in §6.2 is enforced by real adapters, not just specified.
+  A client that declines the capability is told nothing at all, which is why
+  phase 1 alone would have reported "advertises no authentication method" for
+  every Claude session.
+- The terminal flow is not speculative. The one harness this repo configures by
+  default uses it, and `agentCapabilities.providers` on that same response is
+  `null` — so claude-acp is routed by env injection only, and
+  `configure_provider` never fires for it.
 
 Phase 1 is worth landing alone: most of the observed pain in §5.3 is a missing
 sentence, not a missing flow.


### PR DESCRIPTION
## What this does

Makes ACP the source of truth for **agent authentication**: BitRouter now reads what a harness says about its own auth instead of guessing, offers what the harness advertised, and runs the choice.

Adds `docs/ACP_AUTH_SPEC.md` and implements phases 1–3.

## Why

`AcpClient` read `initialize` and kept only `routeControl`, so `authMethods` — the agent's own statement of how it is authenticated — arrived and was dropped. An unauthenticated harness then surfaced as a raw JSON-RPC error, leaving the reader to guess whether it needed a login or the route was dead.

Separately, `ClientCapabilities` has two differently-scoped fields spelled `terminal`: the tooling surface ACP v2 removes, and `auth.terminal`, stabilized in **both** v1 and v2. The comment declining client capabilities reasoned about the first; the two were conflated, and a stabilized auth mechanism went unused as a side effect. That is the whole of the blocking defect — the types were already vendored in the pinned `agent-client-protocol-schema =1.7.0`.

## What changed

**`bitrouter-sdk`**
- `ClientOptions::terminal_auth` wires `clientCapabilities.auth.terminal` as a caller-supplied parameter, never an inference
- `AcpClient::auth_methods()` retains what the agent advertised
- `AcpClient::authenticate` answers `authenticate` for agent-performed methods
- `is_auth_required` classifies by error code, never message text — the rule `RouteError::from_rpc` already follows

**`apps/bitrouter`**
- all three `session/new` sites report an auth failure by naming the harness and what it offers
- a numbered prompt offers the advertised methods; a `terminal` method routes to the out-of-band flow and never to `authenticate`, which ACP forbids
- `run_terminal_login` relaunches the harness's *own* configured program with the descriptor's `args`/`env`; the command is never the descriptor's, so an agent cannot point the client at another binary
- `chat` retries `session/new` after a login, at most once
- `providers login claude-code`'s handoff to `claude auth login` is announced and ruled off at both ends

## Design decisions worth review

**The prompt is a cooked-terminal one, not a TUI modal.** `auth_required` comes from `session/new`, which runs before the renderer opens. The spec originally had a TUI modal and a `/login` command; building it showed that shape was incoherent. Consequence: `bitrouter-tui` needed **no changes**, which is the right outcome for a crate whose charter is that it draws and does not read.

**`terminal_auth` is off by default and only interactive `chat` opts in.** An agent may offer a `terminal` method only when the client claimed support, so `serve`, `prompt`, and a piped `chat` must not claim it — offering a login into a pipe would hang a program nobody is watching.

**The two auth axes are never conflated.** Agent authentication and the daemon's upstream provider credential are different things; an agent-auth message never mentions providers, routes, or `providers login`. Pinned by test.

**Phase 3 was revised, not implemented as specified.** The original "delete the hardcoded `claude auth login` and route it through the ACP flow" was wrong: `claude-code` there is a *provider* and `claude` is its vendor CLI, the same relationship `import_cli_for` has with the Codex, Grok, and Antigravity CLIs. Routing it through a harness would make provider login require an ACP adapter to acquire a credential unrelated to ACP. §8.3 records why the spawn stays; the seam was fixed on its own terms.

## Verification

Probed both adapters directly and drove the flow against a live harness.

Verified end to end against `codex-acp` 1.8.0: `auth_required` detection, retained `authMethods`, the picker reading a typed digit, `authenticate` performing a real sign-in that persisted a credential, the `session/new` retry, and a full TUI turn (`ctx 16.7k/258.4k`, `[EndTurn]`).

Also confirmed the capability gate is enforced by real adapters, not merely specified: `claude-agent-acp@0.70.0` advertises its `terminal` method **only** when the client sends `auth.terminal` — without it, `authMethods` is empty.

`cargo nextest run --all-features`: 2906 passed. `cargo clippy --all-features` and `cargo fmt --check` clean.

## Known gaps

Tracked, not hidden:

- #858 — the typed-decline branch is unverified; declining was confirmed only via EOF, which returns the same result through a different branch
- #859 — `run_terminal_login` is unreachable by any available harness: `claude-agent-acp` advertises a `terminal` method but does not gate `session/new`, and `codex-acp` gates but offers only `agent`-type methods

The second matters beyond testing: the flow cannot fire for the default harness, which is what `auth/status` (spec §11.1) exists to fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
