### PR TITLE
feat(cli): complete searchable ACP onboarding

### DIFF
--- a/apps/bitrouter/build.rs
+++ b/apps/bitrouter/build.rs
@@ -11,8 +11,8 @@
 //! also means a malformed artifact is a build error rather than a startup
 //! failure.
 //!
-//! The Codex and Claude subscription provider defaults are bundled from the
-//! same dist snapshot so their login and model catalog need no user config.
+//! The provider registry is bundled from the same dist snapshot so first-run
+//! selection, login and model discovery also work without a registry cache.
 
 use std::error::Error;
 use std::fmt::Write as _;
@@ -63,22 +63,11 @@ fn main() -> Result<(), Box<dyn Error>> {
     let models_path = root.join("models.json");
     println!("cargo::rerun-if-changed={}", providers_path.display());
     println!("cargo::rerun-if-changed={}", models_path.display());
-    let providers: Vec<_> = read_data(&providers_path)?
-        .into_iter()
-        .filter(|p| matches!(p["name"].as_str(), Some("openai-codex" | "claude-code")))
-        .collect();
-    let model_ids: std::collections::BTreeSet<_> = providers
-        .iter()
-        .flat_map(|p| p["models"].as_array().into_iter().flatten())
-        .filter_map(|m| m["id"].as_str())
-        .collect();
-    let canonical: Vec<_> = read_data(&models_path)?
-        .into_iter()
-        .filter(|m| m["id"].as_str().is_some_and(|id| model_ids.contains(id)))
-        .collect();
+    let providers = read_data(&providers_path)?;
+    let canonical = read_data(&models_path)?;
     let bundled = serde_json::json!({"providers": providers, "canonical": canonical});
     std::fs::write(
-        dest.with_file_name("acp_providers.json"),
+        dest.with_file_name("provider_registry.json"),
         serde_json::to_vec(&bundled)?,
     )?;
     Ok(())

--- a/apps/bitrouter/src/acp_cli.rs
+++ b/apps/bitrouter/src/acp_cli.rs
@@ -1458,7 +1458,7 @@ pub async fn chat(ctx: SpawnContext<'_>) -> Result<()> {
                 let choice = if authenticated {
                     AuthChoice::Declined
                 } else {
-                    choose_auth_method(agent_id, session.client.auth_methods())?
+                    choose_auth_method(agent_id, session.client.auth_methods()).await?
                 };
                 match choice {
                     // No log tail: unlike a launch that died with its reason on
@@ -1561,93 +1561,48 @@ enum AuthChoice {
     Declined,
 }
 
-/// Offer the agent's advertised authentication methods and read one choice.
-///
-/// A cooked-terminal prompt rather than a TUI modal, because this runs *before*
-/// the renderer exists: `session/new` is what reports `auth_required`, and the
-/// view is not opened until a session exists. Numbered like every other choice
-/// this CLI offers.
-///
-/// Declines rather than guesses whenever a person cannot answer — no tty, EOF,
-/// or an empty method list. An unanswered prompt must never resolve to a login
-/// attempt nobody asked for.
-fn choose_auth_method(
+/// Offer the agent's advertised methods through the shared keyboard selector.
+/// Missing terminal input and cancellation never imply a login attempt.
+async fn choose_auth_method(
     agent_id: &str,
     methods: &[agent_client_protocol::schema::v1::AuthMethod],
 ) -> Result<AuthChoice> {
-    use std::io::{BufRead, IsTerminal as _};
-
-    if methods.is_empty() || !std::io::stdin().is_terminal() {
+    use std::io::IsTerminal as _;
+    if methods.is_empty() || !std::io::stdin().is_terminal() || !std::io::stderr().is_terminal() {
         return Ok(AuthChoice::Declined);
     }
-    eprintln!();
-    eprintln!("  '{agent_id}' is not authenticated. How would you like to sign in?");
-    for (index, method) in methods.iter().enumerate() {
-        match method.description() {
-            Some(description) => {
-                eprintln!("    {}) {} — {description}", index + 1, method.name())
-            }
-            None => eprintln!("    {}) {}", index + 1, method.name()),
-        }
-    }
-    eprintln!("    0) cancel");
-
-    let stdin = std::io::stdin();
-    let mut handle = stdin.lock();
-    loop {
-        eprint!("  Choose [1]: ");
-        let mut line = String::new();
-        if handle
-            .read_line(&mut line)
-            .context("reading the authentication choice")?
-            == 0
+    let selected = crate::prompt::select(
+        &format!("Log in to {agent_id}"),
+        "Choose an authentication method advertised by this ACP agent",
+        methods
+            .iter()
+            .map(|method| {
+                bitrouter_tui::select::Item::new(method.name(), method.description().unwrap_or(""))
+            })
+            .collect(),
+        0,
+    )
+    .await;
+    match selected {
+        Ok(index) => Ok(auth_choice(index, methods).unwrap_or(AuthChoice::Declined)),
+        Err(error)
+            if error
+                .downcast_ref::<std::io::Error>()
+                .is_some_and(|e| e.kind() == std::io::ErrorKind::Interrupted) =>
         {
-            // EOF, not a choice.
-            eprintln!();
-            return Ok(AuthChoice::Declined);
+            Ok(AuthChoice::Declined)
         }
-        match classify_choice(&line, methods) {
-            Some(choice) => return Ok(choice),
-            // Not a selection: say why, then ask again.
-            None => match line.trim().parse::<usize>() {
-                Ok(n) => eprintln!(
-                    "    choice must be between 0 and {}, got {n}",
-                    methods.len()
-                ),
-                Err(_) => eprintln!("    '{}' is not a number", line.trim()),
-            },
-        }
+        Err(error) => Err(error),
     }
 }
 
-/// Classify one typed line against the offered methods.
-///
-/// Pure, so the interesting half of the picker is testable without a terminal:
-/// `choose_auth_method` owns stdin and the menu, this owns what the answer
-/// means. The same split `Editor::apply` and `machine::step` already use.
-///
-/// `0` cancels, an empty line takes the `[1]` default, and `1..=methods.len()`
-/// selects. Anything else is `None` — not a selection, ask again. Out-of-range
-/// never wraps onto a method that was not offered.
-fn classify_choice(
-    input: &str,
+fn auth_choice(
+    index: usize,
     methods: &[agent_client_protocol::schema::v1::AuthMethod],
 ) -> Option<AuthChoice> {
     use agent_client_protocol::schema::v1::AuthMethod;
-
-    let trimmed = input.trim();
-    let index = if trimmed.is_empty() {
-        1
-    } else {
-        match trimmed.parse::<usize>() {
-            Ok(0) => return Some(AuthChoice::Declined),
-            Ok(n) if (1..=methods.len()).contains(&n) => n,
-            Ok(_) | Err(_) => return None,
-        }
-    };
-    Some(match methods.get(index - 1)? {
-        // ACP is explicit that a terminal method is never passed to
-        // `authenticate`: the interactive process is not the connection.
+    Some(match methods.get(index)? {
+        // ACP terminal methods run out of band, never through authenticate.
         AuthMethod::Terminal(terminal) => AuthChoice::Terminal(Box::new(terminal.clone())),
         other => AuthChoice::Agent(other.id().clone()),
     })
@@ -2932,10 +2887,10 @@ mod auth_report_tests {
     use agent_client_protocol::schema::v1::{AuthMethod, AuthMethodAgent, AuthMethodTerminal};
 
     use super::{
-        AuthChoice, LaunchOptions, choose_auth_method, classify_choice, unauthenticated_message,
+        AuthChoice, LaunchOptions, auth_choice, choose_auth_method, unauthenticated_message,
     };
 
-    /// Two `agent` methods, in the order the picker numbers them.
+    /// Two agent methods in display order.
     fn two_methods() -> Vec<AuthMethod> {
         vec![
             AuthMethod::Agent(AuthMethodAgent::new("oauth", "Sign in with Anthropic")),
@@ -2959,95 +2914,35 @@ mod auth_report_tests {
         );
     }
 
-    /// **Nobody answering is never a login** (ACP_AUTH_SPEC §6.3). With no
-    /// advertised method there is nothing to offer, and the prompt declines
-    /// rather than inventing one.
+    #[tokio::test]
+    async fn nothing_advertised_declines_without_prompting() -> anyhow::Result<()> {
+        assert!(matches!(
+            choose_auth_method("pi-acp", &[]).await?,
+            AuthChoice::Declined
+        ));
+        Ok(())
+    }
+
     #[test]
-    fn nothing_advertised_declines_without_prompting() {
-        let choice = choose_auth_method("pi-acp", &[]).expect("declining is not an error");
+    fn selection_uses_only_advertised_methods() {
         assert!(
-            matches!(choice, AuthChoice::Declined),
-            "an empty method list must decline"
+            matches!(auth_choice(0, &two_methods()), Some(AuthChoice::Agent(id)) if id.0.as_ref() == "oauth")
         );
-    }
-
-    /// **Cancelling never authenticates** (ACP_AUTH_SPEC §6.3). The typed
-    /// decline is its own branch, distinct from the EOF one that returns the
-    /// same answer — this is the branch a live terminal was needed to reach.
-    #[test]
-    fn a_typed_zero_declines() {
         assert!(
-            matches!(
-                classify_choice("0", &two_methods()),
-                Some(AuthChoice::Declined)
-            ),
-            "'0' is the cancel entry the menu prints"
+            matches!(auth_choice(1, &two_methods()), Some(AuthChoice::Agent(id)) if id.0.as_ref() == "api-key")
         );
+        assert!(auth_choice(2, &two_methods()).is_none());
     }
 
-    /// A bare enter takes the `[1]` the prompt shows as the default — the
-    /// offer on screen and the answer must not disagree.
-    #[test]
-    fn a_bare_enter_takes_the_advertised_default() {
-        let Some(AuthChoice::Agent(id)) = classify_choice("\n", &two_methods()) else {
-            panic!("an empty line selects the first method")
-        };
-        assert_eq!(
-            id.to_string(),
-            "oauth",
-            "the default is the '[1]' on screen"
-        );
-    }
-
-    /// The numbering is the menu's, one-based.
-    #[test]
-    fn a_digit_selects_that_numbered_method() {
-        let Some(AuthChoice::Agent(id)) = classify_choice("2", &two_methods()) else {
-            panic!("'2' selects the second method")
-        };
-        assert_eq!(id.to_string(), "api-key", "numbering starts at one");
-    }
-
-    /// Out of range is not a selection. Nothing wraps onto an index the
-    /// harness never offered — the alternative is authenticating with a method
-    /// nobody was shown.
-    #[test]
-    fn an_unoffered_index_is_not_a_selection() {
-        assert!(
-            classify_choice("9", &two_methods()).is_none(),
-            "'9' against two methods must re-prompt, not wrap"
-        );
-    }
-
-    /// Anything that is not a number re-prompts rather than resolving.
-    #[test]
-    fn a_non_number_is_not_a_selection() {
-        assert!(
-            classify_choice("x", &two_methods()).is_none(),
-            "'x' must re-prompt"
-        );
-    }
-
-    /// A `terminal` method is routed to the out-of-band flow, never to
-    /// `authenticate` — ACP forbids passing it there because the interactive
-    /// process is not the ACP connection.
     #[test]
     fn a_terminal_method_never_becomes_an_authenticate_call() {
         let methods = vec![AuthMethod::Terminal(
             AuthMethodTerminal::new("login", "Log in from the terminal")
                 .args(vec!["--login".to_string()]),
         )];
-        let Some(AuthChoice::Terminal(descriptor)) = classify_choice("1", &methods) else {
-            panic!("a terminal method classifies to the out-of-band branch")
-        };
-        assert_eq!(
-            descriptor.args,
-            vec!["--login".to_string()],
-            "the descriptor's args are what the login appends"
-        );
         assert!(
-            descriptor.env.is_empty(),
-            "an unset env overlays nothing onto the base configuration"
+            matches!(auth_choice(0, &methods), Some(AuthChoice::Terminal(descriptor))
+            if descriptor.args == ["--login"] && descriptor.env.is_empty())
         );
     }
 

--- a/apps/bitrouter/src/assemble.rs
+++ b/apps/bitrouter/src/assemble.rs
@@ -870,6 +870,12 @@ pub async fn build_app_with_path(
     let app = app.prompt_transform(
         Arc::new(crate::claude_code::ClaudeCodeRouter) as Arc<dyn PromptTransform>
     );
+    // Codex ACP keeps its native default/model picker. Qualify known native
+    // names at ingress when the Codex subscription is active, without making
+    // personal subscriptions part of the generic API auto-cascade.
+    let app = app.prompt_transform(Arc::new(crate::codex_router::CodexRouter::new(Arc::clone(
+        &routing_table_for_reload,
+    ))) as Arc<dyn PromptTransform>);
     // Config-driven per-request model routing (`policy_table:`): an ingress
     // transform that fingerprints the agent-loop step and rewrites `prompt.model`
     // to the tier the policy table assigns, enforcing the tool-use guardrail.

--- a/apps/bitrouter/src/bundled_registry.rs
+++ b/apps/bitrouter/src/bundled_registry.rs
@@ -1,6 +1,6 @@
-//! Provider defaults shipped with the maintained ACP harnesses. Generated from
-//! the same registry artifacts as the binary, so fresh installs and a stale
-//! public registry can still resolve their subscription login and models.
+//! Public provider defaults from the committed registry snapshot. A fresh
+//! installation can list providers and resolve login/models without a cache;
+//! fetched metadata takes precedence when it is available.
 
 use anyhow::Result;
 use bitrouter_providers::registry::types::RegistryData;
@@ -35,7 +35,7 @@ fn enable_with_store(
 fn bundled() -> Result<RegistryData> {
     Ok(serde_json::from_str(include_str!(concat!(
         env!("OUT_DIR"),
-        "/acp_providers.json"
+        "/provider_registry.json"
     )))?)
 }
 
@@ -57,7 +57,7 @@ pub(crate) async fn load(registry: &RegistryConfig) -> Option<RegistryData> {
     match supplement(registry, remote.clone()) {
         Ok(data) => data,
         Err(error) => {
-            tracing::warn!(%error, "could not load bundled ACP provider defaults");
+            tracing::warn!(%error, "could not load bundled provider registry");
             remote
         }
     }
@@ -97,6 +97,34 @@ fn supplement(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use anyhow::Context;
+
+    #[test]
+    fn offline_catalog_preserves_all_committed_providers() -> Result<()> {
+        let committed: serde_json::Value =
+            serde_json::from_str(include_str!("../../../dist/registry/providers.json"))?;
+        let data = supplement(&RegistryConfig::default(), None)?.context("no offline catalog")?;
+        let actual: std::collections::BTreeSet<_> = data
+            .providers
+            .iter()
+            .map(|provider| provider.name.as_str())
+            .collect();
+        let expected: std::collections::BTreeSet<_> = committed["data"]
+            .as_array()
+            .context("no provider array")?
+            .iter()
+            .filter_map(|provider| provider["name"].as_str())
+            .collect();
+        assert_eq!(actual, expected);
+        for provider in data
+            .providers
+            .iter()
+            .filter(|provider| provider.is_active() && provider.is_mergeable())
+        {
+            bitrouter_providers::builtin::entry_from_registry(provider)?;
+        }
+        Ok(())
+    }
 
     #[test]
     fn subscription_login_defaults_are_available_without_a_cache() -> Result<()> {

--- a/apps/bitrouter/src/codex_router.rs
+++ b/apps/bitrouter/src/codex_router.rs
@@ -1,0 +1,209 @@
+//! Route a Codex ACP adapter's native model names to its configured subscription.
+//! The harness header is a routing hint, never an authentication credential:
+//! ordinary gateway authorization and provider credentials still apply.
+
+use std::sync::Arc;
+
+use bitrouter_sdk::config::ConfigRoutingTable;
+use bitrouter_sdk::language_model::types::Prompt;
+use bitrouter_sdk::{HeaderMap, PromptTransform};
+
+const PROVIDER: &str = "openai-codex";
+
+pub(crate) struct CodexRouter {
+    routing_table: Arc<ConfigRoutingTable>,
+}
+
+impl CodexRouter {
+    pub(crate) fn new(routing_table: Arc<ConfigRoutingTable>) -> Self {
+        Self { routing_table }
+    }
+}
+
+impl PromptTransform for CodexRouter {
+    fn apply(&self, _prompt: &mut Prompt) {}
+
+    fn apply_with_headers(&self, prompt: &mut Prompt, headers: &HeaderMap) {
+        // Both ACP providers/set and the adapter's environment fallback carry
+        // this marker. Do not infer subscription intent for generic API calls,
+        // other agents, explicit routes, canonical names or preset expressions.
+        if headers
+            .get("x-bitrouter-harness")
+            .and_then(|value| value.to_str().ok())
+            != Some("codex-acp")
+            || prompt.model.contains([':', '/', '@'])
+        {
+            return;
+        }
+        // Consult the live table so a reload's activation/model changes take
+        // effect here too. User-defined virtual models remain authoritative.
+        let config = self.routing_table.snapshot_config();
+        if config.models.contains_key(&prompt.model) {
+            return;
+        }
+        let Some(provider) = config
+            .providers
+            .get(PROVIDER)
+            .filter(|provider| provider.active)
+        else {
+            return;
+        };
+        if provider
+            .models
+            .iter()
+            .any(|model| model.provider_model_id.as_deref().unwrap_or(&model.id) == prompt.model)
+        {
+            // Preserve the native name in the adapter (and its model metadata).
+            // Only gateway ingress qualifies it; normal resolution still owns
+            // protocol, credential, policy and account selection.
+            prompt.model = format!("{PROVIDER}:{}", prompt.model);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::{Context, Result};
+    use bitrouter_sdk::config::Config;
+    use bitrouter_sdk::config::routing_table::resolve_route_chain;
+    use bitrouter_sdk::language_model::routing::RoutingPrefs;
+
+    fn config() -> Result<Config> {
+        Ok(bitrouter_sdk::config::parse_with(
+            r#"
+inherit_defaults: false
+database:
+  url: "sqlite::memory:"
+server:
+  skip_auth: true
+providers:
+  openai-codex:
+    api_base: https://example.invalid
+    class: first-party-subscription
+    models:
+      - id: openai/gpt-native
+        provider_model_id: gpt-native
+        api_protocol: responses
+"#,
+            |_| None,
+        )?)
+    }
+
+    fn prompt(model: &str) -> Prompt {
+        Prompt {
+            model: model.into(),
+            system: None,
+            system_provider_metadata: Default::default(),
+            messages: Vec::new(),
+            tools: Vec::new(),
+            params: Default::default(),
+            response_format: None,
+            tool_choice: None,
+            stream: false,
+        }
+    }
+
+    fn headers(harness: &str) -> Result<HeaderMap> {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-bitrouter-harness", harness.parse()?);
+        Ok(headers)
+    }
+
+    #[tokio::test]
+    async fn assembled_app_routes_unpinned_codex_native_models() -> Result<()> {
+        let config = config()?;
+        // This is the first-run failure: a subscription is absent from the
+        // generic cascade and its catalog id differs from the native default.
+        assert!(resolve_route_chain(&config, "gpt-native", &RoutingPrefs::default()).is_err());
+        let app = crate::assemble::build_app(&config).await?;
+        let mut request = prompt("gpt-native");
+        for transform in app.app.prompt_transforms() {
+            transform.apply_with_headers(&mut request, &headers("codex-acp")?);
+        }
+        assert_eq!(request.model, "openai-codex:gpt-native");
+        let routes = resolve_route_chain(&config, &request.model, &RoutingPrefs::default())?;
+        let target = routes.first().context("no Codex route")?;
+        assert_eq!(target.provider_name, "openai-codex");
+        assert_eq!(target.service_id, "gpt-native");
+        Ok(())
+    }
+
+    #[test]
+    fn generic_requests_and_explicit_model_choices_are_unchanged() -> Result<()> {
+        let config = config()?;
+        let router = CodexRouter::new(Arc::new(ConfigRoutingTable::from_config(config.clone())));
+        for marker in [None, Some("claude-acp"), Some("codex"), Some("CODEX-ACP")] {
+            let mut request = prompt("gpt-native");
+            router.apply_with_headers(
+                &mut request,
+                &marker.map(headers).transpose()?.unwrap_or_default(),
+            );
+            assert_eq!(request.model, "gpt-native");
+        }
+        for model in [
+            "openai/gpt-native",
+            "other:gpt-native",
+            "gpt-native@cheap",
+            "@auto",
+            "gpt-unknown",
+        ] {
+            let mut request = prompt(model);
+            router.apply_with_headers(&mut request, &headers("codex-acp")?);
+            assert_eq!(request.model, model);
+        }
+        // Generic canonical requests still cannot silently use a subscription.
+        assert!(
+            resolve_route_chain(&config, "openai/gpt-native", &RoutingPrefs::default()).is_err()
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn model_changes_in_the_agent_and_daemon_reload_are_respected() -> Result<()> {
+        let table = Arc::new(ConfigRoutingTable::from_config(config()?));
+        let router = CodexRouter::new(Arc::clone(&table));
+        let marker = headers("codex-acp")?;
+        let mut updated = config()?;
+        let provider = updated
+            .providers
+            .get_mut(PROVIDER)
+            .context("missing provider")?;
+        provider.models[0].provider_model_id = Some("gpt-next".into());
+        table.replace_config(updated.clone()).await?;
+        let mut old = prompt("gpt-native");
+        router.apply_with_headers(&mut old, &marker);
+        assert_eq!(old.model, "gpt-native");
+        let mut next = prompt("gpt-next");
+        router.apply_with_headers(&mut next, &marker);
+        router.apply_with_headers(&mut next, &marker);
+        assert_eq!(next.model, "openai-codex:gpt-next");
+        updated
+            .providers
+            .get_mut(PROVIDER)
+            .context("missing provider")?
+            .active = false;
+        table.replace_config(updated).await?;
+        let mut inactive = prompt("gpt-next");
+        router.apply_with_headers(&mut inactive, &marker);
+        assert_eq!(inactive.model, "gpt-next");
+        table.replace_config(Config::default()).await?;
+        router.apply_with_headers(&mut inactive, &marker);
+        assert_eq!(inactive.model, "gpt-next");
+        Ok(())
+    }
+
+    #[test]
+    fn explicit_virtual_models_win_over_the_native_default() -> Result<()> {
+        let mut config = config()?;
+        config.models.insert(
+            "gpt-native".into(),
+            serde_json::from_value(serde_json::json!({"endpoints": []}))?,
+        );
+        let router = CodexRouter::new(Arc::new(ConfigRoutingTable::from_config(config)));
+        let mut request = prompt("gpt-native");
+        router.apply_with_headers(&mut request, &headers("codex-acp")?);
+        assert_eq!(request.model, "gpt-native");
+        Ok(())
+    }
+}

--- a/apps/bitrouter/src/commands.rs
+++ b/apps/bitrouter/src/commands.rs
@@ -438,61 +438,22 @@ fn available_methods(entry: &bitrouter_providers::ProviderEntry) -> Vec<AuthMeth
     methods
 }
 
-/// Prompt for an integer choice between `[1, options.len()]`. Empty
-/// input (or just <enter>) picks option 1. Invalid input (non-number,
-/// out-of-range) prints a one-line error and re-prompts; a true EOF on
-/// stdin (read_line returns 0 bytes) bails so the caller doesn't loop
-/// forever in non-interactive contexts.
-fn prompt_method_choice(provider: &str, options: &[AuthMethod]) -> Result<AuthMethod> {
-    use std::io::BufRead;
-    eprintln!();
-    eprintln!("How would you like to authenticate to {provider}?");
-    for (i, m) in options.iter().enumerate() {
-        eprintln!("  {}) {}", i + 1, m.label());
-    }
-    let stdin = std::io::stdin();
-    let mut handle = stdin.lock();
-    loop {
-        eprint!("Choose [1]: ");
-        let mut line = String::new();
-        let n_bytes = handle
-            .read_line(&mut line)
-            .context("reading method choice from stdin")?;
-        if n_bytes == 0 {
-            anyhow::bail!("stdin closed before a choice was made");
-        }
-        match classify_method_choice(&line, options) {
-            Some(method) => return Ok(method),
-            // Not a selection: say why, then ask again.
-            None => match line.trim().parse::<usize>() {
-                Ok(n) => eprintln!("  choice must be between 1 and {}, got {n}", options.len()),
-                Err(_) => eprintln!("  '{}' is not a number", line.trim()),
-            },
-        }
-    }
-}
-
-/// Classify one typed line against the offered methods.
-///
-/// Pure, so the interesting half of the picker is testable without a terminal:
-/// `prompt_method_choice` owns stdin and the menu, this owns what the answer
-/// means. The same split `classify_choice` gives the ACP picker, and the one
-/// `Editor::apply` and `machine::step` are built on.
-///
-/// An empty line takes the `[1]` default and `1..=options.len()` selects.
-/// Anything else is `None` — not a selection, ask again. Out-of-range never
-/// wraps onto a method that was not offered, and this menu has no cancel entry,
-/// so `0` is out of range like any other unoffered index. Callers offer at
-/// least one method; an empty slice selects nothing.
-fn classify_method_choice(input: &str, options: &[AuthMethod]) -> Option<AuthMethod> {
-    let trimmed = input.trim();
-    if trimmed.is_empty() {
-        return options.first().copied();
-    }
-    match trimmed.parse::<usize>() {
-        Ok(n) if (1..=options.len()).contains(&n) => options.get(n - 1).copied(),
-        Ok(_) | Err(_) => None,
-    }
+/// Use the same searchable keyboard selector as onboarding.
+async fn prompt_method_choice(provider: &str, options: &[AuthMethod]) -> Result<AuthMethod> {
+    let index = crate::prompt::select(
+        &format!("Log in to {provider}"),
+        "Choose an authentication method",
+        options
+            .iter()
+            .map(|method| bitrouter_tui::select::Item::new(method.label(), ""))
+            .collect(),
+        0,
+    )
+    .await?;
+    options
+        .get(index)
+        .copied()
+        .context("no authentication method selected")
 }
 
 /// `bitrouter providers login <provider> [--label <name>]` — interactive
@@ -545,16 +506,15 @@ pub async fn login_provider_with_options(
     {
         Some(e) => e,
         None => {
-            let data = bitrouter_providers::registry::apply::load_or_cached(
-                &bitrouter_sdk::config::RegistryConfig::default(),
-            )
-            .await
-            .ok_or_else(|| {
-                anyhow::anyhow!(
-                    "could not load the provider registry (offline, and nothing cached) \
+            let data =
+                crate::bundled_registry::load(&bitrouter_sdk::config::RegistryConfig::default())
+                    .await
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "could not load the provider registry (offline, and nothing cached) \
                      to resolve '{provider_id}'"
-                )
-            })?;
+                        )
+                    })?;
             let provider = data
                 .providers
                 .iter()
@@ -569,7 +529,29 @@ pub async fn login_provider_with_options(
                 .with_context(|| format!("resolving the auth shape for '{provider_id}'"))?
         }
     };
-    let methods = available_methods(&entry);
+    login_entry(&entry, label, options).await
+}
+
+/// Onboarding uses the exact registry entry shown in its provider list.
+pub(crate) async fn login_registry_provider(
+    provider: &bitrouter_providers::registry::types::RegistryProvider,
+) -> Result<LoginOutcome> {
+    let entry = bitrouter_providers::builtin::entry_from_registry(provider)?;
+    login_entry(
+        &entry,
+        bitrouter_providers::oauth::credential_store::DEFAULT_LABEL,
+        ProviderLoginOptions::default(),
+    )
+    .await
+}
+
+async fn login_entry(
+    entry: &bitrouter_providers::ProviderEntry,
+    label: &str,
+    options: ProviderLoginOptions,
+) -> Result<LoginOutcome> {
+    let provider_id = entry.id.as_str();
+    let methods = available_methods(entry);
     if methods.is_empty() {
         anyhow::bail!(
             "provider '{provider_id}' has no interactive login path \
@@ -577,7 +559,7 @@ pub async fn login_provider_with_options(
             std::mem::discriminant(&entry.auth)
         );
     }
-    let chosen = choose_auth_method(&entry, &methods, &options)?;
+    let chosen = choose_auth_method(entry, &methods, &options).await?;
     eprintln!();
     eprintln!(
         "  Logging in to {} via {}",
@@ -589,7 +571,7 @@ pub async fn login_provider_with_options(
         AuthMethod::ClaudeCodeSession => run_claude_code_session().await?,
         AuthMethod::PkceSubscription => run_pkce_subscription(provider_id).await?,
         AuthMethod::ImportFromCli => run_cli_import(provider_id)?,
-        AuthMethod::DeviceCode => run_device_code(provider_id, &entry).await?,
+        AuthMethod::DeviceCode => run_device_code(provider_id, entry).await?,
         // A flag-supplied key (`--api-key` / `--key-stdin` / the wizard) skips
         // the interactive stdin paste; otherwise prompt for it.
         AuthMethod::ApiKey => match options.api_key.as_deref() {
@@ -623,7 +605,7 @@ pub async fn login_provider_with_options(
     })
 }
 
-fn choose_auth_method(
+async fn choose_auth_method(
     entry: &bitrouter_providers::ProviderEntry,
     methods: &[AuthMethod],
     options: &ProviderLoginOptions,
@@ -670,7 +652,7 @@ fn choose_auth_method(
     if selectable.len() == 1 || options.no_browser {
         Ok(selectable[0])
     } else {
-        prompt_method_choice(&entry.display_name, &selectable)
+        prompt_method_choice(&entry.display_name, &selectable).await
     }
 }
 
@@ -945,6 +927,14 @@ fn run_cli_import(
 fn run_api_key_paste(
     display_name: &str,
 ) -> Result<bitrouter_providers::oauth::credential_store::Credential> {
+    Ok(
+        bitrouter_providers::oauth::credential_store::Credential::api_key(read_api_key(
+            display_name,
+        )?),
+    )
+}
+
+pub(crate) fn read_api_key(display_name: &str) -> Result<String> {
     use std::io::BufRead;
     eprintln!();
     eprintln!("  Paste your {display_name} API key, then press enter:");
@@ -959,7 +949,7 @@ fn run_api_key_paste(
     if key.is_empty() {
         anyhow::bail!("no API key entered — aborting login");
     }
-    Ok(bitrouter_providers::oauth::credential_store::Credential::api_key(key))
+    Ok(key.to_string())
 }
 
 /// `LoginUx` implementation that drives stderr + stdin. Used by the
@@ -1303,65 +1293,8 @@ mod tests {
         assert!(!methods.contains(&AuthMethod::ClaudeCodeSession));
     }
 
-    /// The picker's two offered methods, in the order it numbers them.
-    fn two_methods() -> Vec<AuthMethod> {
-        vec![AuthMethod::ImportFromCli, AuthMethod::PkceSubscription]
-    }
-
-    /// A bare enter takes the `[1]` the prompt shows as the default — the offer
-    /// on screen and the answer must not disagree.
-    #[test]
-    fn a_bare_enter_takes_the_advertised_default() {
-        assert_eq!(
-            classify_method_choice("\n", &two_methods()),
-            Some(AuthMethod::ImportFromCli),
-            "the default is the '[1]' on screen"
-        );
-    }
-
-    /// The numbering is the menu's, one-based.
-    #[test]
-    fn a_digit_selects_that_numbered_method() {
-        assert_eq!(
-            classify_method_choice("2", &two_methods()),
-            Some(AuthMethod::PkceSubscription),
-            "numbering starts at one"
-        );
-    }
-
-    /// Out of range is not a selection. Nothing wraps onto an index the
-    /// provider never offered — the alternative is running a login flow nobody
-    /// was shown.
-    #[test]
-    fn an_unoffered_index_is_not_a_selection() {
-        assert!(
-            classify_method_choice("9", &two_methods()).is_none(),
-            "'9' against two methods must re-prompt, not wrap"
-        );
-    }
-
-    /// Unlike the ACP auth picker, this menu prints no `0) cancel` entry, so
-    /// zero is an unoffered index like any other and re-prompts. Aborting here
-    /// is Ctrl-C, not a hidden entry.
-    #[test]
-    fn zero_is_out_of_range_because_this_menu_offers_no_cancel() {
-        assert!(
-            classify_method_choice("0", &two_methods()).is_none(),
-            "'0' selects nothing on a menu that starts at one"
-        );
-    }
-
-    /// Anything that is not a number re-prompts rather than resolving.
-    #[test]
-    fn a_non_number_is_not_a_selection() {
-        assert!(
-            classify_method_choice("x", &two_methods()).is_none(),
-            "'x' must re-prompt"
-        );
-    }
-
-    #[test]
-    fn import_existing_selects_vendor_cli_import_without_prompting() {
+    #[tokio::test]
+    async fn import_existing_selects_vendor_cli_import_without_prompting() -> Result<()> {
         let entry = entry_for(serde_json::json!({
             "name": "openai-codex",
             "api_base": "https://chatgpt.com/backend-api/codex",
@@ -1379,12 +1312,13 @@ mod tests {
                 api_key: None,
             },
         )
-        .unwrap();
+        .await?;
         assert_eq!(chosen, AuthMethod::ImportFromCli);
+        Ok(())
     }
 
-    #[test]
-    fn api_key_option_selects_api_key_method_without_prompting() {
+    #[tokio::test]
+    async fn api_key_option_selects_api_key_method_without_prompting() -> Result<()> {
         // A `--api-key`/`--key-stdin`-supplied key drives the non-interactive
         // BYOK path: `anthropic` offers the API-key method, so it's chosen.
         let entry = entry_for(serde_json::json!({
@@ -1404,12 +1338,13 @@ mod tests {
                 api_key: Some("sk-ant-test".to_string()),
             },
         )
-        .unwrap();
+        .await?;
         assert_eq!(chosen, AuthMethod::ApiKey);
+        Ok(())
     }
 
-    #[test]
-    fn api_key_option_rejects_oauth_only_providers() {
+    #[tokio::test]
+    async fn api_key_option_rejects_oauth_only_providers() -> Result<()> {
         // `openai-codex` is OAuth-only (no API-key method); a supplied key is a
         // clear error rather than a silently-ignored flag.
         let entry = entry_for(serde_json::json!({
@@ -1429,12 +1364,15 @@ mod tests {
                 api_key: Some("sk-whatever".to_string()),
             },
         )
-        .unwrap_err();
+        .await
+        .err()
+        .context("login flags must be rejected")?;
         assert!(format!("{err:#}").contains("does not accept a pasted API key"));
+        Ok(())
     }
 
-    #[test]
-    fn import_existing_rejects_providers_without_vendor_cli_import() {
+    #[tokio::test]
+    async fn import_existing_rejects_providers_without_vendor_cli_import() -> Result<()> {
         let entry = entry_for(serde_json::json!({
             "name": "anthropic",
             "api_base": "https://api.anthropic.com/v1",
@@ -1452,8 +1390,11 @@ mod tests {
                 api_key: None,
             },
         )
-        .unwrap_err();
+        .await
+        .err()
+        .context("login flags must be rejected")?;
         assert!(format!("{err:#}").contains("cannot import"));
+        Ok(())
     }
 
     fn sample_config() -> Config {

--- a/apps/bitrouter/src/lib.rs
+++ b/apps/bitrouter/src/lib.rs
@@ -22,6 +22,7 @@ mod bundled_registry;
 pub mod chat;
 pub mod claude_code;
 pub mod cloud;
+mod codex_router;
 pub mod commands;
 pub mod config_synthesis;
 pub mod conformance;

--- a/apps/bitrouter/src/lib.rs
+++ b/apps/bitrouter/src/lib.rs
@@ -43,6 +43,7 @@ pub mod policy;
 pub mod policy_compile;
 pub mod policy_lock;
 pub mod policy_table_router;
+mod prompt;
 pub mod reload;
 pub mod result_contract;
 pub mod session_identity;

--- a/apps/bitrouter/src/onboarding.rs
+++ b/apps/bitrouter/src/onboarding.rs
@@ -655,6 +655,14 @@ async fn run_interactive(
     eprintln!("Welcome to BitRouter — let's get you to first value.");
     eprintln!();
 
+    if signals.is_configured() {
+        note(&format!(
+            "Detected: {}",
+            OnboardingStatusReport::from_signals(signals)
+                .signals
+                .join("; ")
+        ));
+    }
     // --- Step 1: credentials ---
     let mut configured = signals.already_configured();
     let mut skipped: Vec<String> = Vec::new();
@@ -675,14 +683,14 @@ async fn run_interactive(
         eprintln!("Step 1/3 — Credentials");
         note("using the detected credential(s)");
     } else if !seeded_from_flags {
-        interactive_credentials(signals, &mut configured, &mut skipped, manager).await?;
+        interactive_credentials(&flags, &mut configured, &mut skipped, manager).await?;
     }
 
     // --- Step 2: harness ---
     let installed = interactive_harness(&flags).await?;
 
     // --- Step 3: finish ---
-    let after = interactive_after(&flags, &installed)?;
+    let after = interactive_after(&flags, &installed).await?;
 
     let agent = installed
         .first()
@@ -703,71 +711,141 @@ async fn run_interactive(
     }
 }
 
+/// Providers offered by the OSS registry, with no special placement for Cloud.
+fn provider_choices(
+    data: &bitrouter_providers::registry::types::RegistryData,
+) -> Vec<&bitrouter_providers::registry::types::RegistryProvider> {
+    let mut providers: Vec<_> = data
+        .providers
+        .iter()
+        .filter(|provider| provider.is_active() && provider.is_mergeable())
+        .collect();
+    providers.sort_by_key(|provider| {
+        (
+            provider
+                .display_name
+                .as_deref()
+                .unwrap_or(&provider.name)
+                .to_lowercase(),
+            provider.name.clone(),
+        )
+    });
+    providers
+}
+
 async fn interactive_credentials(
-    signals: &ProbeSignals,
+    flags: &OnboardingFlags,
     configured: &mut BTreeSet<String>,
     skipped: &mut Vec<String>,
     manager: Arc<CredentialManager>,
 ) -> Result<()> {
-    eprintln!("Step 1/3 — Credentials");
-    if signals.is_configured() {
-        eprintln!(
-            "  Detected: {}",
-            OnboardingStatusReport::from_signals(signals)
-                .signals
-                .join("; ")
-        );
+    use bitrouter_tui::select::Item;
+
+    let path = config_path(flags.config.as_deref())?;
+    let registry = if path.is_file() && !flags.force {
+        serde_saphyr::from_str::<bitrouter_sdk::config::Config>(&std::fs::read_to_string(path)?)?
+            .registry
+    } else {
+        bitrouter_sdk::config::RegistryConfig::default()
+    };
+    note("loading providers from the registry…");
+    let data = crate::bundled_registry::load(&registry).await;
+    let providers = data.as_ref().map(provider_choices).unwrap_or_default();
+    for provider in &providers {
+        if provider
+            .env_credential_var()
+            .is_some_and(|var| crate::spawn::nonempty_env(&var).is_some())
+        {
+            configured.insert(provider.name.clone());
+        }
     }
+    let mut help = if providers.is_empty() {
+        "Registry unavailable or disabled. Continue to set up an ACP harness.".to_string()
+    } else {
+        "Choose a provider to sign in. End jumps to Continue.".to_string()
+    };
+    let mut selected = if configured.is_empty() {
+        0
+    } else {
+        providers.len()
+    };
     loop {
-        eprintln!();
-        eprintln!("  How would you like to authenticate?");
-        eprintln!("    1) Sign in to BitRouter Cloud — one account, every model [default]");
-        eprintln!("    2) Log in to a specific provider (claude-code / openai-codex / …)");
-        if signals.is_configured() {
-            eprintln!("    3) Use the detected credential(s) and continue");
-        }
-        eprintln!("    0) Skip for now");
-        match prompt_line("  Choose [1]: ")?.as_str() {
-            "" | "1" => match seed_cloud_interactive(Arc::clone(&manager)).await {
-                Ok(()) => {
-                    configured.insert(PROVIDER_ID.to_string());
-                }
-                Err(e) => note(&format!("cloud sign-in did not complete: {e:#}")),
-            },
-            "2" => {
-                let id = prompt_line("  Provider id: ")?;
-                if id.is_empty() {
-                    note("no provider id entered — skipping");
+        let mut items: Vec<_> = providers
+            .iter()
+            .map(|provider| {
+                let status = if configured.contains(&provider.name) {
+                    " · configured"
                 } else {
-                    match login_provider_with_options(
-                        &id,
-                        bitrouter_providers::oauth::credential_store::DEFAULT_LABEL,
-                        ProviderLoginOptions::default(),
-                    )
-                    .await
-                    {
-                        Ok(_) => {
-                            configured.insert(id);
-                        }
-                        Err(e) => {
-                            note(&format!("provider '{id}' login did not complete: {e:#}"));
-                            skipped.push(id);
-                        }
-                    }
+                    ""
+                };
+                Item::new(
+                    provider.display_name.as_deref().unwrap_or(&provider.name),
+                    format!("{}{status}", provider.name),
+                )
+            })
+            .collect();
+        items.push(Item::new(
+            "Continue to harness setup",
+            if configured.is_empty() {
+                "skip provider login for now".to_string()
+            } else {
+                format!("use {} configured provider(s)", configured.len())
+            },
+        ));
+        selected = crate::prompt::select("Step 1/3 — Providers", &help, items, selected).await?;
+        let Some(provider) = providers.get(selected) else {
+            return Ok(());
+        };
+        let id = &provider.name;
+        let result = if id == PROVIDER_ID {
+            let method = crate::prompt::select(
+                &format!(
+                    "Log in to {}",
+                    provider.display_name.as_deref().unwrap_or(id)
+                ),
+                "Choose an authentication method",
+                vec![
+                    Item::new("Browser sign-in", "device-code OAuth"),
+                    Item::new("API key", "paste a static credential"),
+                ],
+                0,
+            )
+            .await?;
+            if method == 0 {
+                seed_cloud_interactive(Arc::clone(&manager)).await
+            } else {
+                let key = crate::commands::read_api_key(id)?;
+                seed_cloud_api_key(&key, Arc::clone(&manager)).await
+            }
+        } else {
+            crate::commands::login_registry_provider(provider)
+                .await
+                .map(|_| ())
+        };
+        match result {
+            Ok(()) => {
+                configured.insert(id.clone());
+                skipped.retain(|skipped_id| skipped_id != id);
+                help = format!("{id} configured. Add another provider, or Continue.");
+                selected = providers.len();
+            }
+            Err(error) => {
+                if error
+                    .downcast_ref::<std::io::Error>()
+                    .is_some_and(|e| e.kind() == std::io::ErrorKind::Interrupted)
+                {
+                    return Err(error);
+                }
+                note(&format!(
+                    "provider '{id}' login did not complete: {error:#}"
+                ));
+                help = format!("{id}: {error}. Select to retry, or choose another provider.");
+                if !skipped.contains(id) {
+                    skipped.push(id.clone());
                 }
             }
-            "3" if signals.is_configured() => break,
-            "0" => break,
-            other => {
-                note(&format!("'{other}' is not a choice"));
-                continue;
-            }
-        }
-        if !prompt_yes_no("  Add another provider?", false) {
-            break;
         }
     }
-    Ok(())
 }
 
 /// The cloud device-flow sign-in. Calls the Cloud login flow directly (not
@@ -801,42 +879,59 @@ async fn interactive_harness(flags: &OnboardingFlags) -> Result<Vec<String>> {
             .map(String::from)
             .collect());
     }
-    loop {
-        match prompt_line("  ACP harness [codex/claude] (codex): ")?
-            .to_ascii_lowercase()
-            .as_str()
-        {
-            "" | "codex" | "codex-acp" => return Ok(vec!["codex-acp".into()]),
-            "claude" | "claude-acp" => return Ok(vec!["claude-acp".into()]),
-            _ => note("choose codex or claude"),
-        }
-    }
+    let harnesses = crate::harness::CATALOG;
+    let selected = crate::prompt::select(
+        "Step 2/3 — Default ACP harness",
+        "BitRouter provides the TUI. Choose the agent it runs.",
+        harnesses
+            .iter()
+            .map(|harness| bitrouter_tui::select::Item::new(harness.id, harness.description))
+            .collect(),
+        harnesses
+            .iter()
+            .position(|harness| harness.id == "codex-acp")
+            .unwrap_or(0),
+    )
+    .await?;
+    Ok(vec![
+        harnesses
+            .get(selected)
+            .context("no ACP harness selected")?
+            .id
+            .to_string(),
+    ])
 }
 
-fn interactive_after(flags: &OnboardingFlags, installed: &[String]) -> Result<AfterAction> {
+async fn interactive_after(flags: &OnboardingFlags, installed: &[String]) -> Result<AfterAction> {
+    use bitrouter_tui::select::Item;
     if let Some(after) = flags.after {
         return Ok(after);
     }
-    eprintln!();
-    eprintln!("Step 3/3 — Finish");
-    let can_launch = !installed.is_empty();
-    if can_launch {
-        eprintln!("    1) Open BitRouter ACP TUI now [default]");
+    let mut actions = Vec::new();
+    let mut items = Vec::new();
+    if !installed.is_empty() {
+        actions.push(AfterAction::Launch);
+        items.push(Item::new(
+            "Open BitRouter ACP TUI now",
+            "use the selected default harness",
+        ));
     }
-    eprintln!("    2) Start the daemon and print a paste-in snippet");
-    eprintln!("    3) Exit");
-    let default_choice = if can_launch { "1" } else { "2" };
-    let choice = prompt_line(&format!("  Choose [{default_choice}]: "))?;
-    let choice = if choice.is_empty() {
-        default_choice.to_string()
-    } else {
-        choice
-    };
-    Ok(match choice.as_str() {
-        "1" if can_launch => AfterAction::Launch,
-        "2" => AfterAction::Serve,
-        _ => AfterAction::Exit,
-    })
+    actions.extend([AfterAction::Serve, AfterAction::Exit]);
+    items.extend([
+        Item::new("Start the daemon", "print connection instructions"),
+        Item::new("Save and exit", "run bitrouter whenever you're ready"),
+    ]);
+    let selected = crate::prompt::select(
+        "Step 3/3 — Finish",
+        "Save your setup and choose what happens next",
+        items,
+        0,
+    )
+    .await?;
+    actions
+        .get(selected)
+        .copied()
+        .context("no finish action selected")
 }
 
 // =====================================================================
@@ -926,6 +1021,7 @@ async fn reset_credentials(assume_yes: bool, interactive: bool) -> Result<()> {
             ),
             false,
         )
+        .await?
     } else {
         false
     };
@@ -995,33 +1091,19 @@ fn emit(output: &Output, report: &dyn CliReport) -> Result<()> {
     Output::emit(output, report).map_err(anyhow::Error::from)
 }
 
-/// Prompt on stderr. EOF cancels the wizard before its configuration is saved.
-fn prompt_line(prompt: &str) -> Result<String> {
-    use std::io::{BufRead, Write};
-    eprint!("{prompt}");
-    std::io::stderr().flush().ok();
-    let mut line = String::new();
-    let n = std::io::stdin()
-        .lock()
-        .read_line(&mut line)
-        .context("reading input from stdin")?;
-    if n == 0 {
-        anyhow::bail!("onboarding cancelled: input closed before completion");
-    }
-    Ok(line.trim().to_string())
-}
-
-/// A `[y/N]` (or `[Y/n]`) confirm. Blank accepts the default; EOF declines.
-fn prompt_yes_no(prompt: &str, default_yes: bool) -> bool {
-    let suffix = if default_yes { "[Y/n]" } else { "[y/N]" };
-    match prompt_line(&format!("{prompt} {suffix}: ")) {
-        Ok(answer) => match answer.to_ascii_lowercase().as_str() {
-            "" => default_yes,
-            "y" | "yes" => true,
-            _ => false,
-        },
-        Err(_) => false,
-    }
+/// Confirmation uses the same selector; cancellation propagates before reset.
+async fn prompt_yes_no(prompt: &str, default_yes: bool) -> Result<bool> {
+    let index = crate::prompt::select(
+        prompt,
+        "Choose whether to continue",
+        vec![
+            bitrouter_tui::select::Item::new("Yes", ""),
+            bitrouter_tui::select::Item::new("No", ""),
+        ],
+        usize::from(!default_yes),
+    )
+    .await?;
+    Ok(index == 0)
 }
 
 /// The multi-line onboarding hint (unconfigured, non-TTY). Mirrors the recovery
@@ -1045,6 +1127,27 @@ fn print_hint() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn provider_menu_contains_every_public_active_entry_in_display_order() -> Result<()> {
+        let data: bitrouter_providers::registry::types::RegistryData =
+            serde_json::from_value(serde_json::json!({
+                "providers": [
+                    {"name": "zulu", "display_name": "Zulu", "status": "active"},
+                    {"name": "bitrouter", "display_name": "BitRouter Cloud", "status": "active"},
+                    {"name": "alpha", "display_name": "Alpha", "status": "active"},
+                    {"name": "private", "status": "active", "access": "private"},
+                    {"name": "preview", "status": "staging"},
+                    {"name": "retired", "status": "withdrawn"}
+                ], "canonical": []
+            }))?;
+        let ids: Vec<_> = provider_choices(&data)
+            .iter()
+            .map(|provider| provider.name.as_str())
+            .collect();
+        assert_eq!(ids, ["alpha", "bitrouter", "zulu"]);
+        Ok(())
+    }
 
     #[test]
     fn detected_env_keys_reports_present_vars_only() {

--- a/apps/bitrouter/src/prompt.rs
+++ b/apps/bitrouter/src/prompt.rs
@@ -1,0 +1,59 @@
+//! Terminal input driver for the reusable selection surface.
+
+use std::io::{self, IsTerminal};
+
+use anyhow::{Context, Result};
+use bitrouter_tui::select::{Action, Item, Select, View};
+use futures::StreamExt;
+
+pub(crate) async fn select(
+    title: &str,
+    help: &str,
+    items: Vec<Item>,
+    default: usize,
+) -> Result<usize> {
+    if !io::stdin().is_terminal() || !io::stderr().is_terminal() {
+        anyhow::bail!("interactive selection needs a terminal; use explicit flags or init --yes");
+    }
+    if items.is_empty() {
+        anyhow::bail!("no choices available for {title}");
+    }
+    let mut select = Select::new(items, default);
+    let mut view = View::open().context("opening selection")?;
+    let mut events = crossterm::event::EventStream::new();
+    let interrupted = interruption();
+    tokio::pin!(interrupted);
+    loop {
+        view.draw(&mut select, title, help)?;
+        let event = tokio::select! {
+            event = events.next() => event.context("terminal input closed")??,
+            result = &mut interrupted => {
+                result?;
+                return Err(io::Error::new(io::ErrorKind::Interrupted, "selection cancelled").into());
+            }
+        };
+        match select.handle(event) {
+            Action::Selected(index) => return Ok(index),
+            Action::Cancelled => {
+                return Err(
+                    io::Error::new(io::ErrorKind::Interrupted, "selection cancelled").into(),
+                );
+            }
+            Action::Pending => {}
+        }
+    }
+}
+
+async fn interruption() -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        let mut terminate =
+            tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())?;
+        tokio::select! {
+            result = tokio::signal::ctrl_c() => result,
+            _ = terminate.recv() => Ok(()),
+        }
+    }
+    #[cfg(not(unix))]
+    tokio::signal::ctrl_c().await
+}

--- a/crates/bitrouter-providers/src/builtin.rs
+++ b/crates/bitrouter-providers/src/builtin.rs
@@ -59,12 +59,17 @@ pub fn load_builtins() -> Result<Vec<ProviderEntry>, LoadError> {
 /// — the same mapping the built-ins once used, now applied to a fetched-or-
 /// cached registry entry. Used where a consumer needs the auth shape of a
 /// registry-sourced provider without it being compiled in (e.g. `bitrouter
-/// login <provider>` resolving an OAuth handler + its public params). Errors if
-/// the provider declares no `auth` block.
+/// login <provider>` resolving an OAuth handler + its public params). An omitted
+/// `auth` block uses the registry's conventional Bearer credential env var.
 pub fn entry_from_registry(p: &RegistryProvider) -> Result<ProviderEntry, LoadError> {
-    let auth = p.auth.as_ref().ok_or_else(|| LoadError::Snapshot {
-        message: format!("provider '{}' has no auth", p.name),
-    })?;
+    let auth = match &p.auth {
+        Some(auth) => map_auth(&p.name, auth)?,
+        None => AuthScheme::Bearer {
+            env: p.env_credential_var().ok_or_else(|| LoadError::Snapshot {
+                message: format!("provider '{}' has no credential env var", p.name),
+            })?,
+        },
+    };
     let api_base = p.api_base.clone().ok_or_else(|| LoadError::Snapshot {
         message: format!("provider '{}' has no fixed api_base", p.name),
     })?;
@@ -74,7 +79,7 @@ pub fn entry_from_registry(p: &RegistryProvider) -> Result<ProviderEntry, LoadEr
         api_base,
         api_protocol: derive_protocol_mapping(p),
         protocol_endpoints: p.protocol_endpoints.clone().unwrap_or_default(),
-        auth: map_auth(&p.name, auth)?,
+        auth,
         doc_url: p.doc_url.clone().unwrap_or_default(),
         class: Some(derive_class(p)),
     })
@@ -323,13 +328,17 @@ mod tests {
     }
 
     #[test]
-    fn entry_from_registry_rejects_provider_without_auth() {
-        let provider = reg(serde_json::json!({
-            "name": "noauth",
-            "api_base": "https://noauth.test/v1",
+    fn entry_from_registry_uses_implicit_bearer_auth() -> Result<(), Box<dyn std::error::Error>> {
+        let provider: RegistryProvider = serde_json::from_value(serde_json::json!({
+            "name": "example-provider",
+            "api_base": "https://example.test/v1",
             "status": "active",
             "models": []
-        }));
-        assert!(entry_from_registry(&provider).is_err());
+        }))?;
+        let entry = entry_from_registry(&provider)?;
+        assert!(
+            matches!(entry.auth, AuthScheme::Bearer { env } if env == "EXAMPLE_PROVIDER_API_KEY")
+        );
+        Ok(())
     }
 }

--- a/crates/bitrouter-tui/src/lib.rs
+++ b/crates/bitrouter-tui/src/lib.rs
@@ -63,6 +63,7 @@ pub mod permission;
 pub mod picker;
 pub mod plain;
 pub mod render;
+pub mod select;
 pub mod view;
 pub mod wrap;
 pub mod writer;

--- a/crates/bitrouter-tui/src/select.rs
+++ b/crates/bitrouter-tui/src/select.rs
@@ -1,0 +1,359 @@
+//! Searchable, bounded single-choice lists. Callers supply rows and own input;
+//! selection returns the original row index, even while the list is filtered.
+
+use std::io;
+
+use crossterm::event::{Event, KeyCode, KeyEventKind, KeyModifiers};
+use ratatui::backend::CrosstermBackend;
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, List, ListItem, ListState, Paragraph};
+use ratatui::{Frame, Terminal};
+
+const ROWS: usize = 8;
+
+/// A selectable label and its searchable context (for example a provider id).
+pub struct Item {
+    pub label: String,
+    pub detail: String,
+}
+
+impl Item {
+    pub fn new(label: impl Into<String>, detail: impl Into<String>) -> Self {
+        Self {
+            label: label.into(),
+            detail: detail.into(),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum Action {
+    Pending,
+    Selected(usize),
+    Cancelled,
+}
+
+/// Keyboard/search state, independent of terminal I/O and application data.
+pub struct Select {
+    items: Vec<Item>,
+    query: String,
+    matches: Vec<usize>,
+    list: ListState,
+    page_size: usize,
+}
+
+impl Select {
+    pub fn new(items: Vec<Item>, selected: usize) -> Self {
+        let len = items.len();
+        Self {
+            items,
+            query: String::new(),
+            matches: (0..len).collect(),
+            list: ListState::default()
+                .with_selected((len > 0).then_some(selected.min(len.saturating_sub(1)))),
+            page_size: ROWS,
+        }
+    }
+
+    fn filter(&mut self) {
+        let query = self.query.to_lowercase();
+        self.matches = self
+            .items
+            .iter()
+            .enumerate()
+            .filter(|(_, item)| {
+                format!("{} {}", item.label, item.detail)
+                    .to_lowercase()
+                    .contains(&query)
+            })
+            .map(|(index, _)| index)
+            .collect();
+        self.list = ListState::default().with_selected((!self.matches.is_empty()).then_some(0));
+    }
+
+    fn move_by(&mut self, delta: isize) {
+        if let Some(selected) = self.list.selected() {
+            self.list.select(Some(
+                selected
+                    .saturating_add_signed(delta)
+                    .min(self.matches.len().saturating_sub(1)),
+            ));
+        }
+    }
+
+    /// Digits are search text. Only Enter accepts a row; Esc/Ctrl-C cancel.
+    pub fn handle(&mut self, event: Event) -> Action {
+        match event {
+            Event::Paste(text) => {
+                self.query.extend(text.chars().filter(|c| !c.is_control()));
+                self.filter();
+            }
+            Event::Key(key) if key.kind != KeyEventKind::Release => {
+                if key.modifiers.contains(KeyModifiers::CONTROL) {
+                    match key.code {
+                        KeyCode::Char('c' | 'd') => return Action::Cancelled,
+                        KeyCode::Char('u') => {
+                            self.query.clear();
+                            self.filter();
+                        }
+                        _ => {}
+                    }
+                    return Action::Pending;
+                }
+                match key.code {
+                    KeyCode::Esc => return Action::Cancelled,
+                    KeyCode::Enter => {
+                        if let Some(index) = self
+                            .list
+                            .selected()
+                            .and_then(|selected| self.matches.get(selected))
+                        {
+                            return Action::Selected(*index);
+                        }
+                    }
+                    KeyCode::Up => self.move_by(-1),
+                    KeyCode::Down => self.move_by(1),
+                    KeyCode::PageUp => self.move_by(-(self.page_size as isize)),
+                    KeyCode::PageDown => self.move_by(self.page_size as isize),
+                    KeyCode::Home => self.move_by(-(self.matches.len() as isize)),
+                    KeyCode::End => self.move_by(self.matches.len() as isize),
+                    KeyCode::Backspace => {
+                        self.query.pop();
+                        self.filter();
+                    }
+                    KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::ALT) => {
+                        self.query.push(c);
+                        self.filter();
+                    }
+                    _ => {}
+                }
+            }
+            _ => {}
+        }
+        Action::Pending
+    }
+
+    fn render(&mut self, frame: &mut Frame<'_>, title: &str, help: &str) {
+        let area = frame.area();
+        // Keep the list height steady as results narrow, but fit small terminals.
+        self.page_size = ROWS.min(usize::from(area.height.saturating_sub(8))).max(1);
+        let area = Rect::new(area.x, area.y, area.width.min(100), area.height);
+        let [heading, search, list, footer] = Layout::vertical([
+            Constraint::Length(2),
+            Constraint::Length(3),
+            Constraint::Length(self.page_size as u16 + 2),
+            Constraint::Min(1),
+        ])
+        .areas(area);
+        frame.render_widget(
+            Paragraph::new(vec![
+                Line::styled(
+                    title,
+                    Style::default()
+                        .fg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Line::from(help),
+            ]),
+            heading,
+        );
+        let query = if self.query.is_empty() {
+            "Type to search…".to_string()
+        } else {
+            self.query.clone()
+        };
+        // Keep the end of a long query visible, using terminal cell widths.
+        let width = usize::from(search.width.saturating_sub(2));
+        let mut tail = String::new();
+        let mut cells = 0;
+        for c in query.chars().rev() {
+            cells += unicode_width::UnicodeWidthChar::width(c).unwrap_or(0);
+            if cells > width {
+                break;
+            }
+            tail.push(c);
+        }
+        frame.render_widget(
+            Paragraph::new(tail.chars().rev().collect::<String>())
+                .block(Block::bordered().title(" Search ")),
+            search,
+        );
+        let position = self.list.selected().map_or(0, |index| index + 1);
+        let block = Block::bordered().title(format!(" {position}/{} ", self.matches.len()));
+        if self.matches.is_empty() {
+            frame.render_widget(
+                Paragraph::new("No matches — Ctrl-U clears search").block(block),
+                list,
+            );
+        } else {
+            let rows: Vec<_> = self
+                .matches
+                .iter()
+                .map(|index| {
+                    let item = &self.items[*index];
+                    ListItem::new(Line::from(vec![
+                        Span::raw(item.label.clone()),
+                        Span::styled(
+                            format!("  {}", item.detail),
+                            Style::default().fg(Color::DarkGray),
+                        ),
+                    ]))
+                })
+                .collect();
+            frame.render_stateful_widget(
+                List::new(rows)
+                    .block(block)
+                    .highlight_symbol("› ")
+                    .highlight_style(
+                        Style::default()
+                            .fg(Color::Cyan)
+                            .add_modifier(Modifier::BOLD),
+                    ),
+                list,
+                &mut self.list,
+            );
+        }
+        frame.render_widget(
+            Paragraph::new(
+                "↑/↓ move · Enter select · Esc cancel\nPgUp/PgDn scroll · Home/End · Ctrl-U clear",
+            ),
+            footer,
+        );
+    }
+}
+
+/// A temporary selection surface on stderr; stdout stays available for JSON.
+/// Dropping it restores the terminal before a login flow or chat takes over.
+pub struct View {
+    terminal: Terminal<CrosstermBackend<io::Stderr>>,
+}
+
+impl View {
+    pub fn open() -> io::Result<Self> {
+        let terminal = Terminal::new(CrosstermBackend::new(io::stderr()))?;
+        crate::lifecycle::enter_raw()?;
+        let mut view = Self { terminal };
+        crossterm::execute!(
+            view.terminal.backend_mut(),
+            crossterm::terminal::EnterAlternateScreen,
+            crossterm::event::EnableBracketedPaste,
+            crossterm::cursor::Hide
+        )?;
+        view.terminal.clear()?;
+        Ok(view)
+    }
+
+    pub fn draw(&mut self, select: &mut Select, title: &str, help: &str) -> io::Result<()> {
+        let size = self.terminal.size()?;
+        if size.width < 24 || size.height < 9 {
+            return Err(io::Error::other(
+                "selection needs a terminal at least 24 columns by 9 rows",
+            ));
+        }
+        self.terminal
+            .draw(|frame| select.render(frame, title, help))?;
+        Ok(())
+    }
+}
+
+impl Drop for View {
+    fn drop(&mut self) {
+        let _ = crossterm::terminal::disable_raw_mode();
+        let _ = crossterm::execute!(
+            self.terminal.backend_mut(),
+            crossterm::event::DisableBracketedPaste,
+            crossterm::terminal::LeaveAlternateScreen,
+            crossterm::cursor::Show
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::KeyEvent;
+    use ratatui::backend::TestBackend;
+
+    fn key(select: &mut Select, code: KeyCode) -> Action {
+        select.handle(Event::Key(KeyEvent::new(code, KeyModifiers::NONE)))
+    }
+
+    fn many() -> Select {
+        Select::new(
+            (0..45)
+                .map(|i| Item::new(format!("Provider {i:02}"), format!("id-{i}")))
+                .collect(),
+            0,
+        )
+    }
+
+    #[test]
+    fn search_selects_original_indices_and_digits_never_choose() {
+        let mut select = many();
+        assert_eq!(key(&mut select, KeyCode::Char('4')), Action::Pending);
+        key(&mut select, KeyCode::Down);
+        assert_eq!(key(&mut select, KeyCode::Enter), Action::Selected(14));
+        select.handle(Event::Paste("no-match".into()));
+        assert_eq!(key(&mut select, KeyCode::Enter), Action::Pending);
+        select.handle(Event::Key(KeyEvent::new(
+            KeyCode::Char('u'),
+            KeyModifiers::CONTROL,
+        )));
+        key(&mut select, KeyCode::End);
+        assert_eq!(key(&mut select, KeyCode::Enter), Action::Selected(44));
+        assert_eq!(key(&mut select, KeyCode::Esc), Action::Cancelled);
+    }
+
+    #[test]
+    fn navigation_reaches_every_row_and_stays_in_bounds() {
+        let mut select = many();
+        key(&mut select, KeyCode::Up);
+        for index in 0..45 {
+            assert_eq!(key(&mut select, KeyCode::Enter), Action::Selected(index));
+            key(&mut select, KeyCode::Down);
+        }
+        assert_eq!(key(&mut select, KeyCode::Enter), Action::Selected(44));
+        key(&mut select, KeyCode::Home);
+        key(&mut select, KeyCode::PageDown);
+        assert_eq!(key(&mut select, KeyCode::Enter), Action::Selected(8));
+        key(&mut select, KeyCode::PageUp);
+        assert_eq!(key(&mut select, KeyCode::Enter), Action::Selected(0));
+        let mut empty = Select::new(vec![], 10);
+        key(&mut empty, KeyCode::End);
+        assert_eq!(key(&mut empty, KeyCode::Enter), Action::Pending);
+    }
+
+    #[test]
+    fn rendering_scrolls_and_resizes_without_losing_selection() -> io::Result<()> {
+        let mut select = many();
+        let mut terminal = Terminal::new(TestBackend::new(70, 20))?;
+        key(&mut select, KeyCode::End);
+        terminal.draw(|frame| select.render(frame, "Providers", "Choose a provider"))?;
+        let screen = format!("{:?}", terminal.backend().buffer());
+        assert!(screen.contains("› Provider 44"));
+        assert!(!screen.contains("Provider 00"));
+        assert_eq!(select.page_size, ROWS);
+        terminal.backend_mut().resize(30, 10);
+        terminal.draw(|frame| select.render(frame, "Providers", "Choose a provider"))?;
+        assert!(format!("{:?}", terminal.backend().buffer()).contains("› Provider 44"));
+        assert_eq!(select.page_size, 2);
+        assert_eq!(key(&mut select, KeyCode::Enter), Action::Selected(44));
+        Ok(())
+    }
+
+    #[test]
+    fn unicode_search_backspace_and_paste_are_safe() -> io::Result<()> {
+        let mut select = Select::new(vec![Item::new("云 Provider", "cloud")], 0);
+        select.handle(Event::Paste("云\n".into()));
+        assert_eq!(key(&mut select, KeyCode::Enter), Action::Selected(0));
+        key(&mut select, KeyCode::Backspace);
+        assert!(select.query.is_empty());
+        select.handle(Event::Paste("云".repeat(50)));
+        let mut terminal = Terminal::new(TestBackend::new(24, 9))?;
+        terminal.draw(|frame| select.render(frame, "Providers", "Choose"))?;
+        assert!(format!("{:?}", terminal.backend().buffer()).contains("No matches"));
+        Ok(())
+    }
+}

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -634,6 +634,14 @@ are filled from this snapshot; published metadata takes precedence. A custom
 registry URL or `registry.enabled: false` opts out. A stored subscription login
 auto-enables its provider, so no manual `providers:` entry is required.
 
+When `openai-codex` is active, Codex ACP can use its native default model
+without `chat.model` or `--model`. Requests marked by the maintained adapter
+map declared native model names to the Codex subscription at gateway ingress;
+the CLI retains its native model metadata and picker. Generic API requests do
+not opt into subscriptions this way. Explicit provider/canonical model names,
+presets and user-defined virtual models are preserved. Reloading the daemon
+updates the native-model mapping along with the active provider catalog.
+
 At session startup, BitRouter probes local CLIs with `--version` (two-second
 limit). Codex >=0.153.3 is passed to its adapter via `CODEX_PATH`; Claude Code
 >=2.1.257 is passed via `CLAUDE_CODE_EXECUTABLE`. Missing, old, failing or

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -207,6 +207,21 @@ saved. Credentials alone do not complete setup. The wizard saves `chat.agent`
 and optional `chat.model`, then either opens BitRouter's ACP TUI, starts the
 daemon, or exits. Subsequent bare invocations immediately open the saved TUI.
 
+Interactive setup lists every active, public provider from the registry in one
+alphabetical list. BitRouter Cloud (`bitrouter`) is an ordinary provider row.
+The fetched/cached registry is supplemented by the binary's committed snapshot,
+so a fresh installation also has a catalog offline. A custom or disabled registry
+remains authoritative. Configured credentials are marked; select additional
+providers to sign in, then choose **Continue to harness setup** (End jumps there).
+
+Every setup choice uses the same searchable, eight-row scrolling selector:
+Up/Down moves the pointer, Enter selects, typing filters by label or provider id,
+Backspace edits, Ctrl-U clears, and Home/End or Page Up/Down navigates long lists.
+The list fits smaller terminals. Digits are search text, never choice shortcuts.
+This includes provider/ACP login methods, the registry-derived ACP harness list,
+the finish action and reset confirmation. Esc or Ctrl-C cancels before setup is
+saved; credentials from already completed logins remain available.
+
 Configuration resolves from `./bitrouter.yaml`, then
 `$BITROUTER_HOME/bitrouter.yaml`, then `~/.bitrouter/bitrouter.yaml`. With no
 existing file, onboarding writes to the BitRouter home. `init -c PATH` selects

--- a/skills/bitrouter/SKILL.md
+++ b/skills/bitrouter/SKILL.md
@@ -61,8 +61,9 @@ Verify with `bitrouter --version`; on failure read `references/diagnose.md`.
 
 ### 3. Configure
 
-A human runs `bitrouter` to complete onboarding. After setup the same command
-opens the saved default ACP TUI. Credentials alone do not mark setup complete.
+A human runs `bitrouter` to complete onboarding using searchable Up/Down lists
+of registry providers (including BitRouter Cloud), ACP harnesses and actions.
+After setup the same command opens the saved default ACP TUI. Credentials alone do not mark setup complete.
 For scripted setup:
 
 ```bash

--- a/skills/bitrouter/references/cli.md
+++ b/skills/bitrouter/references/cli.md
@@ -4,6 +4,17 @@ Every subcommand the v1 binary actually exposes. Anything not listed here doesn'
 
 Bare `bitrouter` opens first-run onboarding when no default ACP harness is saved. Credentials alone do not complete setup. The wizard saves `chat.agent` and optional `chat.model`, then either opens BitRouter's ACP TUI, starts the daemon, or exits. Subsequent bare invocations immediately open the saved TUI.  Configuration resolves from `./bitrouter.yaml`, then `$BITROUTER_HOME/bitrouter.yaml`, then `~/.bitrouter/bitrouter.yaml`. With no existing file, onboarding writes to the BitRouter home. `init -c PATH` selects an explicit destination. Existing configuration values are preserved while updating chat defaults; `--force` replaces them with the starter configuration. Writes are atomic. First-run defaults bind `127.0.0.1:4356` with `skip_auth: true`.  `init --yes` saves configuration without interactive credential prompts and exits by default. The default harness is `codex-acp`; `--harness claude` selects `claude-acp`. Repeated `--harness` flags use the first as the default. An explicit `--after launch` opens the ACP TUI even when setup itself was headless. Without a terminal, bare unconfigured invocation prints setup instructions and an inert onboarding envelope; it does not silently complete the wizard.
 
+Interactive onboarding offers every active public registry provider in one
+alphabetical, searchable list; BitRouter Cloud (`bitrouter`) is a normal row.
+The binary includes a registry snapshot for uncached/offline setup. Custom or
+disabled registries remain authoritative. Configured providers are marked; add
+providers, then select **Continue to harness setup**. All setup and login choices
+use Up/Down + Enter, with eight visible rows, typing to search, Backspace/Ctrl-U
+to edit/clear, and Home/End or Page Up/Down to scroll. Digits filter rather than
+select. Esc/Ctrl-C cancels without completing setup. The harness list comes from
+the ACP registry; the headless `--harness` aliases remain `codex` and `claude`.
+
+
 
 ## Daemon lifecycle
 

--- a/skills/bitrouter/references/harness-codex.md
+++ b/skills/bitrouter/references/harness-codex.md
@@ -25,6 +25,13 @@ Older, missing or unresponsive local CLIs use the adapter's bundled worker.
 `--direct` keeps the adapter's own provider authentication; ordinary sessions
 route through BitRouter and auto-start the local daemon.
 
+With an active `openai-codex` provider, no model pin is needed: the ACP
+adapter keeps the Codex CLI's native default and model picker. BitRouter maps
+its declared native model names to the Codex subscription at gateway ingress.
+Generic API calls still require an explicit subscription route; canonical ids,
+provider-qualified routes, presets, and user-defined virtual models retain
+their normal routing behavior. A daemon reload updates this mapping too.
+
 `init --model ID` saves the default model. `chat --model ID` overrides it for
 that explicit session. No vendor CLI config file is rewritten.
 


### PR DESCRIPTION
First-run ACP onboarding now presents every active public registry provider in one searchable list. BitRouter Cloud is an ordinary alphabetically sorted provider row. Users move with Up/Down, type to search, and press Enter; the eight-row viewport scrolls and fits smaller terminals. Configured providers are marked, and users can add more before continuing.

Fix the default Codex launch path too: with a Codex subscription configured, the CLI's native model name previously reached the generic cascade and returned 404 despite the model being in the registry. Codex ACP requests now map declared native names to the active Codex subscription at gateway ingress. The CLI keeps its native default, metadata and model picker; no model pin is required. Generic API requests, explicit routes, canonical names, presets and user-defined virtual models retain their existing behavior. The mapping follows daemon reloads.

The reusable `bitrouter-tui::select` component also drives provider and ACP authentication methods, the registry-derived ACP harness list, finish actions, and reset confirmation. Esc/Ctrl-C and termination restore the terminal without completing setup. Explicit headless flags retain their behavior.

Bundle the complete committed provider registry for fresh/offline installations, preserving fetched metadata and custom/disabled registry behavior. Support registry providers that omit `auth` by applying their conventional Bearer credential, so these selectable providers can log in.

Validation:
- `cargo nextest run --all-features`: 3,077 passed, 11 skipped.
- `cargo clippy --all-features --all-targets -- -D warnings` and `cargo fmt -- --check` passed.
- Regressions cover assembled-app native Codex routing, subscription isolation, explicit/virtual model choices, model changes, and reload activation changes.
- Real macOS PTY walkthrough: provider search/filter/scroll/resize, CLI login import, harness/finish selections, config persistence, and Esc/Ctrl-C/SIGTERM restoration.
- Installed release tested with an empty home/cache and an unreachable registry: the complete offline provider list remains available.
- Installed release tested by running bare `bitrouter` against an unchanged onboarding config, with neither `chat.model` nor a model flag. The native default returned a real response, the request ledger recorded `provider=openai-codex, model=gpt-6-astra`, and Ctrl-D exited cleanly.

Follows #886.
