### PR TITLE
fix(codex): preserve ACP tools through Responses

### DIFF
--- a/apps/bitrouter/src/workflow_state/response_observer.rs
+++ b/apps/bitrouter/src/workflow_state/response_observer.rs
@@ -294,6 +294,7 @@ impl StreamObservationBuffer {
                 id,
                 name,
                 arguments,
+                ..
             } => self.observe_tool_delta(id, name.as_deref(), arguments),
             _ => {}
         }
@@ -1194,11 +1195,13 @@ mod tests {
                 id: "call-1".into(),
                 name: Some("exec_command".into()),
                 arguments: r#"{"cmd":"cargo "#.into(),
+                provider_metadata: Default::default(),
             },
             StreamPart::ToolCallDelta {
                 id: "call-1".into(),
                 name: None,
                 arguments: r#"test --all-features"}"#.into(),
+                provider_metadata: Default::default(),
             },
             StreamPart::Finish {
                 reason: FinishReason::Stop,
@@ -1239,6 +1242,7 @@ mod tests {
                     id: "call-1".into(),
                     name: Some("exec_command".into()),
                     arguments: "x".repeat(8_192),
+                    provider_metadata: Default::default(),
                 },
             )
             .await;
@@ -1287,6 +1291,7 @@ mod tests {
                         id: format!("read-{index}"),
                         name: Some("read_file".into()),
                         arguments: r#"{"path":"src/lib.rs"}"#.into(),
+                        provider_metadata: Default::default(),
                     },
                 )
                 .await;
@@ -1298,6 +1303,7 @@ mod tests {
                     id: "mutation-after-limit".into(),
                     name: Some("apply_patch".into()),
                     arguments: r#"{"patch":"private"}"#.into(),
+                    provider_metadata: Default::default(),
                 },
             )
             .await;
@@ -1337,6 +1343,7 @@ mod tests {
                         id: format!("read-{index}"),
                         name: Some("read_file".into()),
                         arguments: r#"{"path":"src/lib.rs"}"#.into(),
+                        provider_metadata: Default::default(),
                     },
                 )
                 .await;
@@ -1352,6 +1359,7 @@ mod tests {
                         id: "command-mutation-after-limit".into(),
                         name,
                         arguments: arguments.into(),
+                        provider_metadata: Default::default(),
                     },
                 )
                 .await;
@@ -1403,6 +1411,7 @@ mod tests {
                         id: format!("read-{index}"),
                         name: Some("read_file".into()),
                         arguments: r#"{"path":"src/lib.rs"}"#.into(),
+                        provider_metadata: Default::default(),
                     },
                 )
                 .await;
@@ -1423,6 +1432,7 @@ mod tests {
                         id: id.into(),
                         name,
                         arguments: arguments.into(),
+                        provider_metadata: Default::default(),
                     },
                 )
                 .await;
@@ -1470,6 +1480,7 @@ mod tests {
                         id: format!("unknown-{index}"),
                         name: Some("opaque_capability".into()),
                         arguments: r#"{}"#.into(),
+                        provider_metadata: Default::default(),
                     },
                 )
                 .await;
@@ -1482,6 +1493,7 @@ mod tests {
                         id: id.into(),
                         name: Some("exec_command".into()),
                         arguments: r#"{"cmd":"echo harmless"}"#.into(),
+                        provider_metadata: Default::default(),
                     },
                 )
                 .await;
@@ -1536,6 +1548,7 @@ mod tests {
                     id: "nested-command".into(),
                     name: Some("exec_command".into()),
                     arguments: arguments.into(),
+                    provider_metadata: Default::default(),
                 },
             )
             .await;
@@ -1583,6 +1596,7 @@ mod tests {
                         id: format!("unknown-{index}"),
                         name: Some("opaque_capability".into()),
                         arguments: r#"{}"#.into(),
+                        provider_metadata: Default::default(),
                     },
                 )
                 .await;
@@ -1598,6 +1612,7 @@ mod tests {
                         id: id.into(),
                         name,
                         arguments: arguments.into(),
+                        provider_metadata: Default::default(),
                     },
                 )
                 .await;
@@ -1715,6 +1730,7 @@ mod tests {
                     id: "unknown-large".into(),
                     name: Some("opaque_capability".into()),
                     arguments: "x".repeat(8_192),
+                    provider_metadata: Default::default(),
                 },
             )
             .await;
@@ -1725,6 +1741,7 @@ mod tests {
                     id: "mutation-after-bytes".into(),
                     name: Some("apply_patch".into()),
                     arguments: r#"{"patch":"private"}"#.into(),
+                    provider_metadata: Default::default(),
                 },
             )
             .await;
@@ -1771,6 +1788,7 @@ mod tests {
                     id: "unknown-large".into(),
                     name: Some("opaque_capability".into()),
                     arguments: "x".repeat(8_192),
+                    provider_metadata: Default::default(),
                 },
             )
             .await;
@@ -1786,6 +1804,7 @@ mod tests {
                         id: "command-mutation-after-bytes".into(),
                         name,
                         arguments: arguments.into(),
+                        provider_metadata: Default::default(),
                     },
                 )
                 .await;
@@ -1831,6 +1850,7 @@ mod tests {
                     id: "private-call".into(),
                     name: Some("exec_command".into()),
                     arguments: r#"{"cmd":"private-command"}"#.into(),
+                    provider_metadata: Default::default(),
                 },
             )
             .await;
@@ -1867,6 +1887,7 @@ mod tests {
                     id: "removed-terminal".into(),
                     name: Some("exec_command".into()),
                     arguments: r#"{"cmd":"private-command"}"#.into(),
+                    provider_metadata: Default::default(),
                 },
             )
             .await;
@@ -1922,6 +1943,7 @@ mod tests {
                     id: "call-a".into(),
                     name: Some("apply_patch".into()),
                     arguments: r#"{"patch":"private-a"}"#.into(),
+                    provider_metadata: Default::default(),
                 },
             ),
             (
@@ -1930,6 +1952,7 @@ mod tests {
                     id: "call-b".into(),
                     name: Some("read_file".into()),
                     arguments: r#"{"path":"private-b"}"#.into(),
+                    provider_metadata: Default::default(),
                 },
             ),
         ] {
@@ -2015,6 +2038,7 @@ mod tests {
                     id: "unknown-large".into(),
                     name: Some("opaque_capability".into()),
                     arguments: "x".repeat(8_192),
+                    provider_metadata: Default::default(),
                 },
             )
             .await;
@@ -2026,6 +2050,7 @@ mod tests {
                         id: "streamed-command".into(),
                         name: (index == 0).then(|| "exec_command".into()),
                         arguments: (*fragment).into(),
+                        provider_metadata: Default::default(),
                     },
                 )
                 .await;
@@ -2071,6 +2096,7 @@ mod tests {
                         id: format!("retained-{index}"),
                         name: Some("opaque_capability".into()),
                         arguments: r#"{}"#.into(),
+                        provider_metadata: Default::default(),
                     },
                 )
                 .await;
@@ -2086,6 +2112,7 @@ mod tests {
                         id: id.into(),
                         name: Some(name.into()),
                         arguments: arguments.into(),
+                        provider_metadata: Default::default(),
                     },
                 )
                 .await;

--- a/crates/bitrouter-providers/src/codex/mod.rs
+++ b/crates/bitrouter-providers/src/codex/mod.rs
@@ -663,6 +663,33 @@ mod tests {
 
     use super::*;
 
+    #[test]
+    fn routed_codex_input_tools_reach_the_subscription_backend() -> Result<()> {
+        use bitrouter_sdk::language_model::protocol::responses::ResponsesAdapter;
+        use bitrouter_sdk::language_model::protocol::{InboundAdapter, OutboundAdapter};
+
+        let declarations = serde_json::json!([{
+            "type": "namespace", "name": "functions", "tools": [{
+                "type": "custom", "name": "exec", "description": "Read workspace files",
+                "format": {"type": "text"}
+            }]
+        }]);
+        let adapter = ResponsesAdapter;
+        let prompt = adapter.parse_request(serde_json::json!({
+            "model": "m",
+            "input": [
+                {"type": "additional_tools", "role": "developer", "tools": declarations},
+                {"role": "user", "content": "Read README.md"}
+            ]
+        }))?;
+        let mut body = adapter.render_request(&prompt)?;
+        shape_codex_responses_body(&mut body);
+        assert_eq!(body["input"][0]["type"], "additional_tools");
+        assert_eq!(body["input"][0]["tools"], declarations);
+        assert_eq!(body["input"][1]["content"][0]["text"], "Read README.md");
+        Ok(())
+    }
+
     fn tmp_store_path() -> PathBuf {
         use std::sync::atomic::{AtomicU64, Ordering};
         static COUNTER: AtomicU64 = AtomicU64::new(0);

--- a/crates/bitrouter-sdk/src/language_model/executor.rs
+++ b/crates/bitrouter-sdk/src/language_model/executor.rs
@@ -1000,6 +1000,7 @@ impl HttpExecutor {
                     id,
                     name,
                     arguments,
+                    provider_metadata,
                 } => {
                     let index = match tool_indices.get(&id).copied() {
                         Some(index) => index,
@@ -1011,7 +1012,7 @@ impl HttpExecutor {
                                 arguments: String::new(),
                                 provider_executed: false,
                                 dynamic: false,
-                                provider_metadata: Default::default(),
+                                provider_metadata: provider_metadata.clone(),
                             });
                             tool_indices.insert(id, index);
                             index

--- a/crates/bitrouter-sdk/src/language_model/protocol/chat_completions.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/chat_completions.rs
@@ -1631,6 +1631,7 @@ impl StreamDecoder for ChatStreamDecoder {
                             id: self.tool_ids[idx].clone(),
                             name: name.map(|n| n.to_string()),
                             arguments: args.to_string(),
+                            provider_metadata: Default::default(),
                         });
                     }
                 }
@@ -1781,6 +1782,7 @@ impl StreamEncoder for ChatStreamEncoder {
                 id,
                 name,
                 arguments,
+                ..
             } => {
                 let index = self.tool_call_index(id);
                 let name = name.as_deref().filter(|n| !n.is_empty());

--- a/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/generate_content.rs
@@ -1561,6 +1561,7 @@ impl StreamDecoder for GenerateContentStreamDecoder {
                             id,
                             name: Some(name),
                             arguments,
+                            provider_metadata: Default::default(),
                         }),
                         Content::ToolResult { .. } => {}
                         // A generated file (e.g. an image) becomes one whole

--- a/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/messages.rs
@@ -2300,6 +2300,7 @@ impl StreamDecoder for MessagesStreamDecoder {
                             id: tool_id,
                             name,
                             arguments: String::new(),
+                            provider_metadata: Default::default(),
                         });
                     }
                 }
@@ -2337,6 +2338,7 @@ impl StreamDecoder for MessagesStreamDecoder {
                                 id,
                                 name: None,
                                 arguments: partial.to_string(),
+                                provider_metadata: Default::default(),
                             });
                         }
                     }
@@ -2878,6 +2880,7 @@ impl StreamEncoder for MessagesStreamEncoder {
                 id,
                 name,
                 arguments,
+                ..
             } => {
                 self.pending_reasoning = None;
                 if let Some(name) = name.as_deref().filter(|n| !n.is_empty()) {

--- a/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/responses.rs
@@ -324,9 +324,13 @@ fn observe_content(turn: &mut TurnAccumulator, content: &Content) {
             arguments,
             provider_executed,
             dynamic,
-            ..
+            provider_metadata,
         } => {
-            observe_tool_call(turn, id, name, arguments, *provider_executed, *dynamic);
+            if client_tool_metadata_present(provider_metadata) {
+                turn.invalidate();
+            } else {
+                observe_tool_call(turn, id, name, arguments, *provider_executed, *dynamic);
+            }
             return;
         }
         Content::File { .. }
@@ -404,14 +408,16 @@ fn terminal_assistant_turn_commitment(
                 let value = value.finish();
                 turn.add_part(2, std::slice::from_ref(&value), value.len > 0);
             }
-            "function_call" => observe_tool_call(
-                &mut turn,
-                item.get("call_id")?.as_str()?,
-                item.get("name")?.as_str()?,
-                item.get("arguments")?.as_str()?,
-                false,
-                false,
-            ),
+            "function_call" if item.get("namespace").is_none_or(serde_json::Value::is_null) => {
+                observe_tool_call(
+                    &mut turn,
+                    item.get("call_id")?.as_str()?,
+                    item.get("name")?.as_str()?,
+                    item.get("arguments")?.as_str()?,
+                    false,
+                    false,
+                )
+            }
             _ => return None,
         }
     }
@@ -455,8 +461,13 @@ fn observe_causal_content(turn: &mut TurnAccumulator, content: &Content) {
             call_id,
             output,
             dynamic,
+            provider_metadata,
             ..
         } => {
+            if client_tool_metadata_present(provider_metadata) {
+                turn.invalidate();
+                return;
+            }
             let (output_tag, output_value) = match output {
                 ToolResultOutput::Text { value } => ("text", value.as_str()),
                 ToolResultOutput::ErrorText { value } => ("error_text", value.as_str()),
@@ -788,7 +799,14 @@ impl StreamingAssistantTurnCommitment {
                 id,
                 name,
                 arguments,
-            } => self.observe_tool_delta(id, name.as_deref(), arguments),
+                provider_metadata,
+            } => {
+                if provider_metadata.is_empty() {
+                    self.observe_tool_delta(id, name.as_deref(), arguments);
+                } else {
+                    self.turn.invalidate();
+                }
+            }
             StreamPart::ServerToolCall {
                 id,
                 name,
@@ -1047,21 +1065,25 @@ mod assistant_turn_commitment_tests {
                 id: "call-a".into(),
                 name: Some("inspect".into()),
                 arguments: "{\"path\":\"".into(),
+                provider_metadata: Default::default(),
             },
             StreamPart::ToolCallDelta {
                 id: "call-b".into(),
                 name: Some("search".into()),
                 arguments: "{\"query\":\"".into(),
+                provider_metadata: Default::default(),
             },
             StreamPart::ToolCallDelta {
                 id: "call-a".into(),
                 name: None,
                 arguments: "src/\"}".into(),
+                provider_metadata: Default::default(),
             },
             StreamPart::ToolCallDelta {
                 id: "call-b".into(),
                 name: None,
                 arguments: "TODO\"}".into(),
+                provider_metadata: Default::default(),
             },
         ] {
             streamed.observe(&part);
@@ -1079,11 +1101,13 @@ mod assistant_turn_commitment_tests {
                 id: "call-1".into(),
                 name: Some("inspect".into()),
                 arguments: "{".into(),
+                provider_metadata: Default::default(),
             },
             StreamPart::ToolCallDelta {
                 id: "call-1".into(),
                 name: Some("inspect".into()),
                 arguments: "}".into(),
+                provider_metadata: Default::default(),
             },
         ] {
             streamed.observe(&part);
@@ -1100,6 +1124,7 @@ mod assistant_turn_commitment_tests {
                 id: format!("call-{index}"),
                 name: Some(format!("tool-{index}")),
                 arguments: "{}".into(),
+                provider_metadata: Default::default(),
             });
         }
         assert!(at_limit.finish().is_some());
@@ -1110,6 +1135,7 @@ mod assistant_turn_commitment_tests {
                 id: format!("call-{index}"),
                 name: Some(format!("tool-{index}")),
                 arguments: "{}".into(),
+                provider_metadata: Default::default(),
             });
         }
         assert_eq!(over_limit.finish(), None);
@@ -1791,6 +1817,61 @@ fn render_source_annotation(source: &Source) -> serde_json::Value {
     }
 }
 
+/// Preserve the wire identity of client tools across the canonical boundary.
+/// Custom tools take arbitrary text (`input`), and namespace-scoped calls must
+/// retain their namespace even when multiple scopes use the same tool name.
+fn client_tool_metadata(item: &serde_json::Value) -> ProviderMetadata {
+    let mut metadata = ProviderMetadata::new();
+    for key in ["namespace", "type"] {
+        if let Some(value) = item.get(key).filter(|value| value.is_string()) {
+            if key == "type"
+                && !matches!(
+                    value.as_str(),
+                    Some("custom_tool_call" | "custom_tool_call_output")
+                )
+            {
+                continue;
+            }
+            set_provider_metadata(&mut metadata, PROVIDER_ID_OPENAI, key, value.clone());
+        }
+    }
+    metadata
+}
+
+fn custom_call(metadata: &ProviderMetadata) -> bool {
+    provider_namespace(metadata, PROVIDER_ID_OPENAI)
+        .and_then(|fields| fields.get("type"))
+        .and_then(serde_json::Value::as_str)
+        == Some("custom_tool_call")
+}
+
+/// Continuation commitments currently bind ordinary function calls only.
+fn client_tool_metadata_present(metadata: &ProviderMetadata) -> bool {
+    provider_namespace(metadata, PROVIDER_ID_OPENAI)
+        .is_some_and(|fields| fields.contains_key("namespace") || fields.contains_key("type"))
+}
+
+fn client_call_item(
+    id: &str,
+    name: &str,
+    arguments: &str,
+    metadata: &ProviderMetadata,
+) -> serde_json::Value {
+    let custom = custom_call(metadata);
+    let mut item = serde_json::json!({
+        "type": if custom { "custom_tool_call" } else { "function_call" },
+        "call_id": id,
+        "name": name,
+        (if custom { "input" } else { "arguments" }): arguments,
+    });
+    if let Some(namespace) =
+        provider_namespace(metadata, PROVIDER_ID_OPENAI).and_then(|fields| fields.get("namespace"))
+    {
+        item["namespace"] = namespace.clone();
+    }
+    item
+}
+
 /// Parse the Responses `input` field — a string or a heterogeneous item array.
 /// Lenient by design (#454-3): item shapes that are not recognised are skipped,
 /// not rejected.
@@ -1810,7 +1891,7 @@ fn parse_input(value: &serde_json::Value) -> Result<Vec<Message>> {
                             messages.push(Message { role, content });
                         }
                     }
-                    Some("function_call") => {
+                    Some("function_call" | "custom_tool_call") => {
                         messages.push(Message {
                             role: Role::Assistant,
                             // tool calls are single-part assistant turns
@@ -1827,7 +1908,11 @@ fn parse_input(value: &serde_json::Value) -> Result<Vec<Message>> {
                                     .unwrap_or_default()
                                     .to_string(),
                                 arguments: item
-                                    .get("arguments")
+                                    .get(if item_type == Some("custom_tool_call") {
+                                        "input"
+                                    } else {
+                                        "arguments"
+                                    })
                                     .and_then(|a| a.as_str())
                                     .unwrap_or_default()
                                     .to_string(),
@@ -1839,7 +1924,7 @@ fn parse_input(value: &serde_json::Value) -> Result<Vec<Message>> {
                                 // …nor is it a provider-executed MCP (`dynamic`)
                                 // call (those arrive as `mcp_call` items).
                                 dynamic: false,
-                                provider_metadata: ProviderMetadata::new(),
+                                provider_metadata: client_tool_metadata(item),
                             }],
                         });
                     }
@@ -1849,7 +1934,7 @@ fn parse_input(value: &serde_json::Value) -> Result<Vec<Message>> {
                     // wire. A string → Text, a part array → Content, any other
                     // value → Json.
                     // <https://platform.openai.com/docs/api-reference/responses/create>
-                    Some("function_call_output") => {
+                    Some("function_call_output" | "custom_tool_call_output") => {
                         let output = item
                             .get("output")
                             .map(parse_responses_tool_output)
@@ -1869,7 +1954,7 @@ fn parse_input(value: &serde_json::Value) -> Result<Vec<Message>> {
                                 // A `function_call_output` is a plain client
                                 // tool-result item, never an inline MCP result.
                                 dynamic: false,
-                                provider_metadata: ProviderMetadata::new(),
+                                provider_metadata: client_tool_metadata(item),
                             }],
                         });
                     }
@@ -2075,11 +2160,29 @@ impl InboundAdapter for ResponsesAdapter {
         // tool whose config keys ride in `extra` and are preserved verbatim under
         // an `openai.<type>` id.
         // <https://platform.openai.com/docs/api-reference/responses/create#responses-create-tools>
-        let tools = req
+        let mut tools: Vec<_> = req
             .tools
             .into_iter()
             .filter_map(parse_responses_tool)
             .collect();
+        // Recent Codex clients send local tool declarations as developer
+        // `additional_tools` input items instead of the top-level array. They
+        // are declarations, not messages; promote them through the same tool
+        // parser so namespace names and nested custom-tool schemas survive.
+        if let Some(items) = req.input.as_array() {
+            for item in items {
+                if item.get("type").and_then(serde_json::Value::as_str) != Some("additional_tools")
+                {
+                    continue;
+                }
+                let definitions = item.get("tools").cloned().unwrap_or_default();
+                let declarations: Vec<ResponsesTool> = serde_json::from_value(definitions.clone())
+                    .map_err(|error| {
+                        describe_deser_error("additional_tools.tools", &error, &definitions)
+                    })?;
+                tools.extend(declarations.into_iter().filter_map(parse_responses_tool));
+            }
+        }
 
         // `text` is a typed field. Promote `text.format: json_schema` into the
         // canonical slot; other formats and sibling keys (e.g. `verbosity`)
@@ -2362,7 +2465,7 @@ impl OutboundAdapter for ResponsesAdapter {
                         });
                     }
                 }
-                Some("function_call") => {
+                Some("function_call" | "custom_tool_call") => {
                     content.push(Content::ToolCall {
                         id: item
                             .get("call_id")
@@ -2375,14 +2478,22 @@ impl OutboundAdapter for ResponsesAdapter {
                             .unwrap_or_default()
                             .to_string(),
                         arguments: item
-                            .get("arguments")
+                            .get(
+                                if item.get("type").and_then(serde_json::Value::as_str)
+                                    == Some("custom_tool_call")
+                                {
+                                    "input"
+                                } else {
+                                    "arguments"
+                                },
+                            )
                             .and_then(|a| a.as_str())
                             .unwrap_or_default()
                             .to_string(),
                         // A `function_call` output item is a client tool call.
                         provider_executed: false,
                         dynamic: false,
-                        provider_metadata: ProviderMetadata::new(),
+                        provider_metadata: client_tool_metadata(item),
                     });
                 }
                 // OpenAI Responses built-in (server-side) tools surface as their
@@ -2823,6 +2934,7 @@ fn render_message_items(m: &Message) -> Vec<serde_json::Value> {
                 name,
                 arguments,
                 provider_executed,
+                provider_metadata,
                 ..
             } => {
                 // A provider-executed server-tool call is NOT re-sent as a client
@@ -2841,12 +2953,7 @@ fn render_message_items(m: &Message) -> Vec<serde_json::Value> {
                     {
                         items.push(item);
                     } else {
-                        items.push(serde_json::json!({
-                            "type": "function_call",
-                            "call_id": id,
-                            "name": name,
-                            "arguments": arguments,
-                        }));
+                        items.push(client_call_item(id, name, arguments, provider_metadata));
                     }
                 }
             }
@@ -2920,7 +3027,9 @@ fn render_message_items(m: &Message) -> Vec<serde_json::Value> {
                 if !*dynamic && !denial_paired_with_approval {
                     let output_value = render_responses_tool_output(output);
                     items.push(serde_json::json!({
-                        "type": "function_call_output",
+                        "type": if provider_namespace(provider_metadata, PROVIDER_ID_OPENAI)
+                            .and_then(|fields| fields.get("type")).and_then(serde_json::Value::as_str)
+                            == Some("custom_tool_call_output") { "custom_tool_call_output" } else { "function_call_output" },
                         "call_id": call_id,
                         "output": output_value,
                     }));
@@ -3143,6 +3252,7 @@ fn render_output_items(result: &GenerateResult) -> Vec<serde_json::Value> {
             arguments,
             provider_executed,
             dynamic,
+            provider_metadata,
             ..
         } = c
         {
@@ -3219,12 +3329,7 @@ fn render_output_items(result: &GenerateResult) -> Vec<serde_json::Value> {
                 // result was not paired (handled above): both render as a valid
                 // `function_call` item. The MCP tool name keeps its `mcp.` prefix
                 // so a downstream consumer can still recover the bare tool name.
-                items.push(serde_json::json!({
-                    "type": "function_call",
-                    "call_id": id,
-                    "name": name,
-                    "arguments": arguments,
-                }));
+                items.push(client_call_item(id, name, arguments, provider_metadata));
             }
         }
     }
@@ -3497,7 +3602,7 @@ impl StreamDecoder for ResponsesStreamDecoder {
                         // upstream omitted it (used only for marker correlation).
                         "message" => parts.push(StreamPart::TextStart { id: item_id }),
                         "reasoning" => parts.push(StreamPart::ReasoningStart { id: item_id }),
-                        "function_call" => {
+                        "function_call" | "custom_tool_call" => {
                             // A function-call item frames itself via the
                             // `name`-bearing `ToolCallDelta` below — no separate
                             // start marker (see the `StreamPart` enum docs).
@@ -3525,6 +3630,7 @@ impl StreamDecoder for ResponsesStreamDecoder {
                                 id: call_id,
                                 name: Some(name),
                                 arguments: String::new(),
+                                provider_metadata: client_tool_metadata(item),
                             });
                         }
                         // Streaming MCP gap: a streamed `mcp_call` item (a
@@ -3576,7 +3682,7 @@ impl StreamDecoder for ResponsesStreamDecoder {
                     });
                 }
             }
-            "response.function_call_arguments.delta" => {
+            "response.function_call_arguments.delta" | "response.custom_tool_call_input.delta" => {
                 // map item_id → call_id (#434); emit a single arguments delta
                 let item_id = json
                     .get("item_id")
@@ -3589,12 +3695,13 @@ impl StreamDecoder for ResponsesStreamDecoder {
                         id: call_id,
                         name: None,
                         arguments: delta.to_string(),
+                        provider_metadata: Default::default(),
                     });
                 }
             }
             // the `.done` event repeats the full arguments — do NOT re-emit
             // them (would duplicate, #434).
-            "response.function_call_arguments.done" => {}
+            "response.function_call_arguments.done" | "response.custom_tool_call_input.done" => {}
             "response.output_item.done" => {
                 // Close the matching text / reasoning block so the boundary
                 // survives re-encoding (the merged-block fix). A `function_call`
@@ -3835,6 +3942,7 @@ struct ToolItemState {
     tool_name: String,
     /// Accumulated argument JSON fragments.
     accumulated_args: String,
+    provider_metadata: ProviderMetadata,
 }
 
 impl ResponsesStreamEncoder {
@@ -4076,26 +4184,26 @@ impl ResponsesStreamEncoder {
         self.open_text_item(frames);
     }
 
-    /// Open a function-call item: `output_item.added` (type=function_call).
-    /// Closes any other open item first. Idempotent for the same call.
-    fn open_tool_item(&mut self, frames: &mut Vec<SseFrame>, call_id: &str, name: &str) {
+    /// Open a client tool item, preserving its type and namespace.
+    fn open_tool_item(
+        &mut self,
+        frames: &mut Vec<SseFrame>,
+        call_id: &str,
+        name: &str,
+        metadata: &ProviderMetadata,
+    ) {
         self.close_reasoning_item(frames);
         self.close_text_item(frames);
         self.close_tool_item(frames);
         let output_index = self.allocate_output_index();
         let item_id = format!("fc_{}", uuid::Uuid::new_v4());
+        let mut item = client_call_item(call_id, name, "", metadata);
+        item["id"] = item_id.clone().into();
+        item["status"] = "in_progress".into();
         frames.push(self.ev(
             "response.output_item.added",
             serde_json::json!({
-                "output_index": output_index,
-                "item": {
-                    "type": "function_call",
-                    "id": item_id,
-                    "call_id": call_id,
-                    "name": name,
-                    "arguments": "",
-                    "status": "in_progress",
-                },
+                "output_index": output_index, "item": item,
             }),
         ));
         self.tool_item = Some(ToolItemState {
@@ -4104,37 +4212,38 @@ impl ResponsesStreamEncoder {
             output_index,
             tool_name: name.to_string(),
             accumulated_args: String::new(),
+            provider_metadata: metadata.clone(),
         });
     }
 
-    /// Close the open function-call item, if any:
-    /// `function_call_arguments.done` + `output_item.done`.
     fn close_tool_item(&mut self, frames: &mut Vec<SseFrame>) {
         let Some(state) = self.tool_item.take() else {
             return;
         };
-        let final_args = state.accumulated_args;
+        let custom = custom_call(&state.provider_metadata);
         frames.push(self.ev(
-            "response.function_call_arguments.done",
+            if custom {
+                "response.custom_tool_call_input.done"
+            } else {
+                "response.function_call_arguments.done"
+            },
             serde_json::json!({
-                "item_id": state.item_id,
-                "output_index": state.output_index,
-                "arguments": final_args,
+                "item_id": state.item_id, "output_index": state.output_index,
+                (if custom { "input" } else { "arguments" }): state.accumulated_args,
             }),
         ));
-        let item = serde_json::json!({
-            "type": "function_call",
-            "id": state.item_id,
-            "call_id": state.call_id,
-            "name": state.tool_name,
-            "arguments": final_args,
-            "status": "completed",
-        });
+        let mut item = client_call_item(
+            &state.call_id,
+            &state.tool_name,
+            &state.accumulated_args,
+            &state.provider_metadata,
+        );
+        item["id"] = state.item_id.into();
+        item["status"] = "completed".into();
         frames.push(self.ev(
             "response.output_item.done",
             serde_json::json!({
-                "output_index": state.output_index,
-                "item": item.clone(),
+                "output_index": state.output_index, "item": item.clone(),
             }),
         ));
         self.completed_items.push(item);
@@ -4245,6 +4354,7 @@ impl StreamEncoder for ResponsesStreamEncoder {
                 id,
                 name,
                 arguments,
+                provider_metadata,
             } => {
                 // A delta carrying a *non-empty* `name` starts a new
                 // function-call item. `open_tool_item` closes any previously-open
@@ -4256,7 +4366,7 @@ impl StreamEncoder for ResponsesStreamEncoder {
                 // (empty name + partial args) — which Codex rejects as
                 // "unsupported call" / unparsable arguments.
                 if let Some(name) = name.as_deref().filter(|n| !n.is_empty()) {
-                    self.open_tool_item(&mut frames, id, name);
+                    self.open_tool_item(&mut frames, id, name, provider_metadata);
                 }
                 if !arguments.is_empty() {
                     // Append to the in-flight tool item. If a stray
@@ -4264,13 +4374,20 @@ impl StreamEncoder for ResponsesStreamEncoder {
                     // upstream omitted the name), open one with an empty
                     // name rather than dropping the delta.
                     if self.tool_item.is_none() {
-                        self.open_tool_item(&mut frames, id, "");
+                        self.open_tool_item(&mut frames, id, "", provider_metadata);
                     }
-                    let state = self.tool_item.as_mut().expect("tool item just opened");
+                    let Some(state) = self.tool_item.as_mut() else {
+                        return Ok(frames);
+                    };
                     state.accumulated_args.push_str(arguments);
                     let (item_id, output_index) = (state.item_id.clone(), state.output_index);
+                    let custom = custom_call(&state.provider_metadata);
                     frames.push(self.ev(
-                        "response.function_call_arguments.delta",
+                        if custom {
+                            "response.custom_tool_call_input.delta"
+                        } else {
+                            "response.function_call_arguments.delta"
+                        },
                         serde_json::json!({
                             "item_id": item_id,
                             "output_index": output_index,

--- a/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/protocol/tests.rs
@@ -703,6 +703,7 @@ fn conversion_matrix_4x4_streaming() {
             id: "call_9".to_string(),
             name: Some("calc".to_string()),
             arguments: "{\"x\":1}".to_string(),
+            provider_metadata: Default::default(),
         },
         StreamPart::Usage {
             usage: Usage {
@@ -2814,6 +2815,7 @@ fn messages_stream_encoder_closes_block_on_kind_transition() {
             id: "t1".into(),
             name: Some("calc".into()),
             arguments: "{}".into(),
+            provider_metadata: Default::default(),
         },
     ];
     let mut events: Vec<String> = Vec::new();
@@ -3458,11 +3460,13 @@ fn tool_call_streaming_still_frames_distinctly_with_markers_present() {
             id: "call_a".into(),
             name: Some("first".into()),
             arguments: "{}".into(),
+            provider_metadata: Default::default(),
         },
         StreamPart::ToolCallDelta {
             id: "call_b".into(),
             name: Some("second".into()),
             arguments: "{}".into(),
+            provider_metadata: Default::default(),
         },
         StreamPart::Finish {
             reason: FinishReason::Stop,
@@ -4873,6 +4877,7 @@ fn responses_stream_tool_call_lifecycle() {
                 id: "call_1".to_string(),
                 name: Some("shell".to_string()),
                 arguments: "{\"cmd\":".to_string(),
+                provider_metadata: Default::default(),
             })
             .unwrap(),
     );
@@ -4882,6 +4887,7 @@ fn responses_stream_tool_call_lifecycle() {
                 id: "call_1".to_string(),
                 name: None,
                 arguments: "\"ls\"}".to_string(),
+                provider_metadata: Default::default(),
             })
             .unwrap(),
     );
@@ -11720,16 +11726,19 @@ fn responses_encoder_treats_empty_name_delta_as_continuation() {
             id: id.clone(),
             name: Some("exec_command".into()),
             arguments: "".into(),
+            provider_metadata: Default::default(),
         },
         StreamPart::ToolCallDelta {
             id: id.clone(),
             name: Some("".into()),
             arguments: "{\"cmd\":\"".into(),
+            provider_metadata: Default::default(),
         },
         StreamPart::ToolCallDelta {
             id: id.clone(),
             name: Some("".into()),
             arguments: "ls\"}".into(),
+            provider_metadata: Default::default(),
         },
         StreamPart::Finish {
             reason: FinishReason::ToolCalls,
@@ -11839,16 +11848,19 @@ fn messages_encoder_treats_empty_name_delta_as_continuation() {
             id: id.clone(),
             name: Some("exec_command".into()),
             arguments: "".into(),
+            provider_metadata: Default::default(),
         },
         StreamPart::ToolCallDelta {
             id: id.clone(),
             name: Some("".into()),
             arguments: "{\"cmd\":\"".into(),
+            provider_metadata: Default::default(),
         },
         StreamPart::ToolCallDelta {
             id: id.clone(),
             name: Some("".into()),
             arguments: "ls\"}".into(),
+            provider_metadata: Default::default(),
         },
         StreamPart::Finish {
             reason: FinishReason::ToolCalls,
@@ -11906,16 +11918,19 @@ fn gemini_encode_fragmented_args_single_function_call() {
             id: id.clone(),
             name: Some("exec_command".into()),
             arguments: "".into(),
+            provider_metadata: Default::default(),
         },
         StreamPart::ToolCallDelta {
             id: id.clone(),
             name: None,
             arguments: "{\"cmd\":".into(),
+            provider_metadata: Default::default(),
         },
         StreamPart::ToolCallDelta {
             id: id.clone(),
             name: None,
             arguments: "\"ls\"}".into(),
+            provider_metadata: Default::default(),
         },
         StreamPart::Finish {
             reason: FinishReason::ToolCalls,
@@ -11958,11 +11973,13 @@ fn gemini_encode_two_tool_calls_emit_two_function_calls() {
             id: "a".into(),
             name: Some("first".into()),
             arguments: "{\"x\":1}".into(),
+            provider_metadata: Default::default(),
         },
         StreamPart::ToolCallDelta {
             id: "b".into(),
             name: Some("second".into()),
             arguments: "{\"y\":2}".into(),
+            provider_metadata: Default::default(),
         },
         StreamPart::Finish {
             reason: FinishReason::ToolCalls,
@@ -12140,4 +12157,112 @@ fn coarse_wires_drop_server_tool_activity() {
             "coarse wire {proto:?} must drop server-tool activity: {events:?}"
         );
     }
+}
+
+#[test]
+fn responses_additional_tools_preserve_namespaces_and_custom_grammars() -> crate::Result<()> {
+    let tools = serde_json::json!([{
+        "type": "namespace", "name": "functions", "description": "Workspace tools",
+        "tools": [
+            {"type": "custom", "name": "exec", "format": {"type": "grammar", "syntax": "lark", "definition": "start: /.+/"}},
+            {"type": "function", "name": "read_file", "parameters": {"type": "object", "properties": {"path": {"type": "string"}}}}
+        ]
+    }]);
+    let adapter = adapter_for(ApiProtocol::Responses);
+    let prompt = adapter.parse_request(serde_json::json!({
+        "model": "m", "input": [
+            {"type": "additional_tools", "id": "tools-1", "role": "developer", "tools": tools},
+            {"role": "user", "content": "Read README.md"}
+        ]
+    }))?;
+    assert_eq!(prompt.messages.len(), 1);
+    assert_eq!(adapter.render_request(&prompt)?["tools"], tools);
+    assert!(
+        adapter
+            .parse_request(serde_json::json!({
+                "input": [{"type": "additional_tools", "tools": "invalid"}]
+            }))
+            .is_err(),
+        "malformed declarations must not silently disable tools"
+    );
+    Ok(())
+}
+
+#[test]
+fn responses_custom_tool_calls_and_results_round_trip() -> crate::Result<()> {
+    let adapter = adapter_for(ApiProtocol::Responses);
+    for (kind, field, arguments) in [
+        (
+            "custom_tool_call",
+            "input",
+            "text(await tools.read_file({path: 'README.md'}));",
+        ),
+        ("function_call", "arguments", r#"{"path":"README.md"}"#),
+    ] {
+        let call = serde_json::json!({"type": kind, "call_id": "c1", "namespace": "functions", "name": "read", (field): arguments});
+        let result = serde_json::json!({"type": if kind == "custom_tool_call" {"custom_tool_call_output"} else {"function_call_output"}, "call_id": "c1", "output": "Fixture contents"});
+        let prompt =
+            adapter.parse_request(serde_json::json!({"model":"m", "input":[call, result]}))?;
+        assert_eq!(
+            adapter.render_request(&prompt)?["input"],
+            serde_json::json!([call, result])
+        );
+        let parsed = adapter.parse_response(
+            serde_json::json!({"id":"r1", "status":"completed", "output":[call]}),
+        )?;
+        let rendered = adapter.render_response(&parsed, &prompt, "r1")?;
+        assert_eq!(rendered["output"][0], call);
+    }
+    Ok(())
+}
+
+#[test]
+fn responses_custom_tool_stream_preserves_type_namespace_and_text() -> crate::Result<()> {
+    let adapter = adapter_for(ApiProtocol::Responses);
+    let mut decoder = adapter.stream_decoder();
+    let mut encoder = adapter.stream_encoder("r1", "m");
+    let mut frames = Vec::new();
+    for event in [
+        serde_json::json!({"type":"response.output_item.added", "output_index":0, "item":{"id":"custom1", "type":"custom_tool_call", "call_id":"c1", "namespace":"functions", "name":"exec", "input":""}}),
+        serde_json::json!({"type":"response.custom_tool_call_input.delta", "item_id":"custom1", "delta":"const path = 'README.md';\n"}),
+        serde_json::json!({"type":"response.custom_tool_call_input.delta", "item_id":"custom1", "delta":"text(await tools.read_file({path}));"}),
+    ] {
+        for part in decoder.decode(&SseEvent {
+            event: None,
+            data: event.to_string(),
+        })? {
+            frames.extend(encoder.encode(&part)?);
+        }
+    }
+    frames.extend(encoder.encode(&StreamPart::Finish {
+        reason: FinishReason::Stop,
+    })?);
+    let mut completed = None;
+    let mut delta_count = 0;
+    for frame in frames {
+        if let SseFrame::Event { event, data } = frame {
+            let value: serde_json::Value = serde_json::from_str(&data)
+                .map_err(|e| crate::BitrouterError::internal(e.to_string()))?;
+            if event.as_deref() == Some("response.custom_tool_call_input.delta") {
+                delta_count += 1;
+            }
+            if event.as_deref() == Some("response.completed") {
+                completed = Some(value);
+            }
+        }
+    }
+    let completed =
+        completed.ok_or_else(|| crate::BitrouterError::internal("missing completion"))?;
+    let item = &completed["response"]["output"][0];
+    assert_eq!(delta_count, 2);
+    assert_eq!(item["type"], "custom_tool_call");
+    assert_eq!(item["namespace"], "functions");
+    assert_eq!(item["name"], "exec");
+    assert_eq!(item["call_id"], "c1");
+    assert_eq!(
+        item["input"],
+        "const path = 'README.md';\ntext(await tools.read_file({path}));"
+    );
+    assert!(item.get("arguments").is_none());
+    Ok(())
 }

--- a/crates/bitrouter-sdk/src/language_model/server_tools/stream.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/stream.rs
@@ -36,6 +36,7 @@ struct BufferedCall {
     id: String,
     name: String,
     args: String,
+    provider_metadata: ProviderMetadata,
 }
 
 impl ServerToolLoop {
@@ -127,17 +128,20 @@ impl ServerToolLoop {
                             id,
                             name,
                             arguments,
+                            provider_metadata,
                         } => match buffered.iter_mut().find(|b| b.id == id) {
                             Some(b) => {
                                 if let Some(n) = name.as_deref().filter(|n| !n.is_empty()) {
                                     b.name = n.to_string();
                                 }
                                 b.args.push_str(&arguments);
+                                b.provider_metadata.extend(provider_metadata);
                             }
                             None => buffered.push(BufferedCall {
                                 id,
                                 name: name.unwrap_or_default(),
                                 args: arguments,
+                                provider_metadata,
                             }),
                         },
                         StreamPart::TextDelta { text } => {
@@ -158,10 +162,10 @@ impl ServerToolLoop {
                 // force a spurious hand-back of an empty-named tool call.
                 buffered.retain(|b| !b.name.is_empty());
 
-                let has_client = buffered.iter().any(|b| !owned.contains(&b.name));
+                let has_client = buffered.iter().any(|b| !owned.contains(&b.name) || !b.provider_metadata.is_empty());
                 let router: Vec<RouterCall> = buffered
                     .iter()
-                    .filter(|b| owned.contains(&b.name))
+                    .filter(|b| owned.contains(&b.name) && b.provider_metadata.is_empty())
                     .map(|b| RouterCall {
                         id: b.id.clone(),
                         name: b.name.clone(),
@@ -178,6 +182,7 @@ impl ServerToolLoop {
                                 id: b.id.clone(),
                                 name: Some(b.name.clone()),
                                 arguments: b.args.clone(),
+                                provider_metadata: b.provider_metadata.clone(),
                             });
                         }
                     }
@@ -374,6 +379,7 @@ mod tests {
                         id: "c1".into(),
                         name: Some("search".into()),
                         arguments: "{}".into(),
+                        provider_metadata: Default::default(),
                     },
                     StreamPart::Finish {
                         reason: FinishReason::ToolCalls,
@@ -479,6 +485,7 @@ mod tests {
                     id: "c1".into(),
                     name: Some("search".into()),
                     arguments: "{}".into(),
+                    provider_metadata: Default::default(),
                 },
                 StreamPart::Finish {
                     reason: FinishReason::ToolCalls,
@@ -547,6 +554,7 @@ mod tests {
                 id: "x".into(),
                 name: Some("client_fn".into()),
                 arguments: "{}".into(),
+                provider_metadata: Default::default(),
             },
             StreamPart::Finish {
                 reason: FinishReason::ToolCalls,
@@ -696,6 +704,7 @@ mod tests {
                     id: "c1".into(),
                     name: Some("search".into()),
                     arguments: "{}".into(),
+                    provider_metadata: Default::default(),
                 },
                 StreamPart::Finish {
                     reason: FinishReason::ToolCalls,

--- a/crates/bitrouter-sdk/src/language_model/tests.rs
+++ b/crates/bitrouter-sdk/src/language_model/tests.rs
@@ -1971,6 +1971,7 @@ async fn streamed_settlement_carries_finish_reason() {
                 id: "call-1".into(),
                 name: Some("lookup".into()),
                 arguments: "{}".into(),
+                provider_metadata: Default::default(),
             },
             StreamPart::Finish {
                 reason: FinishReason::ToolCalls,
@@ -2081,6 +2082,7 @@ async fn streamed_hook_abort_finalizes_timing_before_settlement() {
                 id: "call-1".into(),
                 name: Some("lookup".into()),
                 arguments: "{}".into(),
+                provider_metadata: Default::default(),
             },
             StreamPart::TextDelta {
                 text: "blocked".into(),
@@ -3971,6 +3973,7 @@ async fn server_tool_streaming_settles_the_final_turn_winner()
                     id: "c1".into(),
                     name: Some("search".into()),
                     arguments: "{}".into(),
+                    provider_metadata: Default::default(),
                 },
                 StreamPart::Finish {
                     reason: FinishReason::ToolCalls,
@@ -4256,6 +4259,7 @@ async fn server_tool_loop_streams_router_tool_activity() {
                 id: "c1".to_string(),
                 name: Some("search".to_string()),
                 arguments: "{}".to_string(),
+                provider_metadata: Default::default(),
             },
             StreamPart::Finish {
                 reason: FinishReason::ToolCalls,

--- a/crates/bitrouter-sdk/src/language_model/timing.rs
+++ b/crates/bitrouter-sdk/src/language_model/timing.rs
@@ -101,6 +101,7 @@ mod tests {
                 id: "call-1".into(),
                 name: None,
                 arguments: String::new(),
+                provider_metadata: Default::default(),
             },
         ];
 

--- a/crates/bitrouter-sdk/src/language_model/types.rs
+++ b/crates/bitrouter-sdk/src/language_model/types.rs
@@ -2023,6 +2023,10 @@ pub enum StreamPart {
         name: Option<String>,
         /// Arguments fragment.
         arguments: String,
+        /// Source-native call type and namespace, sent with the opening delta.
+        /// Responses custom tools use plain text input instead of JSON arguments.
+        #[serde(default, skip_serializing_if = "std::collections::BTreeMap::is_empty")]
+        provider_metadata: ProviderMetadata,
     },
     /// A complete **provider/router-executed** tool call, emitted whole (not as
     /// [`Self::ToolCallDelta`] fragments). The server-side tool loop emits this

--- a/crates/bitrouter-telemetry/src/otel/exporter.rs
+++ b/crates/bitrouter-telemetry/src/otel/exporter.rs
@@ -3078,6 +3078,7 @@ mod hop_tests {
                         id: "call-1".into(),
                         name: Some("get_weather".into()),
                         arguments: String::new(),
+                        provider_metadata: Default::default(),
                     },
                     StreamPart::Finish {
                         reason: FinishReason::Stop,


### PR DESCRIPTION
Recent Codex clients declare local tools in `additional_tools` input items and use custom, namespace-scoped calls. Responses normalization dropped those declarations and custom calls, so routed ACP sessions reported that filesystem tools were unavailable or stopped before executing them.

Preserve these declarations and their schemas, along with call type, namespace, arbitrary text input, results, and streaming events across the Responses pipeline. Carry source metadata through stream collection and tool handback; keep scoped client tools out of router-owned execution and exclude unsupported identities from continuation commitments.

Validation:
- 3,127 tests passed; 11 skipped with all features.
- Strict Clippy across all features and targets, formatting, doctests, and generated-distribution checks passed.
- Regression tests cover declarations, custom and namespaced call/result round trips, streaming events, and the Codex subscription request boundary.
- Installed-release smoke test: bare `bitrouter` opens the unified TUI with local Codex 0.153.4 via codex-acp 1.10.0, executes filesystem reads of two fixture files, reports a hidden random marker, and recalls it on the next turn. User configuration and terminal state are preserved.
