### PR TITLE
fix(telemetry): unblock publishing by dropping a dev-dep version

### DIFF
--- a/crates/bitrouter-telemetry/Cargo.toml
+++ b/crates/bitrouter-telemetry/Cargo.toml
@@ -120,7 +120,15 @@ __otel-core = [
 # no production callers, here or anywhere. This crate's conformance tests are
 # the beneficiary, so the feature is enabled here and nowhere else. It carries
 # no dependency of its own.
-bitrouter-sdk = { workspace = true, features = ["testing"] }
+#
+# Path-only on purpose — NOT `workspace = true`, which would inherit a
+# `version` alongside the path. `cargo package` resolves a versioned
+# dev-dependency against the *registry*, and the published `bitrouter-sdk`
+# 1.0.0-alpha.27 predates the `testing` feature, so inheriting the version made
+# `cargo publish` fail on a feature that exists only in this tree. Dropping the
+# version makes cargo strip this entry from the packaged manifest, which is
+# correct: it is a test-only edge that no consumer of the published crate has.
+bitrouter-sdk = { path = "../bitrouter-sdk", features = ["testing"] }
 tokio = { workspace = true, features = [
     "sync",
     "rt",


### PR DESCRIPTION
## What broke

`Release-plz release` failed on `main` right after #851 merged ([run](https://github.com/bitrouter/bitrouter/actions/runs/33850016651/job/100950456149)):

```
package `bitrouter-telemetry` depends on `bitrouter-sdk` with feature `testing`
but `bitrouter-sdk` does not have that feature.
help: available features: acp, config_file, default, mcp, server
```

## Why

The feature does exist — #851 added it — but only in this tree.

`bitrouter-sdk` 1.0.0-alpha.27 has been on crates.io since **2026-07-18**, and the workspace still carries that same version. So release-plz logged `already published` for the SDK and skipped it. `bitrouter-telemetry` is the one crate at alpha.27 that is *not* published, so it alone got packaged — and `cargo package` resolves a **versioned dev-dependency against the registry**, where alpha.27 predates `testing`.

Nothing was published and no tag was pushed, so there is no partial release to unwind.

## The fix

The dev-dependency takes the path without inheriting the workspace version. Cargo strips a dev-dependency carrying no version requirement when packaging — the correct outcome here, since it is a test-only edge on a feature documented as having no production callers, which no consumer of the published crate can observe.

Verified on the packaged manifest (`[dev-dependencies.bitrouter-sdk]` gone, real `[dependencies.bitrouter-sdk]` kept) and with a full `cargo package -p bitrouter-telemetry`, which compiles against the **registry** copy of the SDK the way CI does.

## Separate problem, not fixed here

`bitrouter-sdk` cannot be published at all right now. On clean `main`:

```
cargo package -p bitrouter-sdk
error: all dependencies must have a version requirement specified when packaging.
dependency `agent-client-protocol` does not specify a version
```

Its ACP dependencies are git-only. This predates #851 and is masked today because the version has not moved since July, so release-plz keeps skipping the crate — **the next version bump will hit it.** Fixing it needs a decision (publish/vendor the ACP crates, or drop `acp` from the published SDK), so it is called out rather than patched here.

## Verification

2963 tests pass; `cargo fmt --check` clean. `bitrouter-guardrails`, `bitrouter-mcp` and `bitrouter-providers` all still package cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)