### PR TITLE
fix(sdk): deduplicate server-tool stream usage

### DIFF
--- a/crates/bitrouter-sdk/src/language_model/server_tools/stream.rs
+++ b/crates/bitrouter-sdk/src/language_model/server_tools/stream.rs
@@ -17,6 +17,7 @@ use super::loop_controller::{ServerToolLoop, add_usage};
 use super::toolset::ToolContext;
 use crate::error::Result;
 use crate::language_model::executor::StreamPartStream;
+use crate::language_model::stream::UsageAccumulator;
 use crate::language_model::types::{
     Content, FinishReason, Message, Prompt, ProviderMetadata, Role, StreamPart, Usage,
 };
@@ -82,9 +83,14 @@ impl ServerToolLoop {
                 let mut assistant_text = String::new();
                 let mut finish: Option<FinishReason> = None;
                 let mut response_completion = None;
+                let mut turn_usage = UsageAccumulator::default();
 
                 // Forward narration in real time; buffer tool-call deltas;
-                // accumulate usage; capture (but suppress) the terminal.
+                // select one cumulative usage snapshot for this upstream turn;
+                // capture (but suppress) the terminal. Providers may repeat a
+                // cumulative snapshot on every chunk, so summing here would
+                // multiply one request's usage. Cross-turn totals are added
+                // only after this upstream stream ends.
                 while let Some(item) = upstream_stream.next().await {
                     let part = match item {
                         Ok(p) => p,
@@ -95,8 +101,7 @@ impl ServerToolLoop {
                     };
                     match part {
                         StreamPart::Usage { usage } => {
-                            add_usage(&mut total, &usage);
-                            had_usage = true;
+                            turn_usage.observe(&StreamPart::Usage { usage });
                         }
                         StreamPart::Finish { reason } => finish = Some(reason),
                         StreamPart::ResponseCompleted {
@@ -110,8 +115,7 @@ impl ServerToolLoop {
                             // a standalone `Usage` part), so it must be folded in
                             // or the loop under-bills a Responses upstream.
                             if let Some(u) = usage {
-                                add_usage(&mut total, &u);
-                                had_usage = true;
+                                turn_usage.observe(&StreamPart::Usage { usage: u });
                             }
                             if finish.is_none() {
                                 finish = Some(FinishReason::Stop);
@@ -142,6 +146,11 @@ impl ServerToolLoop {
                         }
                         other => yield Ok(other),
                     }
+                }
+
+                if let Some(usage) = turn_usage.finalized() {
+                    add_usage(&mut total, &usage);
+                    had_usage = true;
                 }
 
                 // Drop malformed calls whose name never arrived — they are
@@ -614,5 +623,125 @@ mod tests {
             .expect("a consolidated Usage part is emitted");
         assert_eq!(usage.prompt_tokens, 7);
         assert_eq!(usage.completion_tokens, 3);
+    }
+
+    #[tokio::test]
+    async fn deduplicates_cumulative_usage_within_one_upstream_turn() {
+        // Some OpenAI-compatible providers emit a cumulative usage snapshot
+        // with the finish chunk and then an enriched trailing snapshot. The
+        // server-tool stitcher must select one snapshot for this turn, while
+        // retaining details that exist only on the authoritative final frame.
+        let scripts = vec![vec![
+            StreamPart::Usage {
+                usage: Usage {
+                    prompt_tokens: 5_140,
+                    completion_tokens: 61,
+                    ..Default::default()
+                },
+            },
+            StreamPart::Usage {
+                usage: Usage {
+                    prompt_tokens: 5_140,
+                    completion_tokens: 61,
+                    cache_read_tokens: 4_608,
+                    ..Default::default()
+                },
+            },
+            StreamPart::Finish {
+                reason: FinishReason::Stop,
+            },
+        ]];
+        let upstream = Arc::new(ScriptedStream {
+            scripts: Mutex::new(scripts.into()),
+        });
+        let parts = collect(
+            loop_()
+                .run_stream(&base_prompt(), &tool_ctx(), upstream)
+                .await
+                .unwrap(),
+        )
+        .await;
+
+        let usage = parts
+            .iter()
+            .find_map(|part| match part {
+                StreamPart::Usage { usage } => Some(usage),
+                _ => None,
+            })
+            .expect("one consolidated usage part is emitted");
+        assert_eq!(usage.prompt_tokens, 5_140);
+        assert_eq!(usage.completion_tokens, 61);
+        assert_eq!(usage.cache_read_tokens, 4_608);
+    }
+
+    #[tokio::test]
+    async fn sums_selected_usage_across_real_tool_rounds() {
+        let scripts = vec![
+            vec![
+                StreamPart::Usage {
+                    usage: Usage {
+                        prompt_tokens: 10,
+                        completion_tokens: 2,
+                        ..Default::default()
+                    },
+                },
+                StreamPart::Usage {
+                    usage: Usage {
+                        prompt_tokens: 10,
+                        completion_tokens: 3,
+                        ..Default::default()
+                    },
+                },
+                StreamPart::ToolCallDelta {
+                    id: "c1".into(),
+                    name: Some("search".into()),
+                    arguments: "{}".into(),
+                },
+                StreamPart::Finish {
+                    reason: FinishReason::ToolCalls,
+                },
+            ],
+            vec![
+                StreamPart::Usage {
+                    usage: Usage {
+                        prompt_tokens: 20,
+                        completion_tokens: 4,
+                        ..Default::default()
+                    },
+                },
+                StreamPart::Usage {
+                    usage: Usage {
+                        prompt_tokens: 20,
+                        completion_tokens: 5,
+                        cache_read_tokens: 8,
+                        ..Default::default()
+                    },
+                },
+                StreamPart::Finish {
+                    reason: FinishReason::Stop,
+                },
+            ],
+        ];
+        let upstream = Arc::new(ScriptedStream {
+            scripts: Mutex::new(scripts.into()),
+        });
+        let parts = collect(
+            loop_()
+                .run_stream(&base_prompt(), &tool_ctx(), upstream)
+                .await
+                .unwrap(),
+        )
+        .await;
+
+        let usage = parts
+            .iter()
+            .find_map(|part| match part {
+                StreamPart::Usage { usage } => Some(usage),
+                _ => None,
+            })
+            .expect("one cross-round usage total is emitted");
+        assert_eq!(usage.prompt_tokens, 30);
+        assert_eq!(usage.completion_tokens, 8);
+        assert_eq!(usage.cache_read_tokens, 8);
     }
 }


### PR DESCRIPTION
## Summary
- select one cumulative usage snapshot per upstream stream turn
- keep summation only across genuine server-tool rounds
- preserve final cache details from enriched trailing usage frames

## Validation
- `cargo test -p bitrouter-sdk --all-features`
- `cargo clippy -p bitrouter-sdk --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- production reproduction: Tinfoil/Kimi emits cumulative usage on many stream chunks; current server-tool stitcher doubles the finish and trailing snapshots