### PR TITLE
fix(release): package registry build inputs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,11 +41,11 @@ bitrouter-telemetry = { path = "crates/bitrouter-telemetry", version = "1.0.0-al
 # `libc` would need an `unsafe` block, and `bitrouter-sdk` forbids unsafe code.
 rustix = { version = "1", default-features = false }
 
-# ACP SDK crates. The published 2.0.0 runtime pins schema 1.5.0 exactly, while
-# the official SDK revision below consumes schema 1.7.0. Pinning one reviewed
-# revision keeps the runtime and the schema on one ACP v1 type universe.
-agent-client-protocol = { git = "https://github.com/agentclientprotocol/rust-sdk.git", rev = "c63610fc38a642f7a73ba2719f403f17d771c345", features = ["unstable_session_fork"] }
-agent-client-protocol-conductor = { git = "https://github.com/agentclientprotocol/rust-sdk.git", rev = "c63610fc38a642f7a73ba2719f403f17d771c345" }
+# ACP SDK crates. Development pins one reviewed Git revision, whose manifests
+# consume schema 1.7.0. The compatible major-version requirement is retained
+# because Cargo strips `git` when packaging and must resolve published crates.
+agent-client-protocol = { version = "2", git = "https://github.com/agentclientprotocol/rust-sdk.git", rev = "c63610fc38a642f7a73ba2719f403f17d771c345", features = ["unstable_session_fork"] }
+agent-client-protocol-conductor = { version = "2", git = "https://github.com/agentclientprotocol/rust-sdk.git", rev = "c63610fc38a642f7a73ba2719f403f17d771c345" }
 # Shared by `bitrouter status --watch` (in the app) and `bitrouter-tui` (the
 # ACP session renderer), so the version lives here rather than in either.
 ratatui = { version = "0.29", features = [

--- a/apps/bitrouter/build.rs
+++ b/apps/bitrouter/build.rs
@@ -2,7 +2,7 @@
 //!
 //! `registry/agents/` + `registry/runtimes/` are the source of truth for which
 //! agents BitRouter can drive and how their traffic is routed; this turns the
-//! generated `dist/registry/{agents,runtimes}.json` into the `&'static`
+//! generated `dist/registry/{agents,runtimes}.json` snapshot into the `&'static`
 //! catalog `harness.rs` exposes. Editing the registry and rebuilding the dist
 //! artifacts is therefore enough to add or change an agent — no Rust edit.
 //!
@@ -21,9 +21,10 @@ use std::path::{Path, PathBuf};
 use serde_json::Value;
 
 fn main() -> Result<(), Box<dyn Error>> {
-    let root = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR")?)
-        .join("../..")
-        .join("dist/registry");
+    // The package-local snapshot is generated together with `dist/registry`.
+    // Keeping the build input inside the crate is required by `cargo package`,
+    // whose verification build cannot read files outside the packaged crate.
+    let root = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR")?).join("registry-dist");
     let agents_path = root.join("agents.json");
     let runtimes_path = root.join("runtimes.json");
     println!("cargo::rerun-if-changed={}", agents_path.display());

--- a/apps/bitrouter/registry-dist/agents.json
+++ b/apps/bitrouter/registry-dist/agents.json
@@ -1,0 +1,295 @@
+{
+  "data": [
+    {
+      "acp": {
+        "protocol_version": 1
+      },
+      "description": "Anthropic Claude via the maintained Claude Agent ACP adapter",
+      "id": "claude-acp",
+      "interactive_binary": "claude",
+      "name": "Claude Agent ACP",
+      "package_marker": "claude-agent-acp",
+      "project_url": "https://github.com/agentclientprotocol/claude-agent-acp",
+      "routing": {
+        "auth_env": "ANTHROPIC_AUTH_TOKEN",
+        "base_url_env": "ANTHROPIC_BASE_URL",
+        "bearer_auth": true,
+        "kind": "env",
+        "model_env": "ANTHROPIC_MODEL"
+      },
+      "runtimes": [
+        {
+          "runtime": "local",
+          "transport": {
+            "args": [
+              "-y",
+              "@agentclientprotocol/claude-agent-acp@0.75.1"
+            ],
+            "command": "npx",
+            "type": "stdio"
+          }
+        }
+      ]
+    },
+    {
+      "acp": {
+        "protocol_version": 1
+      },
+      "description": "OpenAI Codex via the Agent Client Protocol adapter",
+      "id": "codex-acp",
+      "interactive_binary": "codex",
+      "name": "Codex ACP",
+      "package_marker": "codex-acp",
+      "project_url": "https://github.com/agentclientprotocol/codex-acp",
+      "routing": {
+        "kind": "codex_args"
+      },
+      "runtimes": [
+        {
+          "runtime": "local",
+          "transport": {
+            "args": [
+              "-y",
+              "@agentclientprotocol/codex-acp@1.10.0"
+            ],
+            "command": "npx",
+            "type": "stdio"
+          }
+        }
+      ]
+    },
+    {
+      "acp": {
+        "protocol_version": 1
+      },
+      "description": "Google's Gemini CLI with `--experimental-acp` (best-effort routing)",
+      "id": "gemini-cli",
+      "name": "Gemini CLI",
+      "package_marker": "gemini-cli",
+      "project_url": "https://github.com/google-gemini/gemini-cli",
+      "routing": {
+        "auth_env": "GEMINI_API_KEY",
+        "base_url_env": "GOOGLE_GEMINI_BASE_URL",
+        "bearer_auth": false,
+        "kind": "env",
+        "model_env": "GEMINI_MODEL"
+      },
+      "runtimes": [
+        {
+          "runtime": "local",
+          "transport": {
+            "args": [
+              "-y",
+              "--",
+              "@google/gemini-cli@latest",
+              "--experimental-acp"
+            ],
+            "command": "npx",
+            "type": "stdio"
+          }
+        }
+      ]
+    },
+    {
+      "acp": {
+        "protocol_version": 1
+      },
+      "description": "Nous Research's Hermes Agent via its native `hermes acp`",
+      "id": "hermes-acp",
+      "interactive_binary": "hermes",
+      "name": "Hermes Agent",
+      "package_marker": "hermes",
+      "project_url": "https://github.com/NousResearch/hermes-agent",
+      "routing": {
+        "default_model": {
+          "at": "/model/default",
+          "format": "bare"
+        },
+        "dir": "hermes",
+        "env": [
+          {
+            "name": "HERMES_HOME",
+            "value": "{dir}"
+          },
+          {
+            "name": "CUSTOM_API_KEY",
+            "value": "{auth}"
+          }
+        ],
+        "file": "config.yaml",
+        "kind": "config_file",
+        "mcp": {
+          "at": "/mcp_servers",
+          "entry": "command_args_or_url"
+        },
+        "skeleton": "{ \"model\": { \"provider\": \"custom\", \"base_url\": \"{base_url_v1}\" } }\n"
+      },
+      "runtimes": [
+        {
+          "requires_binary": "hermes",
+          "runtime": "local",
+          "transport": {
+            "args": [
+              "acp"
+            ],
+            "command": "hermes",
+            "type": "stdio"
+          }
+        }
+      ]
+    },
+    {
+      "acp": {
+        "protocol_version": 1
+      },
+      "description": "OpenClaw assistant via its gateway ACP bridge `openclaw acp`",
+      "id": "openclaw",
+      "interactive_binary": "openclaw",
+      "name": "OpenClaw",
+      "package_marker": "openclaw",
+      "project_url": "https://github.com/openclaw/openclaw",
+      "routing": {
+        "args": {
+          "always": [
+            "tui",
+            "--local"
+          ]
+        },
+        "default_model": {
+          "at": "/agents/defaults/model",
+          "format": "provider_prefixed"
+        },
+        "dir": "openclaw",
+        "env": [
+          {
+            "name": "OPENCLAW_STATE_DIR",
+            "value": "{dir}"
+          },
+          {
+            "name": "OPENCLAW_CONFIG_PATH",
+            "value": "{file}"
+          }
+        ],
+        "file": "openclaw.json",
+        "kind": "config_file",
+        "models": {
+          "at": "/models/providers/bitrouter/models",
+          "order": "model_then_catalog",
+          "shape": "array_of_profile"
+        },
+        "skeleton": "{\n  \"gateway\": { \"mode\": \"local\" },\n  \"models\": {\n    \"mode\": \"merge\",\n    \"providers\": {\n      \"bitrouter\": {\n        \"baseUrl\": \"{base_url_v1}\",\n        \"apiKey\": \"{auth}\",\n        \"api\": \"openai-completions\",\n        \"models\": []\n      }\n    }\n  }\n}\n"
+      },
+      "runtimes": [
+        {
+          "requires_binary": "openclaw",
+          "runtime": "local",
+          "transport": {
+            "args": [
+              "acp"
+            ],
+            "command": "openclaw",
+            "type": "stdio"
+          }
+        }
+      ]
+    },
+    {
+      "acp": {
+        "protocol_version": 1
+      },
+      "description": "sst's opencode via its native `opencode acp`",
+      "id": "opencode",
+      "interactive_binary": "opencode",
+      "name": "opencode",
+      "package_marker": "opencode",
+      "project_url": "https://github.com/sst/opencode",
+      "routing": {
+        "default_model": {
+          "at": "/model",
+          "format": "provider_prefixed"
+        },
+        "env": [
+          {
+            "name": "OPENCODE_CONFIG",
+            "value": "{file}"
+          }
+        ],
+        "file": "opencode.json",
+        "kind": "config_file",
+        "mcp": {
+          "at": "/mcp",
+          "entry": "opencode_typed"
+        },
+        "models": {
+          "at": "/provider/bitrouter/models",
+          "order": "catalog_then_model",
+          "shape": "map_of_empty"
+        },
+        "skeleton": "{\n  \"$schema\": \"https://opencode.ai/config.json\",\n  \"provider\": {\n    \"bitrouter\": {\n      \"npm\": \"@ai-sdk/openai-compatible\",\n      \"name\": \"BitRouter\",\n      \"options\": { \"baseURL\": \"{base_url_v1}\", \"apiKey\": \"{auth}\" },\n      \"models\": {}\n    }\n  }\n}\n"
+      },
+      "runtimes": [
+        {
+          "requires_binary": "opencode",
+          "runtime": "local",
+          "transport": {
+            "args": [
+              "acp"
+            ],
+            "command": "opencode",
+            "type": "stdio"
+          }
+        }
+      ]
+    },
+    {
+      "acp": {
+        "protocol_version": 1
+      },
+      "description": "pi coding agent via `pi-acp` (needs `pi` on PATH)",
+      "id": "pi-acp",
+      "interactive_binary": "pi",
+      "name": "pi-acp",
+      "package_marker": "pi-acp",
+      "project_url": "https://github.com/svkozak/pi-acp",
+      "routing": {
+        "args": {
+          "with_default_model": [
+            "--provider",
+            "bitrouter",
+            "--model",
+            "{default_model}"
+          ]
+        },
+        "dir": "pi-agent",
+        "env": [
+          {
+            "name": "PI_CODING_AGENT_DIR",
+            "value": "{dir}"
+          }
+        ],
+        "file": "models.json",
+        "kind": "config_file",
+        "models": {
+          "at": "/providers/bitrouter/models",
+          "order": "catalog_then_model",
+          "shape": "array_of_id"
+        },
+        "skeleton": "{\n  \"providers\": {\n    \"bitrouter\": {\n      \"name\": \"BitRouter\",\n      \"baseUrl\": \"{base_url_v1}\",\n      \"api\": \"openai-completions\",\n      \"apiKey\": \"{auth}\",\n      \"models\": []\n    }\n  }\n}\n"
+      },
+      "runtimes": [
+        {
+          "requires_binary": "pi",
+          "runtime": "local",
+          "transport": {
+            "args": [
+              "-y",
+              "pi-acp@latest"
+            ],
+            "command": "npx",
+            "type": "stdio"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/apps/bitrouter/registry-dist/models.json
+++ b/apps/bitrouter/registry-dist/models.json
@@ -1,0 +1,8750 @@
+{
+  "data": [
+    {
+      "family": "claude-fable",
+      "id": "anthropic/claude-fable-5",
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "knowledge_cutoff": "2026-01-31",
+      "max_input_tokens": 1000000,
+      "max_output_tokens": 128000,
+      "name": "Anthropic: Claude Fable 5",
+      "open_weights": false,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": "anthropic",
+          "capabilities": [
+            "reasoning"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 1.0,
+              "cache_write": 12.5,
+              "no_cache": 10.0
+            },
+            "output_tokens": {
+              "text": 50.0
+            }
+          },
+          "provider": "anthropic",
+          "provider_model_id": "claude-fable-5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          },
+          "reasoning_effort": {
+            "default": "high",
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 1.0,
+              "cache_write": 12.5,
+              "no_cache": 10.0
+            },
+            "output_tokens": {
+              "text": 50.0
+            }
+          },
+          "provider": "aws-bedrock",
+          "provider_model_id": "anthropic.claude-fable-5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 1.0,
+              "cache_write": 12.5,
+              "no_cache": 10.0
+            },
+            "output_tokens": {
+              "text": 50.0
+            }
+          },
+          "provider": "azure",
+          "provider_model_id": "claude-fable-5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 1.0,
+              "cache_write": 12.5,
+              "no_cache": 10.0
+            },
+            "output_tokens": {
+              "text": 50.0
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "anthropic/claude-fable-5",
+          "reasoning_effort": {
+            "default": "high",
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": "anthropic",
+          "capabilities": [
+            "reasoning"
+          ],
+          "provider": "claude-code",
+          "provider_model_id": "claude-fable-5",
+          "reasoning_effort": {
+            "default": "high",
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "provider": "github-copilot",
+          "provider_model_id": "claude-fable-5"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 1.0,
+              "cache_write": 12.5,
+              "no_cache": 10.0
+            },
+            "output_tokens": {
+              "text": 50.0
+            }
+          },
+          "provider": "opencode-zen",
+          "provider_model_id": "claude-fable-5"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 1.0,
+              "cache_write": 12.5,
+              "no_cache": 10.0
+            },
+            "output_tokens": {
+              "text": 50.0
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "anthropic/claude-fable-5"
+        }
+      ],
+      "release_date": "2026-06-09"
+    },
+    {
+      "family": "claude-haiku",
+      "id": "anthropic/claude-haiku-4.5",
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "knowledge_cutoff": "2025-02-28",
+      "max_input_tokens": 200000,
+      "max_output_tokens": 8192,
+      "name": "Anthropic: Claude Haiku 4.5",
+      "open_weights": false,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": "anthropic",
+          "capabilities": [
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.1,
+              "cache_write": 1.25,
+              "no_cache": 1.0
+            },
+            "output_tokens": {
+              "text": 5.0
+            }
+          },
+          "provider": "anthropic",
+          "provider_model_id": "claude-haiku-4-5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.1,
+              "cache_write": 1.25,
+              "no_cache": 1.0
+            },
+            "output_tokens": {
+              "text": 5.0
+            }
+          },
+          "provider": "azure",
+          "provider_model_id": "claude-haiku-4-5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.1,
+              "cache_write": 1.25,
+              "no_cache": 1.0
+            },
+            "output_tokens": {
+              "text": 5.0
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "anthropic/claude-haiku-4.5"
+        },
+        {
+          "api_protocol": "anthropic",
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools"
+          ],
+          "provider": "claude-code",
+          "provider_model_id": "claude-haiku-4-5"
+        },
+        {
+          "api_protocol": "openai",
+          "provider": "github-copilot",
+          "provider_model_id": "claude-haiku-4.5"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.1,
+              "cache_write": 1.25,
+              "no_cache": 1.0
+            },
+            "output_tokens": {
+              "text": 5.0
+            }
+          },
+          "provider": "opencode-zen",
+          "provider_model_id": "claude-haiku-4-5"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.1,
+              "cache_write": 1.25,
+              "no_cache": 1.0
+            },
+            "output_tokens": {
+              "text": 5.0
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "anthropic/claude-haiku-4.5"
+        }
+      ],
+      "release_date": "2025-10-15"
+    },
+    {
+      "family": "claude-opus",
+      "id": "anthropic/claude-opus-4.6",
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "knowledge_cutoff": "2025-05-31",
+      "max_input_tokens": 200000,
+      "max_output_tokens": 16384,
+      "name": "Anthropic: Claude Opus 4.6",
+      "open_weights": false,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": "anthropic",
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider": "anthropic",
+          "provider_model_id": "claude-opus-4-6",
+          "rate_limits": {
+            "requests_per_minute": 60
+          },
+          "reasoning_effort": {
+            "default": "high",
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider": "azure",
+          "provider_model_id": "claude-opus-4-6",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "anthropic/claude-opus-4.6",
+          "reasoning_effort": {
+            "default": "high",
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": "anthropic",
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools"
+          ],
+          "provider": "claude-code",
+          "provider_model_id": "claude-opus-4-6",
+          "reasoning_effort": {
+            "default": "high",
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "provider": "github-copilot",
+          "provider_model_id": "claude-opus-4.6"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider": "gmicloud",
+          "provider_model_id": "anthropic/claude-opus-4.6"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider": "opencode-zen",
+          "provider_model_id": "claude-opus-4-6"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "anthropic/claude-opus-4.6"
+        }
+      ],
+      "release_date": "2026-02-05"
+    },
+    {
+      "family": "claude-opus",
+      "id": "anthropic/claude-opus-4.7",
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "knowledge_cutoff": "2026-01-31",
+      "max_input_tokens": 200000,
+      "max_output_tokens": 16384,
+      "name": "Anthropic: Claude Opus 4.7",
+      "open_weights": false,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": "anthropic",
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider": "anthropic",
+          "provider_model_id": "claude-opus-4-7",
+          "rate_limits": {
+            "requests_per_minute": 60
+          },
+          "reasoning_effort": {
+            "default": "high",
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider": "aws-bedrock",
+          "provider_model_id": "anthropic.claude-opus-4-7",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider": "azure",
+          "provider_model_id": "claude-opus-4-7",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.45,
+              "no_cache": 4.5
+            },
+            "output_tokens": {
+              "text": 22.5
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "anthropic/claude-opus-4.7",
+          "reasoning_effort": {
+            "default": "high",
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": "anthropic",
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools"
+          ],
+          "provider": "claude-code",
+          "provider_model_id": "claude-opus-4-7",
+          "reasoning_effort": {
+            "default": "high",
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "provider": "github-copilot",
+          "provider_model_id": "claude-opus-4.7"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.45,
+              "no_cache": 4.5
+            },
+            "output_tokens": {
+              "text": 22.5
+            }
+          },
+          "provider": "gmicloud",
+          "provider_model_id": "anthropic/claude-opus-4.7"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider": "opencode-zen",
+          "provider_model_id": "claude-opus-4-7"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "anthropic/claude-opus-4.7"
+        }
+      ],
+      "release_date": "2026-04-16"
+    },
+    {
+      "family": "claude-opus",
+      "id": "anthropic/claude-opus-4.8",
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "max_input_tokens": 1000000,
+      "max_output_tokens": 128000,
+      "name": "Anthropic: Claude Opus 4.8",
+      "open_weights": false,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": "anthropic",
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider": "anthropic",
+          "provider_model_id": "claude-opus-4-8",
+          "rate_limits": {
+            "requests_per_minute": 60
+          },
+          "reasoning_effort": {
+            "default": "high",
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider": "aws-bedrock",
+          "provider_model_id": "anthropic.claude-opus-4-8",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider": "azure",
+          "provider_model_id": "claude-opus-4-8",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "anthropic/claude-opus-4.8",
+          "reasoning_effort": {
+            "default": "high",
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": "anthropic",
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools"
+          ],
+          "provider": "claude-code",
+          "provider_model_id": "claude-opus-4-8",
+          "reasoning_effort": {
+            "default": "high",
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "provider": "github-copilot",
+          "provider_model_id": "claude-opus-4.8"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider": "gmicloud",
+          "provider_model_id": "anthropic/claude-opus-4.8"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider": "opencode-zen",
+          "provider_model_id": "claude-opus-4-8"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "anthropic/claude-opus-4.8"
+        }
+      ],
+      "release_date": "2026-05-28"
+    },
+    {
+      "description": "Anthropic's Claude Opus 5.",
+      "family": "claude-opus",
+      "id": "anthropic/claude-opus-5",
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "knowledge_cutoff": "2026-05-31",
+      "max_input_tokens": 1000000,
+      "max_output_tokens": 128000,
+      "name": "Anthropic: Claude Opus 5",
+      "open_weights": false,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": "anthropic",
+          "capabilities": [
+            "reasoning"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider": "anthropic",
+          "provider_model_id": "claude-opus-5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          },
+          "reasoning_effort": {
+            "default": "high",
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider": "atlascloud",
+          "provider_model_id": "anthropic/claude-opus-5-ccmax"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider": "aws-bedrock",
+          "provider_model_id": "anthropic.claude-opus-5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider": "azure",
+          "provider_model_id": "claude-opus-5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "anthropic/claude-opus-5",
+          "reasoning_effort": {
+            "default": "high",
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": "anthropic",
+          "capabilities": [
+            "reasoning"
+          ],
+          "provider": "claude-code",
+          "provider_model_id": "claude-opus-5",
+          "reasoning_effort": {
+            "default": "high",
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "provider": "github-copilot",
+          "provider_model_id": "claude-opus-5"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider": "opencode-zen",
+          "provider_model_id": "claude-opus-5"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "anthropic/claude-opus-5"
+        }
+      ],
+      "release_date": "2026-07-24"
+    },
+    {
+      "description": "Anthropic's Claude Sonnet 4.6.",
+      "family": "claude-sonnet",
+      "id": "anthropic/claude-sonnet-4.6",
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "knowledge_cutoff": "2025-08-31",
+      "max_input_tokens": 1000000,
+      "max_output_tokens": 128000,
+      "name": "Anthropic: Claude Sonnet 4.6",
+      "open_weights": false,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": "anthropic",
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools",
+            "image_input"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.3,
+              "cache_write": 3.75,
+              "no_cache": 3.0
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider": "anthropic",
+          "provider_model_id": "claude-sonnet-4-6",
+          "rate_limits": {
+            "requests_per_minute": 60
+          },
+          "reasoning_effort": {
+            "default": "high",
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.3,
+              "cache_write": 3.75,
+              "no_cache": 3.0
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider": "aws-bedrock",
+          "provider_model_id": "anthropic.claude-sonnet-4-6",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.3,
+              "cache_write": 3.75,
+              "no_cache": 3.0
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider": "azure",
+          "provider_model_id": "claude-sonnet-4-6",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.3,
+              "cache_write": 3.75,
+              "no_cache": 3.0
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "anthropic/claude-sonnet-4.6",
+          "reasoning_effort": {
+            "default": "high",
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": "anthropic",
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools",
+            "image_input"
+          ],
+          "provider": "claude-code",
+          "provider_model_id": "claude-sonnet-4-6",
+          "reasoning_effort": {
+            "default": "high",
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "provider": "github-copilot",
+          "provider_model_id": "claude-sonnet-4.6"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.3,
+              "no_cache": 3.0
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider": "gmicloud",
+          "provider_model_id": "anthropic/claude-sonnet-4.6"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.3,
+              "cache_write": 3.75,
+              "no_cache": 3.0
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider": "opencode-zen",
+          "provider_model_id": "claude-sonnet-4-6"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.3,
+              "cache_write": 3.75,
+              "no_cache": 3.0
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "anthropic/claude-sonnet-4.6"
+        }
+      ],
+      "release_date": "2026-02-17"
+    },
+    {
+      "description": "Anthropic's Claude Sonnet 5.",
+      "family": "claude-sonnet",
+      "id": "anthropic/claude-sonnet-5",
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "knowledge_cutoff": "2026-01-31",
+      "max_input_tokens": 1000000,
+      "max_output_tokens": 128000,
+      "name": "Anthropic: Claude Sonnet 5",
+      "open_weights": false,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": "anthropic",
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools",
+            "image_input"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "cache_write": 2.5,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 10.0
+            }
+          },
+          "provider": "anthropic",
+          "provider_model_id": "claude-sonnet-5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          },
+          "reasoning_effort": {
+            "default": "high",
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "cache_write": 2.5,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 10.0
+            }
+          },
+          "provider": "aws-bedrock",
+          "provider_model_id": "anthropic.claude-sonnet-5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "cache_write": 2.5,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 10.0
+            }
+          },
+          "provider": "azure",
+          "provider_model_id": "claude-sonnet-5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "cache_write": 2.5,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 10.0
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "anthropic/claude-sonnet-5",
+          "reasoning_effort": {
+            "default": "high",
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": "anthropic",
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools",
+            "image_input"
+          ],
+          "provider": "claude-code",
+          "provider_model_id": "claude-sonnet-5",
+          "reasoning_effort": {
+            "default": "high",
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "provider": "github-copilot",
+          "provider_model_id": "claude-sonnet-5"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "cache_write": 2.5,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 10.0
+            }
+          },
+          "provider": "opencode-zen",
+          "provider_model_id": "claude-sonnet-5"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "cache_write": 2.5,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 10.0
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "anthropic/claude-sonnet-5"
+        }
+      ],
+      "release_date": "2026-06-30"
+    },
+    {
+      "description": "DeepSeek-V3.2 — high-efficiency reasoning model.",
+      "family": "deepseek",
+      "id": "deepseek/deepseek-v3.2",
+      "input_modalities": [
+        "text"
+      ],
+      "knowledge_cutoff": "2024-12",
+      "max_input_tokens": 131072,
+      "max_output_tokens": 65536,
+      "name": "DeepSeek: DeepSeek V3.2",
+      "open_weights": true,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.13,
+              "no_cache": 0.26
+            },
+            "output_tokens": {
+              "text": 0.38
+            }
+          },
+          "provider": "atlascloud",
+          "provider_model_id": "deepseek-ai/deepseek-v3.2"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.62
+            },
+            "output_tokens": {
+              "text": 1.85
+            }
+          },
+          "provider": "aws-bedrock",
+          "provider_model_id": "deepseek.v3.2",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.58
+            },
+            "output_tokens": {
+              "text": 1.68
+            }
+          },
+          "provider": "azure",
+          "provider_model_id": "deepseek-v3.2",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.105,
+              "no_cache": 0.21
+            },
+            "output_tokens": {
+              "text": 0.315
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "deepseek/deepseek-v3.2"
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "no_cache": 1.0
+            },
+            "output_tokens": {
+              "text": 1.0
+            }
+          },
+          "provider": "chutes",
+          "provider_model_id": "deepseek-ai/DeepSeek-V3.2-TEE",
+          "rate_limits": {
+            "requests_per_minute": 30
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.1345,
+              "no_cache": 0.269
+            },
+            "output_tokens": {
+              "text": 0.4
+            }
+          },
+          "provider": "novita",
+          "provider_model_id": "deepseek/deepseek-v3.2"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.1345,
+              "no_cache": 0.269
+            },
+            "output_tokens": {
+              "text": 0.4
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "deepseek/deepseek-v3.2"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.0252,
+              "no_cache": 0.252
+            },
+            "output_tokens": {
+              "text": 0.378
+            }
+          },
+          "provider": "qianfan",
+          "provider_model_id": "deepseek-v3.2"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 32000,
+                "input_tokens": {
+                  "no_cache": 0.56
+                },
+                "output_tokens": {
+                  "text": 0.83
+                }
+              }
+            ],
+            "input_tokens": {
+              "no_cache": 0.28
+            },
+            "output_tokens": {
+              "text": 0.42
+            }
+          },
+          "provider": "qianfan_cn",
+          "provider_model_id": "deepseek-v3.2"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.27
+            },
+            "output_tokens": {
+              "text": 0.42
+            }
+          },
+          "provider": "siliconflow",
+          "provider_model_id": "deepseek-ai/DeepSeek-V3.2"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.27
+            },
+            "output_tokens": {
+              "text": 0.42
+            }
+          },
+          "provider": "siliconflow_cn",
+          "provider_model_id": "deepseek-ai/DeepSeek-V3.2"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.114,
+              "no_cache": 0.57
+            },
+            "output_tokens": {
+              "text": 1.71
+            }
+          },
+          "provider": "tencent",
+          "provider_model_id": "deepseek-v3.2",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.114,
+              "no_cache": 0.57
+            },
+            "output_tokens": {
+              "text": 1.71
+            }
+          },
+          "provider": "tencent_cn",
+          "provider_model_id": "deepseek-v3.2",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        }
+      ],
+      "release_date": "2025-01-01"
+    },
+    {
+      "family": "deepseek-flash",
+      "id": "deepseek/deepseek-v4-flash",
+      "input_modalities": [
+        "text"
+      ],
+      "knowledge_cutoff": "2025-05",
+      "max_input_tokens": 262144,
+      "max_output_tokens": 262144,
+      "name": "DeepSeek: DeepSeek V4 Flash",
+      "open_weights": true,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.0028,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider": "alibaba_cn",
+          "provider_model_id": "deepseek-v4-flash",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.028,
+              "cache_write": 0.0,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider": "ambient",
+          "provider_model_id": "deepseek/deepseek-v4-flash",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.028,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider": "atlascloud",
+          "provider_model_id": "deepseek-ai/deepseek-v4-flash"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.19
+            },
+            "output_tokens": {
+              "text": 0.51
+            }
+          },
+          "provider": "azure",
+          "provider_model_id": "deepseek-v4-flash",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.02,
+              "no_cache": 0.09
+            },
+            "output_tokens": {
+              "text": 0.18
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "deepseek/deepseek-v4-flash"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.022,
+              "no_cache": 0.112
+            },
+            "output_tokens": {
+              "text": 0.224
+            }
+          },
+          "provider": "gmicloud",
+          "provider_model_id": "deepseek-ai/DeepSeek-V4-Flash"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.028,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider": "novita",
+          "provider_model_id": "deepseek/deepseek-v4-flash"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.028,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "deepseek/deepseek-v4-flash"
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.2
+            },
+            "output_tokens": {
+              "text": 0.4
+            }
+          },
+          "provider": "phala",
+          "provider_model_id": "deepseek/deepseek-v4-flash"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.028,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider": "qianfan",
+          "provider_model_id": "deepseek-v4-flash"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider": "qianfan_cn",
+          "provider_model_id": "deepseek-v4-flash"
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.2
+            },
+            "output_tokens": {
+              "text": 0.4
+            }
+          },
+          "provider": "redpill",
+          "provider_model_id": "deepseek/deepseek-v4-flash"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.028,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider": "siliconflow",
+          "provider_model_id": "deepseek-ai/DeepSeek-V4-Flash"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.003,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider": "siliconflow_cn",
+          "provider_model_id": "deepseek-ai/DeepSeek-V4-Flash"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.028,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider": "tencent",
+          "provider_model_id": "deepseek-v4-flash",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.028,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider": "tencent_cn",
+          "provider_model_id": "deepseek-v4-flash",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.125,
+              "no_cache": 0.7
+            },
+            "output_tokens": {
+              "text": 1.9
+            }
+          },
+          "provider": "tinfoil",
+          "provider_model_id": "deepseek-v4-flash",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        }
+      ],
+      "release_date": "2026-04-24"
+    },
+    {
+      "description": "Official DeepSeek V4 Flash release with enhanced agentic capabilities.",
+      "family": "deepseek-flash",
+      "id": "deepseek/deepseek-v4-flash-0731",
+      "input_modalities": [
+        "text"
+      ],
+      "knowledge_cutoff": "2025-05",
+      "max_input_tokens": 1000000,
+      "max_output_tokens": 384000,
+      "name": "DeepSeek: DeepSeek V4 Flash 0731",
+      "open_weights": true,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.04,
+              "no_cache": 0.2
+            },
+            "output_tokens": {
+              "text": 0.4
+            }
+          },
+          "provider": "alibaba",
+          "provider_model_id": "deepseek-v4-flash-0731",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.028,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider": "alibaba_cn",
+          "provider_model_id": "deepseek-v4-flash-0731",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.028,
+              "cache_write": 0.0,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider": "ambient",
+          "provider_model_id": "deepseek/deepseek-v4-flash-0731",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.028,
+              "no_cache": 0.44
+            },
+            "output_tokens": {
+              "text": 1.32
+            }
+          },
+          "provider": "atlascloud",
+          "provider_model_id": "deepseek-ai/deepseek-v4-flash-0731"
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.028,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "deepseek/deepseek-v4-flash-0731"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.0028,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider": "deepseek",
+          "provider_model_id": "deepseek-v4-flash",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.014,
+              "no_cache": 0.44
+            },
+            "output_tokens": {
+              "text": 1.32
+            }
+          },
+          "provider": "gmicloud",
+          "provider_model_id": "deepseek-ai/DeepSeek-V4-Flash-0731"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.028,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider": "novita",
+          "provider_model_id": "deepseek/deepseek-v4-flash-0731"
+        },
+        {
+          "api_protocol": "openai",
+          "provider": "opencode-go",
+          "provider_model_id": "deepseek-v4-flash"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.028,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider": "opencode-zen",
+          "provider_model_id": "deepseek-v4-flash"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.018,
+              "no_cache": 0.09
+            },
+            "output_tokens": {
+              "text": 0.18
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "deepseek/deepseek-v4-flash-0731"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.028,
+              "no_cache": 0.44
+            },
+            "output_tokens": {
+              "text": 1.32
+            }
+          },
+          "provider": "phala",
+          "provider_model_id": "deepseek/deepseek-v4-flash-0731"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.028,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider": "qianfan",
+          "provider_model_id": "deepseek-v4-flash-0731"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.028,
+              "no_cache": 0.44
+            },
+            "output_tokens": {
+              "text": 1.32
+            }
+          },
+          "provider": "redpill",
+          "provider_model_id": "deepseek/deepseek-v4-flash-0731"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.028,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider": "siliconflow",
+          "provider_model_id": "deepseek-ai/DeepSeek-V4-Flash-0731"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.014,
+              "no_cache": 0.44
+            },
+            "output_tokens": {
+              "text": 1.32
+            }
+          },
+          "provider": "tencent",
+          "provider_model_id": "deepseek-v4-flash-0731",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        }
+      ],
+      "release_date": "2026-07-31"
+    },
+    {
+      "family": "deepseek-thinking",
+      "id": "deepseek/deepseek-v4-pro",
+      "input_modalities": [
+        "text"
+      ],
+      "knowledge_cutoff": "2025-05",
+      "max_input_tokens": 256000,
+      "max_output_tokens": 16384,
+      "name": "DeepSeek: DeepSeek V4 Pro",
+      "open_weights": true,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.003625,
+              "no_cache": 0.435
+            },
+            "output_tokens": {
+              "text": 0.87
+            }
+          },
+          "provider": "alibaba_cn",
+          "provider_model_id": "deepseek-v4-pro",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.13,
+              "no_cache": 1.68
+            },
+            "output_tokens": {
+              "text": 3.38
+            }
+          },
+          "provider": "atlascloud",
+          "provider_model_id": "deepseek-ai/deepseek-v4-pro"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 1.74
+            },
+            "output_tokens": {
+              "text": 3.48
+            }
+          },
+          "provider": "azure",
+          "provider_model_id": "deepseek-v4-pro",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.003625,
+              "no_cache": 0.435
+            },
+            "output_tokens": {
+              "text": 0.87
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "deepseek/deepseek-v4-pro"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.116,
+              "no_cache": 1.392
+            },
+            "output_tokens": {
+              "text": 2.784
+            }
+          },
+          "provider": "gmicloud",
+          "provider_model_id": "deepseek-ai/DeepSeek-V4-Pro"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.135,
+              "no_cache": 1.6
+            },
+            "output_tokens": {
+              "text": 3.2
+            }
+          },
+          "provider": "novita",
+          "provider_model_id": "deepseek/deepseek-v4-pro"
+        },
+        {
+          "api_protocol": "openai",
+          "provider": "opencode-go",
+          "provider_model_id": "deepseek-v4-pro"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.145,
+              "no_cache": 1.74
+            },
+            "output_tokens": {
+              "text": 3.84
+            }
+          },
+          "provider": "opencode-zen",
+          "provider_model_id": "deepseek-v4-pro"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.003625,
+              "no_cache": 0.435
+            },
+            "output_tokens": {
+              "text": 0.87
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "deepseek/deepseek-v4-pro"
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 1.5
+            },
+            "output_tokens": {
+              "text": 5.25
+            }
+          },
+          "provider": "phala",
+          "provider_model_id": "deepseek/deepseek-v4-pro"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.14,
+              "no_cache": 1.69
+            },
+            "output_tokens": {
+              "text": 3.38
+            }
+          },
+          "provider": "qianfan",
+          "provider_model_id": "deepseek-v4-pro"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 1.67
+            },
+            "output_tokens": {
+              "text": 3.33
+            }
+          },
+          "provider": "qianfan_cn",
+          "provider_model_id": "deepseek-v4-pro"
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 1.5
+            },
+            "output_tokens": {
+              "text": 5.25
+            }
+          },
+          "provider": "redpill",
+          "provider_model_id": "deepseek/deepseek-v4-pro"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.145,
+              "no_cache": 1.74
+            },
+            "output_tokens": {
+              "text": 3.48
+            }
+          },
+          "provider": "siliconflow",
+          "provider_model_id": "deepseek-ai/DeepSeek-V4-Pro"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.145,
+              "no_cache": 1.74
+            },
+            "output_tokens": {
+              "text": 3.48
+            }
+          },
+          "provider": "siliconflow_cn",
+          "provider_model_id": "deepseek-ai/DeepSeek-V4-Pro"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.145,
+              "no_cache": 1.74
+            },
+            "output_tokens": {
+              "text": 3.48
+            }
+          },
+          "provider": "tencent",
+          "provider_model_id": "deepseek-v4-pro",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.145,
+              "no_cache": 1.74
+            },
+            "output_tokens": {
+              "text": 3.48
+            }
+          },
+          "provider": "tencent_cn",
+          "provider_model_id": "deepseek-v4-pro",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 1.5
+            },
+            "output_tokens": {
+              "text": 5.25
+            }
+          },
+          "provider": "tinfoil",
+          "provider_model_id": "deepseek-v4-pro",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        }
+      ],
+      "release_date": "2026-04-24"
+    },
+    {
+      "description": "Generally available DeepSeek V4 Pro release for advanced reasoning, coding, and agentic workloads.",
+      "family": "deepseek-thinking",
+      "id": "deepseek/deepseek-v4-pro-0813",
+      "input_modalities": [
+        "text"
+      ],
+      "max_input_tokens": 1000000,
+      "max_output_tokens": 384000,
+      "name": "DeepSeek: DeepSeek V4 Pro 0813",
+      "open_weights": false,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.132,
+              "no_cache": 1.32
+            },
+            "output_tokens": {
+              "text": 3.96
+            }
+          },
+          "provider": "atlascloud",
+          "provider_model_id": "deepseek-ai/deepseek-v4-pro-0813"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.003625,
+              "no_cache": 0.435
+            },
+            "output_tokens": {
+              "text": 0.87
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "deepseek/deepseek-v4-pro-0813"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.003625,
+              "no_cache": 0.435
+            },
+            "output_tokens": {
+              "text": 0.87
+            }
+          },
+          "provider": "deepseek",
+          "provider_model_id": "deepseek-v4-pro",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.044,
+              "no_cache": 1.32
+            },
+            "output_tokens": {
+              "text": 3.96
+            }
+          },
+          "provider": "gmicloud",
+          "provider_model_id": "deepseek-ai/DeepSeek-V4-Pro-0813"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.022,
+              "no_cache": 0.66
+            },
+            "output_tokens": {
+              "text": 1.98
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "deepseek/deepseek-v4-pro-0813"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.15,
+              "no_cache": 1.45
+            },
+            "output_tokens": {
+              "text": 4.36
+            }
+          },
+          "provider": "redpill",
+          "provider_model_id": "deepseek/deepseek-v4-pro-0813"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.44,
+              "no_cache": 1.32
+            },
+            "output_tokens": {
+              "text": 3.96
+            }
+          },
+          "provider": "siliconflow",
+          "provider_model_id": "deepseek-ai/DeepSeek-V4-Pro-0813"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.044,
+              "no_cache": 1.32
+            },
+            "output_tokens": {
+              "text": 3.96
+            }
+          },
+          "provider": "tencent",
+          "provider_model_id": "deepseek-v4-pro-0813",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        }
+      ],
+      "release_date": "2026-08-13"
+    },
+    {
+      "family": "gemini-flash-lite",
+      "id": "google/gemini-3.1-flash-lite-preview",
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "knowledge_cutoff": "2025-01",
+      "max_input_tokens": 1000000,
+      "max_output_tokens": 8192,
+      "name": "Google: Gemini 3.1 Flash Lite Preview",
+      "open_weights": false,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.025,
+              "no_cache": 0.25
+            },
+            "output_tokens": {
+              "text": 1.5
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "google/gemini-3.1-flash-lite-preview"
+        },
+        {
+          "api_protocol": [
+            "google",
+            "openai"
+          ],
+          "capabilities": [
+            "reasoning"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.025,
+              "no_cache": 0.25
+            },
+            "output_tokens": {
+              "text": 1.5
+            }
+          },
+          "provider": "google",
+          "provider_model_id": "gemini-3.1-flash-lite-preview",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.025,
+              "cache_write": 0.083333,
+              "no_cache": 0.25
+            },
+            "output_tokens": {
+              "text": 1.5
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "google/gemini-3.1-flash-lite-preview"
+        },
+        {
+          "api_protocol": "google",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.025,
+              "no_cache": 0.25
+            },
+            "output_tokens": {
+              "text": 1.5
+            }
+          },
+          "provider": "vertex",
+          "provider_model_id": "gemini-3.1-flash-lite-preview",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        }
+      ],
+      "release_date": "2026-03-03"
+    },
+    {
+      "family": "gemini-pro",
+      "id": "google/gemini-3.1-pro-preview",
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "knowledge_cutoff": "2025-01",
+      "max_input_tokens": 2000000,
+      "max_output_tokens": 8192,
+      "name": "Google: Gemini 3.1 Pro Preview",
+      "open_weights": false,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 12.0
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "google/gemini-3.1-pro-preview",
+          "reasoning_effort": {
+            "default": "high",
+            "levels": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "provider": "github-copilot",
+          "provider_model_id": "gemini-3.1-pro-preview"
+        },
+        {
+          "api_protocol": [
+            "google",
+            "openai"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 12.0
+            }
+          },
+          "provider": "google",
+          "provider_model_id": "gemini-3.1-pro-preview",
+          "rate_limits": {
+            "requests_per_minute": 60
+          },
+          "reasoning_effort": {
+            "default": "high",
+            "levels": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "cache_write": 0.375,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 12.0
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "google/gemini-3.1-pro-preview"
+        },
+        {
+          "api_protocol": "google",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 12.0
+            }
+          },
+          "provider": "vertex",
+          "provider_model_id": "gemini-3.1-pro-preview",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        }
+      ],
+      "release_date": "2026-02-19"
+    },
+    {
+      "family": "gemini-flash",
+      "id": "google/gemini-3.5-flash",
+      "input_modalities": [
+        "text",
+        "image",
+        "audio"
+      ],
+      "knowledge_cutoff": "2025-01",
+      "max_input_tokens": 1048576,
+      "max_output_tokens": 65536,
+      "name": "Google: Gemini 3.5 Flash",
+      "open_weights": false,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.15,
+              "no_cache": 1.5
+            },
+            "output_tokens": {
+              "text": 9.0
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "google/gemini-3.5-flash",
+          "reasoning_effort": {
+            "default": "medium",
+            "levels": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "provider": "github-copilot",
+          "provider_model_id": "gemini-3.5-flash"
+        },
+        {
+          "api_protocol": [
+            "google",
+            "openai"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.15,
+              "no_cache": 1.5
+            },
+            "output_tokens": {
+              "text": 9.0
+            }
+          },
+          "provider": "google",
+          "provider_model_id": "gemini-3.5-flash",
+          "rate_limits": {
+            "requests_per_minute": 60
+          },
+          "reasoning_effort": {
+            "default": "medium",
+            "levels": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.15,
+              "no_cache": 1.5
+            },
+            "output_tokens": {
+              "text": 9.0
+            }
+          },
+          "provider": "opencode-zen",
+          "provider_model_id": "gemini-3.5-flash"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.15,
+              "cache_write": 0.083333,
+              "no_cache": 1.5
+            },
+            "output_tokens": {
+              "text": 9.0
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "google/gemini-3.5-flash"
+        },
+        {
+          "api_protocol": "google",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.15,
+              "no_cache": 1.5
+            },
+            "output_tokens": {
+              "text": 9.0
+            }
+          },
+          "provider": "vertex",
+          "provider_model_id": "gemini-3.5-flash",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        }
+      ],
+      "release_date": "2026-05-19"
+    },
+    {
+      "description": "Efficient multimodal Gemini model for coding, agentic planning, and high-throughput workloads.",
+      "family": "gemini-flash",
+      "id": "google/gemini-3.6-flash",
+      "input_modalities": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "knowledge_cutoff": "2026-03",
+      "max_input_tokens": 1048576,
+      "max_output_tokens": 65536,
+      "name": "Google: Gemini 3.6 Flash",
+      "open_weights": false,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.15,
+              "no_cache": 1.5
+            },
+            "output_tokens": {
+              "text": 7.5
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "google/gemini-3.6-flash"
+        },
+        {
+          "api_protocol": "openai",
+          "provider": "github-copilot",
+          "provider_model_id": "gemini-3.6-flash"
+        },
+        {
+          "api_protocol": [
+            "google",
+            "openai"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.15,
+              "no_cache": 1.5
+            },
+            "output_tokens": {
+              "text": 7.5
+            }
+          },
+          "provider": "google",
+          "provider_model_id": "gemini-3.6-flash",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.15,
+              "no_cache": 1.5
+            },
+            "output_tokens": {
+              "text": 7.5
+            }
+          },
+          "provider": "opencode-zen",
+          "provider_model_id": "gemini-3.6-flash"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.075,
+              "cache_write": 0.041667,
+              "no_cache": 0.75
+            },
+            "output_tokens": {
+              "text": 3.75
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "google/gemini-3.6-flash"
+        },
+        {
+          "api_protocol": "google",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.15,
+              "no_cache": 1.5
+            },
+            "output_tokens": {
+              "text": 7.5
+            }
+          },
+          "provider": "vertex",
+          "provider_model_id": "gemini-3.6-flash",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        }
+      ],
+      "release_date": "2026-07-21"
+    },
+    {
+      "family": "minimax",
+      "id": "minimax/minimax-m2.7",
+      "input_modalities": [
+        "text"
+      ],
+      "max_input_tokens": 196608,
+      "max_output_tokens": 196608,
+      "name": "MiniMax: M2.7",
+      "open_weights": true,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.06,
+              "cache_write": 0.375,
+              "no_cache": 0.3
+            },
+            "output_tokens": {
+              "text": 1.2
+            }
+          },
+          "provider": "alibaba_cn",
+          "provider_model_id": "MiniMax/MiniMax-M2.7",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.045,
+              "cache_write": 0.28125,
+              "no_cache": 0.225
+            },
+            "output_tokens": {
+              "text": 0.9
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "minimax/minimax-m2.7"
+        },
+        {
+          "api_protocol": [
+            "anthropic",
+            "openai"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.06,
+              "cache_write": 0.375,
+              "no_cache": 0.3
+            },
+            "output_tokens": {
+              "text": 1.2
+            }
+          },
+          "provider": "minimax",
+          "provider_model_id": "MiniMax-M2.7",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "anthropic",
+            "openai"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.06,
+              "cache_write": 0.375,
+              "no_cache": 0.3
+            },
+            "output_tokens": {
+              "text": 1.2
+            }
+          },
+          "provider": "minimax_cn",
+          "provider_model_id": "MiniMax-M2.7",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.06,
+              "no_cache": 0.3
+            },
+            "output_tokens": {
+              "text": 1.2
+            }
+          },
+          "provider": "novita",
+          "provider_model_id": "minimax/minimax-m2.7"
+        },
+        {
+          "api_protocol": "openai",
+          "provider": "opencode-go",
+          "provider_model_id": "minimax-m2.7"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.06,
+              "no_cache": 0.3
+            },
+            "output_tokens": {
+              "text": 1.2
+            }
+          },
+          "provider": "opencode-zen",
+          "provider_model_id": "minimax-m2.7"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.05,
+              "no_cache": 0.25
+            },
+            "output_tokens": {
+              "text": 1.0
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "minimax/minimax-m2.7"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.06,
+              "no_cache": 0.3
+            },
+            "output_tokens": {
+              "text": 1.2
+            }
+          },
+          "provider": "tencent",
+          "provider_model_id": "minimax-m2.7",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.06,
+              "no_cache": 0.3
+            },
+            "output_tokens": {
+              "text": 1.2
+            }
+          },
+          "provider": "tencent_cn",
+          "provider_model_id": "minimax-m2.7",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        }
+      ],
+      "release_date": "2026-03-18"
+    },
+    {
+      "family": "minimax",
+      "id": "minimax/minimax-m3",
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "max_input_tokens": 1048576,
+      "max_output_tokens": 512000,
+      "name": "MiniMax: M3",
+      "open_weights": true,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 512000,
+                "input_tokens": {
+                  "cache_read": 0.12,
+                  "no_cache": 0.6
+                },
+                "output_tokens": {
+                  "text": 2.4
+                }
+              }
+            ],
+            "input_tokens": {
+              "cache_read": 0.06,
+              "no_cache": 0.3
+            },
+            "output_tokens": {
+              "text": 1.2
+            }
+          },
+          "provider": "atlascloud",
+          "provider_model_id": "minimaxai/minimax-m3"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.06,
+              "no_cache": 0.3
+            },
+            "output_tokens": {
+              "text": 1.2
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "minimax/minimax-m3"
+        },
+        {
+          "api_protocol": [
+            "anthropic",
+            "openai"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.06,
+              "no_cache": 0.3
+            },
+            "output_tokens": {
+              "text": 1.2
+            }
+          },
+          "provider": "minimax",
+          "provider_model_id": "MiniMax-M3",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "anthropic",
+            "openai"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.06,
+              "no_cache": 0.3
+            },
+            "output_tokens": {
+              "text": 1.2
+            }
+          },
+          "provider": "minimax_cn",
+          "provider_model_id": "MiniMax-M3",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "provider": "opencode-go",
+          "provider_model_id": "minimax-m3"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.06,
+              "no_cache": 0.3
+            },
+            "output_tokens": {
+              "text": 1.2
+            }
+          },
+          "provider": "opencode-zen",
+          "provider_model_id": "minimax-m3"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.06,
+              "no_cache": 0.3
+            },
+            "output_tokens": {
+              "text": 1.2
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "minimax/minimax-m3"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 512000,
+                "input_tokens": {
+                  "cache_read": 0.24,
+                  "no_cache": 1.2
+                },
+                "output_tokens": {
+                  "text": 4.8
+                }
+              }
+            ],
+            "input_tokens": {
+              "cache_read": 0.12,
+              "no_cache": 0.6
+            },
+            "output_tokens": {
+              "text": 2.4
+            }
+          },
+          "provider": "tencent",
+          "provider_model_id": "minimax-m3",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 512000,
+                "input_tokens": {
+                  "cache_read": 0.24,
+                  "no_cache": 1.2
+                },
+                "output_tokens": {
+                  "text": 4.8
+                }
+              }
+            ],
+            "input_tokens": {
+              "cache_read": 0.12,
+              "no_cache": 0.6
+            },
+            "output_tokens": {
+              "text": 2.4
+            }
+          },
+          "provider": "tencent_cn",
+          "provider_model_id": "minimax-m3",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        }
+      ],
+      "release_date": "2026-06-01"
+    },
+    {
+      "family": "kimi-k2",
+      "id": "moonshotai/kimi-k2.6",
+      "input_modalities": [
+        "text"
+      ],
+      "knowledge_cutoff": "2025-01",
+      "max_input_tokens": 256000,
+      "max_output_tokens": 8192,
+      "name": "Kimi: K2.6",
+      "open_weights": true,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.929
+            },
+            "output_tokens": {
+              "text": 3.858
+            }
+          },
+          "provider": "alibaba_cn",
+          "provider_model_id": "kimi-k2.6",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "cache_write": 0.0,
+              "no_cache": 0.95
+            },
+            "output_tokens": {
+              "text": 4.0
+            }
+          },
+          "provider": "ambient",
+          "provider_model_id": "moonshotai/kimi-k2.6",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.16,
+              "no_cache": 0.95
+            },
+            "output_tokens": {
+              "text": 4.0
+            }
+          },
+          "provider": "atlascloud",
+          "provider_model_id": "moonshotai/kimi-k2.6"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.95
+            },
+            "output_tokens": {
+              "text": 4.0
+            }
+          },
+          "provider": "azure",
+          "provider_model_id": "kimi-k2.6",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.12,
+              "no_cache": 0.7125
+            },
+            "output_tokens": {
+              "text": 3.0
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "moonshotai/kimi-k2.6"
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.33,
+              "no_cache": 0.66
+            },
+            "output_tokens": {
+              "text": 3.5
+            }
+          },
+          "provider": "chutes",
+          "provider_model_id": "moonshotai/Kimi-K2.6-TEE",
+          "rate_limits": {
+            "requests_per_minute": 30
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.144,
+              "no_cache": 0.855
+            },
+            "output_tokens": {
+              "text": 3.6
+            }
+          },
+          "provider": "gmicloud",
+          "provider_model_id": "moonshotai/Kimi-K2.6"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.16,
+              "no_cache": 0.95
+            },
+            "output_tokens": {
+              "text": 4.0
+            }
+          },
+          "provider": "moonshotai",
+          "provider_model_id": "kimi-k2.6",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.16,
+              "no_cache": 0.8
+            },
+            "output_tokens": {
+              "text": 3.4
+            }
+          },
+          "provider": "novita",
+          "provider_model_id": "moonshotai/kimi-k2.6"
+        },
+        {
+          "api_protocol": "openai",
+          "provider": "opencode-go",
+          "provider_model_id": "kimi-k2.6"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.16,
+              "no_cache": 0.95
+            },
+            "output_tokens": {
+              "text": 4.0
+            }
+          },
+          "provider": "opencode-zen",
+          "provider_model_id": "kimi-k2.6"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.0992,
+              "no_cache": 0.589
+            },
+            "output_tokens": {
+              "text": 2.48
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "moonshotai/kimi-k2.6"
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.37,
+              "no_cache": 1.09
+            },
+            "output_tokens": {
+              "text": 4.6
+            }
+          },
+          "provider": "phala",
+          "provider_model_id": "moonshotai/kimi-k2.6"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.16,
+              "no_cache": 0.95
+            },
+            "output_tokens": {
+              "text": 4.0
+            }
+          },
+          "provider": "qianfan",
+          "provider_model_id": "kimi-k2.6"
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.37,
+              "no_cache": 1.09
+            },
+            "output_tokens": {
+              "text": 4.6
+            }
+          },
+          "provider": "redpill",
+          "provider_model_id": "moonshotai/kimi-k2.6"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "no_cache": 0.77
+            },
+            "output_tokens": {
+              "text": 4.0
+            }
+          },
+          "provider": "siliconflow",
+          "provider_model_id": "moonshotai/Kimi-K2.6"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.16,
+              "no_cache": 0.95
+            },
+            "output_tokens": {
+              "text": 4.0
+            }
+          },
+          "provider": "siliconflow_cn",
+          "provider_model_id": "Pro/moonshotai/Kimi-K2.6"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.16,
+              "no_cache": 0.95
+            },
+            "output_tokens": {
+              "text": 4.0
+            }
+          },
+          "provider": "tencent",
+          "provider_model_id": "kimi-k2.6",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.16,
+              "no_cache": 0.95
+            },
+            "output_tokens": {
+              "text": 4.0
+            }
+          },
+          "provider": "tencent_cn",
+          "provider_model_id": "kimi-k2.6",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 1.5
+            },
+            "output_tokens": {
+              "text": 5.25
+            }
+          },
+          "provider": "tinfoil",
+          "provider_model_id": "kimi-k2-6",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        }
+      ],
+      "release_date": "2026-05-13"
+    },
+    {
+      "family": "kimi-k2",
+      "id": "moonshotai/kimi-k2.7-code",
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "knowledge_cutoff": "2025-01",
+      "max_input_tokens": 262144,
+      "max_output_tokens": 32768,
+      "name": "Kimi: K2.7 Code",
+      "open_weights": true,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "tools",
+            "structured_outputs"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.15,
+              "no_cache": 0.73
+            },
+            "output_tokens": {
+              "text": 3.5
+            }
+          },
+          "provider": "ambient",
+          "provider_model_id": "moonshotai/kimi-k2.7-code",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.16,
+              "no_cache": 0.95
+            },
+            "output_tokens": {
+              "text": 4.0
+            }
+          },
+          "provider": "atlascloud",
+          "provider_model_id": "moonshotai/kimi-k2.7-code"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.19,
+              "no_cache": 0.95
+            },
+            "output_tokens": {
+              "text": 4.0
+            }
+          },
+          "provider": "azure",
+          "provider_model_id": "kimi-k2.7-code",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.1425,
+              "no_cache": 0.7125
+            },
+            "output_tokens": {
+              "text": 3.0
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "moonshotai/kimi-k2.7-code"
+        },
+        {
+          "api_protocol": "openai",
+          "provider": "github-copilot",
+          "provider_model_id": "kimi-k2.7-code"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.38,
+              "no_cache": 1.9
+            },
+            "output_tokens": {
+              "text": 8.0
+            }
+          },
+          "provider": "gmicloud",
+          "provider_model_id": "moonshotai/kimi-k2.7-code-highspeed"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.19,
+              "no_cache": 0.95
+            },
+            "output_tokens": {
+              "text": 4.0
+            }
+          },
+          "provider": "moonshotai",
+          "provider_model_id": "kimi-k2.7-code",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.19,
+              "no_cache": 0.95
+            },
+            "output_tokens": {
+              "text": 4.0
+            }
+          },
+          "provider": "novita",
+          "provider_model_id": "moonshotai/kimi-k2.7-code"
+        },
+        {
+          "api_protocol": "openai",
+          "provider": "opencode-go",
+          "provider_model_id": "kimi-k2.7-code"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.19,
+              "no_cache": 0.95
+            },
+            "output_tokens": {
+              "text": 4.0
+            }
+          },
+          "provider": "opencode-zen",
+          "provider_model_id": "kimi-k2.7-code"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.15,
+              "no_cache": 0.73
+            },
+            "output_tokens": {
+              "text": 3.5
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "moonshotai/kimi-k2.7-code"
+        }
+      ],
+      "release_date": "2026-06-12"
+    },
+    {
+      "family": "kimi-k3",
+      "id": "moonshotai/kimi-k3",
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "max_input_tokens": 1048576,
+      "max_output_tokens": 131072,
+      "name": "Kimi: K3",
+      "open_weights": true,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.3,
+              "no_cache": 3.0
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "moonshotai/kimi-k3"
+        },
+        {
+          "api_protocol": "openai",
+          "provider": "github-copilot",
+          "provider_model_id": "kimi-k3"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.3,
+              "no_cache": 3.0
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider": "moonshotai",
+          "provider_model_id": "kimi-k3",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "provider": "moonshotai_coding_plan",
+          "provider_model_id": "kimi-for-coding",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.3,
+              "no_cache": 3.0
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider": "novita",
+          "provider_model_id": "moonshotai/kimi-k3"
+        },
+        {
+          "api_protocol": "openai",
+          "provider": "opencode-go",
+          "provider_model_id": "kimi-k3"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.3,
+              "no_cache": 3.0
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider": "opencode-zen",
+          "provider_model_id": "kimi-k3"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.3,
+              "no_cache": 3.0
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "moonshotai/kimi-k3"
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools",
+            "image_input"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 1.5,
+              "no_cache": 3.0
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider": "phala",
+          "provider_model_id": "moonshotai/kimi-k3"
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools",
+            "image_input"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 1.5,
+              "no_cache": 3.0
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider": "redpill",
+          "provider_model_id": "moonshotai/kimi-k3"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 6.0
+            }
+          },
+          "provider": "tinfoil",
+          "provider_model_id": "kimi-k3",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        }
+      ],
+      "release_date": "2026-07-16"
+    },
+    {
+      "family": "gpt",
+      "id": "openai/gpt-5.4",
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "knowledge_cutoff": "2025-08-31",
+      "max_input_tokens": 128000,
+      "max_output_tokens": 16384,
+      "name": "OpenAI: GPT-5.4",
+      "open_weights": false,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.275,
+              "no_cache": 2.75
+            },
+            "output_tokens": {
+              "text": 16.5
+            }
+          },
+          "provider": "aws-bedrock",
+          "provider_model_id": "openai.gpt-5.4",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.25,
+              "no_cache": 2.5
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider": "azure",
+          "provider_model_id": "gpt-5.4",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.25,
+              "no_cache": 2.5
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "openai/gpt-5.4",
+          "reasoning_effort": {
+            "default": "none",
+            "levels": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "provider": "github-copilot",
+          "provider_model_id": "gpt-5.4"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools"
+          ],
+          "compatibility": {
+            "chat_completions": {
+              "token_limit_field": "max_completion_tokens"
+            }
+          },
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.25,
+              "no_cache": 2.5
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider": "openai",
+          "provider_model_id": "gpt-5.4",
+          "rate_limits": {
+            "requests_per_minute": 60
+          },
+          "reasoning_effort": {
+            "default": "none",
+            "levels": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          }
+        },
+        {
+          "api_protocol": "responses",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "provider": "openai-codex",
+          "provider_model_id": "gpt-5.4",
+          "reasoning_effort": {
+            "default": "none",
+            "levels": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.25,
+              "no_cache": 2.5
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider": "opencode-zen",
+          "provider_model_id": "gpt-5.4"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.25,
+              "no_cache": 2.5
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "openai/gpt-5.4"
+        }
+      ],
+      "release_date": "2026-03-05"
+    },
+    {
+      "family": "gpt-mini",
+      "id": "openai/gpt-5.4-mini",
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "knowledge_cutoff": "2025-08-31",
+      "max_input_tokens": 128000,
+      "max_output_tokens": 16384,
+      "name": "OpenAI: GPT-5.4 Mini",
+      "open_weights": false,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.075,
+              "no_cache": 0.75
+            },
+            "output_tokens": {
+              "text": 4.5
+            }
+          },
+          "provider": "azure",
+          "provider_model_id": "gpt-5.4-mini",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.075,
+              "no_cache": 0.75
+            },
+            "output_tokens": {
+              "text": 4.5
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "openai/gpt-5.4-mini",
+          "reasoning_effort": {
+            "default": "none",
+            "levels": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "provider": "github-copilot",
+          "provider_model_id": "gpt-5.4-mini"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools"
+          ],
+          "compatibility": {
+            "chat_completions": {
+              "token_limit_field": "max_completion_tokens"
+            }
+          },
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.075,
+              "no_cache": 0.75
+            },
+            "output_tokens": {
+              "text": 4.5
+            }
+          },
+          "provider": "openai",
+          "provider_model_id": "gpt-5.4-mini",
+          "rate_limits": {
+            "requests_per_minute": 60
+          },
+          "reasoning_effort": {
+            "default": "none",
+            "levels": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          }
+        },
+        {
+          "api_protocol": "responses",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "provider": "openai-codex",
+          "provider_model_id": "gpt-5.4-mini",
+          "reasoning_effort": {
+            "default": "none",
+            "levels": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.075,
+              "no_cache": 0.75
+            },
+            "output_tokens": {
+              "text": 4.5
+            }
+          },
+          "provider": "opencode-zen",
+          "provider_model_id": "gpt-5.4-mini"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.075,
+              "no_cache": 0.75
+            },
+            "output_tokens": {
+              "text": 4.5
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "openai/gpt-5.4-mini"
+        }
+      ],
+      "release_date": "2026-03-17"
+    },
+    {
+      "family": "gpt",
+      "id": "openai/gpt-5.5",
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "knowledge_cutoff": "2025-12-01",
+      "max_input_tokens": 128000,
+      "max_output_tokens": 16384,
+      "name": "OpenAI: GPT-5.5",
+      "open_weights": false,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.55,
+              "no_cache": 5.5
+            },
+            "output_tokens": {
+              "text": 33.0
+            }
+          },
+          "provider": "aws-bedrock",
+          "provider_model_id": "openai.gpt-5.5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 30.0
+            }
+          },
+          "provider": "azure",
+          "provider_model_id": "gpt-5.5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 30.0
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "openai/gpt-5.5",
+          "reasoning_effort": {
+            "default": "medium",
+            "levels": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "provider": "github-copilot",
+          "provider_model_id": "gpt-5.5"
+        },
+        {
+          "api_protocol": "openai",
+          "compatibility": {
+            "chat_completions": {
+              "token_limit_field": "max_completion_tokens"
+            }
+          },
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 30.0
+            }
+          },
+          "provider": "gmicloud",
+          "provider_model_id": "openai/gpt-5.5"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools"
+          ],
+          "compatibility": {
+            "chat_completions": {
+              "token_limit_field": "max_completion_tokens"
+            }
+          },
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 30.0
+            }
+          },
+          "provider": "openai",
+          "provider_model_id": "gpt-5.5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          },
+          "reasoning_effort": {
+            "default": "medium",
+            "levels": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          }
+        },
+        {
+          "api_protocol": "responses",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "provider": "openai-codex",
+          "provider_model_id": "gpt-5.5",
+          "reasoning_effort": {
+            "default": "medium",
+            "levels": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 30.0
+            }
+          },
+          "provider": "opencode-zen",
+          "provider_model_id": "gpt-5.5"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 30.0
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "openai/gpt-5.5"
+        }
+      ],
+      "release_date": "2026-04-23"
+    },
+    {
+      "family": "gpt",
+      "id": "openai/gpt-5.6-luna",
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "knowledge_cutoff": "2026-05-31",
+      "max_input_tokens": 400000,
+      "max_output_tokens": 128000,
+      "name": "OpenAI: GPT-5.6 Luna",
+      "open_weights": false,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.022,
+              "cache_write": 0.275,
+              "no_cache": 0.22
+            },
+            "output_tokens": {
+              "text": 1.32
+            }
+          },
+          "provider": "aws-bedrock",
+          "provider_model_id": "openai.gpt-5.6-luna",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.02,
+              "no_cache": 0.2
+            },
+            "output_tokens": {
+              "text": 1.2
+            }
+          },
+          "provider": "azure",
+          "provider_model_id": "gpt-5.6-luna",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.1,
+              "cache_write": 1.25,
+              "no_cache": 1.0
+            },
+            "output_tokens": {
+              "text": 6.0
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "openai/gpt-5.6-luna",
+          "reasoning_effort": {
+            "default": "medium",
+            "levels": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "provider": "github-copilot",
+          "provider_model_id": "gpt-5.6-luna"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools"
+          ],
+          "compatibility": {
+            "chat_completions": {
+              "token_limit_field": "max_completion_tokens"
+            }
+          },
+          "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 272000,
+                "input_tokens": {
+                  "cache_read": 0.2,
+                  "cache_write": 2.5,
+                  "no_cache": 2.0
+                },
+                "output_tokens": {
+                  "text": 9.0
+                }
+              }
+            ],
+            "input_tokens": {
+              "cache_read": 0.02,
+              "cache_write": 0.25,
+              "no_cache": 0.2
+            },
+            "output_tokens": {
+              "text": 1.2
+            }
+          },
+          "provider": "openai",
+          "provider_model_id": "gpt-5.6-luna",
+          "rate_limits": {
+            "requests_per_minute": 60
+          },
+          "reasoning_effort": {
+            "default": "medium",
+            "levels": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": "responses",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "provider": "openai-codex",
+          "provider_model_id": "gpt-5.6-luna",
+          "reasoning_effort": {
+            "default": "medium",
+            "levels": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "provider": "opencode-go",
+          "provider_model_id": "gpt-5.6-luna"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.02,
+              "cache_write": 0.25,
+              "no_cache": 0.2
+            },
+            "output_tokens": {
+              "text": 1.2
+            }
+          },
+          "provider": "opencode-zen",
+          "provider_model_id": "gpt-5.6-luna"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.01,
+              "cache_write": 0.125,
+              "no_cache": 0.1
+            },
+            "output_tokens": {
+              "text": 0.6
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "openai/gpt-5.6-luna"
+        }
+      ],
+      "release_date": "2026-06-25"
+    },
+    {
+      "family": "gpt",
+      "id": "openai/gpt-5.6-sol",
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "knowledge_cutoff": "2026-05-31",
+      "max_input_tokens": 1000000,
+      "max_output_tokens": 128000,
+      "name": "OpenAI: GPT-5.6 Sol",
+      "open_weights": false,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.55,
+              "cache_write": 6.88,
+              "no_cache": 5.5
+            },
+            "output_tokens": {
+              "text": 33.0
+            }
+          },
+          "provider": "aws-bedrock",
+          "provider_model_id": "openai.gpt-5.6-sol",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 30.0
+            }
+          },
+          "provider": "azure",
+          "provider_model_id": "gpt-5.6-sol",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 30.0
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "openai/gpt-5.6-sol",
+          "reasoning_effort": {
+            "default": "medium",
+            "levels": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "provider": "github-copilot",
+          "provider_model_id": "gpt-5.6-sol"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools"
+          ],
+          "compatibility": {
+            "chat_completions": {
+              "token_limit_field": "max_completion_tokens"
+            }
+          },
+          "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 272000,
+                "input_tokens": {
+                  "cache_read": 1.0,
+                  "cache_write": 12.5,
+                  "no_cache": 10.0
+                },
+                "output_tokens": {
+                  "text": 45.0
+                }
+              }
+            ],
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 30.0
+            }
+          },
+          "provider": "openai",
+          "provider_model_id": "gpt-5.6-sol",
+          "rate_limits": {
+            "requests_per_minute": 60
+          },
+          "reasoning_effort": {
+            "default": "medium",
+            "levels": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": "responses",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "provider": "openai-codex",
+          "provider_model_id": "gpt-5.6-sol",
+          "reasoning_effort": {
+            "default": "medium",
+            "levels": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 30.0
+            }
+          },
+          "provider": "opencode-zen",
+          "provider_model_id": "gpt-5.6-sol"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 30.0
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "openai/gpt-5.6-sol"
+        }
+      ],
+      "release_date": "2026-06-25"
+    },
+    {
+      "family": "gpt",
+      "id": "openai/gpt-5.6-terra",
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "knowledge_cutoff": "2026-05-31",
+      "max_input_tokens": 1000000,
+      "max_output_tokens": 128000,
+      "name": "OpenAI: GPT-5.6 Terra",
+      "open_weights": false,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.22,
+              "cache_write": 2.75,
+              "no_cache": 2.2
+            },
+            "output_tokens": {
+              "text": 13.2
+            }
+          },
+          "provider": "aws-bedrock",
+          "provider_model_id": "openai.gpt-5.6-terra",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 12.0
+            }
+          },
+          "provider": "azure",
+          "provider_model_id": "gpt-5.6-terra",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.25,
+              "cache_write": 3.125,
+              "no_cache": 2.5
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "openai/gpt-5.6-terra",
+          "reasoning_effort": {
+            "default": "medium",
+            "levels": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "provider": "github-copilot",
+          "provider_model_id": "gpt-5.6-terra"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools"
+          ],
+          "compatibility": {
+            "chat_completions": {
+              "token_limit_field": "max_completion_tokens"
+            }
+          },
+          "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 272000,
+                "input_tokens": {
+                  "cache_read": 0.5,
+                  "cache_write": 6.25,
+                  "no_cache": 5.0
+                },
+                "output_tokens": {
+                  "text": 22.5
+                }
+              }
+            ],
+            "input_tokens": {
+              "cache_read": 0.2,
+              "cache_write": 2.5,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 12.0
+            }
+          },
+          "provider": "openai",
+          "provider_model_id": "gpt-5.6-terra",
+          "rate_limits": {
+            "requests_per_minute": 60
+          },
+          "reasoning_effort": {
+            "default": "medium",
+            "levels": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": "responses",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "provider": "openai-codex",
+          "provider_model_id": "gpt-5.6-terra",
+          "reasoning_effort": {
+            "default": "medium",
+            "levels": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.25,
+              "cache_write": 3.125,
+              "no_cache": 2.5
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider": "opencode-zen",
+          "provider_model_id": "gpt-5.6-terra"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.1,
+              "cache_write": 1.25,
+              "no_cache": 1.0
+            },
+            "output_tokens": {
+              "text": 6.0
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "openai/gpt-5.6-terra"
+        }
+      ],
+      "release_date": "2026-06-25"
+    },
+    {
+      "family": "gpt",
+      "id": "openai/gpt-6-astra",
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "name": "OpenAI: GPT-6 Astra",
+      "open_weights": false,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": "responses",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "provider": "openai-codex",
+          "provider_model_id": "gpt-6-astra",
+          "reasoning_effort": {
+            "default": "medium",
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "description": "Qwen3.5 open-source native vision-language MoE (122B total, 10B active).",
+      "family": "qwen3.5",
+      "id": "qwen/qwen3.5-122b-a10b",
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "max_input_tokens": 262144,
+      "max_output_tokens": 65536,
+      "name": "Qwen: Qwen3.5 122B-A10B",
+      "open_weights": true,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.4
+            },
+            "output_tokens": {
+              "text": 3.2
+            }
+          },
+          "provider": "alibaba",
+          "provider_model_id": "qwen3.5-122b-a10b",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.26
+            },
+            "output_tokens": {
+              "text": 2.08
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "qwen/qwen3.5-122b-a10b"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.4
+            },
+            "output_tokens": {
+              "text": 3.2
+            }
+          },
+          "provider": "novita",
+          "provider_model_id": "qwen/qwen3.5-122b-a10b"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.26
+            },
+            "output_tokens": {
+              "text": 2.08
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "qwen/qwen3.5-122b-a10b"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.26
+            },
+            "output_tokens": {
+              "text": 2.08
+            }
+          },
+          "provider": "siliconflow",
+          "provider_model_id": "Qwen/Qwen3.5-122B-A10B"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.29
+            },
+            "output_tokens": {
+              "text": 2.32
+            }
+          },
+          "provider": "siliconflow_cn",
+          "provider_model_id": "Qwen/Qwen3.5-122B-A10B"
+        }
+      ],
+      "release_date": "2026-02-23"
+    },
+    {
+      "description": "Qwen3.5 open-source native vision-language model (27B).",
+      "family": "qwen3.5",
+      "id": "qwen/qwen3.5-27b",
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "max_input_tokens": 262144,
+      "max_output_tokens": 65536,
+      "name": "Qwen: Qwen3.5 27B",
+      "open_weights": true,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.3
+            },
+            "output_tokens": {
+              "text": 2.4
+            }
+          },
+          "provider": "alibaba",
+          "provider_model_id": "qwen3.5-27b",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.25
+            },
+            "output_tokens": {
+              "text": 2.0
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "qwen/qwen3.5-27b"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.3
+            },
+            "output_tokens": {
+              "text": 2.4
+            }
+          },
+          "provider": "novita",
+          "provider_model_id": "qwen/qwen3.5-27b"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.195
+            },
+            "output_tokens": {
+              "text": 1.56
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "qwen/qwen3.5-27b"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.25
+            },
+            "output_tokens": {
+              "text": 2.0
+            }
+          },
+          "provider": "siliconflow",
+          "provider_model_id": "Qwen/Qwen3.5-27B"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.26
+            },
+            "output_tokens": {
+              "text": 2.09
+            }
+          },
+          "provider": "siliconflow_cn",
+          "provider_model_id": "Qwen/Qwen3.5-27B"
+        }
+      ],
+      "release_date": "2026-02-23"
+    },
+    {
+      "description": "Qwen3.6 open-source native vision-language model (27B).",
+      "family": "qwen3.6",
+      "id": "qwen/qwen3.6-27b",
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "max_input_tokens": 262144,
+      "max_output_tokens": 65536,
+      "name": "Qwen: Qwen3.6 27B",
+      "open_weights": true,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.6
+            },
+            "output_tokens": {
+              "text": 3.6
+            }
+          },
+          "provider": "alibaba",
+          "provider_model_id": "qwen3.6-27b",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.3
+            },
+            "output_tokens": {
+              "text": 3.2
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "qwen/qwen3.6-27b"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.15,
+              "no_cache": 0.3
+            },
+            "output_tokens": {
+              "text": 2.0
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "qwen/qwen3.6-27b"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.3
+            },
+            "output_tokens": {
+              "text": 3.2
+            }
+          },
+          "provider": "siliconflow",
+          "provider_model_id": "Qwen/Qwen3.6-27B"
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "tools",
+            "structured_outputs"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.07,
+              "no_cache": 0.28
+            },
+            "output_tokens": {
+              "text": 2.69
+            }
+          },
+          "provider": "tiyuvta",
+          "provider_model_id": "qwen/qwen3.6-27b"
+        }
+      ],
+      "release_date": "2026-04-22"
+    },
+    {
+      "description": "Qwen3.6 open-source native vision-language MoE (35B total, 3B active).",
+      "family": "qwen3.6",
+      "id": "qwen/qwen3.6-35b-a3b",
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "max_input_tokens": 262144,
+      "max_output_tokens": 65536,
+      "name": "Qwen: Qwen3.6 35B-A3B",
+      "open_weights": true,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.248
+            },
+            "output_tokens": {
+              "text": 1.485
+            }
+          },
+          "provider": "alibaba",
+          "provider_model_id": "qwen3.6-35b-a3b",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.2
+            },
+            "output_tokens": {
+              "text": 1.6
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "qwen/qwen3.6-35b-a3b"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 1.0
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "qwen/qwen3.6-35b-a3b"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.2
+            },
+            "output_tokens": {
+              "text": 1.6
+            }
+          },
+          "provider": "siliconflow",
+          "provider_model_id": "Qwen/Qwen3.6-35B-A3B"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.23
+            },
+            "output_tokens": {
+              "text": 1.86
+            }
+          },
+          "provider": "siliconflow_cn",
+          "provider_model_id": "Qwen/Qwen3.6-35B-A3B"
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "tools",
+            "structured_outputs"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.03,
+              "no_cache": 0.12
+            },
+            "output_tokens": {
+              "text": 1.03
+            }
+          },
+          "provider": "tiyuvta",
+          "provider_model_id": "qwen/qwen3.6-35b-a3b"
+        }
+      ],
+      "release_date": "2026-04-17"
+    },
+    {
+      "family": "qwen3.6",
+      "id": "qwen/qwen3.6-flash",
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "knowledge_cutoff": "2025-04",
+      "max_input_tokens": 1000000,
+      "max_output_tokens": 65536,
+      "name": "Qwen: Qwen3.6 Flash",
+      "open_weights": false,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 256000,
+                "input_tokens": {
+                  "no_cache": 1.0
+                },
+                "output_tokens": {
+                  "text": 4.0
+                }
+              }
+            ],
+            "input_tokens": {
+              "cache_write": 0.234375,
+              "no_cache": 0.1875
+            },
+            "output_tokens": {
+              "text": 1.125
+            }
+          },
+          "provider": "alibaba",
+          "provider_model_id": "qwen3.6-flash",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 256000,
+                "input_tokens": {
+                  "no_cache": 0.66
+                },
+                "output_tokens": {
+                  "text": 3.961
+                }
+              }
+            ],
+            "input_tokens": {
+              "cache_write": 0.234375,
+              "no_cache": 0.1875
+            },
+            "output_tokens": {
+              "text": 1.125
+            }
+          },
+          "provider": "alibaba_cn",
+          "provider_model_id": "qwen3.6-flash",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "provider": "alibaba_coding_plan",
+          "provider_model_id": "qwen3.6-flash",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.165
+            },
+            "output_tokens": {
+              "text": 0.99
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "qwen/qwen3.6-flash"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_write": 0.234375,
+              "no_cache": 0.1875
+            },
+            "output_tokens": {
+              "text": 1.125
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "qwen/qwen3.6-flash"
+        }
+      ],
+      "release_date": "2026-04-27"
+    },
+    {
+      "family": "qwen3.7",
+      "id": "qwen/qwen3.7-max",
+      "input_modalities": [
+        "text"
+      ],
+      "max_input_tokens": 1000000,
+      "max_output_tokens": 65536,
+      "name": "Qwen: Qwen3.7 Max",
+      "open_weights": false,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 3.125,
+              "no_cache": 2.5
+            },
+            "output_tokens": {
+              "text": 7.5
+            }
+          },
+          "provider": "alibaba",
+          "provider_model_id": "qwen3.7-max",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 3.125,
+              "no_cache": 2.5
+            },
+            "output_tokens": {
+              "text": 7.5
+            }
+          },
+          "provider": "alibaba_cn",
+          "provider_model_id": "qwen3.7-max",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "provider": "alibaba_coding_plan",
+          "provider_model_id": "qwen3.7-max",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "no_cache": 2.5
+            },
+            "output_tokens": {
+              "text": 7.5
+            }
+          },
+          "provider": "atlascloud",
+          "provider_model_id": "qwen/qwen3.7-max"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.25,
+              "cache_write": 1.5625,
+              "no_cache": 1.25
+            },
+            "output_tokens": {
+              "text": 3.75
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "qwen/qwen3.7-max"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.25,
+              "cache_write": 3.125,
+              "no_cache": 2.5
+            },
+            "output_tokens": {
+              "text": 7.5
+            }
+          },
+          "provider": "gmicloud",
+          "provider_model_id": "Qwen/Qwen3.7-Max"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.25,
+              "cache_write": 1.5625,
+              "no_cache": 1.25
+            },
+            "output_tokens": {
+              "text": 3.75
+            }
+          },
+          "provider": "novita",
+          "provider_model_id": "qwen/qwen3.7-max"
+        },
+        {
+          "api_protocol": "openai",
+          "provider": "opencode-go",
+          "provider_model_id": "qwen3.7-max"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.295,
+              "cache_write": 1.84375,
+              "no_cache": 1.475
+            },
+            "output_tokens": {
+              "text": 4.425
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "qwen/qwen3.7-max"
+        }
+      ],
+      "release_date": "2026-06-10"
+    },
+    {
+      "family": "qwen3.7",
+      "id": "qwen/qwen3.7-plus",
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "knowledge_cutoff": "2025-04",
+      "max_input_tokens": 1000000,
+      "max_output_tokens": 65536,
+      "name": "Qwen: Qwen3.7 Plus",
+      "open_weights": false,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 256000,
+                "input_tokens": {
+                  "no_cache": 1.2
+                },
+                "output_tokens": {
+                  "text": 4.8
+                }
+              }
+            ],
+            "input_tokens": {
+              "cache_read": 0.05,
+              "cache_write": 0.625,
+              "no_cache": 0.5
+            },
+            "output_tokens": {
+              "text": 3.0
+            }
+          },
+          "provider": "alibaba",
+          "provider_model_id": "qwen3.7-plus",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 256000,
+                "input_tokens": {
+                  "no_cache": 0.826
+                },
+                "output_tokens": {
+                  "text": 3.301
+                }
+              }
+            ],
+            "input_tokens": {
+              "cache_read": 0.05,
+              "cache_write": 0.625,
+              "no_cache": 0.5
+            },
+            "output_tokens": {
+              "text": 3.0
+            }
+          },
+          "provider": "alibaba_cn",
+          "provider_model_id": "qwen3.7-plus",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "provider": "alibaba_coding_plan",
+          "provider_model_id": "qwen3.7-plus",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 262144,
+                "input_tokens": {
+                  "cache_read": 0.24,
+                  "no_cache": 1.2
+                },
+                "output_tokens": {
+                  "text": 4.8
+                }
+              }
+            ],
+            "input_tokens": {
+              "cache_read": 0.08,
+              "no_cache": 0.4
+            },
+            "output_tokens": {
+              "text": 1.6
+            }
+          },
+          "provider": "atlascloud",
+          "provider_model_id": "qwen/qwen3.7-plus"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.276
+            },
+            "output_tokens": {
+              "text": 1.101
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "qwen/qwen3.7-plus"
+        },
+        {
+          "api_protocol": "openai",
+          "provider": "opencode-go",
+          "provider_model_id": "qwen3.7-plus"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.064,
+              "cache_write": 0.4,
+              "no_cache": 0.32
+            },
+            "output_tokens": {
+              "text": 1.28
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "qwen/qwen3.7-plus"
+        }
+      ],
+      "release_date": "2026-06-01"
+    },
+    {
+      "description": "Open-weight text MoE with 2.4T total parameters and 95B active parameters for coding, research, and agentic workflows.",
+      "family": "qwen3.8",
+      "id": "qwen/qwen3.8-2.4t-a95b",
+      "input_modalities": [
+        "text"
+      ],
+      "max_input_tokens": 1000000,
+      "max_output_tokens": 131072,
+      "name": "Qwen: Qwen3.8 2.4T-A95B",
+      "open_weights": true,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.17,
+              "cache_write": 2.5,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 6.0
+            }
+          },
+          "provider": "alibaba",
+          "provider_model_id": "qwen3.8-2.4t-a95b",
+          "rate_limits": {
+            "requests_per_minute": 60
+          },
+          "reasoning_effort": {
+            "default": "xhigh",
+            "levels": [
+              "low",
+              "medium",
+              "xhigh"
+            ]
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.167,
+              "cache_write": 2.083,
+              "no_cache": 1.667
+            },
+            "output_tokens": {
+              "text": 5.0
+            }
+          },
+          "provider": "alibaba_cn",
+          "provider_model_id": "qwen3.8-2.4t-a95b",
+          "rate_limits": {
+            "requests_per_minute": 60
+          },
+          "reasoning_effort": {
+            "default": "xhigh",
+            "levels": [
+              "low",
+              "medium",
+              "xhigh"
+            ]
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.17,
+              "cache_write": 2.5,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 6.0
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "qwen/qwen3.8-2.4t-a95b"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.25,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 6.0
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "qwen/qwen3.8-2.4t-a95b",
+          "reasoning_effort": {
+            "default": "xhigh",
+            "levels": [
+              "low",
+              "medium",
+              "xhigh"
+            ]
+          }
+        }
+      ],
+      "release_date": "2026-08-12"
+    },
+    {
+      "description": "Open-weight dense native vision-language model for coding, professional work, and long-running agent tasks.",
+      "family": "qwen3.8",
+      "id": "qwen/qwen3.8-27b",
+      "input_modalities": [
+        "text",
+        "image",
+        "video"
+      ],
+      "max_input_tokens": 1000000,
+      "max_output_tokens": 131072,
+      "name": "Qwen: Qwen3.8 27B",
+      "open_weights": true,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.05,
+              "cache_write": 0.625,
+              "no_cache": 0.5
+            },
+            "output_tokens": {
+              "text": 3.0
+            }
+          },
+          "provider": "alibaba",
+          "provider_model_id": "qwen3.8-27b",
+          "rate_limits": {
+            "requests_per_minute": 60
+          },
+          "reasoning_effort": {
+            "default": "xhigh",
+            "levels": [
+              "low",
+              "medium",
+              "xhigh"
+            ]
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.042,
+              "cache_write": 0.521,
+              "no_cache": 0.417
+            },
+            "output_tokens": {
+              "text": 1.667
+            }
+          },
+          "provider": "alibaba_cn",
+          "provider_model_id": "qwen3.8-27b",
+          "rate_limits": {
+            "requests_per_minute": 60
+          },
+          "reasoning_effort": {
+            "default": "xhigh",
+            "levels": [
+              "low",
+              "medium",
+              "xhigh"
+            ]
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.05,
+              "cache_write": 0.625,
+              "no_cache": 0.5
+            },
+            "output_tokens": {
+              "text": 3.0
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "qwen/qwen3.8-27b"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.085,
+              "cache_write": 0.53125,
+              "no_cache": 0.425
+            },
+            "output_tokens": {
+              "text": 2.55
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "qwen/qwen3.8-27b",
+          "reasoning_effort": {
+            "default": "xhigh",
+            "levels": [
+              "low",
+              "medium",
+              "xhigh"
+            ]
+          }
+        }
+      ],
+      "release_date": "2026-08-14"
+    },
+    {
+      "description": "2.4T-parameter multimodal MoE flagship for coding, professional work, and long-horizon agentic workflows.",
+      "family": "qwen3.8",
+      "id": "qwen/qwen3.8-max",
+      "input_modalities": [
+        "text",
+        "image",
+        "video"
+      ],
+      "max_input_tokens": 1000000,
+      "max_output_tokens": 131072,
+      "name": "Qwen: Qwen3.8 Max",
+      "open_weights": false,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.25,
+              "cache_write": 2.5,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 6.0
+            }
+          },
+          "provider": "alibaba",
+          "provider_model_id": "qwen3.8-max",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.167,
+              "cache_write": 2.083,
+              "no_cache": 1.667
+            },
+            "output_tokens": {
+              "text": 5.0
+            }
+          },
+          "provider": "alibaba_cn",
+          "provider_model_id": "qwen3.8-max",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.25,
+              "cache_write": 2.5,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 6.0
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "qwen/qwen3.8-max"
+        },
+        {
+          "api_protocol": "openai",
+          "provider": "opencode-go",
+          "provider_model_id": "qwen3.8-max"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.25,
+              "cache_write": 2.5,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 6.0
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "qwen/qwen3.8-max"
+        }
+      ],
+      "release_date": "2026-08-03"
+    },
+    {
+      "family": "grok",
+      "id": "x-ai/grok-4.20",
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "max_input_tokens": 131072,
+      "max_output_tokens": 4096,
+      "name": "xAI: Grok 4.20",
+      "open_weights": false,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "no_cache": 1.25
+            },
+            "output_tokens": {
+              "text": 2.5
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "x-ai/grok-4.20"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "no_cache": 1.25
+            },
+            "output_tokens": {
+              "text": 2.5
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "x-ai/grok-4.20"
+        },
+        {
+          "api_protocol": [
+            "responses",
+            "openai"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "provider": "supergrok",
+          "provider_model_id": "grok-4.20"
+        },
+        {
+          "api_protocol": [
+            "responses",
+            "openai"
+          ],
+          "capabilities": [
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "no_cache": 1.25
+            },
+            "output_tokens": {
+              "text": 2.5
+            }
+          },
+          "provider": "xai",
+          "provider_model_id": "grok-4.20-0309-non-reasoning",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        }
+      ],
+      "release_date": "2026-03-12"
+    },
+    {
+      "family": "grok",
+      "id": "x-ai/grok-4.20-multi-agent",
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "max_input_tokens": 1000000,
+      "name": "xAI: Grok 4.20 Multi-Agent",
+      "open_weights": false,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "no_cache": 1.25
+            },
+            "output_tokens": {
+              "text": 2.5
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "x-ai/grok-4.20-multi-agent"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "no_cache": 1.25
+            },
+            "output_tokens": {
+              "text": 2.5
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "x-ai/grok-4.20-multi-agent"
+        },
+        {
+          "api_protocol": [
+            "responses",
+            "openai"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "provider": "supergrok",
+          "provider_model_id": "grok-4.20-multi-agent"
+        },
+        {
+          "api_protocol": [
+            "responses",
+            "openai"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "no_cache": 1.25
+            },
+            "output_tokens": {
+              "text": 2.5
+            }
+          },
+          "provider": "xai",
+          "provider_model_id": "grok-4.20-multi-agent-0309",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        }
+      ]
+    },
+    {
+      "family": "grok",
+      "id": "x-ai/grok-4.3",
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "max_input_tokens": 1000000,
+      "max_output_tokens": 30000,
+      "name": "xAI: Grok 4.3",
+      "open_weights": false,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 200000,
+                "input_tokens": {
+                  "cache_read": 0.4,
+                  "no_cache": 2.5
+                },
+                "output_tokens": {
+                  "text": 5.0
+                }
+              }
+            ],
+            "input_tokens": {
+              "cache_read": 0.2,
+              "no_cache": 1.25
+            },
+            "output_tokens": {
+              "text": 2.5
+            }
+          },
+          "provider": "atlascloud",
+          "provider_model_id": "xai/grok-4.3"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "no_cache": 1.25
+            },
+            "output_tokens": {
+              "text": 2.5
+            }
+          },
+          "provider": "aws-bedrock",
+          "provider_model_id": "xai.grok-4.3",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "no_cache": 1.25
+            },
+            "output_tokens": {
+              "text": 2.5
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "x-ai/grok-4.3"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "no_cache": 1.25
+            },
+            "output_tokens": {
+              "text": 2.5
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "x-ai/grok-4.3"
+        },
+        {
+          "api_protocol": [
+            "responses",
+            "openai"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "provider": "supergrok",
+          "provider_model_id": "grok-4.3"
+        },
+        {
+          "api_protocol": [
+            "responses",
+            "openai"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "no_cache": 1.25
+            },
+            "output_tokens": {
+              "text": 2.5
+            }
+          },
+          "provider": "xai",
+          "provider_model_id": "grok-4.3",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        }
+      ],
+      "release_date": "2026-05-01"
+    },
+    {
+      "family": "grok",
+      "id": "x-ai/grok-4.5",
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "max_input_tokens": 500000,
+      "name": "xAI: Grok 4.5",
+      "open_weights": false,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 6.0
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "x-ai/grok-4.5"
+        },
+        {
+          "api_protocol": "openai",
+          "provider": "github-copilot",
+          "provider_model_id": "grok-4.5"
+        },
+        {
+          "api_protocol": "openai",
+          "provider": "opencode-go",
+          "provider_model_id": "grok-4.5"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 6.0
+            }
+          },
+          "provider": "opencode-zen",
+          "provider_model_id": "grok-4.5"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.3,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 6.0
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "x-ai/grok-4.5"
+        },
+        {
+          "api_protocol": [
+            "responses",
+            "openai"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "provider": "supergrok",
+          "provider_model_id": "grok-4.5"
+        },
+        {
+          "api_protocol": [
+            "responses",
+            "openai"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.3,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 6.0
+            }
+          },
+          "provider": "xai",
+          "provider_model_id": "grok-4.5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        }
+      ],
+      "release_date": "2026-07-08"
+    },
+    {
+      "description": "xAI flagship for coding, reasoning, knowledge work, and agentic tool use.",
+      "family": "grok",
+      "id": "x-ai/grok-4.6",
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "knowledge_cutoff": "2026-02",
+      "max_input_tokens": 500000,
+      "name": "xAI: Grok 4.6",
+      "open_weights": false,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.55,
+              "no_cache": 2.2
+            },
+            "output_tokens": {
+              "text": 6.6
+            }
+          },
+          "provider": "aws-bedrock",
+          "provider_model_id": "xai.grok-4.6",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 6.0
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "x-ai/grok-4.6"
+        },
+        {
+          "api_protocol": "openai",
+          "provider": "github-copilot",
+          "provider_model_id": "grok-4.6"
+        },
+        {
+          "api_protocol": "openai",
+          "provider": "opencode-go",
+          "provider_model_id": "grok-4.6"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 6.0
+            }
+          },
+          "provider": "opencode-zen",
+          "provider_model_id": "grok-4.6"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 6.0
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "x-ai/grok-4.6"
+        },
+        {
+          "api_protocol": [
+            "responses",
+            "openai"
+          ],
+          "provider": "supergrok",
+          "provider_model_id": "grok-4.6"
+        },
+        {
+          "api_protocol": [
+            "responses",
+            "openai"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 6.0
+            }
+          },
+          "provider": "xai",
+          "provider_model_id": "grok-4.6",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        }
+      ],
+      "release_date": "2026-08-12"
+    },
+    {
+      "family": "grok",
+      "id": "x-ai/grok-build-0.1",
+      "input_modalities": [
+        "text"
+      ],
+      "max_input_tokens": 256000,
+      "name": "xAI: Grok Build 0.1",
+      "open_weights": false,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "no_cache": 1.0
+            },
+            "output_tokens": {
+              "text": 2.0
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "x-ai/grok-build-0.1"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "no_cache": 1.0
+            },
+            "output_tokens": {
+              "text": 2.0
+            }
+          },
+          "provider": "opencode-zen",
+          "provider_model_id": "grok-build-0.1"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "no_cache": 1.0
+            },
+            "output_tokens": {
+              "text": 2.0
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "x-ai/grok-build-0.1"
+        },
+        {
+          "api_protocol": [
+            "responses",
+            "openai"
+          ],
+          "capabilities": [
+            "tools"
+          ],
+          "provider": "supergrok",
+          "provider_model_id": "grok-build-0.1"
+        },
+        {
+          "api_protocol": [
+            "responses",
+            "openai"
+          ],
+          "capabilities": [
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "no_cache": 1.0
+            },
+            "output_tokens": {
+              "text": 2.0
+            }
+          },
+          "provider": "xai",
+          "provider_model_id": "grok-build-0.1",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        }
+      ]
+    },
+    {
+      "description": "Xiaomi MiMo V2.5 — standard tier of the MiMo V2.5 family.",
+      "family": "mimo",
+      "id": "xiaomi/mimo-v2.5",
+      "input_modalities": [
+        "text"
+      ],
+      "knowledge_cutoff": "2024-12",
+      "max_input_tokens": 262144,
+      "max_output_tokens": 32768,
+      "name": "Xiaomi: MiMo V2.5",
+      "open_weights": true,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.08,
+              "cache_write": 0.0,
+              "no_cache": 0.4
+            },
+            "output_tokens": {
+              "text": 2.0
+            }
+          },
+          "provider": "ambient",
+          "provider_model_id": "xiaomi/mimo-v2.5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.0028,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "xiaomi/mimo-v2.5"
+        },
+        {
+          "api_protocol": "openai",
+          "provider": "opencode-go",
+          "provider_model_id": "mimo-v2.5"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.0028,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "xiaomi/mimo-v2.5"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.0028,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider": "xiaomi",
+          "provider_model_id": "mimo-v2.5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "provider": "xiaomi_token_plan",
+          "provider_model_id": "mimo-v2.5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "provider": "xiaomi_token_plan_cn",
+          "provider_model_id": "mimo-v2.5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "provider": "xiaomi_token_plan_eu",
+          "provider_model_id": "mimo-v2.5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        }
+      ],
+      "release_date": "2026-04-22"
+    },
+    {
+      "description": "Xiaomi MiMo V2.5 Pro — high-capability tier of the MiMo V2.5 family.",
+      "family": "mimo",
+      "id": "xiaomi/mimo-v2.5-pro",
+      "input_modalities": [
+        "text"
+      ],
+      "knowledge_cutoff": "2024-12",
+      "max_input_tokens": 262144,
+      "max_output_tokens": 32768,
+      "name": "Xiaomi: MiMo V2.5 Pro",
+      "open_weights": true,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.0036,
+              "no_cache": 0.435
+            },
+            "output_tokens": {
+              "text": 0.87
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "xiaomi/mimo-v2.5-pro"
+        },
+        {
+          "api_protocol": "openai",
+          "provider": "opencode-go",
+          "provider_model_id": "mimo-v2.5-pro"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.0036,
+              "no_cache": 0.435
+            },
+            "output_tokens": {
+              "text": 0.87
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "xiaomi/mimo-v2.5-pro"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.0036,
+              "no_cache": 0.435
+            },
+            "output_tokens": {
+              "text": 0.87
+            }
+          },
+          "provider": "xiaomi",
+          "provider_model_id": "mimo-v2.5-pro",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "provider": "xiaomi_token_plan",
+          "provider_model_id": "mimo-v2.5-pro",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "provider": "xiaomi_token_plan_cn",
+          "provider_model_id": "mimo-v2.5-pro",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "provider": "xiaomi_token_plan_eu",
+          "provider_model_id": "mimo-v2.5-pro",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        }
+      ],
+      "release_date": "2026-04-22"
+    },
+    {
+      "family": "glm",
+      "id": "z-ai/glm-4.7",
+      "input_modalities": [
+        "text"
+      ],
+      "max_input_tokens": 200000,
+      "max_output_tokens": 131072,
+      "name": "Zhipu: GLM-4.7",
+      "open_weights": true,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": "openai",
+          "provider": "alibaba_coding_plan",
+          "provider_model_id": "glm-4.7",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.6
+            },
+            "output_tokens": {
+              "text": 2.2
+            }
+          },
+          "provider": "aws-bedrock",
+          "provider_model_id": "zai.glm-4.7",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.11,
+              "no_cache": 0.6
+            },
+            "output_tokens": {
+              "text": 2.2
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "z-ai/glm-4.7"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 2.25,
+              "cache_write": 0.0,
+              "no_cache": 2.25
+            },
+            "output_tokens": {
+              "text": 2.75
+            }
+          },
+          "provider": "cerebras",
+          "provider_model_id": "zai-glm-4.7",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.11,
+              "no_cache": 0.6
+            },
+            "output_tokens": {
+              "text": 2.2
+            }
+          },
+          "provider": "novita",
+          "provider_model_id": "zai-org/glm-4.7"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.1,
+              "no_cache": 0.6
+            },
+            "output_tokens": {
+              "text": 2.2
+            }
+          },
+          "provider": "opencode-zen",
+          "provider_model_id": "glm-4.7"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.08,
+              "no_cache": 0.4
+            },
+            "output_tokens": {
+              "text": 1.75
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "z-ai/glm-4.7"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.11,
+              "cache_write": 0.0,
+              "no_cache": 0.6
+            },
+            "output_tokens": {
+              "text": 2.2
+            }
+          },
+          "provider": "zai",
+          "provider_model_id": "glm-4.7",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "provider": "zai_coding_plan",
+          "provider_model_id": "glm-4.7",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        }
+      ],
+      "release_date": "2025-12-23"
+    },
+    {
+      "family": "glm",
+      "id": "z-ai/glm-5.1",
+      "input_modalities": [
+        "text"
+      ],
+      "knowledge_cutoff": "2025-04",
+      "max_input_tokens": 128000,
+      "max_output_tokens": 8192,
+      "name": "Zhipu: GLM-5.1",
+      "open_weights": true,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.17,
+              "no_cache": 0.87
+            },
+            "output_tokens": {
+              "text": 3.48
+            }
+          },
+          "provider": "alibaba_cn",
+          "provider_model_id": "glm-5.1",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.234,
+              "no_cache": 1.26
+            },
+            "output_tokens": {
+              "text": 3.96
+            }
+          },
+          "provider": "atlascloud",
+          "provider_model_id": "zai-org/glm-5.1"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.182,
+              "no_cache": 0.98
+            },
+            "output_tokens": {
+              "text": 3.08
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "z-ai/glm-5.1"
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.49,
+              "no_cache": 0.98
+            },
+            "output_tokens": {
+              "text": 3.08
+            }
+          },
+          "provider": "chutes",
+          "provider_model_id": "zai-org/GLM-5.1-TEE",
+          "rate_limits": {
+            "requests_per_minute": 30
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.182,
+              "no_cache": 0.98
+            },
+            "output_tokens": {
+              "text": 3.08
+            }
+          },
+          "provider": "gmicloud",
+          "provider_model_id": "zai-org/GLM-5.1-FP8"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.26,
+              "no_cache": 1.38
+            },
+            "output_tokens": {
+              "text": 4.4
+            }
+          },
+          "provider": "novita",
+          "provider_model_id": "zai-org/glm-5.1"
+        },
+        {
+          "api_protocol": "openai",
+          "provider": "opencode-go",
+          "provider_model_id": "glm-5.1"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.26,
+              "no_cache": 1.4
+            },
+            "output_tokens": {
+              "text": 4.4
+            }
+          },
+          "provider": "opencode-zen",
+          "provider_model_id": "glm-5.1"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.1794,
+              "no_cache": 0.966
+            },
+            "output_tokens": {
+              "text": 3.036
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "z-ai/glm-5.1"
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.6,
+              "no_cache": 1.21
+            },
+            "output_tokens": {
+              "text": 4.2
+            }
+          },
+          "provider": "phala",
+          "provider_model_id": "z-ai/glm-5.1"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.26,
+              "no_cache": 1.4
+            },
+            "output_tokens": {
+              "text": 4.4
+            }
+          },
+          "provider": "qianfan",
+          "provider_model_id": "glm-5.1"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 32000,
+                "input_tokens": {
+                  "no_cache": 1.11
+                },
+                "output_tokens": {
+                  "text": 3.89
+                }
+              }
+            ],
+            "input_tokens": {
+              "no_cache": 0.83
+            },
+            "output_tokens": {
+              "text": 3.33
+            }
+          },
+          "provider": "qianfan_cn",
+          "provider_model_id": "glm-5.1"
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.6,
+              "no_cache": 1.21
+            },
+            "output_tokens": {
+              "text": 4.2
+            }
+          },
+          "provider": "redpill",
+          "provider_model_id": "z-ai/glm-5.1"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 1.4
+            },
+            "output_tokens": {
+              "text": 4.4
+            }
+          },
+          "provider": "siliconflow",
+          "provider_model_id": "zai-org/GLM-5.1"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 1.4
+            },
+            "output_tokens": {
+              "text": 4.4
+            }
+          },
+          "provider": "siliconflow_cn",
+          "provider_model_id": "Pro/zai-org/GLM-5.1"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.26,
+              "no_cache": 1.4
+            },
+            "output_tokens": {
+              "text": 4.4
+            }
+          },
+          "provider": "tencent",
+          "provider_model_id": "glm-5.1",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.26,
+              "no_cache": 1.4
+            },
+            "output_tokens": {
+              "text": 4.4
+            }
+          },
+          "provider": "tencent_cn",
+          "provider_model_id": "glm-5.1",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.26,
+              "no_cache": 1.4
+            },
+            "output_tokens": {
+              "text": 4.4
+            }
+          },
+          "provider": "zai",
+          "provider_model_id": "glm-5.1",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "provider": "zai_coding_plan",
+          "provider_model_id": "glm-5.1",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        }
+      ],
+      "release_date": "2026-04-07"
+    },
+    {
+      "family": "glm",
+      "id": "z-ai/glm-5.2",
+      "input_modalities": [
+        "text"
+      ],
+      "max_input_tokens": 1000000,
+      "max_output_tokens": 131072,
+      "name": "Zhipu: GLM-5.2",
+      "open_weights": true,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.28,
+              "cache_write": 0.0,
+              "no_cache": 1.4
+            },
+            "output_tokens": {
+              "text": 4.4
+            }
+          },
+          "provider": "alibaba",
+          "provider_model_id": "glm-5.2",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.275,
+              "cache_write": 0.0,
+              "no_cache": 1.1
+            },
+            "output_tokens": {
+              "text": 3.851
+            }
+          },
+          "provider": "alibaba_cn",
+          "provider_model_id": "glm-5.2",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "cache_write": 0.0,
+              "no_cache": 1.05
+            },
+            "output_tokens": {
+              "text": 4.4
+            }
+          },
+          "provider": "ambient",
+          "provider_model_id": "z-ai/glm-5.2",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.26,
+              "no_cache": 1.4
+            },
+            "output_tokens": {
+              "text": 4.4
+            }
+          },
+          "provider": "atlascloud",
+          "provider_model_id": "zai-org/glm-5.2"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.182,
+              "no_cache": 0.979
+            },
+            "output_tokens": {
+              "text": 3.08
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "z-ai/glm-5.2"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.182,
+              "no_cache": 0.979
+            },
+            "output_tokens": {
+              "text": 3.08
+            }
+          },
+          "provider": "gmicloud",
+          "provider_model_id": "zai-org/GLM-5.2-FP8"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.26,
+              "no_cache": 1.4
+            },
+            "output_tokens": {
+              "text": 4.4
+            }
+          },
+          "provider": "novita",
+          "provider_model_id": "zai-org/glm-5.2"
+        },
+        {
+          "api_protocol": "openai",
+          "provider": "opencode-go",
+          "provider_model_id": "glm-5.2"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.26,
+              "no_cache": 1.4
+            },
+            "output_tokens": {
+              "text": 4.4
+            }
+          },
+          "provider": "opencode-zen",
+          "provider_model_id": "glm-5.2"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.208,
+              "no_cache": 1.12
+            },
+            "output_tokens": {
+              "text": 3.52
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "z-ai/glm-5.2"
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.26,
+              "no_cache": 1.4
+            },
+            "output_tokens": {
+              "text": 4.4
+            }
+          },
+          "provider": "phala",
+          "provider_model_id": "z-ai/glm-5.2"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.26,
+              "no_cache": 1.4
+            },
+            "output_tokens": {
+              "text": 4.4
+            }
+          },
+          "provider": "qianfan",
+          "provider_model_id": "glm-5.2"
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.26,
+              "no_cache": 1.4
+            },
+            "output_tokens": {
+              "text": 4.4
+            }
+          },
+          "provider": "redpill",
+          "provider_model_id": "z-ai/glm-5.2"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 1.4
+            },
+            "output_tokens": {
+              "text": 4.4
+            }
+          },
+          "provider": "siliconflow",
+          "provider_model_id": "zai-org/GLM-5.2"
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 1.4
+            },
+            "output_tokens": {
+              "text": 4.4
+            }
+          },
+          "provider": "siliconflow_cn",
+          "provider_model_id": "zai-org/GLM-5.2"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.26,
+              "no_cache": 1.4
+            },
+            "output_tokens": {
+              "text": 4.4
+            }
+          },
+          "provider": "tencent",
+          "provider_model_id": "glm-5.2",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.26,
+              "no_cache": 1.4
+            },
+            "output_tokens": {
+              "text": 4.4
+            }
+          },
+          "provider": "tencent_cn",
+          "provider_model_id": "glm-5.2",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.375,
+              "no_cache": 1.5
+            },
+            "output_tokens": {
+              "text": 5.25
+            }
+          },
+          "provider": "tinfoil",
+          "provider_model_id": "glm-5-2",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.26,
+              "no_cache": 1.4
+            },
+            "output_tokens": {
+              "text": 4.4
+            }
+          },
+          "provider": "zai",
+          "provider_model_id": "glm-5.2",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "provider": "zai_coding_plan",
+          "provider_model_id": "glm-5.2",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        }
+      ],
+      "release_date": "2026-06-13"
+    },
+    {
+      "description": "Z.ai flagship reasoning model for complex software engineering and long-horizon agent tasks.",
+      "family": "glm",
+      "id": "z-ai/glm-5.3",
+      "input_modalities": [
+        "text"
+      ],
+      "max_input_tokens": 1000000,
+      "max_output_tokens": 131072,
+      "name": "Zhipu: GLM-5.3",
+      "open_weights": false,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.26,
+              "no_cache": 1.4
+            },
+            "output_tokens": {
+              "text": 4.4
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "z-ai/glm-5.3"
+        },
+        {
+          "api_protocol": "openai",
+          "provider": "opencode-go",
+          "provider_model_id": "glm-5.3"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.26,
+              "no_cache": 1.4
+            },
+            "output_tokens": {
+              "text": 4.4
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "z-ai/glm-5.3",
+          "reasoning_effort": {
+            "default": "max",
+            "levels": [
+              "low",
+              "high",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.26,
+              "no_cache": 1.4
+            },
+            "output_tokens": {
+              "text": 4.4
+            }
+          },
+          "provider": "zai",
+          "provider_model_id": "glm-5.3",
+          "rate_limits": {
+            "requests_per_minute": 60
+          },
+          "reasoning_effort": {
+            "default": "max",
+            "levels": [
+              "low",
+              "high",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "provider": "zai_coding_plan",
+          "provider_model_id": "glm-5.3",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        }
+      ],
+      "release_date": "2026-08-14"
+    },
+    {
+      "description": "Open-weight native multimodal MoE for efficient coding, professional work, and long-horizon agent tasks.",
+      "family": "glm",
+      "id": "z-ai/glm-5.3-flash",
+      "input_modalities": [
+        "text",
+        "image",
+        "video"
+      ],
+      "max_input_tokens": 1000000,
+      "max_output_tokens": 131072,
+      "name": "Zhipu: GLM-5.3 Flash",
+      "open_weights": true,
+      "output_modalities": [
+        "text"
+      ],
+      "providers": [
+        {
+          "api_protocol": "openai",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.015,
+              "no_cache": 0.075
+            },
+            "output_tokens": {
+              "text": 0.25
+            }
+          },
+          "provider": "bitrouter",
+          "provider_model_id": "z-ai/glm-5.3-flash"
+        },
+        {
+          "api_protocol": "openai",
+          "provider": "opencode-go",
+          "provider_model_id": "glm-5.3-flash"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.015,
+              "no_cache": 0.075
+            },
+            "output_tokens": {
+              "text": 0.25
+            }
+          },
+          "provider": "openrouter",
+          "provider_model_id": "z-ai/glm-5.3-flash",
+          "reasoning_effort": {
+            "default": "max",
+            "levels": [
+              "low",
+              "high",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.015,
+              "no_cache": 0.075
+            },
+            "output_tokens": {
+              "text": 0.25
+            }
+          },
+          "provider": "zai",
+          "provider_model_id": "glm-5.3-flash",
+          "rate_limits": {
+            "requests_per_minute": 60
+          },
+          "reasoning_effort": {
+            "default": "max",
+            "levels": [
+              "low",
+              "high",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "provider": "zai_coding_plan",
+          "provider_model_id": "glm-5.3-flash",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        }
+      ],
+      "release_date": "2026-08-26"
+    }
+  ]
+}

--- a/apps/bitrouter/registry-dist/providers.json
+++ b/apps/bitrouter/registry-dist/providers.json
@@ -1,0 +1,9699 @@
+{
+  "data": [
+    {
+      "access": "api_key",
+      "api_base": "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+      "auth_scheme": "x-api-key",
+      "billing": "usage_token",
+      "byok": true,
+      "community": false,
+      "display_name": "Alibaba Cloud Model Studio (International)",
+      "id": "alibaba",
+      "metadata": {
+        "datacenters": [
+          "SG"
+        ],
+        "headquarters": "CN",
+        "name": "Alibaba Cloud",
+        "privacy_policy_url": "https://www.alibabacloud.com/help/en/legal/latest/alibaba-cloud-international-website-privacy-policy",
+        "slug": "alibaba-cloud",
+        "status_page_url": "https://status.alibabacloud.com",
+        "terms_of_service_url": "https://www.alibabacloud.com/help/en/legal/latest/alibaba-cloud-international-website-terms-of-use-alibaba-cloud-international-website-terms-of-use"
+      },
+      "models": [
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "qwen/qwen3.8-2.4t-a95b",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.17,
+              "cache_write": 2.5,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 6.0
+            }
+          },
+          "provider_model_id": "qwen3.8-2.4t-a95b",
+          "rate_limits": {
+            "requests_per_minute": 60
+          },
+          "reasoning_effort": {
+            "default": "xhigh",
+            "levels": [
+              "low",
+              "medium",
+              "xhigh"
+            ]
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "qwen/qwen3.8-27b",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.05,
+              "cache_write": 0.625,
+              "no_cache": 0.5
+            },
+            "output_tokens": {
+              "text": 3.0
+            }
+          },
+          "provider_model_id": "qwen3.8-27b",
+          "rate_limits": {
+            "requests_per_minute": 60
+          },
+          "reasoning_effort": {
+            "default": "xhigh",
+            "levels": [
+              "low",
+              "medium",
+              "xhigh"
+            ]
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "tools"
+          ],
+          "id": "qwen/qwen3.8-max",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.25,
+              "cache_write": 2.5,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 6.0
+            }
+          },
+          "provider_model_id": "qwen3.8-max",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "qwen/qwen3.7-max",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 3.125,
+              "no_cache": 2.5
+            },
+            "output_tokens": {
+              "text": 7.5
+            }
+          },
+          "provider_model_id": "qwen3.7-max",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "qwen/qwen3.7-plus",
+          "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 256000,
+                "input_tokens": {
+                  "no_cache": 1.2
+                },
+                "output_tokens": {
+                  "text": 4.8
+                }
+              }
+            ],
+            "input_tokens": {
+              "cache_read": 0.05,
+              "cache_write": 0.625,
+              "no_cache": 0.5
+            },
+            "output_tokens": {
+              "text": 3.0
+            }
+          },
+          "provider_model_id": "qwen3.7-plus",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "qwen/qwen3.6-plus",
+          "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 256000,
+                "input_tokens": {
+                  "no_cache": 2.0
+                },
+                "output_tokens": {
+                  "text": 6.0
+                }
+              }
+            ],
+            "input_tokens": {
+              "cache_read": 0.05,
+              "cache_write": 0.625,
+              "no_cache": 0.5
+            },
+            "output_tokens": {
+              "text": 3.0
+            }
+          },
+          "provider_model_id": "qwen3.6-plus",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "qwen/qwen3.6-flash",
+          "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 256000,
+                "input_tokens": {
+                  "no_cache": 1.0
+                },
+                "output_tokens": {
+                  "text": 4.0
+                }
+              }
+            ],
+            "input_tokens": {
+              "cache_write": 0.234375,
+              "no_cache": 0.1875
+            },
+            "output_tokens": {
+              "text": 1.125
+            }
+          },
+          "provider_model_id": "qwen3.6-flash",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "qwen/qwen3.5-122b-a10b",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.4
+            },
+            "output_tokens": {
+              "text": 3.2
+            }
+          },
+          "provider_model_id": "qwen3.5-122b-a10b",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "qwen/qwen3.5-27b",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.3
+            },
+            "output_tokens": {
+              "text": 2.4
+            }
+          },
+          "provider_model_id": "qwen3.5-27b",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "qwen/qwen3.6-27b",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.6
+            },
+            "output_tokens": {
+              "text": 3.6
+            }
+          },
+          "provider_model_id": "qwen3.6-27b",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "qwen/qwen3.6-35b-a3b",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.248
+            },
+            "output_tokens": {
+              "text": 1.485
+            }
+          },
+          "provider_model_id": "qwen3.6-35b-a3b",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "deepseek/deepseek-v4-flash-0731",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.04,
+              "no_cache": 0.2
+            },
+            "output_tokens": {
+              "text": 0.4
+            }
+          },
+          "provider_model_id": "deepseek-v4-flash-0731",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "z-ai/glm-5.2",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.28,
+              "cache_write": 0.0,
+              "no_cache": 1.4
+            },
+            "output_tokens": {
+              "text": 4.4
+            }
+          },
+          "provider_model_id": "glm-5.2",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        }
+      ],
+      "name": "alibaba",
+      "protocol_endpoints": {
+        "messages": "https://dashscope-intl.aliyuncs.com/api/v2/apps/anthropic-compatible-mode/v1"
+      },
+      "required_config": [
+        "api_key"
+      ],
+      "status": "active",
+      "submitted_at": "2026-05-25",
+      "weight": 1.0
+    },
+    {
+      "access": "api_key",
+      "api_base": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+      "auth_scheme": "x-api-key",
+      "billing": "usage_token",
+      "byok": true,
+      "community": false,
+      "display_name": "Alibaba Cloud Model Studio (China Beijing)",
+      "id": "alibaba_cn",
+      "metadata": {
+        "datacenters": [
+          "CN"
+        ],
+        "headquarters": "CN",
+        "name": "Alibaba Cloud",
+        "privacy_policy_url": "https://terms.alicdn.com/legal-agreement/terms/c_platform_service_agreement/20231023143554936/20231023143554936.html",
+        "slug": "alibaba-cloud",
+        "status_page_url": "https://status.aliyun.com",
+        "terms_of_service_url": "https://help.aliyun.com/zh/model-studio/related-agreements"
+      },
+      "models": [
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "qwen/qwen3.8-2.4t-a95b",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.167,
+              "cache_write": 2.083,
+              "no_cache": 1.667
+            },
+            "output_tokens": {
+              "text": 5.0
+            }
+          },
+          "provider_model_id": "qwen3.8-2.4t-a95b",
+          "rate_limits": {
+            "requests_per_minute": 60
+          },
+          "reasoning_effort": {
+            "default": "xhigh",
+            "levels": [
+              "low",
+              "medium",
+              "xhigh"
+            ]
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "qwen/qwen3.8-27b",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.042,
+              "cache_write": 0.521,
+              "no_cache": 0.417
+            },
+            "output_tokens": {
+              "text": 1.667
+            }
+          },
+          "provider_model_id": "qwen3.8-27b",
+          "rate_limits": {
+            "requests_per_minute": 60
+          },
+          "reasoning_effort": {
+            "default": "xhigh",
+            "levels": [
+              "low",
+              "medium",
+              "xhigh"
+            ]
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "tools"
+          ],
+          "id": "qwen/qwen3.8-max",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.167,
+              "cache_write": 2.083,
+              "no_cache": 1.667
+            },
+            "output_tokens": {
+              "text": 5.0
+            }
+          },
+          "provider_model_id": "qwen3.8-max",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "qwen/qwen3.7-max",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 3.125,
+              "no_cache": 2.5
+            },
+            "output_tokens": {
+              "text": 7.5
+            }
+          },
+          "provider_model_id": "qwen3.7-max",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "qwen/qwen3.7-plus",
+          "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 256000,
+                "input_tokens": {
+                  "no_cache": 0.826
+                },
+                "output_tokens": {
+                  "text": 3.301
+                }
+              }
+            ],
+            "input_tokens": {
+              "cache_read": 0.05,
+              "cache_write": 0.625,
+              "no_cache": 0.5
+            },
+            "output_tokens": {
+              "text": 3.0
+            }
+          },
+          "provider_model_id": "qwen3.7-plus",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "qwen/qwen3.6-plus",
+          "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 256000,
+                "input_tokens": {
+                  "no_cache": 1.101
+                },
+                "output_tokens": {
+                  "text": 6.602
+                }
+              }
+            ],
+            "input_tokens": {
+              "cache_read": 0.05,
+              "cache_write": 0.625,
+              "no_cache": 0.5
+            },
+            "output_tokens": {
+              "text": 3.0
+            }
+          },
+          "provider_model_id": "qwen3.6-plus",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "qwen/qwen3.6-flash",
+          "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 256000,
+                "input_tokens": {
+                  "no_cache": 0.66
+                },
+                "output_tokens": {
+                  "text": 3.961
+                }
+              }
+            ],
+            "input_tokens": {
+              "cache_write": 0.234375,
+              "no_cache": 0.1875
+            },
+            "output_tokens": {
+              "text": 1.125
+            }
+          },
+          "provider_model_id": "qwen3.6-flash",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "minimax/minimax-m2.7",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.06,
+              "cache_write": 0.375,
+              "no_cache": 0.3
+            },
+            "output_tokens": {
+              "text": 1.2
+            }
+          },
+          "provider_model_id": "MiniMax/MiniMax-M2.7",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "deepseek/deepseek-v4-flash",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.0028,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider_model_id": "deepseek-v4-flash",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "deepseek/deepseek-v4-flash-0731",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.028,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider_model_id": "deepseek-v4-flash-0731",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "deepseek/deepseek-v4-pro",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.003625,
+              "no_cache": 0.435
+            },
+            "output_tokens": {
+              "text": 0.87
+            }
+          },
+          "provider_model_id": "deepseek-v4-pro",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "z-ai/glm-5.1",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.17,
+              "no_cache": 0.87
+            },
+            "output_tokens": {
+              "text": 3.48
+            }
+          },
+          "provider_model_id": "glm-5.1",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "z-ai/glm-5.2",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.275,
+              "cache_write": 0.0,
+              "no_cache": 1.1
+            },
+            "output_tokens": {
+              "text": 3.851
+            }
+          },
+          "provider_model_id": "glm-5.2",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "moonshotai/kimi-k2.6",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.929
+            },
+            "output_tokens": {
+              "text": 3.858
+            }
+          },
+          "provider_model_id": "kimi-k2.6",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        }
+      ],
+      "name": "alibaba_cn",
+      "protocol_endpoints": {
+        "messages": "https://dashscope.aliyuncs.com/api/v2/apps/anthropic-compatible-mode/v1"
+      },
+      "required_config": [
+        "api_key"
+      ],
+      "status": "active",
+      "submitted_at": "2026-07-06",
+      "weight": 1.0
+    },
+    {
+      "access": "api_key",
+      "api_base": "https://coding-intl.dashscope.aliyuncs.com/v1",
+      "auth_scheme": "x-api-key",
+      "billing": "subscription",
+      "byok": true,
+      "community": false,
+      "display_name": "Alibaba Cloud Coding Plan (International)",
+      "id": "alibaba_coding_plan",
+      "metadata": {
+        "datacenters": [
+          "SG"
+        ],
+        "headquarters": "CN",
+        "name": "Alibaba Cloud",
+        "privacy_policy_url": "https://www.alibabacloud.com/help/en/legal/latest/alibaba-cloud-international-website-privacy-policy",
+        "slug": "alibaba-cloud",
+        "status_page_url": "https://status.alibabacloud.com",
+        "terms_of_service_url": "https://www.alibabacloud.com/help/en/legal/latest/alibaba-cloud-international-website-terms-of-use-alibaba-cloud-international-website-terms-of-use"
+      },
+      "models": [
+        {
+          "api_protocol": "openai",
+          "id": "qwen/qwen3.7-max",
+          "provider_model_id": "qwen3.7-max",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "id": "qwen/qwen3.6-plus",
+          "provider_model_id": "qwen3.6-plus",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "id": "qwen/qwen3.7-plus",
+          "provider_model_id": "qwen3.7-plus",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "id": "qwen/qwen3.6-flash",
+          "provider_model_id": "qwen3.6-flash",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "id": "z-ai/glm-4.7",
+          "provider_model_id": "glm-4.7",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        }
+      ],
+      "name": "alibaba_coding_plan",
+      "required_config": [
+        "api_key"
+      ],
+      "status": "active",
+      "submitted_at": "2026-06-05",
+      "weight": 1.0
+    },
+    {
+      "access": "api_key",
+      "api_base": "https://api.ambient.xyz/v1",
+      "auth": {
+        "env": "AMBIENT_API_KEY",
+        "kind": "bearer"
+      },
+      "auth_scheme": "x-api-key",
+      "billing": "usage_token",
+      "byok": true,
+      "community": false,
+      "display_name": "Ambient",
+      "doc_url": "https://docs.ambient.xyz/",
+      "id": "ambient",
+      "metadata": {
+        "headquarters": "US",
+        "name": "Ambient",
+        "privacy_policy_url": "https://ambient.xyz/privacy",
+        "slug": "ambient",
+        "terms_of_service_url": "https://ambient.xyz/terms"
+      },
+      "models": [
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "tools",
+            "structured_outputs"
+          ],
+          "id": "moonshotai/kimi-k2.7-code",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.15,
+              "no_cache": 0.73
+            },
+            "output_tokens": {
+              "text": 3.5
+            }
+          },
+          "provider_model_id": "moonshotai/kimi-k2.7-code",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "id": "moonshotai/kimi-k2.6",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "cache_write": 0.0,
+              "no_cache": 0.95
+            },
+            "output_tokens": {
+              "text": 4.0
+            }
+          },
+          "provider_model_id": "moonshotai/kimi-k2.6",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "id": "z-ai/glm-5.2",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "cache_write": 0.0,
+              "no_cache": 1.05
+            },
+            "output_tokens": {
+              "text": 4.4
+            }
+          },
+          "provider_model_id": "z-ai/glm-5.2",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "id": "deepseek/deepseek-v4-flash",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.028,
+              "cache_write": 0.0,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider_model_id": "deepseek/deepseek-v4-flash",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "id": "deepseek/deepseek-v4-flash-0731",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.028,
+              "cache_write": 0.0,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider_model_id": "deepseek/deepseek-v4-flash-0731",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "id": "xiaomi/mimo-v2.5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.08,
+              "cache_write": 0.0,
+              "no_cache": 0.4
+            },
+            "output_tokens": {
+              "text": 2.0
+            }
+          },
+          "provider_model_id": "xiaomi/mimo-v2.5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        }
+      ],
+      "name": "ambient",
+      "required_config": [
+        "api_key"
+      ],
+      "status": "active",
+      "submitted_at": "2026-06-23",
+      "weight": 1.0
+    },
+    {
+      "access": "api_key",
+      "api_base": "https://api.anthropic.com/v1",
+      "auth": {
+        "env": "ANTHROPIC_API_KEY",
+        "extra_headers": {
+          "anthropic-version": "2023-06-01"
+        },
+        "header": "x-api-key",
+        "kind": "header"
+      },
+      "auth_scheme": "x-api-key",
+      "billing": "usage_token",
+      "byok": true,
+      "community": false,
+      "display_name": "Anthropic",
+      "doc_url": "https://docs.anthropic.com/en/api/messages",
+      "id": "anthropic",
+      "kind": "first_party",
+      "metadata": {
+        "headquarters": "US",
+        "name": "Anthropic",
+        "privacy_policy_url": "https://www.anthropic.com/privacy",
+        "slug": "anthropic",
+        "status_page_url": "https://status.anthropic.com",
+        "terms_of_service_url": "https://www.anthropic.com/legal/consumer-terms"
+      },
+      "models": [
+        {
+          "api_protocol": "anthropic",
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools"
+          ],
+          "id": "anthropic/claude-opus-4.8",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider_model_id": "claude-opus-4-8",
+          "rate_limits": {
+            "requests_per_minute": 60
+          },
+          "reasoning_effort": {
+            "default": "high",
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": "anthropic",
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools"
+          ],
+          "id": "anthropic/claude-opus-4.7",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider_model_id": "claude-opus-4-7",
+          "rate_limits": {
+            "requests_per_minute": 60
+          },
+          "reasoning_effort": {
+            "default": "high",
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": "anthropic",
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools"
+          ],
+          "id": "anthropic/claude-opus-4.6",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider_model_id": "claude-opus-4-6",
+          "rate_limits": {
+            "requests_per_minute": 60
+          },
+          "reasoning_effort": {
+            "default": "high",
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": "anthropic",
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools",
+            "image_input"
+          ],
+          "id": "anthropic/claude-sonnet-5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "cache_write": 2.5,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 10.0
+            }
+          },
+          "provider_model_id": "claude-sonnet-5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          },
+          "reasoning_effort": {
+            "default": "high",
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": "anthropic",
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools",
+            "image_input"
+          ],
+          "id": "anthropic/claude-sonnet-4.6",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.3,
+              "cache_write": 3.75,
+              "no_cache": 3.0
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider_model_id": "claude-sonnet-4-6",
+          "rate_limits": {
+            "requests_per_minute": 60
+          },
+          "reasoning_effort": {
+            "default": "high",
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": "anthropic",
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools"
+          ],
+          "id": "anthropic/claude-sonnet-4.5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.3,
+              "cache_write": 3.75,
+              "no_cache": 3.0
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider_model_id": "claude-sonnet-4-5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "anthropic",
+          "capabilities": [
+            "reasoning"
+          ],
+          "id": "anthropic/claude-fable-5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 1.0,
+              "cache_write": 12.5,
+              "no_cache": 10.0
+            },
+            "output_tokens": {
+              "text": 50.0
+            }
+          },
+          "provider_model_id": "claude-fable-5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          },
+          "reasoning_effort": {
+            "default": "high",
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": "anthropic",
+          "capabilities": [
+            "tools"
+          ],
+          "id": "anthropic/claude-haiku-4.5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.1,
+              "cache_write": 1.25,
+              "no_cache": 1.0
+            },
+            "output_tokens": {
+              "text": 5.0
+            }
+          },
+          "provider_model_id": "claude-haiku-4-5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "anthropic",
+          "capabilities": [
+            "reasoning"
+          ],
+          "id": "anthropic/claude-opus-5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider_model_id": "claude-opus-5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          },
+          "reasoning_effort": {
+            "default": "high",
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        }
+      ],
+      "name": "anthropic",
+      "required_config": [
+        "api_key"
+      ],
+      "status": "active",
+      "submitted_at": "2026-05-25",
+      "weight": 1.0
+    },
+    {
+      "access": "api_key",
+      "api_base": "https://api.atlascloud.ai/v1",
+      "auth_scheme": "bearer",
+      "billing": "usage_token",
+      "byok": true,
+      "community": false,
+      "display_name": "Atlas Cloud",
+      "id": "atlascloud",
+      "kind": "gateway",
+      "metadata": {
+        "datacenters": [
+          "US"
+        ],
+        "headquarters": "US",
+        "name": "Atlas Cloud",
+        "privacy_policy_url": "https://www.atlascloud.ai/privacy",
+        "slug": "atlascloud",
+        "terms_of_service_url": "https://www.atlascloud.ai/acceptable-use"
+      },
+      "models": [
+        {
+          "api_protocol": "openai",
+          "id": "qwen/qwen3.7-max",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "no_cache": 2.5
+            },
+            "output_tokens": {
+              "text": 7.5
+            }
+          },
+          "provider_model_id": "qwen/qwen3.7-max"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "qwen/qwen3.7-plus",
+          "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 262144,
+                "input_tokens": {
+                  "cache_read": 0.24,
+                  "no_cache": 1.2
+                },
+                "output_tokens": {
+                  "text": 4.8
+                }
+              }
+            ],
+            "input_tokens": {
+              "cache_read": 0.08,
+              "no_cache": 0.4
+            },
+            "output_tokens": {
+              "text": 1.6
+            }
+          },
+          "provider_model_id": "qwen/qwen3.7-plus"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "deepseek/deepseek-v4-pro",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.13,
+              "no_cache": 1.68
+            },
+            "output_tokens": {
+              "text": 3.38
+            }
+          },
+          "provider_model_id": "deepseek-ai/deepseek-v4-pro"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "deepseek/deepseek-v4-pro-0813",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.132,
+              "no_cache": 1.32
+            },
+            "output_tokens": {
+              "text": 3.96
+            }
+          },
+          "provider_model_id": "deepseek-ai/deepseek-v4-pro-0813"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "deepseek/deepseek-v4-flash",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.028,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider_model_id": "deepseek-ai/deepseek-v4-flash"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "deepseek/deepseek-v4-flash-0731",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.028,
+              "no_cache": 0.44
+            },
+            "output_tokens": {
+              "text": 1.32
+            }
+          },
+          "provider_model_id": "deepseek-ai/deepseek-v4-flash-0731"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "deepseek/deepseek-v3.2",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.13,
+              "no_cache": 0.26
+            },
+            "output_tokens": {
+              "text": 0.38
+            }
+          },
+          "provider_model_id": "deepseek-ai/deepseek-v3.2"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "moonshotai/kimi-k2.6",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.16,
+              "no_cache": 0.95
+            },
+            "output_tokens": {
+              "text": 4.0
+            }
+          },
+          "provider_model_id": "moonshotai/kimi-k2.6"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "moonshotai/kimi-k2.7-code",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.16,
+              "no_cache": 0.95
+            },
+            "output_tokens": {
+              "text": 4.0
+            }
+          },
+          "provider_model_id": "moonshotai/kimi-k2.7-code"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "minimax/minimax-m3",
+          "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 512000,
+                "input_tokens": {
+                  "cache_read": 0.12,
+                  "no_cache": 0.6
+                },
+                "output_tokens": {
+                  "text": 2.4
+                }
+              }
+            ],
+            "input_tokens": {
+              "cache_read": 0.06,
+              "no_cache": 0.3
+            },
+            "output_tokens": {
+              "text": 1.2
+            }
+          },
+          "provider_model_id": "minimaxai/minimax-m3"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "z-ai/glm-5.1",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.234,
+              "no_cache": 1.26
+            },
+            "output_tokens": {
+              "text": 3.96
+            }
+          },
+          "provider_model_id": "zai-org/glm-5.1"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "z-ai/glm-5.2",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.26,
+              "no_cache": 1.4
+            },
+            "output_tokens": {
+              "text": 4.4
+            }
+          },
+          "provider_model_id": "zai-org/glm-5.2"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "x-ai/grok-4.3",
+          "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 200000,
+                "input_tokens": {
+                  "cache_read": 0.4,
+                  "no_cache": 2.5
+                },
+                "output_tokens": {
+                  "text": 5.0
+                }
+              }
+            ],
+            "input_tokens": {
+              "cache_read": 0.2,
+              "no_cache": 1.25
+            },
+            "output_tokens": {
+              "text": 2.5
+            }
+          },
+          "provider_model_id": "xai/grok-4.3"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "anthropic/claude-opus-5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider_model_id": "anthropic/claude-opus-5-ccmax"
+        }
+      ],
+      "name": "atlascloud",
+      "required_config": [
+        "api_key"
+      ],
+      "status": "active",
+      "submitted_at": "2026-07-07",
+      "weight": 1.0
+    },
+    {
+      "access": "api_key",
+      "api_base": "https://bedrock-mantle.${AWS_REGION:-us-east-1}.api.aws/v1",
+      "auth": {
+        "env": "AWS_BEARER_TOKEN_BEDROCK",
+        "kind": "bearer"
+      },
+      "auth_scheme": "x-api-key",
+      "billing": "usage_token",
+      "byok": true,
+      "community": false,
+      "display_name": "Amazon Bedrock",
+      "doc_url": "https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-mantle.html",
+      "id": "aws-bedrock",
+      "kind": "first_party",
+      "metadata": {
+        "headquarters": "US",
+        "name": "Amazon Web Services",
+        "privacy_policy_url": "https://aws.amazon.com/privacy/",
+        "slug": "amazon-bedrock",
+        "status_page_url": "https://health.aws.amazon.com/health/status",
+        "terms_of_service_url": "https://aws.amazon.com/service-terms/"
+      },
+      "models": [
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "id": "anthropic/claude-fable-5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 1.0,
+              "cache_write": 12.5,
+              "no_cache": 10.0
+            },
+            "output_tokens": {
+              "text": 50.0
+            }
+          },
+          "provider_model_id": "anthropic.claude-fable-5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "id": "anthropic/claude-opus-4.7",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider_model_id": "anthropic.claude-opus-4-7",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "id": "anthropic/claude-opus-4.8",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider_model_id": "anthropic.claude-opus-4-8",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "id": "anthropic/claude-sonnet-4.6",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.3,
+              "cache_write": 3.75,
+              "no_cache": 3.0
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider_model_id": "anthropic.claude-sonnet-4-6",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "id": "deepseek/deepseek-v3.2",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.62
+            },
+            "output_tokens": {
+              "text": 1.85
+            }
+          },
+          "provider_model_id": "deepseek.v3.2",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "id": "openai/gpt-5.4",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.275,
+              "no_cache": 2.75
+            },
+            "output_tokens": {
+              "text": 16.5
+            }
+          },
+          "provider_model_id": "openai.gpt-5.4",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "id": "openai/gpt-5.5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.55,
+              "no_cache": 5.5
+            },
+            "output_tokens": {
+              "text": 33.0
+            }
+          },
+          "provider_model_id": "openai.gpt-5.5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "id": "openai/gpt-oss-120b",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.15
+            },
+            "output_tokens": {
+              "text": 0.6
+            }
+          },
+          "provider_model_id": "openai.gpt-oss-120b",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "id": "x-ai/grok-4.3",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "no_cache": 1.25
+            },
+            "output_tokens": {
+              "text": 2.5
+            }
+          },
+          "provider_model_id": "xai.grok-4.3",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "id": "anthropic/claude-sonnet-5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "cache_write": 2.5,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 10.0
+            }
+          },
+          "provider_model_id": "anthropic.claude-sonnet-5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "id": "z-ai/glm-4.7",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.6
+            },
+            "output_tokens": {
+              "text": 2.2
+            }
+          },
+          "provider_model_id": "zai.glm-4.7",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "id": "openai/gpt-5.6-luna",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.022,
+              "cache_write": 0.275,
+              "no_cache": 0.22
+            },
+            "output_tokens": {
+              "text": 1.32
+            }
+          },
+          "provider_model_id": "openai.gpt-5.6-luna",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "id": "openai/gpt-5.6-sol",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.55,
+              "cache_write": 6.88,
+              "no_cache": 5.5
+            },
+            "output_tokens": {
+              "text": 33.0
+            }
+          },
+          "provider_model_id": "openai.gpt-5.6-sol",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "id": "openai/gpt-5.6-terra",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.22,
+              "cache_write": 2.75,
+              "no_cache": 2.2
+            },
+            "output_tokens": {
+              "text": 13.2
+            }
+          },
+          "provider_model_id": "openai.gpt-5.6-terra",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "id": "anthropic/claude-opus-5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider_model_id": "anthropic.claude-opus-5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "id": "x-ai/grok-4.6",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.55,
+              "no_cache": 2.2
+            },
+            "output_tokens": {
+              "text": 6.6
+            }
+          },
+          "provider_model_id": "xai.grok-4.6",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        }
+      ],
+      "name": "aws-bedrock",
+      "required_config": [
+        "api_key"
+      ],
+      "status": "active",
+      "submitted_at": "2026-07-06",
+      "weight": 1.0
+    },
+    {
+      "access": "api_key",
+      "api_base": "https://${AZURE_OPENAI_RESOURCE}.openai.azure.com/openai/v1",
+      "auth": {
+        "env": "AZURE_OPENAI_API_KEY",
+        "kind": "bearer"
+      },
+      "auth_scheme": "x-api-key",
+      "billing": "usage_token",
+      "byok": true,
+      "community": false,
+      "display_name": "Azure OpenAI",
+      "doc_url": "https://learn.microsoft.com/azure/ai-services/openai/reference-preview",
+      "id": "azure",
+      "kind": "first_party",
+      "metadata": {
+        "headquarters": "US",
+        "name": "Microsoft Azure",
+        "privacy_policy_url": "https://privacy.microsoft.com/privacystatement",
+        "slug": "azure",
+        "status_page_url": "https://azure.status.microsoft",
+        "terms_of_service_url": "https://azure.microsoft.com/support/legal/"
+      },
+      "models": [
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "id": "anthropic/claude-fable-5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 1.0,
+              "cache_write": 12.5,
+              "no_cache": 10.0
+            },
+            "output_tokens": {
+              "text": 50.0
+            }
+          },
+          "provider_model_id": "claude-fable-5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "id": "anthropic/claude-haiku-4.5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.1,
+              "cache_write": 1.25,
+              "no_cache": 1.0
+            },
+            "output_tokens": {
+              "text": 5.0
+            }
+          },
+          "provider_model_id": "claude-haiku-4-5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "id": "anthropic/claude-opus-4.6",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider_model_id": "claude-opus-4-6",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "id": "anthropic/claude-opus-4.8",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider_model_id": "claude-opus-4-8",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "id": "anthropic/claude-sonnet-4.5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.3,
+              "cache_write": 3.75,
+              "no_cache": 3.0
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider_model_id": "claude-sonnet-4-5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "id": "anthropic/claude-sonnet-4.6",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.3,
+              "cache_write": 3.75,
+              "no_cache": 3.0
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider_model_id": "claude-sonnet-4-6",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "id": "deepseek/deepseek-v3.2",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.58
+            },
+            "output_tokens": {
+              "text": 1.68
+            }
+          },
+          "provider_model_id": "deepseek-v3.2",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "id": "deepseek/deepseek-v4-flash",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.19
+            },
+            "output_tokens": {
+              "text": 0.51
+            }
+          },
+          "provider_model_id": "deepseek-v4-flash",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "id": "deepseek/deepseek-v4-pro",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 1.74
+            },
+            "output_tokens": {
+              "text": 3.48
+            }
+          },
+          "provider_model_id": "deepseek-v4-pro",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "id": "openai/gpt-5.4",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.25,
+              "no_cache": 2.5
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider_model_id": "gpt-5.4",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "id": "openai/gpt-5.4-mini",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.075,
+              "no_cache": 0.75
+            },
+            "output_tokens": {
+              "text": 4.5
+            }
+          },
+          "provider_model_id": "gpt-5.4-mini",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "id": "openai/gpt-5.5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 30.0
+            }
+          },
+          "provider_model_id": "gpt-5.5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "id": "moonshotai/kimi-k2.6",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.95
+            },
+            "output_tokens": {
+              "text": 4.0
+            }
+          },
+          "provider_model_id": "kimi-k2.6",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "id": "anthropic/claude-sonnet-5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "cache_write": 2.5,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 10.0
+            }
+          },
+          "provider_model_id": "claude-sonnet-5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "id": "openai/gpt-5.6-luna",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.02,
+              "no_cache": 0.2
+            },
+            "output_tokens": {
+              "text": 1.2
+            }
+          },
+          "provider_model_id": "gpt-5.6-luna",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "id": "openai/gpt-5.6-sol",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 30.0
+            }
+          },
+          "provider_model_id": "gpt-5.6-sol",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "id": "openai/gpt-5.6-terra",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 12.0
+            }
+          },
+          "provider_model_id": "gpt-5.6-terra",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "id": "anthropic/claude-opus-5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider_model_id": "claude-opus-5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "id": "moonshotai/kimi-k2.7-code",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.19,
+              "no_cache": 0.95
+            },
+            "output_tokens": {
+              "text": 4.0
+            }
+          },
+          "provider_model_id": "kimi-k2.7-code",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "id": "anthropic/claude-opus-4.7",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider_model_id": "claude-opus-4-7",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        }
+      ],
+      "name": "azure",
+      "required_config": [
+        "api_key"
+      ],
+      "status": "active",
+      "submitted_at": "2026-07-06",
+      "weight": 1.0
+    },
+    {
+      "access": "api_key",
+      "api_base": "https://api.bitrouter.ai/v1",
+      "auth": {
+        "env": "BITROUTER_API_KEY",
+        "kind": "bearer"
+      },
+      "auth_scheme": "x-api-key",
+      "billing": "usage_token",
+      "byok": true,
+      "community": false,
+      "display_name": "BitRouter Cloud",
+      "doc_url": "https://docs.bitrouter.ai",
+      "id": "bitrouter",
+      "kind": "cloud",
+      "metadata": {
+        "headquarters": "US",
+        "name": "BitRouter",
+        "privacy_policy_url": "https://bitrouter.ai/legal/privacy",
+        "slug": "bitrouter",
+        "terms_of_service_url": "https://bitrouter.ai/legal/terms"
+      },
+      "models": [
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning"
+          ],
+          "id": "anthropic/claude-fable-5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 1.0,
+              "cache_write": 12.5,
+              "no_cache": 10.0
+            },
+            "output_tokens": {
+              "text": 50.0
+            }
+          },
+          "provider_model_id": "anthropic/claude-fable-5",
+          "reasoning_effort": {
+            "default": "high",
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "tools"
+          ],
+          "id": "anthropic/claude-haiku-4.5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.1,
+              "cache_write": 1.25,
+              "no_cache": 1.0
+            },
+            "output_tokens": {
+              "text": 5.0
+            }
+          },
+          "provider_model_id": "anthropic/claude-haiku-4.5"
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning"
+          ],
+          "id": "anthropic/claude-opus-4.6",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider_model_id": "anthropic/claude-opus-4.6",
+          "reasoning_effort": {
+            "default": "high",
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning"
+          ],
+          "id": "anthropic/claude-opus-4.7",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.45,
+              "no_cache": 4.5
+            },
+            "output_tokens": {
+              "text": 22.5
+            }
+          },
+          "provider_model_id": "anthropic/claude-opus-4.7",
+          "reasoning_effort": {
+            "default": "high",
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning"
+          ],
+          "id": "anthropic/claude-opus-4.8",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider_model_id": "anthropic/claude-opus-4.8",
+          "reasoning_effort": {
+            "default": "high",
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning"
+          ],
+          "id": "anthropic/claude-sonnet-4.6",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.3,
+              "cache_write": 3.75,
+              "no_cache": 3.0
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider_model_id": "anthropic/claude-sonnet-4.6",
+          "reasoning_effort": {
+            "default": "high",
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning"
+          ],
+          "id": "anthropic/claude-sonnet-5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "cache_write": 2.5,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 10.0
+            }
+          },
+          "provider_model_id": "anthropic/claude-sonnet-5",
+          "reasoning_effort": {
+            "default": "high",
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "id": "deepseek/deepseek-v3.2",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.105,
+              "no_cache": 0.21
+            },
+            "output_tokens": {
+              "text": 0.315
+            }
+          },
+          "provider_model_id": "deepseek/deepseek-v3.2"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "deepseek/deepseek-v4-flash",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.02,
+              "no_cache": 0.09
+            },
+            "output_tokens": {
+              "text": 0.18
+            }
+          },
+          "provider_model_id": "deepseek/deepseek-v4-flash"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "deepseek/deepseek-v4-pro",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.003625,
+              "no_cache": 0.435
+            },
+            "output_tokens": {
+              "text": 0.87
+            }
+          },
+          "provider_model_id": "deepseek/deepseek-v4-pro"
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning"
+          ],
+          "id": "google/gemini-3.1-flash-lite-preview",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.025,
+              "no_cache": 0.25
+            },
+            "output_tokens": {
+              "text": 1.5
+            }
+          },
+          "provider_model_id": "google/gemini-3.1-flash-lite-preview"
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning"
+          ],
+          "id": "google/gemini-3.1-pro-preview",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 12.0
+            }
+          },
+          "provider_model_id": "google/gemini-3.1-pro-preview",
+          "reasoning_effort": {
+            "default": "high",
+            "levels": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning"
+          ],
+          "id": "google/gemini-3.5-flash",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.15,
+              "no_cache": 1.5
+            },
+            "output_tokens": {
+              "text": 9.0
+            }
+          },
+          "provider_model_id": "google/gemini-3.5-flash",
+          "reasoning_effort": {
+            "default": "medium",
+            "levels": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "id": "minimax/minimax-m2.7",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.045,
+              "cache_write": 0.28125,
+              "no_cache": 0.225
+            },
+            "output_tokens": {
+              "text": 0.9
+            }
+          },
+          "provider_model_id": "minimax/minimax-m2.7"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "minimax/minimax-m3",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.06,
+              "no_cache": 0.3
+            },
+            "output_tokens": {
+              "text": 1.2
+            }
+          },
+          "provider_model_id": "minimax/minimax-m3"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "moonshotai/kimi-k2.6",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.12,
+              "no_cache": 0.7125
+            },
+            "output_tokens": {
+              "text": 3.0
+            }
+          },
+          "provider_model_id": "moonshotai/kimi-k2.6"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "moonshotai/kimi-k2.7-code",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.1425,
+              "no_cache": 0.7125
+            },
+            "output_tokens": {
+              "text": 3.0
+            }
+          },
+          "provider_model_id": "moonshotai/kimi-k2.7-code"
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning"
+          ],
+          "id": "openai/gpt-5.4",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.25,
+              "no_cache": 2.5
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider_model_id": "openai/gpt-5.4",
+          "reasoning_effort": {
+            "default": "none",
+            "levels": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning"
+          ],
+          "id": "openai/gpt-5.4-mini",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.075,
+              "no_cache": 0.75
+            },
+            "output_tokens": {
+              "text": 4.5
+            }
+          },
+          "provider_model_id": "openai/gpt-5.4-mini",
+          "reasoning_effort": {
+            "default": "none",
+            "levels": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning"
+          ],
+          "id": "openai/gpt-5.5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 30.0
+            }
+          },
+          "provider_model_id": "openai/gpt-5.5",
+          "reasoning_effort": {
+            "default": "medium",
+            "levels": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "id": "qwen/qwen3.5-122b-a10b",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.26
+            },
+            "output_tokens": {
+              "text": 2.08
+            }
+          },
+          "provider_model_id": "qwen/qwen3.5-122b-a10b"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "qwen/qwen3.5-27b",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.25
+            },
+            "output_tokens": {
+              "text": 2.0
+            }
+          },
+          "provider_model_id": "qwen/qwen3.5-27b"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "qwen/qwen3.6-27b",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.3
+            },
+            "output_tokens": {
+              "text": 3.2
+            }
+          },
+          "provider_model_id": "qwen/qwen3.6-27b"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "qwen/qwen3.6-35b-a3b",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.2
+            },
+            "output_tokens": {
+              "text": 1.6
+            }
+          },
+          "provider_model_id": "qwen/qwen3.6-35b-a3b"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "qwen/qwen3.6-flash",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.165
+            },
+            "output_tokens": {
+              "text": 0.99
+            }
+          },
+          "provider_model_id": "qwen/qwen3.6-flash"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "qwen/qwen3.7-max",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.25,
+              "cache_write": 1.5625,
+              "no_cache": 1.25
+            },
+            "output_tokens": {
+              "text": 3.75
+            }
+          },
+          "provider_model_id": "qwen/qwen3.7-max"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "qwen/qwen3.7-plus",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.276
+            },
+            "output_tokens": {
+              "text": 1.101
+            }
+          },
+          "provider_model_id": "qwen/qwen3.7-plus"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "x-ai/grok-4.20",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "no_cache": 1.25
+            },
+            "output_tokens": {
+              "text": 2.5
+            }
+          },
+          "provider_model_id": "x-ai/grok-4.20"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "x-ai/grok-4.20-multi-agent",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "no_cache": 1.25
+            },
+            "output_tokens": {
+              "text": 2.5
+            }
+          },
+          "provider_model_id": "x-ai/grok-4.20-multi-agent"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "x-ai/grok-4.3",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "no_cache": 1.25
+            },
+            "output_tokens": {
+              "text": 2.5
+            }
+          },
+          "provider_model_id": "x-ai/grok-4.3"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "x-ai/grok-build-0.1",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "no_cache": 1.0
+            },
+            "output_tokens": {
+              "text": 2.0
+            }
+          },
+          "provider_model_id": "x-ai/grok-build-0.1"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "xiaomi/mimo-v2.5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.0028,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider_model_id": "xiaomi/mimo-v2.5"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "xiaomi/mimo-v2.5-pro",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.0036,
+              "no_cache": 0.435
+            },
+            "output_tokens": {
+              "text": 0.87
+            }
+          },
+          "provider_model_id": "xiaomi/mimo-v2.5-pro"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "z-ai/glm-4.7",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.11,
+              "no_cache": 0.6
+            },
+            "output_tokens": {
+              "text": 2.2
+            }
+          },
+          "provider_model_id": "z-ai/glm-4.7"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "z-ai/glm-5.1",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.182,
+              "no_cache": 0.98
+            },
+            "output_tokens": {
+              "text": 3.08
+            }
+          },
+          "provider_model_id": "z-ai/glm-5.1"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "z-ai/glm-5.2",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.182,
+              "no_cache": 0.979
+            },
+            "output_tokens": {
+              "text": 3.08
+            }
+          },
+          "provider_model_id": "z-ai/glm-5.2"
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning"
+          ],
+          "id": "openai/gpt-5.6-luna",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.1,
+              "cache_write": 1.25,
+              "no_cache": 1.0
+            },
+            "output_tokens": {
+              "text": 6.0
+            }
+          },
+          "provider_model_id": "openai/gpt-5.6-luna",
+          "reasoning_effort": {
+            "default": "medium",
+            "levels": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning"
+          ],
+          "id": "openai/gpt-5.6-sol",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 30.0
+            }
+          },
+          "provider_model_id": "openai/gpt-5.6-sol",
+          "reasoning_effort": {
+            "default": "medium",
+            "levels": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning"
+          ],
+          "id": "openai/gpt-5.6-terra",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.25,
+              "cache_write": 3.125,
+              "no_cache": 2.5
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider_model_id": "openai/gpt-5.6-terra",
+          "reasoning_effort": {
+            "default": "medium",
+            "levels": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "id": "x-ai/grok-4.5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 6.0
+            }
+          },
+          "provider_model_id": "x-ai/grok-4.5"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "moonshotai/kimi-k3",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.3,
+              "no_cache": 3.0
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider_model_id": "moonshotai/kimi-k3"
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning"
+          ],
+          "id": "anthropic/claude-opus-5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider_model_id": "anthropic/claude-opus-5",
+          "reasoning_effort": {
+            "default": "high",
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "deepseek/deepseek-v4-flash-0731",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.028,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider_model_id": "deepseek/deepseek-v4-flash-0731"
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "tools"
+          ],
+          "id": "qwen/qwen3.8-max",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.25,
+              "cache_write": 2.5,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 6.0
+            }
+          },
+          "provider_model_id": "qwen/qwen3.8-max"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "deepseek/deepseek-v4-pro-0813",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.003625,
+              "no_cache": 0.435
+            },
+            "output_tokens": {
+              "text": 0.87
+            }
+          },
+          "provider_model_id": "deepseek/deepseek-v4-pro-0813"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "google/gemini-3.6-flash",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.15,
+              "no_cache": 1.5
+            },
+            "output_tokens": {
+              "text": 7.5
+            }
+          },
+          "provider_model_id": "google/gemini-3.6-flash"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "x-ai/grok-4.6",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 6.0
+            }
+          },
+          "provider_model_id": "x-ai/grok-4.6"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "qwen/qwen3.8-2.4t-a95b",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.17,
+              "cache_write": 2.5,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 6.0
+            }
+          },
+          "provider_model_id": "qwen/qwen3.8-2.4t-a95b"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "qwen/qwen3.8-27b",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.05,
+              "cache_write": 0.625,
+              "no_cache": 0.5
+            },
+            "output_tokens": {
+              "text": 3.0
+            }
+          },
+          "provider_model_id": "qwen/qwen3.8-27b"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "z-ai/glm-5.3",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.26,
+              "no_cache": 1.4
+            },
+            "output_tokens": {
+              "text": 4.4
+            }
+          },
+          "provider_model_id": "z-ai/glm-5.3"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "z-ai/glm-5.3-flash",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.015,
+              "no_cache": 0.075
+            },
+            "output_tokens": {
+              "text": 0.25
+            }
+          },
+          "provider_model_id": "z-ai/glm-5.3-flash"
+        }
+      ],
+      "name": "bitrouter",
+      "required_config": [
+        "api_key"
+      ],
+      "status": "active",
+      "weight": 1.0
+    },
+    {
+      "access": "api_key",
+      "api_base": "https://ark.ap-southeast.bytepluses.com/api/v3",
+      "auth_scheme": "bearer",
+      "billing": "usage_token",
+      "byok": true,
+      "community": false,
+      "display_name": "BytePlus ModelArk",
+      "doc_url": "https://docs.byteplus.com/en/docs/ModelArk",
+      "id": "byteplus",
+      "kind": "cloud",
+      "metadata": {
+        "datacenters": [
+          "SG"
+        ],
+        "headquarters": "CN",
+        "name": "BytePlus",
+        "slug": "byteplus"
+      },
+      "models": [
+        {
+          "api_protocol": "openai",
+          "id": "deepseek/deepseek-v3.1",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.56
+            },
+            "output_tokens": {
+              "text": 1.68
+            }
+          },
+          "provider_model_id": "deepseek-v3.1"
+        }
+      ],
+      "name": "byteplus",
+      "required_config": [
+        "api_key"
+      ],
+      "status": "staging",
+      "submitted_at": "2026-07-07",
+      "weight": 1.0
+    },
+    {
+      "access": "api_key",
+      "api_base": "https://api.cerebras.ai/v1",
+      "auth_scheme": "x-api-key",
+      "billing": "usage_token",
+      "byok": true,
+      "community": false,
+      "id": "cerebras",
+      "metadata": {
+        "headquarters": "US",
+        "name": "Cerebras",
+        "privacy_policy_url": "https://www.cerebras.ai/privacy-policy",
+        "slug": "cerebras",
+        "status_page_url": "https://status.cerebras.ai",
+        "terms_of_service_url": "https://www.cerebras.ai/terms-of-service"
+      },
+      "models": [
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools"
+          ],
+          "id": "openai/gpt-oss-120b",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.35
+            },
+            "output_tokens": {
+              "text": 0.75
+            }
+          },
+          "provider_model_id": "gpt-oss-120b",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "id": "z-ai/glm-4.7",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 2.25,
+              "cache_write": 0.0,
+              "no_cache": 2.25
+            },
+            "output_tokens": {
+              "text": 2.75
+            }
+          },
+          "provider_model_id": "zai-glm-4.7",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        }
+      ],
+      "name": "cerebras",
+      "required_config": [
+        "api_key"
+      ],
+      "status": "active",
+      "submitted_at": "2026-06-16",
+      "weight": 1.0
+    },
+    {
+      "access": "api_key",
+      "api_base": "https://llm.chutes.ai/v1",
+      "auth_scheme": "x-api-key",
+      "billing": "usage_token",
+      "byok": true,
+      "community": true,
+      "id": "chutes",
+      "metadata": {
+        "headquarters": "US",
+        "name": "Chutes",
+        "privacy_policy_url": "https://chutes.ai/privacy",
+        "slug": "chutes",
+        "status_page_url": "https://status.chutes.ai",
+        "terms_of_service_url": "https://chutes.ai/terms"
+      },
+      "models": [
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "moonshotai/kimi-k2.6",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.33,
+              "no_cache": 0.66
+            },
+            "output_tokens": {
+              "text": 3.5
+            }
+          },
+          "provider_model_id": "moonshotai/Kimi-K2.6-TEE",
+          "rate_limits": {
+            "requests_per_minute": 30
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "z-ai/glm-5.1",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.49,
+              "no_cache": 0.98
+            },
+            "output_tokens": {
+              "text": 3.08
+            }
+          },
+          "provider_model_id": "zai-org/GLM-5.1-TEE",
+          "rate_limits": {
+            "requests_per_minute": 30
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "deepseek/deepseek-v3.2",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "no_cache": 1.0
+            },
+            "output_tokens": {
+              "text": 1.0
+            }
+          },
+          "provider_model_id": "deepseek-ai/DeepSeek-V3.2-TEE",
+          "rate_limits": {
+            "requests_per_minute": 30
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "xiaomi/mimo-v2-flash",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.045,
+              "no_cache": 0.09
+            },
+            "output_tokens": {
+              "text": 0.29
+            }
+          },
+          "provider_model_id": "XiaomiMiMo/MiMo-V2-Flash-TEE",
+          "rate_limits": {
+            "requests_per_minute": 30
+          }
+        }
+      ],
+      "name": "chutes",
+      "required_config": [
+        "api_key"
+      ],
+      "status": "active",
+      "weight": 1.0
+    },
+    {
+      "access": "local_oauth",
+      "api_base": "https://api.anthropic.com/v1",
+      "auth": {
+        "handler": "anthropic",
+        "kind": "oauth"
+      },
+      "auth_scheme": "x-api-key",
+      "billing": "subscription",
+      "byok": false,
+      "community": false,
+      "display_name": "Claude Code (subscription)",
+      "id": "claude-code",
+      "kind": "first_party",
+      "metadata": {
+        "headquarters": "US",
+        "name": "Anthropic",
+        "privacy_policy_url": "https://www.anthropic.com/privacy",
+        "slug": "anthropic",
+        "status_page_url": "https://status.anthropic.com",
+        "terms_of_service_url": "https://www.anthropic.com/legal/consumer-terms"
+      },
+      "models": [
+        {
+          "api_protocol": "anthropic",
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools"
+          ],
+          "id": "anthropic/claude-opus-4.8",
+          "provider_model_id": "claude-opus-4-8",
+          "reasoning_effort": {
+            "default": "high",
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": "anthropic",
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools"
+          ],
+          "id": "anthropic/claude-opus-4.7",
+          "provider_model_id": "claude-opus-4-7",
+          "reasoning_effort": {
+            "default": "high",
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": "anthropic",
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools"
+          ],
+          "id": "anthropic/claude-opus-4.6",
+          "provider_model_id": "claude-opus-4-6",
+          "reasoning_effort": {
+            "default": "high",
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": "anthropic",
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools",
+            "image_input"
+          ],
+          "id": "anthropic/claude-sonnet-5",
+          "provider_model_id": "claude-sonnet-5",
+          "reasoning_effort": {
+            "default": "high",
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": "anthropic",
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools",
+            "image_input"
+          ],
+          "id": "anthropic/claude-sonnet-4.6",
+          "provider_model_id": "claude-sonnet-4-6",
+          "reasoning_effort": {
+            "default": "high",
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": "anthropic",
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools"
+          ],
+          "id": "anthropic/claude-haiku-4.5",
+          "provider_model_id": "claude-haiku-4-5"
+        },
+        {
+          "api_protocol": "anthropic",
+          "capabilities": [
+            "reasoning"
+          ],
+          "id": "anthropic/claude-fable-5",
+          "provider_model_id": "claude-fable-5",
+          "reasoning_effort": {
+            "default": "high",
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": "anthropic",
+          "capabilities": [
+            "reasoning"
+          ],
+          "id": "anthropic/claude-opus-5",
+          "provider_model_id": "claude-opus-5",
+          "reasoning_effort": {
+            "default": "high",
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        }
+      ],
+      "name": "claude-code",
+      "required_config": [
+        "local_oauth"
+      ],
+      "status": "active",
+      "weight": 1.0
+    },
+    {
+      "access": "api_key",
+      "api_base": "https://api.deepseek.com",
+      "auth_scheme": "x-api-key",
+      "billing": "usage_token",
+      "byok": true,
+      "community": false,
+      "id": "deepseek",
+      "metadata": {
+        "datacenters": [
+          "CN"
+        ],
+        "headquarters": "CN",
+        "name": "DeepSeek",
+        "privacy_policy_url": "https://cdn.deepseek.com/policies/en-US/deepseek-privacy-policy.html",
+        "slug": "deepseek",
+        "terms_of_service_url": "https://cdn.deepseek.com/policies/en-US/deepseek-open-platform-terms-of-service.html"
+      },
+      "models": [
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "deepseek/deepseek-v4-pro-0813",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.003625,
+              "no_cache": 0.435
+            },
+            "output_tokens": {
+              "text": 0.87
+            }
+          },
+          "provider_model_id": "deepseek-v4-pro",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "deepseek/deepseek-v4-flash-0731",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.0028,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider_model_id": "deepseek-v4-flash",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        }
+      ],
+      "name": "deepseek",
+      "protocol_endpoints": {
+        "messages": "https://api.deepseek.com/anthropic"
+      },
+      "required_config": [
+        "api_key"
+      ],
+      "status": "active",
+      "submitted_at": "2026-05-25",
+      "weight": 1.0
+    },
+    {
+      "access": "local_oauth",
+      "api_base": "https://api.githubcopilot.com",
+      "auth": {
+        "handler": "github-copilot",
+        "kind": "oauth",
+        "params": {
+          "client_id": "Ov23li8tweQw6odWQebz",
+          "device_authorization_endpoint": "https://github.com/login/device/code",
+          "scope": "read:user",
+          "token_endpoint": "https://github.com/login/oauth/access_token"
+        }
+      },
+      "auth_scheme": "x-api-key",
+      "billing": "subscription",
+      "byok": false,
+      "community": false,
+      "display_name": "GitHub Copilot",
+      "doc_url": "https://docs.github.com/en/copilot/reference/api-reference/copilot-api-endpoints",
+      "id": "github-copilot",
+      "kind": "gateway",
+      "metadata": {
+        "headquarters": "US",
+        "name": "GitHub",
+        "privacy_policy_url": "https://docs.github.com/site-policy/privacy-policies/github-privacy-statement",
+        "slug": "github",
+        "status_page_url": "https://www.githubstatus.com",
+        "terms_of_service_url": "https://github.com/customer-terms/github-copilot-product-specific-terms"
+      },
+      "models": [
+        {
+          "api_protocol": "openai",
+          "id": "anthropic/claude-sonnet-4.5",
+          "provider_model_id": "claude-sonnet-4.5"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "anthropic/claude-haiku-4.5",
+          "provider_model_id": "claude-haiku-4.5"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "google/gemini-3.5-flash",
+          "provider_model_id": "gemini-3.5-flash"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "anthropic/claude-opus-4.7",
+          "provider_model_id": "claude-opus-4.7"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "anthropic/claude-opus-4.8",
+          "provider_model_id": "claude-opus-4.8"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "anthropic/claude-fable-5",
+          "provider_model_id": "claude-fable-5"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "openai/gpt-5.4",
+          "provider_model_id": "gpt-5.4"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "openai/gpt-5.4-mini",
+          "provider_model_id": "gpt-5.4-mini"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "google/gemini-3.1-pro-preview",
+          "provider_model_id": "gemini-3.1-pro-preview"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "anthropic/claude-sonnet-4.6",
+          "provider_model_id": "claude-sonnet-4.6"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "anthropic/claude-opus-4.6",
+          "provider_model_id": "claude-opus-4.6"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "openai/gpt-5.5",
+          "provider_model_id": "gpt-5.5"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "moonshotai/kimi-k2.7-code",
+          "provider_model_id": "kimi-k2.7-code"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "anthropic/claude-sonnet-5",
+          "provider_model_id": "claude-sonnet-5"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "openai/gpt-5.6-luna",
+          "provider_model_id": "gpt-5.6-luna"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "openai/gpt-5.6-sol",
+          "provider_model_id": "gpt-5.6-sol"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "openai/gpt-5.6-terra",
+          "provider_model_id": "gpt-5.6-terra"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "anthropic/claude-opus-5",
+          "provider_model_id": "claude-opus-5"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "x-ai/grok-4.5",
+          "provider_model_id": "grok-4.5"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "moonshotai/kimi-k3",
+          "provider_model_id": "kimi-k3"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "google/gemini-3.6-flash",
+          "provider_model_id": "gemini-3.6-flash"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "x-ai/grok-4.6",
+          "provider_model_id": "grok-4.6"
+        }
+      ],
+      "name": "github-copilot",
+      "required_config": [
+        "local_oauth"
+      ],
+      "status": "active",
+      "weight": 1.0
+    },
+    {
+      "access": "api_key",
+      "api_base": "https://api.gmi-serving.com/v1",
+      "auth_scheme": "x-api-key",
+      "billing": "usage_token",
+      "byok": true,
+      "community": false,
+      "display_name": "GMI Cloud",
+      "doc_url": "https://docs.gmicloud.ai/inference-engine/api-reference/llm-api-reference",
+      "id": "gmicloud",
+      "kind": "gateway",
+      "metadata": {
+        "headquarters": "US",
+        "name": "GMI Cloud",
+        "slug": "gmicloud"
+      },
+      "models": [
+        {
+          "api_protocol": "openai",
+          "id": "qwen/qwen3.7-max",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.25,
+              "cache_write": 3.125,
+              "no_cache": 2.5
+            },
+            "output_tokens": {
+              "text": 7.5
+            }
+          },
+          "provider_model_id": "Qwen/Qwen3.7-Max"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "deepseek/deepseek-v4-pro",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.116,
+              "no_cache": 1.392
+            },
+            "output_tokens": {
+              "text": 2.784
+            }
+          },
+          "provider_model_id": "deepseek-ai/DeepSeek-V4-Pro"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "deepseek/deepseek-v4-pro-0813",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.044,
+              "no_cache": 1.32
+            },
+            "output_tokens": {
+              "text": 3.96
+            }
+          },
+          "provider_model_id": "deepseek-ai/DeepSeek-V4-Pro-0813"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "deepseek/deepseek-v4-flash",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.022,
+              "no_cache": 0.112
+            },
+            "output_tokens": {
+              "text": 0.224
+            }
+          },
+          "provider_model_id": "deepseek-ai/DeepSeek-V4-Flash"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "deepseek/deepseek-v4-flash-0731",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.014,
+              "no_cache": 0.44
+            },
+            "output_tokens": {
+              "text": 1.32
+            }
+          },
+          "provider_model_id": "deepseek-ai/DeepSeek-V4-Flash-0731"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "moonshotai/kimi-k2.6",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.144,
+              "no_cache": 0.855
+            },
+            "output_tokens": {
+              "text": 3.6
+            }
+          },
+          "provider_model_id": "moonshotai/Kimi-K2.6"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "moonshotai/kimi-k2.7-code",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.38,
+              "no_cache": 1.9
+            },
+            "output_tokens": {
+              "text": 8.0
+            }
+          },
+          "provider_model_id": "moonshotai/kimi-k2.7-code-highspeed"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "z-ai/glm-5.1",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.182,
+              "no_cache": 0.98
+            },
+            "output_tokens": {
+              "text": 3.08
+            }
+          },
+          "provider_model_id": "zai-org/GLM-5.1-FP8"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "z-ai/glm-5.2",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.182,
+              "no_cache": 0.979
+            },
+            "output_tokens": {
+              "text": 3.08
+            }
+          },
+          "provider_model_id": "zai-org/GLM-5.2-FP8"
+        },
+        {
+          "api_protocol": "openai",
+          "compatibility": {
+            "chat_completions": {
+              "token_limit_field": "max_completion_tokens"
+            }
+          },
+          "id": "openai/gpt-5.5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 30.0
+            }
+          },
+          "provider_model_id": "openai/gpt-5.5"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "anthropic/claude-opus-4.8",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider_model_id": "anthropic/claude-opus-4.8"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "anthropic/claude-opus-4.7",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.45,
+              "no_cache": 4.5
+            },
+            "output_tokens": {
+              "text": 22.5
+            }
+          },
+          "provider_model_id": "anthropic/claude-opus-4.7"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "anthropic/claude-opus-4.6",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider_model_id": "anthropic/claude-opus-4.6"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "anthropic/claude-sonnet-4.6",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.3,
+              "no_cache": 3.0
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider_model_id": "anthropic/claude-sonnet-4.6"
+        }
+      ],
+      "name": "gmicloud",
+      "required_config": [
+        "api_key"
+      ],
+      "status": "active",
+      "submitted_at": "2026-07-07",
+      "weight": 1.0
+    },
+    {
+      "access": "api_key",
+      "api_base": "https://generativelanguage.googleapis.com/v1beta",
+      "auth": {
+        "env": "GEMINI_API_KEY",
+        "header": "x-goog-api-key",
+        "kind": "header"
+      },
+      "auth_scheme": "x-api-key",
+      "billing": "usage_token",
+      "byok": true,
+      "community": false,
+      "display_name": "Generate Content",
+      "doc_url": "https://ai.google.dev/api",
+      "id": "google",
+      "kind": "first_party",
+      "metadata": {
+        "headquarters": "US",
+        "name": "Google",
+        "privacy_policy_url": "https://policies.google.com/privacy",
+        "slug": "google",
+        "status_page_url": "https://status.cloud.google.com",
+        "terms_of_service_url": "https://ai.google.dev/gemini-api/terms"
+      },
+      "models": [
+        {
+          "api_protocol": [
+            "google",
+            "openai"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "google/gemini-3.1-pro-preview",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 12.0
+            }
+          },
+          "provider_model_id": "gemini-3.1-pro-preview",
+          "rate_limits": {
+            "requests_per_minute": 60
+          },
+          "reasoning_effort": {
+            "default": "high",
+            "levels": [
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        },
+        {
+          "api_protocol": [
+            "google",
+            "openai"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "google/gemini-3.5-flash",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.15,
+              "no_cache": 1.5
+            },
+            "output_tokens": {
+              "text": 9.0
+            }
+          },
+          "provider_model_id": "gemini-3.5-flash",
+          "rate_limits": {
+            "requests_per_minute": 60
+          },
+          "reasoning_effort": {
+            "default": "medium",
+            "levels": [
+              "minimal",
+              "low",
+              "medium",
+              "high"
+            ]
+          }
+        },
+        {
+          "api_protocol": [
+            "google",
+            "openai"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "google/gemini-3.6-flash",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.15,
+              "no_cache": 1.5
+            },
+            "output_tokens": {
+              "text": 7.5
+            }
+          },
+          "provider_model_id": "gemini-3.6-flash",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "google",
+            "openai"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "deprecation_date": "2026-08-03",
+          "id": "google/gemini-2.5-pro-preview",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.125,
+              "no_cache": 1.25
+            },
+            "output_tokens": {
+              "text": 10.0
+            }
+          },
+          "provider_model_id": "gemini-2.5-pro",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "google",
+            "openai"
+          ],
+          "capabilities": [
+            "reasoning"
+          ],
+          "id": "google/gemini-3.1-flash-lite-preview",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.025,
+              "no_cache": 0.25
+            },
+            "output_tokens": {
+              "text": 1.5
+            }
+          },
+          "provider_model_id": "gemini-3.1-flash-lite-preview",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        }
+      ],
+      "name": "google",
+      "protocol_endpoints": {
+        "chat_completions": "https://generativelanguage.googleapis.com/v1beta/openai"
+      },
+      "required_config": [
+        "api_key"
+      ],
+      "status": "active",
+      "submitted_at": "2026-05-25",
+      "weight": 1.0
+    },
+    {
+      "access": "local_oauth",
+      "api_base": "https://cloudcode-pa.googleapis.com",
+      "auth": {
+        "handler": "google-ai",
+        "kind": "oauth"
+      },
+      "auth_scheme": "x-api-key",
+      "billing": "subscription",
+      "byok": false,
+      "community": false,
+      "display_name": "Google AI (subscription)",
+      "doc_url": "https://antigravity.google/docs/cli/install",
+      "id": "google-ai",
+      "kind": "first_party",
+      "metadata": {
+        "headquarters": "US",
+        "name": "Google",
+        "privacy_policy_url": "https://policies.google.com/privacy",
+        "slug": "google",
+        "status_page_url": "https://status.cloud.google.com",
+        "terms_of_service_url": "https://ai.google.dev/gemini-api/terms"
+      },
+      "models": [
+        {
+          "api_protocol": "antigravity",
+          "capabilities": [
+            "tools",
+            "image_input"
+          ],
+          "id": "google/gemini-2.5-flash",
+          "provider_model_id": "gemini-2.5-flash"
+        },
+        {
+          "api_protocol": "antigravity",
+          "capabilities": [
+            "reasoning",
+            "tools",
+            "image_input"
+          ],
+          "id": "google/gemini-3-flash",
+          "provider_model_id": "gemini-3-flash"
+        },
+        {
+          "api_protocol": "antigravity",
+          "capabilities": [
+            "reasoning",
+            "tools",
+            "image_input"
+          ],
+          "id": "google/gemini-3-pro",
+          "provider_model_id": "gemini-3-pro-high"
+        }
+      ],
+      "name": "google-ai",
+      "required_config": [
+        "local_oauth"
+      ],
+      "status": "active",
+      "weight": 1.0
+    },
+    {
+      "access": "api_key",
+      "api_base": "https://api.minimax.io/anthropic/v1",
+      "auth_scheme": "x-api-key",
+      "billing": "usage_token",
+      "byok": true,
+      "community": false,
+      "id": "minimax",
+      "metadata": {
+        "datacenters": [
+          "SG"
+        ],
+        "headquarters": "CN",
+        "name": "MiniMax",
+        "privacy_policy_url": "https://platform.minimax.io/protocol/privacy-policy",
+        "slug": "minimax",
+        "status_page_url": "https://status.minimax.io",
+        "terms_of_service_url": "https://platform.minimax.io/protocol/terms-of-service"
+      },
+      "models": [
+        {
+          "api_protocol": [
+            "anthropic",
+            "openai"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "minimax/minimax-m2.7",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.06,
+              "cache_write": 0.375,
+              "no_cache": 0.3
+            },
+            "output_tokens": {
+              "text": 1.2
+            }
+          },
+          "provider_model_id": "MiniMax-M2.7",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "anthropic",
+            "openai"
+          ],
+          "id": "minimax/minimax-m3",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.06,
+              "no_cache": 0.3
+            },
+            "output_tokens": {
+              "text": 1.2
+            }
+          },
+          "provider_model_id": "MiniMax-M3",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        }
+      ],
+      "name": "minimax",
+      "protocol_endpoints": {
+        "chat_completions": "https://api.minimax.io/v1"
+      },
+      "required_config": [
+        "api_key"
+      ],
+      "status": "active",
+      "submitted_at": "2026-05-25",
+      "weight": 1.0
+    },
+    {
+      "access": "api_key",
+      "api_base": "https://api.minimaxi.com/anthropic/v1",
+      "auth_scheme": "x-api-key",
+      "billing": "usage_token",
+      "byok": true,
+      "community": false,
+      "id": "minimax_cn",
+      "metadata": {
+        "datacenters": [
+          "CN"
+        ],
+        "headquarters": "CN",
+        "name": "MiniMax",
+        "privacy_policy_url": "https://platform.minimaxi.com/protocol/privacy-policy",
+        "slug": "minimax",
+        "status_page_url": "https://status.minimaxi.com",
+        "terms_of_service_url": "https://platform.minimaxi.com/protocol/terms-of-service"
+      },
+      "models": [
+        {
+          "api_protocol": [
+            "anthropic",
+            "openai"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "minimax/minimax-m2.7",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.06,
+              "cache_write": 0.375,
+              "no_cache": 0.3
+            },
+            "output_tokens": {
+              "text": 1.2
+            }
+          },
+          "provider_model_id": "MiniMax-M2.7",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "anthropic",
+            "openai"
+          ],
+          "id": "minimax/minimax-m3",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.06,
+              "no_cache": 0.3
+            },
+            "output_tokens": {
+              "text": 1.2
+            }
+          },
+          "provider_model_id": "MiniMax-M3",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        }
+      ],
+      "name": "minimax_cn",
+      "protocol_endpoints": {
+        "chat_completions": "https://api.minimaxi.com/v1"
+      },
+      "required_config": [
+        "api_key"
+      ],
+      "status": "active",
+      "submitted_at": "2026-05-25",
+      "weight": 1.0
+    },
+    {
+      "access": "api_key",
+      "api_base": "https://api.moonshot.ai/v1",
+      "auth_scheme": "x-api-key",
+      "billing": "usage_token",
+      "byok": true,
+      "community": false,
+      "id": "moonshotai",
+      "metadata": {
+        "datacenters": [
+          "SG"
+        ],
+        "headquarters": "CN",
+        "name": "Moonshot AI",
+        "privacy_policy_url": "https://platform.kimi.ai/docs/agreement/userprivacy",
+        "slug": "moonshotai",
+        "terms_of_service_url": "https://platform.kimi.ai/docs/agreement/modeluse"
+      },
+      "models": [
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools"
+          ],
+          "id": "moonshotai/kimi-k3",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.3,
+              "no_cache": 3.0
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider_model_id": "kimi-k3",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools"
+          ],
+          "id": "moonshotai/kimi-k2.6",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.16,
+              "no_cache": 0.95
+            },
+            "output_tokens": {
+              "text": 4.0
+            }
+          },
+          "provider_model_id": "kimi-k2.6",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "id": "moonshotai/kimi-k2.7-code",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.19,
+              "no_cache": 0.95
+            },
+            "output_tokens": {
+              "text": 4.0
+            }
+          },
+          "provider_model_id": "kimi-k2.7-code",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        }
+      ],
+      "name": "moonshotai",
+      "protocol_endpoints": {
+        "messages": "https://api.moonshot.ai/anthropic"
+      },
+      "required_config": [
+        "api_key"
+      ],
+      "status": "active",
+      "submitted_at": "2026-05-25",
+      "weight": 1.0
+    },
+    {
+      "access": "api_key",
+      "api_base": "https://api.kimi.com/coding/v1",
+      "auth_scheme": "x-api-key",
+      "billing": "subscription",
+      "byok": true,
+      "community": false,
+      "id": "moonshotai_coding_plan",
+      "metadata": {
+        "datacenters": [
+          "SG"
+        ],
+        "headquarters": "CN",
+        "name": "Moonshot AI",
+        "privacy_policy_url": "https://platform.kimi.ai/docs/agreement/userprivacy",
+        "slug": "moonshotai",
+        "terms_of_service_url": "https://platform.kimi.ai/docs/agreement/modeluse"
+      },
+      "models": [
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "moonshotai/kimi-k3",
+          "provider_model_id": "kimi-for-coding",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        }
+      ],
+      "name": "moonshotai_coding_plan",
+      "required_config": [
+        "api_key"
+      ],
+      "status": "active",
+      "submitted_at": "2026-06-05",
+      "weight": 1.0
+    },
+    {
+      "access": "api_key",
+      "api_base": "https://api.novita.ai/openai",
+      "auth_scheme": "x-api-key",
+      "billing": "usage_token",
+      "byok": true,
+      "community": false,
+      "display_name": "Novita AI",
+      "id": "novita",
+      "kind": "gateway",
+      "metadata": {
+        "headquarters": "US",
+        "name": "Novita AI",
+        "slug": "novita"
+      },
+      "models": [
+        {
+          "api_protocol": "openai",
+          "id": "deepseek/deepseek-v4-pro",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.135,
+              "no_cache": 1.6
+            },
+            "output_tokens": {
+              "text": 3.2
+            }
+          },
+          "provider_model_id": "deepseek/deepseek-v4-pro"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "deepseek/deepseek-v4-flash",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.028,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider_model_id": "deepseek/deepseek-v4-flash"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "deepseek/deepseek-v4-flash-0731",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.028,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider_model_id": "deepseek/deepseek-v4-flash-0731"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "deepseek/deepseek-v3.2",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.1345,
+              "no_cache": 0.269
+            },
+            "output_tokens": {
+              "text": 0.4
+            }
+          },
+          "provider_model_id": "deepseek/deepseek-v3.2"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "qwen/qwen3.7-max",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.25,
+              "cache_write": 1.5625,
+              "no_cache": 1.25
+            },
+            "output_tokens": {
+              "text": 3.75
+            }
+          },
+          "provider_model_id": "qwen/qwen3.7-max"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "qwen/qwen3.5-122b-a10b",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.4
+            },
+            "output_tokens": {
+              "text": 3.2
+            }
+          },
+          "provider_model_id": "qwen/qwen3.5-122b-a10b"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "qwen/qwen3.5-27b",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.3
+            },
+            "output_tokens": {
+              "text": 2.4
+            }
+          },
+          "provider_model_id": "qwen/qwen3.5-27b"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "moonshotai/kimi-k2.6",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.16,
+              "no_cache": 0.8
+            },
+            "output_tokens": {
+              "text": 3.4
+            }
+          },
+          "provider_model_id": "moonshotai/kimi-k2.6"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "minimax/minimax-m2.7",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.06,
+              "no_cache": 0.3
+            },
+            "output_tokens": {
+              "text": 1.2
+            }
+          },
+          "provider_model_id": "minimax/minimax-m2.7"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "z-ai/glm-5.1",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.26,
+              "no_cache": 1.38
+            },
+            "output_tokens": {
+              "text": 4.4
+            }
+          },
+          "provider_model_id": "zai-org/glm-5.1"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "z-ai/glm-5.2",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.26,
+              "no_cache": 1.4
+            },
+            "output_tokens": {
+              "text": 4.4
+            }
+          },
+          "provider_model_id": "zai-org/glm-5.2"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "z-ai/glm-4.7",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.11,
+              "no_cache": 0.6
+            },
+            "output_tokens": {
+              "text": 2.2
+            }
+          },
+          "provider_model_id": "zai-org/glm-4.7"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "openai/gpt-oss-120b",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.05
+            },
+            "output_tokens": {
+              "text": 0.25
+            }
+          },
+          "provider_model_id": "openai/gpt-oss-120b"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "moonshotai/kimi-k2.7-code",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.19,
+              "no_cache": 0.95
+            },
+            "output_tokens": {
+              "text": 4.0
+            }
+          },
+          "provider_model_id": "moonshotai/kimi-k2.7-code"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "moonshotai/kimi-k3",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.3,
+              "no_cache": 3.0
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider_model_id": "moonshotai/kimi-k3"
+        }
+      ],
+      "name": "novita",
+      "required_config": [
+        "api_key"
+      ],
+      "status": "active",
+      "submitted_at": "2026-07-07",
+      "weight": 1.0
+    },
+    {
+      "access": "api_key",
+      "api_base": "https://api.openai.com/v1",
+      "auth": {
+        "env": "OPENAI_API_KEY",
+        "kind": "bearer"
+      },
+      "auth_scheme": "x-api-key",
+      "billing": "usage_token",
+      "byok": true,
+      "community": false,
+      "display_name": "OpenAI",
+      "doc_url": "https://platform.openai.com/docs/api-reference",
+      "id": "openai",
+      "kind": "first_party",
+      "metadata": {
+        "headquarters": "US",
+        "name": "OpenAI",
+        "privacy_policy_url": "https://openai.com/privacy",
+        "slug": "openai",
+        "status_page_url": "https://status.openai.com",
+        "terms_of_service_url": "https://openai.com/terms"
+      },
+      "models": [
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools"
+          ],
+          "compatibility": {
+            "chat_completions": {
+              "token_limit_field": "max_completion_tokens"
+            }
+          },
+          "id": "openai/gpt-5.6-sol",
+          "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 272000,
+                "input_tokens": {
+                  "cache_read": 1.0,
+                  "cache_write": 12.5,
+                  "no_cache": 10.0
+                },
+                "output_tokens": {
+                  "text": 45.0
+                }
+              }
+            ],
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 30.0
+            }
+          },
+          "provider_model_id": "gpt-5.6-sol",
+          "rate_limits": {
+            "requests_per_minute": 60
+          },
+          "reasoning_effort": {
+            "default": "medium",
+            "levels": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools"
+          ],
+          "compatibility": {
+            "chat_completions": {
+              "token_limit_field": "max_completion_tokens"
+            }
+          },
+          "id": "openai/gpt-5.6-terra",
+          "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 272000,
+                "input_tokens": {
+                  "cache_read": 0.5,
+                  "cache_write": 6.25,
+                  "no_cache": 5.0
+                },
+                "output_tokens": {
+                  "text": 22.5
+                }
+              }
+            ],
+            "input_tokens": {
+              "cache_read": 0.2,
+              "cache_write": 2.5,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 12.0
+            }
+          },
+          "provider_model_id": "gpt-5.6-terra",
+          "rate_limits": {
+            "requests_per_minute": 60
+          },
+          "reasoning_effort": {
+            "default": "medium",
+            "levels": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools"
+          ],
+          "compatibility": {
+            "chat_completions": {
+              "token_limit_field": "max_completion_tokens"
+            }
+          },
+          "id": "openai/gpt-5.6-luna",
+          "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 272000,
+                "input_tokens": {
+                  "cache_read": 0.2,
+                  "cache_write": 2.5,
+                  "no_cache": 2.0
+                },
+                "output_tokens": {
+                  "text": 9.0
+                }
+              }
+            ],
+            "input_tokens": {
+              "cache_read": 0.02,
+              "cache_write": 0.25,
+              "no_cache": 0.2
+            },
+            "output_tokens": {
+              "text": 1.2
+            }
+          },
+          "provider_model_id": "gpt-5.6-luna",
+          "rate_limits": {
+            "requests_per_minute": 60
+          },
+          "reasoning_effort": {
+            "default": "medium",
+            "levels": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools"
+          ],
+          "compatibility": {
+            "chat_completions": {
+              "token_limit_field": "max_completion_tokens"
+            }
+          },
+          "id": "openai/gpt-5.5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 30.0
+            }
+          },
+          "provider_model_id": "gpt-5.5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          },
+          "reasoning_effort": {
+            "default": "medium",
+            "levels": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools"
+          ],
+          "compatibility": {
+            "chat_completions": {
+              "token_limit_field": "max_completion_tokens"
+            }
+          },
+          "id": "openai/gpt-5.4",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.25,
+              "no_cache": 2.5
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider_model_id": "gpt-5.4",
+          "rate_limits": {
+            "requests_per_minute": 60
+          },
+          "reasoning_effort": {
+            "default": "none",
+            "levels": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses"
+          ],
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools"
+          ],
+          "compatibility": {
+            "chat_completions": {
+              "token_limit_field": "max_completion_tokens"
+            }
+          },
+          "id": "openai/gpt-5.4-mini",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.075,
+              "no_cache": 0.75
+            },
+            "output_tokens": {
+              "text": 4.5
+            }
+          },
+          "provider_model_id": "gpt-5.4-mini",
+          "rate_limits": {
+            "requests_per_minute": 60
+          },
+          "reasoning_effort": {
+            "default": "none",
+            "levels": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          }
+        }
+      ],
+      "name": "openai",
+      "required_config": [
+        "api_key"
+      ],
+      "status": "active",
+      "submitted_at": "2026-05-25",
+      "weight": 1.0
+    },
+    {
+      "access": "local_pkce",
+      "api_base": "https://chatgpt.com/backend-api/codex",
+      "auth": {
+        "handler": "openai-codex",
+        "kind": "oauth",
+        "params": {
+          "authorize_endpoint": "https://auth.openai.com/oauth/authorize",
+          "client_id": "app_EMoamEEZ73f0CkXaXp7hrann",
+          "redirect_uri": "http://localhost:1455/auth/callback",
+          "scope": "openid profile email offline_access",
+          "token_endpoint": "https://auth.openai.com/oauth/token"
+        }
+      },
+      "auth_scheme": "x-api-key",
+      "billing": "subscription",
+      "byok": false,
+      "community": false,
+      "display_name": "OpenAI Codex",
+      "doc_url": "https://developers.openai.com/codex/auth",
+      "id": "openai-codex",
+      "kind": "first_party",
+      "metadata": {
+        "headquarters": "US",
+        "name": "OpenAI",
+        "privacy_policy_url": "https://openai.com/privacy",
+        "slug": "openai",
+        "status_page_url": "https://status.openai.com",
+        "terms_of_service_url": "https://openai.com/terms"
+      },
+      "models": [
+        {
+          "api_protocol": "responses",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "openai/gpt-6-astra",
+          "provider_model_id": "gpt-6-astra",
+          "reasoning_effort": {
+            "default": "medium",
+            "levels": [
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": "responses",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "openai/gpt-5.6-sol",
+          "provider_model_id": "gpt-5.6-sol",
+          "reasoning_effort": {
+            "default": "medium",
+            "levels": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": "responses",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "openai/gpt-5.6-terra",
+          "provider_model_id": "gpt-5.6-terra",
+          "reasoning_effort": {
+            "default": "medium",
+            "levels": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": "responses",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "openai/gpt-5.6-luna",
+          "provider_model_id": "gpt-5.6-luna",
+          "reasoning_effort": {
+            "default": "medium",
+            "levels": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": "responses",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "openai/gpt-5.5",
+          "provider_model_id": "gpt-5.5",
+          "reasoning_effort": {
+            "default": "medium",
+            "levels": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          }
+        },
+        {
+          "api_protocol": "responses",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "openai/gpt-5.4",
+          "provider_model_id": "gpt-5.4",
+          "reasoning_effort": {
+            "default": "none",
+            "levels": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          }
+        },
+        {
+          "api_protocol": "responses",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "openai/gpt-5.4-mini",
+          "provider_model_id": "gpt-5.4-mini",
+          "reasoning_effort": {
+            "default": "none",
+            "levels": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ]
+          }
+        }
+      ],
+      "name": "openai-codex",
+      "required_config": [
+        "local_pkce"
+      ],
+      "status": "active",
+      "weight": 1.0
+    },
+    {
+      "access": "api_key",
+      "api_base": "https://opencode.ai/zen/go/v1",
+      "auth": {
+        "env": "OPENCODE_ZEN_API_KEY",
+        "kind": "bearer"
+      },
+      "auth_scheme": "x-api-key",
+      "billing": "subscription",
+      "byok": true,
+      "community": false,
+      "display_name": "opencode go",
+      "doc_url": "https://opencode.ai/docs/go/",
+      "id": "opencode-go",
+      "kind": "gateway",
+      "metadata": {
+        "headquarters": "US",
+        "name": "OpenCode",
+        "privacy_policy_url": "https://opencode.ai/legal/privacy-policy",
+        "slug": "opencode",
+        "terms_of_service_url": "https://opencode.ai/legal/terms-of-service"
+      },
+      "models": [
+        {
+          "api_protocol": "openai",
+          "id": "deepseek/deepseek-v4-flash-0731",
+          "provider_model_id": "deepseek-v4-flash"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "qwen/qwen3.7-plus",
+          "provider_model_id": "qwen3.7-plus"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "qwen/qwen3.7-max",
+          "provider_model_id": "qwen3.7-max"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "qwen/qwen3.8-max",
+          "provider_model_id": "qwen3.8-max"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "moonshotai/kimi-k2.7-code",
+          "provider_model_id": "kimi-k2.7-code"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "z-ai/glm-5.1",
+          "provider_model_id": "glm-5.1"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "deepseek/deepseek-v4-pro",
+          "provider_model_id": "deepseek-v4-pro"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "z-ai/glm-5.2",
+          "provider_model_id": "glm-5.2"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "minimax/minimax-m3",
+          "provider_model_id": "minimax-m3"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "minimax/minimax-m2.7",
+          "provider_model_id": "minimax-m2.7"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "xiaomi/mimo-v2.5",
+          "provider_model_id": "mimo-v2.5"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "xiaomi/mimo-v2-omni",
+          "provider_model_id": "mimo-v2-omni"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "moonshotai/kimi-k2.6",
+          "provider_model_id": "kimi-k2.6"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "xiaomi/mimo-v2-pro",
+          "provider_model_id": "mimo-v2-pro"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "xiaomi/mimo-v2.5-pro",
+          "provider_model_id": "mimo-v2.5-pro"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "qwen/qwen3.6-plus",
+          "provider_model_id": "qwen3.6-plus"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "x-ai/grok-4.5",
+          "provider_model_id": "grok-4.5"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "moonshotai/kimi-k3",
+          "provider_model_id": "kimi-k3"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "openai/gpt-5.6-luna",
+          "provider_model_id": "gpt-5.6-luna"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "z-ai/glm-5.3",
+          "provider_model_id": "glm-5.3"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "z-ai/glm-5.3-flash",
+          "provider_model_id": "glm-5.3-flash"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "x-ai/grok-4.6",
+          "provider_model_id": "grok-4.6"
+        }
+      ],
+      "name": "opencode-go",
+      "required_config": [
+        "api_key"
+      ],
+      "status": "active",
+      "weight": 1.0
+    },
+    {
+      "access": "api_key",
+      "api_base": "https://opencode.ai/zen/v1",
+      "auth": {
+        "env": "OPENCODE_ZEN_API_KEY",
+        "kind": "bearer"
+      },
+      "auth_scheme": "x-api-key",
+      "billing": "usage_token",
+      "byok": true,
+      "community": false,
+      "display_name": "opencode zen",
+      "doc_url": "https://opencode.ai/docs/zen/",
+      "id": "opencode-zen",
+      "kind": "gateway",
+      "metadata": {
+        "headquarters": "US",
+        "name": "OpenCode",
+        "privacy_policy_url": "https://opencode.ai/legal/privacy-policy",
+        "slug": "opencode",
+        "terms_of_service_url": "https://opencode.ai/legal/terms-of-service"
+      },
+      "models": [
+        {
+          "api_protocol": "openai",
+          "id": "deepseek/deepseek-v4-flash-0731",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.028,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider_model_id": "deepseek-v4-flash"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "google/gemini-3.5-flash",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.15,
+              "no_cache": 1.5
+            },
+            "output_tokens": {
+              "text": 9.0
+            }
+          },
+          "provider_model_id": "gemini-3.5-flash"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "z-ai/glm-5.1",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.26,
+              "no_cache": 1.4
+            },
+            "output_tokens": {
+              "text": 4.4
+            }
+          },
+          "provider_model_id": "glm-5.1"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "deepseek/deepseek-v4-pro",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.145,
+              "no_cache": 1.74
+            },
+            "output_tokens": {
+              "text": 3.84
+            }
+          },
+          "provider_model_id": "deepseek-v4-pro"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "anthropic/claude-sonnet-4.5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.3,
+              "cache_write": 3.75,
+              "no_cache": 3.0
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider_model_id": "claude-sonnet-4-5"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "anthropic/claude-opus-4.7",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider_model_id": "claude-opus-4-7"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "anthropic/claude-opus-4.8",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider_model_id": "claude-opus-4-8"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "minimax/minimax-m2.7",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.06,
+              "no_cache": 0.3
+            },
+            "output_tokens": {
+              "text": 1.2
+            }
+          },
+          "provider_model_id": "minimax-m2.7"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "anthropic/claude-fable-5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 1.0,
+              "cache_write": 12.5,
+              "no_cache": 10.0
+            },
+            "output_tokens": {
+              "text": 50.0
+            }
+          },
+          "provider_model_id": "claude-fable-5"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "anthropic/claude-haiku-4.5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.1,
+              "cache_write": 1.25,
+              "no_cache": 1.0
+            },
+            "output_tokens": {
+              "text": 5.0
+            }
+          },
+          "provider_model_id": "claude-haiku-4-5"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "openai/gpt-5.4",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.25,
+              "no_cache": 2.5
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider_model_id": "gpt-5.4"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "openai/gpt-5.4-mini",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.075,
+              "no_cache": 0.75
+            },
+            "output_tokens": {
+              "text": 4.5
+            }
+          },
+          "provider_model_id": "gpt-5.4-mini"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "moonshotai/kimi-k2.6",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.16,
+              "no_cache": 0.95
+            },
+            "output_tokens": {
+              "text": 4.0
+            }
+          },
+          "provider_model_id": "kimi-k2.6"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "anthropic/claude-opus-4.6",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider_model_id": "claude-opus-4-6"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "anthropic/claude-sonnet-4.6",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.3,
+              "cache_write": 3.75,
+              "no_cache": 3.0
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider_model_id": "claude-sonnet-4-6"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "qwen/qwen3.6-plus",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.05,
+              "cache_write": 0.625,
+              "no_cache": 0.5
+            },
+            "output_tokens": {
+              "text": 3.0
+            }
+          },
+          "provider_model_id": "qwen3.6-plus"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "openai/gpt-5.5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 30.0
+            }
+          },
+          "provider_model_id": "gpt-5.5"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "z-ai/glm-5.2",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.26,
+              "no_cache": 1.4
+            },
+            "output_tokens": {
+              "text": 4.4
+            }
+          },
+          "provider_model_id": "glm-5.2"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "moonshotai/kimi-k2.7-code",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.19,
+              "no_cache": 0.95
+            },
+            "output_tokens": {
+              "text": 4.0
+            }
+          },
+          "provider_model_id": "kimi-k2.7-code"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "minimax/minimax-m3",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.06,
+              "no_cache": 0.3
+            },
+            "output_tokens": {
+              "text": 1.2
+            }
+          },
+          "provider_model_id": "minimax-m3"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "x-ai/grok-build-0.1",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "no_cache": 1.0
+            },
+            "output_tokens": {
+              "text": 2.0
+            }
+          },
+          "provider_model_id": "grok-build-0.1"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "anthropic/claude-sonnet-5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "cache_write": 2.5,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 10.0
+            }
+          },
+          "provider_model_id": "claude-sonnet-5"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "z-ai/glm-4.7",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.1,
+              "no_cache": 0.6
+            },
+            "output_tokens": {
+              "text": 2.2
+            }
+          },
+          "provider_model_id": "glm-4.7"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "x-ai/grok-4.5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 6.0
+            }
+          },
+          "provider_model_id": "grok-4.5"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "openai/gpt-5.6-luna",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.02,
+              "cache_write": 0.25,
+              "no_cache": 0.2
+            },
+            "output_tokens": {
+              "text": 1.2
+            }
+          },
+          "provider_model_id": "gpt-5.6-luna"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "openai/gpt-5.6-sol",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 30.0
+            }
+          },
+          "provider_model_id": "gpt-5.6-sol"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "openai/gpt-5.6-terra",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.25,
+              "cache_write": 3.125,
+              "no_cache": 2.5
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider_model_id": "gpt-5.6-terra"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "moonshotai/kimi-k3",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.3,
+              "no_cache": 3.0
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider_model_id": "kimi-k3"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "anthropic/claude-opus-5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider_model_id": "claude-opus-5"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "google/gemini-3.6-flash",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.15,
+              "no_cache": 1.5
+            },
+            "output_tokens": {
+              "text": 7.5
+            }
+          },
+          "provider_model_id": "gemini-3.6-flash"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "x-ai/grok-4.6",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 6.0
+            }
+          },
+          "provider_model_id": "grok-4.6"
+        }
+      ],
+      "name": "opencode-zen",
+      "required_config": [
+        "api_key"
+      ],
+      "status": "active",
+      "weight": 1.0
+    },
+    {
+      "access": "api_key",
+      "api_base": "https://openrouter.ai/api/v1",
+      "auth": {
+        "env": "OPENROUTER_API_KEY",
+        "kind": "bearer"
+      },
+      "auth_scheme": "x-api-key",
+      "billing": "usage_token",
+      "byok": true,
+      "community": false,
+      "display_name": "OpenRouter",
+      "doc_url": "https://openrouter.ai/docs/api-reference/overview",
+      "id": "openrouter",
+      "kind": "gateway",
+      "metadata": {
+        "headquarters": "US",
+        "name": "OpenRouter",
+        "privacy_policy_url": "https://openrouter.ai/privacy",
+        "slug": "openrouter",
+        "status_page_url": "https://status.openrouter.ai",
+        "terms_of_service_url": "https://openrouter.ai/terms"
+      },
+      "models": [
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "moonshotai/kimi-k2.7-code",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.15,
+              "no_cache": 0.73
+            },
+            "output_tokens": {
+              "text": 3.5
+            }
+          },
+          "provider_model_id": "moonshotai/kimi-k2.7-code"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "moonshotai/kimi-k2.6",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.0992,
+              "no_cache": 0.589
+            },
+            "output_tokens": {
+              "text": 2.48
+            }
+          },
+          "provider_model_id": "moonshotai/kimi-k2.6"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "google/gemini-3.5-flash",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.15,
+              "cache_write": 0.083333,
+              "no_cache": 1.5
+            },
+            "output_tokens": {
+              "text": 9.0
+            }
+          },
+          "provider_model_id": "google/gemini-3.5-flash"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "google/gemini-3.1-pro-preview",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "cache_write": 0.375,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 12.0
+            }
+          },
+          "provider_model_id": "google/gemini-3.1-pro-preview"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "google/gemini-2.5-pro-preview",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.125,
+              "cache_write": 0.375,
+              "no_cache": 1.25
+            },
+            "output_tokens": {
+              "text": 10.0
+            }
+          },
+          "provider_model_id": "google/gemini-2.5-pro-preview"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "google/gemini-3.1-flash-lite-preview",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.025,
+              "cache_write": 0.083333,
+              "no_cache": 0.25
+            },
+            "output_tokens": {
+              "text": 1.5
+            }
+          },
+          "provider_model_id": "google/gemini-3.1-flash-lite-preview"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "x-ai/grok-4.20",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "no_cache": 1.25
+            },
+            "output_tokens": {
+              "text": 2.5
+            }
+          },
+          "provider_model_id": "x-ai/grok-4.20"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "x-ai/grok-4.3",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "no_cache": 1.25
+            },
+            "output_tokens": {
+              "text": 2.5
+            }
+          },
+          "provider_model_id": "x-ai/grok-4.3"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "z-ai/glm-5.1",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.1794,
+              "no_cache": 0.966
+            },
+            "output_tokens": {
+              "text": 3.036
+            }
+          },
+          "provider_model_id": "z-ai/glm-5.1"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "z-ai/glm-5.2",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.208,
+              "no_cache": 1.12
+            },
+            "output_tokens": {
+              "text": 3.52
+            }
+          },
+          "provider_model_id": "z-ai/glm-5.2"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "z-ai/glm-5.3",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.26,
+              "no_cache": 1.4
+            },
+            "output_tokens": {
+              "text": 4.4
+            }
+          },
+          "provider_model_id": "z-ai/glm-5.3",
+          "reasoning_effort": {
+            "default": "max",
+            "levels": [
+              "low",
+              "high",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "z-ai/glm-5.3-flash",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.015,
+              "no_cache": 0.075
+            },
+            "output_tokens": {
+              "text": 0.25
+            }
+          },
+          "provider_model_id": "z-ai/glm-5.3-flash",
+          "reasoning_effort": {
+            "default": "max",
+            "levels": [
+              "low",
+              "high",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "openai/gpt-oss-120b",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.037
+            },
+            "output_tokens": {
+              "text": 0.17
+            }
+          },
+          "provider_model_id": "openai/gpt-oss-120b"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "openai/gpt-5.4",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.25,
+              "no_cache": 2.5
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider_model_id": "openai/gpt-5.4"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "openai/gpt-5.4-mini",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.075,
+              "no_cache": 0.75
+            },
+            "output_tokens": {
+              "text": 4.5
+            }
+          },
+          "provider_model_id": "openai/gpt-5.4-mini"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "openai/gpt-5.5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 30.0
+            }
+          },
+          "provider_model_id": "openai/gpt-5.5"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "xiaomi/mimo-v2.5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.0028,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider_model_id": "xiaomi/mimo-v2.5"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "xiaomi/mimo-v2.5-pro",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.0036,
+              "no_cache": 0.435
+            },
+            "output_tokens": {
+              "text": 0.87
+            }
+          },
+          "provider_model_id": "xiaomi/mimo-v2.5-pro"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "anthropic/claude-sonnet-4.5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.3,
+              "cache_write": 3.75,
+              "no_cache": 3.0
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider_model_id": "anthropic/claude-sonnet-4.5"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "tools"
+          ],
+          "id": "anthropic/claude-haiku-4.5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.1,
+              "cache_write": 1.25,
+              "no_cache": 1.0
+            },
+            "output_tokens": {
+              "text": 5.0
+            }
+          },
+          "provider_model_id": "anthropic/claude-haiku-4.5"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "anthropic/claude-opus-4.7",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider_model_id": "anthropic/claude-opus-4.7"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "anthropic/claude-opus-4.8",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider_model_id": "anthropic/claude-opus-4.8"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "anthropic/claude-sonnet-4.6",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.3,
+              "cache_write": 3.75,
+              "no_cache": 3.0
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider_model_id": "anthropic/claude-sonnet-4.6"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "anthropic/claude-opus-4.6",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider_model_id": "anthropic/claude-opus-4.6"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "qwen/qwen3.7-plus",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.064,
+              "cache_write": 0.4,
+              "no_cache": 0.32
+            },
+            "output_tokens": {
+              "text": 1.28
+            }
+          },
+          "provider_model_id": "qwen/qwen3.7-plus"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "qwen/qwen3.7-max",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.295,
+              "cache_write": 1.84375,
+              "no_cache": 1.475
+            },
+            "output_tokens": {
+              "text": 4.425
+            }
+          },
+          "provider_model_id": "qwen/qwen3.7-max"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "qwen/qwen3.8-2.4t-a95b",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.25,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 6.0
+            }
+          },
+          "provider_model_id": "qwen/qwen3.8-2.4t-a95b",
+          "reasoning_effort": {
+            "default": "xhigh",
+            "levels": [
+              "low",
+              "medium",
+              "xhigh"
+            ]
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "qwen/qwen3.8-27b",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.085,
+              "cache_write": 0.53125,
+              "no_cache": 0.425
+            },
+            "output_tokens": {
+              "text": 2.55
+            }
+          },
+          "provider_model_id": "qwen/qwen3.8-27b",
+          "reasoning_effort": {
+            "default": "xhigh",
+            "levels": [
+              "low",
+              "medium",
+              "xhigh"
+            ]
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "tools"
+          ],
+          "id": "qwen/qwen3.8-max",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.25,
+              "cache_write": 2.5,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 6.0
+            }
+          },
+          "provider_model_id": "qwen/qwen3.8-max"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "qwen/qwen3.6-flash",
+          "pricing": {
+            "input_tokens": {
+              "cache_write": 0.234375,
+              "no_cache": 0.1875
+            },
+            "output_tokens": {
+              "text": 1.125
+            }
+          },
+          "provider_model_id": "qwen/qwen3.6-flash"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "qwen/qwen3.6-plus",
+          "pricing": {
+            "input_tokens": {
+              "cache_write": 0.40625,
+              "no_cache": 0.325
+            },
+            "output_tokens": {
+              "text": 1.95
+            }
+          },
+          "provider_model_id": "qwen/qwen3.6-plus"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "deepseek/deepseek-v4-flash",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.028,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider_model_id": "deepseek/deepseek-v4-flash"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "deepseek/deepseek-v4-flash-0731",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.018,
+              "no_cache": 0.09
+            },
+            "output_tokens": {
+              "text": 0.18
+            }
+          },
+          "provider_model_id": "deepseek/deepseek-v4-flash-0731"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "deepseek/deepseek-v4-pro",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.003625,
+              "no_cache": 0.435
+            },
+            "output_tokens": {
+              "text": 0.87
+            }
+          },
+          "provider_model_id": "deepseek/deepseek-v4-pro"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "deepseek/deepseek-v3.2",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.1345,
+              "no_cache": 0.269
+            },
+            "output_tokens": {
+              "text": 0.4
+            }
+          },
+          "provider_model_id": "deepseek/deepseek-v3.2"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "minimax/minimax-m3",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.06,
+              "no_cache": 0.3
+            },
+            "output_tokens": {
+              "text": 1.2
+            }
+          },
+          "provider_model_id": "minimax/minimax-m3"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "minimax/minimax-m2.7",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.05,
+              "no_cache": 0.25
+            },
+            "output_tokens": {
+              "text": 1.0
+            }
+          },
+          "provider_model_id": "minimax/minimax-m2.7"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "anthropic/claude-fable-5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 1.0,
+              "cache_write": 12.5,
+              "no_cache": 10.0
+            },
+            "output_tokens": {
+              "text": 50.0
+            }
+          },
+          "provider_model_id": "anthropic/claude-fable-5"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "x-ai/grok-4.20-multi-agent",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "no_cache": 1.25
+            },
+            "output_tokens": {
+              "text": 2.5
+            }
+          },
+          "provider_model_id": "x-ai/grok-4.20-multi-agent"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "x-ai/grok-build-0.1",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "no_cache": 1.0
+            },
+            "output_tokens": {
+              "text": 2.0
+            }
+          },
+          "provider_model_id": "x-ai/grok-build-0.1"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "anthropic/claude-sonnet-5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "cache_write": 2.5,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 10.0
+            }
+          },
+          "provider_model_id": "anthropic/claude-sonnet-5"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "qwen/qwen3.5-122b-a10b",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.26
+            },
+            "output_tokens": {
+              "text": 2.08
+            }
+          },
+          "provider_model_id": "qwen/qwen3.5-122b-a10b"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "qwen/qwen3.5-27b",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.195
+            },
+            "output_tokens": {
+              "text": 1.56
+            }
+          },
+          "provider_model_id": "qwen/qwen3.5-27b"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "qwen/qwen3.6-27b",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.15,
+              "no_cache": 0.3
+            },
+            "output_tokens": {
+              "text": 2.0
+            }
+          },
+          "provider_model_id": "qwen/qwen3.6-27b"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "qwen/qwen3.6-35b-a3b",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 1.0
+            }
+          },
+          "provider_model_id": "qwen/qwen3.6-35b-a3b"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "z-ai/glm-4.7",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.08,
+              "no_cache": 0.4
+            },
+            "output_tokens": {
+              "text": 1.75
+            }
+          },
+          "provider_model_id": "z-ai/glm-4.7"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "openai/gpt-5.6-luna",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.01,
+              "cache_write": 0.125,
+              "no_cache": 0.1
+            },
+            "output_tokens": {
+              "text": 0.6
+            }
+          },
+          "provider_model_id": "openai/gpt-5.6-luna"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "openai/gpt-5.6-sol",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 30.0
+            }
+          },
+          "provider_model_id": "openai/gpt-5.6-sol"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "openai/gpt-5.6-terra",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.1,
+              "cache_write": 1.25,
+              "no_cache": 1.0
+            },
+            "output_tokens": {
+              "text": 6.0
+            }
+          },
+          "provider_model_id": "openai/gpt-5.6-terra"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "x-ai/grok-4.5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.3,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 6.0
+            }
+          },
+          "provider_model_id": "x-ai/grok-4.5"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "moonshotai/kimi-k3",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.3,
+              "no_cache": 3.0
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider_model_id": "moonshotai/kimi-k3"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "anthropic/claude-opus-5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "cache_write": 6.25,
+              "no_cache": 5.0
+            },
+            "output_tokens": {
+              "text": 25.0
+            }
+          },
+          "provider_model_id": "anthropic/claude-opus-5"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "deepseek/deepseek-v4-pro-0813",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.022,
+              "no_cache": 0.66
+            },
+            "output_tokens": {
+              "text": 1.98
+            }
+          },
+          "provider_model_id": "deepseek/deepseek-v4-pro-0813"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "google/gemini-3.6-flash",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.075,
+              "cache_write": 0.041667,
+              "no_cache": 0.75
+            },
+            "output_tokens": {
+              "text": 3.75
+            }
+          },
+          "provider_model_id": "google/gemini-3.6-flash"
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "id": "x-ai/grok-4.6",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 6.0
+            }
+          },
+          "provider_model_id": "x-ai/grok-4.6"
+        }
+      ],
+      "name": "openrouter",
+      "protocol_endpoints": {
+        "messages": "https://openrouter.ai/api"
+      },
+      "required_config": [
+        "api_key"
+      ],
+      "status": "active",
+      "weight": 1.0
+    },
+    {
+      "access": "api_key",
+      "api_base": "https://inference.phala.com/v1",
+      "auth_scheme": "bearer",
+      "billing": "usage_token",
+      "byok": true,
+      "community": false,
+      "display_name": "Phala",
+      "id": "phala",
+      "kind": "gateway",
+      "metadata": {
+        "headquarters": "US",
+        "name": "Phala",
+        "privacy_policy_url": "https://phala.com/privacy",
+        "slug": "phala",
+        "status_page_url": "https://status.phala.network",
+        "terms_of_service_url": "https://phala.network/terms"
+      },
+      "models": [
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "deepseek/deepseek-v4-pro",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 1.5
+            },
+            "output_tokens": {
+              "text": 5.25
+            }
+          },
+          "provider_model_id": "deepseek/deepseek-v4-pro"
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "deepseek/deepseek-v4-flash",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.2
+            },
+            "output_tokens": {
+              "text": 0.4
+            }
+          },
+          "provider_model_id": "deepseek/deepseek-v4-flash"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "deepseek/deepseek-v4-flash-0731",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.028,
+              "no_cache": 0.44
+            },
+            "output_tokens": {
+              "text": 1.32
+            }
+          },
+          "provider_model_id": "deepseek/deepseek-v4-flash-0731"
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "moonshotai/kimi-k2.6",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.37,
+              "no_cache": 1.09
+            },
+            "output_tokens": {
+              "text": 4.6
+            }
+          },
+          "provider_model_id": "moonshotai/kimi-k2.6"
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools",
+            "image_input"
+          ],
+          "id": "moonshotai/kimi-k3",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 1.5,
+              "no_cache": 3.0
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider_model_id": "moonshotai/kimi-k3"
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "z-ai/glm-5.1",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.6,
+              "no_cache": 1.21
+            },
+            "output_tokens": {
+              "text": 4.2
+            }
+          },
+          "provider_model_id": "z-ai/glm-5.1"
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "z-ai/glm-5.2",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.26,
+              "no_cache": 1.4
+            },
+            "output_tokens": {
+              "text": 4.4
+            }
+          },
+          "provider_model_id": "z-ai/glm-5.2"
+        }
+      ],
+      "name": "phala",
+      "required_config": [
+        "api_key"
+      ],
+      "status": "active",
+      "submitted_at": "2026-07-07",
+      "weight": 1.0
+    },
+    {
+      "access": "api_key",
+      "api_base": "https://api.baiduqianfan.ai/v1",
+      "auth_scheme": "bearer",
+      "billing": "usage_token",
+      "byok": true,
+      "community": false,
+      "display_name": "Baidu Qianfan (International)",
+      "id": "qianfan",
+      "kind": "cloud",
+      "metadata": {
+        "headquarters": "CN",
+        "name": "Baidu AI Cloud",
+        "privacy_policy_url": "https://intl.cloud.baidu.com/en/doc/Agreements/s/Plr0fi68q-intl-en",
+        "slug": "qianfan",
+        "terms_of_service_url": "https://intl.cloud.baidu.com/doc/Agreements/s/Kjwvy245m-en"
+      },
+      "models": [
+        {
+          "api_protocol": "openai",
+          "id": "deepseek/deepseek-v3.2",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.0252,
+              "no_cache": 0.252
+            },
+            "output_tokens": {
+              "text": 0.378
+            }
+          },
+          "provider_model_id": "deepseek-v3.2"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "deepseek/deepseek-v4-pro",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.14,
+              "no_cache": 1.69
+            },
+            "output_tokens": {
+              "text": 3.38
+            }
+          },
+          "provider_model_id": "deepseek-v4-pro"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "deepseek/deepseek-v4-flash",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.028,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider_model_id": "deepseek-v4-flash"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "deepseek/deepseek-v4-flash-0731",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.028,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider_model_id": "deepseek-v4-flash-0731"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "moonshotai/kimi-k2.6",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.16,
+              "no_cache": 0.95
+            },
+            "output_tokens": {
+              "text": 4.0
+            }
+          },
+          "provider_model_id": "kimi-k2.6"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "z-ai/glm-5.1",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.26,
+              "no_cache": 1.4
+            },
+            "output_tokens": {
+              "text": 4.4
+            }
+          },
+          "provider_model_id": "glm-5.1"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "z-ai/glm-5.2",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.26,
+              "no_cache": 1.4
+            },
+            "output_tokens": {
+              "text": 4.4
+            }
+          },
+          "provider_model_id": "glm-5.2"
+        }
+      ],
+      "name": "qianfan",
+      "required_config": [
+        "api_key"
+      ],
+      "status": "active",
+      "submitted_at": "2026-07-07",
+      "weight": 1.0
+    },
+    {
+      "access": "api_key",
+      "api_base": "https://qianfan.baidubce.com/v2",
+      "auth_scheme": "bearer",
+      "billing": "usage_token",
+      "byok": true,
+      "community": false,
+      "display_name": "Baidu Qianfan (China)",
+      "id": "qianfan_cn",
+      "kind": "cloud",
+      "metadata": {
+        "datacenters": [
+          "CN"
+        ],
+        "headquarters": "CN",
+        "name": "Baidu AI Cloud",
+        "privacy_policy_url": "https://intl.cloud.baidu.com/en/doc/Agreements/s/Plr0fi68q-intl-en",
+        "slug": "qianfan",
+        "status_page_url": "https://cloud.baidu.com/status.html",
+        "terms_of_service_url": "https://intl.cloud.baidu.com/doc/Agreements/s/Kjwvy245m-en"
+      },
+      "models": [
+        {
+          "api_protocol": "openai",
+          "id": "deepseek/deepseek-v4-pro",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 1.67
+            },
+            "output_tokens": {
+              "text": 3.33
+            }
+          },
+          "provider_model_id": "deepseek-v4-pro"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "deepseek/deepseek-v4-flash",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider_model_id": "deepseek-v4-flash"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "deepseek/deepseek-v3.2",
+          "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 32000,
+                "input_tokens": {
+                  "no_cache": 0.56
+                },
+                "output_tokens": {
+                  "text": 0.83
+                }
+              }
+            ],
+            "input_tokens": {
+              "no_cache": 0.28
+            },
+            "output_tokens": {
+              "text": 0.42
+            }
+          },
+          "provider_model_id": "deepseek-v3.2"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "z-ai/glm-5.1",
+          "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 32000,
+                "input_tokens": {
+                  "no_cache": 1.11
+                },
+                "output_tokens": {
+                  "text": 3.89
+                }
+              }
+            ],
+            "input_tokens": {
+              "no_cache": 0.83
+            },
+            "output_tokens": {
+              "text": 3.33
+            }
+          },
+          "provider_model_id": "glm-5.1"
+        }
+      ],
+      "name": "qianfan_cn",
+      "required_config": [
+        "api_key"
+      ],
+      "status": "active",
+      "submitted_at": "2026-07-07",
+      "weight": 1.0
+    },
+    {
+      "access": "api_key",
+      "api_base": "https://api.redpill.ai/v1",
+      "auth_scheme": "bearer",
+      "billing": "usage_token",
+      "byok": true,
+      "community": false,
+      "display_name": "RedPill (Phala Network)",
+      "doc_url": "https://docs.redpill.ai/get-started/introduction",
+      "id": "redpill",
+      "kind": "gateway",
+      "metadata": {
+        "headquarters": "SG",
+        "name": "RedPill",
+        "privacy_policy_url": "https://redpill.ai/privacy",
+        "slug": "redpill",
+        "terms_of_service_url": "https://redpill.ai/terms"
+      },
+      "models": [
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "deepseek/deepseek-v4-pro",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 1.5
+            },
+            "output_tokens": {
+              "text": 5.25
+            }
+          },
+          "provider_model_id": "deepseek/deepseek-v4-pro"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "deepseek/deepseek-v4-pro-0813",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.15,
+              "no_cache": 1.45
+            },
+            "output_tokens": {
+              "text": 4.36
+            }
+          },
+          "provider_model_id": "deepseek/deepseek-v4-pro-0813"
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "deepseek/deepseek-v4-flash",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.2
+            },
+            "output_tokens": {
+              "text": 0.4
+            }
+          },
+          "provider_model_id": "deepseek/deepseek-v4-flash"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "deepseek/deepseek-v4-flash-0731",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.028,
+              "no_cache": 0.44
+            },
+            "output_tokens": {
+              "text": 1.32
+            }
+          },
+          "provider_model_id": "deepseek/deepseek-v4-flash-0731"
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "moonshotai/kimi-k2.6",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.37,
+              "no_cache": 1.09
+            },
+            "output_tokens": {
+              "text": 4.6
+            }
+          },
+          "provider_model_id": "moonshotai/kimi-k2.6"
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools",
+            "image_input"
+          ],
+          "id": "moonshotai/kimi-k3",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 1.5,
+              "no_cache": 3.0
+            },
+            "output_tokens": {
+              "text": 15.0
+            }
+          },
+          "provider_model_id": "moonshotai/kimi-k3"
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "z-ai/glm-5.1",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.6,
+              "no_cache": 1.21
+            },
+            "output_tokens": {
+              "text": 4.2
+            }
+          },
+          "provider_model_id": "z-ai/glm-5.1"
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "z-ai/glm-5.2",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.26,
+              "no_cache": 1.4
+            },
+            "output_tokens": {
+              "text": 4.4
+            }
+          },
+          "provider_model_id": "z-ai/glm-5.2"
+        }
+      ],
+      "name": "redpill",
+      "required_config": [
+        "api_key"
+      ],
+      "status": "active",
+      "submitted_at": "2026-07-08",
+      "weight": 1.0
+    },
+    {
+      "access": "api_key",
+      "api_base": "https://api.siliconflow.com/v1",
+      "auth_scheme": "x-api-key",
+      "billing": "usage_token",
+      "byok": true,
+      "community": false,
+      "display_name": "SiliconFlow",
+      "id": "siliconflow",
+      "kind": "gateway",
+      "metadata": {
+        "headquarters": "CN",
+        "name": "SiliconFlow",
+        "slug": "siliconflow"
+      },
+      "models": [
+        {
+          "api_protocol": "openai",
+          "id": "deepseek/deepseek-v4-pro",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.145,
+              "no_cache": 1.74
+            },
+            "output_tokens": {
+              "text": 3.48
+            }
+          },
+          "provider_model_id": "deepseek-ai/DeepSeek-V4-Pro"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "deepseek/deepseek-v4-pro-0813",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.44,
+              "no_cache": 1.32
+            },
+            "output_tokens": {
+              "text": 3.96
+            }
+          },
+          "provider_model_id": "deepseek-ai/DeepSeek-V4-Pro-0813"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "deepseek/deepseek-v4-flash",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.028,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider_model_id": "deepseek-ai/DeepSeek-V4-Flash"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "deepseek/deepseek-v4-flash-0731",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.028,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider_model_id": "deepseek-ai/DeepSeek-V4-Flash-0731"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "deepseek/deepseek-v3.2",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.27
+            },
+            "output_tokens": {
+              "text": 0.42
+            }
+          },
+          "provider_model_id": "deepseek-ai/DeepSeek-V3.2"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "moonshotai/kimi-k2.6",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "no_cache": 0.77
+            },
+            "output_tokens": {
+              "text": 4.0
+            }
+          },
+          "provider_model_id": "moonshotai/Kimi-K2.6"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "qwen/qwen3.5-122b-a10b",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.26
+            },
+            "output_tokens": {
+              "text": 2.08
+            }
+          },
+          "provider_model_id": "Qwen/Qwen3.5-122B-A10B"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "qwen/qwen3.5-27b",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.25
+            },
+            "output_tokens": {
+              "text": 2.0
+            }
+          },
+          "provider_model_id": "Qwen/Qwen3.5-27B"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "qwen/qwen3.6-27b",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.3
+            },
+            "output_tokens": {
+              "text": 3.2
+            }
+          },
+          "provider_model_id": "Qwen/Qwen3.6-27B"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "qwen/qwen3.6-35b-a3b",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.2
+            },
+            "output_tokens": {
+              "text": 1.6
+            }
+          },
+          "provider_model_id": "Qwen/Qwen3.6-35B-A3B"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "z-ai/glm-5.1",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 1.4
+            },
+            "output_tokens": {
+              "text": 4.4
+            }
+          },
+          "provider_model_id": "zai-org/GLM-5.1"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "z-ai/glm-5.2",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 1.4
+            },
+            "output_tokens": {
+              "text": 4.4
+            }
+          },
+          "provider_model_id": "zai-org/GLM-5.2"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "openai/gpt-oss-120b",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.05
+            },
+            "output_tokens": {
+              "text": 0.45
+            }
+          },
+          "provider_model_id": "openai/gpt-oss-120b"
+        }
+      ],
+      "name": "siliconflow",
+      "required_config": [
+        "api_key"
+      ],
+      "status": "active",
+      "submitted_at": "2026-07-07",
+      "weight": 1.0
+    },
+    {
+      "access": "api_key",
+      "api_base": "https://api.siliconflow.cn/v1",
+      "auth_scheme": "x-api-key",
+      "billing": "usage_token",
+      "byok": true,
+      "community": false,
+      "display_name": "SiliconFlow (China)",
+      "id": "siliconflow_cn",
+      "kind": "gateway",
+      "metadata": {
+        "datacenters": [
+          "CN"
+        ],
+        "headquarters": "CN",
+        "name": "SiliconFlow",
+        "slug": "siliconflow"
+      },
+      "models": [
+        {
+          "api_protocol": "openai",
+          "id": "deepseek/deepseek-v4-pro",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.145,
+              "no_cache": 1.74
+            },
+            "output_tokens": {
+              "text": 3.48
+            }
+          },
+          "provider_model_id": "deepseek-ai/DeepSeek-V4-Pro"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "deepseek/deepseek-v4-flash",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.003,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider_model_id": "deepseek-ai/DeepSeek-V4-Flash"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "deepseek/deepseek-v3.2",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.27
+            },
+            "output_tokens": {
+              "text": 0.42
+            }
+          },
+          "provider_model_id": "deepseek-ai/DeepSeek-V3.2"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "moonshotai/kimi-k2.6",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.16,
+              "no_cache": 0.95
+            },
+            "output_tokens": {
+              "text": 4.0
+            }
+          },
+          "provider_model_id": "Pro/moonshotai/Kimi-K2.6"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "qwen/qwen3.5-122b-a10b",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.29
+            },
+            "output_tokens": {
+              "text": 2.32
+            }
+          },
+          "provider_model_id": "Qwen/Qwen3.5-122B-A10B"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "qwen/qwen3.5-27b",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.26
+            },
+            "output_tokens": {
+              "text": 2.09
+            }
+          },
+          "provider_model_id": "Qwen/Qwen3.5-27B"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "qwen/qwen3.6-35b-a3b",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 0.23
+            },
+            "output_tokens": {
+              "text": 1.86
+            }
+          },
+          "provider_model_id": "Qwen/Qwen3.6-35B-A3B"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "z-ai/glm-5.1",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 1.4
+            },
+            "output_tokens": {
+              "text": 4.4
+            }
+          },
+          "provider_model_id": "Pro/zai-org/GLM-5.1"
+        },
+        {
+          "api_protocol": "openai",
+          "id": "z-ai/glm-5.2",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 1.4
+            },
+            "output_tokens": {
+              "text": 4.4
+            }
+          },
+          "provider_model_id": "zai-org/GLM-5.2"
+        }
+      ],
+      "name": "siliconflow_cn",
+      "required_config": [
+        "api_key"
+      ],
+      "status": "active",
+      "submitted_at": "2026-07-07",
+      "weight": 1.0
+    },
+    {
+      "access": "local_oauth",
+      "api_base": "https://api.x.ai/v1",
+      "auth": {
+        "handler": "supergrok",
+        "kind": "oauth",
+        "params": {
+          "authorize_endpoint": "https://auth.x.ai/oauth2/authorize",
+          "client_id": "b1a00492-073a-47ea-816f-4c329264a828",
+          "issuer": "https://auth.x.ai",
+          "scope": "openid profile email offline_access grok-cli:access api:access",
+          "token_endpoint": "https://auth.x.ai/oauth2/token"
+        }
+      },
+      "auth_scheme": "x-api-key",
+      "billing": "subscription",
+      "byok": false,
+      "community": false,
+      "display_name": "SuperGrok (subscription)",
+      "id": "supergrok",
+      "kind": "first_party",
+      "metadata": {
+        "headquarters": "US",
+        "name": "xAI",
+        "privacy_policy_url": "https://x.ai/legal/privacy-policy",
+        "slug": "xai",
+        "status_page_url": "https://status.x.ai",
+        "terms_of_service_url": "https://x.ai/legal/terms-of-service"
+      },
+      "models": [
+        {
+          "api_protocol": [
+            "responses",
+            "openai"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "x-ai/grok-4.5",
+          "provider_model_id": "grok-4.5"
+        },
+        {
+          "api_protocol": [
+            "responses",
+            "openai"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "x-ai/grok-4.20-multi-agent",
+          "provider_model_id": "grok-4.20-multi-agent"
+        },
+        {
+          "api_protocol": [
+            "responses",
+            "openai"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "x-ai/grok-4.20",
+          "provider_model_id": "grok-4.20"
+        },
+        {
+          "api_protocol": [
+            "responses",
+            "openai"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "x-ai/grok-4.3",
+          "provider_model_id": "grok-4.3"
+        },
+        {
+          "api_protocol": [
+            "responses",
+            "openai"
+          ],
+          "capabilities": [
+            "tools"
+          ],
+          "id": "x-ai/grok-build-0.1",
+          "provider_model_id": "grok-build-0.1"
+        },
+        {
+          "api_protocol": [
+            "responses",
+            "openai"
+          ],
+          "id": "x-ai/grok-4.6",
+          "provider_model_id": "grok-4.6"
+        }
+      ],
+      "name": "supergrok",
+      "required_config": [
+        "local_oauth"
+      ],
+      "status": "active",
+      "weight": 1.0
+    },
+    {
+      "access": "api_key",
+      "api_base": "https://tokenhub-intl.tencentcloudmaas.com/v1",
+      "auth_scheme": "x-api-key",
+      "billing": "usage_token",
+      "byok": true,
+      "community": false,
+      "id": "tencent",
+      "metadata": {
+        "datacenters": [
+          "SG"
+        ],
+        "headquarters": "CN",
+        "name": "Tencent Cloud",
+        "privacy_policy_url": "https://www.tencentcloud.com/document/product/301/17345",
+        "slug": "tencent-cloud",
+        "status_page_url": "https://status.tencentcloud.com",
+        "terms_of_service_url": "https://www.tencentcloud.com/document/product/301/9248"
+      },
+      "models": [
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools"
+          ],
+          "id": "deepseek/deepseek-v3.2",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.114,
+              "no_cache": 0.57
+            },
+            "output_tokens": {
+              "text": 1.71
+            }
+          },
+          "provider_model_id": "deepseek-v3.2",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "deepseek/deepseek-v4-flash",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.028,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider_model_id": "deepseek-v4-flash",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "deepseek/deepseek-v4-pro",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.145,
+              "no_cache": 1.74
+            },
+            "output_tokens": {
+              "text": 3.48
+            }
+          },
+          "provider_model_id": "deepseek-v4-pro",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "deepseek/deepseek-v4-flash-0731",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.014,
+              "no_cache": 0.44
+            },
+            "output_tokens": {
+              "text": 1.32
+            }
+          },
+          "provider_model_id": "deepseek-v4-flash-0731",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "deepseek/deepseek-v4-pro-0813",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.044,
+              "no_cache": 1.32
+            },
+            "output_tokens": {
+              "text": 3.96
+            }
+          },
+          "provider_model_id": "deepseek-v4-pro-0813",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "z-ai/glm-5.1",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.26,
+              "no_cache": 1.4
+            },
+            "output_tokens": {
+              "text": 4.4
+            }
+          },
+          "provider_model_id": "glm-5.1",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "z-ai/glm-5.2",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.26,
+              "no_cache": 1.4
+            },
+            "output_tokens": {
+              "text": 4.4
+            }
+          },
+          "provider_model_id": "glm-5.2",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "moonshotai/kimi-k2.6",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.16,
+              "no_cache": 0.95
+            },
+            "output_tokens": {
+              "text": 4.0
+            }
+          },
+          "provider_model_id": "kimi-k2.6",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "minimax/minimax-m2.7",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.06,
+              "no_cache": 0.3
+            },
+            "output_tokens": {
+              "text": 1.2
+            }
+          },
+          "provider_model_id": "minimax-m2.7",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "minimax/minimax-m3",
+          "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 512000,
+                "input_tokens": {
+                  "cache_read": 0.24,
+                  "no_cache": 1.2
+                },
+                "output_tokens": {
+                  "text": 4.8
+                }
+              }
+            ],
+            "input_tokens": {
+              "cache_read": 0.12,
+              "no_cache": 0.6
+            },
+            "output_tokens": {
+              "text": 2.4
+            }
+          },
+          "provider_model_id": "minimax-m3",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        }
+      ],
+      "name": "tencent",
+      "required_config": [
+        "api_key"
+      ],
+      "status": "active",
+      "submitted_at": "2026-05-23",
+      "weight": 1.0
+    },
+    {
+      "access": "api_key",
+      "api_base": "https://tokenhub.tencentmaas.com/v1",
+      "auth_scheme": "x-api-key",
+      "billing": "usage_token",
+      "byok": true,
+      "community": false,
+      "id": "tencent_cn",
+      "metadata": {
+        "datacenters": [
+          "CN"
+        ],
+        "headquarters": "CN",
+        "name": "Tencent Cloud",
+        "privacy_policy_url": "https://cloud.tencent.com/document/product/301/11470",
+        "slug": "tencent-cloud",
+        "status_page_url": "https://status.cloud.tencent.com",
+        "terms_of_service_url": "https://cloud.tencent.com/document/product/301/1967"
+      },
+      "models": [
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools"
+          ],
+          "id": "deepseek/deepseek-v3.2",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.114,
+              "no_cache": 0.57
+            },
+            "output_tokens": {
+              "text": 1.71
+            }
+          },
+          "provider_model_id": "deepseek-v3.2",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "deepseek/deepseek-v4-flash",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.028,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider_model_id": "deepseek-v4-flash",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "deepseek/deepseek-v4-pro",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.145,
+              "no_cache": 1.74
+            },
+            "output_tokens": {
+              "text": 3.48
+            }
+          },
+          "provider_model_id": "deepseek-v4-pro",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "z-ai/glm-5.1",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.26,
+              "no_cache": 1.4
+            },
+            "output_tokens": {
+              "text": 4.4
+            }
+          },
+          "provider_model_id": "glm-5.1",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "z-ai/glm-5.2",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.26,
+              "no_cache": 1.4
+            },
+            "output_tokens": {
+              "text": 4.4
+            }
+          },
+          "provider_model_id": "glm-5.2",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "moonshotai/kimi-k2.6",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.16,
+              "no_cache": 0.95
+            },
+            "output_tokens": {
+              "text": 4.0
+            }
+          },
+          "provider_model_id": "kimi-k2.6",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "minimax/minimax-m2.7",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.06,
+              "no_cache": 0.3
+            },
+            "output_tokens": {
+              "text": 1.2
+            }
+          },
+          "provider_model_id": "minimax-m2.7",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "minimax/minimax-m3",
+          "pricing": {
+            "context_tiers": [
+              {
+                "above_input_tokens": 512000,
+                "input_tokens": {
+                  "cache_read": 0.24,
+                  "no_cache": 1.2
+                },
+                "output_tokens": {
+                  "text": 4.8
+                }
+              }
+            ],
+            "input_tokens": {
+              "cache_read": 0.12,
+              "no_cache": 0.6
+            },
+            "output_tokens": {
+              "text": 2.4
+            }
+          },
+          "provider_model_id": "minimax-m3",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        }
+      ],
+      "name": "tencent_cn",
+      "required_config": [
+        "api_key"
+      ],
+      "status": "active",
+      "submitted_at": "2026-05-23",
+      "weight": 1.0
+    },
+    {
+      "access": "api_key",
+      "api_base": "https://inference.tinfoil.sh/v1",
+      "auth_scheme": "x-api-key",
+      "billing": "usage_token",
+      "byok": true,
+      "community": true,
+      "id": "tinfoil",
+      "metadata": {
+        "headquarters": "US",
+        "name": "Tinfoil",
+        "privacy_policy_url": "https://tinfoil.sh/privacy",
+        "slug": "tinfoil",
+        "status_page_url": "https://status.tinfoil.sh",
+        "terms_of_service_url": "https://tinfoil.sh/terms"
+      },
+      "models": [
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools"
+          ],
+          "id": "deepseek/deepseek-v4-pro",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 1.5
+            },
+            "output_tokens": {
+              "text": 5.25
+            }
+          },
+          "provider_model_id": "deepseek-v4-pro",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "reasoning",
+            "structured_outputs",
+            "tools"
+          ],
+          "id": "moonshotai/kimi-k2.6",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 1.5
+            },
+            "output_tokens": {
+              "text": 5.25
+            }
+          },
+          "provider_model_id": "kimi-k2-6",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "id": "z-ai/glm-5.2",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.375,
+              "no_cache": 1.5
+            },
+            "output_tokens": {
+              "text": 5.25
+            }
+          },
+          "provider_model_id": "glm-5-2",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "id": "moonshotai/kimi-k3",
+          "pricing": {
+            "input_tokens": {
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 6.0
+            }
+          },
+          "provider_model_id": "kimi-k3",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "openai",
+          "id": "deepseek/deepseek-v4-flash",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.125,
+              "no_cache": 0.7
+            },
+            "output_tokens": {
+              "text": 1.9
+            }
+          },
+          "provider_model_id": "deepseek-v4-flash",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        }
+      ],
+      "name": "tinfoil",
+      "required_config": [
+        "api_key"
+      ],
+      "status": "active",
+      "submitted_at": "2026-05-12",
+      "weight": 1.0
+    },
+    {
+      "access": "api_key",
+      "api_base": "https://api.tiyuvta.ai/v1",
+      "auth": {
+        "env": "TIYUVTA_API_KEY",
+        "kind": "bearer"
+      },
+      "auth_scheme": "x-api-key",
+      "billing": "usage_token",
+      "byok": true,
+      "community": true,
+      "display_name": "tiyuvta",
+      "doc_url": "https://tiyuvta.ai/inference/",
+      "id": "tiyuvta",
+      "kind": "first_party",
+      "metadata": {
+        "datacenters": [
+          "CA"
+        ],
+        "headquarters": "IL",
+        "name": "tiyuvta",
+        "privacy_policy_url": "https://tiyuvta.ai/privacy/",
+        "slug": "tiyuvta",
+        "terms_of_service_url": "https://tiyuvta.ai/terms/"
+      },
+      "models": [
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "tools",
+            "structured_outputs"
+          ],
+          "id": "qwen/qwen3.6-27b",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.07,
+              "no_cache": 0.28
+            },
+            "output_tokens": {
+              "text": 2.69
+            }
+          },
+          "provider_model_id": "qwen/qwen3.6-27b"
+        },
+        {
+          "api_protocol": "openai",
+          "capabilities": [
+            "tools",
+            "structured_outputs"
+          ],
+          "id": "qwen/qwen3.6-35b-a3b",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.03,
+              "no_cache": 0.12
+            },
+            "output_tokens": {
+              "text": 1.03
+            }
+          },
+          "provider_model_id": "qwen/qwen3.6-35b-a3b"
+        }
+      ],
+      "name": "tiyuvta",
+      "required_config": [
+        "api_key"
+      ],
+      "status": "active",
+      "submitted_at": "2026-08-12",
+      "weight": 1.0
+    },
+    {
+      "access": "api_key",
+      "api_base": "https://aiplatform.googleapis.com/v1/publishers/google",
+      "auth": {
+        "env": "VERTEX_EXPRESS_API_KEY",
+        "header": "x-goog-api-key",
+        "kind": "header"
+      },
+      "auth_scheme": "x-api-key",
+      "billing": "usage_token",
+      "byok": true,
+      "community": false,
+      "display_name": "Vertex AI",
+      "doc_url": "https://cloud.google.com/vertex-ai/generative-ai/docs/start/express-mode/overview",
+      "id": "vertex",
+      "kind": "first_party",
+      "metadata": {
+        "headquarters": "US",
+        "name": "Google Cloud",
+        "privacy_policy_url": "https://cloud.google.com/terms/cloud-privacy-notice",
+        "slug": "google-vertex",
+        "status_page_url": "https://status.cloud.google.com",
+        "terms_of_service_url": "https://cloud.google.com/terms"
+      },
+      "models": [
+        {
+          "api_protocol": "google",
+          "id": "google/gemini-3.1-flash-lite-preview",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.025,
+              "no_cache": 0.25
+            },
+            "output_tokens": {
+              "text": 1.5
+            }
+          },
+          "provider_model_id": "gemini-3.1-flash-lite-preview",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "google",
+          "id": "google/gemini-3.1-pro-preview",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 12.0
+            }
+          },
+          "provider_model_id": "gemini-3.1-pro-preview",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "google",
+          "id": "google/gemini-3.5-flash",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.15,
+              "no_cache": 1.5
+            },
+            "output_tokens": {
+              "text": 9.0
+            }
+          },
+          "provider_model_id": "gemini-3.5-flash",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": "google",
+          "id": "google/gemini-3.6-flash",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.15,
+              "no_cache": 1.5
+            },
+            "output_tokens": {
+              "text": 7.5
+            }
+          },
+          "provider_model_id": "gemini-3.6-flash",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        }
+      ],
+      "name": "vertex",
+      "required_config": [
+        "api_key"
+      ],
+      "status": "active",
+      "submitted_at": "2026-07-06",
+      "weight": 1.0
+    },
+    {
+      "access": "api_key",
+      "api_base": "https://api.x.ai/v1",
+      "auth_scheme": "x-api-key",
+      "billing": "usage_token",
+      "byok": true,
+      "community": false,
+      "id": "xai",
+      "metadata": {
+        "headquarters": "US",
+        "name": "xAI",
+        "privacy_policy_url": "https://x.ai/legal/privacy-policy",
+        "slug": "xai",
+        "status_page_url": "https://status.x.ai",
+        "terms_of_service_url": "https://x.ai/legal/terms-of-service"
+      },
+      "models": [
+        {
+          "api_protocol": [
+            "responses",
+            "openai"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "x-ai/grok-4.6",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.5,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 6.0
+            }
+          },
+          "provider_model_id": "grok-4.6",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "responses",
+            "openai"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "x-ai/grok-4.5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.3,
+              "no_cache": 2.0
+            },
+            "output_tokens": {
+              "text": 6.0
+            }
+          },
+          "provider_model_id": "grok-4.5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "responses",
+            "openai"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "x-ai/grok-4.3",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "no_cache": 1.25
+            },
+            "output_tokens": {
+              "text": 2.5
+            }
+          },
+          "provider_model_id": "grok-4.3",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "responses",
+            "openai"
+          ],
+          "capabilities": [
+            "tools"
+          ],
+          "id": "x-ai/grok-4.20",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "no_cache": 1.25
+            },
+            "output_tokens": {
+              "text": 2.5
+            }
+          },
+          "provider_model_id": "grok-4.20-0309-non-reasoning",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "responses",
+            "openai"
+          ],
+          "capabilities": [
+            "tools"
+          ],
+          "id": "x-ai/grok-build-0.1",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "no_cache": 1.0
+            },
+            "output_tokens": {
+              "text": 2.0
+            }
+          },
+          "provider_model_id": "grok-build-0.1",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "responses",
+            "openai"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "x-ai/grok-4.20-multi-agent",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.2,
+              "no_cache": 1.25
+            },
+            "output_tokens": {
+              "text": 2.5
+            }
+          },
+          "provider_model_id": "grok-4.20-multi-agent-0309",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        }
+      ],
+      "name": "xai",
+      "required_config": [
+        "api_key"
+      ],
+      "status": "active",
+      "submitted_at": "2026-05-25",
+      "weight": 1.0
+    },
+    {
+      "access": "api_key",
+      "api_base": "https://api.xiaomimimo.com/v1",
+      "auth_scheme": "x-api-key",
+      "billing": "usage_token",
+      "byok": true,
+      "community": false,
+      "id": "xiaomi",
+      "metadata": {
+        "headquarters": "CN",
+        "name": "Xiaomi",
+        "privacy_policy_url": "https://mimo.mi.com/docs/terms/privacy-policy",
+        "slug": "xiaomi",
+        "terms_of_service_url": "https://mimo.mi.com/docs/terms/user-agreement"
+      },
+      "models": [
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "xiaomi/mimo-v2.5-pro",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.0036,
+              "no_cache": 0.435
+            },
+            "output_tokens": {
+              "text": 0.87
+            }
+          },
+          "provider_model_id": "mimo-v2.5-pro",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "xiaomi/mimo-v2.5",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.0028,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider_model_id": "mimo-v2.5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "deprecation_date": "2026-06-30",
+          "id": "xiaomi/mimo-v2-pro",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.0036,
+              "no_cache": 0.435
+            },
+            "output_tokens": {
+              "text": 0.87
+            }
+          },
+          "provider_model_id": "mimo-v2-pro",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "deprecation_date": "2026-06-30",
+          "id": "xiaomi/mimo-v2-omni",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.0028,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider_model_id": "mimo-v2-omni",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "deprecation_date": "2026-06-30",
+          "id": "xiaomi/mimo-v2-flash",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.0028,
+              "no_cache": 0.14
+            },
+            "output_tokens": {
+              "text": 0.28
+            }
+          },
+          "provider_model_id": "mimo-v2-flash",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        }
+      ],
+      "name": "xiaomi",
+      "protocol_endpoints": {
+        "messages": "https://api.xiaomimimo.com/anthropic"
+      },
+      "required_config": [
+        "api_key"
+      ],
+      "status": "active",
+      "submitted_at": "2026-05-25",
+      "weight": 1.0
+    },
+    {
+      "access": "api_key",
+      "api_base": "https://token-plan-sgp.xiaomimimo.com/v1",
+      "auth_scheme": "x-api-key",
+      "billing": "subscription",
+      "byok": true,
+      "community": false,
+      "display_name": "Xiaomi MiMo Token Plan (International)",
+      "id": "xiaomi_token_plan",
+      "metadata": {
+        "datacenters": [
+          "SG"
+        ],
+        "headquarters": "CN",
+        "name": "Xiaomi",
+        "privacy_policy_url": "https://mimo.mi.com/docs/terms/privacy-policy",
+        "slug": "xiaomi",
+        "terms_of_service_url": "https://mimo.mi.com/docs/terms/user-agreement"
+      },
+      "models": [
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "xiaomi/mimo-v2.5-pro",
+          "provider_model_id": "mimo-v2.5-pro",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "xiaomi/mimo-v2.5",
+          "provider_model_id": "mimo-v2.5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        }
+      ],
+      "name": "xiaomi_token_plan",
+      "protocol_endpoints": {
+        "messages": "https://token-plan-sgp.xiaomimimo.com/anthropic"
+      },
+      "required_config": [
+        "api_key"
+      ],
+      "status": "active",
+      "submitted_at": "2026-07-06",
+      "weight": 1.0
+    },
+    {
+      "access": "api_key",
+      "api_base": "https://token-plan-cn.xiaomimimo.com/v1",
+      "auth_scheme": "x-api-key",
+      "billing": "subscription",
+      "byok": true,
+      "community": false,
+      "display_name": "Xiaomi MiMo Token Plan (China)",
+      "id": "xiaomi_token_plan_cn",
+      "metadata": {
+        "datacenters": [
+          "CN"
+        ],
+        "headquarters": "CN",
+        "name": "Xiaomi",
+        "privacy_policy_url": "https://mimo.mi.com/docs/terms/privacy-policy",
+        "slug": "xiaomi",
+        "terms_of_service_url": "https://mimo.mi.com/docs/terms/user-agreement"
+      },
+      "models": [
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "xiaomi/mimo-v2.5-pro",
+          "provider_model_id": "mimo-v2.5-pro",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "xiaomi/mimo-v2.5",
+          "provider_model_id": "mimo-v2.5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        }
+      ],
+      "name": "xiaomi_token_plan_cn",
+      "protocol_endpoints": {
+        "messages": "https://token-plan-cn.xiaomimimo.com/anthropic"
+      },
+      "required_config": [
+        "api_key"
+      ],
+      "status": "active",
+      "submitted_at": "2026-07-06",
+      "weight": 1.0
+    },
+    {
+      "access": "api_key",
+      "api_base": "https://token-plan-ams.xiaomimimo.com/v1",
+      "auth_scheme": "x-api-key",
+      "billing": "subscription",
+      "byok": true,
+      "community": false,
+      "display_name": "Xiaomi MiMo Token Plan (Europe)",
+      "id": "xiaomi_token_plan_eu",
+      "metadata": {
+        "datacenters": [
+          "EU"
+        ],
+        "headquarters": "CN",
+        "name": "Xiaomi",
+        "privacy_policy_url": "https://mimo.mi.com/docs/terms/privacy-policy",
+        "slug": "xiaomi",
+        "terms_of_service_url": "https://mimo.mi.com/docs/terms/user-agreement"
+      },
+      "models": [
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "xiaomi/mimo-v2.5-pro",
+          "provider_model_id": "mimo-v2.5-pro",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "responses",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "xiaomi/mimo-v2.5",
+          "provider_model_id": "mimo-v2.5",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        }
+      ],
+      "name": "xiaomi_token_plan_eu",
+      "protocol_endpoints": {
+        "messages": "https://token-plan-ams.xiaomimimo.com/anthropic"
+      },
+      "required_config": [
+        "api_key"
+      ],
+      "status": "active",
+      "submitted_at": "2026-07-06",
+      "weight": 1.0
+    },
+    {
+      "access": "api_key",
+      "api_base": "https://api.z.ai/api/paas/v4",
+      "auth_scheme": "x-api-key",
+      "billing": "usage_token",
+      "byok": true,
+      "community": false,
+      "id": "zai",
+      "metadata": {
+        "headquarters": "CN",
+        "name": "Z.ai",
+        "privacy_policy_url": "https://docs.z.ai/legal-agreement/privacy-policy",
+        "slug": "zai",
+        "terms_of_service_url": "https://docs.z.ai/legal-agreement/terms-of-use"
+      },
+      "models": [
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "z-ai/glm-5.3",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.26,
+              "no_cache": 1.4
+            },
+            "output_tokens": {
+              "text": 4.4
+            }
+          },
+          "provider_model_id": "glm-5.3",
+          "rate_limits": {
+            "requests_per_minute": 60
+          },
+          "reasoning_effort": {
+            "default": "max",
+            "levels": [
+              "low",
+              "high",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "z-ai/glm-5.3-flash",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.015,
+              "no_cache": 0.075
+            },
+            "output_tokens": {
+              "text": 0.25
+            }
+          },
+          "provider_model_id": "glm-5.3-flash",
+          "rate_limits": {
+            "requests_per_minute": 60
+          },
+          "reasoning_effort": {
+            "default": "max",
+            "levels": [
+              "low",
+              "high",
+              "max"
+            ]
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "z-ai/glm-5.1",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.26,
+              "no_cache": 1.4
+            },
+            "output_tokens": {
+              "text": 4.4
+            }
+          },
+          "provider_model_id": "glm-5.1",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "z-ai/glm-5.2",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.26,
+              "no_cache": 1.4
+            },
+            "output_tokens": {
+              "text": 4.4
+            }
+          },
+          "provider_model_id": "glm-5.2",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "id": "z-ai/glm-4.7",
+          "pricing": {
+            "input_tokens": {
+              "cache_read": 0.11,
+              "cache_write": 0.0,
+              "no_cache": 0.6
+            },
+            "output_tokens": {
+              "text": 2.2
+            }
+          },
+          "provider_model_id": "glm-4.7",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        }
+      ],
+      "name": "zai",
+      "required_config": [
+        "api_key"
+      ],
+      "status": "active",
+      "submitted_at": "2026-05-25",
+      "weight": 1.0
+    },
+    {
+      "access": "api_key",
+      "api_base": "https://api.z.ai/api/coding/paas/v4",
+      "auth_scheme": "x-api-key",
+      "billing": "subscription",
+      "byok": true,
+      "community": false,
+      "id": "zai_coding_plan",
+      "metadata": {
+        "headquarters": "CN",
+        "name": "Z.ai",
+        "privacy_policy_url": "https://docs.z.ai/legal-agreement/privacy-policy",
+        "slug": "zai",
+        "terms_of_service_url": "https://docs.z.ai/legal-agreement/terms-of-use"
+      },
+      "models": [
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "z-ai/glm-5.1",
+          "provider_model_id": "glm-5.1",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "capabilities": [
+            "reasoning",
+            "tools"
+          ],
+          "id": "z-ai/glm-5.2",
+          "provider_model_id": "glm-5.2",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "id": "z-ai/glm-4.7",
+          "provider_model_id": "glm-4.7",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "id": "z-ai/glm-5.3",
+          "provider_model_id": "glm-5.3",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        },
+        {
+          "api_protocol": [
+            "openai",
+            "anthropic"
+          ],
+          "id": "z-ai/glm-5.3-flash",
+          "provider_model_id": "glm-5.3-flash",
+          "rate_limits": {
+            "requests_per_minute": 60
+          }
+        }
+      ],
+      "name": "zai_coding_plan",
+      "required_config": [
+        "api_key"
+      ],
+      "status": "active",
+      "submitted_at": "2026-06-05",
+      "weight": 1.0
+    }
+  ]
+}

--- a/apps/bitrouter/registry-dist/runtimes.json
+++ b/apps/bitrouter/registry-dist/runtimes.json
@@ -1,0 +1,93 @@
+{
+  "data": [
+    {
+      "agents": [
+        {
+          "id": "claude-acp",
+          "transport": {
+            "args": [
+              "-y",
+              "@agentclientprotocol/claude-agent-acp@0.75.1"
+            ],
+            "command": "npx",
+            "type": "stdio"
+          }
+        },
+        {
+          "id": "codex-acp",
+          "transport": {
+            "args": [
+              "-y",
+              "@agentclientprotocol/codex-acp@1.10.0"
+            ],
+            "command": "npx",
+            "type": "stdio"
+          }
+        },
+        {
+          "id": "gemini-cli",
+          "transport": {
+            "args": [
+              "-y",
+              "--",
+              "@google/gemini-cli@latest",
+              "--experimental-acp"
+            ],
+            "command": "npx",
+            "type": "stdio"
+          }
+        },
+        {
+          "id": "opencode",
+          "requires_binary": "opencode",
+          "transport": {
+            "args": [
+              "acp"
+            ],
+            "command": "opencode",
+            "type": "stdio"
+          }
+        },
+        {
+          "id": "pi-acp",
+          "requires_binary": "pi",
+          "transport": {
+            "args": [
+              "-y",
+              "pi-acp@latest"
+            ],
+            "command": "npx",
+            "type": "stdio"
+          }
+        },
+        {
+          "id": "hermes-acp",
+          "requires_binary": "hermes",
+          "transport": {
+            "args": [
+              "acp"
+            ],
+            "command": "hermes",
+            "type": "stdio"
+          }
+        },
+        {
+          "id": "openclaw",
+          "requires_binary": "openclaw",
+          "transport": {
+            "args": [
+              "acp"
+            ],
+            "command": "openclaw",
+            "type": "stdio"
+          }
+        }
+      ],
+      "display_name": "Local process",
+      "id": "local",
+      "kind": "local",
+      "name": "local",
+      "status": "active"
+    }
+  ]
+}

--- a/apps/bitrouter/src/policy_lock.rs
+++ b/apps/bitrouter/src/policy_lock.rs
@@ -1976,9 +1976,9 @@ fn embedded_catalog_supports_capability(
     model_id: &str,
     capability: bitrouter_sdk::language_model::types::Capability,
 ) -> bool {
-    let Ok(catalog) = serde_json::from_str::<serde_json::Value>(include_str!(
-        "../../../dist/registry/models.json"
-    )) else {
+    let Ok(catalog) =
+        serde_json::from_str::<serde_json::Value>(include_str!("../registry-dist/models.json"))
+    else {
         return false;
     };
     catalog

--- a/helpers/dist-helper/src/registry.rs
+++ b/helpers/dist-helper/src/registry.rs
@@ -40,15 +40,19 @@ pub fn build(root: &Path, check: bool) -> Result<()> {
         ("agents.json", &artifacts.agents),
         ("runtimes.json", &artifacts.runtimes),
     ];
+    let output_dirs = [dist_dir(root), package_registry_dir(root)];
     if check {
-        for (name, rendered) in documents {
-            let path = dist_dir(root).join(name);
-            let current =
-                fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
-            if &current != rendered {
-                bail!(
-                    "registry dist is stale ({name}) - run `cargo run -p dist-helper -- registry build` and commit dist/registry"
-                );
+        for output_dir in &output_dirs {
+            for (name, rendered) in documents {
+                let path = output_dir.join(name);
+                let current = fs::read_to_string(&path)
+                    .with_context(|| format!("reading {}", path.display()))?;
+                if &current != rendered {
+                    bail!(
+                        "registry dist is stale ({}) - run `cargo run -p dist-helper -- registry build` and commit generated registry artifacts",
+                        path.display()
+                    );
+                }
             }
         }
         println!(
@@ -60,11 +64,13 @@ pub fn build(root: &Path, check: bool) -> Result<()> {
         );
         return Ok(());
     }
-    fs::create_dir_all(dist_dir(root))
-        .with_context(|| format!("creating {}", dist_dir(root).display()))?;
-    for (name, rendered) in documents {
-        let path = dist_dir(root).join(name);
-        fs::write(&path, rendered).with_context(|| format!("writing {}", path.display()))?;
+    for output_dir in &output_dirs {
+        fs::create_dir_all(output_dir)
+            .with_context(|| format!("creating {}", output_dir.display()))?;
+        for (name, rendered) in documents {
+            let path = output_dir.join(name);
+            fs::write(&path, rendered).with_context(|| format!("writing {}", path.display()))?;
+        }
     }
     println!(
         "wrote dist/registry: {} providers, {} canonical models, {} runtimes, {} agents",
@@ -74,6 +80,10 @@ pub fn build(root: &Path, check: bool) -> Result<()> {
         artifacts.agent_count
     );
     Ok(())
+}
+
+fn package_registry_dir(root: &Path) -> PathBuf {
+    root.join("apps/bitrouter/registry-dist")
 }
 
 pub async fn sync(root: &Path, write: bool) -> Result<()> {


### PR DESCRIPTION
## Summary
- retain crates.io-compatible ACP version requirements alongside the pinned Git revision
- generate a package-local registry snapshot with the canonical dist artifacts
- compile the CLI exclusively from the checked package-local snapshot

## Verification
- `cargo run -p dist-helper -- check`
- `cargo package --workspace --allow-dirty`
- `cargo clippy --all-features -- -D warnings`
- `cargo fmt -- --check`
- `git diff --check`