### PR TITLE
test(acp): make the auth-method choice testable without a tty

### DIFF
--- a/apps/bitrouter/src/acp_cli.rs
+++ b/apps/bitrouter/src/acp_cli.rs
@@ -1349,7 +1349,6 @@ fn choose_auth_method(
     agent_id: &str,
     methods: &[agent_client_protocol::schema::v1::AuthMethod],
 ) -> Result<AuthChoice> {
-    use agent_client_protocol::schema::v1::AuthMethod;
     use std::io::{BufRead, IsTerminal as _};
 
     if methods.is_empty() || !std::io::stdin().is_terminal() {
@@ -1381,33 +1380,51 @@ fn choose_auth_method(
             eprintln!();
             return Ok(AuthChoice::Declined);
         }
-        let trimmed = line.trim();
-        let index = if trimmed.is_empty() {
-            1
-        } else {
-            match trimmed.parse::<usize>() {
-                Ok(0) => return Ok(AuthChoice::Declined),
-                Ok(n) if (1..=methods.len()).contains(&n) => n,
-                Ok(n) => {
-                    eprintln!(
-                        "    choice must be between 0 and {}, got {n}",
-                        methods.len()
-                    );
-                    continue;
-                }
-                Err(_) => {
-                    eprintln!("    '{trimmed}' is not a number");
-                    continue;
-                }
-            }
-        };
-        return Ok(match &methods[index - 1] {
-            // ACP is explicit that a terminal method is never passed to
-            // `authenticate`: the interactive process is not the connection.
-            AuthMethod::Terminal(terminal) => AuthChoice::Terminal(Box::new(terminal.clone())),
-            other => AuthChoice::Agent(other.id().clone()),
-        });
+        match classify_choice(&line, methods) {
+            Some(choice) => return Ok(choice),
+            // Not a selection: say why, then ask again.
+            None => match line.trim().parse::<usize>() {
+                Ok(n) => eprintln!(
+                    "    choice must be between 0 and {}, got {n}",
+                    methods.len()
+                ),
+                Err(_) => eprintln!("    '{}' is not a number", line.trim()),
+            },
+        }
     }
+}
+
+/// Classify one typed line against the offered methods.
+///
+/// Pure, so the interesting half of the picker is testable without a terminal:
+/// `choose_auth_method` owns stdin and the menu, this owns what the answer
+/// means. The same split `Editor::apply` and `machine::step` already use.
+///
+/// `0` cancels, an empty line takes the `[1]` default, and `1..=methods.len()`
+/// selects. Anything else is `None` — not a selection, ask again. Out-of-range
+/// never wraps onto a method that was not offered.
+fn classify_choice(
+    input: &str,
+    methods: &[agent_client_protocol::schema::v1::AuthMethod],
+) -> Option<AuthChoice> {
+    use agent_client_protocol::schema::v1::AuthMethod;
+
+    let trimmed = input.trim();
+    let index = if trimmed.is_empty() {
+        1
+    } else {
+        match trimmed.parse::<usize>() {
+            Ok(0) => return Some(AuthChoice::Declined),
+            Ok(n) if (1..=methods.len()).contains(&n) => n,
+            Ok(_) | Err(_) => return None,
+        }
+    };
+    Some(match methods.get(index - 1)? {
+        // ACP is explicit that a terminal method is never passed to
+        // `authenticate`: the interactive process is not the connection.
+        AuthMethod::Terminal(terminal) => AuthChoice::Terminal(Box::new(terminal.clone())),
+        other => AuthChoice::Agent(other.id().clone()),
+    })
 }
 
 /// Run a `terminal` method's login: the harness's **own** program, relaunched
@@ -2322,7 +2339,17 @@ pub fn launch_options(turn_timeout_secs: Option<u64>) -> LaunchOptions {
 mod auth_report_tests {
     use agent_client_protocol::schema::v1::{AuthMethod, AuthMethodAgent, AuthMethodTerminal};
 
-    use super::{AuthChoice, LaunchOptions, choose_auth_method, unauthenticated_message};
+    use super::{
+        AuthChoice, LaunchOptions, choose_auth_method, classify_choice, unauthenticated_message,
+    };
+
+    /// Two `agent` methods, in the order the picker numbers them.
+    fn two_methods() -> Vec<AuthMethod> {
+        vec![
+            AuthMethod::Agent(AuthMethodAgent::new("oauth", "Sign in with Anthropic")),
+            AuthMethod::Agent(AuthMethodAgent::new("api-key", "Paste an API key")),
+        ]
+    }
 
     /// **A control that cannot act is absent** (ACP_AUTH_SPEC §6.2). Only the
     /// interactive caller may claim it can run a terminal login; every other
@@ -2352,23 +2379,74 @@ mod auth_report_tests {
         );
     }
 
+    /// **Cancelling never authenticates** (ACP_AUTH_SPEC §6.3). The typed
+    /// decline is its own branch, distinct from the EOF one that returns the
+    /// same answer — this is the branch a live terminal was needed to reach.
+    #[test]
+    fn a_typed_zero_declines() {
+        assert!(
+            matches!(
+                classify_choice("0", &two_methods()),
+                Some(AuthChoice::Declined)
+            ),
+            "'0' is the cancel entry the menu prints"
+        );
+    }
+
+    /// A bare enter takes the `[1]` the prompt shows as the default — the
+    /// offer on screen and the answer must not disagree.
+    #[test]
+    fn a_bare_enter_takes_the_advertised_default() {
+        let Some(AuthChoice::Agent(id)) = classify_choice("\n", &two_methods()) else {
+            panic!("an empty line selects the first method")
+        };
+        assert_eq!(
+            id.to_string(),
+            "oauth",
+            "the default is the '[1]' on screen"
+        );
+    }
+
+    /// The numbering is the menu's, one-based.
+    #[test]
+    fn a_digit_selects_that_numbered_method() {
+        let Some(AuthChoice::Agent(id)) = classify_choice("2", &two_methods()) else {
+            panic!("'2' selects the second method")
+        };
+        assert_eq!(id.to_string(), "api-key", "numbering starts at one");
+    }
+
+    /// Out of range is not a selection. Nothing wraps onto an index the
+    /// harness never offered — the alternative is authenticating with a method
+    /// nobody was shown.
+    #[test]
+    fn an_unoffered_index_is_not_a_selection() {
+        assert!(
+            classify_choice("9", &two_methods()).is_none(),
+            "'9' against two methods must re-prompt, not wrap"
+        );
+    }
+
+    /// Anything that is not a number re-prompts rather than resolving.
+    #[test]
+    fn a_non_number_is_not_a_selection() {
+        assert!(
+            classify_choice("x", &two_methods()).is_none(),
+            "'x' must re-prompt"
+        );
+    }
+
     /// A `terminal` method is routed to the out-of-band flow, never to
     /// `authenticate` — ACP forbids passing it there because the interactive
     /// process is not the ACP connection.
     #[test]
     fn a_terminal_method_never_becomes_an_authenticate_call() {
-        let terminal = AuthMethod::Terminal(
+        let methods = vec![AuthMethod::Terminal(
             AuthMethodTerminal::new("login", "Log in from the terminal")
                 .args(vec!["--login".to_string()]),
-        );
-        // Classification is the branch `choose_auth_method` takes on a chosen
-        // method; assert on the shape it must produce.
-        assert!(
-            matches!(&terminal, AuthMethod::Terminal(_)),
-            "the fixture is the terminal variant"
-        );
-        let AuthMethod::Terminal(descriptor) = &terminal else {
-            unreachable!("matched above")
+        )];
+        let Some(AuthChoice::Terminal(descriptor)) = classify_choice("1", &methods) else {
+            panic!("a terminal method classifies to the out-of-band branch")
         };
         assert_eq!(
             descriptor.args,

--- a/apps/bitrouter/src/commands.rs
+++ b/apps/bitrouter/src/commands.rs
@@ -448,15 +448,37 @@ fn prompt_method_choice(provider: &str, options: &[AuthMethod]) -> Result<AuthMe
         if n_bytes == 0 {
             anyhow::bail!("stdin closed before a choice was made");
         }
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            return Ok(options[0]);
+        match classify_method_choice(&line, options) {
+            Some(method) => return Ok(method),
+            // Not a selection: say why, then ask again.
+            None => match line.trim().parse::<usize>() {
+                Ok(n) => eprintln!("  choice must be between 1 and {}, got {n}", options.len()),
+                Err(_) => eprintln!("  '{}' is not a number", line.trim()),
+            },
         }
-        match trimmed.parse::<usize>() {
-            Ok(n) if (1..=options.len()).contains(&n) => return Ok(options[n - 1]),
-            Ok(n) => eprintln!("  choice must be between 1 and {}, got {n}", options.len()),
-            Err(_) => eprintln!("  '{trimmed}' is not a number"),
-        }
+    }
+}
+
+/// Classify one typed line against the offered methods.
+///
+/// Pure, so the interesting half of the picker is testable without a terminal:
+/// `prompt_method_choice` owns stdin and the menu, this owns what the answer
+/// means. The same split `classify_choice` gives the ACP picker, and the one
+/// `Editor::apply` and `machine::step` are built on.
+///
+/// An empty line takes the `[1]` default and `1..=options.len()` selects.
+/// Anything else is `None` — not a selection, ask again. Out-of-range never
+/// wraps onto a method that was not offered, and this menu has no cancel entry,
+/// so `0` is out of range like any other unoffered index. Callers offer at
+/// least one method; an empty slice selects nothing.
+fn classify_method_choice(input: &str, options: &[AuthMethod]) -> Option<AuthMethod> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return options.first().copied();
+    }
+    match trimmed.parse::<usize>() {
+        Ok(n) if (1..=options.len()).contains(&n) => options.get(n - 1).copied(),
+        Ok(_) | Err(_) => None,
     }
 }
 
@@ -1274,6 +1296,63 @@ mod tests {
         assert!(methods.contains(&AuthMethod::ImportFromCli));
         assert!(methods.contains(&AuthMethod::PkceSubscription));
         assert!(!methods.contains(&AuthMethod::ClaudeCodeSession));
+    }
+
+    /// The picker's two offered methods, in the order it numbers them.
+    fn two_methods() -> Vec<AuthMethod> {
+        vec![AuthMethod::ImportFromCli, AuthMethod::PkceSubscription]
+    }
+
+    /// A bare enter takes the `[1]` the prompt shows as the default — the offer
+    /// on screen and the answer must not disagree.
+    #[test]
+    fn a_bare_enter_takes_the_advertised_default() {
+        assert_eq!(
+            classify_method_choice("\n", &two_methods()),
+            Some(AuthMethod::ImportFromCli),
+            "the default is the '[1]' on screen"
+        );
+    }
+
+    /// The numbering is the menu's, one-based.
+    #[test]
+    fn a_digit_selects_that_numbered_method() {
+        assert_eq!(
+            classify_method_choice("2", &two_methods()),
+            Some(AuthMethod::PkceSubscription),
+            "numbering starts at one"
+        );
+    }
+
+    /// Out of range is not a selection. Nothing wraps onto an index the
+    /// provider never offered — the alternative is running a login flow nobody
+    /// was shown.
+    #[test]
+    fn an_unoffered_index_is_not_a_selection() {
+        assert!(
+            classify_method_choice("9", &two_methods()).is_none(),
+            "'9' against two methods must re-prompt, not wrap"
+        );
+    }
+
+    /// Unlike the ACP auth picker, this menu prints no `0) cancel` entry, so
+    /// zero is an unoffered index like any other and re-prompts. Aborting here
+    /// is Ctrl-C, not a hidden entry.
+    #[test]
+    fn zero_is_out_of_range_because_this_menu_offers_no_cancel() {
+        assert!(
+            classify_method_choice("0", &two_methods()).is_none(),
+            "'0' selects nothing on a menu that starts at one"
+        );
+    }
+
+    /// Anything that is not a number re-prompts rather than resolving.
+    #[test]
+    fn a_non_number_is_not_a_selection() {
+        assert!(
+            classify_method_choice("x", &two_methods()).is_none(),
+            "'x' must re-prompt"
+        );
     }
 
     #[test]

--- a/crates/bitrouter-sdk/src/acp/client.rs
+++ b/crates/bitrouter-sdk/src/acp/client.rs
@@ -436,7 +436,7 @@ impl RouteControlCapability {
 ///
 /// Classified by **error code** (`auth_required`, -32000), never by message
 /// text, so every consumer agrees on what the state looks like — the same rule
-/// [`RouteError::from_rpc`] follows.
+/// [`RouteError`] classification follows.
 ///
 /// A `false` here is not a claim that the agent *is* authenticated. ACP does
 /// not require `session/new` to check authorization at all: some agents verify


### PR DESCRIPTION
Closes #858. Stacked on #860 — `choose_auth_method` only exists on that branch, so this targets it rather than `main`.

## What this does

Splits both interactive method pickers into a pure classifier and an I/O shell:

```rust
// apps/bitrouter/src/acp_cli.rs — the harness auth picker
fn classify_choice(input: &str, methods: &[AuthMethod]) -> Option<AuthChoice>  // pure
fn choose_auth_method(...) -> Result<AuthChoice>                               // I/O shell

// apps/bitrouter/src/commands.rs — the provider login picker
fn classify_method_choice(input: &str, options: &[AuthMethod]) -> Option<AuthMethod>  // pure
fn prompt_method_choice(...) -> Result<AuthMethod>                                    // I/O shell
```

`None` means "not a selection, re-prompt". No behaviour change in either — same menus, same notes, same answers.

## Why

Each function mixed three jobs: gating on a tty, printing the menu, and classifying the typed input. Only the third is interesting, and it was the one that could not be tested, because it reads real stdin.

That showed up during #860's manual verification. Declining was confirmed only via **EOF**, which returns `Declined` through the zero-byte branch. A typed `0` returns `Declined` through a *different* branch and prints the identical message, so the two are indistinguishable from the outside — and the typed path had never been exercised. Re-reaching the picker by hand needs a throwaway credential store, since a harness holding credentials stops offering it at all.

## Why this shape

The existing house pattern, not a new one. `Editor::apply` is deliberately a pure state machine over already-decoded key events so that who owns stdin stays the caller's, and `machine::step` is a pure reducer for the same reason. These were the two input paths in the auth work that had not had that treatment.

Each shell keeps exactly one decision: which of the two rejection notes to print before asking again.

## The two pickers stay different, deliberately

They are not merged, and the differences are now pinned rather than incidental:

| | ACP harness picker | Provider login picker |
|---|---|---|
| `0` | `Declined` — the menu prints `0) cancel` | out of range, re-prompts — no cancel entry |
| EOF | `Declined` | an error; aborting is Ctrl-C |
| no tty | declines without prompting | not gated |

A test pins the `0` case on the provider side so the two are not later "fixed" into agreement.

## Tests

Eleven, none needing a tty.

**`classify_choice`** (ACP):
- `"0"` → `Declined` — the typed decline branch, distinct from EOF (ACP_AUTH_SPEC §6.3)
- `""` (bare enter) → the first method, matching the `[1]` the prompt advertises
- `"2"` → the second method
- `"9"` against two methods → `None` — no wraparound onto an index nobody was offered
- `"x"` → `None`
- an `AuthMethod::Terminal` entry → the out-of-band branch, never `authenticate` (ACP forbids passing a terminal method there)

The last replaces a test that asserted on a fixture it built itself rather than on what the function returns.

**`classify_method_choice`** (provider login): the same bare-enter, second-method, out-of-range and non-number cases, plus `"0"` being out of range on a menu that offers no cancel.

## Also

Selection on the provider side reads through `first()`/`get()` rather than indexing, so an empty option list selects nothing instead of panicking. Callers already bail before offering an empty list; this only stops the unreachable case being a panic.

## Verification

`cargo nextest run --all-features`: 2916 passed. `cargo clippy --all-features` and `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
