### PR TITLE
feat(tui): improve scrollback and transcript rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -829,6 +829,7 @@ dependencies = [
  "ratatui",
  "serde_json",
  "similar",
+ "unicode-segmentation",
  "unicode-width 0.2.0",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -827,7 +827,9 @@ dependencies = [
  "agent-client-protocol-schema",
  "crossterm",
  "ratatui",
+ "ratatui-markdown",
  "serde_json",
+ "shell-words",
  "similar",
  "unicode-segmentation",
  "unicode-width 0.2.0",
@@ -3861,6 +3863,16 @@ dependencies = [
  "strum 0.26.3",
  "unicode-segmentation",
  "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "ratatui-markdown"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e44e5c1fcb6b71a3e639b5218ea181ef42b8b05ae87ba4afdc962b48548079ab"
+dependencies = [
+ "ratatui",
  "unicode-width 0.2.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ similar = "3.1"
 # the same ones ratatui measures with, which is why this tracks the version
 # ratatui itself depends on. Adds no crate to the build graph.
 unicode-width = "0.2"
+unicode-segmentation = "1.12"
 # `unstable_llm_providers` gives the draft `providers/*` schema types used only
 # for controller-to-harness endpoint setup. `unstable_session_fork` lets tests
 # exercise the advertised lifecycle method. We deliberately do not enable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,11 +54,14 @@ ratatui = { version = "0.29", features = [
     "unstable-rendered-line-info",
 ] }
 crossterm = { version = "0.28", features = ["event-stream"] }
+# Transcript Markdown only; do not bring a second scroll/viewer implementation.
+ratatui-markdown = { version = "0.3.6", default-features = false, features = ["markdown"] }
 # The line diff behind `bitrouter-tui`'s hunked diff rendering. A dependency
 # rather than a hand-rolled diff because subtly wrong diff output is worse than
 # a dependency, and hunk grouping with context is exactly where the subtle
 # wrongness would live — see TUI_RENDERER_PLAN §C.1 (§19.2).
 similar = "3.1"
+shell-words = "1"
 # The display width of a grapheme cluster, for `bitrouter-tui`'s own wrap.
 # Ratatui's `reflow` is private, so the wrap is ours — but the widths must be
 # the same ones ratatui measures with, which is why this tracks the version

--- a/apps/bitrouter/src/dashboard.rs
+++ b/apps/bitrouter/src/dashboard.rs
@@ -187,6 +187,8 @@ async fn drive(
     // The initial snapshot was fetched before opening the terminal; do not
     // immediately repeat it on Interval's eager first tick.
     refresh_tick.tick().await;
+    let mut animation_tick = tokio::time::interval(std::time::Duration::from_millis(100));
+    animation_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     let mut shutdown = crate::chat::signals::Shutdown::install();
     view.draw(dashboard)
         .context("drawing operations dashboard")?;
@@ -206,7 +208,6 @@ async fn drive(
             update = session.updates.next() => {
                 if let Some(update) = update {
                     dashboard.conversation.journal.apply(update);
-                    dashboard.conversation.scroll = 0;
                     view.draw(dashboard).context("drawing ACP update")?;
                 }
             }
@@ -235,6 +236,10 @@ async fn drive(
                     }
                 };
                 view.draw(dashboard).context("drawing completed turn")?;
+            }
+            _ = animation_tick.tick(), if session.turn.is_some() && session.pending_permission.is_none() => {
+                view.tick();
+                view.draw(dashboard).context("drawing thinking indicator")?;
             }
             _ = refresh_tick.tick() => {
                 refresh(target, dashboard).await;
@@ -280,6 +285,9 @@ async fn handle_event(
             }
             if exit_key(&key, view.page()) {
                 return Ok(true);
+            }
+            if bitrouter_tui::editor::is_redraw(&Event::Key(key)) {
+                view.invalidate();
             }
             if key.code == KeyCode::Tab {
                 view.next_page();
@@ -380,7 +388,7 @@ async fn open_session(
         options: crate::acp_cli::launch_options(request.turn_timeout),
         routing: request.routing,
     };
-    // The full-screen shell cannot relinquish the terminal for an external
+    // The live shell cannot relinquish the terminal for an external
     // authentication flow, so advertise only the capabilities it can honor.
     let mut diagnostics = Vec::new();
     let prepared =
@@ -495,72 +503,46 @@ async fn handle_conversation_key(
     driver: &mut SessionDriver,
     key: KeyEvent,
 ) -> Result<()> {
-    match key.code {
-        KeyCode::PageUp => {
-            let _ = bitrouter_tui::dashboard::step(
-                dashboard,
-                bitrouter_tui::dashboard::Action::ScrollUp,
-            );
+    if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
+        if let (Some(handle), Some(turn)) = (driver.handle.as_ref(), driver.turn.take()) {
+            turn.abort();
+            handle.client.deny_session_permissions(&handle.session_id);
+            handle.client.cancel(&handle.session_id).await?;
+            dashboard.conversation.status = "cancelled".to_string();
         }
-        KeyCode::PageDown => {
-            let _ = bitrouter_tui::dashboard::step(
-                dashboard,
-                bitrouter_tui::dashboard::Action::ScrollDown,
-            );
-        }
-        KeyCode::Backspace if driver.turn.is_none() => {
-            let _ = bitrouter_tui::dashboard::step(
-                dashboard,
-                bitrouter_tui::dashboard::Action::Backspace,
-            );
-        }
-        KeyCode::Enter if driver.turn.is_none() => {
-            let Some(bitrouter_tui::dashboard::Effect::Prompt(prompt)) =
-                bitrouter_tui::dashboard::step(
-                    dashboard,
-                    bitrouter_tui::dashboard::Action::SubmitPrompt,
-                )
-            else {
-                return Ok(());
-            };
-            let Some(handle) = driver.handle.as_ref() else {
-                dashboard.error = Some("Select an ACP agent before sending a prompt.".to_string());
-                return Ok(());
-            };
-            dashboard
-                .conversation
-                .journal
-                .apply(SessionUpdate::UserMessageChunk(ContentChunk::new(
-                    ContentBlock::Text(TextContent::new(prompt.clone())),
-                )));
-            dashboard.conversation.scroll = 0;
-            dashboard.conversation.status = "working".to_string();
-            let client = handle.client.clone();
-            let session_id = handle.session_id.clone();
-            driver.turn = Some(tokio::spawn(async move {
-                client.prompt(&session_id, &prompt).await
-            }));
-        }
-        KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-            if let (Some(handle), Some(turn)) = (driver.handle.as_ref(), driver.turn.take()) {
-                turn.abort();
-                handle.client.deny_session_permissions(&handle.session_id);
-                handle.client.cancel(&handle.session_id).await?;
-                dashboard.conversation.status = "cancelled".to_string();
-            }
-        }
-        KeyCode::Esc => {}
-        KeyCode::Char(character)
-            if driver.turn.is_none()
-                && (key.modifiers.is_empty() || key.modifiers == KeyModifiers::SHIFT) =>
-        {
-            let _ = bitrouter_tui::dashboard::step(
-                dashboard,
-                bitrouter_tui::dashboard::Action::Type(character),
-            );
-        }
-        _ => {}
+        return Ok(());
     }
+    // Keep a draft editable during a turn, but submission waits for the agent.
+    if driver.turn.is_some()
+        && key.code == KeyCode::Enter
+        && !key
+            .modifiers
+            .intersects(KeyModifiers::SHIFT | KeyModifiers::ALT)
+    {
+        return Ok(());
+    }
+    let Some(bitrouter_tui::dashboard::Effect::Prompt(prompt)) =
+        bitrouter_tui::dashboard::step(dashboard, bitrouter_tui::dashboard::Action::Key(key))
+    else {
+        return Ok(());
+    };
+    let Some(handle) = driver.handle.as_ref() else {
+        dashboard.error = Some("Select an ACP agent before sending a prompt.".to_string());
+        dashboard.conversation.input.paste(&prompt);
+        return Ok(());
+    };
+    dashboard
+        .conversation
+        .journal
+        .apply(SessionUpdate::UserMessageChunk(ContentChunk::new(
+            ContentBlock::Text(TextContent::new(prompt.clone())),
+        )));
+    dashboard.conversation.status = "working".to_string();
+    let client = handle.client.clone();
+    let session_id = handle.session_id.clone();
+    driver.turn = Some(tokio::spawn(async move {
+        client.prompt(&session_id, &prompt).await
+    }));
     Ok(())
 }
 
@@ -739,6 +721,41 @@ fn route_line(report: RouteReport) -> bitrouter_tui::dashboard::RouteLine {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn a_busy_composer_keeps_one_turn_and_preserves_the_draft() -> Result<()> {
+        let mut dashboard = bitrouter_tui::dashboard::Dashboard::default();
+        dashboard.conversation.input.paste("first line");
+        let mut driver = SessionDriver {
+            turn: Some(tokio::spawn(std::future::pending())),
+            ..Default::default()
+        };
+        let turn_id = driver.turn.as_ref().map(tokio::task::JoinHandle::id);
+        for modifiers in [KeyModifiers::NONE, KeyModifiers::CONTROL] {
+            handle_conversation_key(
+                &mut dashboard,
+                &mut driver,
+                KeyEvent::new(KeyCode::Enter, modifiers),
+            )
+            .await?;
+            assert_eq!(dashboard.conversation.input.line(), "first line");
+            assert_eq!(
+                driver.turn.as_ref().map(tokio::task::JoinHandle::id),
+                turn_id
+            );
+        }
+        handle_conversation_key(
+            &mut dashboard,
+            &mut driver,
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::SHIFT),
+        )
+        .await?;
+        assert_eq!(dashboard.conversation.input.line(), "first line\n");
+        if let Some(turn) = driver.turn.take() {
+            turn.abort();
+        }
+        Ok(())
+    }
 
     #[test]
     fn snapshot_refresh_preserves_interactive_diagnostics() {

--- a/apps/bitrouter/src/main.rs
+++ b/apps/bitrouter/src/main.rs
@@ -681,7 +681,7 @@ enum Command {
     /// session to an ACP client over stdio, this renders it for you — messages,
     /// tool calls, permission prompts, and what the turn cost.
     ///
-    /// The session opens in the same full-screen shell as bare `bitrouter code`.
+    /// The session opens in the same terminal shell as bare `bitrouter code`.
     #[command(hide = true)]
     Chat {
         /// Agent id — a bundled-catalog id (`claude-acp`, `codex-acp`,

--- a/crates/bitrouter-tui/Cargo.toml
+++ b/crates/bitrouter-tui/Cargo.toml
@@ -21,3 +21,4 @@ serde_json.workspace = true
 crossterm.workspace = true
 similar.workspace = true
 unicode-width.workspace = true
+unicode-segmentation.workspace = true

--- a/crates/bitrouter-tui/Cargo.toml
+++ b/crates/bitrouter-tui/Cargo.toml
@@ -17,8 +17,10 @@ rust-version.workspace = true
 [dependencies]
 agent-client-protocol-schema.workspace = true
 ratatui.workspace = true
+ratatui-markdown.workspace = true
 serde_json.workspace = true
 crossterm.workspace = true
 similar.workspace = true
+shell-words.workspace = true
 unicode-width.workspace = true
 unicode-segmentation.workspace = true

--- a/crates/bitrouter-tui/src/dashboard.rs
+++ b/crates/bitrouter-tui/src/dashboard.rs
@@ -1,4 +1,4 @@
-//! Full-screen operations dashboard renderer.
+//! ACP transcript in native scrollback, with a docked operations shell.
 //!
 //! The application owns every read and every async effect. This module accepts
 //! plain display data, owns terminal lifecycle, and renders it; it cannot reach
@@ -6,15 +6,18 @@
 
 use std::io::{self, IsTerminal};
 
-use crossterm::cursor::Hide;
-use crossterm::execute;
-use crossterm::terminal::EnterAlternateScreen;
-use ratatui::backend::CrosstermBackend;
-use ratatui::layout::{Constraint, Layout};
+use crossterm::event::KeyEvent;
+use ratatui::backend::{CrosstermBackend, TestBackend};
+use ratatui::buffer::Buffer;
+use ratatui::layout::{Constraint, Layout, Margin, Position, Rect, Size};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table, Tabs, Wrap};
 use ratatui::{Frame, Terminal};
+use unicode_width::UnicodeWidthStr as _;
+
+use crate::editor::{Edit, Editor};
+use crate::writer::{Cache, Writer};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Page {
@@ -97,25 +100,20 @@ pub struct Conversation {
     pub lifecycle: Option<String>,
     pub route: Option<String>,
     pub status: String,
-    pub input: String,
-    pub scroll: usize,
+    pub input: Editor,
     pub journal: crate::journal::Journal,
     pub permission: Option<crate::permission::Prompt>,
 }
 
 /// Pure Code-shell state transition. Async launch/prompt effects stay in the
-/// application driver; this reducer owns selection, drafts, and scrolling.
+/// application driver; this reducer owns selection and the multiline draft.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Action {
     SelectPreviousAgent,
     SelectNextAgent,
     ActivateSelectedAgent,
-    Type(char),
+    Key(KeyEvent),
     Paste(String),
-    Backspace,
-    SubmitPrompt,
-    ScrollUp,
-    ScrollDown,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -141,31 +139,15 @@ pub fn step(dashboard: &mut Dashboard, action: Action) -> Option<Effect> {
             .agents
             .get(dashboard.selected_agent)
             .map(|agent| Effect::StartAgent(agent.id.clone())),
-        Action::Type(character) => {
-            dashboard.conversation.input.push(character);
+        Action::Key(key) => {
+            if dashboard.conversation.input.apply(key) == Edit::Submitted {
+                let prompt = dashboard.conversation.input.take();
+                return (!prompt.trim().is_empty()).then_some(Effect::Prompt(prompt));
+            }
             None
         }
         Action::Paste(text) => {
-            dashboard
-                .conversation
-                .input
-                .push_str(&text.replace(['\n', '\r'], " "));
-            None
-        }
-        Action::Backspace => {
-            dashboard.conversation.input.pop();
-            None
-        }
-        Action::SubmitPrompt => {
-            let prompt = std::mem::take(&mut dashboard.conversation.input);
-            (!prompt.trim().is_empty()).then_some(Effect::Prompt(prompt))
-        }
-        Action::ScrollUp => {
-            dashboard.conversation.scroll = dashboard.conversation.scroll.saturating_add(10);
-            None
-        }
-        Action::ScrollDown => {
-            dashboard.conversation.scroll = dashboard.conversation.scroll.saturating_sub(10);
+            dashboard.conversation.input.paste(&text);
             None
         }
     }
@@ -196,39 +178,41 @@ pub struct RouteLine {
 }
 
 pub struct DashboardView {
-    terminal: Terminal<CrosstermBackend<std::io::Stdout>>,
+    writer: Writer<CrosstermBackend<io::Stdout>>,
     page: Page,
-    conversation_cache: crate::writer::Cache,
+    conversation_cache: Cache,
     conversation_registry: crate::render::Registry,
+    session: Option<String>,
+    animation: usize,
     finished: bool,
 }
 
 impl DashboardView {
     pub fn open() -> io::Result<Self> {
-        if !std::io::stdin().is_terminal() || !std::io::stdout().is_terminal() {
+        if !io::stdin().is_terminal() || !io::stdout().is_terminal() {
             return Err(io::Error::other(
                 "bitrouter tui requires an interactive stdin and stdout",
             ));
         }
         crate::lifecycle::install_panic_restore();
         crate::lifecycle::enter_raw()?;
-        let mut stdout = std::io::stdout();
-        if let Err(error) = execute!(stdout, EnterAlternateScreen, Hide) {
-            crate::lifecycle::restore();
-            return Err(error);
-        }
-        let terminal = match Terminal::new(CrosstermBackend::new(stdout)) {
-            Ok(terminal) => terminal,
+        let writer = match (|| {
+            crate::lifecycle::enable_session_keys()?;
+            Writer::new(CrosstermBackend::new(io::stdout()))
+        })() {
+            Ok(writer) => writer,
             Err(error) => {
                 crate::lifecycle::restore();
                 return Err(error);
             }
         };
         Ok(Self {
-            terminal,
+            writer,
             page: Page::Home,
-            conversation_cache: crate::writer::Cache::default(),
+            conversation_cache: Cache::default(),
             conversation_registry: crate::render::Registry::default(),
+            session: None,
+            animation: 0,
             finished: false,
         })
     }
@@ -236,39 +220,59 @@ impl DashboardView {
     pub fn page(&self) -> Page {
         self.page
     }
-
     pub fn set_page(&mut self, page: Page) {
         self.page = page;
     }
-
     pub fn next_page(&mut self) {
         self.page = self.page.next();
     }
+    pub fn tick(&mut self) {
+        self.animation = (self.animation + 1) % SPINNER.len();
+    }
+    pub fn invalidate(&mut self) {
+        self.writer.invalidate();
+    }
 
-    pub fn draw(&mut self, dashboard: &Dashboard) -> io::Result<()> {
-        let page = self.page;
-        let cache = &mut self.conversation_cache;
-        let registry = &self.conversation_registry;
-        self.terminal
-            .draw(|frame| {
-                let conversation = (page == Page::Conversation).then(|| {
-                    cache.document(
-                        &dashboard.conversation.journal,
-                        registry,
-                        ratatui::layout::Size::new(
-                            frame.area().width.max(1),
-                            frame.area().height.max(1),
-                        ),
-                        &[],
-                    )
-                });
-                draw(frame, page, dashboard, conversation.as_deref());
-            })
-            .map(|_| ())
+    pub fn draw(&mut self, dashboard: &mut Dashboard) -> io::Result<()> {
+        if self.session != dashboard.conversation.native_session_id {
+            self.writer.new_document()?;
+            self.conversation_cache = Cache::default();
+            self.session
+                .clone_from(&dashboard.conversation.native_session_id);
+        }
+        let size = self.writer.size();
+        let padding = padding(size.width);
+        let width = size.width.saturating_sub(padding * 2).max(1);
+        dashboard
+            .conversation
+            .input
+            .set_width(width.saturating_sub(2));
+        let document = self.conversation_cache.document(
+            &dashboard.conversation.journal,
+            &self.conversation_registry,
+            Size::new(width, size.height),
+            &[],
+        );
+        let transcript = padded_transcript(&document, size.width);
+        let height = dock_height(dashboard, self.page, size);
+        // Off-screen ratatui rendering keeps widgets reusable while the writer
+        // owns the real terminal and its native scrollback.
+        let mut dock = Terminal::new(TestBackend::new(size.width.max(1), height))?;
+        let mut cursor = None;
+        let frame = dock.draw(|frame| {
+            cursor = draw(frame, self.page, dashboard, self.animation);
+        })?;
+        let cursor = cursor.map(|position| {
+            Position::new(position.x, size.height.saturating_sub(height) + position.y)
+        });
+        let footer = buffer_lines(frame.buffer);
+        self.writer.docked_frame(&transcript, &footer)?;
+        self.writer.cursor(cursor)
     }
 
     pub fn finish(&mut self) {
         if !self.finished {
+            let _ = self.writer.finish();
             crate::lifecycle::restore();
             self.finished = true;
         }
@@ -281,80 +285,167 @@ impl Drop for DashboardView {
     }
 }
 
-fn draw(
-    frame: &mut Frame<'_>,
-    page: Page,
-    dashboard: &Dashboard,
-    conversation: Option<&[Line<'static>]>,
-) {
-    let area = frame.area();
-    let error_messages = dashboard
+const SPINNER: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+fn padding(width: u16) -> u16 {
+    width.saturating_sub(4).saturating_div(2).min(2)
+}
+
+fn buffer_lines(buffer: &Buffer) -> Vec<Line<'static>> {
+    (buffer.area.top()..buffer.area.bottom())
+        .map(|y| {
+            let mut spans = Vec::new();
+            let mut x = buffer.area.left();
+            while x < buffer.area.right() {
+                let cell = &buffer[(x, y)];
+                spans.push(Span::styled(cell.symbol().to_string(), cell.style()));
+                x = x.saturating_add(u16::try_from(cell.symbol().width()).unwrap_or(1).max(1));
+            }
+            Line::from(spans)
+        })
+        .collect()
+}
+
+fn padded_transcript(document: &[Line<'static>], width: u16) -> Vec<Line<'static>> {
+    let padding = padding(width);
+    let inner = width.saturating_sub(2 * padding).max(1);
+    document
+        .iter()
+        .flat_map(|line| {
+            let rows = crate::wrap::wrap(line, inner);
+            if rows.iter().all(|row| row.width() <= usize::from(inner)) {
+                return rows;
+            }
+            // The word wrapper can overflow by a wide cluster. Fall back to
+            // grapheme wrapping for this line instead of clipping CJK/emoji or
+            // painting into the right gutter.
+            let mut rows = Vec::new();
+            let mut row = Line::default();
+            let mut used = 0;
+            for grapheme in line.styled_graphemes(Style::default()) {
+                let cells = grapheme.symbol.width();
+                if used > 0 && used + cells > usize::from(inner) {
+                    rows.push(std::mem::take(&mut row));
+                    used = 0;
+                }
+                row.spans
+                    .push(Span::styled(grapheme.symbol.to_string(), grapheme.style));
+                used += cells;
+            }
+            rows.push(row);
+            rows
+        })
+        .map(|mut line| {
+            line.spans
+                .insert(0, Span::raw(" ".repeat(usize::from(padding))));
+            line
+        })
+        .collect()
+}
+
+fn composer_height(dashboard: &Dashboard, width: u16, height: u16) -> u16 {
+    let rows = dashboard
+        .conversation
+        .input
+        .layout(width.saturating_sub(2))
+        .rows
+        .len();
+    let max_rows = height.saturating_sub(7).clamp(1, 8);
+    u16::try_from(rows).unwrap_or(u16::MAX).clamp(1, max_rows) + 2
+}
+
+fn dock_height(dashboard: &Dashboard, page: Page, size: Size) -> u16 {
+    let width = size.width.saturating_sub(2 * padding(size.width));
+    let input = if page == Page::Conversation {
+        composer_height(dashboard, width, size.height)
+    } else {
+        0
+    };
+    let notice = u16::from(dashboard.notice.is_some()) * 3;
+    let errors = dashboard
         .error
         .iter()
         .chain(dashboard.refresh_error.iter())
         .cloned()
-        .collect::<Vec<_>>();
-    let error_message = error_messages.join("\n");
+        .collect::<Vec<_>>()
+        .join("\n");
+    let error = error_layout(&errors, Rect::new(0, 0, width, size.height), notice).0;
+    let controls =
+        input + notice + error + 3 + u16::from(dashboard.conversation.permission.is_some());
+    let panel = if page == Page::Conversation {
+        0
+    } else {
+        size.height.saturating_sub(controls + 1).min(14)
+    };
+    (controls + panel)
+        .min(size.height.saturating_sub(1).max(1))
+        .max(1)
+}
+
+fn draw(
+    frame: &mut Frame<'_>,
+    page: Page,
+    dashboard: &Dashboard,
+    animation: usize,
+) -> Option<Position> {
+    let area = frame
+        .area()
+        .inner(Margin::new(padding(frame.area().width), 0));
+    let error_message = dashboard
+        .error
+        .iter()
+        .chain(dashboard.refresh_error.iter())
+        .cloned()
+        .collect::<Vec<_>>()
+        .join("\n");
     let notice_height = u16::from(dashboard.notice.is_some()) * 3;
     let (error_height, error_scroll) = error_layout(&error_message, area, notice_height);
-    let [header, content, notice, error, footer] = Layout::vertical([
-        Constraint::Length(3),
-        Constraint::Min(4),
+    let input_height = if page == Page::Conversation {
+        composer_height(dashboard, area.width, area.height + 7)
+    } else {
+        0
+    };
+    let [
+        content,
+        notice,
+        error,
+        permission,
+        status,
+        input,
+        tabs,
+        help,
+    ] = Layout::vertical([
+        Constraint::Min(0),
         Constraint::Length(notice_height),
         Constraint::Length(error_height),
+        Constraint::Length(u16::from(dashboard.conversation.permission.is_some())),
+        Constraint::Length(1),
+        Constraint::Length(input_height),
+        Constraint::Length(1),
         Constraint::Length(1),
     ])
     .areas(area);
-
-    let titles = [
-        "Home",
-        "Agents",
-        "Conversation",
-        "Sessions",
-        "Models",
-        "Requests",
-        "Route",
-    ]
-    .into_iter()
-    .map(Line::from);
-    let tabs = Tabs::new(titles)
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .title(format!(" BitRouter · {} ", dashboard.target)),
-        )
-        .select(page.index())
-        .highlight_style(
-            Style::default()
-                .fg(Color::Cyan)
-                .add_modifier(Modifier::BOLD),
-        )
-        .divider("│");
-    frame.render_widget(tabs, header);
-
+    let mut cursor = None;
     match page {
         Page::Home => draw_home(frame, content, dashboard),
         Page::Agents => draw_agents(frame, content, dashboard),
         Page::Conversation => {
-            draw_conversation(frame, content, dashboard, conversation.unwrap_or_default())
+            cursor = draw_composer(frame, input, &dashboard.conversation);
         }
         Page::Sessions => draw_sessions(frame, content, dashboard),
         Page::Models => draw_models(frame, content, dashboard),
         Page::Requests => draw_requests(frame, content, dashboard),
         Page::Route => draw_route(frame, content, dashboard),
     }
-
     if let Some(message) = &dashboard.notice {
         frame.render_widget(
             Paragraph::new(message.as_str())
                 .style(Style::default().fg(Color::Yellow))
-                .block(Block::default().borders(Borders::TOP).title(" Notice "))
                 .wrap(Wrap { trim: true }),
             notice,
         );
     }
-
-    if !error_messages.is_empty() {
+    if !error_message.is_empty() {
         frame.render_widget(
             Paragraph::new(error_message)
                 .style(Style::default().fg(Color::Red))
@@ -364,19 +455,53 @@ fn draw(
             error,
         );
     }
-
-    let help = match page {
-        Page::Agents => "↑/↓ select · Enter connect · Tab pages · Esc/Ctrl-C quit",
-        Page::Conversation => {
-            "type prompt · Enter send · PgUp/PgDn scroll · Tab views · Ctrl-D quit"
-        }
-        Page::Route => "Tab pages · type model · Enter preview · Ctrl-U clear · Esc/Ctrl-C quit",
-        _ => "Tab pages · r refresh · 1-7 jump · q/Esc/Ctrl-C quit",
+    if let Some(prompt) = &dashboard.conversation.permission {
+        frame.render_widget(Paragraph::new(prompt.render()), permission);
+    }
+    let busy =
+        dashboard.conversation.status == "working" && dashboard.conversation.permission.is_none();
+    let activity = if busy {
+        format!("{} Thinking…", SPINNER[animation % SPINNER.len()])
+    } else if dashboard.conversation.permission.is_some() {
+        "Waiting for permission".to_string()
+    } else {
+        conversation_status(&dashboard.conversation)
     };
     frame.render_widget(
-        Paragraph::new(help).style(Style::default().fg(Color::DarkGray)),
-        footer,
+        Paragraph::new(format!("BitRouter · {} · {activity}", dashboard.target))
+            .style(Style::default().fg(if busy { Color::Cyan } else { Color::DarkGray })),
+        status,
     );
+    frame.render_widget(
+        Tabs::new([
+            "Home",
+            "Agents",
+            "Conversation",
+            "Sessions",
+            "Models",
+            "Requests",
+            "Route",
+        ])
+        .select(page.index())
+        .highlight_style(
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        )
+        .divider("│"),
+        tabs,
+    );
+    let hint = match page {
+        Page::Agents => "↑/↓ select · Enter connect · Tab views · Ctrl-C quit",
+        Page::Conversation => "Enter send · Shift+Enter/Ctrl+J newline · Tab views · Ctrl-D quit",
+        Page::Route => "type model · Enter preview · Ctrl-U clear · Tab views · Ctrl-C quit",
+        _ => "Tab views · r refresh · 1-7 jump · q/Esc/Ctrl-C quit",
+    };
+    frame.render_widget(
+        Paragraph::new(hint).style(Style::default().fg(Color::DarkGray)),
+        help,
+    );
+    cursor
 }
 
 /// Size a diagnostic pane from its wrapped rows while reserving the main view.
@@ -492,48 +617,41 @@ fn draw_agents(frame: &mut Frame<'_>, area: ratatui::layout::Rect, dashboard: &D
     frame.render_widget(table, area);
 }
 
-fn draw_conversation(
+fn draw_composer(
     frame: &mut Frame<'_>,
-    area: ratatui::layout::Rect,
-    dashboard: &Dashboard,
-    document: &[Line<'static>],
-) {
-    let [transcript, status, input] = Layout::vertical([
-        Constraint::Min(4),
-        Constraint::Length(2),
-        Constraint::Length(3),
-    ])
-    .areas(area);
-    let visible = usize::from(transcript.height.saturating_sub(2));
-    let end = document.len().saturating_sub(dashboard.conversation.scroll);
-    let start = end.saturating_sub(visible);
-    frame.render_widget(
-        Paragraph::new(document.get(start..end).unwrap_or_default().to_vec())
-            .block(Block::default().borders(Borders::ALL).title(" Transcript "))
-            .wrap(Wrap { trim: false }),
-        transcript,
-    );
-    let status_line = conversation_status(&dashboard.conversation);
-    frame.render_widget(
-        Paragraph::new(status_line).style(Style::default().fg(Color::DarkGray)),
-        status,
-    );
-    let title =
-        dashboard
-            .conversation
-            .permission
-            .as_ref()
-            .map_or(" Message ".to_string(), |permission| {
-                format!(
-                    " Permission: {} · choose 1-9, Esc denies ",
-                    permission.title()
-                )
-            });
-    frame.render_widget(
-        Paragraph::new(dashboard.conversation.input.as_str())
-            .block(Block::default().borders(Borders::ALL).title(title)),
-        input,
-    );
+    area: Rect,
+    conversation: &Conversation,
+) -> Option<Position> {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan))
+        .title(" Message ");
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    if inner.is_empty() {
+        return None;
+    }
+    let layout = conversation.input.layout(inner.width);
+    let offset = layout
+        .cursor
+        .0
+        .saturating_sub(usize::from(inner.height).saturating_sub(1));
+    let lines: Vec<Line<'static>> = layout
+        .rows
+        .iter()
+        .skip(offset)
+        .take(usize::from(inner.height))
+        .cloned()
+        .map(Line::from)
+        .collect();
+    frame.render_widget(Paragraph::new(lines), inner);
+    if conversation.permission.is_none() {
+        return Some(Position::new(
+            inner.x + layout.cursor.1.min(inner.width.saturating_sub(1)),
+            inner.y + u16::try_from(layout.cursor.0.saturating_sub(offset)).unwrap_or(0),
+        ));
+    }
+    None
 }
 
 fn conversation_status(conversation: &Conversation) -> String {
@@ -702,9 +820,73 @@ mod tests {
             ..Dashboard::default()
         };
         for page in Page::ALL {
-            terminal.draw(|frame| draw(frame, page, &dashboard, None))?;
+            terminal.draw(|frame| {
+                draw(frame, page, &dashboard, 0);
+            })?;
         }
         Ok(())
+    }
+
+    #[test]
+    fn multiline_dock_keeps_the_cursor_visible_at_small_sizes() -> io::Result<()> {
+        let mut dashboard = Dashboard::default();
+        dashboard
+            .conversation
+            .input
+            .paste("first line\n你好 👩‍💻\nthird\nfourth\nfifth\nsixth\nseventh\neighth\nlast line");
+        for (width, height) in [(110, 38), (40, 16), (20, 10), (8, 5), (1, 1)] {
+            let height = dock_height(&dashboard, Page::Conversation, Size::new(width, height));
+            let mut terminal = Terminal::new(TestBackend::new(width, height))?;
+            let mut cursor = None;
+            terminal.draw(|frame| {
+                cursor = draw(frame, Page::Conversation, &dashboard, 0);
+            })?;
+            if let Some(cursor) = cursor {
+                assert!(
+                    cursor.x < width && cursor.y < height,
+                    "{width}x{height}: {cursor:?}"
+                );
+                assert!(rendered_text(&terminal).contains("last line") || width < 20);
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn thinking_animates_without_new_agent_chunks_and_stops_when_idle() -> io::Result<()> {
+        let mut dashboard = Dashboard::default();
+        dashboard.conversation.status = "working".to_string();
+        let mut terminal = Terminal::new(TestBackend::new(100, 12))?;
+        terminal.draw(|frame| {
+            draw(frame, Page::Conversation, &dashboard, 0);
+        })?;
+        let first = rendered_text(&terminal);
+        terminal.draw(|frame| {
+            draw(frame, Page::Conversation, &dashboard, 1);
+        })?;
+        let second = rendered_text(&terminal);
+        assert!(first.contains("⠋ Thinking…"));
+        assert!(second.contains("⠙ Thinking…"));
+        dashboard.conversation.status = "idle".to_string();
+        terminal.draw(|frame| {
+            draw(frame, Page::Conversation, &dashboard, 2);
+        })?;
+        assert!(!rendered_text(&terminal).contains("Thinking…"));
+        Ok(())
+    }
+
+    #[test]
+    fn transcript_keeps_both_gutters_without_dropping_wide_graphemes() {
+        let content = "你好世界这是一个终端测试 👩‍💻 hello world";
+        for width in [9, 13, 20, 31, 80] {
+            let rows = padded_transcript(&[Line::from(content)], width);
+            let text = rows.iter().map(crate::plain::text).collect::<String>();
+            assert_eq!(text.replace(' ', ""), content.replace(' ', ""));
+            for row in rows {
+                assert!(crate::plain::text(&row).starts_with("  "));
+                assert!(row.width() <= usize::from(width - 2));
+            }
+        }
     }
 
     #[test]
@@ -738,7 +920,9 @@ mod tests {
             ..Dashboard::default()
         };
 
-        terminal.draw(|frame| draw(frame, Page::Agents, &dashboard, None))?;
+        terminal.draw(|frame| {
+            draw(frame, Page::Agents, &dashboard, 0);
+        })?;
         let rendered = rendered_text(&terminal);
         assert!(rendered.contains("routing fallback remains visible"));
         assert!(rendered.contains("Missing optional dependency"));
@@ -747,7 +931,7 @@ mod tests {
     }
 
     #[test]
-    fn reducer_preserves_draft_while_agents_and_scroll_change() {
+    fn reducer_preserves_multiline_draft_while_agents_change() {
         let mut dashboard = Dashboard {
             agents: vec![
                 AgentLine {
@@ -767,13 +951,17 @@ mod tests {
             ],
             ..Dashboard::default()
         };
-        let _ = step(&mut dashboard, Action::Type('d'));
+        let _ = step(
+            &mut dashboard,
+            Action::Key(KeyEvent::new(
+                crossterm::event::KeyCode::Char('d'),
+                crossterm::event::KeyModifiers::NONE,
+            )),
+        );
         let _ = step(&mut dashboard, Action::Paste("raft\ntext".to_string()));
         let _ = step(&mut dashboard, Action::SelectNextAgent);
-        let _ = step(&mut dashboard, Action::ScrollUp);
-        assert_eq!(dashboard.conversation.input, "draft text");
+        assert_eq!(dashboard.conversation.input.line(), "draft\ntext");
         assert_eq!(dashboard.selected_agent, 1);
-        assert_eq!(dashboard.conversation.scroll, 10);
         assert_eq!(
             step(&mut dashboard, Action::ActivateSelectedAgent),
             Some(Effect::StartAgent("codex".to_string()))
@@ -785,11 +973,26 @@ mod tests {
         let mut dashboard = Dashboard::default();
         let _ = step(&mut dashboard, Action::Paste("review this".to_string()));
         assert_eq!(
-            step(&mut dashboard, Action::SubmitPrompt),
+            step(
+                &mut dashboard,
+                Action::Key(KeyEvent::new(
+                    crossterm::event::KeyCode::Enter,
+                    crossterm::event::KeyModifiers::NONE
+                ))
+            ),
             Some(Effect::Prompt("review this".to_string()))
         );
-        assert!(dashboard.conversation.input.is_empty());
-        assert_eq!(step(&mut dashboard, Action::SubmitPrompt), None);
+        assert!(dashboard.conversation.input.line().is_empty());
+        assert_eq!(
+            step(
+                &mut dashboard,
+                Action::Key(KeyEvent::new(
+                    crossterm::event::KeyCode::Enter,
+                    crossterm::event::KeyModifiers::NONE
+                ))
+            ),
+            None
+        );
     }
 
     #[test]

--- a/crates/bitrouter-tui/src/editor.rs
+++ b/crates/bitrouter-tui/src/editor.rs
@@ -1,134 +1,238 @@
-//! The single-line editor, and what the keys of a raw terminal mean.
-//!
-//! Raw mode is not free. It means the terminal no longer echoes, no longer
-//! assembles a line, and no longer turns Ctrl-C into a signal — all three
-//! become the client's. [`Editor`] pays for the first two; [`is_cancel`] pays
-//! for the third.
-//!
-//! # No I/O, no runtime
-//!
-//! Nothing here reads a terminal. [`Editor::apply`] is a state machine over
-//! `crossterm`'s already-decoded [`KeyEvent`], so *who owns stdin* and *how
-//! events are delivered* stay the caller's — and they have to, because the
-//! answer depends on what else that process is selecting over. An ACP client
-//! typically pumps events into a channel so its reader is cancel-safe beside
-//! the session's own futures; that pump needs an async runtime, and keeping it
-//! out is what lets this crate stay a synchronous library.
-//!
-//! Deliberately absent: history, multi-line entry, and cursor movement within
-//! the line. Each is a real feature with real state, and a renderer that grew
-//! them would be a text editor.
+//! A multiline prompt editor. Cursor offsets are grapheme boundaries; layout
+//! and vertical movement share the same terminal-cell coordinates.
 
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use unicode_segmentation::UnicodeSegmentation as _;
+use unicode_width::UnicodeWidthStr as _;
 
-/// What one key did to the line.
+/// What one key did to the editor.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Edit {
-    /// Nothing — a key this editor does not bind, or a key *release*.
     Ignored,
-    /// The line changed and the screen should show it.
     Changed,
-    /// The line is unchanged; what is stale is the terminal (Ctrl-L).
     Redrawn,
-    /// Enter. Whether an empty line counts as a submission is the caller's
-    /// call, because only the caller knows what an empty prompt would do.
     Submitted,
-    /// Ctrl-C or Ctrl-D. The session is over.
     Ended,
 }
 
-/// One line being typed.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 pub struct Editor {
     line: String,
+    cursor: usize,
+    width: u16,
+    preferred_column: Option<u16>,
+}
+
+impl Default for Editor {
+    fn default() -> Self {
+        Self {
+            line: String::new(),
+            cursor: 0,
+            width: 80,
+            preferred_column: None,
+        }
+    }
+}
+
+/// Hard and soft line breaks, and the cursor's physical position in them.
+pub struct InputLayout {
+    pub rows: Vec<String>,
+    pub cursor: (usize, u16),
+    positions: Vec<(usize, usize, u16)>,
 }
 
 impl Editor {
-    /// The line so far, for echoing.
     pub fn line(&self) -> &str {
         &self.line
     }
 
-    /// Discard the line, keeping the editor.
+    pub fn set_width(&mut self, width: u16) {
+        self.width = width.max(1);
+    }
+
     pub fn clear(&mut self) {
         self.line.clear();
+        self.cursor = 0;
+        self.preferred_column = None;
     }
 
-    /// Take the line and leave an empty editor behind.
     pub fn take(&mut self) -> String {
-        std::mem::take(&mut self.line)
+        let text = std::mem::take(&mut self.line);
+        self.clear();
+        text
     }
 
-    /// Apply one key.
+    /// Lay out exactly as the composer paints: preserve whitespace and wrap
+    /// at grapheme boundaries. A full row leaves room on the next for a cursor.
+    pub fn layout(&self, width: u16) -> InputLayout {
+        let width = width.max(1);
+        let mut rows = vec![String::new()];
+        let mut positions = Vec::new();
+        let mut column = 0;
+        for (index, grapheme) in self.line.grapheme_indices(true) {
+            let cells = u16::try_from(grapheme.width()).unwrap_or(width).min(width);
+            if grapheme == "\n" {
+                // An explicit newline at a soft-wrap boundary consumes that
+                // break once, instead of inventing a blank line in the prompt.
+                let position = if column == width {
+                    (rows.len(), 0)
+                } else {
+                    (rows.len() - 1, column)
+                };
+                positions.push((index, position.0, position.1));
+                rows.push(String::new());
+                column = 0;
+                continue;
+            }
+            if column > 0 && column + cells > width {
+                rows.push(String::new());
+                column = 0;
+            }
+            positions.push((index, rows.len() - 1, column));
+            if let Some(row) = rows.last_mut() {
+                row.push_str(grapheme);
+            }
+            column += cells;
+        }
+        if column == width {
+            rows.push(String::new());
+            column = 0;
+        }
+        positions.push((self.line.len(), rows.len() - 1, column));
+        let cursor = positions
+            .iter()
+            .find(|(byte, _, _)| *byte == self.cursor)
+            .map_or((0, 0), |(_, row, column)| (*row, *column));
+        InputLayout {
+            rows,
+            cursor,
+            positions,
+        }
+    }
+
     pub fn apply(&mut self, key: KeyEvent) -> Edit {
-        // Key *release* events exist on some platforms; acting on both would
-        // double every keystroke.
-        if key.kind != KeyEventKind::Press {
+        if key.kind == KeyEventKind::Release {
             return Edit::Ignored;
         }
         let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
         let alt = key.modifiers.contains(KeyModifiers::ALT);
+        if !matches!(key.code, KeyCode::Up | KeyCode::Down) {
+            self.preferred_column = None;
+        }
         match key.code {
-            // Ctrl-C and Ctrl-D at an idle prompt both end the session. Ctrl-C
-            // does not clear the line first: the session is idle either way,
-            // and one meaning per key beats two.
-            KeyCode::Char('c' | 'd') if ctrl => Edit::Ended,
-            // The screen, not the line: the buffer is untouched.
-            KeyCode::Char('l') if ctrl => Edit::Redrawn,
-            KeyCode::Char('w') if ctrl => {
-                self.delete_word();
-                Edit::Changed
+            KeyCode::Char('c' | 'd') if ctrl => return Edit::Ended,
+            KeyCode::Char('l') if ctrl => return Edit::Redrawn,
+            KeyCode::Char('j') if ctrl => self.insert("\n"),
+            KeyCode::Enter if alt || key.modifiers.contains(KeyModifiers::SHIFT) => {
+                self.insert("\n")
             }
-            KeyCode::Backspace if alt => {
-                self.delete_word();
-                Edit::Changed
-            }
+            KeyCode::Enter => return Edit::Submitted,
+            KeyCode::Char('w') if ctrl => self.delete_word(),
+            KeyCode::Backspace if alt => self.delete_word(),
             KeyCode::Backspace => {
-                self.line.pop();
-                Edit::Changed
+                let previous = self.previous();
+                self.line.replace_range(previous..self.cursor, "");
+                self.cursor = previous;
             }
-            KeyCode::Enter => Edit::Submitted,
-            KeyCode::Char(c) if !ctrl && !alt => {
-                self.line.push(c);
-                Edit::Changed
+            KeyCode::Delete => {
+                let next = self.next();
+                self.line.replace_range(self.cursor..next, "");
             }
-            _ => Edit::Ignored,
+            KeyCode::Left => self.cursor = self.previous(),
+            KeyCode::Right => self.cursor = self.next(),
+            KeyCode::Up => self.vertical(-1),
+            KeyCode::Down => self.vertical(1),
+            KeyCode::Home if ctrl => self.cursor = 0,
+            KeyCode::End if ctrl => self.cursor = self.line.len(),
+            KeyCode::Home | KeyCode::Char('a') if key.code == KeyCode::Home || ctrl => {
+                self.cursor = self.line[..self.cursor].rfind('\n').map_or(0, |i| i + 1);
+            }
+            KeyCode::End | KeyCode::Char('e') if key.code == KeyCode::End || ctrl => {
+                self.cursor += self.line[self.cursor..]
+                    .find('\n')
+                    .unwrap_or(self.line.len() - self.cursor);
+            }
+            KeyCode::Char('u') if ctrl => {
+                let start = self.line[..self.cursor].rfind('\n').map_or(0, |i| i + 1);
+                self.line.replace_range(start..self.cursor, "");
+                self.cursor = start;
+            }
+            KeyCode::Char(c) if !ctrl && !alt && !c.is_control() => self.insert(&c.to_string()),
+            _ => return Edit::Ignored,
+        }
+        Edit::Changed
+    }
+
+    /// Bracketed paste never submits. Normalize newlines, expand tabs, and
+    /// discard terminal controls; the entire block remains editable.
+    pub fn paste(&mut self, text: &str) {
+        let text = text
+            .replace("\r\n", "\n")
+            .replace('\r', "\n")
+            .replace('\t', "    ");
+        let text: String = text
+            .chars()
+            .filter(|c| *c == '\n' || !c.is_control())
+            .collect();
+        self.insert(&text);
+    }
+
+    fn insert(&mut self, text: &str) {
+        self.line.insert_str(self.cursor, text);
+        self.cursor += text.len();
+        // Insertion can join an adjacent combining mark / ZWJ sequence.
+        self.cursor = self
+            .line
+            .grapheme_indices(true)
+            .map(|(i, _)| i)
+            .find(|i| *i >= self.cursor)
+            .unwrap_or(self.line.len());
+        self.preferred_column = None;
+    }
+
+    fn previous(&self) -> usize {
+        self.line[..self.cursor]
+            .grapheme_indices(true)
+            .next_back()
+            .map_or(0, |(i, _)| i)
+    }
+
+    fn next(&self) -> usize {
+        self.line[self.cursor..]
+            .graphemes(true)
+            .next()
+            .map_or(self.cursor, |s| self.cursor + s.len())
+    }
+
+    fn vertical(&mut self, delta: isize) {
+        let layout = self.layout(self.width);
+        let (row, column) = layout.cursor;
+        let goal = *self.preferred_column.get_or_insert(column);
+        let target = row.saturating_add_signed(delta).min(layout.rows.len() - 1);
+        if let Some((byte, _, _)) = layout
+            .positions
+            .iter()
+            .filter(|(_, row, _)| *row == target)
+            .min_by_key(|(_, _, col)| col.abs_diff(goal))
+        {
+            self.cursor = *byte;
         }
     }
 
-    /// Append a bracketed paste, flattened to one line.
-    ///
-    /// Bracketed paste arrives whole, which is the point: without it a pasted
-    /// line is indistinguishable from a fast typist and its newline submits
-    /// half of it. This editor has no second row to put the rest on, so the
-    /// block becomes one line rather than a silently truncated fragment.
-    pub fn paste(&mut self, text: &str) {
-        self.line.push_str(&text.replace(['\n', '\r'], " "));
-    }
-
-    /// Delete the trailing word, and the whitespace before it.
     fn delete_word(&mut self) {
-        let end = self.line.trim_end().len();
-        // Indexed by `char_indices` rather than `rfind` + 1: whitespace is not
-        // always one byte, and truncating inside a character would panic.
-        let start = self.line[..end]
+        let prefix = &self.line[..self.cursor];
+        let end = prefix.trim_end().len();
+        let start = prefix[..end]
             .char_indices()
             .rev()
             .find(|(_, c)| c.is_whitespace())
             .map_or(0, |(i, c)| i + c.len_utf8());
-        self.line.truncate(start);
+        self.line.replace_range(start..self.cursor, "");
+        self.cursor = start;
     }
 }
 
-/// Does this event cancel a running turn — Ctrl-C, or `Esc`?
-///
-/// In raw mode the terminal no longer sends SIGINT, so every consumer that
-/// wants to be interruptible has to recognise the key itself. One predicate,
-/// so they all agree on what it looks like.
-///
-/// `Esc` belongs here only when no modal is open: a modal owns the key stream
-/// while it runs, so by the time an event reaches the turn loop there is
-/// nothing else for `Esc` to close.
+/// Escape and Ctrl-C cancel a running turn.
 pub fn is_cancel(event: &Event) -> bool {
     press(event).is_some_and(|key| {
         key.code == KeyCode::Esc
@@ -245,10 +349,10 @@ mod tests {
 
     /// A pasted paragraph is one prompt, not the first line of one.
     #[test]
-    fn paste_is_flattened_to_a_single_line() {
+    fn paste_preserves_paragraphs_as_one_prompt() {
         let mut editor = Editor::default();
         editor.paste("first\nsecond\r\nthird");
-        assert_eq!(editor.line(), "first second  third");
+        assert_eq!(editor.line(), "first\nsecond\nthird");
     }
 
     /// A key release must not double the keystroke.
@@ -288,5 +392,97 @@ mod tests {
         typed(&mut editor, "half typed");
         assert_eq!(editor.apply(ctrl('l')), Edit::Redrawn);
         assert_eq!(editor.line(), "half typed");
+    }
+}
+
+#[cfg(test)]
+mod multiline_tests {
+    use super::*;
+
+    fn key(editor: &mut Editor, code: KeyCode) -> Edit {
+        editor.apply(KeyEvent::new(code, KeyModifiers::NONE))
+    }
+
+    #[test]
+    fn newlines_are_editable_and_only_plain_enter_submits() {
+        let mut editor = Editor::default();
+        editor.paste("first");
+        for modifiers in [KeyModifiers::SHIFT, KeyModifiers::ALT] {
+            assert_eq!(
+                editor.apply(KeyEvent::new(KeyCode::Enter, modifiers)),
+                Edit::Changed
+            );
+        }
+        editor.paste("last");
+        assert_eq!(editor.line(), "first\n\nlast");
+        key(&mut editor, KeyCode::Up);
+        editor.paste("middle");
+        assert_eq!(editor.line(), "first\nmiddle\nlast");
+        key(&mut editor, KeyCode::Home);
+        key(&mut editor, KeyCode::Delete);
+        assert_eq!(editor.line(), "first\niddle\nlast");
+        assert_eq!(key(&mut editor, KeyCode::Enter), Edit::Submitted);
+        assert_eq!(editor.take(), "first\niddle\nlast");
+        assert_eq!(editor.layout(10).cursor, (0, 0));
+    }
+
+    #[test]
+    fn cursor_and_deletion_follow_graphemes_including_emoji() {
+        let mut editor = Editor::default();
+        editor.paste("中e\u{301}👩‍💻文");
+        key(&mut editor, KeyCode::Left);
+        key(&mut editor, KeyCode::Backspace);
+        assert_eq!(editor.line(), "中e\u{301}文");
+        key(&mut editor, KeyCode::Backspace);
+        assert_eq!(editor.line(), "中文");
+        editor.paste("🙂");
+        assert_eq!(editor.line(), "中🙂文");
+        assert_eq!(editor.layout(6).cursor, (0, 4));
+        key(&mut editor, KeyCode::Delete);
+        assert_eq!(editor.line(), "中🙂");
+    }
+
+    #[test]
+    fn vertical_motion_follows_soft_wrap_and_restores_column() {
+        let mut editor = Editor::default();
+        editor.set_width(4);
+        editor.paste("abcdefghij");
+        assert_eq!(editor.layout(4).cursor, (2, 2));
+        key(&mut editor, KeyCode::Up);
+        editor.paste("!");
+        assert_eq!(editor.line(), "abcdef!ghij");
+        editor.clear();
+        editor.paste("1234\nx\n1234");
+        editor.set_width(10);
+        key(&mut editor, KeyCode::Up);
+        assert_eq!(editor.layout(10).cursor, (1, 1));
+        key(&mut editor, KeyCode::Up);
+        assert_eq!(editor.layout(10).cursor, (0, 4));
+    }
+
+    #[test]
+    fn newline_at_a_full_row_does_not_add_a_phantom_blank_line() {
+        let mut editor = Editor::default();
+        editor.paste("abcd\nnext");
+        assert_eq!(editor.layout(4).rows, ["abcd", "next", ""]);
+        assert_eq!(editor.line(), "abcd\nnext");
+    }
+
+    #[test]
+    fn every_cursor_stays_inside_its_row_at_narrow_widths() {
+        for width in [1, 2, 3, 4, 8] {
+            let mut editor = Editor::default();
+            editor.paste("abcd\n中文👩‍💻 e\u{301}\n");
+            for _ in 0..20 {
+                let layout = editor.layout(width);
+                assert!(layout.cursor.0 < layout.rows.len());
+                assert!(
+                    layout.cursor.1 < width,
+                    "width {width}, cursor {:?}",
+                    layout.cursor
+                );
+                key(&mut editor, KeyCode::Left);
+            }
+        }
     }
 }

--- a/crates/bitrouter-tui/src/lifecycle.rs
+++ b/crates/bitrouter-tui/src/lifecycle.rs
@@ -8,28 +8,33 @@
 //! The third is the caller's: registering for signals means naming them, and
 //! which signals exist is a property of the host process, not of the terminal.
 //!
-//! # Why this lives here
-//!
-//! [`Writer::new`](crate::writer::Writer::new) asks the terminal where the
-//! cursor is before it draws a single row, so entering raw mode and opening
-//! the view are two halves of one ordering contract. Splitting them across a
-//! crate boundary left that contract documented in two places and enforced in
-//! neither. Terminal custody is one responsibility; it belongs in one module,
-//! and this crate is already the one holding `crossterm`.
+//! Keyboard protocols are restored only when this session enabled them, so
+//! repeated cleanup cannot pop another application's keyboard state.
 
 use std::io::{self, Write};
+use std::sync::atomic::{AtomicBool, Ordering};
+
+static ENHANCED_KEYS: AtomicBool = AtomicBool::new(false);
 
 use crossterm::execute;
-use crossterm::terminal::{LeaveAlternateScreen, disable_raw_mode, enable_raw_mode};
+use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
 
-/// Take raw mode, and nothing else.
-///
-/// The inline chat renderer wants the keys but not the screen switch — its
-/// whole design is that finished rows stay in ordinary scrollback. Splitting
-/// this out is also what keeps `enable_raw_mode` to a single call site, so
-/// there is exactly one thing for [`restore`] to undo.
+/// Take raw mode before the session starts its single input reader.
 pub fn enter_raw() -> io::Result<()> {
     enable_raw_mode()
+}
+
+/// Request disambiguated Enter modifiers on supporting terminals. Older
+/// terminals ignore the sequence; Alt+Enter and Ctrl+J remain available.
+pub fn enable_session_keys() -> io::Result<()> {
+    ENHANCED_KEYS.store(true, Ordering::SeqCst);
+    execute!(
+        io::stdout(),
+        crossterm::event::EnableBracketedPaste,
+        crossterm::event::PushKeyboardEnhancementFlags(
+            crossterm::event::KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
+        )
+    )
 }
 
 /// Best-effort return to the terminal the user had. Needs no handle so the
@@ -39,13 +44,15 @@ pub fn enter_raw() -> io::Result<()> {
 pub fn restore() {
     let _ = disable_raw_mode();
     let mut out = io::stdout();
-    // Bracketed paste is the chat session's, not the full-screen view's, and
+    if ENHANCED_KEYS.swap(false, Ordering::SeqCst) {
+        let _ = execute!(out, crossterm::event::PopKeyboardEnhancementFlags);
+    }
+    // Bracketed paste belongs to the chat session, and
     // disabling a mode that was never enabled costs nothing — which is why it
     // belongs here, in the one function every exit already reaches.
     let _ = execute!(
         out,
         crossterm::event::DisableBracketedPaste,
-        LeaveAlternateScreen,
         crossterm::cursor::Show
     );
     // XTWINOPS pop: put the user's window title back.

--- a/crates/bitrouter-tui/src/render/markdown.rs
+++ b/crates/bitrouter-tui/src/render/markdown.rs
@@ -1,0 +1,209 @@
+//! Markdown parsing and layout belong to ratatui-markdown. This adapter supplies
+//! BitRouter's code-frame style and a readable fallback for oversized tables.
+
+use ratatui::style::{Color, Style};
+use ratatui::text::{Line, Span};
+use ratatui_markdown::markdown::{MarkdownBlock, MarkdownRenderer, RenderHooks};
+use ratatui_markdown::theme::ThemeConfig;
+use unicode_segmentation::UnicodeSegmentation as _;
+use unicode_width::UnicodeWidthStr as _;
+
+/// Render the accumulated message, including incomplete streamed Markdown.
+pub fn render(text: &str, width: u16) -> Vec<Line<'static>> {
+    let width = width.max(1);
+    let renderer =
+        MarkdownRenderer::new(usize::from(width)).with_render_hooks(Box::new(CodeFrame { width }));
+    let theme = ThemeConfig::default()
+        .with_text_color(Color::Reset)
+        .with_primary_color(Color::Cyan)
+        .with_secondary_color(Color::White)
+        .with_accent_yellow(Color::Gray);
+    let mut blocks = Vec::new();
+    for block in renderer.parse(text) {
+        if let MarkdownBlock::Table { headers, rows } = &block
+            && !rows.is_empty()
+            && renderer
+                .render(std::slice::from_ref(&block), &theme)
+                .iter()
+                .any(|line| line.width() > usize::from(width))
+        {
+            // The library preserves long tokens when sizing table columns. If
+            // that exceeds the viewport, show each record as labeled fields;
+            // keep every value instead of clipping it or breaking the grid.
+            for row in rows {
+                for (index, value) in row.iter().enumerate() {
+                    let label = headers.get(index).map(String::as_str).unwrap_or("");
+                    let field = MarkdownBlock::Paragraph(vec![format!("**{label}:** {value}")]);
+                    blocks.push(field);
+                }
+                blocks.push(MarkdownBlock::BlankLine);
+            }
+        } else {
+            blocks.push(block);
+        }
+    }
+    let mut lines = renderer.render(&blocks, &theme);
+    if lines.is_empty() {
+        lines.push(Line::default());
+    }
+    lines
+}
+
+struct CodeFrame {
+    width: u16,
+}
+
+impl RenderHooks for CodeFrame {
+    fn render_code_block(&self, _lang: &str, content: &str) -> Option<Vec<Line<'static>>> {
+        Some(code_block(content, self.width))
+    }
+}
+
+/// A literal, subdued code frame. Wrap graphemes rather than words so shell
+/// whitespace, quoting and indentation survive; Markdown never parses code.
+pub fn code_block(code: &str, width: u16) -> Vec<Line<'static>> {
+    let width = usize::from(width.max(1));
+    let framed = width >= 6;
+    let inner = if framed { width - 4 } else { width };
+    let style = Style::default().fg(Color::DarkGray);
+    let mut lines = Vec::new();
+    if framed {
+        lines.push(Line::styled(format!("┌{}┐", "─".repeat(width - 2)), style));
+    }
+    for line in code.split('\n') {
+        let expanded = line.replace('\t', "    ");
+        let mut row = String::new();
+        let mut cells = 0;
+        for grapheme in expanded.graphemes(true) {
+            let size = grapheme.width();
+            if cells + size > inner && !row.is_empty() {
+                push_code_row(&mut lines, &row, cells, inner, framed, style);
+                row.clear();
+                cells = 0;
+            }
+            row.push_str(grapheme);
+            cells += size;
+        }
+        push_code_row(&mut lines, &row, cells, inner, framed, style);
+    }
+    if framed {
+        lines.push(Line::styled(format!("└{}┘", "─".repeat(width - 2)), style));
+    }
+    lines
+}
+
+fn push_code_row(
+    lines: &mut Vec<Line<'static>>,
+    row: &str,
+    cells: usize,
+    inner: usize,
+    framed: bool,
+    style: Style,
+) {
+    let text = if framed {
+        format!("│ {row}{} │", " ".repeat(inner.saturating_sub(cells)))
+    } else {
+        row.to_string()
+    };
+    lines.push(Line::from(Span::styled(text, style)));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::style::Modifier;
+
+    fn text(lines: &[Line<'_>]) -> String {
+        lines
+            .iter()
+            .map(|line| line.to_string())
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn markdown_formats_prose_tables_links_and_literal_code() {
+        let source = "## Workspace\n\n**Router** and *cloud*. Use `bitrouter`.\n\n- First\n- Second\n\n| Repo | Role |\n|---|---|\n| [bitrouter](/tmp/README.md) | Router |\n\n```sh\necho '**literal**'\n```";
+        let lines = render(source, 80);
+        let output = text(&lines);
+        assert!(output.starts_with("Workspace\n"), "{output}");
+        assert!(
+            !output.contains("**Router**") && !output.contains("*cloud*"),
+            "{output}"
+        );
+        assert!(
+            !output.contains("[bitrouter]") && !output.contains("/tmp/README.md"),
+            "{output}"
+        );
+        assert!(
+            output.contains("┬") && output.contains("Repo") && output.contains("Role"),
+            "{output}"
+        );
+        assert!(output.contains("echo '**literal**'"), "{output}");
+        assert!(!output.contains("```"), "{output}");
+        assert!(lines.iter().flat_map(|line| &line.spans).any(
+            |span| span.content == "Router" && span.style.add_modifier.contains(Modifier::BOLD)
+        ));
+    }
+
+    #[test]
+    fn narrow_tables_retain_each_labeled_value_and_hide_link_syntax() {
+        let source = "| Repository | Role |\n|---|---|\n| [bitrouter](/Users/example/a/very/long/workspace/path/README.md) | Routes requests safely |\n| cloud | Hosted platform |";
+        let lines = render(source, 24);
+        let output = text(&lines);
+        assert!(lines.iter().all(|line| line.width() <= 24), "{output}");
+        assert!(output.contains("Repository: bitrouter"), "{output}");
+        assert!(output.contains("Role: Routes requests"), "{output}");
+        assert!(
+            output.contains("safely") && output.contains("Hosted platform"),
+            "{output}"
+        );
+        assert!(
+            !output.contains("/Users/") && !output.contains("[bitrouter]"),
+            "{output}"
+        );
+    }
+
+    #[test]
+    fn streaming_reparses_completed_formatting_and_unclosed_fences() {
+        let partial = render("**Inspecting", 40);
+        assert!(text(&partial).contains("Inspecting"));
+        assert_eq!(
+            text(&render("**Inspecting files**", 40)),
+            "Inspecting files"
+        );
+        let code = text(&render("```sh\nprintf '**raw**'", 40));
+        assert!(code.contains("printf '**raw**'"), "{code}");
+        assert!(code.contains('┌') && code.contains('└'), "{code}");
+    }
+
+    #[test]
+    fn command_frames_preserve_wrapped_graphemes_and_indentation() {
+        let code = "  echo '你好👩‍💻**raw**'";
+        let lines = code_block(code, 16);
+        assert!(
+            lines.iter().all(|line| line.width() == 16),
+            "{}",
+            text(&lines)
+        );
+        let restored: String = lines
+            .iter()
+            .skip(1)
+            .take(lines.len() - 2)
+            .map(|line| {
+                line.to_string()
+                    .trim_start_matches("│ ")
+                    .trim_end_matches(" │")
+                    .trim_end()
+                    .to_string()
+            })
+            .collect();
+        assert_eq!(restored, code);
+        assert!(
+            lines
+                .iter()
+                .flat_map(|line| &line.spans)
+                .all(|span| !span.style.add_modifier.contains(Modifier::BOLD))
+        );
+    }
+}

--- a/crates/bitrouter-tui/src/render/mod.rs
+++ b/crates/bitrouter-tui/src/render/mod.rs
@@ -20,22 +20,21 @@
 //!
 //! # What a renderer is given
 //!
-//! [`ToolContext`] carries the id, kind, status, title, content, and height —
-//! and nothing else. No `expanded` (expand/collapse is deferred), no
-//! `raw_input`, no `locations`: no renderer here reads them, and a field
-//! added before its reader exists is dead code. Width is absent for that
-//! reason: the writer wraps the finished document itself, so no renderer ever
-//! needed it. Height stays because a diff is capped by it.
+//! [`ToolContext`] includes command input and viewport size so commands can be
+//! framed at the available width and diffs bounded by the terminal height.
 
 pub mod content;
 pub mod diff;
+pub mod markdown;
 pub mod session;
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 
 use agent_client_protocol_schema::v1::{
     ToolCall, ToolCallContent, ToolCallId, ToolCallStatus, ToolKind,
 };
+use ratatui::layout::Size;
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 
@@ -54,6 +53,10 @@ pub struct ToolContext<'a> {
     /// The terminal height, which is what bounds a single diff: one edit must
     /// never occupy more than the screen the rest of the session lives in.
     pub height: u16,
+    /// Available transcript width, excluding the outer padding.
+    pub width: u16,
+    /// Structured tool arguments, including the command for execution calls.
+    pub raw_input: Option<&'a serde_json::Value>,
 }
 
 impl<'a> ToolContext<'a> {
@@ -61,14 +64,16 @@ impl<'a> ToolContext<'a> {
     ///
     /// One place knows which fields a renderer may see, so adding a field to
     /// the protocol does not quietly widen what renderers can reach.
-    pub fn new(call: &'a ToolCall, height: u16) -> Self {
+    pub fn new(call: &'a ToolCall, size: Size) -> Self {
         Self {
             id: &call.tool_call_id,
             kind: call.kind,
             status: call.status,
             title: &call.title,
             content: &call.content,
-            height,
+            height: size.height,
+            width: size.width,
+            raw_input: call.raw_input.as_ref(),
         }
     }
 }
@@ -135,21 +140,13 @@ pub struct Registry {
 }
 
 impl Default for Registry {
-    /// The v1 set: [`Reasoning`] for thinking, and [`Generic`] for everything
-    /// else.
-    ///
-    /// `Edit` and `Execute` are deliberately *not* registered. Both had a
-    /// renderer of their own whose body was identical to `Generic`'s — a
-    /// header and the call's content — because what makes an edit look like a
-    /// diff is [`diff`] rendering its content, not the renderer that dispatched
-    /// to it. Two names for one behaviour is the dead code this rule forbids;
-    /// they fall through to the fallback and draw exactly what they drew.
     fn default() -> Self {
         let mut registry = Self {
             renderers: HashMap::new(),
             fallback: Box::new(Generic),
         };
         registry.register(ToolKey::Think, Box::new(Reasoning));
+        registry.register(ToolKey::Execute, Box::new(Execute));
         registry
     }
 }
@@ -174,29 +171,84 @@ pub struct Generic;
 
 impl ToolRenderer for Generic {
     fn render(&self, ctx: &ToolContext<'_>) -> Vec<Line<'static>> {
+        if command_input(ctx).is_some() {
+            return Execute.render(ctx);
+        }
         let mut lines = vec![header(ctx)];
         lines.extend(content_lines(ctx));
         lines
     }
 }
 
-/// `Think` calls — the agent reasoning through a tool rather than in a thought
-/// chunk. Drawn in the same dimmed voice, because it is the same voice.
+/// Execution calls show their literal shell command in a subdued code frame.
+pub struct Execute;
+
+impl ToolRenderer for Execute {
+    fn render(&self, ctx: &ToolContext<'_>) -> Vec<Line<'static>> {
+        let command = command_input(ctx).unwrap_or(Cow::Borrowed(ctx.title));
+        let title_is_command = ctx.title == command
+            || shell_words::split(ctx.title)
+                .ok()
+                .is_some_and(|words| words.len() == 1 && words[0] == command);
+        let title = if title_is_command || ctx.title.is_empty() {
+            "Command"
+        } else {
+            ctx.title
+        };
+        let mut lines = vec![titled_header(ctx.status, title)];
+        if !command.is_empty() {
+            lines.extend(markdown::code_block(&command, ctx.width));
+        }
+        lines.extend(content_lines(ctx));
+        lines
+    }
+}
+
+// ACP adapters may publish a shell script or argv, and may classify shell
+// reads/searches by intent. Recognize structured command input for both.
+fn command_input<'a>(ctx: &ToolContext<'a>) -> Option<Cow<'a, str>> {
+    let input = ctx.raw_input?;
+    let value = input.get("command").or_else(|| input.get("cmd"))?;
+    if let Some(command) = value.as_str() {
+        return Some(Cow::Borrowed(command));
+    }
+    let argv: Vec<&str> = value
+        .as_array()?
+        .iter()
+        .map(|value| value.as_str())
+        .collect::<Option<_>>()?;
+    if let [shell, flag, script] = argv.as_slice()
+        && matches!(
+            shell.rsplit('/').next(),
+            Some("sh" | "bash" | "zsh" | "fish" | "dash")
+        )
+        && matches!(*flag, "-c" | "-lc" | "-ic")
+    {
+        return Some(Cow::Borrowed(script));
+    }
+    (!argv.is_empty()).then(|| Cow::Owned(shell_words::join(argv)))
+}
+
+/// Reasoning tools use the same bright action style as thought messages.
 pub struct Reasoning;
 
 impl ToolRenderer for Reasoning {
     fn render(&self, ctx: &ToolContext<'_>) -> Vec<Line<'static>> {
         let mut lines = vec![header(ctx)];
-        for line in content_lines(ctx) {
-            lines.push(Line::from(
-                line.spans
-                    .into_iter()
-                    .map(|span| {
-                        let content = span.content.into_owned();
-                        Span::styled(content, thought_style())
-                    })
-                    .collect::<Vec<_>>(),
-            ));
+        for item in ctx.content {
+            match item {
+                ToolCallContent::Content(block) => {
+                    if let agent_client_protocol_schema::v1::ContentBlock::Text(text) =
+                        &block.content
+                    {
+                        lines.extend(thought(&text.text, ctx.width));
+                    } else {
+                        lines.extend(content::render(&block.content));
+                    }
+                }
+                ToolCallContent::Diff(file) => lines.extend(diff::render(file, ctx.height)),
+                _ => {}
+            }
         }
         lines
     }
@@ -207,35 +259,43 @@ impl ToolRenderer for Reasoning {
 /// Not a registry entry: the registry keys on `ToolKind`, and a message has no
 /// kind. There are exactly three voices and they are fixed by the protocol, so
 /// a lookup table would be indirection with nothing to look up.
-pub fn message(message: &crate::journal::Message) -> Vec<Line<'static>> {
-    let (prefix, style) = match message.voice {
-        // The user's own words, marked the way they were entered.
-        crate::journal::Voice::User => ("> ", Style::default().fg(Color::Cyan)),
-        crate::journal::Voice::Agent => ("", Style::default()),
-        crate::journal::Voice::Thought => (THOUGHT_PREFIX, thought_style()),
-    };
-    // An empty run still occupies a row: it is a message that has arrived and
-    // has no text yet, and collapsing it would make the document jump when the
-    // first chunk lands.
-    if message.text.is_empty() {
-        return vec![Line::from(Span::styled(prefix.to_string(), style))];
+pub fn message(message: &crate::journal::Message, width: u16) -> Vec<Line<'static>> {
+    match message.voice {
+        crate::journal::Voice::User => {
+            let mut lines = vec![Line::default()];
+            lines.extend(message.text.split('\n').map(|line| {
+                Line::from(Span::styled(
+                    format!("> {line}"),
+                    Style::default().fg(Color::Cyan),
+                ))
+            }));
+            lines.push(Line::default());
+            lines
+        }
+        crate::journal::Voice::Agent => markdown::render(&message.text, width),
+        crate::journal::Voice::Thought => thought(&message.text, width),
     }
-    message
-        .text
-        .lines()
-        .map(|line| Line::from(Span::styled(format!("{prefix}{line}"), style)))
+}
+
+fn thought(text: &str, width: u16) -> Vec<Line<'static>> {
+    markdown::render(text, width.saturating_sub(2).max(1))
+        .into_iter()
+        .map(|line| {
+            let mut spans = vec![Span::styled("· ", thought_style())];
+            spans.extend(
+                line.spans
+                    .into_iter()
+                    .map(|span| Span::styled(span.content, span.style.patch(thought_style()))),
+            );
+            Line::from(spans)
+        })
         .collect()
 }
 
-/// Marks the agent's reasoning as reasoning, in the transcript as well as on
-/// a `Think` call.
-const THOUGHT_PREFIX: &str = "· ";
-
-/// The dimmed italic the agent's reasoning is drawn in, wherever it appears.
 fn thought_style() -> Style {
     Style::default()
-        .fg(Color::DarkGray)
-        .add_modifier(Modifier::ITALIC)
+        .fg(Color::White)
+        .add_modifier(Modifier::BOLD)
 }
 
 /// What a tool call is doing, as one glyph.
@@ -259,15 +319,19 @@ fn status_glyph(status: ToolCallStatus) -> (&'static str, Color) {
 /// A call with no title is named by its id rather than left blank — an
 /// unlabelled row is still traceable, an empty one is not.
 fn header(ctx: &ToolContext<'_>) -> Line<'static> {
-    let (glyph, color) = status_glyph(ctx.status);
     let title = if ctx.title.is_empty() {
         ctx.id.0.to_string()
     } else {
         ctx.title.to_string()
     };
+    titled_header(ctx.status, &title)
+}
+
+fn titled_header(status: ToolCallStatus, title: &str) -> Line<'static> {
+    let (glyph, color) = status_glyph(status);
     Line::from(vec![
         Span::styled(format!("{glyph} "), Style::default().fg(color)),
-        Span::raw(title),
+        Span::styled(title.to_string(), thought_style()),
     ])
 }
 
@@ -279,15 +343,8 @@ fn content_lines(ctx: &ToolContext<'_>) -> Vec<Line<'static>> {
         match item {
             ToolCallContent::Content(block) => lines.extend(content::render(&block.content)),
             ToolCallContent::Diff(file) => lines.extend(diff::render(file, ctx.height)),
-            // A terminal is a live thing owned by the agent, addressed by id.
-            // Naming it is all a static renderer can honestly do; embedding it
-            // would mean rendering a stream this crate does not hold.
-            ToolCallContent::Terminal(terminal) => {
-                lines.push(Line::from(Span::styled(
-                    format!("  [terminal {}]", terminal.terminal_id),
-                    Style::default().fg(Color::DarkGray),
-                )));
-            }
+            // Terminal handles are protocol metadata, not transcript content.
+            ToolCallContent::Terminal(_) => {}
             // `ToolCallContent` is `#[non_exhaustive]`.
             _ => {}
         }
@@ -340,7 +397,7 @@ mod tests {
 
         let searched = call(ToolKind::Search, "grep for it");
         assert_eq!(
-            text(&registry.render(&ToolContext::new(&searched, 24))),
+            text(&registry.render(&ToolContext::new(&searched, Size::new(80, 24)))),
             "searched",
             "a registered key reaches its renderer"
         );
@@ -348,7 +405,7 @@ mod tests {
         // `Fetch` has no renderer registered, so this must reach `Generic` —
         // and `Generic` draws the title, which no spy does.
         let fetched = call(ToolKind::Fetch, "GET https://example.test");
-        let rendered = text(&registry.render(&ToolContext::new(&fetched, 24)));
+        let rendered = text(&registry.render(&ToolContext::new(&fetched, Size::new(80, 24))));
         assert!(
             rendered.contains("GET https://example.test"),
             "an unregistered key falls through to the default: {rendered:?}"
@@ -368,7 +425,7 @@ mod tests {
         registry.register(ToolKey::Edit, Box::new(Spy("second")));
         let edit = call(ToolKind::Edit, "Edit src/lib.rs");
         assert_eq!(
-            text(&registry.render(&ToolContext::new(&edit, 24))),
+            text(&registry.render(&ToolContext::new(&edit, Size::new(80, 24)))),
             "second"
         );
     }
@@ -422,7 +479,7 @@ mod tests {
             ToolKind::SwitchMode,
         ] {
             let drawn = call(kind, "a title");
-            let rendered = text(&registry.render(&ToolContext::new(&drawn, 24)));
+            let rendered = text(&registry.render(&ToolContext::new(&drawn, Size::new(80, 24))));
             assert!(
                 rendered.contains("a title"),
                 "{kind:?} rendered nothing: {rendered:?}"
@@ -440,7 +497,8 @@ mod tests {
                     TextContent::new("running 3 tests\ntest result: ok."),
                 )),
             )]);
-        let rendered = text(&Registry::default().render(&ToolContext::new(&executed, 24)));
+        let rendered =
+            text(&Registry::default().render(&ToolContext::new(&executed, Size::new(80, 24))));
         assert!(rendered.contains("cargo test"), "{rendered:?}");
         assert!(rendered.contains("running 3 tests"), "{rendered:?}");
         assert!(rendered.contains("test result: ok."), "{rendered:?}");
@@ -452,7 +510,8 @@ mod tests {
         let edited = call(ToolKind::Edit, "Edit src/lib.rs").content(vec![ToolCallContent::Diff(
             Diff::new("src/lib.rs", "let b = 2;").old_text("let a = 1;".to_string()),
         )]);
-        let rendered = text(&Registry::default().render(&ToolContext::new(&edited, 24)));
+        let rendered =
+            text(&Registry::default().render(&ToolContext::new(&edited, Size::new(80, 24))));
         // The name, not the shape: the diff renderer absolutizes, and an
         // absolute path is `D:\...\src\lib.rs` on Windows.
         assert!(rendered.contains("lib.rs"), "{rendered:?}");
@@ -460,8 +519,7 @@ mod tests {
         assert!(rendered.contains("+let b = 2;"), "{rendered:?}");
     }
 
-    /// Reasoning is drawn as reasoning: the same dimmed italic a thought
-    /// chunk gets, so the two cannot be confused with the agent's answer.
+    /// Reasoning tool content shares the bright style of action messages.
     #[test]
     fn a_think_call_is_drawn_in_the_reasoning_voice() {
         let thinking = call(ToolKind::Think, "considering the options").content(vec![
@@ -469,7 +527,7 @@ mod tests {
                 ContentBlock::Text(TextContent::new("weighing two designs")),
             )),
         ]);
-        let lines = Registry::default().render(&ToolContext::new(&thinking, 24));
+        let lines = Registry::default().render(&ToolContext::new(&thinking, Size::new(80, 24)));
         let styles: Vec<Style> = lines
             .iter()
             .skip(1)
@@ -503,7 +561,79 @@ mod tests {
     #[test]
     fn an_untitled_call_is_named_by_its_id() {
         let untitled = ToolCall::new(ToolCallId::new("t-42"), String::new());
-        let rendered = text(&Registry::default().render(&ToolContext::new(&untitled, 24)));
+        let rendered =
+            text(&Registry::default().render(&ToolContext::new(&untitled, Size::new(80, 24))));
         assert!(rendered.contains("t-42"), "{rendered:?}");
+    }
+    #[test]
+    fn user_messages_keep_literal_text_and_surrounding_space() {
+        let input = crate::journal::Message {
+            voice: crate::journal::Voice::User,
+            text: "Explain **this**\nand `that`".into(),
+            complete: true,
+        };
+        assert_eq!(
+            text(&message(&input, 80)),
+            "\n> Explain **this**\n> and `that`\n"
+        );
+    }
+
+    #[test]
+    fn thought_captions_render_without_markdown_delimiters_in_bright_white() {
+        let input = crate::journal::Message {
+            voice: crate::journal::Voice::Thought,
+            text: "**Inspecting root files**".into(),
+            complete: false,
+        };
+        let lines = message(&input, 80);
+        assert_eq!(text(&lines), "· Inspecting root files");
+        assert!(lines.iter().flat_map(|line| &line.spans).all(|span| {
+            span.style.fg == Some(Color::White)
+                && span.style.add_modifier.contains(Modifier::BOLD)
+                && !span.style.add_modifier.contains(Modifier::DIM)
+        }));
+    }
+
+    #[test]
+    fn shell_reads_render_commands_without_terminal_handles_or_losing_output() {
+        let read = call(ToolKind::Read, "Read README.md")
+            .raw_input(serde_json::json!({"command": ["/bin/zsh", "-lc", "cat README.md"]}))
+            .content(vec![
+                ToolCallContent::Terminal(agent_client_protocol_schema::v1::Terminal::new(
+                    "exec-secret-id",
+                )),
+                ToolCallContent::Content(agent_client_protocol_schema::v1::Content::new(
+                    ContentBlock::Text(TextContent::new("# raw output")),
+                )),
+            ]);
+        let lines = Registry::default().render(&ToolContext::new(&read, Size::new(40, 24)));
+        let output = text(&lines);
+        assert!(output.contains("● Read README.md"), "{output}");
+        assert!(output.contains("│ cat README.md"), "{output}");
+        assert!(output.contains("# raw output"), "{output}");
+        assert!(!output.contains("exec-secret-id"), "{output}");
+        assert!(!output.contains("/bin/zsh"), "{output}");
+        let command_spans = lines
+            .iter()
+            .flat_map(|line| &line.spans)
+            .filter(|span| span.content.contains("cat README.md"));
+        for span in command_spans {
+            assert_eq!(span.style.fg, Some(Color::DarkGray));
+            assert!(!span.style.add_modifier.contains(Modifier::BOLD));
+        }
+    }
+
+    #[test]
+    fn argv_quoting_and_literal_execute_titles_survive() {
+        let executed = call(ToolKind::Execute, "Run checks")
+            .raw_input(serde_json::json!({"command": ["printf", "%s", "two words"]}));
+        let output =
+            text(&Registry::default().render(&ToolContext::new(&executed, Size::new(80, 24))));
+        assert!(output.contains("printf '%s' 'two words'"), "{output}");
+        let fallback = call(ToolKind::Execute, "echo '**literal**'");
+        let output =
+            text(&Registry::default().render(&ToolContext::new(&fallback, Size::new(80, 24))));
+        assert!(output.starts_with("● Command\n┌"), "{output}");
+        assert!(output.contains("│ echo '**literal**'"), "{output}");
     }
 }

--- a/crates/bitrouter-tui/src/writer.rs
+++ b/crates/bitrouter-tui/src/writer.rs
@@ -602,8 +602,8 @@ impl Cache {
                 .is_some_and(|cached| cached.size == size && cached.revision == item.revision);
             if !fresh {
                 let rows = match item.entry {
-                    Entry::Message(message) => render::message(message),
-                    Entry::Tool(call) => registry.render(&ToolContext::new(call, size.height)),
+                    Entry::Message(message) => render::message(message, size.width),
+                    Entry::Tool(call) => registry.render(&ToolContext::new(call, size)),
                     Entry::Plan(plan) => render::session::plan(plan),
                 };
                 self.rows.insert(

--- a/crates/bitrouter-tui/src/writer.rs
+++ b/crates/bitrouter-tui/src/writer.rs
@@ -120,6 +120,7 @@ pub struct Writer<B> {
     anchor: u16,
     width: u16,
     height: u16,
+    footer_rows: usize,
 }
 
 impl<B: Backend + SyncSink> Writer<B> {
@@ -151,6 +152,7 @@ impl<B: Backend + SyncSink> Writer<B> {
             anchor,
             width: size.width.max(1),
             height,
+            footer_rows: 0,
         })
     }
 
@@ -159,7 +161,62 @@ impl<B: Backend + SyncSink> Writer<B> {
     /// Renderers need it: a diff is capped at a terminal height, and what a
     /// row costs depends on the width.
     pub fn size(&self) -> Size {
-        Size::new(self.width, self.height)
+        self.backend
+            .size()
+            .unwrap_or(Size::new(self.width, self.height))
+    }
+
+    /// Keep transient controls at the bottom while only transcript rows enter
+    /// native scrollback. Space released by a shrinking footer stays blank;
+    /// it must not pull already-scrolled transcript rows back onto the screen.
+    /// Both inputs are physical rows, already wrapped to the terminal width.
+    pub fn docked_frame(
+        &mut self,
+        transcript: &[Line<'static>],
+        footer: &[Line<'static>],
+    ) -> io::Result<()> {
+        let size = self.size();
+        let rows = usize::from(size.height.max(1));
+        let footer = &footer[footer.len().saturating_sub(rows)..];
+        let mut document = transcript.to_vec();
+        let minimum = if size.width == self.width && size.height == self.height {
+            self.viewport_top + self.capacity()
+        } else {
+            rows.saturating_sub(usize::from(self.anchor.min(size.height.saturating_sub(1))))
+        };
+        document.resize(
+            document.len().max(minimum.saturating_sub(footer.len())),
+            Line::default(),
+        );
+        document.extend_from_slice(footer);
+        self.physical_frame(document)?;
+        self.footer_rows = footer.len();
+        Ok(())
+    }
+
+    /// Move the visible input cursor without querying stdin.
+    pub fn cursor(&mut self, position: Option<Position>) -> io::Result<()> {
+        if let Some(position) = position {
+            self.position(
+                position.x.min(self.width.saturating_sub(1)),
+                position.y.min(self.height.saturating_sub(1)),
+            )?;
+            self.backend.show_cursor()?;
+        } else {
+            self.backend.hide_cursor()?;
+        }
+        self.backend.flush()
+    }
+
+    /// Begin another native session below the previous transcript.
+    pub fn new_document(&mut self) -> io::Result<()> {
+        self.finish()?;
+        self.anchor = self
+            .screen_row(self.prev.len())
+            .unwrap_or(self.height.saturating_sub(1));
+        self.prev.clear();
+        self.viewport_top = 0;
+        Ok(())
     }
 
     /// Paint one frame of `lines`, which are logical lines — the writer wraps
@@ -169,10 +226,15 @@ impl<B: Backend + SyncSink> Writer<B> {
     /// optimisation but the contract the scheduler is built on: it may call
     /// this on every tick.
     pub fn frame(&mut self, lines: &[Line<'static>]) -> io::Result<()> {
+        let width = self.backend.size()?.width.max(1);
+        let next = lines.iter().flat_map(|line| wrap(line, width)).collect();
+        self.physical_frame(next)
+    }
+
+    fn physical_frame(&mut self, next: Vec<Line<'static>>) -> io::Result<()> {
         let size = self.backend.size()?;
         let width = size.width.max(1);
         let height = size.height.max(1);
-        let next: Vec<Line<'static>> = lines.iter().flat_map(|line| wrap(line, width)).collect();
 
         // A resize invalidates every row position we hold: the terminal has
         // reflowed underneath us and the old `viewport_top` describes a
@@ -250,6 +312,15 @@ impl<B: Backend + SyncSink> Writer<B> {
     /// nothing, which is why `Ctrl-C` leaves a readable transcript rather than
     /// a blank screen.
     pub fn finish(&mut self) -> io::Result<()> {
+        if self.footer_rows > 0 {
+            let end = self.prev.len().saturating_sub(self.footer_rows);
+            if let Some(row) = self.screen_row(end) {
+                self.position(0, row)?;
+                self.backend.clear_region(ClearType::AfterCursor)?;
+            }
+            self.prev.truncate(end);
+            self.footer_rows = 0;
+        }
         let below = self.prev.len();
         match self.screen_row(below) {
             Some(row) => self.position(0, row)?,
@@ -603,6 +674,7 @@ mod tests {
                 // `TestBackend` cannot fail; returning a fresh one keeps this
                 // helper total without a panic.
                 Writer {
+                    footer_rows: 0,
                     backend: TestBackend::new(width, height),
                     prev: Vec::new(),
                     viewport_top: 0,
@@ -620,6 +692,81 @@ mod tests {
         let mut writer = writer(20, 6);
         writer.frame(&document(&["one", "two", "three"]))?;
         assert_eq!(screen(&writer)[..3], ["one", "two", "three"]);
+        Ok(())
+    }
+
+    #[test]
+    fn docked_controls_stay_at_the_bottom_and_out_of_history() -> io::Result<()> {
+        let mut writer = writer(32, 12);
+        let mut transcript = Vec::new();
+        for index in 0..80 {
+            transcript.push(Line::from(format!("row:{index:03}")));
+            let footer = vec![Line::from("CONTROL"); [2, 5, 3][index % 3]];
+            writer.docked_frame(&transcript, &footer)?;
+            assert_eq!(screen(&writer).last().map(String::as_str), Some("CONTROL"));
+            assert!(
+                scrollback(&writer)
+                    .iter()
+                    .all(|row| !row.contains("CONTROL"))
+            );
+        }
+        let before = scrollback(&writer);
+        writer.docked_frame(&transcript, &document(&["CONTROL"]))?;
+        assert_eq!(
+            scrollback(&writer),
+            before,
+            "shrinking input cannot replay history"
+        );
+        writer.finish()?;
+        let rendered: Vec<_> = scrollback(&writer)
+            .into_iter()
+            .chain(screen(&writer))
+            .filter(|row| row.starts_with("row:"))
+            .collect();
+        assert_eq!(
+            rendered,
+            (0..80)
+                .map(|index| format!("row:{index:03}"))
+                .collect::<Vec<_>>()
+        );
+        assert!(screen(&writer).iter().all(|row| !row.contains("CONTROL")));
+        Ok(())
+    }
+
+    #[test]
+    fn pre_rendered_footer_rows_are_not_wrapped_again() -> io::Result<()> {
+        let mut writer = writer(32, 12);
+        let footer = document(&[&" ".repeat(32), &"═".repeat(32), " Message"]);
+        writer.docked_frame(&document(&["transcript"]), &footer)?;
+        assert_eq!(screen(&writer)[0], "transcript");
+        assert_eq!(screen(&writer)[10], "═".repeat(32));
+        assert_eq!(screen(&writer)[11], " Message");
+        assert!(scrollback(&writer).is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn switching_documents_preserves_the_previous_transcript() -> io::Result<()> {
+        let mut writer = writer(32, 8);
+        let first: Vec<_> = (0..20).map(|i| Line::from(format!("first:{i}"))).collect();
+        writer.docked_frame(&first, &document(&["OLD CONTROL"]))?;
+        writer.new_document()?;
+        writer.docked_frame(&document(&["second session"]), &document(&["NEW CONTROL"]))?;
+        writer.finish()?;
+        let all = scrollback(&writer)
+            .into_iter()
+            .chain(screen(&writer))
+            .collect::<Vec<_>>();
+        for i in 0..20 {
+            assert_eq!(
+                all.iter()
+                    .filter(|row| **row == format!("first:{i}"))
+                    .count(),
+                1
+            );
+        }
+        assert!(all.iter().any(|row| row == "second session"));
+        assert!(all.iter().all(|row| !row.contains("CONTROL")));
         Ok(())
     }
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -682,6 +682,11 @@ cursor visible. Bracketed paste preserves newlines. A rotating thinking
 indicator runs while waiting for the agent, including before its first chunk.
 Exiting clears the controls and leaves the transcript in terminal history.
 
+User messages have blank lines above and below. Agent replies render Markdown
+headings, emphasis, lists, links, tables, and code blocks. Tables too wide for
+the terminal fall back to labeled fields. Action descriptions are bright white;
+shell commands use subdued code frames. ACP terminal IDs are not displayed.
+
 **Keys**
 
 | Key | Effect |

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -650,7 +650,7 @@ bitrouter code [-c <path>] [--socket <path>]
 bitrouter --context <name> code
 ```
 
-Opens a full-screen dashboard over the same status, models, recent-requests,
+Opens a terminal dashboard over the same status, models, recent-requests,
 and route-preview actions the headless CLI uses. `Tab` switches pages, `1`–`7`
 jump directly, `r` refreshes, and `q`/`Esc`/`Ctrl-C` exits. On the Route page,
 type a model selector and press `Enter`; `Ctrl-U` clears it. Status, model, and
@@ -666,7 +666,7 @@ starts or mutates a daemon.
 bitrouter code <agent> [--load <id>|--resume <id>] [--model <id>] [--turn-timeout <secs>] [--direct] [--base-url <url>] [--no-start] [-c <path>]
 ```
 
-Opens the same full-screen, alternate-screen shell as bare `bitrouter code`,
+Opens the same terminal shell as bare `bitrouter code`,
 initially focused on Conversation with a harness-native ACP session. `Tab`
 moves between Conversation and the Home, Agents, Sessions, Models, Requests,
 and Route operations views without ending the session or losing the draft.
@@ -674,13 +674,24 @@ and Route operations views without ending the session or losing the draft.
 replay when the harness advertises the selected operation. BitRouter does not
 create a second session database.
 
+The transcript uses the terminal’s main screen and native scrollback, with
+left/right padding and no surrounding frame. Navigation, status, permissions,
+and the composer stay at the bottom; operations views open in that same dock.
+The composer grows to eight visible lines and scrolls internally to keep the
+cursor visible. Bracketed paste preserves newlines. A rotating thinking
+indicator runs while waiting for the agent, including before its first chunk.
+Exiting clears the controls and leaves the transcript in terminal history.
+
 **Keys**
 
 | Key | Effect |
 |---|---|
-| `Enter` | Send the composer text, or open the selected agent from Agents |
+| `Enter` | Send the composer text when idle, or open the selected agent from Agents |
 | `Tab` | Move to the next view while preserving the active conversation |
-| `PageUp` / `PageDown` | Scroll the conversation transcript |
+| `Shift+Enter`, `Alt+Enter`, `Ctrl+J` | Insert a newline (`Ctrl+J` also works in terminals without enhanced key reporting) |
+| Arrow keys, `Home` / `End` | Move within the multiline draft |
+| Terminal scroll wheel / scrollback keys | Scroll the transcript |
+| `Ctrl-L` | Repaint the current view |
 | `1`–`9` | Choose an open permission option |
 | `Esc` | Deny the open permission request |
 | `Ctrl-C` | Cancel the running turn; outside a running turn, exit |

--- a/skills/bitrouter/references/cli.md
+++ b/skills/bitrouter/references/cli.md
@@ -203,18 +203,22 @@ See `references/sessions.md` for the controller/native-session boundary and what
 
 ## Interactive interface (`bitrouter code`)
 
-Bare `bitrouter code` opens the full-screen unified shell on Home with Agents,
+Bare `bitrouter code` opens the unified terminal shell on Home with Agents,
 Conversation, Sessions, Models, Requests, and Route views. It refreshes read
 views every two seconds. `bitrouter code <agent>` enters Conversation in that
-same alternate-screen app, backed by the same ACP session host as `run`.
+same terminal app, backed by the same ACP session host as `run`.
 
 | Command | What it does |
 |---|---|
 | `bitrouter code [<agent>] [--load ID\|--resume ID] [--turn-timeout SECS] [routing flags] [--config PATH]` | With no agent, open Home/operations. With an agent, open or restore one harness-native ACP session in Conversation. Friendly aliases such as `claude` and `codex` resolve to their ACP adapters unless shadowed by an exact configured id. `tui` and `chat` are hidden compatibility aliases. |
 
-**Terminal ownership**: Code uses raw mode and an alternate screen for its
-whole lifetime. Changing views does not end the ACP session or lose the draft;
-normal terminal state is restored when the shell exits or unwinds.
+**Terminal ownership**: Code uses raw mode on the main terminal screen. The
+unframed transcript has left/right padding and uses native terminal scrollback.
+Controls and operations views are docked at the bottom. Changing views keeps
+the session and multiline draft; exiting clears the controls, preserves the
+transcript, and restores terminal state. The composer grows to eight visible
+lines, preserves pasted newlines, and keeps the cursor visible. A rotating
+thinking indicator continues while the agent is waiting for a response.
 
 **Keys**
 
@@ -222,7 +226,10 @@ normal terminal state is restored when the shell exits or unwinds.
 |---|---|
 | `Enter` | Send the composer text, or connect to the selected agent |
 | `Tab` | Move to the next view while keeping the session alive |
-| `PageUp` / `PageDown` | Scroll the transcript |
+| `Shift+Enter`, `Alt+Enter`, `Ctrl+J` | Insert a newline; `Ctrl+J` works without enhanced key reporting |
+| Arrow keys, `Home` / `End` | Edit within the multiline draft |
+| Terminal scroll wheel / scrollback keys | Scroll the transcript |
+| `Ctrl-L` | Repaint the view |
 | `1`–`9` | Choose an open permission option |
 | `Esc` | Deny the open permission request |
 | `Ctrl-C` | Cancel a running turn; otherwise exit |

--- a/skills/bitrouter/references/cli.md
+++ b/skills/bitrouter/references/cli.md
@@ -220,6 +220,11 @@ transcript, and restores terminal state. The composer grows to eight visible
 lines, preserves pasted newlines, and keeps the cursor visible. A rotating
 thinking indicator continues while the agent is waiting for a response.
 
+User messages have blank lines above and below. Agent replies render Markdown
+headings, emphasis, lists, links, tables, and code blocks. Tables too wide for
+the terminal fall back to labeled fields. Action descriptions are bright white;
+shell commands use subdued code frames. ACP terminal IDs are not displayed.
+
 **Keys**
 
 | Key | Effect |


### PR DESCRIPTION
ACP conversations were confined to a framed, alternate-screen transcript with navigation above it and a single-line composer. Render the transcript on the main terminal screen with two-column side padding, and dock navigation, status, permissions, operations views, and the composer at the bottom. Terminal scrollback retains the conversation after exit; controls are cleared without erasing history.

The composer preserves pasted paragraphs, supports grapheme-aware cursor movement and deletion, and grows to eight visible lines. Enter sends when idle; Shift+Enter, Alt+Enter, and Ctrl+J insert a newline. A rotating thinking indicator continues before the first agent chunk and during response waits. Drafts remain editable during a turn without starting another concurrent request.

Make transcript messages readable: surround user prompts with blank lines, show action captions in bright white, and put literal shell commands in subdued code frames. Recognize command strings and argv arrays, including shell calls classified as reads or searches, and hide ACP terminal handles while retaining tool output and diffs. Agent Markdown is parsed and rendered by `ratatui-markdown` with only its Markdown feature enabled; headings, emphasis, lists, links, tables, and code fences render during streaming. Tables that exceed the viewport fall back to labeled fields without clipping values.

Validation:
- 3,148 tests passed with all features; 11 skipped. Loopback addresses bypass the local proxy for the test process.
- Strict Clippy, formatting, doctests, and generated-distribution checks passed.
- Real CLI over a PTY: user spacing, literal commands, white action captions, hidden terminal IDs, Markdown tables/links/styles, multiline payloads, delayed spinner, permission decisions, tool output/diffs, view switching, cancellation, resize, and terminal restoration.
- 180 transcript lines each appear exactly once across scrollback and the live screen; dock controls never enter history. Unit coverage also checks shrinking the composer and switching sessions without replaying or dropping transcript rows.
- Installed release-build smoke test: bare `bitrouter` with the saved default Codex ACP harness reads two fixture files, renders a Markdown heading and table, reports a hidden marker, and recalls it in the next turn. User configuration and terminal state are preserved.
