### PR TITLE
feat(registry): add dated DeepSeek V4 routes

### DIFF
--- a/dist/registry/models.json
+++ b/dist/registry/models.json
@@ -2075,10 +2075,10 @@
           "pricing": {
             "input_tokens": {
               "cache_read": 0.028,
-              "no_cache": 0.14
+              "no_cache": 0.44
             },
             "output_tokens": {
-              "text": 0.28
+              "text": 1.32
             }
           },
           "provider": "atlascloud",
@@ -2126,6 +2126,20 @@
           "rate_limits": {
             "requests_per_minute": 60
           }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.014,
+              "no_cache": 0.44
+            },
+            "output_tokens": {
+              "text": 1.32
+            }
+          },
+          "provider": "gmicloud",
+          "provider_model_id": "deepseek-ai/DeepSeek-V4-Flash-0731"
         },
         {
           "api_protocol": [
@@ -2187,6 +2201,20 @@
           "pricing": {
             "input_tokens": {
               "cache_read": 0.028,
+              "no_cache": 0.44
+            },
+            "output_tokens": {
+              "text": 1.32
+            }
+          },
+          "provider": "phala",
+          "provider_model_id": "deepseek/deepseek-v4-flash-0731"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.028,
               "no_cache": 0.14
             },
             "output_tokens": {
@@ -2195,6 +2223,34 @@
           },
           "provider": "qianfan",
           "provider_model_id": "deepseek-v4-flash-0731"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.028,
+              "no_cache": 0.44
+            },
+            "output_tokens": {
+              "text": 1.32
+            }
+          },
+          "provider": "redpill",
+          "provider_model_id": "deepseek/deepseek-v4-flash-0731"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.028,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider": "siliconflow",
+          "provider_model_id": "deepseek-ai/DeepSeek-V4-Flash-0731"
         },
         {
           "api_protocol": [
@@ -2551,6 +2607,20 @@
           "api_protocol": "openai",
           "pricing": {
             "input_tokens": {
+              "cache_read": 0.132,
+              "no_cache": 1.32
+            },
+            "output_tokens": {
+              "text": 3.96
+            }
+          },
+          "provider": "atlascloud",
+          "provider_model_id": "deepseek-ai/deepseek-v4-pro-0813"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
               "cache_read": 0.003625,
               "no_cache": 0.435
             },
@@ -2587,6 +2657,20 @@
           }
         },
         {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.044,
+              "no_cache": 1.32
+            },
+            "output_tokens": {
+              "text": 3.96
+            }
+          },
+          "provider": "gmicloud",
+          "provider_model_id": "deepseek-ai/DeepSeek-V4-Pro-0813"
+        },
+        {
           "api_protocol": [
             "openai",
             "responses",
@@ -2603,6 +2687,34 @@
           },
           "provider": "openrouter",
           "provider_model_id": "deepseek/deepseek-v4-pro-0813"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.15,
+              "no_cache": 1.45
+            },
+            "output_tokens": {
+              "text": 4.36
+            }
+          },
+          "provider": "redpill",
+          "provider_model_id": "deepseek/deepseek-v4-pro-0813"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.44,
+              "no_cache": 1.32
+            },
+            "output_tokens": {
+              "text": 3.96
+            }
+          },
+          "provider": "siliconflow",
+          "provider_model_id": "deepseek-ai/DeepSeek-V4-Pro-0813"
         },
         {
           "api_protocol": [

--- a/dist/registry/providers.json
+++ b/dist/registry/providers.json
@@ -1445,6 +1445,20 @@
         },
         {
           "api_protocol": "openai",
+          "id": "deepseek/deepseek-v4-pro-0813",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.132,
+              "no_cache": 1.32
+            },
+            "output_tokens": {
+              "text": 3.96
+            }
+          },
+          "provider_model_id": "deepseek-ai/deepseek-v4-pro-0813"
+        },
+        {
+          "api_protocol": "openai",
           "id": "deepseek/deepseek-v4-flash",
           "pricing": {
             "input_tokens": {
@@ -1463,10 +1477,10 @@
           "pricing": {
             "input_tokens": {
               "cache_read": 0.028,
-              "no_cache": 0.14
+              "no_cache": 0.44
             },
             "output_tokens": {
-              "text": 0.28
+              "text": 1.32
             }
           },
           "provider_model_id": "deepseek-ai/deepseek-v4-flash-0731"
@@ -4251,6 +4265,20 @@
         },
         {
           "api_protocol": "openai",
+          "id": "deepseek/deepseek-v4-pro-0813",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.044,
+              "no_cache": 1.32
+            },
+            "output_tokens": {
+              "text": 3.96
+            }
+          },
+          "provider_model_id": "deepseek-ai/DeepSeek-V4-Pro-0813"
+        },
+        {
+          "api_protocol": "openai",
           "id": "deepseek/deepseek-v4-flash",
           "pricing": {
             "input_tokens": {
@@ -4262,6 +4290,20 @@
             }
           },
           "provider_model_id": "deepseek-ai/DeepSeek-V4-Flash"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "deepseek/deepseek-v4-flash-0731",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.014,
+              "no_cache": 0.44
+            },
+            "output_tokens": {
+              "text": 1.32
+            }
+          },
+          "provider_model_id": "deepseek-ai/DeepSeek-V4-Flash-0731"
         },
         {
           "api_protocol": "openai",
@@ -7656,6 +7698,20 @@
         },
         {
           "api_protocol": "openai",
+          "id": "deepseek/deepseek-v4-flash-0731",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.028,
+              "no_cache": 0.44
+            },
+            "output_tokens": {
+              "text": 1.32
+            }
+          },
+          "provider_model_id": "deepseek/deepseek-v4-flash-0731"
+        },
+        {
+          "api_protocol": "openai",
           "capabilities": [
             "reasoning",
             "tools"
@@ -8045,6 +8101,20 @@
         },
         {
           "api_protocol": "openai",
+          "id": "deepseek/deepseek-v4-pro-0813",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.15,
+              "no_cache": 1.45
+            },
+            "output_tokens": {
+              "text": 4.36
+            }
+          },
+          "provider_model_id": "deepseek/deepseek-v4-pro-0813"
+        },
+        {
+          "api_protocol": "openai",
           "capabilities": [
             "reasoning",
             "tools"
@@ -8059,6 +8129,20 @@
             }
           },
           "provider_model_id": "deepseek/deepseek-v4-flash"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "deepseek/deepseek-v4-flash-0731",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.028,
+              "no_cache": 0.44
+            },
+            "output_tokens": {
+              "text": 1.32
+            }
+          },
+          "provider_model_id": "deepseek/deepseek-v4-flash-0731"
         },
         {
           "api_protocol": "openai",
@@ -8175,6 +8259,20 @@
         },
         {
           "api_protocol": "openai",
+          "id": "deepseek/deepseek-v4-pro-0813",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.44,
+              "no_cache": 1.32
+            },
+            "output_tokens": {
+              "text": 3.96
+            }
+          },
+          "provider_model_id": "deepseek-ai/DeepSeek-V4-Pro-0813"
+        },
+        {
+          "api_protocol": "openai",
           "id": "deepseek/deepseek-v4-flash",
           "pricing": {
             "input_tokens": {
@@ -8186,6 +8284,20 @@
             }
           },
           "provider_model_id": "deepseek-ai/DeepSeek-V4-Flash"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "deepseek/deepseek-v4-flash-0731",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.028,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider_model_id": "deepseek-ai/DeepSeek-V4-Flash-0731"
         },
         {
           "api_protocol": "openai",

--- a/registry/providers/atlascloud.yaml
+++ b/registry/providers/atlascloud.yaml
@@ -1,4 +1,4 @@
-# Verified 2026-08-01 against the public
+# Verified 2026-09-05 against the public
 # `GET https://api.atlascloud.ai/v1/models` catalog and Atlas Cloud docs.
 # Atlas exposes an OpenAI-compatible LLM endpoint; catalog pricing is per token,
 # converted below to USD per 1M tokens. `openai/gpt-oss-120b` was removed because
@@ -50,6 +50,14 @@ models:
         cache_read: 0.13
       output_tokens:
         text: 3.38
+  - id: deepseek/deepseek-v4-pro-0813
+    provider_model_id: deepseek-ai/deepseek-v4-pro-0813
+    pricing:
+      input_tokens:
+        no_cache: 1.32
+        cache_read: 0.132
+      output_tokens:
+        text: 3.96
   - id: deepseek/deepseek-v4-flash
     provider_model_id: deepseek-ai/deepseek-v4-flash
     pricing:
@@ -63,10 +71,10 @@ models:
     provider_model_id: deepseek-ai/deepseek-v4-flash-0731
     pricing:
       input_tokens:
-        no_cache: 0.14
+        no_cache: 0.44
         cache_read: 0.028
       output_tokens:
-        text: 0.28
+        text: 1.32
   - id: deepseek/deepseek-v3.2
     provider_model_id: deepseek-ai/deepseek-v3.2
     pricing:

--- a/registry/providers/gmicloud.yaml
+++ b/registry/providers/gmicloud.yaml
@@ -30,6 +30,15 @@ models:
         cache_read: 0.116
       output_tokens:
         text: 2.784
+  # Verified 2026-09-05 against https://api.gmi-serving.com/v1/models.
+  - id: deepseek/deepseek-v4-pro-0813
+    provider_model_id: deepseek-ai/DeepSeek-V4-Pro-0813
+    pricing:
+      input_tokens:
+        no_cache: 1.32
+        cache_read: 0.044
+      output_tokens:
+        text: 3.96
   - id: deepseek/deepseek-v4-flash
     provider_model_id: deepseek-ai/DeepSeek-V4-Flash
     pricing:
@@ -38,6 +47,15 @@ models:
         cache_read: 0.022
       output_tokens:
         text: 0.224
+  # Verified 2026-09-05 against https://api.gmi-serving.com/v1/models.
+  - id: deepseek/deepseek-v4-flash-0731
+    provider_model_id: deepseek-ai/DeepSeek-V4-Flash-0731
+    pricing:
+      input_tokens:
+        no_cache: 0.44
+        cache_read: 0.014
+      output_tokens:
+        text: 1.32
   - id: moonshotai/kimi-k2.6
     provider_model_id: moonshotai/Kimi-K2.6
     pricing:

--- a/registry/providers/phala.yaml
+++ b/registry/providers/phala.yaml
@@ -12,7 +12,7 @@ api_protocol:
   - "*": openai
 auth_scheme: bearer
 kind: gateway
-# Phala Cloud confidential (GPU-TEE) inference gateway. Verified 2026-08-01
+# Phala Cloud confidential (GPU-TEE) inference gateway. Verified 2026-09-05
 # against the public `GET https://inference.phala.com/v1/models` catalog.
 # Distinct from the `redpill` provider, which uses `https://api.redpill.ai/v1`.
 # Prices below are the live catalog's per-token prices converted to USD per 1M.
@@ -37,6 +37,15 @@ models:
     capabilities:
       - reasoning
       - tools
+  # Catalog and model page: https://phala.com/models/deepseek/deepseek-v4-flash-0731
+  - id: deepseek/deepseek-v4-flash-0731
+    provider_model_id: deepseek/deepseek-v4-flash-0731
+    pricing:
+      input_tokens:
+        no_cache: 0.44
+        cache_read: 0.028
+      output_tokens:
+        text: 1.32
   - id: moonshotai/kimi-k2.6
     provider_model_id: moonshotai/kimi-k2.6
     pricing:

--- a/registry/providers/redpill.yaml
+++ b/registry/providers/redpill.yaml
@@ -12,10 +12,9 @@ api_protocol:
 auth_scheme: bearer
 kind: gateway
 doc_url: https://docs.redpill.ai/get-started/introduction
-# RedPill is Phala Network's confidential AI gateway. Verified 2026-08-01
-# against public `GET https://api.redpill.ai/v1/models`; the response currently
-# matches Phala's inference catalog for these models. Prices below are converted
-# from per-token catalog values to USD per 1M tokens.
+# RedPill is Phala Network's confidential AI gateway. Verified 2026-09-05
+# against public `GET https://api.redpill.ai/v1/models`. Prices below are
+# converted from per-token catalog values to USD per 1M tokens.
 models:
   - id: deepseek/deepseek-v4-pro
     provider_model_id: deepseek/deepseek-v4-pro
@@ -27,6 +26,15 @@ models:
     capabilities:
       - reasoning
       - tools
+  # Catalog and model page: https://redpill.ai/models/deepseek/deepseek-v4-pro-0813
+  - id: deepseek/deepseek-v4-pro-0813
+    provider_model_id: deepseek/deepseek-v4-pro-0813
+    pricing:
+      input_tokens:
+        no_cache: 1.45
+        cache_read: 0.15
+      output_tokens:
+        text: 4.36
   - id: deepseek/deepseek-v4-flash
     provider_model_id: deepseek/deepseek-v4-flash
     pricing:
@@ -37,6 +45,14 @@ models:
     capabilities:
       - reasoning
       - tools
+  - id: deepseek/deepseek-v4-flash-0731
+    provider_model_id: deepseek/deepseek-v4-flash-0731
+    pricing:
+      input_tokens:
+        no_cache: 0.44
+        cache_read: 0.028
+      output_tokens:
+        text: 1.32
   - id: moonshotai/kimi-k2.6
     provider_model_id: moonshotai/kimi-k2.6
     pricing:

--- a/registry/providers/siliconflow.yaml
+++ b/registry/providers/siliconflow.yaml
@@ -21,8 +21,28 @@ models:
         cache_read: 0.145
       output_tokens:
         text: 3.48
+  # Verified 2026-09-05 against the live catalog and official launch pricing:
+  # https://www.siliconflow.com/blog/deepseek-v4-pro-0813-now-live-on-siliconflow-enhanced-agent-capabilities-for-production-workflows
+  - id: deepseek/deepseek-v4-pro-0813
+    provider_model_id: deepseek-ai/DeepSeek-V4-Pro-0813
+    pricing:
+      input_tokens:
+        no_cache: 1.32
+        cache_read: 0.44
+      output_tokens:
+        text: 3.96
   - id: deepseek/deepseek-v4-flash
     provider_model_id: deepseek-ai/DeepSeek-V4-Flash
+    pricing:
+      input_tokens:
+        no_cache: 0.14
+        cache_read: 0.028
+      output_tokens:
+        text: 0.28
+  # Verified 2026-09-05 against the live catalog and official launch pricing:
+  # https://www.siliconflow.com/blog/deepseek-v4-flash-0731-now-live-on-siliconflow
+  - id: deepseek/deepseek-v4-flash-0731
+    provider_model_id: deepseek-ai/DeepSeek-V4-Flash-0731
     pricing:
       input_tokens:
         no_cache: 0.14


### PR DESCRIPTION
Several providers expose the dated DeepSeek V4 releases in their live catalogs, but the registry only routed the generic aliases. Atlas Cloud's existing Flash 0731 entry also retained an earlier, lower price.

This change adds the provider-specific mappings and verified per-million-token prices for:

- SiliconFlow: Flash 0731 and Pro 0813
- Atlas Cloud: Pro 0813, plus corrected Flash 0731 input/output pricing
- GMI Cloud: Flash 0731 and Pro 0813
- Phala: Flash 0731
- RedPill: Flash 0731 and Pro 0813

The source YAML records the live catalog or official model-page evidence, and the generated registry artifacts are rebuilt.

Validation:

- `cargo run -p dist-helper -- registry validate`
- `cargo run -p dist-helper -- registry build`
- `cargo run -p dist-helper -- check`
