### PR TITLE
fix(sdk): normalize routed stream usage

### DIFF
--- a/apps/bitrouter/tests/trajectory_progress_control.rs
+++ b/apps/bitrouter/tests/trajectory_progress_control.rs
@@ -2033,7 +2033,9 @@ async fn nonstream_exact_parent_detaches_once_with_equal_body_and_response() -> 
     );
     assert_eq!(followup["object"], "response");
     assert_eq!(followup["status"], "completed");
-    assert_eq!(followup["model"], "@auto");
+    // The response identifies the concrete model selected by the routing
+    // table, rather than echoing the virtual `@auto` request alias.
+    assert_eq!(followup["model"], "balanced-model");
     assert_eq!(
         followup["output"],
         json!([{

--- a/crates/bitrouter-sdk/src/config/routing_table.rs
+++ b/crates/bitrouter-sdk/src/config/routing_table.rs
@@ -18,7 +18,44 @@ use crate::caller::CallerContext;
 use crate::config::{Config, presets::resolve_presets};
 use crate::error::{BitrouterError, Result};
 use crate::language_model::routing::{ModelInfo, RoutingPrefs, RoutingTable, SortOrder};
+use crate::language_model::stream::{UsagePricing, UsagePricingBracket, UsagePricingTier};
 use crate::language_model::types::{ApiProtocol, RoutingTarget};
+
+fn usage_pricing(pricing: &crate::config::PricingConfig) -> UsagePricing {
+    let base = UsagePricingBracket {
+        input_micro_usd_per_token: pricing.input_micro_usd_per_token,
+        cache_read_micro_usd_per_token: pricing.cache_read_micro_usd_per_token,
+        cache_write_micro_usd_per_token: pricing.cache_write_micro_usd_per_token,
+        output_micro_usd_per_token: pricing.output_micro_usd_per_token,
+        reasoning_output_micro_usd_per_token: None,
+    };
+    let context_tiers = pricing
+        .context_tiers
+        .iter()
+        .map(|tier| UsagePricingTier {
+            above_input_tokens: tier.above_input_tokens,
+            bracket: UsagePricingBracket {
+                input_micro_usd_per_token: tier
+                    .input_micro_usd_per_token
+                    .or(base.input_micro_usd_per_token),
+                cache_read_micro_usd_per_token: tier
+                    .cache_read_micro_usd_per_token
+                    .or(base.cache_read_micro_usd_per_token),
+                cache_write_micro_usd_per_token: tier
+                    .cache_write_micro_usd_per_token
+                    .or(base.cache_write_micro_usd_per_token),
+                output_micro_usd_per_token: tier
+                    .output_micro_usd_per_token
+                    .or(base.output_micro_usd_per_token),
+                reasoning_output_micro_usd_per_token: None,
+            },
+        })
+        .collect();
+    UsagePricing {
+        base,
+        context_tiers,
+    }
+}
 
 /// A `RoutingTable` over an in-memory `bitrouter.yaml` config. Reloadable.
 pub struct ConfigRoutingTable {
@@ -556,6 +593,34 @@ impl RoutingTable for ConfigRoutingTable {
     ) -> Result<Vec<RoutingTarget>> {
         let config = self.config.read().expect("config lock poisoned");
         resolve_clean_route_chain(&config, model, prefs)
+    }
+
+    fn usage_pricing(&self, _model: &str, target: &RoutingTarget) -> Option<UsagePricing> {
+        let config = self.config.read().expect("config lock poisoned");
+        config
+            .providers
+            .get(&target.provider_name)?
+            .model_config(&target.service_id)?
+            .pricing
+            .as_ref()
+            .map(usage_pricing)
+    }
+
+    fn canonical_model_id(&self, model: &str, target: &RoutingTarget) -> Option<String> {
+        let config = self.config.read().expect("config lock poisoned");
+        let provider = config.providers.get(&target.provider_name)?;
+        provider
+            .models
+            .iter()
+            .find(|candidate| {
+                candidate
+                    .provider_model_id
+                    .as_deref()
+                    .unwrap_or(&candidate.id)
+                    == target.service_id
+            })
+            .map(|candidate| candidate.id.clone())
+            .or_else(|| Some(model.to_owned()))
     }
 
     fn list_models(&self) -> Vec<ModelInfo> {
@@ -1626,6 +1691,11 @@ providers:
         assert_eq!(chain[0].provider_name, "anthropic");
         // Dispatched against the upstream id, not the canonical match key.
         assert_eq!(chain[0].service_id, "claude-sonnet-4-6");
+        assert_eq!(
+            t.canonical_model_id("anthropic/claude-sonnet-4.6", &chain[0])
+                .as_deref(),
+            Some("anthropic/claude-sonnet-4.6")
+        );
     }
 
     #[tokio::test]

--- a/crates/bitrouter-sdk/src/language_model/mod.rs
+++ b/crates/bitrouter-sdk/src/language_model/mod.rs
@@ -97,8 +97,9 @@ pub use routing::{
 };
 pub use settlement::{SettlementContext, SettlementRecorder};
 pub use stream::{
-    SseFrame, SseKeepaliveStream, StreamAction, StreamInterest, StreamOutcome, StreamProcessor,
-    UsageAccumulator,
+    STREAM_USAGE_ESTIMATOR_CHARS_PER_TOKEN, STREAM_USAGE_ESTIMATOR_VERSION, SseFrame,
+    SseKeepaliveStream, StreamAction, StreamInterest, StreamOutcome, StreamProcessor,
+    UsageAccumulator, UsagePricing, UsagePricingBracket, UsagePricingTier,
 };
 pub use types::{
     ApiProtocol, Capability, Content, DataContent, ExecutionResult, FinishReason, GenerateResult,

--- a/crates/bitrouter-sdk/src/language_model/pipeline.rs
+++ b/crates/bitrouter-sdk/src/language_model/pipeline.rs
@@ -135,6 +135,14 @@ pub(crate) struct PreparedStreamPart {
 pub(crate) struct PreparedPipelineResponse {
     pub(crate) response: PipelineResponse,
     pub(crate) delivery: DeliveryPermit,
+    #[cfg(feature = "server")]
+    pub(crate) model_id: String,
+}
+
+pub(crate) struct PreparedPipelineStream {
+    pub(crate) parts: Pin<Box<dyn Stream<Item = Result<PreparedStreamPart>> + Send>>,
+    #[cfg(feature = "server")]
+    pub(crate) model_id: String,
 }
 
 enum DeliveryAuthorizationOutcome {
@@ -619,6 +627,11 @@ impl Pipeline {
         self.run_settlement(&mut ctx, false, None).await;
         self.observe_after(Phase::Settlement, &ctx).await;
         let response = ctx.response();
+        #[cfg(feature = "server")]
+        let model_id = ctx
+            .successful_target()
+            .and_then(|target| self.routing_table.canonical_model_id(ctx.model(), &target))
+            .unwrap_or_else(|| ctx.model().to_owned());
         let (delivery, authorization) = finalization.begin_delivery();
         let observe_hooks = self.observe_hooks.clone();
         self.spawn_stream_finalization(async move {
@@ -637,7 +650,12 @@ impl Pipeline {
             }
         });
 
-        Ok(PreparedPipelineResponse { response, delivery })
+        Ok(PreparedPipelineResponse {
+            response,
+            delivery,
+            #[cfg(feature = "server")]
+            model_id,
+        })
     }
 
     /// Execute a streaming request: Stages 1–3 run eagerly (so pre-stream
@@ -648,7 +666,7 @@ impl Pipeline {
         req: PipelineRequest,
     ) -> Result<Pin<Box<dyn Stream<Item = Result<StreamPart>> + Send>>> {
         let prepared = self.execute_stream_prepared(req).await?;
-        Ok(Box::pin(prepared.then(|item| async move {
+        Ok(Box::pin(prepared.parts.then(|item| async move {
             let PreparedStreamPart { part, delivery } = item?;
             if let Some(delivery) = delivery {
                 delivery.deliver().await?;
@@ -660,7 +678,7 @@ impl Pipeline {
     pub(crate) async fn execute_stream_prepared(
         self: Arc<Self>,
         req: PipelineRequest,
-    ) -> Result<Pin<Box<dyn Stream<Item = Result<PreparedStreamPart>> + Send>>> {
+    ) -> Result<PreparedPipelineStream> {
         let mut ctx = PipelineContext::new(req);
         self.observe_start(&ctx).await;
 
@@ -764,16 +782,26 @@ impl Pipeline {
         });
         self.observe_after(Phase::Execution, &ctx).await;
 
+        let mut stream_context = ctx.stream_context();
+        stream_context.accumulated_usage.set_pricing(
+            self.routing_table
+                .usage_pricing(ctx.model(), &upstream.target),
+        );
         let processor = StreamProcessor::new(
             self.stream_hooks.clone(),
             self.observe_hooks.clone(),
-            ctx.stream_context(),
+            stream_context,
         );
 
         // The guard owns the processor + context. Whatever happens to the
         // returned stream — drained to completion, errored, or **dropped early
         // by the client** — `on_stream_end` and Settlement run exactly once
         // so streaming settlement is never lost.
+        #[cfg(feature = "server")]
+        let model_id = self
+            .routing_table
+            .canonical_model_id(ctx.model(), &upstream.target)
+            .unwrap_or_else(|| ctx.model().to_owned());
         let guard = StreamSettlementGuard {
             pipeline: self.clone(),
             latest_attempt,
@@ -786,7 +814,11 @@ impl Pipeline {
             ))),
         };
 
-        Ok(Box::pin(self.drive_stream(upstream.stream, guard)))
+        Ok(PreparedPipelineStream {
+            parts: Box::pin(self.drive_stream(upstream.stream, guard)),
+            #[cfg(feature = "server")]
+            model_id,
+        })
     }
 
     /// The streaming driver: feeds upstream parts through the guard's

--- a/crates/bitrouter-sdk/src/language_model/protocol/chat_completions.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/chat_completions.rs
@@ -760,6 +760,7 @@ impl InboundAdapter for ChatCompletionsAdapter {
             model: model.to_string(),
             role_sent: false,
             tool_calls: Vec::new(),
+            pending_usage: None,
         })
     }
 }
@@ -1519,6 +1520,10 @@ struct ChatStreamDecoder {
     /// continuation chunks.
     tool_ids: Vec<String>,
     done: bool,
+    /// Chat providers commonly emit `finish_reason`, then a usage-only chunk,
+    /// then `[DONE]`. Hold the terminal until the sentinel/EOF so the trailing
+    /// authoritative usage remains reachable by the pipeline.
+    pending_finish: Option<FinishReason>,
     /// Whether the one-shot [`StreamPart::ResponseStarted`] has been emitted.
     /// Every chunk repeats the top-level `id`; we surface it only once.
     response_started_emitted: bool,
@@ -1532,7 +1537,11 @@ impl StreamDecoder for ChatStreamDecoder {
         }
         if data == "[DONE]" {
             self.done = true;
-            return Ok(Vec::new());
+            return Ok(self
+                .pending_finish
+                .take()
+                .map(|reason| vec![StreamPart::Finish { reason }])
+                .unwrap_or_default());
         }
         let chunk: serde_json::Value = match serde_json::from_str(data) {
             Ok(v) => v,
@@ -1630,13 +1639,25 @@ impl StreamDecoder for ChatStreamDecoder {
                 if let Some(usage) = chunk.get("usage").and_then(parse_usage) {
                     parts.push(StreamPart::Usage { usage });
                 }
-                parts.push(StreamPart::Finish { reason });
+                self.pending_finish = Some(reason);
             }
         } else if let Some(usage) = chunk.get("usage").and_then(parse_usage) {
             // Some providers send a trailing usage-only chunk.
             parts.push(StreamPart::Usage { usage });
         }
         Ok(parts)
+    }
+
+    fn finish(&mut self) -> Result<Vec<StreamPart>> {
+        if self.done {
+            return Ok(Vec::new());
+        }
+        self.done = true;
+        Ok(self
+            .pending_finish
+            .take()
+            .map(|reason| vec![StreamPart::Finish { reason }])
+            .unwrap_or_default())
     }
 }
 
@@ -1660,6 +1681,7 @@ struct ChatStreamEncoder {
     role_sent: bool,
     /// Per tool-call state, keyed by id and ordered by first sight.
     tool_calls: Vec<ChatToolCallState>,
+    pending_usage: Option<Usage>,
 }
 
 impl ChatStreamEncoder {
@@ -1694,6 +1716,20 @@ impl ChatStreamEncoder {
         SseFrame::Event {
             event: None,
             data: data.to_string(),
+        }
+    }
+
+    fn usage_chunk(&self, usage: &Usage) -> SseFrame {
+        SseFrame::Event {
+            event: None,
+            data: serde_json::json!({
+                "id": self.request_id,
+                "object": "chat.completion.chunk",
+                "model": self.model,
+                "choices": [],
+                "usage": render_usage(usage),
+            })
+            .to_string(),
         }
     }
 }
@@ -1784,8 +1820,8 @@ impl StreamEncoder for ChatStreamEncoder {
                     frames.push(self.chunk(serde_json::Value::Object(delta), None));
                 }
             }
-            StreamPart::Usage { .. } => {
-                // usage is attached to the Finish chunk below; nothing here.
+            StreamPart::Usage { usage } => {
+                self.pending_usage = Some(usage.clone());
             }
             StreamPart::File { .. } => {
                 // Chat Completions streaming has no native file-output frame
@@ -1841,8 +1877,11 @@ impl StreamEncoder for ChatStreamEncoder {
                 let delta = self.open_delta();
                 let reason_str = finish_reason_str(reason);
                 frames.push(self.chunk(serde_json::Value::Object(delta), Some(&reason_str)));
+                if let Some(usage) = self.pending_usage.take() {
+                    frames.push(self.usage_chunk(&usage));
+                }
             }
-            StreamPart::ResponseCompleted { status, .. } => {
+            StreamPart::ResponseCompleted { status, usage, .. } => {
                 // Inbound was Responses; Chat has no response-completed
                 // concept — terminate with a finish chunk derived from status.
                 let reason = if status == "incomplete" {
@@ -1853,6 +1892,10 @@ impl StreamEncoder for ChatStreamEncoder {
                 let delta = self.open_delta();
                 let reason_str = finish_reason_str(&reason);
                 frames.push(self.chunk(serde_json::Value::Object(delta), Some(&reason_str)));
+                let usage = usage.clone().or_else(|| self.pending_usage.take());
+                if let Some(usage) = usage {
+                    frames.push(self.usage_chunk(&usage));
+                }
             }
         }
         Ok(frames)
@@ -1902,5 +1945,55 @@ impl StreamEncoder for ChatStreamEncoder {
             event: None,
             data: "[DONE]".to_string(),
         }])
+    }
+}
+
+#[cfg(test)]
+mod trailing_usage_tests {
+    use super::*;
+
+    #[test]
+    fn decoder_keeps_trailing_usage_reachable_before_finish() -> Result<()> {
+        let mut decoder = ChatStreamDecoder::default();
+        let finish = decoder.decode(&SseEvent {
+            event: None,
+            data: serde_json::json!({
+                "id": "chatcmpl-audit",
+                "choices": [{"delta": {}, "finish_reason": "stop"}]
+            })
+            .to_string(),
+        })?;
+        assert!(
+            finish
+                .iter()
+                .all(|part| !matches!(part, StreamPart::Finish { .. }))
+        );
+
+        let usage = decoder.decode(&SseEvent {
+            event: None,
+            data: serde_json::json!({
+                "id": "chatcmpl-audit",
+                "choices": [],
+                "usage": {"prompt_tokens": 12, "completion_tokens": 7}
+            })
+            .to_string(),
+        })?;
+        assert!(matches!(
+            usage.as_slice(),
+            [StreamPart::Usage { usage }]
+                if usage.prompt_tokens == 12 && usage.completion_tokens == 7
+        ));
+
+        let terminal = decoder.decode(&SseEvent {
+            event: None,
+            data: "[DONE]".to_owned(),
+        })?;
+        assert!(matches!(
+            terminal.as_slice(),
+            [StreamPart::Finish {
+                reason: FinishReason::Stop
+            }]
+        ));
+        Ok(())
     }
 }

--- a/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
@@ -1480,6 +1480,7 @@ fn parse_usage_retains_provider_payload_and_origin() {
 #[derive(Default)]
 struct GenerateContentStreamDecoder {
     finished: bool,
+    pending_finish: Option<FinishReason>,
     /// Whether the one-shot [`StreamPart::ResponseStarted`] has been emitted.
     /// Every chunk repeats `responseId`; we surface it only once.
     response_started_emitted: bool,
@@ -1592,12 +1593,32 @@ impl StreamDecoder for GenerateContentStreamDecoder {
             {
                 if let Some(usage) = chunk.get("usageMetadata").and_then(parse_usage) {
                     parts.push(StreamPart::Usage { usage });
+                    parts.push(StreamPart::Finish { reason });
+                    self.finished = true;
+                } else {
+                    self.pending_finish = Some(reason);
                 }
+            }
+        } else if let Some(usage) = chunk.get("usageMetadata").and_then(parse_usage) {
+            parts.push(StreamPart::Usage { usage });
+            if let Some(reason) = self.pending_finish.take() {
                 parts.push(StreamPart::Finish { reason });
                 self.finished = true;
             }
         }
         Ok(parts)
+    }
+
+    fn finish(&mut self) -> Result<Vec<StreamPart>> {
+        if self.finished {
+            return Ok(Vec::new());
+        }
+        self.finished = true;
+        Ok(self
+            .pending_finish
+            .take()
+            .map(|reason| vec![StreamPart::Finish { reason }])
+            .unwrap_or_default())
     }
 }
 

--- a/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
@@ -1179,6 +1179,7 @@ impl InboundAdapter for MessagesAdapter {
             block_index: 0,
             pending_sources: Vec::new(),
             pending_reasoning: None,
+            pending_usage: None,
         })
     }
 }
@@ -2551,6 +2552,7 @@ struct MessagesStreamEncoder {
     /// reasoning has no valid signature, so it must not be exposed as a
     /// `thinking` block on this wire.
     pending_reasoning: Option<String>,
+    pending_usage: Option<Usage>,
 }
 
 impl MessagesStreamEncoder {
@@ -3002,14 +3004,15 @@ impl StreamEncoder for MessagesStreamEncoder {
                     self.pending_sources.push(serde_json::Value::Object(entry));
                 }
             }
-            StreamPart::Usage { .. } => {}
+            StreamPart::Usage { usage } => self.pending_usage = Some(usage.clone()),
             StreamPart::ResponseStarted { .. } => {
                 // Observability-only metadata (upstream response id); the
                 // Messages-protocol client gets its id from the
                 // `message_start` event `ensure_started` emits.
             }
             StreamPart::Finish { reason } => {
-                self.emit_terminal(&mut frames, &finish_to_stop_reason(reason), None);
+                let usage = self.pending_usage.take();
+                self.emit_terminal(&mut frames, &finish_to_stop_reason(reason), usage);
             }
             StreamPart::ResponseCompleted { status, usage, .. } => {
                 // Inbound was Responses; map its status onto Messages'
@@ -3019,7 +3022,8 @@ impl StreamEncoder for MessagesStreamEncoder {
                 } else {
                     "end_turn"
                 };
-                self.emit_terminal(&mut frames, stop_reason, usage.clone());
+                let usage = usage.clone().or_else(|| self.pending_usage.take());
+                self.emit_terminal(&mut frames, stop_reason, usage);
             }
         }
         Ok(frames)

--- a/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
@@ -2230,6 +2230,7 @@ impl InboundAdapter for ResponsesAdapter {
             completed_items: Vec::new(),
             annotation_index: 0,
             pending_mcp_call: None,
+            pending_usage: None,
         })
     }
 }
@@ -3761,6 +3762,7 @@ struct ResponsesStreamEncoder {
     /// pair emits as one `mcp_call` output item (OpenAI carries arguments +
     /// output on a single item).
     pending_mcp_call: Option<PendingMcpCall>,
+    pending_usage: Option<Usage>,
 }
 
 /// A buffered router tool call awaiting its [`StreamPart::ServerToolResult`].
@@ -4353,7 +4355,7 @@ impl StreamEncoder for ResponsesStreamEncoder {
                     ));
                 }
             }
-            StreamPart::Usage { .. } => {}
+            StreamPart::Usage { usage } => self.pending_usage = Some(usage.clone()),
             StreamPart::ResponseStarted { .. } => {
                 // Provider response identity is request-local continuation
                 // metadata. The public lifecycle remains on the gateway id.
@@ -4367,11 +4369,13 @@ impl StreamEncoder for ResponsesStreamEncoder {
                     _ => "completed",
                 };
                 let response_id = self.response_id.clone()?;
-                self.emit_terminal(&mut frames, status, &response_id, None);
+                let usage = self.pending_usage.take();
+                self.emit_terminal(&mut frames, status, &response_id, usage);
             }
             StreamPart::ResponseCompleted { status, usage, .. } => {
                 let response_id = self.response_id.clone()?;
-                self.emit_terminal(&mut frames, status, &response_id, usage.clone());
+                let usage = usage.clone().or_else(|| self.pending_usage.take());
+                self.emit_terminal(&mut frames, status, &response_id, usage);
             }
         }
         Ok(frames)

--- a/crates/bitrouter-sdk/src/language_model/routing.rs
+++ b/crates/bitrouter-sdk/src/language_model/routing.rs
@@ -14,6 +14,7 @@ use crate::caller::CallerContext;
 use crate::error::{BitrouterError, Result};
 use crate::language_model::context::PipelineContext;
 use crate::language_model::hooks::FallbackDecision;
+use crate::language_model::stream::UsagePricing;
 use crate::language_model::types::{ApiProtocol, Capability, RoutingTarget};
 
 /// How a cascade chain should be ordered.
@@ -154,6 +155,21 @@ pub trait RoutingTable: Send + Sync {
         caller: &CallerContext,
     ) -> Result<Vec<RoutingTarget>> {
         self.route_chain(model, prefs, caller).await
+    }
+
+    /// Immutable pricing for one concrete route, used only to resolve
+    /// conflicting cumulative usage snapshots conservatively. Implementations
+    /// without trustworthy pricing return `None`; stream normalization then
+    /// falls back to the provider's last usage snapshot.
+    fn usage_pricing(&self, _model: &str, _target: &RoutingTarget) -> Option<UsagePricing> {
+        None
+    }
+
+    /// Canonical model id represented by a successful concrete route.
+    /// Deployments with a registry should reverse-resolve provider wire ids;
+    /// the default preserves the resolved request model.
+    fn canonical_model_id(&self, model: &str, _target: &RoutingTarget) -> Option<String> {
+        Some(model.to_owned())
     }
 
     /// List every routable model (for `GET /v1/models`).

--- a/crates/bitrouter-sdk/src/language_model/stream.rs
+++ b/crates/bitrouter-sdk/src/language_model/stream.rs
@@ -16,6 +16,12 @@ use crate::language_model::context::StreamContext;
 use crate::language_model::hooks::{ObserveHook, StreamHook};
 use crate::language_model::types::{StreamPart, Usage};
 
+/// Stable identifier for the SDK's character-count fallback estimator.
+pub const STREAM_USAGE_ESTIMATOR_VERSION: &str = "bitrouter-sdk/stream-char-div-ceil-4-v1";
+
+/// Characters per token used by the SDK's fallback stream estimator.
+pub const STREAM_USAGE_ESTIMATOR_CHARS_PER_TOKEN: u64 = 4;
+
 /// A bitset of the `StreamPart` kinds a hook cares about. Lets the pipeline skip
 /// hooks on parts they declared no interest in (keeps the per-token hot path
 /// proportional to declared interest).
@@ -228,8 +234,97 @@ where
     }
 }
 
-/// Accumulates token usage seen across a stream. The last `Usage` part wins
-/// (providers send a running or final total, not deltas).
+/// One flat bracket used to compare provider-reported usage snapshots.
+///
+/// Rates are micro-USD per token. This type deliberately performs no billing:
+/// it only gives the stream normalizer enough information to choose the most
+/// conservative snapshot when an upstream emits conflicting cumulative usage.
+#[derive(Debug, Clone, Default)]
+pub struct UsagePricingBracket {
+    /// Uncached prompt-token rate.
+    pub input_micro_usd_per_token: Option<f64>,
+    /// Cache-read prompt-token rate; missing falls back to `input`.
+    pub cache_read_micro_usd_per_token: Option<f64>,
+    /// Cache-write prompt-token rate; missing falls back to `input`.
+    pub cache_write_micro_usd_per_token: Option<f64>,
+    /// Non-reasoning completion-token rate.
+    pub output_micro_usd_per_token: Option<f64>,
+    /// Reasoning-token rate; missing falls back to `output`.
+    pub reasoning_output_micro_usd_per_token: Option<f64>,
+}
+
+/// A higher context-pricing bracket. The greatest threshold strictly below
+/// the reported prompt-token count wins.
+#[derive(Debug, Clone, Default)]
+pub struct UsagePricingTier {
+    /// Exclusive lower bound for selecting this tier.
+    pub above_input_tokens: u64,
+    /// Complete pricing bracket active above the threshold.
+    pub bracket: UsagePricingBracket,
+}
+
+/// Route-local pricing used only for conservative stream-usage selection.
+#[derive(Debug, Clone, Default)]
+pub struct UsagePricing {
+    /// Pricing for the lowest context range.
+    pub base: UsagePricingBracket,
+    /// Optional higher context brackets.
+    pub context_tiers: Vec<UsagePricingTier>,
+}
+
+impl UsagePricing {
+    fn bracket_for(&self, input_tokens: u64) -> &UsagePricingBracket {
+        self.context_tiers
+            .iter()
+            .filter(|tier| input_tokens > tier.above_input_tokens)
+            .max_by_key(|tier| tier.above_input_tokens)
+            .map_or(&self.base, |tier| &tier.bracket)
+    }
+
+    fn nominal_cost(&self, usage: &Usage) -> Option<f64> {
+        if usage.web_search_count > 0 {
+            return None;
+        }
+        let bracket = self.bracket_for(usage.prompt_tokens);
+        let input_rate = valid_rate(bracket.input_micro_usd_per_token)?;
+        let output_rate = valid_rate(bracket.output_micro_usd_per_token)?;
+        let cache_total = usage
+            .cache_read_tokens
+            .checked_add(usage.cache_write_tokens)?;
+        let uncached_input = usage.prompt_tokens.checked_sub(cache_total)?;
+        let text_output = usage
+            .completion_tokens
+            .checked_sub(usage.reasoning_tokens)?;
+        let cache_read_rate =
+            optional_rate(bracket.cache_read_micro_usd_per_token)?.unwrap_or(input_rate);
+        let cache_write_rate =
+            optional_rate(bracket.cache_write_micro_usd_per_token)?.unwrap_or(input_rate);
+        let reasoning_rate =
+            optional_rate(bracket.reasoning_output_micro_usd_per_token)?.unwrap_or(output_rate);
+        let cost = uncached_input as f64 * input_rate
+            + usage.cache_read_tokens as f64 * cache_read_rate
+            + usage.cache_write_tokens as f64 * cache_write_rate
+            + text_output as f64 * output_rate
+            + usage.reasoning_tokens as f64 * reasoning_rate;
+        cost.is_finite().then_some(cost)
+    }
+}
+
+fn valid_rate(rate: Option<f64>) -> Option<f64> {
+    rate.filter(|value| value.is_finite() && *value >= 0.0)
+}
+
+fn optional_rate(rate: Option<f64>) -> Option<Option<f64>> {
+    match rate {
+        Some(value) if value.is_finite() && value >= 0.0 => Some(Some(value)),
+        Some(_) => None,
+        None => Some(None),
+    }
+}
+
+/// Accumulates token usage seen across a stream. With complete route pricing,
+/// the highest-cost cumulative snapshot wins; without usable pricing, the last
+/// snapshot wins. Provider usage frames are cumulative totals, never deltas.
 ///
 /// Also tracks the total *character* count of text and reasoning deltas
 /// observed so that — when the consumer hangs up before the upstream `Usage`
@@ -247,6 +342,9 @@ where
 pub struct UsageAccumulator {
     usage: Usage,
     seen: bool,
+    pricing: Option<UsagePricing>,
+    priced_winner: Option<(f64, Usage)>,
+    every_snapshot_priced: bool,
     /// Total `char` count of `TextDelta` + `ReasoningDelta` text observed.
     delta_chars: u64,
     /// `char` count of the request prompt's text, seeded at stream start. Lets a
@@ -258,15 +356,22 @@ pub struct UsageAccumulator {
 impl UsageAccumulator {
     /// Chars-per-token estimate for the disconnect-time billing heuristic.
     /// Conservative-ish: too small bills extra, too large bills less.
-    const CHARS_PER_TOKEN_ESTIMATE: u64 = 4;
-
     /// A fresh accumulator seeded with the request prompt's `char` count, so a
     /// disconnect before the upstream usage frame can still estimate prompt
     /// tokens. Pass `0` when no prompt-token estimate is wanted.
     pub fn with_prompt_chars(prompt_chars: u64) -> Self {
         Self {
             prompt_chars,
+            every_snapshot_priced: true,
             ..Default::default()
+        }
+    }
+
+    /// Supply the selected route's immutable pricing snapshot.
+    pub fn set_pricing(&mut self, pricing: Option<UsagePricing>) {
+        self.pricing = pricing;
+        if !self.seen {
+            self.every_snapshot_priced = true;
         }
     }
 
@@ -281,6 +386,22 @@ impl UsageAccumulator {
             } => {
                 self.usage = usage.clone();
                 self.seen = true;
+                match self
+                    .pricing
+                    .as_ref()
+                    .and_then(|pricing| pricing.nominal_cost(usage))
+                {
+                    Some(cost) => {
+                        if self
+                            .priced_winner
+                            .as_ref()
+                            .is_none_or(|(winner, _)| cost >= *winner)
+                        {
+                            self.priced_winner = Some((cost, usage.clone()));
+                        }
+                    }
+                    None => self.every_snapshot_priced = false,
+                }
             }
             StreamPart::TextDelta { text } | StreamPart::ReasoningDelta { text } => {
                 self.delta_chars = self.delta_chars.saturating_add(text.chars().count() as u64);
@@ -291,21 +412,32 @@ impl UsageAccumulator {
 
     /// The accumulated usage, if any `Usage` part was seen.
     pub fn finalized(&self) -> Option<Usage> {
-        self.seen.then_some(self.usage.clone())
+        if !self.seen {
+            return None;
+        }
+        if self.pricing.is_some()
+            && self.every_snapshot_priced
+            && let Some((_, usage)) = &self.priced_winner
+        {
+            return Some(usage.clone());
+        }
+        Some(self.usage.clone())
     }
 
     /// Estimated output-token count from accumulated delta text, for the
     /// disconnect-billing fallback. Returns `0` when no text deltas were
     /// observed.
     pub fn estimated_output_tokens(&self) -> u64 {
-        self.delta_chars.div_ceil(Self::CHARS_PER_TOKEN_ESTIMATE)
+        self.delta_chars
+            .div_ceil(STREAM_USAGE_ESTIMATOR_CHARS_PER_TOKEN)
     }
 
     /// Estimated prompt-token count from the seeded prompt char count, for the
     /// disconnect-billing fallback. Returns `0` when the accumulator was not
     /// seeded with a prompt char count.
     pub fn estimated_prompt_tokens(&self) -> u64 {
-        self.prompt_chars.div_ceil(Self::CHARS_PER_TOKEN_ESTIMATE)
+        self.prompt_chars
+            .div_ceil(STREAM_USAGE_ESTIMATOR_CHARS_PER_TOKEN)
     }
 }
 
@@ -347,13 +479,39 @@ impl StreamProcessor {
     ///
     /// Each hook in registration order sees the (possibly rewritten) output of
     /// the previous hook. The accumulator always observes the *original*
-    /// upstream part so usage is never lost to a rewrite.
+    /// upstream part so usage is never lost to a rewrite. Standalone provider
+    /// usage snapshots are buffered; immediately before the terminal, hooks
+    /// and downstream observers see exactly one normalized snapshot.
     pub async fn process_part(&mut self, part: StreamPart) -> Result<Vec<StreamPart>> {
         self.ctx.accumulated_usage.observe(&part);
         self.ctx.observe_upstream_part(&part);
         self.ctx.parts_emitted += 1;
 
-        let mut current = vec![part];
+        let mut current = match part {
+            StreamPart::Usage { .. } => Vec::new(),
+            StreamPart::Finish { reason } => {
+                let mut parts = Vec::new();
+                if let Some(usage) = self.ctx.accumulated_usage.finalized() {
+                    parts.push(StreamPart::Usage { usage });
+                }
+                parts.push(StreamPart::Finish { reason });
+                parts
+            }
+            StreamPart::ResponseCompleted {
+                id,
+                source_protocol,
+                status,
+                response_output_commitment,
+                ..
+            } => vec![StreamPart::ResponseCompleted {
+                id,
+                source_protocol,
+                status,
+                usage: self.ctx.accumulated_usage.finalized(),
+                response_output_commitment,
+            }],
+            part => vec![part],
+        };
         for hook in &self.hooks {
             let interest = hook.interest();
             let mut next = Vec::with_capacity(current.len());
@@ -516,6 +674,97 @@ mod tests {
         ));
         ctx.set_stream_provider_started_at(std::time::Instant::now());
         ctx.stream_context()
+    }
+
+    fn usage(prompt_tokens: u64, completion_tokens: u64) -> Usage {
+        Usage {
+            prompt_tokens,
+            completion_tokens,
+            origin: crate::language_model::types::UsageOrigin::ProviderReported,
+            ..Usage::default()
+        }
+    }
+
+    fn asymmetric_pricing() -> UsagePricing {
+        UsagePricing {
+            base: UsagePricingBracket {
+                input_micro_usd_per_token: Some(1.0),
+                output_micro_usd_per_token: Some(10.0),
+                ..UsagePricingBracket::default()
+            },
+            context_tiers: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn usage_accumulator_uses_highest_nominal_cost_when_priced() {
+        let expensive = usage(1_000, 1);
+        let last = usage(10, 50);
+        let mut accumulator = UsageAccumulator::default();
+        accumulator.set_pricing(Some(asymmetric_pricing()));
+        accumulator.observe(&StreamPart::Usage {
+            usage: expensive.clone(),
+        });
+        accumulator.observe(&StreamPart::Usage {
+            usage: last.clone(),
+        });
+
+        assert_eq!(accumulator.finalized(), Some(expensive));
+    }
+
+    #[test]
+    fn usage_accumulator_uses_last_snapshot_without_complete_pricing() {
+        let first = usage(1_000, 1);
+        let last = usage(10, 50);
+        let mut accumulator = UsageAccumulator::default();
+        accumulator.observe(&StreamPart::Usage { usage: first });
+        accumulator.observe(&StreamPart::Usage {
+            usage: last.clone(),
+        });
+
+        assert_eq!(accumulator.finalized(), Some(last));
+    }
+
+    #[tokio::test]
+    async fn processor_emits_one_selected_usage_immediately_before_terminal() -> Result<()> {
+        let expensive = usage(1_000, 1);
+        let last = usage(10, 50);
+        let mut context = timed_stream_context();
+        context
+            .accumulated_usage
+            .set_pricing(Some(asymmetric_pricing()));
+        let mut processor = StreamProcessor::new(Vec::new(), Vec::new(), context);
+
+        assert!(
+            processor
+                .process_part(StreamPart::Usage {
+                    usage: expensive.clone(),
+                })
+                .await?
+                .is_empty()
+        );
+        assert!(
+            processor
+                .process_part(StreamPart::Usage { usage: last })
+                .await?
+                .is_empty()
+        );
+        let emitted = processor
+            .process_part(StreamPart::Finish {
+                reason: FinishReason::Stop,
+            })
+            .await?;
+
+        assert_eq!(
+            emitted,
+            vec![
+                StreamPart::Usage { usage: expensive },
+                StreamPart::Finish {
+                    reason: FinishReason::Stop,
+                },
+            ]
+        );
+        Ok(())
     }
 
     #[tokio::test]

--- a/crates/bitrouter-sdk/src/server.rs
+++ b/crates/bitrouter-sdk/src/server.rs
@@ -817,13 +817,7 @@ async fn handle(
     req.inbound_protocol = Some(inbound.clone());
 
     if prompt.stream {
-        stream_response(
-            state.language_model.clone(),
-            req,
-            inbound.clone(),
-            &prompt.model,
-        )
-        .await
+        stream_response(state.language_model.clone(), req, inbound.clone()).await
     } else {
         // `execute_detached`, not `execute`: a non-streaming request must run to
         // completion and settle even if the client disconnects (axum drops this
@@ -835,20 +829,24 @@ async fn handle(
             .execute_detached_prepared(req)
             .await
         {
-            Ok(prepared) => match adapter.render_response(
-                &prepared.response.result,
-                &prompt,
-                &prepared.response.request_id,
-            ) {
-                Ok(json) => match prepared.delivery.deliver().await {
-                    Ok(()) => Json(json).into_response(),
-                    Err(error) => error.into_response(),
-                },
-                Err(e) => match prepared.delivery.fail(e.clone()).await {
-                    Ok(()) => e.into_response(),
-                    Err(authorization_error) => authorization_error.into_response(),
-                },
-            },
+            Ok(prepared) => {
+                let mut response_prompt = prompt.clone();
+                response_prompt.model = prepared.model_id.clone();
+                match adapter.render_response(
+                    &prepared.response.result,
+                    &response_prompt,
+                    &prepared.response.request_id,
+                ) {
+                    Ok(json) => match prepared.delivery.deliver().await {
+                        Ok(()) => Json(json).into_response(),
+                        Err(error) => error.into_response(),
+                    },
+                    Err(e) => match prepared.delivery.fail(e.clone()).await {
+                        Ok(()) => e.into_response(),
+                        Err(authorization_error) => authorization_error.into_response(),
+                    },
+                }
+            }
             Err(e) => e.into_response(),
         }
     }
@@ -888,7 +886,6 @@ async fn stream_response(
     pipeline: Arc<Pipeline>,
     req: PipelineRequest,
     inbound: ApiProtocol,
-    model: &str,
 ) -> Response {
     let adapter = match inbound_adapter_for(&inbound) {
         Some(a) => a,
@@ -900,17 +897,19 @@ async fn stream_response(
             .into_response();
         }
     };
-    let mut encoder = adapter.stream_encoder(&req.request_id, model);
+    let request_id = req.request_id.clone();
     let keepalive = pipeline.keepalive_interval();
 
     // Route resolution and the upstream HTTP handshake happen before the SSE
     // response is constructed. Pre-stream failures therefore retain their real
     // HTTP status (notably upstream 429) instead of being trapped inside an
     // already-committed HTTP 200 event stream.
-    let mut parts = match pipeline.execute_stream_prepared(req).await {
-        Ok(parts) => parts,
+    let prepared = match pipeline.execute_stream_prepared(req).await {
+        Ok(prepared) => prepared,
         Err(error) => return error.into_response(),
     };
+    let mut encoder = adapter.stream_encoder(&request_id, &prepared.model_id);
+    let mut parts = prepared.parts;
 
     let frame_stream = async_stream::stream! {
         while let Some(item) = parts.next().await {


### PR DESCRIPTION
## Summary

- normalize multiple cumulative provider usage snapshots inside bitrouter-sdk
- select the highest nominal-cost snapshot when route pricing is complete, with last-win fallback for unpriced routes
- emit one terminal usage record and expose the concrete routed model identity across protocols
- map OSS registry and custom-provider pricing into the shared SDK policy

## Verification

- `NO_PROXY=127.0.0.1,localhost cargo nextest run --all-features` (3069 passed, 11 skipped)
- `cargo clippy --all-features -- -D warnings`
- `cargo fmt -- --check`